### PR TITLE
fix(hooks): correct CC HTTP hook response format (#79)

### DIFF
--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -132,7 +132,7 @@ describe('HTTP Hooks (Issue #169)', () => {
   });
 
   describe('POST /v1/hooks/PreToolUse (decision event)', () => {
-    it('should return permissionDecision with decision: allow', async () => {
+    it('should return hookSpecificOutput with permissionDecision for PreToolUse (v2)', async () => {
       const res = await app.inject({
         method: 'POST',
         url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
@@ -143,7 +143,7 @@ describe('HTTP Hooks (Issue #169)', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.json().decision).toBe('allow');
+      expect(res.json().hookSpecificOutput?.permissionDecision).toBe('allow');
     });
 
     it('should emit hook event to SSE subscribers', async () => {
@@ -165,7 +165,7 @@ describe('HTTP Hooks (Issue #169)', () => {
   });
 
   describe('POST /v1/hooks/PermissionRequest (decision event)', () => {
-    it('should return decision: allow', async () => {
+    it('should return hookSpecificOutput with permissionDecision for PermissionRequest (v2)', async () => {
       const res = await app.inject({
         method: 'POST',
         url: `/v1/hooks/PermissionRequest?sessionId=${session.id}`,
@@ -173,7 +173,7 @@ describe('HTTP Hooks (Issue #169)', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.json().decision).toBe('allow');
+      expect(res.json().hookSpecificOutput?.permissionDecision).toBe('allow');
     });
   });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -99,8 +99,36 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
     }
 
     // Decision events need a response body that CC uses
+    // Format: { hookSpecificOutput: { hookEventName, permissionDecision, reason? } }
     if (DECISION_EVENTS.has(eventName)) {
-      return reply.status(200).send({ decision: 'allow' });
+      const hookBody = req.body as Record<string, unknown>;
+      const toolName = (hookBody?.tool_name as string) || '';
+      const permissionPrompt = (hookBody?.permission_prompt as string) || '';
+
+      // For PreToolUse: check tool name
+      // For PermissionRequest: check prompt content
+      // Default: allow (existing bypassPermissions behavior preserved)
+      const decision = 'allow';
+
+      if (eventName === 'PreToolUse') {
+        return reply.status(200).send({
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: decision,
+          },
+        });
+      }
+
+      if (eventName === 'PermissionRequest') {
+        return reply.status(200).send({
+          hookSpecificOutput: {
+            hookEventName: 'PermissionRequest',
+            permissionDecision: decision,
+          },
+        });
+      }
+
+      return reply.status(200).send({ ok: true });
     }
 
     // Non-decision events: simple acknowledgement

--- a/state/current-release.json
+++ b/state/current-release.json
@@ -1,1 +1,1 @@
-{"version":"1.2.1","branch":"main","status":"production","deployedAt":"2026-03-26T04:58:00Z"}
+{"version":"1.3.0","branch":"main","status":"production","deployedAt":"2026-03-26T10:53:00Z"}


### PR DESCRIPTION
Fixes #79. CC expects hookSpecificOutput format, not bare { decision }.\n\nBefore: { decision: 'allow' }\nAfter: { hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } }