### PR TITLE
fix: swarm parent matching via PID — Issue #353

### DIFF
--- a/src/__tests__/swarm-monitor.test.ts
+++ b/src/__tests__/swarm-monitor.test.ts
@@ -1,5 +1,6 @@
 /**
  * swarm-monitor.test.ts — Tests for Issue #81: Agent Swarm Awareness.
+ * Updated for Issue #353: PID-based parent matching.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -115,21 +116,56 @@ describe('SwarmMonitor', () => {
 });
 
 describe('SwarmMonitor with mocked parent sessions', () => {
-  it('should match parent session with active subagents', async () => {
+  it('should match parent session by ccPid (Issue #353)', async () => {
     const session = makeSession({
       id: 'parent-session',
-      activeSubagents: ['explore-agent', 'code-agent'],
+      ccPid: 12345,
       status: 'working',
     });
 
     const monitor = new SwarmMonitor(createMockSessionManager([session]));
-    // The scan won't find real swarm sockets, but the parent matching logic is tested
-    const result = await monitor.scan();
-    expect(result).toBeDefined();
-    expect(result.totalSockets).toBeGreaterThanOrEqual(0);
+    // Inspect a swarm socket with matching PID
+    const swarm = await monitor.inspectSwarmSocket('claude-swarm-12345');
+    expect(swarm.parentSession).not.toBeNull();
+    expect(swarm.parentSession?.id).toBe('parent-session');
   });
 
-  it('should not match session without active subagents', async () => {
+  it('should not match session with wrong ccPid', async () => {
+    const session = makeSession({
+      id: 'wrong-session',
+      ccPid: 99999,
+      status: 'working',
+    });
+
+    const monitor = new SwarmMonitor(createMockSessionManager([session]));
+    const swarm = await monitor.inspectSwarmSocket('claude-swarm-12345');
+    expect(swarm.parentSession).toBeNull();
+  });
+
+  it('should not match session without ccPid', async () => {
+    const session = makeSession({
+      id: 'no-pid-session',
+      activeSubagents: ['explore-agent'],
+      status: 'working',
+    });
+
+    const monitor = new SwarmMonitor(createMockSessionManager([session]));
+    const swarm = await monitor.inspectSwarmSocket('claude-swarm-12345');
+    // Old behavior would match via activeSubagents; new behavior requires ccPid match
+    expect(swarm.parentSession).toBeNull();
+  });
+
+  it('should match correct session when multiple sessions have ccPid (Issue #353)', async () => {
+    const session1 = makeSession({ id: 'session-1', ccPid: 11111 });
+    const session2 = makeSession({ id: 'session-2', ccPid: 22222 });
+    const session3 = makeSession({ id: 'session-3', ccPid: 33333 });
+
+    const monitor = new SwarmMonitor(createMockSessionManager([session1, session2, session3]));
+    const swarm = await monitor.inspectSwarmSocket('claude-swarm-22222');
+    expect(swarm.parentSession?.id).toBe('session-2');
+  });
+
+  it('should not match plain session without active subagents', async () => {
     const session = makeSession({
       id: 'plain-session',
       status: 'idle',
@@ -138,5 +174,37 @@ describe('SwarmMonitor with mocked parent sessions', () => {
     const monitor = new SwarmMonitor(createMockSessionManager([session]));
     const result = await monitor.scan();
     expect(result).toBeDefined();
+  });
+});
+
+describe('SwarmMonitor previousTeammates tracking (Issue #353)', () => {
+  it('should not fire repeated spawn events when parent is unresolved', async () => {
+    const events: Array<{ type: string }> = [];
+    const session = makeSession({ id: 's1' }); // no ccPid, so no parent match
+    const monitor = new SwarmMonitor(createMockSessionManager([session]));
+    monitor.onEvent(e => events.push(e));
+
+    // Manually trigger detectChanges with a swarm that has no parent session
+    // by scanning twice with no matching sessions
+    await monitor.scan();
+    await monitor.scan();
+
+    // No events should fire since there's no parent session match
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('SwarmMonitor scan error handling (Issue #353)', () => {
+  it('should return a result even when scan throws', async () => {
+    const monitor = new SwarmMonitor(createMockSessionManager([]));
+
+    // Force an error by making discoverSwarmSockets throw
+    vi.spyOn(monitor as unknown as { discoverSwarmSockets: () => Promise<string[]> }, 'discoverSwarmSockets')
+      .mockRejectedValue(new Error('fs error'));
+
+    const result = await monitor.scan();
+    expect(result).toBeDefined();
+    expect(result.swarms).toEqual([]);
+    expect(result.totalSockets).toBe(0);
   });
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -42,6 +42,7 @@ export interface SessionInfo {
   lastHookEventAt?: number;      // Unix timestamp from the hook payload (CC's timestamp)
   model?: string;                // Issue #89 L25: Model name from hook payload (e.g. "claude-sonnet-4-6")
   lastDeadAt?: number;           // Unix timestamp when session was detected as dead (Issue #283)
+  ccPid?: number;                // PID of the CC process in the tmux pane (Issue #353: swarm parent matching)
 }
 
 export interface SessionState {
@@ -380,6 +381,15 @@ export class SessionManager {
 
     this.state.sessions[id] = session;
     await this.save();
+
+    // Issue #353: Fetch CC process PID for swarm parent matching.
+    // Fire-and-forget — PID is not needed synchronously.
+    void this.tmux.listPanePid(windowId).then(pid => {
+      if (pid !== null) {
+        session.ccPid = pid;
+        void this.save();
+      }
+    });
 
     // Start BOTH discovery methods in parallel:
     // 1. Hook-based: fast, relies on SessionStart hook writing session_map.json

--- a/src/swarm-monitor.ts
+++ b/src/swarm-monitor.ts
@@ -15,7 +15,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { readdir } from 'node:fs/promises';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { SessionManager, SessionInfo } from './session.js';
 
@@ -135,23 +134,40 @@ export class SwarmMonitor {
 
   /** Run a single scan and return the result. */
   async scan(): Promise<SwarmScanResult> {
-    const sockets = await this.discoverSwarmSockets();
-    const swarms: SwarmInfo[] = [];
+    try {
+      const sockets = await this.discoverSwarmSockets();
 
-    for (const socketName of sockets) {
-      const swarm = await this.inspectSwarmSocket(socketName);
-      swarms.push(swarm);
+      // Issue #353: Inspect sockets in parallel to avoid N×timeout accumulation.
+      const results = await Promise.allSettled(
+        sockets.map(socketName => this.inspectSwarmSocket(socketName)),
+      );
+
+      const swarms: SwarmInfo[] = [];
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          swarms.push(result.value);
+        }
+      }
+
+      this.lastResult = {
+        swarms,
+        totalSockets: sockets.length,
+        totalTeammates: swarms.reduce((sum, s) => sum + s.teammates.length, 0),
+        scannedAt: Date.now(),
+      };
+
+      this.detectChanges();
+      return this.lastResult;
+    } catch (e) {
+      // Issue #353: Prevent unhandled rejection from setInterval fire-and-forget.
+      console.error('SwarmMonitor scan error:', e);
+      return this.lastResult ?? {
+        swarms: [],
+        totalSockets: 0,
+        totalTeammates: 0,
+        scannedAt: Date.now(),
+      };
     }
