### PR TITLE
fix: terminal parser edge cases — Issue #362

### DIFF
--- a/src/__tests__/terminal-parser.test.ts
+++ b/src/__tests__/terminal-parser.test.ts
@@ -679,15 +679,17 @@ describe('detectUIState', () => {
   });
 
   describe('L30: compacting detection', () => {
-    it('detects compacting with spinner', () => {
-      expect(detectUIState(COMPACTING_SPINNER)).toBe('compacting');
+    it('active compacting with spinner is working (spinner takes priority)', () => {
+      // Issue #362 fix #2: active spinners should be working, not compacting,
+      // to ensure stall detection monitors these correctly
+      expect(detectUIState(COMPACTING_SPINNER)).toBe('working');
     });
 
-    it('detects compacting with status text', () => {
-      expect(detectUIState(COMPACTING_STATUS)).toBe('compacting');
+    it('active compacting with status text is working (spinner takes priority)', () => {
+      expect(detectUIState(COMPACTING_STATUS)).toBe('working');
     });
 
-    it('detects compacting plain text', () => {
+    it('detects compacting plain text (no spinner)', () => {
       expect(detectUIState(COMPACTING_PLAIN)).toBe('compacting');
     });
 
@@ -746,6 +748,90 @@ Do you want to proceed?
       expect(detectUIState(mixedPane)).toBe('permission_prompt');
     });
   });
+
+  // Issue #362 edge case tests
+  describe('issue #362: error regex anchoring', () => {
+    it('"429" in middle of line is NOT detected as error', () => {
+      const pane = `
+The server returned HTTP 429 which we handled with retry logic.
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+`;
+      expect(detectUIState(pane)).toBe('idle');
+    });
+
+    it('"Error:" in middle of line is NOT detected as error', () => {
+      const pane = `
+The function handles Error: cases gracefully and returns null.
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+`;
+      expect(detectUIState(pane)).toBe('idle');
+    });
+
+    it('"429" at line start IS detected as error', () => {
+      const pane = `
+429 Too Many Requests
+
+❯
+`;
+      expect(detectUIState(pane)).toBe('error');
+    });
+
+    it('"Error:" at line start IS detected as error', () => {
+      const pane = `
+Error: Something went wrong
+
+❯
+`;
+      expect(detectUIState(pane)).toBe('error');
+    });
+  });
+
+  describe('issue #362: markdown bullet false positive', () => {
+    it('markdown bullet "* Fixed the auth bug" is NOT detected as working', () => {
+      const pane = `
+* Fixed the auth bug
+* Added a new feature
+* Cleaned up tests
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+`;
+      expect(detectUIState(pane)).not.toBe('working');
+    });
+
+    it('spinner with asterisk and ellipsis "* Perambulating…" IS detected as working', () => {
+      const pane = `
+* Perambulating… (2m 27s)
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+      expect(detectUIState(pane)).toBe('working');
+    });
+  });
+
+  describe('issue #362: tryMatchPattern backtracking', () => {
+    it('matches second top when first has no matching bottom', () => {
+      // First "Would you like to proceed?" has no "Esc to cancel" nearby,
+      // but the second one does — should match the second one
+      const pane = `
+Would you like to proceed?
+Some old text without matching bottom
+More text here
+Even more text
+Would you like to proceed?
+
+  ctrl-g to edit in $EDITOR
+  Esc to cancel
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+      expect(detectUIState(pane)).toBe('plan_mode');
+    });
+  });
 });
 
 describe('parseStatusLine', () => {
@@ -774,6 +860,19 @@ describe('parseStatusLine', () => {
     // Previously the 5-line scan limit would miss this
     const status = parseStatusLine(pane);
     expect(status).toContain('Analyzing code structure');
+  });
+
+  it('issue #362: finds spinner past tool output between spinner and separator', () => {
+    // Tool output between the spinner and the chrome separator should not block detection
+    const pane = `· Reading files...
+Tool output line 1
+Tool output line 2
+Tool output line 3
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+    const status = parseStatusLine(pane);
+    expect(status).toContain('Reading files');
   });
 });
 

--- a/src/terminal-parser.ts
+++ b/src/terminal-parser.ts
@@ -95,12 +95,12 @@ const UI_PATTERNS: UIPattern[] = [
   {
     name: 'error',
     top: [
-      /Error:/,
+      /^Error:/,
       /Rate limit/,
       /Authentication failed/,
       /overloaded/i,
       /API error/,
-      /429/,
+      /^429\b/,
     ],
     bottom: [/^\s*❯\s*$/],
     minGap: 1,
@@ -128,14 +128,6 @@ export function detectUIState(paneText: string): UIState {
     }
   }
 
-  // L30: Check for compacting state — CC shows "Compacting..." when compacting context
-  const compactingState = detectCompacting(lines);
-  if (compactingState) return 'compacting';
-
-  // L31: Check for context window warning — CC shows "Context window X% full"
-  const contextWarning = detectContextWarning(lines);
-  if (contextWarning) return 'context_warning';
-
   // Check for working status — scan entire pane for active spinners
   const statusText = parseStatusLine(paneText);
   const hasActiveSpinner = hasSpinnerAnywhere(lines);
@@ -157,6 +149,15 @@ export function detectUIState(paneText: string): UIState {
   if (hasActiveSpinner) {
     return 'working';
   }
+
+  // L30: Check for compacting state — CC shows "Compacting..." when compacting context
+  // Checked after working so active spinners take priority over compacting text
+  const compactingState = detectCompacting(lines);
+  if (compactingState) return 'compacting';
+
+  // L31: Check for context window warning — CC shows "Context window X% full"
+  const contextWarning = detectContextWarning(lines);
+  if (contextWarning) return 'context_warning';
 
   if (hasPrompt) {
     // L32: Differentiate idle (chrome separator present) vs waiting_for_input (no chrome)
@@ -182,7 +183,14 @@ function hasSpinnerAnywhere(lines: string[]): boolean {
     const stripped = lines[i].trim();
     if (!stripped) continue;
     // Check for spinner characters at start of line, followed by text containing "…" or "..."
-    if (STATUS_SPINNERS.has(stripped[0]) && stripped.length > 1 && (stripped.includes('…') || stripped.includes('...') || /[^\s\u00a0]/.test(stripped.slice(1)))) {
+    const firstChar = stripped[0];
+    if (STATUS_SPINNERS.has(firstChar) && stripped.length > 1) {
+      // For `*` (also a markdown bullet), require `* ` + ellipsis/dots to avoid false positives
+      if (firstChar === '*') {
+        if (stripped[1] !== ' ' || !(stripped.includes('…') || stripped.includes('...'))) continue;
+      } else if (!(stripped.includes('…') || stripped.includes('...') || /[^\s\u00a0]/.test(stripped.slice(1)))) {
+        continue;
+      }
       // Exclude "Worked for" which is a completion indicator, and "Aborted" which means CC stopped
       if (/^.Worked for/i.test(stripped) || /^.Compacted/i.test(stripped) || /aborted/i.test(stripped)) continue;
       return true;
@@ -296,36 +304,43 @@ export function parseStatusLine(paneText: string): string | null {
     const line = lines[i].trim();
     if (!line) continue;
     if (STATUS_SPINNERS.has(line[0])) {
+      // For `*`, require `* ` + ellipsis/dots to avoid matching markdown bullets
+      if (line[0] === '*' && (line[1] !== ' ' || !(line.includes('…') || line.includes('...')))) {
+        // Not a real spinner line — skip
+        continue;
+      }
       return line.slice(1).trim();
     }
-    return null; // First non-empty line isn't a spinner
+    // Skip non-spinner lines (tool output between spinner and separator) and keep scanning
   }
   return null;
 }
 
 function tryMatchPattern(lines: string[], pattern: UIPattern): boolean {
-  let topIdx: number | null = null;
-
   // Only search the last 30 lines to avoid matching scrollback text
   const searchStart = Math.max(0, lines.length - 30);
-  for (let i = searchStart; i < lines.length; i++) {
-    if (topIdx === null) {
-      if (pattern.top.some(re => re.test(lines[i]))) {
-        topIdx = i;
-      }
-    } else if (pattern.bottom.length > 0) {
-      if (pattern.bottom.some(re => re.test(lines[i]))) {
-        return i - topIdx >= pattern.minGap;
-      }
-    }
-  }
 
-  // No bottom pattern = match if we found top + enough lines after
-  if (topIdx !== null && pattern.bottom.length === 0) {
-    const lastNonEmpty = findLastNonEmpty(lines, topIdx + 1);
-    if (lastNonEmpty !== null && lastNonEmpty - topIdx >= pattern.minGap) {
-      return true;
+  // Try each top match — don't give up after the first one fails to find a bottom
+  for (let t = searchStart; t < lines.length; t++) {
+    if (!pattern.top.some(re => re.test(lines[t]))) continue;
+
+    if (pattern.bottom.length === 0) {
+      const lastNonEmpty = findLastNonEmpty(lines, t + 1);
+      if (lastNonEmpty !== null && lastNonEmpty - t >= pattern.minGap) {
+        return true;
+      }
+      continue;
     }
+
+    // Search for a matching bottom after this top
+    for (let b = t + 1; b < lines.length; b++) {
+      if (pattern.bottom.some(re => re.test(lines[b]))) {
+        if (b - t >= pattern.minGap) {
+          return true;
+        }
+      }
+    }
+    // No matching bottom for this top — try next top match
   }
 
   return false;


### PR DESCRIPTION
Fixes #362

## Changes (2 files, +147/-33)
1. Anchor error regexes to line start: /^Error:/, /^429\b/
2. Move compacting check after working state in detectUIState
3. Tighten spinner detection: require '* ' + ellipsis/dots, not bare '*'
4. Continue scanning past non-spinner lines in parseStatusLine
5. Iterate all top matches in tryMatchPattern before giving up

1036 tests passing (+8 new edge case tests).

Generated by Hephaestus (Aegis dev agent)