### PR TITLE
feat(hooks): subagent lifecycle tracking (#88)

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -9,14 +9,14 @@
 import { EventEmitter } from 'node:events';
 
 export interface SessionSSEEvent {
-  event: 'status' | 'message' | 'approval' | 'ended' | 'heartbeat' | 'stall' | 'dead' | 'hook';
+  event: 'status' | 'message' | 'approval' | 'ended' | 'heartbeat' | 'stall' | 'dead' | 'hook' | 'subagent_start' | 'subagent_stop';
   sessionId: string;
   timestamp: string;
   data: Record<string, unknown>;
 }
 
 export interface GlobalSSEEvent {
-  event: 'session_status_change' | 'session_message' | 'session_approval' | 'session_ended' | 'session_created' | 'session_stall' | 'session_dead';
+  event: 'session_status_change' | 'session_message' | 'session_approval' | 'session_ended' | 'session_created' | 'session_stall' | 'session_dead' | 'session_subagent_start' | 'session_subagent_stop';
   sessionId: string;
   timestamp: string;
   data: Record<string, unknown>;
@@ -32,6 +32,8 @@ function toGlobalEvent(event: SessionSSEEvent): GlobalSSEEvent {
     heartbeat: 'session_status_change',
     stall: 'session_stall',
     dead: 'session_dead',
+    subagent_start: 'session_subagent_start',
+    subagent_stop: 'session_subagent_stop',
     hook: 'session_message',
   };
   return {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -89,6 +89,28 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
       return reply.status(404).send({ error: `Session ${sessionId} not found` });
     }
 
+    // Issue #88: Track active subagents
+    const hookBody = req.body as Record<string, unknown>;
+    if (eventName === 'SubagentStart') {
+      const agentName = (hookBody?.agent_name as string) || ((hookBody?.tool_input as Record<string, unknown>)?.command as string) || 'unknown';
+      deps.sessions.addSubagent(sessionId, agentName);
+      deps.eventBus.emit(sessionId, {
+        event: 'subagent_start',
+        sessionId,
+        timestamp: new Date().toISOString(),
+        data: { agentName },
+      });
+    } else if (eventName === 'SubagentStop') {
+      const agentName = (hookBody?.agent_name as string) || 'unknown';
+      deps.sessions.removeSubagent(sessionId, agentName);
+      deps.eventBus.emit(sessionId, {
+        event: 'subagent_stop',
+        sessionId,
+        timestamp: new Date().toISOString(),
+        data: { agentName },
+      });
+    }
+
     // Forward the raw hook event to SSE subscribers
     deps.eventBus.emitHook(sessionId, eventName, req.body as Record<string, unknown>);
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -33,6 +33,7 @@ export interface SessionInfo {
   settingsPatched?: boolean;     // Permission guard: settings.local.json was patched
   hookSettingsFile?: string;     // Temp file with HTTP hook settings (Issue #169)
   lastHookAt?: number;           // Unix timestamp of last received hook event (Issue #169 Phase 3)
+  activeSubagents?: string[];    // Active subagent names (Issue #88)
 }
 
 export interface SessionState {
@@ -396,6 +397,23 @@ export class SessionManager {
     session.lastActivity = now;
 
     return prevStatus;
+  }
+
+  /** Issue #88: Add an active subagent to a session. */
+  addSubagent(id: string, name: string): void {
+    const session = this.state.sessions[id];
+    if (!session) return;
+    if (!session.activeSubagents) session.activeSubagents = [];
+    if (!session.activeSubagents.includes(name)) {
+      session.activeSubagents.push(name);
+    }
+  }
+
+  /** Issue #88: Remove an active subagent from a session. */
+  removeSubagent(id: string, name: string): void {
+    const session = this.state.sessions[id];
+    if (!session || !session.activeSubagents) return;
+    session.activeSubagents = session.activeSubagents.filter(n => n !== name);
   }
 
   /** Check if a session's tmux window still exists and has a live process.


### PR DESCRIPTION
Fixes #88. Tracks active subagents via SubagentStart/Stop CC hooks.

- activeSubagents field on SessionInfo
- SSE events: subagent_start, subagent_stop
- Global SSE events: session_subagent_start, session_subagent_stop
- addSubagent/removeSubagent on SessionManager