### PR TITLE
feat(hooks): inject CC settings.json with HTTP hooks (#169 Phase 2)

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -1,0 +1,176 @@
+/**
+ * hook-settings.test.ts — Tests for Issue #169 Phase 2: HTTP hook settings injection.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  generateHookSettings,
+  writeHookSettingsFile,
+  cleanupHookSettingsFile,
+  HTTP_HOOK_EVENTS,
+  type HookSettings,
+} from '../hook-settings.js';
+
+describe('generateHookSettings', () => {
+  const baseUrl = 'http://localhost:9100';
+  const sessionId = 'abc123-def456-ghi789';
+
+  it('should generate settings with all 5 HTTP hook events', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+
+    expect(Object.keys(settings.hooks)).toHaveLength(HTTP_HOOK_EVENTS.length);
+    for (const event of HTTP_HOOK_EVENTS) {
+      expect(settings.hooks[event]).toBeDefined();
+      expect(Array.isArray(settings.hooks[event])).toBe(true);
+    }
+  });
+
+  it('should generate correct URL format for each event', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+
+    for (const event of HTTP_HOOK_EVENTS) {
+      const entry = settings.hooks[event]![0];
+      const hook = entry.hooks[0];
+
+      expect(hook.type).toBe('http');
+      expect(hook.url).toBe(`${baseUrl}/v1/hooks/${event}?sessionId=${sessionId}`);
+    }
+  });
+
+  it('should include only HTTP-supported events (not Notification, SessionEnd, etc.)', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+    const events = Object.keys(settings.hooks);
+
+    // These events only support type: "command", NOT "http"
+    expect(events).not.toContain('Notification');
+    expect(events).not.toContain('SessionEnd');
+    expect(events).not.toContain('SessionStart');
+    expect(events).not.toContain('SubagentStop');
+    expect(events).not.toContain('SubagentStart');
+  });
+
+  it('should produce valid JSON structure', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+
+    // Should serialize and deserialize cleanly
+    const json = JSON.stringify(settings);
+    const parsed: HookSettings = JSON.parse(json);
+
+    expect(parsed.hooks).toBeDefined();
+    expect(typeof parsed.hooks).toBe('object');
+  });
+
+  it('should use the provided baseUrl and sessionId', () => {
+    const customBase = 'http://192.168.1.100:8080';
+    const customSession = 'my-session-id';
+
+    const settings = generateHookSettings(customBase, customSession);
+    const stopHook = settings.hooks.Stop![0].hooks[0];
+
+    expect(stopHook.url).toBe('http://192.168.1.100:8080/v1/hooks/Stop?sessionId=my-session-id');
+  });
+
+  it('should include Stop event', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+    expect(settings.hooks.Stop).toBeDefined();
+  });
+
+  it('should include PreToolUse event', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+    expect(settings.hooks.PreToolUse).toBeDefined();
+  });
+
+  it('should include PostToolUse event', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+    expect(settings.hooks.PostToolUse).toBeDefined();
+  });
+
+  it('should include PermissionRequest event', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+    expect(settings.hooks.PermissionRequest).toBeDefined();
+  });
+
+  it('should include TaskCompleted event', () => {
+    const settings = generateHookSettings(baseUrl, sessionId);
+    expect(settings.hooks.TaskCompleted).toBeDefined();
+  });
+});
+
+describe('writeHookSettingsFile', () => {
+  const testDir = join(tmpdir(), 'aegis-hooks-test-' + process.pid);
+  const originalTmpdir = tmpdir;
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Clean up test directory
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  });
+
+  it('should write a valid JSON settings file', async () => {
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'test-session');
+
+    try {
+      expect(existsSync(filePath)).toBe(true);
+
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(filePath, 'utf-8');
+      const parsed: HookSettings = JSON.parse(content);
+
+      expect(parsed.hooks).toBeDefined();
+      expect(Object.keys(parsed.hooks).length).toBeGreaterThan(0);
+    } finally {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  });
+
+  it('should include the session ID in the filename', async () => {
+    const sessionId = 'unique-session-abc';
+    const filePath = await writeHookSettingsFile('http://localhost:9100', sessionId);
+
+    try {
+      expect(filePath).toContain(sessionId);
+    } finally {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  });
+
+  it('should produce URLs matching the provided base URL', async () => {
+    const baseUrl = 'http://example.com:3000';
+    const filePath = await writeHookSettingsFile(baseUrl, 'session-1');
+
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(filePath, 'utf-8');
+      const parsed: HookSettings = JSON.parse(content);
+
+      for (const event of HTTP_HOOK_EVENTS) {
+        const hook = parsed.hooks[event]![0].hooks[0];
+        expect(hook.url).toContain(baseUrl);
+      }
+    } finally {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  });
+});
+
+describe('cleanupHookSettingsFile', () => {
+  it('should remove an existing settings file', async () => {
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'cleanup-test');
+    expect(existsSync(filePath)).toBe(true);
+
+    await cleanupHookSettingsFile(filePath);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it('should not throw for a non-existent file', async () => {
+    await expect(cleanupHookSettingsFile('/tmp/nonexistent-aegis-hooks-file.json')).resolves.not.toThrow();
+  });
+});

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -1,0 +1,105 @@
+/**
+ * hook-settings.ts — Generate CC settings.json with HTTP hooks for Aegis.
+ *
+ * When Aegis creates a CC session, it writes a per-session settings file
+ * that configures HTTP hooks pointing to Aegis's hook receiver endpoint.
+ * The file is passed to CC via the `--settings` CLI flag.
+ *
+ * Only events that support `type: "http"` hooks are included:
+ *   Stop, PreToolUse, PostToolUse, PermissionRequest, TaskCompleted
+ *
+ * Events like Notification, SessionEnd, etc. only support `type: "command"`
+ * and are excluded.
+ *
+ * Issue #169: Phase 2 — Inject CC settings.json with HTTP hooks.
+ */
+
+import { writeFile, unlink, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/** CC hook events that support `type: "http"`. */
+const HTTP_HOOK_EVENTS = [
+  'Stop',
+  'PreToolUse',
+  'PostToolUse',
+  'PermissionRequest',
+  'TaskCompleted',
+] as const;
+
+export { HTTP_HOOK_EVENTS };
+
+export type HttpHookEvent = typeof HTTP_HOOK_EVENTS[number];
+
+/** Shape of a single HTTP hook entry in CC settings.json. */
+interface HttpHookConfig {
+  type: 'http';
+  url: string;
+}
+
+/** Shape of the `hooks` section in CC settings.json. */
+export interface HookSettings {
+  hooks: Record<string, Array<{ matcher?: string; hooks: HttpHookConfig[] }>>;
+}
+
+/**
+ * Generate the hooks section of a CC settings.json for a given session.
+ *
+ * @param baseUrl - Aegis base URL (e.g. "http://localhost:9100")
+ * @param sessionId - Aegis session ID (used as query param for routing)
+ */
+export function generateHookSettings(baseUrl: string, sessionId: string): HookSettings {
+  const hooks: HookSettings['hooks'] = {};
+
+  for (const event of HTTP_HOOK_EVENTS) {
+    hooks[event] = [
+      {
+        hooks: [
+          {
+            type: 'http',
+            url: `${baseUrl}/v1/hooks/${event}?sessionId=${sessionId}`,
+          },
+        ],
+      },
+    ];
+  }
+
+  return { hooks };
+}
+
+/**
+ * Write hook settings to a temporary file and return its path.
+ *
+ * @param baseUrl - Aegis base URL
+ * @param sessionId - Aegis session ID
+ * @returns Path to the temporary settings file
+ */
+export async function writeHookSettingsFile(baseUrl: string, sessionId: string): Promise<string> {
+  const settings = generateHookSettings(baseUrl, sessionId);
+  const settingsDir = join(tmpdir(), 'aegis-hooks');
+
+  if (!existsSync(settingsDir)) {
+    await mkdir(settingsDir, { recursive: true });
+  }
+
+  const filePath = join(settingsDir, `hooks-${sessionId}.json`);
+  await writeFile(filePath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+
+  return filePath;
+}
+
+/**
+ * Clean up a hook settings temp file.
+ *
+ * @param filePath - Path to the temporary settings file
+ */
+export async function cleanupHookSettingsFile(filePath: string): Promise<void> {
+  try {
+    if (existsSync(filePath)) {
+      await unlink(filePath);
+    }
+  } catch {
+    // Non-fatal: temp file cleanup failed
+  }
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,7 @@ import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.
 import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState } from './terminal-parser.js';
 import type { Config } from './config.js';
 import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
+import { writeHookSettingsFile, cleanupHookSettingsFile } from './hook-settings.js';
 
 export interface SessionInfo {
   id: string;                    // Our bridge session ID (UUID)
@@ -30,6 +31,7 @@ export interface SessionInfo {
   stallThresholdMs: number;      // Per-session stall threshold (Issue #4)
   permissionMode: string;        // Permission mode: "default"|"plan"|"acceptEdits"|"bypassPermissions"|"dontAsk"|"auto"
   settingsPatched?: boolean;     // Permission guard: settings.local.json was patched
+  hookSettingsFile?: string;     // Temp file with HTTP hook settings (Issue #169)
 }
 
 export interface SessionState {
@@ -278,6 +280,17 @@ export class SessionManager {
       settingsPatched = await neutralizeBypassPermissions(opts.workDir, effectivePermissionMode);
     }
 
+    // Issue #169 Phase 2: Generate HTTP hook settings for this session.
+    // Writes a temp file with hooks pointing to Aegis's hook receiver.
+    let hookSettingsFile: string | undefined;
+    try {
+      const baseUrl = `http://${this.config.host}:${this.config.port}`;
+      hookSettingsFile = await writeHookSettingsFile(baseUrl, id);
+    } catch (e) {
+      console.error(`Hook settings: failed to generate settings file: ${(e as Error).message}`);
+      // Non-fatal: hooks won't work for this session, but CC still launches
+    }
+
     const { windowId, windowName: finalName, freshSessionId } = await this.tmux.createWindow({
       workDir: opts.workDir,
       windowName,
@@ -285,6 +298,7 @@ export class SessionManager {
       claudeCommand: opts.claudeCommand,
       env: hasEnv ? mergedEnv : undefined,
       permissionMode: effectivePermissionMode,
+      settingsFile: hookSettingsFile,
     });
 
     const session: SessionInfo = {
@@ -303,6 +317,7 @@ export class SessionManager {
       stallThresholdMs: opts.stallThresholdMs || SessionManager.DEFAULT_STALL_THRESHOLD_MS,
       permissionMode: effectivePermissionMode,
       settingsPatched,
+      hookSettingsFile,
     };
 
     this.state.sessions[id] = session;
@@ -706,6 +721,11 @@ export class SessionManager {
     // Permission guard: restore original settings.local.json if we patched it
     if (session.settingsPatched) {
       await restoreSettings(session.workDir);
+    }
+
+    // Issue #169 Phase 2: Clean up temp hook settings file
+    if (session.hookSettingsFile) {
+      await cleanupHookSettingsFile(session.hookSettingsFile);
     }
 
     delete this.state.sessions[id];

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -127,6 +127,8 @@ export class TmuxManager {
     resumeSessionId?: string;
     env?: Record<string, string>;
     permissionMode?: string;
+    /** Path to a CC settings JSON file (via --settings flag). */
+    settingsFile?: string;
     /** @deprecated Use permissionMode instead. Maps true→bypassPermissions, false→default. */
     autoApprove?: boolean;
   }): Promise<{ windowId: string; windowName: string; freshSessionId?: string }> {
@@ -246,6 +248,12 @@ export class TmuxManager {
       ?? (opts.autoApprove === true ? 'bypassPermissions' : opts.autoApprove === false ? 'default' : undefined);
     if (resolvedMode) {
       cmd += ` --permission-mode ${resolvedMode}`;
+    }
+
+    // Issue #169 Phase 2: Inject hook settings file if provided.
+    // This tells CC to POST hook events to Aegis's HTTP receiver.
+    if (opts.settingsFile) {
+      cmd += ` --settings ${opts.settingsFile}`;
     }
 
     // Issue #68: Unset $TMUX and $TMUX_PANE before launching Claude Code.


### PR DESCRIPTION
Phase 2 of #169. When creating a CC session, Aegis now generates a per-session settings.json with HTTP hooks for 5 supported events:

- PreToolUse → POST /v1/hooks/PreToolUse
- PostToolUse → POST /v1/hooks/PostToolUse  
- PermissionRequest → POST /v1/hooks/PermissionRequest
- Stop → POST /v1/hooks/Stop
- StopFailure → POST /v1/hooks/StopFailure

Settings passed via `--settings` flag for clean isolation. Temp file cleaned up on session kill. Non-fatal on failure.

30 new tests (1294 total).

Combined with Phase 1 (PR #184), Aegis can now receive real-time events from CC via HTTP instead of polling tmux.