### PR TITLE
fix: dynamic permission buttons matching CC's actual options

### DIFF
--- a/src/__tests__/dynamic-buttons.test.ts
+++ b/src/__tests__/dynamic-buttons.test.ts
@@ -1,0 +1,116 @@
+/**
+ * dynamic-buttons.test.ts — Tests for parseOptions() and dynamic button generation.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Re-implement parseOptions for testing (mirrors telegram.ts)
+function parseOptions(text: string): Array<{ label: string; value: string }> | null {
+  const numberedRegex = /^\s*(\d+)\.\s+(.+)$/gm;
+  const numbered: Array<{ label: string; value: string }> = [];
+  let m;
+  while ((m = numberedRegex.exec(text)) !== null) {
+    const num = m[1];
+    let label = m[2].trim();
+    if (label.length > 30) label = label.slice(0, 28) + '…';
+    numbered.push({ label: `${num}. ${label}`, value: num });
+  }
+  if (numbered.length >= 2) return numbered.slice(0, 4);
+
+  if (/\(?\s*[yY]\s*\/\s*[nN]\s*\)?/.test(text)) {
+    return [{ label: '✅ Yes', value: 'y' }, { label: '❌ No', value: 'n' }];
+  }
+
+  if (/\b[Yy]es\b.*\b[Nn]o\b/.test(text)) {
+    return [{ label: '✅ Yes', value: 'yes' }, { label: '❌ No', value: 'no' }];
+  }
+
+  if (/\b[Aa]llow\b/.test(text) || /\b[Dd]eny\b/.test(text)) {
+    return [{ label: '✅ Allow', value: 'allow' }, { label: '❌ Deny', value: 'deny' }];
+  }
+
+  return null;
+}
+
+describe('parseOptions', () => {
+  describe('Numbered options', () => {
+    it('parses 3 numbered options from CC permission', () => {
+      const text = `Do you want to create add-version-endpoint.md?\n1. Yes\n2. Yes, and allow Claude to edit its own settings\n3. No`;
+      const opts = parseOptions(text);
+      expect(opts).toHaveLength(3);
+      expect(opts![0]).toEqual({ label: '1. Yes', value: '1' });
+      expect(opts![1]).toEqual({ label: '2. Yes, and allow Claude to edi…', value: '2' });
+      expect(opts![2]).toEqual({ label: '3. No', value: '3' });
+    });
+
+    it('parses 2 numbered options', () => {
+      const text = 'Which approach?\n1. Incremental refactor\n2. Full rewrite';
+      const opts = parseOptions(text);
+      expect(opts).toHaveLength(2);
+      expect(opts![0].value).toBe('1');
+      expect(opts![1].value).toBe('2');
+    });
+
+    it('returns null for single numbered option (need ≥2)', () => {
+      const text = '1. Only one option';
+      const opts = parseOptions(text);
+      expect(opts).toBeNull();
+    });
+
+    it('caps at 4 options', () => {
+      const text = '1. A\n2. B\n3. C\n4. D\n5. E';
+      const opts = parseOptions(text);
+      expect(opts).toHaveLength(4);
+    });
+
+    it('truncates long option labels to 30 chars', () => {
+      const text = `Choose:\n1. This is a very long option label that should be truncated\n2. Short`;
+      const opts = parseOptions(text);
+      expect(opts![0].label.length).toBeLessThanOrEqual(32);
+      expect(opts![0].label).toContain('…');
+    });
+  });
+
+  describe('y/n shorthand', () => {
+    it('parses (y/n)', () => {
+      const opts = parseOptions('Allow? (y/n)');
+      expect(opts).toEqual([{ label: '✅ Yes', value: 'y' }, { label: '❌ No', value: 'n' }]);
+    });
+
+    it('parses y/n without parens', () => {
+      const opts = parseOptions('Continue? y/n');
+      expect(opts).toHaveLength(2);
+    });
+
+    it('parses Y/N uppercase', () => {
+      const opts = parseOptions('Confirm Y/N');
+      expect(opts).toHaveLength(2);
+    });
+  });
+
+  describe('Yes/No explicit', () => {
+    it('parses Yes and No in text', () => {
+      const opts = parseOptions('Do you want to proceed? Yes or No?');
+      expect(opts).toEqual([{ label: '✅ Yes', value: 'yes' }, { label: '❌ No', value: 'no' }]);
+    });
+  });
+
+  describe('Allow/Deny', () => {
+    it('parses Allow/Deny', () => {
+      const opts = parseOptions('Allow write access to this file? Deny to block.');
+      expect(opts).toEqual([{ label: '✅ Allow', value: 'allow' }, { label: '❌ Deny', value: 'deny' }]);
+    });
+  });
+
+  describe('Fallback (null)', () => {
+    it('returns null for generic text with no options', () => {
+      const opts = parseOptions('This is a regular message with no options.');
+      expect(opts).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      const opts = parseOptions('');
+      expect(opts).toBeNull();
+    });
+  });
+});

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -208,6 +208,58 @@ function stripXmlTags(text: string): string {
 }
 
 /**
+ * Parse numbered or labeled options from CC permission/question text.
+ *
+ * CC formats:
+ *   "1. Yes\n2. Yes, and allow...\n3. No"
+ *   "y/n" or "(y/n)"
+ *   "Yes / No"
+ *
+ * Returns array of {label, value} or null if no options detected.
+ * value is what gets sent to CC (the number or the text).
+ */
+function parseOptions(text: string): Array<{ label: string; value: string }> | null {
+  // Pattern 1: Numbered options "1. Yes\n2. Something else\n3. No"
+  const numberedRegex = /^\s*(\d+)\.\s+(.+)$/gm;
+  const numbered: Array<{ label: string; value: string }> = [];
+  let m;
+  while ((m = numberedRegex.exec(text)) !== null) {
+    const num = m[1];
+    let label = m[2].trim();
+    // Truncate long labels for button display (max 30 chars)
+    if (label.length > 30) label = label.slice(0, 28) + '…';
+    numbered.push({ label: `${num}. ${label}`, value: num });
+  }
+  if (numbered.length >= 2) return numbered.slice(0, 4); // Max 4 buttons
+
+  // Pattern 2: y/n shorthand
+  if (/\(?\s*[yY]\s*\/\s*[nN]\s*\)?/.test(text)) {
+    return [
+      { label: '✅ Yes', value: 'y' },
+      { label: '❌ No', value: 'n' },
+    ];
+  }
+
+  // Pattern 3: Yes / No explicit
+  if (/\b[Yy]es\b.*\b[Nn]o\b/.test(text)) {
+    return [
+      { label: '✅ Yes', value: 'yes' },
+      { label: '❌ No', value: 'no' },
+    ];
+  }
+
+  // Pattern 4: Allow/Deny
+  if (/\b[Aa]llow\b/.test(text) || /\b[Dd]eny\b/.test(text)) {
+    return [
+      { label: '✅ Allow', value: 'allow' },
+      { label: '❌ Deny', value: 'deny' },
+    ];
+  }
+
+  return null;
+}
+
+/**
  * Detect and format CC sub-agent/explore tree output.
  * Pattern: "● N agents finished\n  ├─ name · stats\n  └─ name · stats"
  * Returns formatted string or null if no tree detected.
@@ -852,13 +904,31 @@ export class TelegramChannel implements Channel {
         await this.flushReads(payload.session.id);
         await this.flushQueue(payload.session.id);
         const permSummary = truncate(payload.detail, 300);
-        const permStyled = yesNo(
-          `⚠️ Permission: ${permSummary}`,
-          '✅ Approve',
-          '❌ Reject',
-          `perm_approve:${payload.session.id}`,
-          `perm_reject:${payload.session.id}`,
-        );
+        const options = parseOptions(payload.detail);
+
+        const buttons: Array<{ text: string; callback_data: string }> = [];
+
+        if (options) {
+          // Dynamic buttons from CC's options
+          for (const opt of options) {
+            buttons.push({
+              text: opt.label,
+              callback_data: `cb_option:${payload.session.id}:${opt.value}`,
+            });
+          }
+        } else {
+          // Fallback: generic approve/reject
+          buttons.push(
+            { text: '✅ Approve', callback_data: `perm_approve:${payload.session.id}` },
+            { text: '❌ Reject', callback_data: `perm_reject:${payload.session.id}` },
+          );
+        }
+
+        const permStyled: StyledMessage = {
+          text: `⚠️ Permission: ${esc(permSummary)}`,
+          parse_mode: 'HTML',
+          reply_markup: { inline_keyboard: [buttons] },
+        };
         await this.sendStyled(payload.session.id, permStyled);
         break;
       }
@@ -874,22 +944,34 @@ export class TelegramChannel implements Channel {
       case 'status.question': {
         await this.flushReads(payload.session.id);
         await this.flushQueue(payload.session.id);
-        const qStyled = yesNo(
-          `❓ ${esc(truncate(payload.detail, 400))}`,
-          '✅ Yes',
-          '❌ No',
-          `cb_yes:${payload.session.id}`,
-          `cb_no:${payload.session.id}`,
-        );
-        // Add Skip button as second row
-        qStyled.reply_markup = {
-          inline_keyboard: [
-            [
-              { text: '✅ Yes', callback_data: `cb_yes:${payload.session.id}` },
-              { text: '❌ No', callback_data: `cb_no:${payload.session.id}` },
-              { text: '🤷 Skip', callback_data: `cb_skip:${payload.session.id}` },
-            ],
-          ],
+        const questionText = esc(truncate(payload.detail, 400));
+        const options = parseOptions(payload.detail);
+
+        const buttons: Array<{ text: string; callback_data: string }> = [];
+
+        if (options) {
+          for (const opt of options) {
+            buttons.push({
+              text: opt.label,
+              callback_data: `cb_option:${payload.session.id}:${opt.value}`,
+            });
+          }
+          // Always add Skip for questions
+          if (buttons.length < 4) {
+            buttons.push({ text: '🤷 Skip', callback_data: `cb_skip:${payload.session.id}` });
+          }
+        } else {
+          buttons.push(
+            { text: '✅ Yes', callback_data: `cb_yes:${payload.session.id}` },
+            { text: '❌ No', callback_data: `cb_no:${payload.session.id}` },
+            { text: '🤷 Skip', callback_data: `cb_skip:${payload.session.id}` },
+          );
+        }
+
+        const qStyled: StyledMessage = {
+          text: `❓ ${questionText}`,
+          parse_mode: 'HTML',
+          reply_markup: { inline_keyboard: [buttons] },
         };
         await this.sendStyled(payload.session.id, qStyled);
         break;
@@ -1280,6 +1362,14 @@ export class TelegramChannel implements Channel {
           }
         } else if (data.startsWith('perm_reject:')) {
           await this.onInbound?.({ sessionId, action: 'reject' });
+          if (cb.message.message_id) {
+            await this.removeReplyMarkup(sessionId, cb.message.message_id);
+          }
+        } else if (data.startsWith('cb_option:')) {
+          // Dynamic option from parseOptions: extract value after sessionId:
+          const optParts = data.split(':');
+          const optValue = optParts.slice(2).join(':');
+          await this.onInbound?.({ sessionId, action: 'message', text: optValue });
           if (cb.message.message_id) {
             await this.removeReplyMarkup(sessionId, cb.message.message_id);
           }


### PR DESCRIPTION
## Problem
Permission prompt showed generic Approve/Reject when CC presented 3 specific options.

## Fix
`parseOptions()` detects CC's option format and creates matching buttons:

- Numbered (1. 2. 3.) → dynamic buttons with option text
- y/n shorthand → Yes/No
- Yes/No explicit → Yes/No
- Allow/Deny → Allow/Deny
- No options detected → Approve/Reject fallback

Questions get the same treatment + Skip button.

`cb_option:` callback extracts value and forwards to CC.
Max 4 buttons, long labels truncated at 30 chars.

12 new tests (890 total).