### PR TITLE
feat: auto-approve mode for CI/batch workflows (#26)

### DIFF
--- a/src/__tests__/auto-approve.test.ts
+++ b/src/__tests__/auto-approve.test.ts
@@ -1,0 +1,121 @@
+/**
+ * auto-approve.test.ts — Tests for Issue #26: auto-approve mode.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+describe('Auto-approve mode (Issue #26)', () => {
+  describe('SessionInfo.autoApprove', () => {
+    it('should default to false when not specified', () => {
+      const val: boolean | undefined = undefined;
+      const autoApprove = val ?? false;
+      expect(autoApprove).toBe(false);
+    });
+
+    it('should accept true from session creation opts', () => {
+      const opts = { autoApprove: true };
+      const autoApprove = opts.autoApprove ?? false;
+      expect(autoApprove).toBe(true);
+    });
+
+    it('should respect config default when opts not specified', () => {
+      const opts: { autoApprove?: boolean } = {};
+      const configDefault = true;
+      const autoApprove = opts.autoApprove ?? configDefault ?? false;
+      expect(autoApprove).toBe(true);
+    });
+
+    it('should prefer session-level over config default', () => {
+      const opts = { autoApprove: false };
+      const configDefault = true;
+      const autoApprove = opts.autoApprove ?? configDefault ?? false;
+      expect(autoApprove).toBe(false);
+    });
+  });
+
+  describe('Auto-approve trigger conditions', () => {
+    it('should trigger on permission_prompt when autoApprove is true', () => {
+      const status = 'permission_prompt';
+      const autoApprove = true;
+      const shouldAutoApprove = (status === 'permission_prompt' || status === 'bash_approval') && autoApprove;
+      expect(shouldAutoApprove).toBe(true);
+    });
+
+    it('should trigger on bash_approval when autoApprove is true', () => {
+      const status: string = 'bash_approval';
+      const autoApprove = true;
+      const shouldAutoApprove = (status === 'permission_prompt' || status === 'bash_approval') && autoApprove;
+      expect(shouldAutoApprove).toBe(true);
+    });
+
+    it('should NOT trigger on permission_prompt when autoApprove is false', () => {
+      const status = 'permission_prompt';
+      const autoApprove = false;
+      const shouldAutoApprove = (status === 'permission_prompt' || status === 'bash_approval') && autoApprove;
+      expect(shouldAutoApprove).toBe(false);
+    });
+
+    it('should NOT trigger on working status even with autoApprove', () => {
+      const status: string = 'working';
+      const autoApprove = true;
+      const shouldAutoApprove = (status === 'permission_prompt' || status === 'bash_approval') && autoApprove;
+      expect(shouldAutoApprove).toBe(false);
+    });
+  });
+
+  describe('Audit logging format', () => {
+    it('should prefix auto-approved messages with [AUTO-APPROVED]', () => {
+      const content = 'Write to /home/user/project/src/index.ts';
+      const logMessage = `[AUTO-APPROVED] ${content}`;
+      expect(logMessage).toContain('[AUTO-APPROVED]');
+      expect(logMessage).toContain(content);
+    });
+
+    it('should prefix failed auto-approvals with [AUTO-APPROVE FAILED]', () => {
+      const error = 'Session not found';
+      const logMessage = `[AUTO-APPROVE FAILED] permission prompt: ${error}`;
+      expect(logMessage).toContain('[AUTO-APPROVE FAILED]');
+      expect(logMessage).toContain(error);
+    });
+
+    it('should include session name in audit log', () => {
+      const windowName = 'cc-build-login';
+      const sessionId = 'abc123def456';
+      const logLine = `[AUTO-APPROVED] Session ${windowName} (${sessionId.slice(0, 8)}): file write`;
+      expect(logLine).toContain(windowName);
+      expect(logLine).toContain('abc123de');
+    });
+  });
+
+  describe('Config.defaultAutoApprove', () => {
+    it('should default to false', () => {
+      const defaultAutoApprove = false;
+      expect(defaultAutoApprove).toBe(false);
+    });
+
+    it('should be overridable to true', () => {
+      const config = { defaultAutoApprove: true };
+      expect(config.defaultAutoApprove).toBe(true);
+    });
+  });
+
+  describe('API contract', () => {
+    it('should accept autoApprove in session create body', () => {
+      const body = {
+        workDir: '/tmp/project',
+        name: 'test',
+        autoApprove: true,
+      };
+      expect(body.autoApprove).toBe(true);
+    });
+
+    it('should include autoApprove in session response', () => {
+      const session = {
+        id: 'test-id',
+        autoApprove: true,
+        status: 'working',
+      };
+      expect(session.autoApprove).toBe(true);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,10 @@ export interface Config {
   /** Default env vars injected into every CC session (e.g. model overrides, API keys).
    *  Per-session env vars from the API merge on top (per-session wins). */
   defaultSessionEnv: Record<string, string>;
+  /** Issue #26: Default auto-approve for new sessions (default: false). */
+  defaultAutoApprove: boolean;
+  /** Stall threshold for monitor (ms). */
+  stallThresholdMs: number;
 }
 
 /** Default configuration values */
