### PR TITLE
fix: dead session detection verifies process alive, not just window (#69)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ state.json
 *.swp
 Thumbs.db
 .vscode/
+.claude/settings.local.json.aegis-backup
+*.aegis-backup

--- a/src/session.ts
+++ b/src/session.ts
@@ -309,12 +309,18 @@ export class SessionManager {
     return this.state.sessions[id] || null;
   }
 
-  /** Check if a session's tmux window still exists. */
+  /** Check if a session's tmux window still exists and has a live process.
+   *  Issue #69: A window can exist with a crashed/zombie CC process (zombie window).
+   *  After checking window exists, also verify the pane PID is alive. */
   async isWindowAlive(id: string): Promise<boolean> {
     const session = this.state.sessions[id];
     if (!session) return false;
     try {
-      return await this.tmux.windowExists(session.windowId);
+      if (!(await this.tmux.windowExists(session.windowId))) return false;
+      // Verify the process inside the pane is still alive
+      const panePid = await this.tmux.listPanePid(session.windowId);
+      if (panePid !== null && !this.tmux.isPidAlive(panePid)) return false;
+      return true;
     } catch {
       return false;
     }
@@ -349,7 +355,20 @@ export class SessionManager {
 
     // Get terminal state
     let status: UIState = 'unknown';
+    // Issue #69: Also check if the pane PID is alive (zombie window detection)
+    let processAlive = true;
     if (windowHealth.windowExists) {
+      try {
+        const panePid = await this.tmux.listPanePid(session.windowId);
+        if (panePid !== null) {
+          processAlive = this.tmux.isPidAlive(panePid);
+        }
+      } catch {
+        processAlive = false;
+      }
+    }
+
+    if (windowHealth.windowExists && processAlive) {
       try {
         const paneText = await this.tmux.capturePane(session.windowId);
         status = detectUIState(paneText);
@@ -364,14 +383,16 @@ export class SessionManager {
     const sessionAge = now - session.createdAt;
 
     // Determine if session is alive
-    // Alive = window exists AND (Claude running OR recently active)
+    // Alive = window exists AND process alive AND (Claude running OR recently active)
     const recentlyActive = lastActivityAgo < 5 * 60 * 1000; // 5 minutes
-    const alive = windowHealth.windowExists && (windowHealth.claudeRunning || recentlyActive);
+    const alive = windowHealth.windowExists && processAlive && (windowHealth.claudeRunning || recentlyActive);
 
     // Human-readable detail
     let details: string;
     if (!windowHealth.windowExists) {
       details = 'Tmux window does not exist — session is dead';
+    } else if (!processAlive) {
+      details = 'Tmux window exists but pane process is dead — session is dead (zombie window)';
     } else if (!windowHealth.claudeRunning && !recentlyActive) {
       details = `Claude not running (pane: ${windowHealth.paneCommand}), no activity for ${Math.round(lastActivityAgo / 60000)}min`;
     } else if (status === 'idle') {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -348,6 +348,29 @@ export class TmuxManager {
     }
   }
 
+  /** Issue #69: Get the PID of the first pane in a window. Returns null on error. */
+  async listPanePid(windowId: string): Promise<number | null> {
+    try {
+      const target = `${this.sessionName}:${windowId}`;
+      const raw = await this.tmux('list-panes', '-t', target, '-F', '#{pane_pid}');
+      if (!raw) return null;
+      const pid = parseInt(raw.split('\n')[0]!, 10);
+      return Number.isFinite(pid) ? pid : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Issue #69: Check if a PID is alive using kill -0. */
+  isPidAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /** Get detailed window info for health checks.
    *  Issue #2: Returns window existence, pane command, and whether Claude is running.
    */


### PR DESCRIPTION
## Fix

Dead session detection only checked if tmux window exists. But a window can exist with a crashed/zombie CC process inside (zombie window).

### Changes
- `isWindowAlive()` now also verifies the pane PID is alive via `kill -0`
- Added `TmuxManager.listPanePid(windowId)` — gets pane PID via `tmux list-panes -F #{pane_pid}`
- Added `TmuxManager.isPidAlive(pid)` — checks PID with `process.kill(pid, 0)`
- Updated .gitignore to exclude `*.aegis-backup` files

### Dogfooding note 🐕
This fix was developed using Aegis itself (session via `POST /sessions`). Found a monitor bug during testing: session status stays `working` when CC is actually idle.

### Tests
- 1006 tests pass

Closes #69