### PR TITLE
fix: graceful shutdown and crash recovery gaps — Issue #361

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -688,15 +688,23 @@ export class TelegramChannel implements Channel {
 
   constructor(private config: TelegramChannelConfig) {}
 
+  private pollLoopPromise: Promise<void> = Promise.resolve();
+
   async init(onInbound: InboundHandler): Promise<void> {
     this.onInbound = onInbound;
     this.polling = true;
-    this.pollLoop(); // fire-and-forget
+    this.pollLoopPromise = this.pollLoop(); // store promise for graceful shutdown
     console.log(`Telegram channel: polling started, group ${this.config.groupChatId}`);
   }
 
   async destroy(): Promise<void> {
     this.polling = false;
+    // Await poll loop exit (it waits for in-flight getUpdates, up to 10s + buffer)
+    const timeoutMs = 12_000;
+    await Promise.race([
+      this.pollLoopPromise,
+      new Promise<void>(resolve => setTimeout(resolve, timeoutMs)),
+    ]);
     for (const timer of this.flushTimers.values()) clearTimeout(timer);
     for (const timer of this.readTimer.values()) clearTimeout(timer);
     this.flushTimers.clear();

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -16,7 +16,7 @@
  * }
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { execSync } from 'node:child_process';
@@ -74,7 +74,10 @@ function handleStopEvent(
     stop_reason: (payload as any).stop_reason || null,
   };
 
-  writeFileSync(signalFile, JSON.stringify(signals, null, 2));
+  // Atomic write: write to temp file then rename (prevents partial writes on crash)
+  const tmpSignalFile = signalFile + '.tmp';
+  writeFileSync(tmpSignalFile, JSON.stringify(signals, null, 2));
+  renameSync(tmpSignalFile, signalFile);
   console.error(`Aegis hook: ${event} for session ${sessionId.slice(0, 8)}...`);
 }
 
@@ -176,7 +179,10 @@ function main(): void {
     written_at: Date.now(),
   };
 
-  writeFileSync(MAP_FILE, JSON.stringify(sessionMap, null, 2));
+  // Atomic write: write to temp file then rename (prevents race-condition data loss)
+  const tmpMapFile = MAP_FILE + '.tmp';
+  writeFileSync(tmpMapFile, JSON.stringify(sessionMap, null, 2));
+  renameSync(tmpMapFile, MAP_FILE);
   console.error(`Aegis hook: mapped ${key} -> ${sessionId}`);
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@
 
 import Fastify from 'fastify';
 import fs from 'node:fs/promises';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import fastifyStatic from '@fastify/static';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyCors from '@fastify/cors';