-
-    this.lastResult = {
-      swarms,
-      totalSockets: sockets.length,
-      totalTeammates: swarms.reduce((sum, s) => sum + s.teammates.length, 0),
-      scannedAt: Date.now(),
-    };
-
-    this.detectChanges();
-    return this.lastResult;
   }
 
   /** Compare current scan result against previous to detect teammate changes. */
@@ -159,11 +175,14 @@ export class SwarmMonitor {
     if (!this.lastResult) return;
 
     for (const swarm of this.lastResult.swarms) {
+      // Issue #353: Always update previous snapshot, even without a parent session,
+      // to prevent repeated spawn events on every scan cycle.
+      const prevSwarm = this.previousTeammates.get(swarm.socketName);
+      this.previousTeammates.set(swarm.socketName, swarm.teammates.map(t => ({ ...t })));
+
       if (!swarm.parentSession) continue;
 
-      const prevSwarm = this.previousTeammates.get(swarm.socketName);
       const prevNames = new Set(prevSwarm?.map(t => t.windowName) ?? []);
-      const currentNames = new Set(swarm.teammates.map(t => t.windowName));
 
       // New teammates
       for (const teammate of swarm.teammates) {
@@ -184,8 +203,6 @@ export class SwarmMonitor {
           }
         }
       }
-
-      this.previousTeammates.set(swarm.socketName, swarm.teammates.map(t => ({ ...t })));
     }
 
     // Clean up stale socket tracking
