### PR TITLE
feat(ws): WebSocket terminal streaming endpoint (#108 Sprint 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^9.0.0",
+        "@fastify/websocket": "^11.2.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/node": "^25.5.0",
         "fastify": "^5.8.2",
@@ -20,6 +21,7 @@
         "aegis-bridge": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/ws": "^8.18.1",
         "vitest": "^4.1.0"
       },
       "engines": {
@@ -232,6 +234,27 @@
         "fastify-plugin": "^5.0.0",
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
+      }
+    },
+    "node_modules/@fastify/websocket": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.2.0.tgz",
+      "integrity": "sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.3",
+        "fastify-plugin": "^5.0.0",
+        "ws": "^8.16.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -647,6 +670,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1087,6 +1120,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1100,6 +1145,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2423,6 +2477,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -2515,6 +2583,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-regex2": {
       "version": "5.1.0",
@@ -2789,6 +2877,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
@@ -2912,6 +3015,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -3119,6 +3228,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@fastify/static": "^9.0.0",
+    "@fastify/websocket": "^11.2.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/node": "^25.5.0",
     "fastify": "^5.8.2",
@@ -41,6 +42,7 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@types/ws": "^8.18.1",
     "vitest": "^4.1.0"
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import Fastify from 'fastify';
 import fs from 'node:fs/promises';
 import { readFileSync, writeFileSync } from 'node:fs';
 import fastifyStatic from '@fastify/static';
+import fastifyWebsocket from '@fastify/websocket';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { TmuxManager } from './tmux.js';
@@ -33,6 +34,7 @@ import { PipelineManager, type BatchSessionSpec, type PipelineConfig } from './p
 import { AuthManager } from './auth.js';
 import { MetricsCollector } from './metrics.js';
 import { registerHookRoutes } from './hooks.js';
+import { registerWsTerminalRoute } from './ws-terminal.js';
 import { SwarmMonitor } from './swarm-monitor.js';
 import { execSync } from 'node:child_process';
 
@@ -1224,6 +1226,10 @@ async function main(): Promise<void> {
   auth = new AuthManager(join(config.stateDir, 'keys.json'), config.authToken);
   await auth.load();
   setupAuth(auth);
+
+  // Register WebSocket plugin for live terminal streaming (Issue #108)
+  await app.register(fastifyWebsocket);
+  registerWsTerminalRoute(app, sessions, tmux);
 
   // Load persisted sessions
   await sessions.load();

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -677,6 +677,12 @@ export class TmuxManager {
     }
   }
 
+  /** Resize a window's pane to the given dimensions. */
+  async resizePane(windowId: string, cols: number, rows: number): Promise<void> {
+    const target = `${this.sessionName}:${windowId}`;
+    await this.tmux('resize-pane', '-t', target, '-x', String(cols), '-y', String(rows));
+  }
+
   /** Kill a window. */
   async killWindow(windowId: string): Promise<void> {
     const target = `${this.sessionName}:${windowId}`;

--- a/src/ws-terminal.ts
+++ b/src/ws-terminal.ts
@@ -1,0 +1,137 @@
+/**
+ * ws-terminal.ts — WebSocket endpoint for live terminal streaming.
+ *
+ * WS /v1/sessions/:id/terminal
+ *
+ * Protocol:
+ *   Server → Client: { type: "pane", content: "..." }
+ *   Server → Client: { type: "status", status: "idle" }
+ *   Server → Client: { type: "error", message: "..." }
+ *   Client → Server: { type: "input", text: "..." }
+ *   Client → Server: { type: "resize", cols: 80, rows: 24 }
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { SessionManager } from './session.js';
+import type { TmuxManager } from './tmux.js';
+import type WebSocket from 'ws';
+
+const POLL_INTERVAL_MS = 500;
+
+interface WsPaneMessage {
+  type: 'pane';
+  content: string;
+}
+
+interface WsStatusMessage {
+  type: 'status';
+  status: string;
+}
+
+interface WsErrorMessage {
+  type: 'error';
+  message: string;
+}
+
+type WsOutboundMessage = WsPaneMessage | WsStatusMessage | WsErrorMessage;
+
+interface WsInputMessage {
+  type: 'input';
+  text: string;
+}
+
+interface WsResizeMessage {
+  type: 'resize';
+  cols: number;
+  rows: number;
+}
+
+type WsInboundMessage = WsInputMessage | WsResizeMessage;
+
+export function registerWsTerminalRoute(
+  app: FastifyInstance,
+  sessions: SessionManager,
+  tmux: TmuxManager,
+): void {
+  app.get<{ Params: { id: string } }>('/v1/sessions/:id/terminal', { websocket: true }, (socket, req) => {
+    const sessionId = req.params.id;
+    const session = sessions.getSession(sessionId);
+
+    if (!session) {
+      sendError(socket, 'Session not found');
+      socket.close();
+      return;
+    }
+
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+    let lastContent = '';
+    let lastStatus = '';
+    let closed = false;
+
+    // Start polling pane content
+    pollTimer = setInterval(async () => {
+      if (closed) return;
+      try {
+        const content = await tmux.capturePane(session.windowId);
+        if (content !== lastContent) {
+          lastContent = content;
+          send(socket, { type: 'pane', content });
+        }
+
+        // Also emit status changes
+        const currentStatus = session.status;
+        if (currentStatus !== lastStatus) {
+          lastStatus = currentStatus;
+          send(socket, { type: 'status', status: currentStatus });
+        }
+      } catch {
+        // Session may have been killed
+        if (!closed) {
+          sendError(socket, 'Failed to capture pane — session may have ended');
+          close();
+        }
+      }
+    }, POLL_INTERVAL_MS);
+
+    // Handle incoming messages
+    socket.on('message', async (data: Buffer | string) => {
+      if (closed) return;
+      try {
+        const msg: WsInboundMessage = JSON.parse(data.toString());
+
+        if (msg.type === 'input' && typeof msg.text === 'string') {
+          await sessions.sendMessage(sessionId, msg.text);
+        } else if (msg.type === 'resize') {
+          const cols = typeof msg.cols === 'number' ? msg.cols : 80;
+          const rows = typeof msg.rows === 'number' ? msg.rows : 24;
+          await tmux.resizePane(session.windowId, cols, rows);
+        } else {
+          sendError(socket, `Unknown message type: ${(msg as { type: string }).type}`);
+        }
+      } catch (e) {
+        sendError(socket, `Invalid message: ${(e as Error).message}`);
+      }
+    });
+
+    socket.on('close', close);
+
+    function close(): void {
+      if (closed) return;
+      closed = true;
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+    }
+  });
+}
+
+function send(ws: WebSocket, msg: WsOutboundMessage): void {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify(msg));
+  }
+}
+
+function sendError(ws: WebSocket, message: string): void {
+  send(ws, { type: 'error', message });
+}


### PR DESCRIPTION
Backend for Dashboard v2 Sprint 3.2 — Terminal Embed.

- WS /v1/sessions/:id/terminal for live terminal streaming
- Protocol: pane/status/error (server), input/resize (client)
- 500ms poll with dedup, auto-cleanup on disconnect
- Added @fastify/websocket dependency

1652 tests pass