### PR TITLE
chore: rename manus → aegis throughout codebase

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -7,9 +7,9 @@ describe('config', () => {
   beforeEach(() => {
     originalEnv = { ...process.env };
 
-    // Clear any MANUS env vars
+    // Clear any AEGIS/MANUS env vars
     for (const key of Object.keys(process.env)) {
-      if (key.startsWith('MANUS_')) {
+      if (key.startsWith('AEGIS_') || key.startsWith('MANUS_')) {
         delete process.env[key];
       }
     }
@@ -18,12 +18,12 @@ describe('config', () => {
   afterEach(() => {
     // Restore env
     for (const key of Object.keys(process.env)) {
-      if (key.startsWith('MANUS_')) {
+      if (key.startsWith('AEGIS_') || key.startsWith('MANUS_')) {
         delete process.env[key];
       }
     }
     for (const [key, value] of Object.entries(originalEnv)) {
-      if (key.startsWith('MANUS_')) {
+      if (key.startsWith('AEGIS_') || key.startsWith('MANUS_')) {
         if (value === undefined) {
           delete process.env[key];
         } else {
@@ -40,7 +40,7 @@ describe('config', () => {
       expect(config.port).toBe(9100);
       expect(config.host).toBe('127.0.0.1');
       expect(config.authToken).toBe('');
-      expect(config.tmuxSession).toBe('manus');
+      expect(config.tmuxSession).toBe('aegis');
       expect(config.maxSessionAgeMs).toBe(2 * 60 * 60 * 1000);
       expect(config.reaperIntervalMs).toBe(5 * 60 * 1000);
       expect(config.webhooks).toEqual([]);
@@ -49,95 +49,146 @@ describe('config', () => {
     });
   });
 
-  describe('environment variable overrides', () => {
-    it('overrides port via MANUS_PORT', () => {
-      process.env.MANUS_PORT = '3000';
+  describe('AEGIS_* environment variable overrides (new)', () => {
+    it('overrides port via AEGIS_PORT', () => {
+      process.env.AEGIS_PORT = '3000';
       const config = getConfig();
-
       expect(config.port).toBe(3000);
     });
 
-    it('overrides host via MANUS_HOST', () => {
-      process.env.MANUS_HOST = '0.0.0.0';
+    it('overrides host via AEGIS_HOST', () => {
+      process.env.AEGIS_HOST = '0.0.0.0';
       const config = getConfig();
-
       expect(config.host).toBe('0.0.0.0');
     });
 
-    it('overrides authToken via MANUS_AUTH_TOKEN', () => {
-      process.env.MANUS_AUTH_TOKEN = 'secret-token';
+    it('overrides authToken via AEGIS_AUTH_TOKEN', () => {
+      process.env.AEGIS_AUTH_TOKEN = 'secret-token';
       const config = getConfig();
-
       expect(config.authToken).toBe('secret-token');
     });
 
-    it('overrides tmuxSession via MANUS_TMUX_SESSION', () => {
-      process.env.MANUS_TMUX_SESSION = 'my-session';
+    it('overrides tmuxSession via AEGIS_TMUX_SESSION', () => {
+      process.env.AEGIS_TMUX_SESSION = 'my-session';
       const config = getConfig();
-
       expect(config.tmuxSession).toBe('my-session');
     });
 
-    it('overrides stateDir via MANUS_STATE_DIR', () => {
-      process.env.MANUS_STATE_DIR = '/custom/state';
+    it('overrides stateDir via AEGIS_STATE_DIR', () => {
+      process.env.AEGIS_STATE_DIR = '/custom/state';
       const config = getConfig();
-
       expect(config.stateDir).toBe('/custom/state');
     });
 
-    it('overrides claudeProjectsDir via MANUS_CLAUDE_PROJECTS_DIR', () => {
-      process.env.MANUS_CLAUDE_PROJECTS_DIR = '/custom/claude';
+    it('overrides webhooks via AEGIS_WEBHOOKS', () => {
+      process.env.AEGIS_WEBHOOKS = 'https://example.com/hook';
       const config = getConfig();
-
-      expect(config.claudeProjectsDir).toBe('/custom/claude');
-    });
-
-    it('overrides maxSessionAgeMs via MANUS_MAX_SESSION_AGE_MS', () => {
-      process.env.MANUS_MAX_SESSION_AGE_MS = '3600000';
-      const config = getConfig();
-
-      expect(config.maxSessionAgeMs).toBe(3600000);
-    });
-
-    it('overrides reaperIntervalMs via MANUS_REAPER_INTERVAL_MS', () => {
-      process.env.MANUS_REAPER_INTERVAL_MS = '60000';
-      const config = getConfig();
-
-      expect(config.reaperIntervalMs).toBe(60000);
-    });
-
-    it('overrides tgBotToken via MANUS_TG_TOKEN', () => {
-      process.env.MANUS_TG_TOKEN = 'bot123:abc';
-      const config = getConfig();
-
-      expect(config.tgBotToken).toBe('bot123:abc');
-    });
-
-    it('overrides tgGroupId via MANUS_TG_GROUP', () => {
-      process.env.MANUS_TG_GROUP = '-12345';
-      const config = getConfig();
-
-      expect(config.tgGroupId).toBe('-12345');
-    });
-
-    it('parses single webhook from MANUS_WEBHOOKS', () => {
-      process.env.MANUS_WEBHOOKS = 'https://example.com/hook';
-      const config = getConfig();
-
       expect(config.webhooks).toEqual(['https://example.com/hook']);
     });
 
-    it('parses comma-separated webhooks from MANUS_WEBHOOKS', () => {
-      process.env.MANUS_WEBHOOKS = 'https://a.com/hook, https://b.com/hook';
+    it('parses comma-separated webhooks', () => {
+      process.env.AEGIS_WEBHOOKS = 'https://a.com/hook, https://b.com/hook';
       const config = getConfig();
-
       expect(config.webhooks).toEqual(['https://a.com/hook', 'https://b.com/hook']);
     });
+  });
 
+  describe('MANUS_* backward compatibility', () => {
+    it('overrides port via MANUS_PORT (legacy)', () => {
+      process.env.MANUS_PORT = '3000';
+      const config = getConfig();
+      expect(config.port).toBe(3000);
+    });
+
+    it('overrides host via MANUS_HOST (legacy)', () => {
+      process.env.MANUS_HOST = '0.0.0.0';
+      const config = getConfig();
+      expect(config.host).toBe('0.0.0.0');
+    });
+
+    it('overrides authToken via MANUS_AUTH_TOKEN (legacy)', () => {
+      process.env.MANUS_AUTH_TOKEN = 'secret-token';
+      const config = getConfig();
+      expect(config.authToken).toBe('secret-token');
+    });
+
+    it('overrides tmuxSession via MANUS_TMUX_SESSION (legacy)', () => {
+      process.env.MANUS_TMUX_SESSION = 'my-session';
+      const config = getConfig();
+      expect(config.tmuxSession).toBe('my-session');
+    });
+
+    it('overrides stateDir via MANUS_STATE_DIR (legacy)', () => {
+      process.env.MANUS_STATE_DIR = '/custom/state';
+      const config = getConfig();
+      expect(config.stateDir).toBe('/custom/state');
+    });
+
+    it('overrides claudeProjectsDir via MANUS_CLAUDE_PROJECTS_DIR (legacy)', () => {
+      process.env.MANUS_CLAUDE_PROJECTS_DIR = '/custom/claude';
+      const config = getConfig();
+      expect(config.claudeProjectsDir).toBe('/custom/claude');
+    });
+
+    it('overrides maxSessionAgeMs via MANUS_MAX_SESSION_AGE_MS (legacy)', () => {
+      process.env.MANUS_MAX_SESSION_AGE_MS = '3600000';
+      const config = getConfig();
+      expect(config.maxSessionAgeMs).toBe(3600000);
+    });
+
+    it('overrides reaperIntervalMs via MANUS_REAPER_INTERVAL_MS (legacy)', () => {
+      process.env.MANUS_REAPER_INTERVAL_MS = '60000';
+      const config = getConfig();
+      expect(config.reaperIntervalMs).toBe(60000);
+    });
+
+    it('overrides tgBotToken via MANUS_TG_TOKEN (legacy)', () => {
+      process.env.MANUS_TG_TOKEN = 'bot123:abc';
+      const config = getConfig();
+      expect(config.tgBotToken).toBe('bot123:abc');
+    });
+
+    it('overrides tgGroupId via MANUS_TG_GROUP (legacy)', () => {
+      process.env.MANUS_TG_GROUP = '-12345';
+      const config = getConfig();
+      expect(config.tgGroupId).toBe('-12345');
+    });
+
+    it('parses single webhook from MANUS_WEBHOOKS (legacy)', () => {
+      process.env.MANUS_WEBHOOKS = 'https://example.com/hook';
+      const config = getConfig();
+      expect(config.webhooks).toEqual(['https://example.com/hook']);
+    });
+  });
+
+  describe('AEGIS_* takes priority over MANUS_*', () => {
+    it('AEGIS_PORT wins over MANUS_PORT', () => {
+      process.env.MANUS_PORT = '3000';
+      process.env.AEGIS_PORT = '4000';
+      const config = getConfig();
+      expect(config.port).toBe(4000);
+    });
+
+    it('AEGIS_AUTH_TOKEN wins over MANUS_AUTH_TOKEN', () => {
+      process.env.MANUS_AUTH_TOKEN = 'old-token';
+      process.env.AEGIS_AUTH_TOKEN = 'new-token';
+      const config = getConfig();
+      expect(config.authToken).toBe('new-token');
+    });
+
+    it('AEGIS_TMUX_SESSION wins over MANUS_TMUX_SESSION', () => {
+      process.env.MANUS_TMUX_SESSION = 'manus';
+      process.env.AEGIS_TMUX_SESSION = 'aegis';
+      const config = getConfig();
+      expect(config.tmuxSession).toBe('aegis');
+    });
+  });
+
+  describe('numeric parsing', () => {
     it('parses numeric values correctly', () => {
-      process.env.MANUS_PORT = '8080';
-      process.env.MANUS_MAX_SESSION_AGE_MS = '7200000';
-      process.env.MANUS_REAPER_INTERVAL_MS = '120000';
+      process.env.AEGIS_PORT = '8080';
+      process.env.AEGIS_MAX_SESSION_AGE_MS = '7200000';
+      process.env.AEGIS_REAPER_INTERVAL_MS = '120000';
 
       const config = getConfig();
 
@@ -148,12 +199,14 @@ describe('config', () => {
       expect(config.maxSessionAgeMs).toBe(7200000);
       expect(config.reaperIntervalMs).toBe(120000);
     });
+  });
 
+  describe('multiple overrides', () => {
     it('multiple env overrides work together', () => {
-      process.env.MANUS_PORT = '3000';
-      process.env.MANUS_HOST = '0.0.0.0';
-      process.env.MANUS_AUTH_TOKEN = 'test-token';
-      process.env.MANUS_WEBHOOKS = 'https://webhook.example.com';
+      process.env.AEGIS_PORT = '3000';
+      process.env.AEGIS_HOST = '0.0.0.0';
+      process.env.AEGIS_AUTH_TOKEN = 'test-token';
+      process.env.AEGIS_WEBHOOKS = 'https://webhook.example.com';
 
       const config = getConfig();
 

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -2,7 +2,7 @@
  * channels/webhook.ts — Generic webhook notification channel.
  *
  * Fires HTTP POST to configured URLs on session events.
- * Configure via MANUS_WEBHOOKS env var or config file.
+ * Configure via AEGIS_WEBHOOKS (or legacy MANUS_WEBHOOKS) env var or config file.
  */
 
 import type {
@@ -35,16 +35,16 @@ export class WebhookChannel implements Channel {
     this.endpoints = config.endpoints;
   }
 
-  /** Create from MANUS_WEBHOOKS env var. Returns null if not set. */
+  /** Create from AEGIS_WEBHOOKS (or legacy MANUS_WEBHOOKS) env var. Returns null if not set. */
   static fromEnv(): WebhookChannel | null {
-    const raw = process.env.MANUS_WEBHOOKS;
+    const raw = process.env.AEGIS_WEBHOOKS ?? process.env.MANUS_WEBHOOKS;
     if (!raw) return null;
     try {
       const endpoints = JSON.parse(raw) as WebhookEndpoint[];
       if (!Array.isArray(endpoints) || endpoints.length === 0) return null;
       return new WebhookChannel({ endpoints });
     } catch (e) {
-      console.error('Failed to parse MANUS_WEBHOOKS:', e);
+      console.error('Failed to parse AEGIS_WEBHOOKS:', e);
       return null;
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,14 @@
 /**
- * config.ts — Configuration loader for Manus.
+ * config.ts — Configuration loader for Aegis.
  *
  * Priority (highest to lowest):
  * 1. CLI argument --config <path>
- * 2. ./manus.config.json (cwd)
- * 3. ~/.manus/config.json
+ * 2. ./aegis.config.json (cwd) — fallback: ./manus.config.json
+ * 3. ~/.aegis/config.json — fallback: ~/.manus/config.json
  * 4. Defaults
  *
  * Environment variables override config file values.
+ * AEGIS_* env vars take priority; MANUS_* still supported for backward compat.
  */
 
 import { readFile } from 'node:fs/promises';
@@ -45,8 +46,8 @@ const defaults: Config = {
   port: 9100,
   host: '127.0.0.1',
   authToken: '',
-  tmuxSession: 'manus',
-  stateDir: join(homedir(), '.manus'),
+  tmuxSession: 'aegis',
+  stateDir: join(homedir(), '.aegis'),
   claudeProjectsDir: join(homedir(), '.claude', 'projects'),
   maxSessionAgeMs: 2 * 60 * 60 * 1000, // 2 hours
   reaperIntervalMs: 5 * 60 * 1000, // 5 minutes
@@ -64,10 +65,16 @@ function getConfigPathFromArgv(): string | null {
   return null;
 }
 
-/** Find and load config file from possible locations */
+/** Find and load config file from possible locations.
+ *  Checks aegis paths first, falls back to manus paths for backward compat.
+ */
 async function loadConfigFile(): Promise<Partial<Config>> {
   const locations = [
     getConfigPathFromArgv(),
+    // New aegis paths (preferred)
+    resolve('aegis.config.json'),
+    join(homedir(), '.aegis', 'config.json'),
+    // Legacy manus paths (backward compat)
     resolve('manus.config.json'),
     join(homedir(), '.manus', 'config.json'),
   ].filter(Boolean) as string[];
@@ -83,6 +90,10 @@ async function loadConfigFile(): Promise<Partial<Config>> {
         }
         if (typeof parsed.claudeProjectsDir === 'string') {
           parsed.claudeProjectsDir = expandTilde(parsed.claudeProjectsDir);
+        }
+        // Log if using legacy path
+        if (path.includes('manus')) {
+          console.log(`Config: loaded from legacy path ${path} — consider migrating to aegis paths`);
         }
         return parsed;
       } catch (e) {
@@ -102,41 +113,61 @@ function expandTilde(path: string): string {
   return path;
 }
 
-/** Apply environment variable overrides */
+/** Apply environment variable overrides.
+ *  AEGIS_* vars take priority over MANUS_* (backward compat).
+ */
 function applyEnvOverrides(config: Config): Config {
-  const envMappings: Record<string, keyof Config> = {
-    MANUS_PORT: 'port',
-    MANUS_HOST: 'host',
-    MANUS_AUTH_TOKEN: 'authToken',
-    MANUS_TMUX_SESSION: 'tmuxSession',
-    MANUS_STATE_DIR: 'stateDir',
-    MANUS_CLAUDE_PROJECTS_DIR: 'claudeProjectsDir',
-    MANUS_MAX_SESSION_AGE_MS: 'maxSessionAgeMs',
-    MANUS_REAPER_INTERVAL_MS: 'reaperIntervalMs',
-    MANUS_TG_TOKEN: 'tgBotToken',
-    MANUS_TG_GROUP: 'tgGroupId',
-    MANUS_WEBHOOKS: 'webhooks',
-  };
+  // AEGIS_* (new, preferred) and MANUS_* (legacy, backward compat)
+  const envMappings: Array<{ aegis: string; manus: string; key: keyof Config }> = [
+    { aegis: 'AEGIS_PORT', manus: 'MANUS_PORT', key: 'port' },
+    { aegis: 'AEGIS_HOST', manus: 'MANUS_HOST', key: 'host' },
+    { aegis: 'AEGIS_AUTH_TOKEN', manus: 'MANUS_AUTH_TOKEN', key: 'authToken' },
+    { aegis: 'AEGIS_TMUX_SESSION', manus: 'MANUS_TMUX_SESSION', key: 'tmuxSession' },
+    { aegis: 'AEGIS_STATE_DIR', manus: 'MANUS_STATE_DIR', key: 'stateDir' },
+    { aegis: 'AEGIS_CLAUDE_PROJECTS_DIR', manus: 'MANUS_CLAUDE_PROJECTS_DIR', key: 'claudeProjectsDir' },
+    { aegis: 'AEGIS_MAX_SESSION_AGE_MS', manus: 'MANUS_MAX_SESSION_AGE_MS', key: 'maxSessionAgeMs' },
+    { aegis: 'AEGIS_REAPER_INTERVAL_MS', manus: 'MANUS_REAPER_INTERVAL_MS', key: 'reaperIntervalMs' },
+    { aegis: 'AEGIS_TG_TOKEN', manus: 'MANUS_TG_TOKEN', key: 'tgBotToken' },
+    { aegis: 'AEGIS_TG_GROUP', manus: 'MANUS_TG_GROUP', key: 'tgGroupId' },
+    { aegis: 'AEGIS_WEBHOOKS', manus: 'MANUS_WEBHOOKS', key: 'webhooks' },
+  ];
 
-  for (const [envKey, configKey] of Object.entries(envMappings)) {
-    const value = process.env[envKey];
+  for (const { aegis, manus, key } of envMappings) {
+    // AEGIS_* takes priority over MANUS_*
+    const value = process.env[aegis] ?? process.env[manus];
     if (value === undefined) continue;
 
-    switch (configKey) {
+    switch (key) {
       case 'port':
       case 'maxSessionAgeMs':
       case 'reaperIntervalMs':
-        config[configKey] = parseInt(value, 10);
+        config[key] = parseInt(value, 10);
         break;
       case 'webhooks':
         // Support comma-separated webhooks
-        config[configKey] = value.includes(',')
+        config[key] = value.includes(',')
           ? value.split(',').map(s => s.trim())
           : [value];
         break;
       default:
-        config[configKey] = value;
+        config[key] = value;
     }
+  }
+
+  return config;
+}
+
+/** Resolve the state directory.
+ *  If ~/.aegis doesn't exist but ~/.manus does, use ~/.manus for backward compat.
+ */
+function resolveStateDir(config: Config): Config {
+  const aegisDir = join(homedir(), '.aegis');
+  const manusDir = join(homedir(), '.manus');
+
+  // If stateDir is the default aegis path but doesn't exist, check for legacy manus path
+  if (config.stateDir === aegisDir && !existsSync(aegisDir) && existsSync(manusDir)) {
+    console.log(`Config: using legacy state dir ${manusDir} — consider migrating to ${aegisDir}`);
+    config.stateDir = manusDir;
   }
 
   return config;
@@ -145,13 +176,16 @@ function applyEnvOverrides(config: Config): Config {
 /** Load and merge configuration from all sources */
 export async function loadConfig(): Promise<Config> {
   const fileConfig = await loadConfigFile();
-  const config: Config = { ...defaults, ...fileConfig };
-  return applyEnvOverrides(config);
+  let config: Config = { ...defaults, ...fileConfig };
+  config = applyEnvOverrides(config);
+  config = resolveStateDir(config);
+  return config;
 }
 
 /** Get config without async file loading (for tests or synchronous contexts) */
 export function getConfig(): Config {
   // This returns defaults + env overrides only (no file loading)
-  const config: Config = { ...defaults };
-  return applyEnvOverrides(config);
+  let config: Config = { ...defaults };
+  config = applyEnvOverrides(config);
+  return config;
 }

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
- * hook.ts — Claude Code SessionStart hook for Manus.
+ * hook.ts — Claude Code SessionStart hook for Aegis.
  * 
- * Writes session_id → window_id mapping to ~/.manus/session_map.json.
+ * Writes session_id → window_id mapping to ~/.aegis/session_map.json.
+ * Falls back to ~/.manus/ for backward compatibility.
  * Called by CC's hook system, reads payload from stdin.
  * 
  * Install: add to ~/.claude/settings.json:
@@ -24,7 +25,10 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const BRIDGE_DIR = join(homedir(), '.manus');
+// Use ~/.aegis if it exists, fall back to ~/.manus for backward compat
+const AEGIS_DIR = join(homedir(), '.aegis');
+const MANUS_DIR = join(homedir(), '.manus');
+const BRIDGE_DIR = existsSync(AEGIS_DIR) ? AEGIS_DIR : MANUS_DIR;
 const MAP_FILE = join(BRIDGE_DIR, 'session_map.json');
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -101,7 +105,7 @@ function main(): void {
   };
 
   writeFileSync(MAP_FILE, JSON.stringify(sessionMap, null, 2));
-  console.error(`Manus hook: mapped ${key} -> ${sessionId}`);
+  console.error(`Aegis hook: mapped ${key} -> ${sessionId}`);
 }
 
 function install(): void {
@@ -123,11 +127,11 @@ function install(): void {
 
   // Check if already installed
   const isInstalled = sessionStart.some(entry =>
-    entry.hooks?.some(h => h.command?.includes('manus') || h.command?.includes('hook.js'))
+    entry.hooks?.some(h => h.command?.includes('aegis') || h.command?.includes('manus') || h.command?.includes('hook.js'))
   );
 
   if (isInstalled) {
-    console.log('Manus hook already installed');
+    console.log('Aegis hook already installed');
     return;
   }
 
@@ -140,7 +144,7 @@ function install(): void {
 
   mkdirSync(join(homedir(), '.claude'), { recursive: true });
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-  console.log(`Manus hook installed in ${settingsPath}`);
+  console.log(`Aegis hook installed in ${settingsPath}`);
 }
 
 main();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * server.ts — HTTP API server for Manus.
+ * server.ts — HTTP API server for Aegis.
  *
  * Exposes RESTful endpoints for creating, managing, and interacting
  * with Claude Code sessions running in tmux.
@@ -485,7 +485,7 @@ async function main(): Promise<void> {
   );
 
   await app.listen({ port: config.port, host: config.host });
-  console.log(`Manus running on http://${config.host}:${config.port}`);
+  console.log(`Aegis running on http://${config.host}:${config.port}`);
   console.log(`Channels: ${channels.count} registered`);
   console.log(`State dir: ${config.stateDir}`);
   console.log(`Claude projects dir: ${config.claudeProjectsDir}`);
@@ -493,6 +493,6 @@ async function main(): Promise<void> {
 }
 
 main().catch(err => {
-  console.error('Failed to start Manus:', err);
+  console.error('Failed to start Aegis:', err);
   process.exit(1);
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -92,8 +92,8 @@ export class SessionManager {
       await this.save();
     }
 
-    // P0 fix: On startup, purge session_map entries that don't correspond to active manus sessions.
-    // This prevents stale windowId collisions after manus restarts where old @5 entries
+    // P0 fix: On startup, purge session_map entries that don't correspond to active sessions.
+    // This prevents stale windowId collisions after aegis restarts where old @5 entries
     // could match newly assigned @5 windows pointing to completely different sessions.
     await this.purgeStaleSessionMapEntries(windowIds, windowNames);
   }
@@ -324,7 +324,7 @@ export class SessionManager {
   }
 
   /** Remove stale entries from session_map.json for a given window.
-   *  P0 fix: After manus.service restarts, old session_map entries with stale windowIds
+   *  P0 fix: After aegis service restarts, old session_map entries with stale windowIds
    *  can survive and cause new sessions to inherit context from old sessions.
    *  We must clean by BOTH windowName AND windowId to prevent collisions.
    *
@@ -358,8 +358,8 @@ export class SessionManager {
     } catch { /* ignore parse/write errors */ }
   }
 
-  /** P0 fix: Purge session_map entries that don't correspond to active manus sessions.
-   *  After manus restarts, old session_map entries with stale windowIds can survive
+  /** P0 fix: Purge session_map entries that don't correspond to active aegis sessions.
+   *  After aegis restarts, old session_map entries with stale windowIds can survive
    *  and cause new sessions to inherit context from old sessions.
    */
   private async purgeStaleSessionMapEntries(
@@ -456,7 +456,7 @@ export class SessionManager {
 
         // Find matching entry by window ID (exact match to avoid @1 matching @10, @11, etc.)
         for (const [key, info] of Object.entries(mapData) as [string, any][]) {
-          // P0 fix: Match by exact windowId suffix (e.g., "manus:@5"), not substring
+          // P0 fix: Match by exact windowId suffix (e.g., "aegis:@5"), not substring
           // This prevents @5 from matching @15, @50, etc.
           const keyWindowId = key.includes(':') ? key.split(':').pop() : null;
           const matchesWindowId = keyWindowId === session.windowId;

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -22,7 +22,7 @@ export interface TmuxWindow {
 }
 
 export class TmuxManager {
-  constructor(private sessionName: string = 'manus') {}
+  constructor(private sessionName: string = 'aegis') {}
 
   /** Run a tmux command and return stdout. */
   private async tmux(...args: string[]): Promise<string> {


### PR DESCRIPTION
## Issue #3 — Rename manus → aegis

### Changes
- **config.ts**: defaults to `aegis` tmux session, `~/.aegis/` state dir
- **config.ts**: `AEGIS_*` env vars added (`MANUS_*` still supported, lower priority)
- **config.ts**: checks `aegis.config.json` before `manus.config.json`
- **config.ts**: `resolveStateDir()` falls back to `~/.manus/` if `~/.aegis/` doesn't exist
- **hook.ts**: uses `~/.aegis/` if it exists, falls back to `~/.manus/`
- **tmux.ts**: default session name `aegis`
- **server.ts**: log messages say `Aegis`
- **webhook.ts**: `AEGIS_WEBHOOKS` env var (`MANUS_WEBHOOKS` fallback)
- All comments updated from manus → aegis

### Backward Compatibility
✅ All `MANUS_*` env vars still work
✅ `~/.manus/` paths still used if `~/.aegis/` doesn't exist
✅ `manus.config.json` still loaded if `aegis.config.json` not found
✅ `AEGIS_*` takes priority when both are set

### Tests
- Config tests expanded: 15 → 24 tests
- Added AEGIS_* priority tests
- All 226 tests pass

Closes #3