### PR TITLE
feat(telegram): teammate/subagent awareness + /swarm command (#71)

### DIFF
--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -79,9 +79,19 @@ export class ChannelManager {
     await this.fanOut(payload, ch => ch.onStatusChange?.(payload));
   }
 
+  /** Fan out a swarm teammate event. */
+  async swarmEvent(payload: SessionEventPayload): Promise<void> {
+    await this.fanOut(payload, ch => ch.onStatusChange?.(payload));
+  }
+
   /** How many channels are registered. */
   get count(): number {
     return this.channels.length;
+  }
+
+  /** Get all registered channels (for wiring optional dependencies). */
+  getChannels(): readonly Channel[] {
+    return this.channels;
   }
 
   /** Fan out to channels, respecting filters, swallowing errors. */

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -12,6 +12,7 @@ import type {
   SessionEventPayload,
   InboundHandler,
 } from './types.js';
+import type { SwarmMonitor } from '../swarm-monitor.js';
 
 import {
   esc as styleEsc,
@@ -677,6 +678,14 @@ export class TelegramChannel implements Channel {
   // Dedup: track last user message text per session to avoid duplicates
   private lastUserMessage = new Map<string, string>();
 
+  // Issue #71: Swarm monitor for /swarm command
+  private swarmMonitor: SwarmMonitor | null = null;
+
+  /** Set the swarm monitor for /swarm command support. */
+  setSwarmMonitor(monitor: SwarmMonitor): void {
+    this.swarmMonitor = monitor;
+  }
+
   constructor(private config: TelegramChannelConfig) {}
 
   async init(onInbound: InboundHandler): Promise<void> {
@@ -1003,6 +1012,22 @@ export class TelegramChannel implements Channel {
         await this.sendStyled(payload.session.id, planStyled);
         break;
       }
+
+      case 'swarm.teammate_spawned': {
+        await this.flushReads(payload.session.id);
+        const teammateName = (payload.meta?.teammateName as string) || 'unknown';
+        const teammateId = (payload.meta?.teammateWindowId as string) || '';
+        const label = `${bold(teammateName)}${teammateId ? `  ${code(teammateId)}` : ''}`;
+        await this.sendImmediate(payload.session.id, `🔧 Teammate ${label} spawned`);
+        break;
+      }
+
+      case 'swarm.teammate_finished': {
+        await this.flushReads(payload.session.id);
+        const teammateName = (payload.meta?.teammateName as string) || 'unknown';
+        await this.sendImmediate(payload.session.id, `✅ Teammate ${bold(teammateName)} finished`);
+        break;
+      }
     }
   }
 
@@ -1274,6 +1299,35 @@ export class TelegramChannel implements Channel {
     if (rt) { clearTimeout(rt); this.readTimer.delete(sessionId); }
   }
 
+  // ── /swarm command ──────────────────────────────────────────────────
+
+  private async handleSwarmCommand(sessionId: string): Promise<void> {
+    if (!this.swarmMonitor) {
+      await this.sendImmediate(sessionId, '⚠️ Swarm monitoring not available');
+      return;
+    }
+
+    const swarm = this.swarmMonitor.findSwarmByParentSessionId(sessionId);
+    if (!swarm || swarm.teammates.length === 0) {
+      await this.sendImmediate(sessionId, '🐝 No active swarm teammates');
+      return;
+    }
+
+    const statusEmoji: Record<string, string> = {
+      running: '🔄',
+      idle: '💤',
+      dead: '💀',
+    };
+
+    const lines = [`🐝 ${bold('Swarm')}  ${swarm.teammates.length} teammate${swarm.teammates.length !== 1 ? 's' : ''}\n`];
+    for (const t of swarm.teammates) {
+      const emoji = statusEmoji[t.status] || '❓';
+      lines.push(`${emoji} ${bold(t.windowName)}  ${code(t.windowId)}  ${t.status}`);
+    }
+
+    await this.sendImmediate(sessionId, lines.join('\n'));
+  }
+
   // ── Bidirectional polling ─────────────────────────────────────────────────
 
   private async pollLoop(): Promise<void> {
@@ -1326,6 +1380,8 @@ export class TelegramChannel implements Channel {
           await this.onInbound?.({ sessionId, action: 'escape' });
         } else if (text === 'kill' || text === 'stop') {
           await this.onInbound?.({ sessionId, action: 'kill' });
+        } else if (text === '/swarm') {
+          await this.handleSwarmCommand(sessionId);
         } else if (raw.startsWith('/')) {
           await this.onInbound?.({ sessionId, action: 'command', text: raw });
         } else {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -24,7 +24,9 @@ export type SessionEvent =
   | 'status.dead'
   | 'status.stopped'
   | 'status.error'
-  | 'status.rate_limited';
+  | 'status.rate_limited'
+  | 'swarm.teammate_spawned'
+  | 'swarm.teammate_finished';
 
 /** Payload for all session events. */
 export interface SessionEventPayload {

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import {
   TelegramChannel,
   WebhookChannel,
   type InboundCommand,
+  type SessionEvent,
   type SessionEventPayload,
 } from './channels/index.js';
 import { loadConfig, type Config } from './config.js';
@@ -965,7 +966,12 @@ function addActionHints(session: import('./session.js').SessionInfo): Record<str
   return result;
 }
 
-function makePayload(event: 'session.ended', sessionId: string, detail: string): SessionEventPayload {
+function makePayload(
+  event: SessionEvent,
+  sessionId: string,
+  detail: string,
+  meta?: Record<string, unknown>,
+): SessionEventPayload {
   const session = sessions.getSession(sessionId);
   return {
     event,
@@ -976,6 +982,7 @@ function makePayload(event: 'session.ended', sessionId: string, detail: string):
       workDir: session?.workDir || '',
     },
     detail,
+    ...(meta && { meta }),
   };
 }
 
@@ -1234,7 +1241,45 @@ async function main(): Promise<void> {
 
   // Issue #81: Start swarm monitor for agent swarm awareness
   swarmMonitor = new SwarmMonitor(sessions);
+  swarmMonitor.onEvent((event) => {
+    if (!event.swarm.parentSession) return;
+    const parentId = event.swarm.parentSession.id;
+    const teammate = event.teammate;
+
+    if (event.type === 'teammate_spawned') {
+      const detail = `🔧 Teammate ${teammate.windowName} spawned`;
+      eventBus.emit(parentId, {
+        event: 'subagent_start',
+        sessionId: parentId,
+        timestamp: new Date().toISOString(),
+        data: { teammate: teammate.windowName, windowId: teammate.windowId },
+      });
+      channels.swarmEvent(makePayload('swarm.teammate_spawned', parentId, detail, {
+        teammateName: teammate.windowName,
+        teammateWindowId: teammate.windowId,
+        teammateCwd: teammate.cwd,
+      }));
+    } else if (event.type === 'teammate_finished') {
+      const detail = `✅ Teammate ${teammate.windowName} finished`;
+      eventBus.emit(parentId, {
+        event: 'subagent_stop',
+        sessionId: parentId,
+        timestamp: new Date().toISOString(),
+        data: { teammate: teammate.windowName },
+      });
+      channels.swarmEvent(makePayload('swarm.teammate_finished', parentId, detail, {
+        teammateName: teammate.windowName,
+      }));
+    }
+  });
   swarmMonitor.start();
+
+  // Issue #71: Wire swarm monitor into Telegram channel for /swarm command
+  for (const ch of channels.getChannels()) {
+    if ('setSwarmMonitor' in ch && typeof (ch as { setSwarmMonitor: unknown }).setSwarmMonitor === 'function') {
+      (ch as TelegramChannel).setSwarmMonitor(swarmMonitor);
+    }
+  }
 
   // Start reaper
   setInterval(() => reapStaleSessions(config.maxSessionAgeMs), config.reaperIntervalMs);

--- a/src/swarm-monitor.ts
+++ b/src/swarm-monitor.ts
@@ -75,15 +75,39 @@ export const DEFAULT_SWARM_CONFIG: SwarmMonitorConfig = {
   socketGlobPattern: 'tmux-claude-swarm-*',
 };
 
+/** Events emitted by SwarmMonitor when teammate state changes. */
+export type SwarmEvent =
+  | { type: 'teammate_spawned'; swarm: SwarmInfo; teammate: TeammateInfo }
+  | { type: 'teammate_finished'; swarm: SwarmInfo; teammate: TeammateInfo };
+
+/** Callback for swarm events. */
+export type SwarmEventHandler = (event: SwarmEvent) => void;
+
 export class SwarmMonitor {
   private running = false;
   private lastResult: SwarmScanResult | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private eventHandlers: SwarmEventHandler[] = [];
 
   constructor(
     private sessions: SessionManager,
     private config: SwarmMonitorConfig = DEFAULT_SWARM_CONFIG,
   ) {}
+
+  /** Register an event handler for teammate lifecycle events. */
+  onEvent(handler: SwarmEventHandler): void {
+    this.eventHandlers.push(handler);
+  }
+
+  private emitEvent(event: SwarmEvent): void {
+    for (const handler of this.eventHandlers) {
+      try {
+        handler(event);
+      } catch (e) {
+        console.error('SwarmMonitor event handler error:', e);
+      }
+    }
+  }
 
   /** Start the periodic scan loop. */
   start(): void {
@@ -126,8 +150,54 @@ export class SwarmMonitor {
       scannedAt: Date.now(),
     };
 
+    this.detectChanges();
     return this.lastResult;
   }
+
+  /** Compare current scan result against previous to detect teammate changes. */
+  private detectChanges(): void {
+    if (!this.lastResult) return;
+
+    for (const swarm of this.lastResult.swarms) {
+      if (!swarm.parentSession) continue;
+
+      const prevSwarm = this.previousTeammates.get(swarm.socketName);
+      const prevNames = new Set(prevSwarm?.map(t => t.windowName) ?? []);
+      const currentNames = new Set(swarm.teammates.map(t => t.windowName));
+
+      // New teammates
+      for (const teammate of swarm.teammates) {
+        if (!prevNames.has(teammate.windowName) && teammate.status !== 'dead') {
+          this.emitEvent({ type: 'teammate_spawned', swarm, teammate });
+        }
+      }
+
+      // Finished teammates (previously seen, now dead)
+      if (prevSwarm) {
+        for (const prev of prevSwarm) {
+          const current = swarm.teammates.find(t => t.windowName === prev.windowName);
+          if (!current) {
+            // Teammate window gone entirely
+            this.emitEvent({ type: 'teammate_finished', swarm, teammate: { ...prev, status: 'dead', alive: false } });
+          } else if (prev.status === 'running' && current.status === 'dead') {
+            this.emitEvent({ type: 'teammate_finished', swarm, teammate: current });
+          }
+        }
+      }
+
+      this.previousTeammates.set(swarm.socketName, swarm.teammates.map(t => ({ ...t })));
+    }
+
+    // Clean up stale socket tracking
+    for (const socketName of this.previousTeammates.keys()) {
+      if (!this.lastResult.swarms.find(s => s.socketName === socketName)) {
+        this.previousTeammates.delete(socketName);
+      }
+    }
+  }
+
+  /** Snapshot of teammates from previous scan for diffing. */
+  private previousTeammates = new Map<string, TeammateInfo[]>();
 
   /** Discover swarm socket directories in /tmp. */
   private async discoverSwarmSockets(): Promise<string[]> {


### PR DESCRIPTION
Telegram now detects and notifies when CC spawns teammates.

- SwarmMonitor emits teammate_spawned/teammate_finished events
- Parent Telegram topic receives 🔧/✅ notifications
- /swarm command shows current teammate status
- Event dedup via previous scan tracking