### PR TITLE
fix: detect Perambulating/bullet status in terminal parser (#102)

### DIFF
--- a/src/__tests__/terminal-parser.test.ts
+++ b/src/__tests__/terminal-parser.test.ts
@@ -29,6 +29,18 @@ Some content being generated...
 ────────────────────────────────────────────────────────────────────────────────
 `;
 
+const WORKING_PERAMBULATING = `
+* Perambulating… (2m 27s · ↑ 4.5k tokens)
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+
+const WORKING_BULLET_STATUS = `
+● Reading file…
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+
 const WORKED_FOR = `
 ✻ Worked for 45s
 
@@ -212,6 +224,14 @@ describe('detectUIState', () => {
 
     it('detects working with 8-dot braille spinner (⣾)', () => {
       expect(detectUIState(WORKING_BRAILLE_DOTS8)).toBe('working');
+    });
+
+    it('detects working with asterisk status (* Perambulating…)', () => {
+      expect(detectUIState(WORKING_PERAMBULATING)).toBe('working');
+    });
+
+    it('detects working with bullet status (● Reading…)', () => {
+      expect(detectUIState(WORKING_BULLET_STATUS)).toBe('working');
     });
   });
 

--- a/src/terminal-parser.ts
+++ b/src/terminal-parser.ts
@@ -91,8 +91,9 @@ const UI_PATTERNS: UIPattern[] = [
 ];
 
 // Spinner characters Claude Code uses (including braille spinners with TERM=xterm-256color)
+// Issue #102: CC also uses * (asterisk) and ● (bullet) for status lines like "* Perambulating…"
 const STATUS_SPINNERS = new Set([
-  '·', '✻', '✽', '✶', '✳', '✢',
+  '·', '✻', '✽', '✶', '✳', '✢', '*', '●',
   '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏',
   '⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷',
 ]);


### PR DESCRIPTION
## Fix

CC uses `*` (asterisk) and `●` (bullet) for status lines like `* Perambulating…` and `● Reading…`. Without these in STATUS_SPINNERS, the parser returned `unknown` instead of `working`.

### Found via dogfooding 🐕
Used Aegis to create a CC session → observed status stuck on unknown while CC was clearly working.

### Changes
- Added `*` and `●` to STATUS_SPINNERS set
- 2 new test cases for asterisk and bullet status patterns
- 1010 tests pass

Closes #102