### PR TITLE
feat: StopFailure hook support for CC error detection

### DIFF
--- a/src/__tests__/stop-failure.test.ts
+++ b/src/__tests__/stop-failure.test.ts
@@ -1,0 +1,116 @@
+/**
+ * stop-failure.test.ts — Tests for Issue #15: StopFailure hook support.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readFile } from 'node:fs/promises';
+
+describe('StopFailure hook support', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-stop-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('stop signal file format', () => {
+    it('should write valid stop signal JSON', () => {
+      const signalFile = join(tmpDir, 'stop_signals.json');
+      const signals: Record<string, unknown> = {};
+
+      signals['test-session-id'] = {
+        event: 'StopFailure',
+        timestamp: Date.now(),
+        error: 'Rate limit exceeded',
+        stop_reason: 'rate_limit',
+      };
+
+      writeFileSync(signalFile, JSON.stringify(signals, null, 2));
+
+      const parsed = JSON.parse(require('fs').readFileSync(signalFile, 'utf-8'));
+      expect(parsed['test-session-id'].event).toBe('StopFailure');
+      expect(parsed['test-session-id'].error).toBe('Rate limit exceeded');
+    });
+
+    it('should write Stop event signal', () => {
+      const signal = {
+        event: 'Stop',
+        timestamp: Date.now(),
+        error: null,
+        stop_reason: 'end_turn',
+      };
+
+      expect(signal.event).toBe('Stop');
+      expect(signal.error).toBeNull();
+    });
+
+    it('should handle StopFailure with no error details', () => {
+      const signal = {
+        event: 'StopFailure',
+        timestamp: Date.now(),
+        error: null,
+        stop_reason: null,
+      };
+
+      const errorDetail = signal.error || signal.stop_reason || 'Unknown API error';
+      expect(errorDetail).toBe('Unknown API error');
+    });
+  });
+
+  describe('signal deduplication', () => {
+    it('should not re-process same signal', () => {
+      const processedSignals = new Set<string>();
+      const signalKey = 'session-123:1711072800000';
+
+      // First time — should process
+      expect(processedSignals.has(signalKey)).toBe(false);
+      processedSignals.add(signalKey);
+
+      // Second time — should skip
+      expect(processedSignals.has(signalKey)).toBe(true);
+    });
+
+    it('should process different timestamps for same session', () => {
+      const processedSignals = new Set<string>();
+
+      processedSignals.add('session-123:1000');
+      expect(processedSignals.has('session-123:2000')).toBe(false);
+    });
+  });
+
+  describe('event type routing', () => {
+    it('should route StopFailure to status.error', () => {
+      const event = 'StopFailure';
+      const channelEvent = event === 'StopFailure' ? 'status.error' : 'status.stopped';
+      expect(channelEvent).toBe('status.error');
+    });
+
+    it('should route Stop to status.stopped', () => {
+      const event: string = 'Stop';
+      const channelEvent = event === 'StopFailure' ? 'status.error' : 'status.stopped';
+      expect(channelEvent).toBe('status.stopped');
+    });
+  });
+
+  describe('hook install for Stop/StopFailure', () => {
+    it('should register hooks for all three events', () => {
+      const events = ['SessionStart', 'Stop', 'StopFailure'];
+      const hooks: Record<string, unknown[]> = {};
+
+      for (const event of events) {
+        hooks[event] = [{ hooks: [{ type: 'command', command: 'node hook.js' }] }];
+      }
+
+      expect(Object.keys(hooks)).toEqual(events);
+      expect(hooks.SessionStart).toHaveLength(1);
+      expect(hooks.Stop).toHaveLength(1);
+      expect(hooks.StopFailure).toHaveLength(1);
+    });
+  });
+});

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -20,7 +20,9 @@ export type SessionEvent =
   | 'status.permission'
   | 'status.question'
   | 'status.plan'
-  | 'status.stall';
+  | 'status.stall'
+  | 'status.stopped'
+  | 'status.error';
 
 /** Payload for all session events. */
 export interface SessionEventPayload {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -32,6 +32,36 @@ const BRIDGE_DIR = existsSync(AEGIS_DIR) ? AEGIS_DIR : MANUS_DIR;
 const MAP_FILE = join(BRIDGE_DIR, 'session_map.json');
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
+/** Handle Stop/StopFailure events.
+ *  Writes a signal file that the Aegis monitor can detect.
+ *  Issue #15: StopFailure fires on API errors (rate limit, auth failure).
+ */
+function handleStopEvent(
+  sessionId: string,
+  event: string,
+  payload: Record<string, unknown>,
+): void {
+  const signalFile = join(BRIDGE_DIR, 'stop_signals.json');
+
+  let signals: Record<string, unknown> = {};
+  if (existsSync(signalFile)) {
+    try {
+      signals = JSON.parse(readFileSync(signalFile, 'utf-8'));
+    } catch { /* fresh */ }
+  }
+
+  signals[sessionId] = {
+    event,
+    timestamp: Date.now(),
+    // StopFailure may include error info in the payload
+    error: (payload as any).error || (payload as any).message || null,
+    stop_reason: (payload as any).stop_reason || null,
+  };
+
+  writeFileSync(signalFile, JSON.stringify(signals, null, 2));
+  console.error(`Aegis hook: ${event} for session ${sessionId.slice(0, 8)}...`);
+}
+
 function main(): void {
   // Check for --install flag
   if (process.argv.includes('--install')) {
@@ -52,7 +82,17 @@ function main(): void {
   const cwd = payload.cwd || '';
   const event = payload.hook_event_name || '';
 
-  if (!sessionId || event !== 'SessionStart') {
+  if (!sessionId) {
+    process.exit(0);
+  }
+
+  // Handle Stop and StopFailure events — write signal file for monitor
+  if (event === 'Stop' || event === 'StopFailure') {
+    handleStopEvent(sessionId, event, payload);
+    process.exit(0);
+  }
+
+  if (event !== 'SessionStart') {
     process.exit(0);
   }
 
@@ -140,6 +180,20 @@ function install(): void {
   });
 
   hooks.SessionStart = sessionStart;
+
+  // Issue #15: Also register Stop and StopFailure hooks
+  const hookEntry = { hooks: [{ type: 'command', command: hookCommand, timeout: 5 } as any] };
+  for (const event of ['Stop', 'StopFailure'] as const) {
+    const existing = (hooks[event] || []) as Array<{ hooks?: Array<{ command?: string }> }>;
+    const alreadyInstalled = existing.some(entry =>
+      entry.hooks?.some(h => h.command?.includes('aegis') || h.command?.includes('manus') || h.command?.includes('hook.js'))
+    );
+    if (!alreadyInstalled) {
+      existing.push({ ...hookEntry });
+      hooks[event] = existing;
+    }
+  }
+
   settings.hooks = hooks;
 
   mkdirSync(join(homedir(), '.claude'), { recursive: true });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -7,6 +7,10 @@
  * 3. Routes events to the ChannelManager (which fans out to Telegram, webhooks, etc.)
  */
 
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { type SessionManager, type SessionInfo } from './session.js';
 import { type ParsedEntry } from './transcript.js';
 import { type UIState } from './terminal-parser.js';
@@ -33,6 +37,7 @@ export class SessionMonitor {
   private lastStallCheck = 0;
   private idleNotified = new Set<string>();       // prevent idle spam
   private idleSince = new Map<string, number>();  // debounce: when idle started
+  private processedStopSignals = new Set<string>(); // Issue #15: don't re-process signals
 
   constructor(
     private sessions: SessionManager,
@@ -77,6 +82,7 @@ export class SessionMonitor {
     if (now - this.lastStallCheck >= this.config.stallCheckIntervalMs) {
       this.lastStallCheck = now;
       await this.checkForStalls(now);
+      await this.checkStopSignals();
     }
   }
 
@@ -120,6 +126,51 @@ export class SessionMonitor {
         );
       }
     }
+  }
+
+  /** Issue #15: Check for Stop/StopFailure signals written by hook.ts. */
+  private async checkStopSignals(): Promise<void> {
+    // Check both aegis and manus dirs for backward compat
+    const aegisDir = join(homedir(), '.aegis');
+    const manusDir = join(homedir(), '.manus');
+    const signalFile = existsSync(join(aegisDir, 'stop_signals.json'))
+      ? join(aegisDir, 'stop_signals.json')
+      : join(manusDir, 'stop_signals.json');
+
+    if (!existsSync(signalFile)) return;
+
+    try {
+      const signals = JSON.parse(await readFile(signalFile, 'utf-8'));
+
+      for (const session of this.sessions.listSessions()) {
+        if (!session.claudeSessionId) continue;
+        const signal = signals[session.claudeSessionId] as {
+          event?: string;
+          timestamp?: number;
+          error?: string;
+          stop_reason?: string;
+        } | undefined;
+
+        if (!signal) continue;
+
+        const signalKey = `${session.claudeSessionId}:${signal.timestamp}`;
+        if (this.processedStopSignals.has(signalKey)) continue;
+        this.processedStopSignals.add(signalKey);
+
+        if (signal.event === 'StopFailure') {
+          const errorDetail = signal.error || signal.stop_reason || 'Unknown API error';
+          await this.channels.statusChange(
+            this.makePayload('status.error', session,
+              `⚠️ Claude Code error: ${errorDetail}`),
+          );
+        } else if (signal.event === 'Stop') {
+          await this.channels.statusChange(
+            this.makePayload('status.stopped', session,
+              'Claude Code session ended normally'),
+          );
+        }
+      }
+    } catch { /* ignore parse errors */ }
   }
 
   private async checkSession(session: SessionInfo): Promise<void> {
@@ -224,6 +275,8 @@ export class SessionMonitor {
     this.stallNotified.delete(sessionId);
     this.idleNotified.delete(sessionId);
     this.idleSince.delete(sessionId);
+    // Note: processedStopSignals uses claudeSessionId:timestamp keys, not bridge sessionId.
+    // We don't clean them here — they're small and prevent re-processing.
   }
 }
 


### PR DESCRIPTION
## Issue #15 — StopFailure hook support

CC v2.1.78 added `StopFailure` hook event for API errors. Aegis now handles it.

### Changes
- `hook.ts`: handles Stop + StopFailure events, writes `stop_signals.json`
- `hook.ts --install`: registers all 3 hooks (SessionStart, Stop, StopFailure)
- `monitor.ts`: `checkStopSignals()` reads signal file, emits `status.error`/`status.stopped`
- `channels/types.ts`: added `status.stopped` and `status.error` events

### Tests
- 8 new tests, 290 total pass

Closes #15