### PR TITLE
fix: handle SSE back-pressure, disconnect slow clients (#302)

### DIFF
--- a/src/__tests__/sse-writer.test.ts
+++ b/src/__tests__/sse-writer.test.ts
@@ -1,0 +1,184 @@
+/**
+ * sse-writer.test.ts — Tests for Issue #302: SSE back-pressure handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ServerResponse, IncomingMessage } from 'node:http';
+import { SSEWriter } from '../sse-writer.js';
+
+/** Create a mock ServerResponse for testing. */
+function createMockRes(): { res: ServerResponse; destroyed: boolean; written: string[]; corkCalls: number } {
+  const written: string[] = [];
+  let corkCalls = 0;
+  let destroyed = false;
+
+  const res = {
+    write(chunk: string): boolean {
+      if (destroyed) throw new Error('Response was destroyed');
+      written.push(chunk);
+      return true; // buffer not full by default
+    },
+    destroy(): void {
+      destroyed = true;
+    },
+    cork(): void {
+      corkCalls++;
+    },
+    setHeader(): ServerResponse { return res as unknown as ServerResponse; },
+    writeHead(): ServerResponse { return res as unknown as ServerResponse; },
+  } as unknown as ServerResponse;
+
+  return { res, destroyed: false, written, corkCalls: 0 };
+}
+
+describe('SSEWriter (Issue #302)', () => {
+  it('should write SSE data to the response', () => {
+    const { res, written } = createMockRes();
+    const req = { on: vi.fn() } as unknown as IncomingMessage;
+    const writer = new SSEWriter(res, req, vi.fn());
+
+    const ok = writer.write('data: {"event":"test"}\n\n');
+
+    expect(ok).toBe(true);
+    expect(written).toHaveLength(1);
+    expect(written[0]).toBe('data: {"event":"test"}\n\n');
+  });
+
+  it('should return false and destroy connection after MAX_CONSECUTIVE_FAILURES failed writes', () => {
+    const { res, written } = createMockRes();
+    // Make write return false (buffer full)
+    vi.spyOn(res, 'write').mockReturnValue(false);
+    const req = { on: vi.fn() } as unknown as IncomingMessage;
+    const writer = new SSEWriter(res, req, vi.fn());
+
+    // 1st failure
+    expect(writer.write('data: 1\n\n')).toBe(true); // still within threshold
+    // 2nd failure
+    expect(writer.write('data: 2\n\n')).toBe(true); // still within threshold
+    // 3rd failure — should destroy
+    expect(writer.write('data: 3\n\n')).toBe(false);
+    expect(written).toHaveLength(0); // never actually wrote (or wrote but we track failures)
+  });
+
+  it('should reset failure counter on successful write', () => {
+    const { res, written } = createMockRes();
+    const writeMock = vi.spyOn(res, 'write');
+    const req = { on: vi.fn() } as unknown as IncomingMessage;
+    const writer = new SSEWriter(res, req, vi.fn());
+
+    // Fail twice
+    writeMock.mockReturnValue(false);
+    writer.write('data: fail1\n\n');
+    writer.write('data: fail2\n\n');
+
+    // Succeed — resets counter
+    writeMock.mockReturnValue(true);
+    expect(writer.write('data: ok\n\n')).toBe(true);
+
+    // Fail twice more — should NOT destroy (counter was reset)
+    writeMock.mockReturnValue(false);
+    writer.write('data: fail3\n\n');
+    writer.write('data: fail4\n\n');
+    // 3rd failure after reset should destroy
+    expect(writer.write('data: fail5\n\n')).toBe(false);
+  });
+
+  it('should call onCleanup when destroyed due to back-pressure', () => {
+    const { res } = createMockRes();
+    vi.spyOn(res, 'write').mockReturnValue(false);
+    const req = { on: vi.fn() } as unknown as IncomingMessage;
+    const onCleanup = vi.fn();
+    const writer = new SSEWriter(res, req, onCleanup);
+
+    // Trigger destroy via consecutive failures
+    writer.write('data: 1\n\n');
+    writer.write('data: 2\n\n');
+    writer.write('data: 3\n\n');
+
+    expect(onCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('should register close listener on req', () => {
+    const { res } = createMockRes();
+    let closeHandler: (() => void) | undefined;
+    const req = {
+      on(event: string, handler: () => void): IncomingMessage {
+        if (event === 'close') closeHandler = handler;
+        return req as unknown as IncomingMessage;
+      },
+    } as unknown as IncomingMessage;
+    const onCleanup = vi.fn();
+    new SSEWriter(res, req, onCleanup);
+
+    expect(closeHandler).toBeDefined();
+    closeHandler!();
+    expect(onCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not write after connection is destroyed', () => {
+    const { res, written } = createMockRes();
+    vi.spyOn(res, 'write').mockReturnValue(false);
+    const req = { on: vi.fn() } as unknown as IncomingMessage;
+    const writer = new SSEWriter(res, req, vi.fn());
+
+    // Destroy via back-pressure
+    writer.write('data: 1\n\n');
+    writer.write('data: 2\n\n');
+    writer.write('data: 3\n\n');
+
+    // Further writes should be no-ops
+    writer.write('data: after\n\n');
+    expect(written).toHaveLength(0);
+  });
+
+  describe('heartbeat', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should send heartbeat at interval', () => {
+      const { res, written } = createMockRes();
+      const req = { on: vi.fn() } as unknown as IncomingMessage;
+      const writer = new SSEWriter(res, req, vi.fn());
+
+      writer.startHeartbeat(30_000, 90_000, () => 'data: {"event":"heartbeat"}\n\n');
+
+      vi.advanceTimersByTime(30_000);
+      expect(written.some(w => w.includes('"heartbeat"'))).toBe(true);
+    });
+
+    it('should destroy connection after idle timeout', () => {
+      const { res } = createMockRes();
+      // Make writes fail so heartbeat doesn't reset the idle timer
+      vi.spyOn(res, 'write').mockReturnValue(false);
+      const req = { on: vi.fn() } as unknown as IncomingMessage;
+      const onCleanup = vi.fn();
+      const writer = new SSEWriter(res, req, onCleanup);
+
+      writer.startHeartbeat(30_000, 90_000, () => 'data: {"event":"heartbeat"}\n\n');
+
+      // Advance past idle timeout. Since writes fail, lastWrite is never updated.
+      // At 120s interval fire, Date.now()-lastWrite = 120000 > 90000
+      vi.advanceTimersByTime(120_001);
+
+      expect(onCleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clean up interval when stopped', () => {
+      const { res, written } = createMockRes();
+      const req = { on: vi.fn() } as unknown as IncomingMessage;
+      const writer = new SSEWriter(res, req, vi.fn());
+
+      const stop = writer.startHeartbeat(30_000, 90_000, () => 'data: {"event":"heartbeat"}\n\n');
+
+      stop();
+      const countBefore = written.filter(w => w.includes('"heartbeat"')).length;
+      vi.advanceTimersByTime(120_000);
+      const countAfter = written.filter(w => w.includes('"heartbeat"')).length;
+      expect(countAfter).toBe(countBefore);
+    });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import {
 import { loadConfig, type Config } from './config.js';
 import { captureScreenshot, isPlaywrightAvailable } from './screenshot.js';
 import { SessionEventBus, type SessionSSEEvent, type GlobalSSEEvent } from './events.js';
+import { SSEWriter } from './sse-writer.js';
 import { PipelineManager, type BatchSessionSpec, type PipelineConfig } from './pipeline.js';
 import { AuthManager } from './auth.js';
 import { MetricsCollector } from './metrics.js';
@@ -312,42 +313,23 @@ app.get('/v1/events', async (_req, reply) => {
     'X-Accel-Buffering': 'no',
   });
 
-  let lastWrite = Date.now();
+  let unsubscribe: (() => void) | undefined;
 
-  const activeSessions = sessions.listSessions();
-  reply.raw.write(`data: ${JSON.stringify({
+  const writer = new SSEWriter(reply.raw, _req.raw, () => unsubscribe?.());
+  writer.write(`data: ${JSON.stringify({
     event: 'connected',
     timestamp: new Date().toISOString(),
-    data: { activeSessions: activeSessions.length },
+    data: { activeSessions: sessions.listSessions().length },
   })}\n\n`);
 
-  const handler = (event: GlobalSSEEvent) => {
-    try {
-      reply.raw.write(`data: ${JSON.stringify(event)}\n\n`);
-      lastWrite = Date.now();
-    } catch { /* connection closed */ }
+  const handler = (event: GlobalSSEEvent): void => {
+    writer.write(`data: ${JSON.stringify(event)}\n\n`);
   };
 
-  const unsubscribe = eventBus.subscribeGlobal(handler);
-
-  const heartbeat = setInterval(() => {
-    // Issue #308: Close zombie connections (no successful write in 90s)
-    if (Date.now() - lastWrite > 90_000) {
-      try { reply.raw.destroy(); } catch { /* already closed */ }
-      clearInterval(heartbeat);
-      unsubscribe();
-      return;
-    }
-    try {
-      reply.raw.write(`data: ${JSON.stringify({ event: 'heartbeat', timestamp: new Date().toISOString() })}\n\n`);
-      lastWrite = Date.now();
-    } catch { clearInterval(heartbeat); unsubscribe(); }
-  }, 30_000);
-
-  _req.raw.on('close', () => {
-    unsubscribe();
-    clearInterval(heartbeat);
-  });
+  unsubscribe = eventBus.subscribeGlobal(handler);
+  writer.startHeartbeat(30_000, 90_000, () =>
+    `data: ${JSON.stringify({ event: 'heartbeat', timestamp: new Date().toISOString() })}\n\n`
+  );
 
   await reply;
 });
@@ -916,21 +898,17 @@ app.get<{ Params: { id: string } }>('/v1/sessions/:id/events', async (req, reply
     'X-Accel-Buffering': 'no',
   });
 
-  let lastWrite = Date.now();
+  let unsubscribe: (() => void) | undefined;
+
+  const writer = new SSEWriter(reply.raw, req.raw, () => unsubscribe?.());
 
   const writeSSE = (event: SessionSSEEvent): boolean => {
-    try {
-      const id = event.id != null ? `id: ${event.id}\n` : '';
-      reply.raw.write(`${id}data: ${JSON.stringify(event)}\n\n`);
-      lastWrite = Date.now();
-      return true;
-    } catch {
-      return false;
-    }
+    const id = event.id != null ? `id: ${event.id}\n` : '';
+    return writer.write(`${id}data: ${JSON.stringify(event)}\n\n`);
   };
 
   // Send initial connected event
-  reply.raw.write(`data: ${JSON.stringify({ event: 'connected', sessionId: session.id, timestamp: new Date().toISOString() })}\n\n`);
+  writer.write(`data: ${JSON.stringify({ event: 'connected', sessionId: session.id, timestamp: new Date().toISOString() })}\n\n`);
 
   // Issue #308: Replay missed events if client sends Last-Event-ID
   const lastEventId = req.headers['last-event-id'];
@@ -942,35 +920,14 @@ app.get<{ Params: { id: string } }>('/v1/sessions/:id/events', async (req, reply
   }
 
   // Subscribe to session events
-  const handler = (event: SessionSSEEvent) => {
+  const handler = (event: SessionSSEEvent): void => {
     writeSSE(event);
   };
 
-  const unsubscribe = eventBus.subscribe(req.params.id, handler);
-
-  // Heartbeat every 30s + idle timeout check
-  const heartbeat = setInterval(() => {
-    // Issue #308: Close zombie connections (no successful write in 90s)
-    if (Date.now() - lastWrite > 90_000) {
-      try { reply.raw.destroy(); } catch { /* already closed */ }
-      clearInterval(heartbeat);
-      unsubscribe();
-      return;
-    }
-    try {
-      reply.raw.write(`data: ${JSON.stringify({ event: 'heartbeat', sessionId: session.id, timestamp: new Date().toISOString() })}\n\n`);
-      lastWrite = Date.now();
-    } catch {
-      clearInterval(heartbeat);
-      unsubscribe();
-    }
-  }, 30_000);
-
-  // Clean up on disconnect
-  req.raw.on('close', () => {
-    unsubscribe();
-    clearInterval(heartbeat);
-  });
+  unsubscribe = eventBus.subscribe(req.params.id, handler);
+  writer.startHeartbeat(30_000, 90_000, () =>
+    `data: ${JSON.stringify({ event: 'heartbeat', sessionId: session.id, timestamp: new Date().toISOString() })}\n\n`
+  );
 
   // Don't let Fastify auto-send (we manage the response manually)
   await reply;

--- a/src/sse-writer.ts
+++ b/src/sse-writer.ts
@@ -1,0 +1,98 @@
+/**
+ * sse-writer.ts — SSE write helper with back-pressure handling.
+ *
+ * Issue #302: Check reply.raw.write() return value and disconnect
+ * slow clients after consecutive failed writes.
+ */
+
+import type { ServerResponse, IncomingMessage } from 'node:http';
+
+export class SSEWriter {
+  private consecutiveFailures = 0;
+  private isDestroyed = false;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private lastWrite = Date.now();
+
+  /** Drop slow clients after this many consecutive write() calls returning false. */
+  private static readonly MAX_CONSECUTIVE_FAILURES = 3;
+
+  constructor(
+    private readonly res: ServerResponse,
+    req: IncomingMessage,
+    private readonly onCleanup: () => void,
+  ) {
+    req.on('close', () => this.cleanup());
+  }
+
+  /**
+   * Write SSE data to the response.
+   * Returns true if the write succeeded (or is within failure threshold).
+   * Returns false if the connection was destroyed due to back-pressure.
+   */
+  write(data: string): boolean {
+    if (this.isDestroyed) return false;
+
+    try {
+      const canContinue = this.res.write(data);
+      if (!canContinue) {
+        this.consecutiveFailures++;
+        if (this.consecutiveFailures >= SSEWriter.MAX_CONSECUTIVE_FAILURES) {
+          this.destroy();
+          return false;
+        }
+      } else {
+        this.consecutiveFailures = 0;
+        this.lastWrite = Date.now();
+      }
+      return true;
+    } catch {
+      this.destroy();
+      return false;
+    }
+  }
+
+  /**
+   * Start heartbeat + idle timeout loop.
+   * Returns a stop function to cancel the timer.
+   */
+  startHeartbeat(intervalMs: number, idleTimeoutMs: number, buildEvent: () => string): () => void {
+    this.heartbeatTimer = setInterval(() => {
+      if (this.isDestroyed) {
+        clearInterval(this.heartbeatTimer!);
+        return;
+      }
+      if (Date.now() - this.lastWrite > idleTimeoutMs) {
+        this.destroy();
+        return;
+      }
+      this.write(buildEvent());
+    }, intervalMs);
+
+    return () => {
+      if (this.heartbeatTimer) {
+        clearInterval(this.heartbeatTimer);
+        this.heartbeatTimer = null;
+      }
+    };
+  }
+
+  private destroy(): void {
+    if (this.isDestroyed) return;
+    this.isDestroyed = true;
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    try { this.res.destroy(); } catch { /* already closed */ }
+    this.onCleanup();
+  }
+
+  private cleanup(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.isDestroyed = true;
+    this.onCleanup();
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SSEWriter` class that checks `reply.raw.write()` return value and destroys connections after 3 consecutive back-pressure failures
- Refactor both SSE routes (`/v1/events` and `/v1/sessions/:id/events`) to use `SSEWriter`, eliminating duplicated heartbeat/idle-timeout/close-handler logic

Fixes #302

## Test plan
- [x] 9 new tests in `sse-writer.test.ts` covering write success, back-pressure disconnect, failure counter reset, cleanup callbacks, destroyed-state guard, and heartbeat idle timeout
- [x] All 891 existing tests pass
- [x] `tsc --noEmit` passes

Generated by Hephaestus (Aegis dev agent)