### PR TITLE
feat(dashboard): toast notifications for error handling (#139)

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { useStore } from '../store/useStore';
 import { subscribeGlobalSSE } from '../api/client';
+import ToastContainer from './ToastContainer';
 
 const NAV_ITEMS = [
   { to: '/', label: 'Overview', icon: LayoutDashboard },
@@ -108,6 +109,8 @@ export default function Layout() {
           <Outlet />
         </main>
       </div>
+      {/* Toast notifications */}
+      <ToastContainer />
     </div>
   );
 }

--- a/dashboard/src/components/ToastContainer.tsx
+++ b/dashboard/src/components/ToastContainer.tsx
@@ -1,0 +1,53 @@
+/**
+ * components/ToastContainer.tsx — Global toast notification renderer.
+ */
+
+import { X } from 'lucide-react';
+import { useToastStore } from '../store/useToastStore';
+import type { ToastType } from '../store/useToastStore';
+
+const TYPE_STYLES: Record<ToastType, string> = {
+  error: 'border-red-500/50 bg-red-950/80 text-red-200',
+  success: 'border-green-500/50 bg-green-950/80 text-green-200',
+  info: 'border-cyan-500/50 bg-cyan-950/80 text-cyan-200',
+  warning: 'border-yellow-500/50 bg-yellow-950/80 text-yellow-200',
+};
+
+function ToastItem({ id, type, title, description }: { id: string; type: ToastType; title: string; description?: string }) {
+  const removeToast = useToastStore((s) => s.removeToast);
+
+  return (
+    <div
+      role="alert"
+      className={`flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm animate-slide-in ${TYPE_STYLES[type]}`}
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">{title}</p>
+        {description && <p className="mt-0.5 text-xs opacity-80">{description}</p>}
+      </div>
+      <button
+        onClick={() => removeToast(id)}
+        className="shrink-0 rounded p-0.5 opacity-60 hover:opacity-100 transition-opacity"
+        aria-label="Dismiss"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+export default function ToastContainer() {
+  const toasts = useToastStore((s) => s.toasts);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm w-full pointer-events-none">
+      {toasts.map((t) => (
+        <div key={t.id} className="pointer-events-auto">
+          <ToastItem id={t.id} type={t.type} title={t.title} description={t.description} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { Activity, Clock, Layers, Zap } from 'lucide-react';
 import { getMetrics, getHealth } from '../../api/client';
 import { useStore } from '../../store/useStore';
+import { useToastStore } from '../../store/useToastStore';
 import { formatUptime } from '../../utils/format';
 import MetricCard from './MetricCard';
 import type { HealthResponse } from '../../types';
@@ -14,14 +15,15 @@ export default function MetricCards() {
   const metrics = useStore((s) => s.metrics);
   const setMetrics = useStore((s) => s.setMetrics);
   const [health, setHealth] = useState<HealthResponse | null>(null);
+  const addToast = useToastStore((t) => t.addToast);
 
   const fetchData = async () => {
     try {
       const [m, h] = await Promise.all([getMetrics(), getHealth()]);
       setMetrics(m);
       setHealth(h);
-    } catch {
-      // Silently ignore — cards show placeholder
+    } catch (e: unknown) {
+      addToast('error', 'Failed to load metrics', e instanceof Error ? e.message : undefined);
     }
   };
 

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -12,6 +12,7 @@ import {
   Play,
 } from 'lucide-react';
 import { getSessions, getAllSessionsHealth, approve, interrupt, killSession } from '../../api/client';
+import { useToastStore } from '../../store/useToastStore';
 import { formatTimeAgo } from '../../utils/format';
 import StatusDot from './StatusDot';
 import type { SessionInfo } from '../../types';
@@ -25,6 +26,7 @@ export default function SessionTable() {
   const sessions = useStore((s) => s.sessions);
   const setSessions = useStore((s) => s.setSessions);
   const [healthMap, setHealthMap] = useState<Record<string, RowHealth>>({});
+  const addToast = useToastStore((t) => t.addToast);
 
   const fetchSessions = useCallback(async () => {
     try {
@@ -44,10 +46,10 @@ export default function SessionTable() {
       } catch {
         // Health fetch failed — show sessions without health data
       }
-    } catch {
-      // Silently ignore
+    } catch (e: unknown) {
+      addToast('error', 'Failed to fetch sessions', e instanceof Error ? e.message : undefined);
     }
-  }, []);
+  }, [addToast]);
 
   useEffect(() => {
     fetchSessions();
@@ -57,18 +59,24 @@ export default function SessionTable() {
 
   const handleApprove = async (e: React.MouseEvent, id: string) => {
     e.preventDefault();
-    try { await approve(id); } catch { /* ignore */ }
+    try { await approve(id); } catch (err: unknown) {
+      addToast('error', 'Approve failed', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleInterrupt = async (e: React.MouseEvent, id: string) => {
     e.preventDefault();
-    try { await interrupt(id); } catch { /* ignore */ }
+    try { await interrupt(id); } catch (err: unknown) {
+      addToast('error', 'Interrupt failed', err instanceof Error ? err.message : undefined);
+    }
   };
 
   const handleKill = async (e: React.MouseEvent, id: string) => {
     e.preventDefault();
     if (!confirm('Kill this session?')) return;
-    try { await killSession(id); } catch { /* ignore */ }
+    try { await killSession(id); } catch (err: unknown) {
+      addToast('error', 'Failed to kill session', err instanceof Error ? err.message : undefined);
+    }
   };
 
   if (sessions.length === 0) {

--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -8,6 +8,7 @@ import {
   subscribeSSE,
 } from '../api/client';
 import { useStore } from '../store/useStore';
+import { useToastStore } from '../store/useToastStore';
 
 interface SessionSSEEventData {
   event: 'status' | 'message' | 'approval' | 'ended' | 'heartbeat' | 'stall' | 'dead' | 'connected';
@@ -30,6 +31,7 @@ interface UseSessionPollingReturn {
 
 export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   const token = useStore((s) => s.token);
+  const addToast = useToastStore((t) => t.addToast);
 
   // Session + health state
   const [session, setSession] = useState<SessionInfo | null>(null);
@@ -68,8 +70,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
 
       if (sessionRes.status === 'fulfilled') setSession(sessionRes.value);
       if (healthRes.status === 'fulfilled') setHealth(healthRes.value);
-    } catch {
-      // network error
+    } catch (e: unknown) {
+      addToast('error', 'Failed to load session', e instanceof Error ? e.message : undefined);
     } finally {
       setLoading(false);
     }
@@ -83,8 +85,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     try {
       const data = await getSessionPane(sid);
       if (!cancelledRef.current) setPaneContent(data.pane ?? '');
-    } catch {
-      // pane may not be available
+    } catch (e: unknown) {
+      addToast('warning', 'Failed to load terminal pane', e instanceof Error ? e.message : undefined);
     } finally {
       if (!cancelledRef.current) setPaneLoading(false);
     }
@@ -92,8 +94,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     try {
       const data = await getSessionMetrics(sid);
       if (!cancelledRef.current) setMetrics(data);
-    } catch {
-      // metrics may not be available
+    } catch (e: unknown) {
+      addToast('warning', 'Failed to load session metrics', e instanceof Error ? e.message : undefined);
     } finally {
       if (!cancelledRef.current) setMetricsLoading(false);
     }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -106,3 +106,20 @@ body {
 .glow-text-cyan {
   text-shadow: 0 0 8px var(--color-cyan-dim);
 }
+
+/* ── Toast Animation ───────────────────────────────────────────── */
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in {
+  animation: slide-in 0.2s ease-out;
+}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   CornerDownLeft,
 } from 'lucide-react';
 import { sendMessage, approve, reject, interrupt, escape, killSession } from '../api/client';
+import { useToastStore } from '../store/useToastStore';
 import { useSessionPolling } from '../hooks/useSessionPolling';
 import { SessionHeader } from '../components/session/SessionHeader';
 import { TranscriptViewer } from '../components/session/TranscriptViewer';
@@ -58,16 +59,35 @@ export default function SessionDetailPage() {
   const s = session;
   const h = health;
   const needsApproval = h.status === 'permission_prompt' || h.status === 'bash_approval';
+  const addToast = useToastStore((t) => t.addToast);
 
-  function handleApprove() { approve(s.id).catch(() => {}); }
-  function handleReject() { reject(s.id).catch(() => {}); }
-  function handleInterrupt() { interrupt(s.id).catch(() => {}); }
-  function handleEscape() { escape(s.id).catch(() => {}); }
+  function handleApprove() {
+    approve(s.id).catch((e: unknown) =>
+      addToast('error', 'Approve failed', e instanceof Error ? e.message : undefined),
+    );
+  }
+  function handleReject() {
+    reject(s.id).catch((e: unknown) =>
+      addToast('error', 'Reject failed', e instanceof Error ? e.message : undefined),
+    );
+  }
+  function handleInterrupt() {
+    interrupt(s.id).catch((e: unknown) =>
+      addToast('error', 'Interrupt failed', e instanceof Error ? e.message : undefined),
+    );
+  }
+  function handleEscape() {
+    escape(s.id).catch((e: unknown) =>
+      addToast('error', 'Escape failed', e instanceof Error ? e.message : undefined),
+    );
+  }
   async function handleKill() {
     try {
       await killSession(s.id);
       navigate('/dashboard');
-    } catch {}
+    } catch (e: unknown) {
+      addToast('error', 'Failed to kill session', e instanceof Error ? e.message : undefined);
+    }
   }
 
   async function handleSend() {
@@ -77,8 +97,8 @@ export default function SessionDetailPage() {
     try {
       await sendMessage(s.id, text);
       setMsgInput('');
-    } catch {
-      // handled silently
+    } catch (e: unknown) {
+      addToast('error', 'Failed to send message', e instanceof Error ? e.message : undefined);
     } finally {
       setSending(false);
       msgInputRef.current?.focus();

--- a/dashboard/src/store/useToastStore.ts
+++ b/dashboard/src/store/useToastStore.ts
@@ -1,0 +1,39 @@
+/**
+ * store/useToastStore.ts — Lightweight toast notification store.
+ */
+
+import { create } from 'zustand';
+
+export type ToastType = 'error' | 'success' | 'info' | 'warning';
+
+export interface Toast {
+  id: string;
+  type: ToastType;
+  title: string;
+  description?: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (type: ToastType, title: string, description?: string) => string;
+  removeToast: (id: string) => void;
+}
+
+let nextId = 0;
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+
+  addToast: (type, title, description) => {
+    const id = `toast-${++nextId}`;
+    set((s) => ({ toasts: [...s.toasts, { id, type, title, description }] }));
+    // Auto-dismiss after 4s
+    setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, 4000);
+    return id;
+  },
+
+  removeToast: (id) =>
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));


### PR DESCRIPTION
Fixes #139. Adds Toast system and wires error notifications into all empty catch blocks.