### PR TITLE
fix: StopFailure hook captures error_details, last_assistant_message, agent_id (#64)

### DIFF
--- a/src/__tests__/stop-failure.test.ts
+++ b/src/__tests__/stop-failure.test.ts
@@ -55,11 +55,30 @@ describe('StopFailure hook support', () => {
         event: 'StopFailure',
         timestamp: Date.now(),
         error: null,
+        error_details: null,
+        last_assistant_message: null,
+        agent_id: null,
         stop_reason: null,
       };
 
       const errorDetail = signal.error || signal.stop_reason || 'Unknown API error';
       expect(errorDetail).toBe('Unknown API error');
+    });
+
+    it('should capture error_details, last_assistant_message, agent_id from StopFailure', () => {
+      const signal = {
+        event: 'StopFailure',
+        timestamp: Date.now(),
+        error: 'Rate limit exceeded',
+        error_details: 'Too many requests, retry after 30s',
+        last_assistant_message: 'I was working on fixing the bug...',
+        agent_id: 'agent-123',
+        stop_reason: 'rate_limit',
+      };
+
+      expect(signal.error_details).toBe('Too many requests, retry after 30s');
+      expect(signal.last_assistant_message).toBe('I was working on fixing the bug...');
+      expect(signal.agent_id).toBe('agent-123');
     });
   });
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -55,6 +55,9 @@ function handleStopEvent(
     timestamp: Date.now(),
     // StopFailure may include error info in the payload
     error: (payload as any).error || (payload as any).message || null,
+    error_details: (payload as any).error_details || null,
+    last_assistant_message: (payload as any).last_assistant_message || null,
+    agent_id: (payload as any).agent_id || null,
     stop_reason: (payload as any).stop_reason || null,
   };
 


### PR DESCRIPTION
## Fix

StopFailure hook was only capturing `error` and `stop_reason`. CC also provides `error_details`, `last_assistant_message`, and `agent_id` — critical for debugging and intelligent recovery.

### Changes
- Added 3 fields to signal object in `handleStopEvent()`
- Added test for new fields

### Tests
- 982 tests pass

Closes #64