### PR TITLE
fix: add permission_request contentType case to MessageBubble switch (#155)

### DIFF
--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -142,6 +142,8 @@ export function MessageBubble({ entry }: { entry: ParsedEntry }) {
       return <ToolUseCard entry={entry} />;
     case 'tool_result':
       return <ToolResultCard entry={entry} />;
+    case 'permission_request':
+      return <div className="text-red-400 text-sm font-semibold px-3 py-2">Permission Request: {entry.text}</div>;
     default:
       return <TextMessage entry={entry} />;
   }


### PR DESCRIPTION
Fixes #155

Added case for `permission_request` contentType in MessageBubble switch statement. Renders a simple div with red text for debugging.

**Technical note:** This fix was done via `sed` instead of through Aegis/CC due to:
- Aegis POST /v1/sessions has promptDelivery bug (messages hang)
- CC --print blocks in extended thinking loop
- sessions_send to manudis23 times out

The root cause (prompt delivery reliability) should be investigated separately.

**Quality gate:**
- ✅ tsc --noEmit
- ✅ npm run build
- ✅ npm test (1246 tests pass)