### PR TITLE
fix: pass --permission-mode flag to CC based on autoApprove

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -189,6 +189,7 @@ export class SessionManager {
       resumeSessionId: opts.resumeSessionId,
       claudeCommand: opts.claudeCommand,
       env: hasEnv ? mergedEnv : undefined,
+      autoApprove: opts.autoApprove,
     });
 
     const session: SessionInfo = {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -83,6 +83,7 @@ export class TmuxManager {
     claudeCommand?: string;
     resumeSessionId?: string;
     env?: Record<string, string>;
+    autoApprove?: boolean;
   }): Promise<{ windowId: string; windowName: string; freshSessionId?: string }> {
     await this.ensureSession();
 
@@ -192,6 +193,15 @@ export class TmuxManager {
       cmd += ` --resume ${opts.resumeSessionId}`;
     } else if (freshSessionId) {
       cmd += ` --session-id ${freshSessionId}`;
+    }
+
+    // Set permission mode based on autoApprove
+    // autoApprove=true → bypassPermissions (never prompt)
+    // autoApprove=false → default (prompts for tool use)
+    if (opts.autoApprove === true) {
+      cmd += ' --permission-mode bypassPermissions';
+    } else if (opts.autoApprove === false) {
+      cmd += ' --permission-mode default';
     }
 
     // Send the command to start Claude


### PR DESCRIPTION
## Bug
CC always started with `bypass permissions on` even when autoApprove=false. Permission prompts never fired.

## Fix
- `autoApprove=true` → `claude --permission-mode bypassPermissions`
- `autoApprove=false` → `claude --permission-mode default`

Flag flows: createSession() → session.ts → tmux.ts → claude command.

11 lines changed. 902 tests pass.