### PR TITLE
fix(medium): Telegram XML, CreateSessionModal race, SSE relative URL (#267 #268 #271)

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -136,10 +136,12 @@ export function getSession(id: string): Promise<SessionInfo> {
   return request(`/v1/sessions/${encodeURIComponent(id)}`, { schema: SessionInfoSchema, schemaContext: 'getSession' });
 }
 
-export function createSession(opts: CreateSessionRequest): Promise<SessionInfo> {
+export function createSession(opts: CreateSessionRequest & { signal?: AbortSignal }): Promise<SessionInfo> {
+  const { signal, ...body } = opts;
   return request('/v1/sessions', {
     method: 'POST',
-    body: JSON.stringify(opts),
+    body: JSON.stringify(body),
+    signal,
   });
 }
 
@@ -233,11 +235,12 @@ export function subscribeSSE(
   handler: (event: MessageEvent) => void,
   token?: string | null,
 ): () => void {
-  const url = new URL(`/v1/sessions/${encodeURIComponent(sessionId)}/events`, BASE_URL);
-  // #124/#125: Pass token as query param — EventSource cannot set headers
-  if (token) url.searchParams.set('token', token);
+  // #268: Use relative URL in dev so requests go through Vite proxy,
+  // avoiding token leakage in absolute URLs
+  const basePath = `/v1/sessions/${encodeURIComponent(sessionId)}/events`;
+  const url = token ? `${basePath}?token=${encodeURIComponent(token)}` : basePath;
 
-  const eventSource = new EventSource(url.toString());
+  const eventSource = new EventSource(url);
 
   eventSource.onmessage = handler;
   eventSource.onerror = () => {
@@ -257,11 +260,11 @@ export function subscribeGlobalSSE(
   handler: (event: GlobalSSEEvent) => void,
   token?: string | null,
 ): () => void {
-  const url = new URL('/v1/events', BASE_URL);
-  // #124/#125: Pass token as query param — EventSource cannot set headers
-  if (token) url.searchParams.set('token', token);
+  // #268: Use relative URL in dev so requests go through Vite proxy
+  const basePath = '/v1/events';
+  const url = token ? `${basePath}?token=${encodeURIComponent(token)}` : basePath;
 
-  const eventSource = new EventSource(url.toString());
+  const eventSource = new EventSource(url);
 
   eventSource.onmessage = (e: MessageEvent) => {
     try {

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -15,12 +15,21 @@ interface CreateSessionModalProps {
 export default function CreateSessionModal({ open, onClose }: CreateSessionModalProps) {
   const navigate = useNavigate();
   const workDirRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
-  // Close on Escape key
+  const handleClose = useCallback((): void => {
+    resetForm();
+    onClose();
+  }, [onClose]);
+
+  // Close on Escape key — abort in-flight request
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') handleClose();
+      if (e.key === 'Escape') {
+        abortRef.current?.abort();
+        handleClose();
+      }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
@@ -51,11 +60,6 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
     setError(null);
   }
 
-  const handleClose = useCallback((): void => {
-    resetForm();
-    onClose();
-  }, [onClose]);
-
   if (!open) return null;
 
   async function handleSubmit(e: React.FormEvent) {
@@ -68,20 +72,27 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
     }
 
     setLoading(true);
+    const controller = new AbortController();
+    abortRef.current = controller;
     try {
       const session = await createSession({
         workDir: workDir.trim(),
         name: name.trim() || undefined,
         prompt: prompt.trim() || undefined,
         permissionMode,
+        signal: controller.signal,
       });
       resetForm();
       onClose();
       navigate(`/sessions/${session.id}`);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setError(err instanceof Error ? err.message : 'Failed to create session');
     } finally {
-      setLoading(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setLoading(false);
+      }
     }
   }
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -194,13 +194,9 @@ function stripXmlTags(text: string): string {
   result = result.replace(/<antml:[a-z]+>[\s\S]*?<\/antml:[a-z]+>/gi, '');
   result = result.replace(/<antml:[a-z]+\/>/gi, '');
 
-  // 4. Strip any leftover self-closing XML-like tags
-  result = result.replace(/<\/?[a-z][a-z0-9_-]*(?:\s[^>]*)?\/?>/gi, (match) => {
-    // But preserve HTML tags we use: <b>, <i>, <code>, <pre>, <blockquote>, <a>
-    const tag = match.match(/<\/?([a-z]+)/i)?.[1]?.toLowerCase() || '';
-    if (['b', 'i', 'code', 'pre', 'blockquote', 'a'].includes(tag)) return match;
-    return '';
-  });
+  // 4. Strip remaining known CC internal tags (self-closing or unmatched)
+  // Only strip tags from known CC namespaces, not arbitrary angle-bracket content
+  result = result.replace(/<\/?(?:local-command-[a-z]+|antml:[a-z]+)(?:\s[^>]*)?\/?>/gi, '');
 
   // 5. Clean up whitespace left behind
   result = result.replace(/\n{3,}/g, '\n\n').trim();


### PR DESCRIPTION
3 Medium priority bug fixes.

- #267: CreateSessionModal AbortController for Escape-during-submit
- #268: SSE EventSource uses relative URL via Vite proxy
- #271: Telegram XML stripping only targets known CC tags

1684 tests pass