### PR TITLE
fix(critical): MCP listSessions extracts .sessions from paginated response (#254)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -37,7 +37,8 @@ export class AegisClient {
   }
 
   async listSessions(filter?: { status?: string; workDir?: string }): Promise<any[]> {
-    let sessions = await this.request<any[]>('/v1/sessions');
+    const response = await this.request<{ sessions: any[]; total: number }>('/v1/sessions');
+    let sessions = response.sessions;
     if (filter?.status) {
       sessions = sessions.filter((s: any) => s.status === filter.status);
     }


### PR DESCRIPTION
Critical bug from auto-analysis (#254).

The /v1/sessions endpoint now returns  but MCP client expected a raw array. This broke MCP session listing.

Fix: Extract response.sessions before filtering in listSessions().