### PR TITLE
fix: neutralize project-level bypassPermissions when autoApprove is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,24 @@ src/
 
 ---
 
+## Troubleshooting
+
+### Permission prompts not working with `autoApprove: false`
+
+If you create a session with `autoApprove: false` but Claude Code skips permission prompts, check your project's `.claude/settings.local.json`:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "bypassPermissions"  // ← This overrides the CLI flag!
+  }
+}
+```
+
+Claude Code's project-level settings take precedence over the `--permission-mode` CLI flag. Aegis automatically detects and neutralizes this when `autoApprove` is `false` — it backs up the file, patches `defaultMode` to `"default"`, and restores the original on session cleanup. If you're running an older version, either remove the `defaultMode` key or set it to `"default"` in projects where you need permission prompts.
+
+---
+
 ## Contributing
 
 1. Fork the repository

--- a/src/__tests__/permission-guard.test.ts
+++ b/src/__tests__/permission-guard.test.ts
@@ -1,0 +1,195 @@
+/**
+ * permission-guard.test.ts — Tests for settings.local.json permission guard.
+ *
+ * When autoApprove is false, Aegis must neutralize bypassPermissions in the
+ * project's .claude/settings.local.json to prevent it from overriding the
+ * CLI --permission-mode default flag.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  neutralizeBypassPermissions,
+  restoreSettings,
+  cleanOrphanedBackup,
+  settingsPath,
+  backupPath,
+} from '../permission-guard.js';
+
+describe('Permission guard', () => {
+  let workDir: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'aegis-perm-guard-'));
+    await mkdir(join(workDir, '.claude'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  describe('neutralizeBypassPermissions', () => {
+    it('should patch bypassPermissions to default', async () => {
+      const settings = {
+        permissions: { defaultMode: 'bypassPermissions' },
+        other: 'preserved',
+      };
+      await writeFile(settingsPath(workDir), JSON.stringify(settings));
+
+      const result = await neutralizeBypassPermissions(workDir);
+
+      expect(result).toBe(true);
+      const patched = JSON.parse(await readFile(settingsPath(workDir), 'utf-8'));
+      expect(patched.permissions.defaultMode).toBe('default');
+      expect(patched.other).toBe('preserved');
+    });
+
+    it('should create a backup of original file', async () => {
+      const settings = { permissions: { defaultMode: 'bypassPermissions' } };
+      await writeFile(settingsPath(workDir), JSON.stringify(settings));
+
+      await neutralizeBypassPermissions(workDir);
+
+      expect(existsSync(backupPath(workDir))).toBe(true);
+      const backup = JSON.parse(await readFile(backupPath(workDir), 'utf-8'));
+      expect(backup.permissions.defaultMode).toBe('bypassPermissions');
+    });
+
+    it('should return false if no settings file exists', async () => {
+      const result = await neutralizeBypassPermissions(workDir);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if defaultMode is not bypassPermissions', async () => {
+      const settings = { permissions: { defaultMode: 'default' } };
+      await writeFile(settingsPath(workDir), JSON.stringify(settings));
+
+      const result = await neutralizeBypassPermissions(workDir);
+
+      expect(result).toBe(false);
+      expect(existsSync(backupPath(workDir))).toBe(false);
+    });
+
+    it('should return false if no permissions key at all', async () => {
+      const settings = { someOther: 'config' };
+      await writeFile(settingsPath(workDir), JSON.stringify(settings));
+
+      const result = await neutralizeBypassPermissions(workDir);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for malformed JSON', async () => {
+      await writeFile(settingsPath(workDir), '{ not valid json');
+
+      const result = await neutralizeBypassPermissions(workDir);
+      expect(result).toBe(false);
+    });
+
+    it('should preserve all other settings fields', async () => {
+      const settings = {
+        permissions: {
+          defaultMode: 'bypassPermissions',
+          allow: ['Bash(*)', 'Read(*)'],
+        },
+        model: 'claude-sonnet-4-20250514',
+        env: { DEBUG: '1' },
+      };
+      await writeFile(settingsPath(workDir), JSON.stringify(settings));
+
+      await neutralizeBypassPermissions(workDir);
+
+      const patched = JSON.parse(await readFile(settingsPath(workDir), 'utf-8'));
+      expect(patched.permissions.defaultMode).toBe('default');
+      expect(patched.permissions.allow).toEqual(['Bash(*)', 'Read(*)']);
+      expect(patched.model).toBe('claude-sonnet-4-20250514');
+      expect(patched.env).toEqual({ DEBUG: '1' });
+    });
+  });
+
+  describe('restoreSettings', () => {
+    it('should restore original file from backup', async () => {
+      const original = { permissions: { defaultMode: 'bypassPermissions' } };
+      await writeFile(settingsPath(workDir), JSON.stringify(original));
+      await neutralizeBypassPermissions(workDir);
+
+      await restoreSettings(workDir);
+
+      const restored = JSON.parse(await readFile(settingsPath(workDir), 'utf-8'));
+      expect(restored.permissions.defaultMode).toBe('bypassPermissions');
+      expect(existsSync(backupPath(workDir))).toBe(false);
+    });
+
+    it('should do nothing if no backup exists', async () => {
+      const settings = { permissions: { defaultMode: 'default' } };
+      await writeFile(settingsPath(workDir), JSON.stringify(settings));
+
+      await restoreSettings(workDir);
+
+      const unchanged = JSON.parse(await readFile(settingsPath(workDir), 'utf-8'));
+      expect(unchanged.permissions.defaultMode).toBe('default');
+    });
+  });
+
+  describe('cleanOrphanedBackup', () => {
+    it('should restore orphaned backup (crash recovery)', async () => {
+      // Simulate crash: backup exists but settings is patched
+      const original = { permissions: { defaultMode: 'bypassPermissions' } };
+      const patched = { permissions: { defaultMode: 'default' } };
+      await writeFile(backupPath(workDir), JSON.stringify(original));
+      await writeFile(settingsPath(workDir), JSON.stringify(patched));
+
+      await cleanOrphanedBackup(workDir);
+
+      const restored = JSON.parse(await readFile(settingsPath(workDir), 'utf-8'));
+      expect(restored.permissions.defaultMode).toBe('bypassPermissions');
+      expect(existsSync(backupPath(workDir))).toBe(false);
+    });
+
+    it('should do nothing if no orphaned backup', async () => {
+      await cleanOrphanedBackup(workDir);
+      // Should not throw
+    });
+  });
+
+  describe('path helpers', () => {
+    it('settingsPath should point to .claude/settings.local.json', () => {
+      expect(settingsPath('/tmp/project')).toBe('/tmp/project/.claude/settings.local.json');
+    });
+
+    it('backupPath should add .aegis-backup suffix', () => {
+      expect(backupPath('/tmp/project')).toBe('/tmp/project/.claude/settings.local.json.aegis-backup');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle .claude dir not existing', async () => {
+      const emptyDir = await mkdtemp(join(tmpdir(), 'aegis-perm-empty-'));
+      const result = await neutralizeBypassPermissions(emptyDir);
+      expect(result).toBe(false);
+      await rm(emptyDir, { recursive: true, force: true });
+    });
+
+    it('should handle concurrent neutralize+restore cycle', async () => {
+      const settings = { permissions: { defaultMode: 'bypassPermissions' } };
+      await writeFile(settingsPath(workDir), JSON.stringify(settings));
+
+      // Neutralize
+      const patched = await neutralizeBypassPermissions(workDir);
+      expect(patched).toBe(true);
+
+      // Verify patched
+      const during = JSON.parse(await readFile(settingsPath(workDir), 'utf-8'));
+      expect(during.permissions.defaultMode).toBe('default');
+
+      // Restore
+      await restoreSettings(workDir);
+
+      // Verify restored
+      const after = JSON.parse(await readFile(settingsPath(workDir), 'utf-8'));
+      expect(after.permissions.defaultMode).toBe('bypassPermissions');
+    });
+  });
+});

--- a/src/permission-guard.ts
+++ b/src/permission-guard.ts
@@ -1,0 +1,97 @@
+/**
+ * permission-guard.ts — Guard against project-level settings overriding CLI permission mode.
+ *
+ * Problem: Claude Code's `.claude/settings.local.json` can set
+ * `permissions.defaultMode: "bypassPermissions"` which OVERRIDES the CLI
+ * `--permission-mode default` flag. When Aegis spawns a session with
+ * `autoApprove: false`, the user expects permission prompts — but the
+ * project-level settings silently bypass them.
+ *
+ * Fix: Before launching CC, if autoApprove is false, we neutralize any
+ * `bypassPermissions` in the project's settings.local.json by backing it
+ * up and patching the permission mode. On session cleanup we restore it.
+ */
+
+import { readFile, writeFile, rename, unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SETTINGS_DIR = '.claude';
+const SETTINGS_FILE = 'settings.local.json';
+const BACKUP_SUFFIX = '.aegis-backup';
+
+export function settingsPath(workDir: string): string {
+  return join(workDir, SETTINGS_DIR, SETTINGS_FILE);
+}
+
+export function backupPath(workDir: string): string {
+  return settingsPath(workDir) + BACKUP_SUFFIX;
+}
+
+/**
+ * If the project's settings.local.json has bypassPermissions and autoApprove
+ * is false, back it up and patch to "default" mode.
+ *
+ * Returns true if a backup was created (and restore is needed later).
+ */
+export async function neutralizeBypassPermissions(workDir: string): Promise<boolean> {
+  const path = settingsPath(workDir);
+  if (!existsSync(path)) return false;
+
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const settings = JSON.parse(raw);
+
+    // Check if permissions.defaultMode is bypassPermissions
+    const mode = settings?.permissions?.defaultMode;
+    if (mode !== 'bypassPermissions') return false;
+
+    // Back up the original file (atomic rename)
+    const backup = backupPath(workDir);
+    await writeFile(backup, raw);
+
+    // Patch: remove the bypassPermissions override so CLI flag takes effect
+    settings.permissions.defaultMode = 'default';
+    await writeFile(path, JSON.stringify(settings, null, 2) + '\n');
+
+    console.log(`Permission guard: neutralized bypassPermissions in ${path}`);
+    return true;
+  } catch (e) {
+    console.error(`Permission guard: failed to neutralize ${path}: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+/**
+ * Restore the original settings.local.json from backup.
+ */
+export async function restoreSettings(workDir: string): Promise<void> {
+  const backup = backupPath(workDir);
+  const path = settingsPath(workDir);
+
+  if (!existsSync(backup)) return;
+
+  try {
+    await rename(backup, path);
+    console.log(`Permission guard: restored ${path} from backup`);
+  } catch (e) {
+    console.error(`Permission guard: failed to restore ${path}: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Clean up any orphaned backups (e.g. from a crash).
+ * Call on startup for all known workDirs if needed.
+ */
+export async function cleanOrphanedBackup(workDir: string): Promise<void> {
+  const backup = backupPath(workDir);
+  if (!existsSync(backup)) return;
+
+  try {
+    // Restore — the user's original settings should be preserved
+    await rename(backup, settingsPath(workDir));
+    console.log(`Permission guard: cleaned orphaned backup in ${workDir}`);
+  } catch (e) {
+    console.error(`Permission guard: failed to clean orphaned backup: ${(e as Error).message}`);
+  }
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,6 +13,7 @@ import { TmuxManager } from './tmux.js';
 import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.js';
 import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState } from './terminal-parser.js';
 import type { Config } from './config.js';
+import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
 
 export interface SessionInfo {
   id: string;                    // Our bridge session ID (UUID)
@@ -28,6 +29,7 @@ export interface SessionInfo {
   lastActivity: number;          // Unix timestamp of last activity
   stallThresholdMs: number;      // Per-session stall threshold (Issue #4)
   autoApprove: boolean;          // Issue #26: auto-approve permission prompts
+  settingsPatched?: boolean;     // Permission guard: settings.local.json was patched
 }
 
 export interface SessionState {
@@ -78,6 +80,10 @@ export class SessionManager {
       const alive = windowIds.has(session.windowId) || windowNames.has(session.windowName);
       if (!alive) {
         console.log(`Reconcile: session ${session.windowName} (${id.slice(0, 8)}) — tmux window gone, removing`);
+        // Restore patched settings before removing dead session
+        if (session.settingsPatched) {
+          await cleanOrphanedBackup(session.workDir);
+        }
         delete this.state.sessions[id];
         changed = true;
       } else {
@@ -183,6 +189,16 @@ export class SessionManager {
     };
     const hasEnv = Object.keys(mergedEnv).length > 0;
 
+    // Permission guard: if autoApprove is false, neutralize any project-level
+    // settings.local.json that has bypassPermissions. The CLI flag --permission-mode
+    // should be authoritative, but CC lets project settings override it.
+    // We back up the file, patch it, and restore on session cleanup.
+    const effectiveAutoApprove = opts.autoApprove ?? this.config.defaultAutoApprove ?? false;
+    let settingsPatched = false;
+    if (!effectiveAutoApprove) {
+      settingsPatched = await neutralizeBypassPermissions(opts.workDir);
+    }
+
     const { windowId, windowName: finalName, freshSessionId } = await this.tmux.createWindow({
       workDir: opts.workDir,
       windowName,
@@ -207,6 +223,7 @@ export class SessionManager {
       lastActivity: Date.now(),
       stallThresholdMs: opts.stallThresholdMs || SessionManager.DEFAULT_STALL_THRESHOLD_MS,
       autoApprove: opts.autoApprove ?? this.config.defaultAutoApprove ?? false,
+      settingsPatched,
     };
 
     this.state.sessions[id] = session;
@@ -522,6 +539,12 @@ export class SessionManager {
     }
 
     await this.tmux.killWindow(session.windowId);
+
+    // Permission guard: restore original settings.local.json if we patched it
+    if (session.settingsPatched) {
+      await restoreSettings(session.workDir);
+    }
+
     delete this.state.sessions[id];
     await this.save();
   }


### PR DESCRIPTION
## Problem

Claude Code's `.claude/settings.local.json` can set `permissions.defaultMode: bypassPermissions` which **overrides** the CLI `--permission-mode default` flag. When Aegis spawns a session with `autoApprove: false`, the user expects permission prompts — but project settings silently bypass them.

## Fix

Before launching CC, if `autoApprove` is `false`, Aegis checks the workDir's `settings.local.json`. If it has `bypassPermissions`:
1. **Backup** the original file
2. **Patch** `defaultMode` to `default`
3. **Restore** the original on session cleanup (`killSession`)
4. **Crash recovery**: orphaned backups are restored during `reconcile()`

## Changes
- New module: `src/permission-guard.ts` — neutralize/restore/cleanOrphanedBackup
- `session.ts`: integrated in createSession, killSession, reconcile
- 18 new tests (932 total)
- README: added Troubleshooting section

## Testing
- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npm test` ✅ (932 passed)