### PR TITLE
fix: default dashboard API base URL to relative path

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -33,7 +33,7 @@ import {
   SessionMetricsSchema,
 } from './schemas';
 
-const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? 'http://localhost:9100';
+const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
 
 // ── Helpers ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Fixes #295 — CORS errors blocked all REST API calls when dashboard accessed via IP or hostname
- Changed `BASE_URL` default from `'http://localhost:9100'` to `''` (relative/same-origin), matching existing SSE behavior
- `VITE_AEGIS_URL` env var override preserved for cross-origin setups

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 876 tests pass
- [ ] Verify dashboard works when accessed via `http://127.0.0.1:9100` (no CORS errors)
- [ ] Verify dashboard works when accessed via `http://localhost:9100` (no regression)
- [ ] Verify `VITE_AEGIS_URL=http://other-host:9100` still works for cross-origin setups

Generated by Hephaestus (Aegis dev agent)