### PR TITLE
fix: add global event ring buffer and Last-Event-ID replay

### DIFF
--- a/src/__tests__/sse-events.test.ts
+++ b/src/__tests__/sse-events.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SessionEventBus, type SessionSSEEvent } from '../events.js';
+import { SessionEventBus, type SessionSSEEvent, type GlobalSSEEvent } from '../events.js';
 
 /** Flush all pending setImmediate callbacks. */
 function flushAsync(): Promise<void> {
@@ -294,6 +294,81 @@ describe('SSE Event System (Issue #32)', () => {
       const s2 = bus.getEventsSince('sess-2', 0);
       expect(s2).toHaveLength(1);
       expect(s2[0].id).toBe(2);
+    });
+  });
+
+  describe('Global Event Ring Buffer (Issue #301)', () => {
+    it('should store global events in a ring buffer', async () => {
+      bus.subscribeGlobal(() => {}); // activate global emitter
+      bus.emitStatus('sess-1', 'working', 'event a');
+      bus.emitStatus('sess-2', 'working', 'event b');
+      await flushAsync();
+
+      const missed = bus.getGlobalEventsSince(0);
+      expect(missed).toHaveLength(2);
+      expect(missed[0].id).toBe(1);
+      expect(missed[0].event.event).toBe('session_status_change');
+      expect(missed[0].event.sessionId).toBe('sess-1');
+      expect(missed[1].id).toBe(2);
+      expect(missed[1].event.sessionId).toBe('sess-2');
+    });
+
+    it('should return only events after a given ID', async () => {
+      bus.subscribeGlobal(() => {});
+      for (let i = 0; i < 10; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+      await flushAsync();
+
+      const missed = bus.getGlobalEventsSince(5);
+      expect(missed).toHaveLength(5);
+      expect(missed[0].id).toBe(6);
+      expect(missed[4].id).toBe(10);
+    });
+
+    it('should trim global ring buffer to 50 events', async () => {
+      bus.subscribeGlobal(() => {});
+      for (let i = 0; i < 60; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+      await flushAsync();
+
+      const missed = bus.getGlobalEventsSince(0);
+      expect(missed).toHaveLength(50);
+      expect(missed[0].id).toBe(11);
+      expect(missed[49].id).toBe(60);
+    });
+
+    it('should return empty array when no events buffered', () => {
+      expect(bus.getGlobalEventsSince(0)).toEqual([]);
+    });
+
+    it('should return empty array when all buffered events are before given ID', async () => {
+      bus.subscribeGlobal(() => {});
+      bus.emitStatus('sess-1', 'working', 'a');
+      await flushAsync();
+
+      expect(bus.getGlobalEventsSince(999)).toEqual([]);
+    });
+
+    it('should include global-only events (emitCreated) in the buffer', () => {
+      bus.subscribeGlobal(() => {});
+      bus.emitCreated('sess-new', 'my session', '/tmp');
+      // emitCreated goes directly to global emitter, not through emit()
+      // so it should still be buffered
+      const missed = bus.getGlobalEventsSince(0);
+      expect(missed).toHaveLength(1);
+      expect(missed[0].event.event).toBe('session_created');
+      expect(missed[0].event.sessionId).toBe('sess-new');
+    });
+
+    it('should clear global buffer on destroy', async () => {
+      bus.subscribeGlobal(() => {});
+      bus.emitStatus('sess-1', 'working', 'a');
+      await flushAsync();
+
+      bus.destroy();
+      expect(bus.getGlobalEventsSince(0)).toEqual([]);
     });
   });
 });

--- a/src/events.ts
+++ b/src/events.ts
@@ -24,6 +24,8 @@ export interface GlobalSSEEvent {
   sessionId: string;
   timestamp: string;
   data: Record<string, unknown>;
+  /** Issue #301: Incrementing event ID for Last-Event-ID replay. */
+  id?: number;
 }
 
 /** Map per-session event types to global event types. */
@@ -46,6 +48,7 @@ function toGlobalEvent(event: SessionSSEEvent): GlobalSSEEvent {
     sessionId: event.sessionId,
     timestamp: event.timestamp,
     data: event.data,
+    id: event.id,
   };
 }
 
