### PR TITLE
fix: add braille spinner chars to terminal parser (#65)

### DIFF
--- a/src/__tests__/terminal-parser.test.ts
+++ b/src/__tests__/terminal-parser.test.ts
@@ -107,6 +107,18 @@ Settings: tab to cycle
 
 `;
 
+const WORKING_BRAILLE_SPINNER = `
+⠙ Reading file…
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+
+const WORKING_BRAILLE_DOTS8 = `
+⣾ Analyzing code...
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+
 const UNKNOWN_PANE = `
 Some random output
 without any recognizable patterns
@@ -145,6 +157,15 @@ describe('detectUIState', () => {
 
     it('detects working with status text', () => {
       expect(detectUIState(WORKING_STATUS)).toBe('working');
+    });
+
+
+    it('detects working with braille spinner (⠙)', () => {
+      expect(detectUIState(WORKING_BRAILLE_SPINNER)).toBe('working');
+    });
+
+    it('detects working with 8-dot braille spinner (⣾)', () => {
+      expect(detectUIState(WORKING_BRAILLE_DOTS8)).toBe('working');
     });
   });
 

--- a/src/terminal-parser.ts
+++ b/src/terminal-parser.ts
@@ -83,8 +83,12 @@ const UI_PATTERNS: UIPattern[] = [
   },
 ];
 
-// Spinner characters Claude Code uses
-const STATUS_SPINNERS = new Set(['·', '✻', '✽', '✶', '✳', '✢']);
+// Spinner characters Claude Code uses (including braille spinners with TERM=xterm-256color)
+const STATUS_SPINNERS = new Set([
+  '·', '✻', '✽', '✶', '✳', '✢',
+  '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏',
+  '⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷',
+]);
 
 /** Detect the UI state from captured pane text. */
 export function detectUIState(paneText: string): UIState {


### PR DESCRIPTION
## Fix

CC uses braille spinners (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷`) with `TERM=xterm-256color`. Without these chars in STATUS_SPINNERS, working state was misdetected as unknown/idle.

### Changes
- Added 18 braille spinner chars to `STATUS_SPINNERS` set in `terminal-parser.ts`
- Tests already present from prior session — 984 tests pass

### Impact: HIGH | Effort: Low
Closes #65