### PR TITLE
fix: distinguish API rate-limit from active work in stall detection

### DIFF
--- a/src/__tests__/stall-detection.test.ts
+++ b/src/__tests__/stall-detection.test.ts
@@ -101,4 +101,77 @@ describe('Configurable stall detection', () => {
       expect(pollIntervalMs).toBe(2000);
     });
   });
+
+  describe('rate-limited session stall exemption', () => {
+    it('should skip Type 1 JSONL stall detection when session is rate-limited', () => {
+      const rateLimitedSessions = new Set<string>();
+      const sessionId = 'rate-limited-session';
+      rateLimitedSessions.add(sessionId);
+
+      // Simulate the guard at top of Type 1 stall check
+      const shouldSkipStallCheck = rateLimitedSessions.has(sessionId);
+      expect(shouldSkipStallCheck).toBe(true);
+    });
+
+    it('should not skip stall detection for non-rate-limited sessions', () => {
+      const rateLimitedSessions = new Set<string>();
+      const sessionId = 'normal-session';
+
+      const shouldSkipStallCheck = rateLimitedSessions.has(sessionId);
+      expect(shouldSkipStallCheck).toBe(false);
+    });
+
+    it('should clear rate-limited state when new JSONL messages arrive', () => {
+      const rateLimitedSessions = new Set<string>();
+      const sessionId = 'rate-limited-session';
+      rateLimitedSessions.add(sessionId);
+
+      expect(rateLimitedSessions.has(sessionId)).toBe(true);
+
+      // Simulate new messages arriving — clear rate-limited state
+      const messages = [{ role: 'assistant', contentType: 'text' }];
+      if (messages.length > 0) {
+        rateLimitedSessions.delete(sessionId);
+      }
+
+      expect(rateLimitedSessions.has(sessionId)).toBe(false);
+    });
+
+    it('should clear rate-limited state when session goes idle', () => {
+      const rateLimitedSessions = new Set<string>();
+      const sessionId = 'rate-limited-session';
+      rateLimitedSessions.add(sessionId);
+
+      expect(rateLimitedSessions.has(sessionId)).toBe(true);
+
+      // Simulate idle cleanup
+      const currentStatus = 'idle';
+      if (currentStatus === 'idle') {
+        rateLimitedSessions.delete(sessionId);
+      }
+
+      expect(rateLimitedSessions.has(sessionId)).toBe(false);
+    });
+
+    it('should route rate_limit stop_reason to status.rate_limited event', () => {
+      const stopReason = 'rate_limit';
+      const isRateLimited = stopReason === 'rate_limit' || stopReason === 'overloaded';
+      const channelEvent = isRateLimited ? 'status.rate_limited' : 'status.error';
+      expect(channelEvent).toBe('status.rate_limited');
+    });
+
+    it('should route overloaded stop_reason to status.rate_limited event', () => {
+      const stopReason: string = 'overloaded';
+      const isRateLimited = stopReason === 'rate_limit' || stopReason === 'overloaded';
+      const channelEvent = isRateLimited ? 'status.rate_limited' : 'status.error';
+      expect(channelEvent).toBe('status.rate_limited');
+    });
+
+    it('should route other stop_reasons to status.error event', () => {
+      const stopReason: string = 'api_error';
+      const isRateLimited = stopReason === 'rate_limit' || stopReason === 'overloaded';
+      const channelEvent = isRateLimited ? 'status.rate_limited' : 'status.error';
+      expect(channelEvent).toBe('status.error');
+    });
+  });
 });

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -23,7 +23,8 @@ export type SessionEvent =
   | 'status.stall'
   | 'status.dead'
   | 'status.stopped'
