### PR TITLE
fix: auth bypass via broad path matching — Issue #349

### DIFF
--- a/src/__tests__/auth-bypass-349.test.ts
+++ b/src/__tests__/auth-bypass-349.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for Issue #349: Auth bypass via broad path matching in middleware.
+ *
+ * Covers:
+ * 1. Exact path matching for auth skips (hook routes, terminal routes)
+ * 2. workDir allowlist + symlink resolution
+ * 3. Hook event name validation against known list
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { registerHookRoutes } from '../hooks.js';
+import { SessionEventBus } from '../events.js';
+import type { SessionManager, SessionInfo } from '../session.js';
+import type { UIState } from '../terminal-parser.js';
+
+// ── Auth skip regex patterns (duplicated from server.ts setupAuth) ──
+
+/** Matches exactly /v1/hooks/{eventName} where eventName is alpha-only. */
+const HOOK_ROUTE_RE = /^\/v1\/hooks\/[A-Za-z]+$/;
+
+/** Matches exactly /v1/sessions/{id}/terminal. */
+const TERMINAL_ROUTE_RE = /^\/v1\/sessions\/[^/]+\/terminal$/;
+
+// ── Helpers ──
+
+function createMockSessionManager(session: SessionInfo | null): SessionManager {
+  return {
+    getSession: vi.fn().mockReturnValue(session),
+    updateStatusFromHook: vi.fn((_id: string, _hookEvent: string, _hookTimestamp?: number): UIState | null => {
+      return session?.status ?? null;
+    }),
+    updateSessionModel: vi.fn(),
+    waitForPermissionDecision: vi.fn(() => Promise.resolve('allow' as const)),
+    hasPendingPermission: vi.fn().mockReturnValue(false),
+    getPendingPermissionInfo: vi.fn().mockReturnValue(null),
+    resolvePendingPermission: vi.fn().mockReturnValue(false),
+    cleanupPendingPermission: vi.fn(),
+    approve: vi.fn(),
+    reject: vi.fn(),
+  } as unknown as SessionManager;
+}
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'test-session-123',
+    windowId: '@5',
+    windowName: 'cc-test',
+    workDir: '/tmp/test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+// ── Tests ──
+
+describe('Issue #349: Auth bypass via broad path matching', () => {
+  describe('Fix 1: Exact path matching for auth skips', () => {
+    it('should match /v1/hooks/Stop', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks/Stop')).toBe(true);
+    });
+
+    it('should match /v1/hooks/PreToolUse', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks/PreToolUse')).toBe(true);
+    });
+
+    it('should match /v1/hooks/PermissionRequest', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks/PermissionRequest')).toBe(true);
+    });
+
+    it('should NOT match /v1/hooks (no event name)', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks')).toBe(false);
+    });
+
+    it('should NOT match /v1/hooks/ (trailing slash)', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks/')).toBe(false);
+    });
+
+    it('should NOT match /v1/hooks../../sessions (path traversal)', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks../../sessions')).toBe(false);
+    });
+
+    it('should NOT match /v1/hooks/foo/bar (extra segments)', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks/foo/bar')).toBe(false);
+    });
+
+    it('should NOT match /v1/hooks/../../../etc/passwd', () => {
+      expect(HOOK_ROUTE_RE.test('/v1/hooks/../../../etc/passwd')).toBe(false);
+    });
+
+    it('should NOT match /v1/hooks/Stop?sessionId=abc (query string)', () => {
+      // Auth middleware strips query string before matching: urlPath = url.split('?')[0]
+      // So the regex tests on the path part only
+      expect(HOOK_ROUTE_RE.test('/v1/hooks/Stop?sessionId=abc')).toBe(false);
+    });
+
+    it('should match /v1/hooks/Stop with query string stripped', () => {
+      const urlPath = '/v1/hooks/Stop?sessionId=abc'.split('?')[0];
+      expect(HOOK_ROUTE_RE.test(urlPath)).toBe(true);
+    });
+
+    it('should match /v1/sessions/abc-123/terminal', () => {
+      expect(TERMINAL_ROUTE_RE.test('/v1/sessions/abc-123/terminal')).toBe(true);
+    });
+
+    it('should NOT match /v1/sessions/some-terminal-data (substring)', () => {
+      // Old code: includes('/terminal') would match this. New code: exact pattern.
+      expect(TERMINAL_ROUTE_RE.test('/v1/sessions/some-terminal-data')).toBe(false);
+    });
+
+    it('should NOT match /v1/sessions/abc/terminal/extra (extra segments)', () => {
+      expect(TERMINAL_ROUTE_RE.test('/v1/sessions/abc/terminal/extra')).toBe(false);
+    });
+
+    it('should NOT match /v1/terminal (no session ID)', () => {
+      expect(TERMINAL_ROUTE_RE.test('/v1/terminal')).toBe(false);
+    });
+
+    it('should NOT match /terminal (bare substring match)', () => {
+      expect(TERMINAL_ROUTE_RE.test('/terminal')).toBe(false);
+    });
+  });
+
+  describe('Fix 5: Hook event name validation', () => {
+    let app: ReturnType<typeof Fastify>;
+    let eventBus: SessionEventBus;
+    let session: SessionInfo;
+
+    beforeEach(async () => {
+      app = Fastify({ logger: false });
+      eventBus = new SessionEventBus();
+      session = makeSession();
+      const mockSessions = createMockSessionManager(session);
+      registerHookRoutes(app, { sessions: mockSessions, eventBus });
+    });
+
+    const KNOWN_EVENTS = [
+      'Stop', 'StopFailure', 'PreToolUse', 'PostToolUse',
+      'PostToolUseFailure', 'Notification', 'PermissionRequest',
+      'SessionStart', 'SessionEnd', 'SubagentStart', 'SubagentStop',
+      'TaskCompleted', 'TeammateIdle', 'PreCompact', 'PostCompact',
+      'UserPromptSubmit', 'WorktreeCreate', 'WorktreeCreateFailed',
+      'WorktreeRemove', 'WorktreeRemoveFailed', 'Elicitation',
+      'ElicitationResult', 'FileChanged', 'CwdChanged',
+    ];
+
+    for (const eventName of KNOWN_EVENTS) {
+      it(`should accept known event: ${eventName}`, async () => {
+        const res = await app.inject({
+          method: 'POST',
+          url: `/v1/hooks/${eventName}`,
+          headers: { 'X-Session-Id': session.id },
+          payload: {},
+        });
+        expect(res.statusCode).not.toBe(400);
+      });
+    }
+
+    it('should reject unknown event name EvilEvent', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/hooks/EvilEvent',
+        headers: { 'X-Session-Id': session.id },
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('Unknown hook event');
+    });
+
+    it('should reject unknown event name with special chars', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/hooks/../../etc/passwd',
+        payload: {},
+      });
+      // Fastify may 404 this as unmatched route, or 400 from validation
+      expect([400, 404]).toContain(res.statusCode);
+    });
+
+    it('should reject empty event name', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/hooks/',
+        payload: {},
+      });
+      // Empty eventName is not in KNOWN_HOOK_EVENTS — returns 400
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('Unknown hook event');
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@
  * AEGIS_* env vars take priority; MANUS_* still supported for backward compat.
  */
 
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -54,6 +54,10 @@ export interface Config {
   sseMaxConnections: number;
   /** Maximum concurrent SSE connections per client IP (default: 10). Env: AEGIS_SSE_MAX_PER_IP */
   sseMaxPerIp: number;
+  /** Allowed working directories for session creation (Issue #349).
+   *  Empty array = all directories allowed (backward compatible).
+   *  Paths are resolved and symlink-resolved before checking. */
+  allowedWorkDirs: string[];
 }
 
 /** Default configuration values */
