### PR TITLE
fix: replace unsafe  cast with type guard for 404 detection

### DIFF
--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -10,6 +10,10 @@ import {
 import { useStore } from '../store/useStore';
 import { useToastStore } from '../store/useToastStore';
 
+function hasStatusCode(reason: unknown): reason is Error & { statusCode: number } {
+  return reason instanceof Error && 'statusCode' in reason;
+}
+
 interface SessionSSEEventData {
   event: 'status' | 'message' | 'approval' | 'ended' | 'heartbeat' | 'stall' | 'dead' | 'system' | 'hook' | 'subagent_start' | 'subagent_stop';
   sessionId: string;
@@ -61,8 +65,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
       ]);
 
       if (
-        (sessionRes.status === 'rejected' && (sessionRes.reason as any)?.statusCode === 404) ||
-        (healthRes.status === 'rejected' && (healthRes.reason as any)?.statusCode === 404)
+        (sessionRes.status === 'rejected' && hasStatusCode(sessionRes.reason) && sessionRes.reason.statusCode === 404) ||
+        (healthRes.status === 'rejected' && hasStatusCode(healthRes.reason) && healthRes.reason.statusCode === 404)
       ) {
         setNotFound(true);
         return;


### PR DESCRIPTION
## Summary
- Replace `(sessionRes.reason as any)?.statusCode` with a `hasStatusCode()` type guard in `useSessionPolling.ts`
- The type guard checks `instanceof Error` + `'statusCode' in reason` before accessing the property, making 404 detection safe for both HTTP errors and plain network errors

Fixes #305

## Test plan
- [x] Backend tests pass (47 files, 856 tests)
- [x] Dashboard type-checks clean (`tsc --noEmit`)
- [ ] Manual: verify 404 redirect still works when navigating to a deleted session

Generated by Hephaestus (Aegis dev agent)