-  | 'status.error';
+  | 'status.error'
+  | 'status.rate_limited';
 
 /** Payload for all session events. */
 export interface SessionEventPayload {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -46,6 +46,7 @@ export class SessionMonitor {
   // Smart stall detection: track when each non-working state started
   private stateSince = new Map<string, number>();  // sessionId → timestamp when current non-working state began
   private deadNotified = new Set<string>();  // don't spam dead session events
+  private rateLimitedSessions = new Set<string>();  // sessions in rate-limit backoff
 
   /** Issue #32: Optional SSE event bus for real-time streaming. */
   private eventBus?: SessionEventBus;
@@ -125,6 +126,11 @@ export class SessionMonitor {
 
       // --- Type 1: JSONL stall (working but no output) ---
       if (currentStatus === 'working') {
+        // Skip stall detection for rate-limited sessions — CC is in backoff
+        if (this.rateLimitedSessions.has(session.id)) {
+          continue;
+        }
+
         const prev = this.lastBytesSeen.get(session.id);
         const currentBytes = session.monitorOffset;
 
@@ -217,6 +223,8 @@ export class SessionMonitor {
 
       // Clean up state tracking when status changes
       if (currentStatus === 'idle') {
+        // Clear rate-limited state — session recovered
+        this.rateLimitedSessions.delete(session.id);
         // Clean all non-idle state tracking for this session
         for (const key of this.stateSince.keys()) {
           if (key.startsWith(session.id + ':')) {
@@ -263,11 +271,20 @@ export class SessionMonitor {
         this.processedStopSignals.add(signalKey);
 
         if (signal.event === 'StopFailure') {
-          const errorDetail = signal.error || signal.stop_reason || 'Unknown API error';
-          await this.channels.statusChange(
-            this.makePayload('status.error', session,
-              `⚠️ Claude Code error: ${errorDetail}`),
-          );
+          const stopReason = signal.stop_reason || '';
+          if (stopReason === 'rate_limit' || stopReason === 'overloaded') {
+            this.rateLimitedSessions.add(session.id);
+            await this.channels.statusChange(
+              this.makePayload('status.rate_limited', session,
+                `Claude API rate limited (${stopReason}). Session will resume when the backoff window expires.`),
+            );
+          } else {
+            const errorDetail = signal.error || signal.stop_reason || 'Unknown API error';
+            await this.channels.statusChange(
+              this.makePayload('status.error', session,
+                `⚠️ Claude Code error: ${errorDetail}`),
+            );
+          }
         } else if (signal.event === 'Stop') {
           await this.channels.statusChange(
             this.makePayload('status.stopped', session,
@@ -285,6 +302,8 @@ export class SessionMonitor {
 
     // Forward new messages to channels
     if (result.messages.length > 0) {
+      // Clear rate-limited state — CC resumed producing real output
+      this.rateLimitedSessions.delete(session.id);
       for (const msg of result.messages) {
         await this.forwardMessage(session, msg);
       }
@@ -432,6 +451,7 @@ export class SessionMonitor {
     this.lastMessageCount.delete(sessionId);
     this.lastBytesSeen.delete(sessionId);
     this.deadNotified.delete(sessionId);
+    this.rateLimitedSessions.delete(sessionId);
     // Clean all stall notifications for this session
     for (const key of this.stallNotified) {
       if (key.startsWith(sessionId)) {


### PR DESCRIPTION
## Summary

Fixes #70 (H8) — Stall detection can't distinguish rate-limit from active work

### Problem
When CC hits rate-limit (429) or overloaded, it enters internal backoff (minutes). Aegis sees `working` + possible JSONL bytes (retry entries) → stall detection doesn't fire correctly.

### Solution
- Parse `stop_reason` from JSONL StopFailure signals
- When `stop_reason` is `rate_limit` or `overloaded`, add session to `rateLimitedSessions` set
- Rate-limited sessions are exempted from Type 1 (JSONL) stall detection
- Emit `status.rate_limited` event (not `status.error`) for clear distinction
- Auto-clear rate-limited state when session resumes, goes idle, or is removed

### Changes
- `monitor.ts`: Added `rateLimitedSessions` Set, detect rate-limit in `processStopSignals`, skip stall for rate-limited sessions
- `channels/types.ts`: Added `rate_limited` to `ChannelEvent` type
- `stall-detection.test.ts`: Added tests for rate-limited handling

### Test Results
- ✅ 68 test files, 1105 tests passing (+7 new tests)
- ✅ TypeScript: 0 errors