@@ -199,9 +216,20 @@ export class SwarmMonitor {
   /** Snapshot of teammates from previous scan for diffing. */
   private previousTeammates = new Map<string, TeammateInfo[]>();
 
+  /** Cached /tmp listing to avoid redundant I/O on every scan. */
+  private cachedSocketNames: string[] = [];
+  private cachedSocketAt = 0;
+  private static readonly SOCKET_CACHE_TTL_MS = 5_000;
+
   /** Discover swarm socket directories in /tmp. */
   private async discoverSwarmSockets(): Promise<string[]> {
     try {
+      // Issue #353: Cache /tmp listing for 5s to avoid redundant I/O.
+      const now = Date.now();
+      if (this.cachedSocketNames.length > 0 && now - this.cachedSocketAt < SwarmMonitor.SOCKET_CACHE_TTL_MS) {
+        return this.cachedSocketNames;
+      }
+
       const entries = await readdir(tmpdir());
       const pattern = this.config.socketGlobPattern.replace('tmux-', '');
       // Match "tmux-<socketName>" directories (tmux socket dirs start with "tmux-")
@@ -216,6 +244,9 @@ export class SwarmMonitor {
           }
         }
       }
+
+      this.cachedSocketNames = socketNames;
+      this.cachedSocketAt = now;
       return socketNames;
     } catch {
       return [];
@@ -281,18 +312,14 @@ export class SwarmMonitor {
     }
   }
 
-  /** Find the parent Aegis session for a swarm. */
+  /** Find the parent Aegis session for a swarm by matching the CC process PID. */
   private findParentSession(pid: number, _teammates: TeammateInfo[]): SessionInfo | null {
     if (pid === 0) return null;
 
-    // Strategy 1: Match by PID — look for a session whose CC process has this PID
-    // The swarm socket name contains the PID of the parent CC process
+    // Issue #353: Match swarm socket PID against session.ccPid.
+    // The swarm socket name (claude-swarm-{pid}) contains the PID of the parent CC process.
     for (const session of this.sessions.listSessions()) {
-      // We can't directly check PIDs from SessionInfo, so match by checking
-      // if any session has active subagents (suggesting it's a swarm parent)
-      if (session.activeSubagents && session.activeSubagents.length > 0) {
-        // Best-effort: return the first session with active subagents
-        // A more precise approach would require PID tracking
+      if (session.ccPid === pid) {
         return session;
       }
     }


### PR DESCRIPTION
Fixes #353

## Changes
- Track CC process PID in SessionInfo (fetched via tmux pane PID after session creation)
- PID-based parent matching in findParentSession() instead of first-match
- Move previousTeammates.set() outside parentSession guard (prevents repeated spawn events)
- Promise.allSettled for parallel socket inspection
- try-catch wrapper on scan() body
- Cache /tmp listing (5s TTL)

## Tests
- 5 new tests: PID matching, wrong PID rejection, no-PID rejection, multi-session disambiguation, scan error resilience
- All 975 tests passing