### PR TITLE
feat: session health check endpoint

### DIFF
--- a/src/__tests__/session-health.test.ts
+++ b/src/__tests__/session-health.test.ts
@@ -1,0 +1,123 @@
+/**
+ * session-health.test.ts — Tests for Issue #2: session health check endpoint.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('Session health check', () => {
+  describe('alive determination', () => {
+    it('should be alive when window exists and Claude is running', () => {
+      const windowExists = true;
+      const claudeRunning = true;
+      const recentlyActive = false;
+      const alive = windowExists && (claudeRunning || recentlyActive);
+      expect(alive).toBe(true);
+    });
+
+    it('should be alive when window exists and recently active', () => {
+      const windowExists = true;
+      const claudeRunning = false;
+      const lastActivityAgo = 2 * 60 * 1000; // 2 minutes
+      const recentlyActive = lastActivityAgo < 5 * 60 * 1000;
+      const alive = windowExists && (claudeRunning || recentlyActive);
+      expect(alive).toBe(true);
+    });
+
+    it('should be dead when window does not exist', () => {
+      const windowExists = false;
+      const claudeRunning = false;
+      const recentlyActive = true;
+      const alive = windowExists && (claudeRunning || recentlyActive);
+      expect(alive).toBe(false);
+    });
+
+    it('should be dead when window exists but Claude not running and not recently active', () => {
+      const windowExists = true;
+      const claudeRunning = false;
+      const lastActivityAgo = 10 * 60 * 1000; // 10 minutes
+      const recentlyActive = lastActivityAgo < 5 * 60 * 1000;
+      const alive = windowExists && (claudeRunning || recentlyActive);
+      expect(alive).toBe(false);
+    });
+  });
+
+  describe('Claude process detection', () => {
+    it('should detect Claude process', () => {
+      const claudeProcesses = ['claude', 'node'];
+      for (const proc of claudeProcesses) {
+        const running = proc === 'claude' || proc === 'node';
+        expect(running).toBe(true);
+      }
+    });
+
+    it('should not detect shell as Claude', () => {
+      const shellProcesses = ['bash', 'zsh', 'sh', 'fish'];
+      for (const proc of shellProcesses) {
+        const running = proc === 'claude' || proc === 'node';
+        expect(running).toBe(false);
+      }
+    });
+  });
+
+  describe('health response shape', () => {
+    it('should contain all required fields', () => {
+      const response = {
+        alive: true,
+        windowExists: true,
+        claudeRunning: true,
+        paneCommand: 'claude',
+        status: 'working',
+        hasTranscript: true,
+        lastActivity: Date.now(),
+        lastActivityAgo: 5000,
+        sessionAge: 60000,
+        details: 'Claude is actively working',
+      };
+
+      expect(response).toHaveProperty('alive');
+      expect(response).toHaveProperty('windowExists');
+      expect(response).toHaveProperty('claudeRunning');
+      expect(response).toHaveProperty('paneCommand');
+      expect(response).toHaveProperty('status');
+      expect(response).toHaveProperty('hasTranscript');
+      expect(response).toHaveProperty('lastActivity');
+      expect(response).toHaveProperty('lastActivityAgo');
+      expect(response).toHaveProperty('sessionAge');
+      expect(response).toHaveProperty('details');
+    });
+  });
+
+  describe('detail messages', () => {
+    it('should report dead window', () => {
+      const windowExists = false;
+      const detail = !windowExists
+        ? 'Tmux window does not exist — session is dead'
+        : 'ok';
+      expect(detail).toContain('dead');
+    });
+
+    it('should report idle Claude', () => {
+      const status = 'idle';
+      const detail = status === 'idle'
+        ? 'Claude is idle, awaiting input'
+        : 'other';
+      expect(detail).toContain('idle');
+    });
+
+    it('should report working Claude', () => {
+      const status = 'working';
+      const detail = status === 'working'
+        ? 'Claude is actively working'
+        : 'other';
+      expect(detail).toContain('working');
+    });
+
+    it('should report permission needed', () => {
+      const status = 'permission_prompt';
+      const detail = (status === 'permission_prompt' || status === 'bash_approval')
+        ? 'Claude is waiting for permission approval'
+        : 'other';
+      expect(detail).toContain('permission');
+    });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -165,6 +165,22 @@ app.get<{ Params: { id: string } }>('/sessions/:id', async (req, reply) => {
   return session;
 });
 
+// Session health check (Issue #2)
+app.get<{ Params: { id: string } }>('/v1/sessions/:id/health', async (req, reply) => {
+  try {
+    return await sessions.getHealth(req.params.id);
+  } catch (e: any) {
+    return reply.status(404).send({ error: e.message });
+  }
+});
+app.get<{ Params: { id: string } }>('/sessions/:id/health', async (req, reply) => {
+  try {
+    return await sessions.getHealth(req.params.id);
+  } catch (e: any) {
+    return reply.status(404).send({ error: e.message });
+  }
+});
+
 // Send message (with delivery verification — Issue #1)
 app.post<{ Params: { id: string }; Body: { text: string } }>(
   '/v1/sessions/:id/send',

--- a/src/session.ts
+++ b/src/session.ts
@@ -165,6 +165,78 @@ export class SessionManager {
     return Object.values(this.state.sessions);
   }
 
+  /** Get health info for a session.
+   *  Issue #2: Returns comprehensive health status for orchestrators.
+   */
+  async getHealth(id: string): Promise<{
+    alive: boolean;
+    windowExists: boolean;
+    claudeRunning: boolean;
+    paneCommand: string | null;
+    status: UIState;
+    hasTranscript: boolean;
+    lastActivity: number;
+    lastActivityAgo: number;
+    sessionAge: number;
+    details: string;
+  }> {
+    const session = this.state.sessions[id];
+    if (!session) throw new Error(`Session ${id} not found`);
+
+    const now = Date.now();
+    const windowHealth = await this.tmux.getWindowHealth(session.windowId);
+
+    // Get terminal state
+    let status: UIState = 'unknown';
+    if (windowHealth.windowExists) {
+      try {
+        const paneText = await this.tmux.capturePane(session.windowId);
+        status = detectUIState(paneText);
+        session.status = status;
+      } catch {
+        status = 'unknown';
+      }
+    }
+
+    const hasTranscript = !!(session.claudeSessionId && session.jsonlPath);
+    const lastActivityAgo = now - session.lastActivity;
+    const sessionAge = now - session.createdAt;
+
+    // Determine if session is alive
+    // Alive = window exists AND (Claude running OR recently active)
+    const recentlyActive = lastActivityAgo < 5 * 60 * 1000; // 5 minutes
+    const alive = windowHealth.windowExists && (windowHealth.claudeRunning || recentlyActive);
+
+    // Human-readable detail
+    let details: string;
+    if (!windowHealth.windowExists) {
+      details = 'Tmux window does not exist — session is dead';
+    } else if (!windowHealth.claudeRunning && !recentlyActive) {
+      details = `Claude not running (pane: ${windowHealth.paneCommand}), no activity for ${Math.round(lastActivityAgo / 60000)}min`;
+    } else if (status === 'idle') {
+      details = 'Claude is idle, awaiting input';
+    } else if (status === 'working') {
+      details = 'Claude is actively working';
+    } else if (status === 'permission_prompt' || status === 'bash_approval') {
+      details = 'Claude is waiting for permission approval';
+    } else {
+      details = `Status: ${status}, pane: ${windowHealth.paneCommand}`;
+    }
+
+    return {
+      alive,
+      windowExists: windowHealth.windowExists,
+      claudeRunning: windowHealth.claudeRunning,
+      paneCommand: windowHealth.paneCommand,
+      status,
+      hasTranscript,
+      lastActivity: session.lastActivity,
+      lastActivityAgo,
+      sessionAge,
+      details,
+    };
+  }
+
   /** Send a message to a session with delivery verification.
    *  Issue #1: Uses capture-pane to verify the prompt was delivered.
    *  Returns delivery status for API response.

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -263,6 +263,29 @@ export class TmuxManager {
     }
   }
 
+  /** Get detailed window info for health checks.
+   *  Issue #2: Returns window existence, pane command, and whether Claude is running.
+   */
+  async getWindowHealth(windowId: string): Promise<{
+    windowExists: boolean;
+    paneCommand: string | null;
+    claudeRunning: boolean;
+  }> {
+    try {
+      const windows = await this.listWindows();
+      const win = windows.find(w => w.windowId === windowId);
+      if (!win) {
+        return { windowExists: false, paneCommand: null, claudeRunning: false };
+      }
+      const paneCmd = win.paneCommand.toLowerCase();
+      // Claude runs as 'claude' or 'node' process
+      const claudeRunning = paneCmd === 'claude' || paneCmd === 'node';
+      return { windowExists: true, paneCommand: win.paneCommand, claudeRunning };
+    } catch {
+      return { windowExists: false, paneCommand: null, claudeRunning: false };
+    }
+  }
+
   /** Send text to a window's active pane. */
   async sendKeys(windowId: string, text: string, enter: boolean = true): Promise<void> {
     // P1 fix: Verify window exists before sending keys


### PR DESCRIPTION
## Issue #2 — Session health check endpoint

**Problem:** No API to distinguish between "CC is working" and "CC crashed silently." Zeus/orchestrators need to know if a session is actually alive.

### New endpoint: `GET /v1/sessions/:id/health`

Returns:
```json
{
  "alive": true,
  "windowExists": true,
  "claudeRunning": true,
  "paneCommand": "claude",
  "status": "working",
  "hasTranscript": true,
  "lastActivity": 1711072800000,
  "lastActivityAgo": 5000,
  "sessionAge": 120000,
  "details": "Claude is actively working"
}
```

**Alive** = window exists AND (Claude running OR activity in last 5min)

### Implementation
- `tmux.ts`: `getWindowHealth()` — checks window + pane command
- `session.ts`: `getHealth()` — combines tmux, terminal state, transcript, timing
- `server.ts`: `/v1/sessions/:id/health` + `/sessions/:id/health` (compat)

### Tests
- 11 new tests, 248 total pass

Closes #2