### PR TITLE
fix: prevent flaky auth test collision

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -13,7 +13,7 @@ describe('Authentication and API key management (Issue #39)', () => {
   let tmpFile: string;
 
   beforeEach(async () => {
-    tmpFile = join(tmpdir(), `aegis-keys-${Date.now()}.json`);
+    tmpFile = join(tmpdir(), `aegis-keys-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
     auth = new AuthManager(tmpFile, '');
   });
 


### PR DESCRIPTION
## Problem
 uses  for the temp file path. When src and dist test files run in parallel (both exist in vitest), they can share the same millisecond timestamp, causing file collisions and test failures.

## Fix
Added  suffix to the tmpFile path, making collisions practically impossible.

## Verification
- 3 consecutive full test runs: 1246/1246 pass ✅
- tsc --noEmit: clean ✅
- npm run build: clean ✅