### PR TITLE
fix: detect --bare flag, use filesystem discovery

### DIFF
--- a/src/__tests__/bare-flag.test.ts
+++ b/src/__tests__/bare-flag.test.ts
@@ -1,0 +1,61 @@
+/**
+ * bare-flag.test.ts — Tests for Issue #16: --bare flag detection.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('--bare flag detection', () => {
+  describe('flag detection in claudeCommand', () => {
+    it('should detect --bare flag', () => {
+      const cmd = 'claude --bare -p "do something"';
+      expect(cmd.includes('--bare')).toBe(true);
+    });
+
+    it('should not detect bare without dashes', () => {
+      const cmd = 'claude -p "use bare minimum"';
+      expect(cmd.includes('--bare')).toBe(false);
+    });
+
+    it('should detect --bare at end of command', () => {
+      const cmd = 'claude --bare';
+      expect(cmd.includes('--bare')).toBe(true);
+    });
+
+    it('should handle empty command', () => {
+      const cmd = '';
+      expect(cmd.includes('--bare')).toBe(false);
+    });
+  });
+
+  describe('filesystem discovery logic', () => {
+    it('should compute project hash correctly', () => {
+      const workDir = '/home/user/projects/foo';
+      const hash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
+      expect(hash).toBe('-home-user-projects-foo');
+    });
+
+    it('should validate UUID format for session ID from filename', () => {
+      const validUuid = 'f3cab47d-1234-5678-9abc-def012345678';
+      const invalidName = 'sessions-index';
+      const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+      expect(uuidRe.test(validUuid)).toBe(true);
+      expect(uuidRe.test(invalidName)).toBe(false);
+    });
+
+    it('should only accept files newer than session creation', () => {
+      const sessionCreatedAt = 1000;
+      const oldFileMtime = 500;
+      const newFileMtime = 1500;
+
+      expect(oldFileMtime < sessionCreatedAt).toBe(true);   // Skip
+      expect(newFileMtime < sessionCreatedAt).toBe(false);  // Accept
+    });
+
+    it('should extract session ID from filename', () => {
+      const filename = 'f3cab47d-1234-5678-9abc-def012345678.jsonl';
+      const sessionId = filename.replace('.jsonl', '');
+      expect(sessionId).toBe('f3cab47d-1234-5678-9abc-def012345678');
+    });
+  });
+});

--- a/src/session.ts
+++ b/src/session.ts
@@ -149,6 +149,14 @@ export class SessionManager {
     this.state.sessions[id] = session;
     await this.save();
 
+    // Issue #16: Detect --bare flag which skips hooks (breaks session discovery).
+    // Fall back to filesystem-based discovery when --bare is used.
+    const claudeCmd = opts.claudeCommand || '';
+    if (claudeCmd.includes('--bare')) {
+      console.warn(`Session ${id}: --bare flag detected — hook-based discovery disabled, using filesystem scan`);
+      this.startFilesystemDiscovery(id, opts.workDir);
+    }
+
     // P0 fix: Clean stale entries from session_map.json for BOTH window name AND id.
     // After archiving old .jsonl files, stale session_map entries would point
     // to moved files, causing discovery to pick up ghost session IDs.
@@ -518,6 +526,68 @@ export class SessionManager {
         if (session && !session.claudeSessionId) {
           console.log(`Discovery: session ${session.windowName} — timed out after 5min, no session_id found`);
         }
+      }
+    }, 5 * 60 * 1000);
+  }
+
+  /** Issue #16: Filesystem-based discovery for --bare mode (no hooks).
+   *  Scans the Claude projects directory for new .jsonl files created after the session.
+   */
+  private startFilesystemDiscovery(id: string, workDir: string): void {
+    const projectHash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
+    const projectDir = join(this.config.claudeProjectsDir, projectHash);
+
+    const interval = setInterval(async () => {
+      const session = this.state.sessions[id];
+      if (!session) {
+        clearInterval(interval);
+        this.pollTimers.delete(`fs-${id}`);
+        return;
+      }
+
+      if (session.claudeSessionId && session.jsonlPath) {
+        clearInterval(interval);
+        this.pollTimers.delete(`fs-${id}`);
+        return;
+      }
+
+      try {
+        if (!existsSync(projectDir)) return;
+        const { readdir } = await import('node:fs/promises');
+        const files = await readdir(projectDir);
+        const jsonlFiles = files.filter(f =>
+          f.endsWith('.jsonl') && !f.startsWith('.')
+        );
+
+        for (const file of jsonlFiles) {
+          const filePath = join(projectDir, file);
+          const fileStat = await stat(filePath);
+
+          // Only consider files created after the session
+          if (fileStat.mtimeMs < session.createdAt) continue;
+
+          // Extract session ID from filename (filename = sessionId.jsonl)
+          const sessionId = file.replace('.jsonl', '');
+          if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(sessionId)) continue;
+
+          session.claudeSessionId = sessionId;
+          session.jsonlPath = filePath;
+          session.byteOffset = 0;
+          console.log(`Discovery (filesystem): session ${session.windowName} mapped to ${sessionId.slice(0, 8)}...`);
+          await this.save();
+          break;
+        }
+      } catch { /* ignore */ }
+    }, 3000);
+
+    this.pollTimers.set(`fs-${id}`, interval);
+
+    // Timeout after 5 minutes
+    setTimeout(() => {
+      const timer = this.pollTimers.get(`fs-${id}`);
+      if (timer) {
+        clearInterval(timer);
+        this.pollTimers.delete(`fs-${id}`);
       }
     }, 5 * 60 * 1000);
   }


### PR DESCRIPTION
Issue #16. Filesystem-based discovery when --bare skips hooks. 7 new tests, 306 total.

Closes #16