### PR TITLE
fix: prevent AbortError retry and stale debounce timers (#298, #299)

### DIFF
--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -1,0 +1,33 @@
+/**
+ * client.test.ts — Tests for retry logic (Issue #298).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isRetryableError } from '../api/client';
+
+describe('isRetryableError', () => {
+  it('returns false for AbortError (should not retry)', () => {
+    const error = new DOMException('The operation was aborted', 'AbortError');
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  it('returns false for errors with HTTP status in message', () => {
+    const error = new Error('HTTP 500 Internal Server Error');
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  it('returns true for network errors', () => {
+    const error = new Error('fetch failed');
+    expect(isRetryableError(error)).toBe(true);
+  });
+
+  it('returns true for timeout errors', () => {
+    const error = new Error('NetworkError: Failed to fetch');
+    expect(isRetryableError(error)).toBe(true);
+  });
+
+  it('returns false for errors without a message', () => {
+    const error = new Error('');
+    expect(isRetryableError(error)).toBe(false);
+  });
+});

--- a/dashboard/src/__tests__/useSessionPolling.test.ts
+++ b/dashboard/src/__tests__/useSessionPolling.test.ts
@@ -1,0 +1,206 @@
+/**
+ * useSessionPolling.test.ts — Tests for debounce timer cleanup (Issue #299).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSessionPolling } from '../hooks/useSessionPolling';
+
+// Mock dependencies
+vi.mock('../api/client', () => ({
+  getSession: vi.fn(),
+  getSessionHealth: vi.fn(),
+  getSessionPane: vi.fn(),
+  getSessionMetrics: vi.fn(),
+  subscribeSSE: vi.fn(),
+}));
+
+vi.mock('../store/useStore', () => ({
+  useStore: vi.fn(),
+}));
+
+vi.mock('../store/useToastStore', () => ({
+  useToastStore: vi.fn(),
+}));
+
+import { getSession, getSessionHealth, getSessionPane, getSessionMetrics, subscribeSSE } from '../api/client';
+import { useStore } from '../store/useStore';
+import { useToastStore } from '../store/useToastStore';
+
+const mockedGetSession = vi.mocked(getSession);
+const mockedGetSessionHealth = vi.mocked(getSessionHealth);
+const mockedGetSessionPane = vi.mocked(getSessionPane);
+const mockedGetSessionMetrics = vi.mocked(getSessionMetrics);
+const mockedSubscribeSSE = vi.mocked(subscribeSSE);
+
+describe('useSessionPolling', () => {
+  let capturedHandler: ((e: MessageEvent) => void) | null = null;
+  let unsubscribeFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    capturedHandler = null;
+    unsubscribeFn = vi.fn();
+
+    vi.mocked(useStore).mockReturnValue({ token: 'test-token' });
+    vi.mocked(useToastStore).mockReturnValue({ addToast: vi.fn() });
+
+    mockedGetSession.mockResolvedValue({
+      id: 'session-a',
+      windowId: 'w1',
+      windowName: 'test',
+      workDir: '/tmp',
+      status: 'idle',
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+      stallThresholdMs: 300000,
+      permissionMode: 'default',
+      byteOffset: 0,
+      monitorOffset: 0,
+    } as any);
+    mockedGetSessionHealth.mockResolvedValue({
+      alive: true,
+      windowExists: true,
+      claudeRunning: true,
+      paneCommand: null,
+      status: 'idle',
+      hasTranscript: false,
+      lastActivity: Date.now(),
+      lastActivityAgo: 0,
+      sessionAge: 0,
+      details: '',
+    });
+    mockedGetSessionPane.mockResolvedValue({ pane: 'content' });
+    mockedGetSessionMetrics.mockResolvedValue({
+      durationSec: 0,
+      messages: 0,
+      toolCalls: 0,
+      approvals: 0,
+      autoApprovals: 0,
+      statusChanges: [],
+    });
+
+    mockedSubscribeSSE.mockImplementation((_: string, handler: (e: MessageEvent) => void) => {
+      capturedHandler = handler;
+      return unsubscribeFn;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('cancels pending debounce timers when sessionId changes', async () => {
+    const { rerender } = renderHook(
+      ({ id }) => useSessionPolling(id),
+      { initialProps: { id: 'session-a' } },
+    );
+
+    // Wait for initial load to complete
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Reset call counts after initial load
+    mockedGetSessionPane.mockClear();
+    mockedGetSessionHealth.mockClear();
+
+    // Simulate an SSE event that triggers debounced refetch
+    act(() => {
+      capturedHandler!(
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            event: 'status',
+            sessionId: 'session-a',
+            timestamp: new Date().toISOString(),
+            data: {},
+          }),
+        }),
+      );
+    });
+
+    // Change sessionId BEFORE debounce fires (debounce is 1000ms)
+    mockedGetSession.mockResolvedValue({
+      id: 'session-b',
+      windowId: 'w2',
+      windowName: 'test-b',
+      workDir: '/tmp',
+      status: 'idle',
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+      stallThresholdMs: 300000,
+      permissionMode: 'default',
+      byteOffset: 0,
+      monitorOffset: 0,
+    } as any);
+
+    rerender({ id: 'session-b' });
+
+    // Wait for new session's initial load
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Reset after new session load
+    mockedGetSessionPane.mockClear();
+    mockedGetSessionHealth.mockClear();
+
+    // Advance past the debounce period
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    // The old debounce timer should NOT have fired
+    // If the fix is missing, getSessionPane would be called with the stale ref
+    expect(mockedGetSessionPane).not.toHaveBeenCalled();
+    expect(mockedGetSessionHealth).not.toHaveBeenCalled();
+  });
+
+  it('discards stale debounce callbacks via generation counter', async () => {
+    const { rerender } = renderHook(
+      ({ id }) => useSessionPolling(id),
+      { initialProps: { id: 'session-a' } },
+    );
+
+    // Wait for initial load
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    mockedGetSessionPane.mockClear();
+
+    // Simulate SSE event triggering debounce
+    act(() => {
+      capturedHandler!(
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            event: 'message',
+            sessionId: 'session-a',
+            timestamp: new Date().toISOString(),
+            data: {},
+          }),
+        }),
+      );
+    });
+
+    // Switch session immediately
+    rerender({ id: 'session-b' });
+
+    // Wait for new session's initial load
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Clear counters after new session load
+    const callsAfterSwitch = mockedGetSessionPane.mock.calls.length;
+
+    // Advance past debounce period
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    // No additional calls should have been made by the old debounce
+    expect(mockedGetSessionPane.mock.calls.length).toBe(callsAfterSwitch);
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -60,6 +60,16 @@ function validateResponse<T>(data: unknown, schema: z.ZodType<T>, context: strin
   return data as T;
 }
 
+// ── Error classification ────────────────────────────────────────
+
+/** Returns true if the error is a transient failure worth retrying. */
+export function isRetryableError(error: Error): boolean {
+  if (error.name === 'AbortError') return false;
+  if (!error.message) return false;
+  if (error.message.includes('HTTP ')) return false;
+  return true;
+}
+
 // ── Fetch wrapper ───────────────────────────────────────────────
 
 interface RequestOptions extends RequestInit {
@@ -101,8 +111,8 @@ async function request<T>(
       return data as T;
     } catch (e) {
       lastError = e as Error;
-      // Retry only on network errors (not on HTTP error responses)
-      if (attempt < retries && lastError.message && !lastError.message.includes('HTTP ')) {
+      // Retry only on transient network errors (not HTTP errors or AbortError)
+      if (attempt < retries && isRetryableError(lastError)) {
         await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt)));
       } else {
         throw lastError;

--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -55,6 +55,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
   const cancelledRef = useRef(false);
+  const generationRef = useRef(0);
 
   // Fetch session + health
   const loadSessionAndHealth = useCallback(async () => {
@@ -108,6 +109,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   // Initial load
   useEffect(() => {
     cancelledRef.current = false;
+    generationRef.current++;
     setLoading(true);
     setPaneLoading(true);
     setMetricsLoading(true);
@@ -115,7 +117,11 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     loadSessionAndHealth();
     loadPaneAndMetrics();
 
-    return () => { cancelledRef.current = true; };
+    return () => {
+      cancelledRef.current = true;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (sessionDebounceRef.current) clearTimeout(sessionDebounceRef.current);
+    };
   }, [sessionId, loadSessionAndHealth, loadPaneAndMetrics]);
 
   // Debounced refetch timers
@@ -124,25 +130,21 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
 
   const schedulePaneAndMetricsRefetch = useCallback(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    const gen = generationRef.current;
     debounceRef.current = setTimeout(() => {
+      if (generationRef.current !== gen) return;
       loadPaneAndMetrics();
     }, 1000);
   }, [loadPaneAndMetrics]);
 
   const scheduleSessionAndHealthRefetch = useCallback(() => {
     if (sessionDebounceRef.current) clearTimeout(sessionDebounceRef.current);
+    const gen = generationRef.current;
     sessionDebounceRef.current = setTimeout(() => {
+      if (generationRef.current !== gen) return;
       loadSessionAndHealth();
     }, 1000);
   }, [loadSessionAndHealth]);
-
-  // Cleanup debounce on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      if (sessionDebounceRef.current) clearTimeout(sessionDebounceRef.current);
-    };
-  }, []);
 
   // SSE subscription — drives all refetching
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **#298**: Extract `isRetryableError()` to classify errors for retry eligibility — `AbortError` now propagates immediately instead of being retried, fixing request cancellation
- **#299**: Add generation counter and move debounce timer cleanup into the `sessionId`-dependent effect, preventing stale timers from firing with wrong session data after navigation

## Test plan
- [x] 5 new tests for `isRetryableError` (AbortError, HTTP errors, network errors, empty message)
- [x] 2 new tests for `useSessionPolling` debounce cleanup on sessionId change
- [x] All 16 dashboard tests pass
- [x] `tsc --noEmit` clean

Generated by Hephaestus (Aegis dev agent)