@@ -64,6 +67,9 @@ export class SessionEventBus {
 
   /** Per-session ring buffer for event replay. */
   private eventBuffers = new Map<string, Array<{ id: number; event: SessionSSEEvent }>>();
+
+  /** Global ring buffer for event replay across all sessions (Issue #301). */
+  private globalEventBuffer: Array<{ id: number; event: GlobalSSEEvent }> = [];
 
   /** Get or create the emitter for a session. */
   private getEmitter(sessionId: string): EventEmitter {
@@ -116,7 +122,13 @@ export class SessionEventBus {
     }
     // Forward to global subscribers
     if (this.globalEmitter) {
-      setImmediate(() => this.globalEmitter!.emit('event', toGlobalEvent(event)));
+      const globalEvent = toGlobalEvent(event);
+      // Issue #301: push to global ring buffer
+      this.globalEventBuffer.push({ id: event.id, event: globalEvent });
+      if (this.globalEventBuffer.length > SessionEventBus.BUFFER_SIZE) {
+        this.globalEventBuffer.splice(0, this.globalEventBuffer.length - SessionEventBus.BUFFER_SIZE);
+      }
+      setImmediate(() => this.globalEmitter!.emit('event', globalEvent));
     }
   }
 
@@ -251,12 +263,25 @@ export class SessionEventBus {
   /** Emit a session created event to global subscribers. */
   emitCreated(sessionId: string, name: string, workDir: string): void {
     if (!this.globalEmitter) return;
-    this.globalEmitter.emit('event', {
+    const id = this.nextEventId++;
+    const globalEvent: GlobalSSEEvent = {
       event: 'session_created',
       sessionId,
       timestamp: new Date().toISOString(),
       data: { name, workDir },
-    });
+      id,
+    };
+    // Issue #301: buffer global-only events
+    this.globalEventBuffer.push({ id, event: globalEvent });
+    if (this.globalEventBuffer.length > SessionEventBus.BUFFER_SIZE) {
+      this.globalEventBuffer.splice(0, this.globalEventBuffer.length - SessionEventBus.BUFFER_SIZE);
+    }
+    this.globalEmitter.emit('event', globalEvent);
+  }
+
+  /** Get global events emitted after the given event ID (Issue #301). */
+  getGlobalEventsSince(lastEventId: number): Array<{ id: number; event: GlobalSSEEvent }> {
+    return this.globalEventBuffer.filter(e => e.id > lastEventId);
   }
 
   /** Clean up all emitters. */
@@ -266,6 +291,7 @@ export class SessionEventBus {
     }
     this.emitters.clear();
     this.eventBuffers.clear();
+    this.globalEventBuffer = [];
     this.globalEmitter?.removeAllListeners();
     this.globalEmitter = null;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -305,7 +305,7 @@ app.get<{ Params: { id: string } }>('/v1/sessions/:id/latency', async (req, repl
 });
 
 // Global SSE event stream — aggregates events from ALL active sessions
-app.get('/v1/events', async (_req, reply) => {
+app.get('/v1/events', async (req, reply) => {
   reply.raw.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
@@ -315,15 +315,25 @@ app.get('/v1/events', async (_req, reply) => {
 
   let unsubscribe: (() => void) | undefined;
 
-  const writer = new SSEWriter(reply.raw, _req.raw, () => unsubscribe?.());
+  const writer = new SSEWriter(reply.raw, req.raw, () => unsubscribe?.());
   writer.write(`data: ${JSON.stringify({
     event: 'connected',
     timestamp: new Date().toISOString(),
     data: { activeSessions: sessions.listSessions().length },
   })}\n\n`);
 
+  // Issue #301: Replay missed global events if client sends Last-Event-ID
+  const lastEventId = req.headers['last-event-id'];
+  if (lastEventId) {
+    const missed = eventBus.getGlobalEventsSince(parseInt(lastEventId as string, 10) || 0);
+    for (const { id, event: globalEvent } of missed) {
+      writer.write(`id: ${id}\ndata: ${JSON.stringify(globalEvent)}\n\n`);
+    }
+  }
+
   const handler = (event: GlobalSSEEvent): void => {
-    writer.write(`data: ${JSON.stringify(event)}\n\n`);
+    const id = event.id != null ? `id: ${event.id}\n` : '';
+    writer.write(`${id}data: ${JSON.stringify(event)}\n\n`);
   };
 
   unsubscribe = eventBus.subscribeGlobal(handler);


### PR DESCRIPTION
## Summary
- Add a global event ring buffer (last 50 events) to `SessionEventBus`, reusing the same `BUFFER_SIZE = 50` and trim logic as the per-session buffer
- Wire `Last-Event-ID` replay into the `/v1/events` global SSE endpoint — clients connecting mid-session now receive missed events
- Add `id` field to `GlobalSSEEvent` and include `id:` SSE wire field on both replayed and live events

## Test plan
- [x] 7 new tests for global ring buffer: store/retrieve, filter by ID, trim to 50, empty buffer, all-before-ID, emitCreated buffering, destroy cleanup
- [x] All 898 tests pass
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean

Closes #301

Generated by Hephaestus (Aegis dev agent)