### PR TITLE
fix: prompt delivery v2 — state-change detection, no blind re-send (#1)

### DIFF
--- a/src/__tests__/prompt-delivery.test.ts
+++ b/src/__tests__/prompt-delivery.test.ts
@@ -1,39 +1,91 @@
 /**
- * prompt-delivery.test.ts — Tests for Issue #1: prompt delivery verification.
+ * prompt-delivery.test.ts — Tests for Issue #1 v2: prompt delivery verification.
  *
  * Tests the verifyDelivery logic and sendKeysVerified retry pattern.
+ * v2: state-change detection + no blind re-send when CC is active.
  */
 
 import { describe, it, expect } from 'vitest';
-import { detectUIState } from '../terminal-parser.js';
+import { detectUIState, type UIState } from '../terminal-parser.js';
 
-describe('Prompt delivery verification', () => {
+describe('Prompt delivery verification v2', () => {
+  const isActiveState = (state: string) =>
+    ['working', 'permission_prompt', 'bash_approval', 'plan_mode', 'ask_question'].includes(state);
+
   describe('delivery evidence from pane state', () => {
-    it('should confirm delivery when CC is working (spinner visible)', () => {
-      const state = 'working';
-      const delivered = state === 'working';
-      expect(delivered).toBe(true);
-    });
-
-    it('should confirm delivery when CC shows permission prompt', () => {
-      const interactiveStates = ['permission_prompt', 'bash_approval', 'plan_mode', 'ask_question'];
-      for (const state of interactiveStates) {
-        const delivered = interactiveStates.includes(state);
-        expect(delivered).toBe(true);
+    it('should confirm delivery when CC is working', () => {
+      const activeStates: string[] = ['working', 'permission_prompt', 'bash_approval', 'plan_mode', 'ask_question'];
+      for (const state of activeStates) {
+        expect(isActiveState(state)).toBe(true);
       }
     });
 
     it('should reject delivery when CC is clearly idle', () => {
-      const state = 'idle';
-      const delivered = state !== 'idle';
-      expect(delivered).toBe(false);
+      expect(isActiveState('idle')).toBe(false);
     });
 
     it('should give benefit of doubt on unknown state', () => {
       const state: string = 'unknown';
-      // Unknown could mean CC is loading/transitioning
-      const delivered = state !== 'idle';
+      // unknown ≠ idle → benefit of the doubt
+      expect(state !== 'idle').toBe(true);
+    });
+  });
+
+  describe('state-change detection (v2 core improvement)', () => {
+    it('should confirm delivery when state changed from idle to unknown (transitional)', () => {
+      const preSendState: string = 'idle';
+      const postSendState: string = 'unknown';
+      const delivered = preSendState === 'idle' && postSendState !== 'idle';
       expect(delivered).toBe(true);
+    });
+
+    it('should confirm delivery when state changed from idle to working', () => {
+      const preSendState: string = 'idle';
+      const postSendState: string = 'working';
+      const delivered = preSendState === 'idle' && postSendState !== 'idle';
+      expect(delivered).toBe(true);
+    });
+
+    it('should NOT confirm when state stayed idle', () => {
+      const preSendState: string = 'idle';
+      const postSendState: string = 'idle';
+      const stateChanged = preSendState === 'idle' && postSendState !== 'idle';
+      const active = isActiveState(postSendState);
+      expect(stateChanged || active).toBe(false);
+    });
+
+    it('should still use text-match fallback when state is ambiguous', () => {
+      const paneText = `
+        Some output
+        Build a login page with React and TypeScript
+        ❯
+      `;
+      const sentText = 'Build a login page with React and TypeScript';
+      const searchText = sentText.slice(0, 60).trim();
+      expect(searchText.length >= 5 && paneText.includes(searchText)).toBe(true);
+    });
+  });
+
+  describe('no-blind-resend logic (v2 duplicate prevention)', () => {
+    const shouldResend = (attempt: number, preState: string) =>
+      attempt === 1 || preState === 'idle';
+
+    it('should NOT re-send when CC is in active state on retry', () => {
+      expect(shouldResend(2, 'working')).toBe(false);
+    });
+
+    it('should re-send when CC is idle on retry (text was lost)', () => {
+      expect(shouldResend(2, 'idle')).toBe(true);
+    });
+
+    it('should NOT re-send when CC is in unknown state (could be transitioning)', () => {
+      expect(shouldResend(2, 'unknown')).toBe(false);
+    });
+
+    it('should always send on first attempt regardless of state', () => {
+      expect(shouldResend(1, 'working')).toBe(true);
+      expect(shouldResend(1, 'idle')).toBe(true);
+      expect(shouldResend(1, 'unknown')).toBe(true);
     });
   });
 
@@ -45,31 +97,45 @@ describe('Prompt delivery verification', () => {
         ❯
       `;
       const sentText = 'Build a login page with React and TypeScript';
-      const searchText = sentText.slice(0, 40).trim();
+      const searchText = sentText.slice(0, 60).trim();
       expect(paneText.includes(searchText)).toBe(true);
     });
 
-    it('should match prefix of long text', () => {
-      const longText = 'Implement a comprehensive authentication system with OAuth2, JWT tokens, refresh token rotation, and multi-factor authentication support for the dashboard application';
+    it('should match prefix of long text (up to 60 chars now)', () => {
+      const longText = 'Implement a comprehensive authentication system with OAuth2, JWT tokens, refresh token rotation, and multi-factor authentication';
       const paneText = `
         ${longText.slice(0, 80)}...
       `;
-      const searchText = longText.slice(0, 40).trim();
+      const searchText = longText.slice(0, 60).trim();
       expect(paneText.includes(searchText)).toBe(true);
     });
 
     it('should not match short texts (< 5 chars) to avoid false positives', () => {
       const sentText = 'yes';
-      const searchText = sentText.slice(0, 40).trim();
-      const shouldSearch = searchText.length >= 5;
-      expect(shouldSearch).toBe(false);
+      const searchText = sentText.slice(0, 60).trim();
+      expect(searchText.length >= 5).toBe(false);
     });
 
     it('should handle empty pane text', () => {
       const paneText = '';
       const sentText = 'Build something';
-      const searchText = sentText.slice(0, 40).trim();
+      const searchText = sentText.slice(0, 60).trim();
       expect(paneText.includes(searchText)).toBe(false);
+    });
+  });
+
+  describe('graduated verification timing', () => {
+    it('first attempt should check 3 times (800, 1500, 2500ms)', () => {
+      const attempt = 1;
+      const checkDelays = attempt === 1 ? [800, 1500, 2500] : [500, 1500];
+      expect(checkDelays).toEqual([800, 1500, 2500]);
+      expect(checkDelays.reduce((a, b) => a + b, 0)).toBe(4800);
+    });
+
+    it('retry attempts should check 2 times (500, 1500ms)', () => {
+      const checkDelays = [500, 1500]; // attempt > 1
+      expect(checkDelays).toEqual([500, 1500]);
+      expect(checkDelays.reduce((a, b) => a + b, 0)).toBe(2000);
     });
   });
 
@@ -92,8 +158,6 @@ describe('Prompt delivery verification', () => {
         '─'.repeat(50),
       ].join('\n');
       const state = detectUIState(paneText);
-      // The spinner is above the chrome, so this depends on exact parsing
-      // At minimum it should not be 'idle' when there's a spinner
       expect(['working', 'idle']).toContain(state);
     });
   });
@@ -105,7 +169,6 @@ describe('Prompt delivery verification', () => {
         const maxAttempts = 3;
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
           attempts++;
-          // Simulate: delivery confirmed on first try
           const delivered = true;
           if (delivered) return { delivered: true, attempts: attempt };
         }
@@ -115,7 +178,6 @@ describe('Prompt delivery verification', () => {
       const result = await sendKeysVerified();
       expect(result.delivered).toBe(true);
       expect(result.attempts).toBe(1);
-      expect(attempts).toBe(1);
     });
 
     it('should retry and succeed on second attempt', async () => {
@@ -124,7 +186,6 @@ describe('Prompt delivery verification', () => {
         const maxAttempts = 3;
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
           attempts++;
-          // Simulate: fails first, succeeds second
           const delivered = attempt >= 2;
           if (delivered) return { delivered: true, attempts: attempt };
         }
@@ -137,13 +198,10 @@ describe('Prompt delivery verification', () => {
     });
 
     it('should fail after max attempts exhausted', async () => {
-      let attempts = 0;
       const sendKeysVerified = async () => {
         const maxAttempts = 3;
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-          attempts++;
-          const delivered = false; // Never succeeds
-          if (delivered) return { delivered: true, attempts: attempt };
+          if (false as boolean) return { delivered: true, attempts: attempt };
         }
         return { delivered: false, attempts: maxAttempts };
       };
@@ -151,14 +209,6 @@ describe('Prompt delivery verification', () => {
       const result = await sendKeysVerified();
       expect(result.delivered).toBe(false);
       expect(result.attempts).toBe(3);
-    });
-
-    it('should use exponential backoff delays', () => {
-      const delays = [500, 1500, 3000];
-      expect(delays[0]).toBeLessThan(delays[1]);
-      expect(delays[1]).toBeLessThan(delays[2]);
-      // Total max wait: 5 seconds — reasonable for delivery verification
-      expect(delays.reduce((a, b) => a + b, 0)).toBe(5000);
     });
   });
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -350,45 +350,53 @@ export class TmuxManager {
     }
   }
 
-  /** Verify that a message was delivered to Claude Code.
-   *  Issue #1: ~20% of prompts don't arrive due to tmux send-keys being fire-and-forget.
-   *
-   *  Strategy: after sending text + Enter, capture the pane and check for evidence
-   *  that CC received the input. Evidence includes:
-   *  1. The sent text (or a significant prefix) visible in the pane
-   *  2. CC transitioning from idle to working (spinner visible, prompt gone)
-   *  3. A status line showing CC is processing
-   *
-   *  Returns true if delivery is confirmed, false if we can't confirm.
-   */
-  async verifyDelivery(windowId: string, sentText: string): Promise<boolean> {
-    const paneText = await this.capturePane(windowId);
+  /** Check if a pane state indicates CC has received input (non-idle). */
+  private isActiveState(state: string): boolean {
+    return state === 'working' || state === 'permission_prompt' ||
+      state === 'bash_approval' || state === 'plan_mode' || state === 'ask_question';
+  }
 
-    // Evidence 1: CC is now working (spinner or status line visible, no idle prompt)
-    // Import inline to avoid circular dependency issues
+  /** Verify that a message was delivered to Claude Code.
+   *  Issue #1 v2: Compares pre-send and post-send pane state to detect delivery.
+   *
+   *  Strategy:
+   *  1. If CC transitioned from idle → active state → confirmed
+   *  2. If CC is in any active state (working, permission, etc.) → confirmed
+   *  3. If sent text (prefix) is visible in the pane → confirmed
+   *  4. If CC is still idle with no trace of input → NOT confirmed
+   *  5. Unknown state → benefit of the doubt (confirmed)
+   *
+   *  The `preSendState` parameter enables state-change detection to avoid
+   *  false negatives during transitional moments.
+   */
+  async verifyDelivery(
+    windowId: string,
+    sentText: string,
+    preSendState?: string,
+  ): Promise<boolean> {
+    const paneText = await this.capturePane(windowId);
     const { detectUIState } = await import('./terminal-parser.js');
     const state = detectUIState(paneText);
-    if (state === 'working') {
-      return true; // CC is processing — delivery confirmed
+
+    // Evidence 1: CC is in an active state — delivery confirmed
+    if (this.isActiveState(state)) {
+      return true;
     }
 
-    // Evidence 2: CC is asking a question or showing permission prompt
-    // (means it already processed input and is acting on it)
-    if (state === 'permission_prompt' || state === 'bash_approval' || state === 'plan_mode' || state === 'ask_question') {
+    // Evidence 2: State changed from idle to anything else (even unknown = transitioning)
+    if (preSendState === 'idle' && state !== 'idle') {
       return true;
     }
 
     // Evidence 3: The sent text appears in the pane
-    // Use a significant prefix (first 40 chars) to match — CC may have reformatted
-    const searchText = sentText.slice(0, 40).trim();
+    const searchText = sentText.slice(0, 60).trim();
     if (searchText.length >= 5 && paneText.includes(searchText)) {
       return true;
     }
 
-    // Evidence 4: Pane is NOT idle (unknown state could mean CC is loading/processing)
-    // Only return false if pane is clearly idle — the ❯ prompt is visible
+    // Evidence 4: Pane is clearly idle — delivery likely failed
     if (state === 'idle') {
-      return false; // Pane is idle with no trace of input — delivery failed
+      return false;
     }
 
     // Unknown state — give benefit of the doubt
@@ -396,41 +404,54 @@ export class TmuxManager {
   }
 
   /** Send text and verify delivery with retry.
-   *  Issue #1: Returns delivery status for API response.
+   *  Issue #1 v2: Captures pre-send state and only re-sends if pane is still idle.
+   *  Prevents duplicate prompt delivery that plagued v1.
    */
   async sendKeysVerified(
     windowId: string,
     text: string,
     maxAttempts: number = 3,
   ): Promise<{ delivered: boolean; attempts: number }> {
-    const delays = [500, 1500, 3000]; // Exponential-ish backoff for verification checks
+    const { detectUIState } = await import('./terminal-parser.js');
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      // Send the text
-      if (attempt > 1) {
-        console.log(`Tmux: delivery retry ${attempt}/${maxAttempts} for ${text.slice(0, 50)}...`);
+      // Capture pane state BEFORE sending
+      const prePaneText = await this.capturePane(windowId);
+      const preState = detectUIState(prePaneText);
+
+      // Only send if pane is idle (or first attempt).
+      // If CC is already active/working, don't re-send — just verify.
+      if (attempt === 1 || preState === 'idle') {
+        if (attempt > 1) {
+          console.log(`Tmux: delivery retry ${attempt}/${maxAttempts} — pane is idle, re-sending`);
+        }
+        await this.sendKeys(windowId, text, true);
+      } else {
+        // CC is not idle — it may have received the text but is in transition.
+        // Don't re-send (would duplicate the prompt).
+        console.log(`Tmux: delivery check ${attempt}/${maxAttempts} — pane is '${preState}', skipping re-send`);
       }
-      await this.sendKeys(windowId, text, true);
 
-      // Wait before checking delivery
-      const checkDelay = delays[attempt - 1] || 3000;
-      await sleep(checkDelay);
-
-      // Verify delivery
-      const delivered = await this.verifyDelivery(windowId, text);
-      if (delivered) {
-        return { delivered: true, attempts: attempt };
+      // Graduated verification: check multiple times with increasing delays.
+      // CC needs time to process input and transition states.
+      const checkDelays = attempt === 1 ? [800, 1500, 2500] : [500, 1500];
+      for (const delay of checkDelays) {
+        await sleep(delay);
+        const delivered = await this.verifyDelivery(windowId, text, preState);
+        if (delivered) {
+          if (attempt > 1) {
+            console.log(`Tmux: delivery confirmed on attempt ${attempt}`);
+          }
+          return { delivered: true, attempts: attempt };
+        }
       }
 
-      // Not delivered — if we have more attempts, the next sendKeys call will resend
       if (attempt < maxAttempts) {
-        console.warn(`Tmux: delivery not confirmed for ${text.slice(0, 50)}... (attempt ${attempt})`);
-        // Small delay before retry
-        await sleep(500);
+        console.warn(`Tmux: delivery not confirmed for "${text.slice(0, 50)}..." (attempt ${attempt}/${maxAttempts})`);
       }
     }
 
-    console.error(`Tmux: delivery FAILED after ${maxAttempts} attempts for ${text.slice(0, 50)}...`);
+    console.error(`Tmux: delivery FAILED after ${maxAttempts} attempts for "${text.slice(0, 50)}..."`);
     return { delivered: false, attempts: maxAttempts };
   }
 


### PR DESCRIPTION
## Problem

Prompt delivery ~20% failure rate. v1 blindly re-sent text on every retry, duplicating prompts when CC was in transitional states.

## Solution

State-change detection: capture pane BEFORE sending, only re-send if still idle.

- Graduated verification: 3 checks on first attempt (800/1500/2500ms)
- Skip re-send when CC is active/unknown (prevents duplicates)
- Increased text-match prefix 40→60 chars
- 24 tests, 836 total ✅