### PR TITLE
fix: default to bypassPermissions for headless sessions

### DIFF
--- a/src/__tests__/auto-approve.test.ts
+++ b/src/__tests__/auto-approve.test.ts
@@ -9,15 +9,15 @@ const AUTO_APPROVE_MODES = new Set(['bypassPermissions', 'dontAsk', 'acceptEdits
 
 describe('Permission mode', () => {
   describe('SessionInfo.permissionMode', () => {
-    it('should default to "default" when not specified', () => {
+    it('should default to "bypassPermissions" when not specified', () => {
       const val: string | undefined = undefined;
-      const permissionMode = val ?? 'default';
-      expect(permissionMode).toBe('default');
+      const permissionMode = val ?? 'bypassPermissions';
+      expect(permissionMode).toBe('bypassPermissions');
     });
 
     it('should accept a permission mode string from session creation opts', () => {
       const opts = { permissionMode: 'acceptEdits' };
-      const permissionMode = opts.permissionMode ?? 'default';
+      const permissionMode = opts.permissionMode ?? 'bypassPermissions';
       expect(permissionMode).toBe('acceptEdits');
     });
 
@@ -145,9 +145,9 @@ describe('Permission mode', () => {
   });
 
   describe('Config.defaultPermissionMode', () => {
-    it('should default to "default"', () => {
-      const defaultPermissionMode = 'default';
-      expect(defaultPermissionMode).toBe('default');
+    it('should default to "bypassPermissions"', () => {
+      const defaultPermissionMode = 'bypassPermissions';
+      expect(defaultPermissionMode).toBe('bypassPermissions');
     });
 
     it('should be overridable to other modes', () => {

--- a/src/__tests__/session-persistence.test.ts
+++ b/src/__tests__/session-persistence.test.ts
@@ -55,9 +55,9 @@ describe('Session persistence and resume (Issue #35)', () => {
       expect(workDir).toBe(homedir());
     });
 
-    it('should set permissionMode to "default" for adopted sessions', () => {
-      const permissionMode = 'default';
-      expect(permissionMode).toBe('default');
+    it('should set permissionMode to "bypassPermissions" for adopted sessions', () => {
+      const permissionMode = 'bypassPermissions';
+      expect(permissionMode).toBe('bypassPermissions');
     });
 
     it('should set status to unknown for adopted sessions', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,9 @@ export interface Config {
   /** Default env vars injected into every CC session (e.g. model overrides, API keys).
    *  Per-session env vars from the API merge on top (per-session wins). */
   defaultSessionEnv: Record<string, string>;
-  /** Default permission mode for new sessions (default: "default").
+  /** Default permission mode for new sessions (default: "bypassPermissions").
+   *  Aegis is headless — there is no human at the TTY to approve prompts.
+   *  Set explicitly to "default" if approval gating is needed.
    *  Values: "default" | "plan" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "auto" */
   defaultPermissionMode: string;
   /** Stall threshold for monitor (ms). */
@@ -63,7 +65,7 @@ const defaults: Config = {
   tgGroupId: '',
   webhooks: [],
   defaultSessionEnv: {},
-  defaultPermissionMode: 'default',
+  defaultPermissionMode: 'bypassPermissions',
   stallThresholdMs: 5 * 60 * 1000,
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -413,12 +413,13 @@ app.post('/v1/sessions', async (req, reply) => {
   console.timeEnd("POST_CHANNEL_CREATED"); console.time("POST_SEND_INITIAL_PROMPT");
 
   // Now send the prompt (topic exists, monitor can forward messages)
-  console.timeEnd("POST_SEND_INITIAL_PROMPT"); console.time("POST_REPLY");
   let promptDelivery: { delivered: boolean; attempts: number } | undefined;
-  console.timeEnd("POST_REPLY");
   if (prompt) {
     promptDelivery = await sessions.sendInitialPrompt(session.id, prompt);
+    console.timeEnd("POST_SEND_INITIAL_PROMPT");
     metrics.promptSent(promptDelivery.delivered);
+  } else {
+    console.timeEnd("POST_SEND_INITIAL_PROMPT");
   }
 
   return reply.status(201).send({ ...session, promptDelivery });

--- a/src/session.ts
+++ b/src/session.ts
@@ -322,7 +322,7 @@ export class SessionManager {
     const effectivePermissionMode = opts.permissionMode
       ?? (opts.autoApprove === true ? 'bypassPermissions' : opts.autoApprove === false ? 'default' : undefined)
       ?? this.config.defaultPermissionMode
-      ?? 'default';
+      ?? 'bypassPermissions';
     let settingsPatched = false;
     if (effectivePermissionMode !== 'bypassPermissions') {
       settingsPatched = await neutralizeBypassPermissions(opts.workDir, effectivePermissionMode);


### PR DESCRIPTION
## Summary

Fixes #320 — Claude Code never starts because sessions default to `"default"` permission mode, causing CC to ask for approval on every tool use with no human to approve it. CC times out after ~7s and fires the Stop hook.

- **Change default permission mode** from `"default"` to `"bypassPermissions"` in both `config.ts` defaults and the `session.ts` hardcoded fallback
- **Fix misleading `console.time/timeEnd`** in `POST /v1/sessions` — `POST_SEND_INITIAL_PROMPT` was ending before `sendInitialPrompt()` was actually called
- Update affected tests to reflect the new default

Sessions that need approval gating can explicitly set `permissionMode: "default"` in the create request.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 1712 passed, 0 failures
- [ ] Manual: create a session without `permissionMode` → should start in `bypassPermissions` mode
- [ ] Manual: create a session with `permissionMode: "default"` → should still respect explicit setting

Generated by Hephaestus (Aegis dev agent)