@@ -74,6 +78,7 @@ const defaults: Config = {
   stallThresholdMs: 5 * 60 * 1000,
   sseMaxConnections: 100,
   sseMaxPerIp: 10,
+  allowedWorkDirs: [],
 };
 
 /** Parse CLI args for --config flag */
@@ -206,6 +211,18 @@ export async function loadConfig(): Promise<Config> {
   let config: Config = { ...defaults, ...fileConfig };
   config = applyEnvOverrides(config);
   config = resolveStateDir(config);
+  // Issue #349: Resolve allowedWorkDirs entries via realpath so symlink targets match
+  if (config.allowedWorkDirs.length > 0) {
+    config.allowedWorkDirs = await Promise.all(
+      config.allowedWorkDirs.map(async (dir) => {
+        try {
+          return await realpath(resolve(dir));
+        } catch {
+          return resolve(dir);
+        }
+      }),
+    );
+  }
   return config;
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -120,6 +120,10 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
     Querystring: { sessionId?: string };
   }>('/v1/hooks/:eventName', async (req, reply) => {
     const { eventName } = req.params;
+    // Issue #349: Validate event name against known list to prevent injection
+    if (!KNOWN_HOOK_EVENTS.has(eventName)) {
+      return reply.status(400).send({ error: `Unknown hook event: ${eventName}` });
+    }
     const sessionId = (req.headers['x-session-id'] as string) || req.query.sessionId;
 
     if (!sessionId) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,6 +54,9 @@ const __dirname = path.dirname(__filename);
 
 // ── Configuration ────────────────────────────────────────────────────
 
+// Issue #349: CSP policy for dashboard responses (shared between static and SPA fallback)
+const DASHBOARD_CSP = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:";
+
 // Config loaded at startup; env vars override file values
 let config: Config;
 
@@ -101,6 +104,7 @@ async function handleInbound(cmd: InboundCommand): Promise<void> {
 // ── HTTP Server ─────────────────────────────────────────────────────
 
 const app = Fastify({
+  bodyLimit: 1048576, // 1MB — Issue #349: explicit body size limit
   logger: {
     // #230: Redact auth tokens from request logs
     serializers: {
@@ -153,13 +157,16 @@ function checkIpRateLimit(ip: string, isMaster: boolean): boolean {
 
 function setupAuth(authManager: AuthManager): void {
   app.addHook('onRequest', async (req, reply) => {
-    // Skip auth for health endpoint, auth key management, and dashboard
+    // Skip auth for health endpoint and dashboard (Issue #349: exact path matching)
     // #126: Dashboard is served as public static files; API endpoints are protected
-    if (req.url === '/health' || req.url === '/v1/health' || req.url === '/dashboard' || req.url?.startsWith('/dashboard/') || req.url?.startsWith('/dashboard?')) return;
-    if (req.url?.startsWith('/v1/hooks')) return;
+    const urlPath = req.url?.split('?')[0] ?? '';
+    if (urlPath === '/health' || urlPath === '/v1/health') return;
+    if (urlPath === '/dashboard' || urlPath.startsWith('/dashboard/')) return;
+    // Hook routes — exact match: /v1/hooks/{eventName} (alpha only, no path traversal)
+    if (/^\/v1\/hooks\/[A-Za-z]+$/.test(urlPath)) return;
     // #303: WS terminal routes have their own preHandler for auth (supports ?token=)
-    if (req.url?.includes('/terminal')) return;
-    if (req.url === '/dashboard' || req.url?.startsWith('/dashboard/') || req.url?.startsWith('/dashboard?')) return;
+    // Exact match: /v1/sessions/{id}/terminal
+    if (/^\/v1\/sessions\/[^/]+\/terminal$/.test(urlPath)) return;
 
     // If no auth configured (no master token, no keys), allow all
     if (!authManager.authEnabled) return;
@@ -432,18 +439,34 @@ app.get<{
 // Backwards compat: /sessions (no prefix) returns raw array
 app.get('/sessions', async () => sessions.listSessions());
 
-/** Validate workDir to prevent path traversal attacks. Resolves the path and
- *  rejects it if it contains '..' components after resolution. */
-function validateWorkDir(workDir: string): string | { error: string } {
+/** Validate workDir to prevent path traversal attacks. Resolves the path,
+ *  resolves symlinks via fs.realpath(), and checks the configurable allowlist.
+ *  Issue #349: symlink bypass + configurable directory allowlist. */
+async function validateWorkDir(workDir: string): Promise<string | { error: string }> {
   if (typeof workDir !== 'string') return { error: 'workDir must be a string' };
-  const resolved = path.resolve(workDir);
-  // Reject any path that contains '..' (resolved paths won't have '..' unless
-  // something very unusual happened, but check the original too)
   const normalized = path.normalize(workDir);
   if (normalized.includes('..')) {
     return { error: 'workDir must not contain path traversal components (..)' };
   }
-  return resolved;
+  const resolved = path.resolve(workDir);
+  // Resolve symlinks to prevent bypass via symlink (e.g., /tmp/evil -> /etc)
+  let realPath: string;
+  try {
+    realPath = await fs.realpath(resolved);
+  } catch {
+    return { error: 'workDir path does not exist or cannot be resolved' };
+  }
+  // Check allowlist if configured (Issue #349)
+  if (config.allowedWorkDirs.length > 0) {
+    const allowed = config.allowedWorkDirs.some((dir) => {
+      const resolvedDir = path.resolve(dir);
+      return realPath === resolvedDir || realPath.startsWith(resolvedDir + path.sep);
+    });
+    if (!allowed) {
+      return { error: 'workDir is not in the allowed directories list' };
+    }
+  }
+  return realPath;
 }
 
 // Create session
@@ -455,7 +478,7 @@ app.post('/v1/sessions', async (req, reply) => {
   const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove } = parsed.data;
   console.time("POST_CREATE_SESSION");
   if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
-  const safeWorkDir = validateWorkDir(workDir);
+  const safeWorkDir = await validateWorkDir(workDir);
   if (typeof safeWorkDir === 'object') return reply.status(400).send({ error: safeWorkDir.error });
 
   const session = await sessions.createSession({ workDir: safeWorkDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove });
@@ -496,7 +519,7 @@ app.post('/sessions', async (req, reply) => {
   }
   const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove } = parsed.data;
   if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
-  const safeWorkDir = validateWorkDir(workDir);
+  const safeWorkDir = await validateWorkDir(workDir);
   if (typeof safeWorkDir === 'object') return reply.status(400).send({ error: safeWorkDir.error });
 
   const session = await sessions.createSession({ workDir: safeWorkDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove });
@@ -1086,7 +1109,7 @@ app.post('/v1/sessions/batch', async (req, reply) => {
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
   const specs = parsed.data.sessions;
   for (const spec of specs) {
-    const safeWorkDir = validateWorkDir(spec.workDir);
+    const safeWorkDir = await validateWorkDir(spec.workDir);
     if (typeof safeWorkDir === 'object') {
       return reply.status(400).send({ error: `Invalid workDir "${spec.workDir}": ${safeWorkDir.error}` });
     }
@@ -1101,7 +1124,7 @@ app.post('/v1/pipelines', async (req, reply) => {
   const parsed = pipelineSchema.safeParse(req.body);
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
   const pipeConfig = parsed.data;
-  const safeWorkDir = validateWorkDir(pipeConfig.workDir);
+  const safeWorkDir = await validateWorkDir(pipeConfig.workDir);
   if (typeof safeWorkDir === 'object') {
     return reply.status(400).send({ error: `Invalid workDir: ${safeWorkDir.error}` });
   }
@@ -1600,6 +1623,8 @@ async function main(): Promise<void> {
         reply.setHeader('X-Frame-Options', 'DENY');
         reply.setHeader('X-Content-Type-Options', 'nosniff');
         reply.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+        // Issue #349: Content-Security-Policy for dashboard
+        reply.setHeader('Content-Security-Policy', DASHBOARD_CSP);
         // Cache control (#146)
         if (pathname === '/index.html' || pathname === '/') {
           reply.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
@@ -1613,6 +1638,8 @@ async function main(): Promise<void> {
   // SPA fallback for dashboard routes (Issue #105)
   app.setNotFoundHandler(async (req, reply) => {
     if (dashboardAvailable && (req.url === "/dashboard" || req.url?.startsWith("/dashboard/") || req.url?.startsWith("/dashboard?"))) {
+      // Issue #349: CSP header for SPA dashboard responses
+      reply.header('Content-Security-Policy', DASHBOARD_CSP);
       return reply.sendFile("index.html", dashboardRoot);
     }
     return reply.status(404).send({ error: "Not found" });


### PR DESCRIPTION
Fixes #349

## Changes
1. Exact path matching for auth skips instead of startsWith/includes
2. Configurable workDir allowlist + fs.realpath() symlink resolution
3. Explicit bodyLimit on Fastify constructor
4. Content-Security-Policy header for dashboard responses (extracted to constant)
5. Hook event name validation against known list
6. Symlink resolution for allowedWorkDirs at config load time

1157 tests passing.