@@ -1157,7 +1157,11 @@ app.get('/v1/pipelines', async () => pipelines.listPipelines());
 
 async function reapStaleSessions(maxAgeMs: number): Promise<void> {
   const now = Date.now();
-  for (const session of sessions.listSessions()) {
+  // Snapshot list before iterating — killSession() modifies the sessions map
+  const snapshot = [...sessions.listSessions()];
+  for (const session of snapshot) {
+    // Guard: session may have been deleted by DELETE handler between snapshot and here
+    if (!sessions.getSession(session.id)) continue;
     const age = now - session.createdAt;
     if (age > maxAgeMs) {
     const ageMin = Math.round(age / 60000);
@@ -1187,7 +1191,11 @@ const ZOMBIE_REAP_INTERVAL_MS = parseInt(process.env.ZOMBIE_REAP_INTERVAL_MS || 
 
 async function reapZombieSessions(): Promise<void> {
   const now = Date.now();
-  for (const session of sessions.listSessions()) {
+  // Snapshot list before iterating — killSession() modifies the sessions map
+  const snapshot = [...sessions.listSessions()];
+  for (const session of snapshot) {
+    // Guard: session may have been deleted between snapshot and here
+    if (!sessions.getSession(session.id)) continue;
     if (!session.lastDeadAt) continue;
     const deadDuration = now - session.lastDeadAt;
     if (deadDuration < ZOMBIE_REAP_DELAY_MS) continue;
@@ -1500,8 +1508,47 @@ async function main(): Promise<void> {
   // Initialize metrics (Issue #40)
   metrics = new MetricsCollector(join(config.stateDir, 'metrics.json'));
   await metrics.load();
-  process.on('SIGTERM', async () => { await metrics.save(); process.exit(0); });
-  process.on('SIGINT', async () => { await metrics.save(); process.exit(0); });
+
+  // Issue #361: Store interval refs so graceful shutdown can clear them
+  const reaperInterval = setInterval(() => reapStaleSessions(config.maxSessionAgeMs), config.reaperIntervalMs);
+  const zombieReaperInterval = setInterval(() => reapZombieSessions(), ZOMBIE_REAP_INTERVAL_MS);
+  const metricsSaveInterval = setInterval(() => { void metrics.save(); }, 5 * 60 * 1000);
+
+  // Issue #361: Graceful shutdown handler
+  let shuttingDown = false;
+  async function gracefulShutdown(signal: string): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`${signal} received, shutting down gracefully...`);
+
+    // 1. Stop accepting new requests
+    try { await app.close(); } catch (e) { console.error('Error closing server:', e); }
+
+    // 2. Stop background monitors and intervals
+    monitor.stop();
+    swarmMonitor.stop();
+    clearInterval(reaperInterval);
+    clearInterval(zombieReaperInterval);
+    clearInterval(metricsSaveInterval);
+
+    // 3. Destroy channels (awaits Telegram poll loop)
+    try { await channels.destroy(); } catch (e) { console.error('Error destroying channels:', e); }
+
+    // 4. Save session state
+    try { await sessions.save(); } catch (e) { console.error('Error saving sessions:', e); }
+
+    // 5. Save metrics
+    try { await metrics.save(); } catch (e) { console.error('Error saving metrics:', e); }
+
+    // 6. Cleanup PID file
+    try { if (pidFilePath) { unlinkSync(pidFilePath); } } catch { /* non-critical */ }
+
+    console.log('Graceful shutdown complete');
+    process.exit(0);
+  }
+
+  process.on('SIGTERM', () => { void gracefulShutdown('SIGTERM'); });
+  process.on('SIGINT', () => { void gracefulShutdown('SIGINT'); });
   process.on('unhandledRejection', (reason) => {
     console.error('unhandledRejection:', reason);
   });
@@ -1551,14 +1598,12 @@ async function main(): Promise<void> {
     }
   }
 
-  // Start reaper
-  setInterval(() => reapStaleSessions(config.maxSessionAgeMs), config.reaperIntervalMs);
+  // Start reaper (intervals already created above with stored refs for graceful shutdown)
   console.log(
     `Session reaper active: max age ${config.maxSessionAgeMs / 3600000}h, check every ${config.reaperIntervalMs / 60000}min`,
   );
 
   // Start zombie reaper (Issue #283)
-  setInterval(() => reapZombieSessions(), ZOMBIE_REAP_INTERVAL_MS);
   console.log(
     `Zombie reaper active: grace period ${ZOMBIE_REAP_DELAY_MS / 1000}s, check every ${ZOMBIE_REAP_INTERVAL_MS / 1000}s`,
   );

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,8 +5,8 @@
  * Tracks: session ID, window ID, byte offset for JSONL reading, status.
  */
 
-import { readFile, writeFile, rename, mkdir, stat } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { readFile, writeFile, rename, mkdir, stat, readdir, unlink } from 'node:fs/promises';
+import { existsSync, unlinkSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { TmuxManager } from './tmux.js';
@@ -103,20 +103,77 @@ export class SessionManager {
     this.sessionMapFile = join(config.stateDir, 'session_map.json');
   }
 
+  /** Validate that parsed data looks like a valid SessionState. */
+  private isValidState(data: unknown): data is SessionState {
+    if (typeof data !== 'object' || data === null) return false;
+    const obj = data as Record<string, unknown>;
+    if (typeof obj.sessions !== 'object' || obj.sessions === null) return false;
+    const sessions = obj.sessions as Record<string, unknown>;
+    for (const val of Object.values(sessions)) {
+      if (typeof val !== 'object' || val === null) return false;
+      const s = val as Record<string, unknown>;
+      if (typeof s.id !== 'string' || typeof s.windowId !== 'string') return false;
+    }
+    return true;
+  }
+
+  /** Clean up stale .tmp files left by crashed writes. */
+  private cleanTmpFiles(dir: string): void {
+    try {
+      for (const entry of readdirSync(dir)) {
+        if (entry.endsWith('.tmp')) {
+          const fullPath = join(dir, entry);
+          try { unlinkSync(fullPath); } catch { /* best effort */ }
+          console.log(`Cleaned stale tmp file: ${entry}`);
+        }
+      }
+    } catch { /* dir may not exist yet */ }
+  }
+
   /** Load state from disk. */
   async load(): Promise<void> {
     const dir = dirname(this.stateFile);
     if (!existsSync(dir)) {
       await mkdir(dir, { recursive: true });
     }
+
+    // Clean stale .tmp files from crashed writes
+    this.cleanTmpFiles(dir);
+
     if (existsSync(this.stateFile)) {
       try {
         const data = JSON.parse(await readFile(this.stateFile, 'utf-8'));
-        this.state = data;
+        if (this.isValidState(data)) {
+          this.state = data;
+        } else {
+          console.error('State file schema invalid, attempting backup restore');
+          // Try loading from backup before resetting
+          const backupFile = `${this.stateFile}.bak`;
+          if (existsSync(backupFile)) {
+            try {
+              const backupData = JSON.parse(await readFile(backupFile, 'utf-8'));
+              if (this.isValidState(backupData)) {
+                this.state = backupData;
+                console.log('Restored state from backup');
+              } else {
+                this.state = { sessions: {} };
+              }
+            } catch {
+              this.state = { sessions: {} };
+            }
+          } else {
+            this.state = { sessions: {} };
+          }
+        }
       } catch {
         this.state = { sessions: {} };
       }
     }
+
+    // Create backup of successfully loaded state
+    try {
+      await writeFile(`${this.stateFile}.bak`, JSON.stringify(this.state, null, 2));
+    } catch { /* non-critical */ }
 
     // Reconcile: verify tmux windows still exist, clean up dead sessions
     await this.reconcile();

--- a/src/swarm-monitor.ts
+++ b/src/swarm-monitor.ts
@@ -112,7 +112,7 @@ export class SwarmMonitor {
   start(): void {
     if (this.running) return;
     this.running = true;
-    this.scan();
+    void this.scan();
     this.timer = setInterval(() => {
       void this.scan();
     }, this.config.scanIntervalMs);


### PR DESCRIPTION
Fixes #361

## Changes (5 files, 132 insertions, 16 deletions)
1. Graceful shutdown: close Fastify, stop monitors, destroy channels, save state/metrics, PID cleanup
2. Atomic rename for session_map.json and stop_signals.json writes
3. Schema validation on state.json load with .bak fallback
4. Clean stale .tmp files on startup
5. Await poll loop with 12s timeout in TelegramChannel.destroy()
6. void prefix on scan() fire-and-forget
7. Periodic metrics saves every 5 min
8. Guard reaper against already-deleted sessions
9. Snapshot session list before iterating in reapers

All 975 tests passing.

Generated by Hephaestus (Aegis dev agent)