### PR TITLE
fix(high): pipeline break, permission_prompt, stateSince cleanup (#256 #257 #258)

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -298,7 +298,24 @@ export class SessionMonitor {
         }
       }
 
-      // Clean up state tracking when status changes
+      // Clean up stale state tracking on status transitions
+      const prevStatus = this.lastStatus.get(session.id);
+      if (currentStatus && currentStatus !== prevStatus) {
+        // Remove stateSince entries that no longer match current state
+        for (const key of this.stateSince.keys()) {
+          if (key.startsWith(session.id + ':') && key !== `${session.id}:${currentStatus}`) {
+            this.stateSince.delete(key);
+          }
+        }
+        // Clear stall notifications for states we're no longer in
+        for (const key of this.stallNotified.keys()) {
+          if (key.startsWith(session.id) && !key.includes(currentStatus)) {
+            this.stallNotified.delete(key);
+          }
+        }
+      }
+
+      // Full cleanup on idle recovery
       if (currentStatus === 'idle') {
         // Clear rate-limited state — session recovered
         this.rateLimitedSessions.delete(session.id);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -222,6 +222,7 @@ export class PipelineManager {
         stage.status = 'failed';
         stage.error = e.message;
         pipeline.status = 'failed';
+        break;  // Stop processing remaining stages on failure
       }
     }
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -388,7 +388,7 @@ export class SessionManager {
         session.status = 'working';
         break;
       case 'PermissionRequest':
-        session.status = 'ask_question';
+        session.status = 'permission_prompt';
         break;
       case 'StopFailure':
       case 'PostToolUseFailure':


### PR DESCRIPTION
3 High priority bug fixes.

- #256: Pipeline breaks loop on stage failure
- #257: PermissionRequest → permission_prompt (matches stall detection logic)
- #258: stateSince entries cleaned on non-idle transitions (prevents false stalls)