@@ -58,6 +62,8 @@ const defaults: Config = {
   tgGroupId: '',
   webhooks: [],
   defaultSessionEnv: {},
+  defaultAutoApprove: false,
+  stallThresholdMs: 5 * 60 * 1000,
 };
 
 /** Parse CLI args for --config flag */

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -230,9 +230,27 @@ export class SessionMonitor {
     result: { statusText: string | null; interactiveContent: string | null },
   ): Promise<void> {
     if (status === 'permission_prompt' || status === 'bash_approval') {
-      await this.channels.statusChange(
-        this.makePayload('status.permission', session, result.interactiveContent || 'Permission requested'),
-      );
+      // Issue #26: Auto-approve if session has autoApprove enabled
+      if (session.autoApprove) {
+        console.log(`[AUTO-APPROVED] Session ${session.windowName} (${session.id.slice(0, 8)}): ${result.interactiveContent || 'permission prompt'}`);
+        try {
+          await this.sessions.approve(session.id);
+          await this.channels.statusChange(
+            this.makePayload('status.permission', session,
+              `[AUTO-APPROVED] ${result.interactiveContent || 'Permission auto-approved'}`),
+          );
+        } catch (e: any) {
+          console.error(`[AUTO-APPROVE FAILED] Session ${session.id}: ${e.message}`);
+          await this.channels.statusChange(
+            this.makePayload('status.permission', session,
+              `[AUTO-APPROVE FAILED] ${result.interactiveContent || 'Permission requested'}: ${e.message}`),
+          );
+        }
+      } else {
+        await this.channels.statusChange(
+          this.makePayload('status.permission', session, result.interactiveContent || 'Permission requested'),
+        );
+      }
     } else if (status === 'plan_mode') {
       await this.channels.statusChange(
         this.makePayload('status.plan', session, result.interactiveContent || 'Plan review requested'),

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,12 +114,13 @@ app.post<{
     claudeCommand?: string;
     env?: Record<string, string>;
     stallThresholdMs?: number;
+    autoApprove?: boolean;
   };
 }>('/v1/sessions', async (req, reply) => {
-  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs } = req.body;
+  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, autoApprove } = req.body;
   if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
 
-  const session = await sessions.createSession({ workDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs });
+  const session = await sessions.createSession({ workDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs, autoApprove });
 
   // If a prompt was provided, wait for CC to be ready and send it
   let promptDelivery: { delivered: boolean; attempts: number } | undefined;
@@ -147,12 +148,13 @@ app.post<{
     claudeCommand?: string;
     env?: Record<string, string>;
     stallThresholdMs?: number;
+    autoApprove?: boolean;
   };
 }>('/sessions', async (req, reply) => {
-  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs } = req.body;
+  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, autoApprove } = req.body;
   if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
 
-  const session = await sessions.createSession({ workDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs });
+  const session = await sessions.createSession({ workDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs, autoApprove });
 
   let promptDelivery: { delivered: boolean; attempts: number } | undefined;
   if (prompt) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -27,6 +27,7 @@ export interface SessionInfo {
   createdAt: number;             // Unix timestamp
   lastActivity: number;          // Unix timestamp of last activity
   stallThresholdMs: number;      // Per-session stall threshold (Issue #4)
+  autoApprove: boolean;          // Issue #26: auto-approve permission prompts
 }
 
 export interface SessionState {
@@ -142,6 +143,7 @@ export class SessionManager {
     claudeCommand?: string;
     env?: Record<string, string>;
     stallThresholdMs?: number;
+    autoApprove?: boolean;
   }): Promise<SessionInfo> {
     const id = crypto.randomUUID();
     const windowName = opts.name || `cc-${id.slice(0, 8)}`;
@@ -172,6 +174,7 @@ export class SessionManager {
       createdAt: Date.now(),
       lastActivity: Date.now(),
       stallThresholdMs: opts.stallThresholdMs || SessionManager.DEFAULT_STALL_THRESHOLD_MS,
+      autoApprove: opts.autoApprove ?? this.config.defaultAutoApprove ?? false,
     };
 
     this.state.sessions[id] = session;


### PR DESCRIPTION
Issue #26. Auto-approve permission prompts per-session or config-level. Audit logging. 13 new tests. Closes #26.