### PR TITLE
fix: test mock assertion bugs and type errors

### DIFF
--- a/src/__tests__/dead-session.test.ts
+++ b/src/__tests__/dead-session.test.ts
@@ -1,0 +1,877 @@
+/**
+ * dead-session.test.ts — Comprehensive tests for checkDeadSessions, removeSession,
+ * and related dead session detection in monitor.ts.
+ *
+ * Covers:
+ * - Dead session detection (isWindowAlive returning false)
+ * - lastDeadAt timestamp assignment
+ * - EventBus emission (emitDead)
+ * - Channel notification (statusChange with 'status.dead')
+ * - killSession cleanup call
+ * - removeSession internal state cleanup
+ * - deadNotified dedup set
+ * - Error handling (killSession throws, isWindowAlive throws)
+ * - Multiple sessions (mixed alive/dead, all alive)
+ * - Dead check interval gating
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SessionInfo } from '../session.js';
+import type { ChannelManager, SessionEventPayload } from '../channels/index.js';
+import type { SessionEventBus } from '../events.js';
+import type { JsonlWatcher } from '../jsonl-watcher.js';
+import { SessionMonitor, DEFAULT_MONITOR_CONFIG } from '../monitor.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a full SessionInfo object with sensible defaults. */
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'session-1',
+    windowId: '@0',
+    windowName: 'test-session',
+    workDir: '/tmp/test',
+    claudeSessionId: 'claude-abc',
+    jsonlPath: '/tmp/test/session.jsonl',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now() - 60_000,
+    lastActivity: Date.now() - 10_000,
+    stallThresholdMs: 5 * 60 * 1000,
+    permissionStallMs: 5 * 60 * 1000,
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+/** Create a mock SessionManager with the given sessions and behaviours. */
+function mockSessionManager(sessions: SessionInfo[] = []) {
+  const sessionMap = new Map<string, SessionInfo>();
+  for (const s of sessions) sessionMap.set(s.id, { ...s });
+
+  return {
+    listSessions: vi.fn(() => [...sessionMap.values()]),
+    getSession: vi.fn((id: string) => sessionMap.get(id) ?? null),
+    isWindowAlive: vi.fn<(id: string) => Promise<boolean>>(async () => true),
+    killSession: vi.fn(async () => {}),
+    readMessagesForMonitor: vi.fn(async () => ({
+      messages: [],
+      status: 'idle' as const,
+      statusText: null,
+      interactiveContent: null,
+    })),
+    approve: vi.fn(async () => {}),
+    reject: vi.fn(async () => {}),
+  };
+}
+
+/** Create a mock ChannelManager. */
+function mockChannelManager() {
+  return {
+    statusChange: vi.fn(async (_payload: SessionEventPayload) => {}),
+    message: vi.fn(async (_payload: SessionEventPayload) => {}),
+  };
+}
+
+/** Create a mock SessionEventBus. */
+function mockEventBus() {
+  return {
+    emitDead: vi.fn(),
+    emitStall: vi.fn(),
+    emitMessage: vi.fn(),
+    emitSystem: vi.fn(),
+    emitStatus: vi.fn(),
+    emitApproval: vi.fn(),
+  };
+}
+
+/** Create a mock JsonlWatcher. */
+function mockJsonlWatcher() {
+  return {
+    watch: vi.fn(),
+    unwatch: vi.fn(),
+    isWatching: vi.fn(() => false),
+    onEntries: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// checkDeadSessions — basic detection
+// ---------------------------------------------------------------------------
+
+describe('checkDeadSessions', () => {
+  it('detects a session with isWindowAlive() returning false as dead', async () => {
+    const session = makeSession({ id: 'dead-1' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    expect(sessions.isWindowAlive).toHaveBeenCalledWith('dead-1');
+  });
+
+  it('sets session.lastDeadAt timestamp when session is dead', async () => {
+    const session = makeSession({ id: 'dead-ts' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    const before = Date.now();
+
+    await (monitor as any).checkDeadSessions();
+
+    // lastDeadAt should be set on the session object passed to listSessions
+    const updatedSession = sessions.listSessions()[0];
+    expect(updatedSession.lastDeadAt).toBeGreaterThanOrEqual(before);
+    expect(updatedSession.lastDeadAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('emits via eventBus.emitDead with session id and detail', async () => {
+    const session = makeSession({ id: 'emit-dead', windowName: 'my-window', lastActivity: 12345 });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const bus = mockEventBus();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    monitor.setEventBus(bus as unknown as SessionEventBus);
+
+    await (monitor as any).checkDeadSessions();
+
+    expect(bus.emitDead).toHaveBeenCalledTimes(1);
+    expect(bus.emitDead).toHaveBeenCalledWith('emit-dead', expect.stringContaining('my-window'));
+    expect(bus.emitDead).toHaveBeenCalledWith('emit-dead', expect.stringContaining('tmux window no longer exists'));
+  });
+
+  it('emits via channels.statusChange with "status.dead" event', async () => {
+    const session = makeSession({ id: 'ch-dead', windowName: 'ch-win' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    expect(channels.statusChange).toHaveBeenCalledTimes(1);
+    const payload = channels.statusChange.mock.calls[0][0] as SessionEventPayload;
+    expect(payload.event).toBe('status.dead');
+    expect(payload.session.id).toBe('ch-dead');
+    expect(payload.session.name).toBe('ch-win');
+    expect(payload.detail).toContain('tmux window no longer exists');
+  });
+
+  it('calls removeSession(sessionId) to clean up tracking state', async () => {
+    const session = makeSession({ id: 'rm-dead' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    const removeSpy = vi.spyOn(monitor as any, 'removeSession');
+
+    await (monitor as any).checkDeadSessions();
+
+    expect(removeSpy).toHaveBeenCalledWith('rm-dead');
+  });
+
+  it('calls sessions.killSession(sessionId) for cleanup', async () => {
+    const session = makeSession({ id: 'kill-dead' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    expect(sessions.killSession).toHaveBeenCalledWith('kill-dead');
+  });
+
+  it('includes lastActivity timestamp in the detail message', async () => {
+    const fixedActivity = new Date('2026-01-15T12:30:00Z').getTime();
+    const session = makeSession({ id: 'ts-detail', lastActivity: fixedActivity });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    const payload = channels.statusChange.mock.calls[0][0] as SessionEventPayload;
+    expect(payload.detail).toContain('2026-01-15');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dead session dedup — deadNotified set
+// ---------------------------------------------------------------------------
+
+describe('deadNotified dedup set', () => {
+  it('does NOT re-detect a session already in deadNotified', async () => {
+    const session = makeSession({ id: 'dup-dead' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    // First detection — this also calls removeSession which clears deadNotified.
+    // To test dedup, we need deadNotified to still contain the id on the next check.
+    await (monitor as any).checkDeadSessions();
+    expect(channels.statusChange).toHaveBeenCalledTimes(1);
+
+    // Manually re-add to deadNotified (simulating a scenario where removeSession
+    // has not been called, or to directly test the deadNotified guard)
+    (monitor as any).deadNotified.add('dup-dead');
+    // Ensure the session is still listed
+    sessions.listSessions.mockReturnValue([{ ...session }]);
+
+    // Second check — should be skipped because id is in deadNotified
+    await (monitor as any).checkDeadSessions();
+
+    // isWindowAlive should NOT be called again (deadNotified check happens first)
+    expect(sessions.isWindowAlive).toHaveBeenCalledTimes(1);
+    // statusChange still only called once (no new notification)
+    expect(channels.statusChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('prevents duplicate dead notifications for the same session', async () => {
+    const session = makeSession({ id: 'dup-notify' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const bus = mockEventBus();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    monitor.setEventBus(bus as unknown as SessionEventBus);
+
+    // Run first time — detects and removes, clearing deadNotified.
+    // To test dedup across runs, keep deadNotified populated.
+    await (monitor as any).checkDeadSessions();
+
+    // Manually re-add to deadNotified to simulate the guard being active
+    (monitor as any).deadNotified.add('dup-notify');
+
+    // Run 2 more times — should be skipped because deadNotified contains the id
+    for (let i = 0; i < 2; i++) {
+      sessions.listSessions.mockReturnValue([{ ...session }]);
+      await (monitor as any).checkDeadSessions();
+    }
+
+    // Only 1 notification despite 3 total checks
+    expect(bus.emitDead).toHaveBeenCalledTimes(1);
+    expect(channels.statusChange).toHaveBeenCalledTimes(1);
+    expect(sessions.killSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('error handling', () => {
+  it('catches killSession errors silently (window already gone)', async () => {
+    const session = makeSession({ id: 'kill-err' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    sessions.killSession.mockRejectedValue(new Error('tmux window not found'));
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    // Should NOT throw
+    await expect((monitor as any).checkDeadSessions()).resolves.toBeUndefined();
+
+    // But other notifications should still have fired
+    expect(channels.statusChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles isWindowAlive throwing gracefully', async () => {
+    const session = makeSession({ id: 'alive-throw' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockRejectedValue(new Error('tmux command failed'));
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    // checkDeadSessions itself doesn't have a try/catch around isWindowAlive,
+    // so the error will propagate. This test documents the current behavior.
+    await expect((monitor as any).checkDeadSessions()).rejects.toThrow('tmux command failed');
+  });
+
+  it('killSession error does not prevent removeSession from running', async () => {
+    const session = makeSession({ id: 'kill-err-rm' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    sessions.killSession.mockRejectedValue(new Error('kill failed'));
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    // removeSession should have been called before killSession
+    const removeSpy = vi.spyOn(monitor as any, 'removeSession');
+    // Calling checkDeadSessions again with same session won't call removeSession again
+    // because deadNotified is already set. Let's verify the state was cleaned.
+    expect((monitor as any).deadNotified.has('kill-err-rm')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple sessions
+// ---------------------------------------------------------------------------
+
+describe('multiple sessions', () => {
+  it('detects only dead sessions among mixed alive/dead', async () => {
+    const alive1 = makeSession({ id: 'alive-1', windowName: 'alive-1' });
+    const dead1 = makeSession({ id: 'dead-1', windowName: 'dead-1' });
+    const alive2 = makeSession({ id: 'alive-2', windowName: 'alive-2' });
+    const dead2 = makeSession({ id: 'dead-2', windowName: 'dead-2' });
+
+    const sessions = mockSessionManager([alive1, dead1, alive2, dead2]);
+    sessions.isWindowAlive.mockImplementation(async (id: string) => {
+      return !id.startsWith('dead-');
+    });
+
+    const channels = mockChannelManager();
+    const bus = mockEventBus();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    monitor.setEventBus(bus as unknown as SessionEventBus);
+
+    await (monitor as any).checkDeadSessions();
+
+    // Only the two dead sessions should trigger notifications
+    expect(bus.emitDead).toHaveBeenCalledTimes(2);
+    expect(channels.statusChange).toHaveBeenCalledTimes(2);
+    expect(sessions.killSession).toHaveBeenCalledTimes(2);
+
+    // Verify the correct sessions were reported dead
+    const deadCalls = bus.emitDead.mock.calls.map((c: string[]) => c[0]);
+    expect(deadCalls).toContain('dead-1');
+    expect(deadCalls).toContain('dead-2');
+    expect(deadCalls).not.toContain('alive-1');
+    expect(deadCalls).not.toContain('alive-2');
+  });
+
+  it('does not emit any dead notifications when all sessions are alive', async () => {
+    const s1 = makeSession({ id: 'a-1' });
+    const s2 = makeSession({ id: 'a-2' });
+    const s3 = makeSession({ id: 'a-3' });
+
+    const sessions = mockSessionManager([s1, s2, s3]);
+    sessions.isWindowAlive.mockResolvedValue(true);
+    const channels = mockChannelManager();
+    const bus = mockEventBus();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    monitor.setEventBus(bus as unknown as SessionEventBus);
+
+    await (monitor as any).checkDeadSessions();
+
+    expect(bus.emitDead).not.toHaveBeenCalled();
+    expect(channels.statusChange).not.toHaveBeenCalled();
+    expect(sessions.killSession).not.toHaveBeenCalled();
+  });
+
+  it('handles empty session list gracefully', async () => {
+    const sessions = mockSessionManager([]);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await expect((monitor as any).checkDeadSessions()).resolves.toBeUndefined();
+    expect(channels.statusChange).not.toHaveBeenCalled();
+  });
+
+  it('detects newly dead sessions across successive checks', async () => {
+    const s1 = makeSession({ id: 'later-dead' });
+    const sessions = mockSessionManager([s1]);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    // First check — alive
+    sessions.isWindowAlive.mockResolvedValue(true);
+    await (monitor as any).checkDeadSessions();
+    expect(channels.statusChange).toHaveBeenCalledTimes(0);
+
+    // Second check — now dead
+    sessions.isWindowAlive.mockResolvedValue(false);
+    sessions.listSessions.mockReturnValue([{ ...s1 }]);
+    await (monitor as any).checkDeadSessions();
+    expect(channels.statusChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeSession cleanup
+// ---------------------------------------------------------------------------
+
+describe('removeSession cleanup', () => {
+  it('clears lastStatus for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).lastStatus.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).lastStatus.has('s1')).toBe(false);
+  });
+
+  it('clears lastBytesSeen for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).lastBytesSeen.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).lastBytesSeen.has('s1')).toBe(false);
+  });
+
+  it('clears deadNotified for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).deadNotified.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).deadNotified.has('s1')).toBe(false);
+  });
+
+  it('clears rateLimitedSessions for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).rateLimitedSessions.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).rateLimitedSessions.has('s1')).toBe(false);
+  });
+
+  it('clears pending statusChangeDebounce timer', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).statusChangeDebounce.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).statusChangeDebounce.has('s1')).toBe(false);
+  });
+
+  it('clears stallNotified entries matching the session id', () => {
+    const { monitor } = setupMonitorWithState();
+    // We added s1:stall:jsonl and s1:stall:permission
+    const stallKeys = [...(monitor as any).stallNotified];
+    expect(stallKeys.filter(k => k.startsWith('s1')).length).toBeGreaterThan(0);
+
+    (monitor as any).removeSession('s1');
+
+    const remaining = [...(monitor as any).stallNotified];
+    expect(remaining.filter(k => k.startsWith('s1'))).toHaveLength(0);
+    // Other sessions' stall keys should remain
+    expect(remaining.filter(k => k.startsWith('s2')).length).toBeGreaterThan(0);
+  });
+
+  it('clears idleNotified for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).idleNotified.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).idleNotified.has('s1')).toBe(false);
+  });
+
+  it('clears idleSince for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).idleSince.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).idleSince.has('s1')).toBe(false);
+  });
+
+  it('clears stateSince for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).stateSince.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).stateSince.has('s1')).toBe(false);
+  });
+
+  it('clears prevStatusForStall for the session', () => {
+    const { monitor } = setupMonitorWithState();
+    expect((monitor as any).prevStatusForStall.has('s1')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    expect((monitor as any).prevStatusForStall.has('s1')).toBe(false);
+  });
+
+  it('does NOT clear processedStopSignals (uses different key format)', () => {
+    const { monitor } = setupMonitorWithState();
+    const sizeBefore = (monitor as any).processedStopSignals.size;
+
+    (monitor as any).removeSession('s1');
+
+    // processedStopSignals uses claudeSessionId:timestamp keys, not bridge session id
+    // So removing session 's1' should NOT clear anything from processedStopSignals
+    expect((monitor as any).processedStopSignals.size).toBe(sizeBefore);
+    expect((monitor as any).processedStopSignals.has('claude-xyz:1700000000')).toBe(true);
+  });
+
+  it('stops JSONL watcher for the session', () => {
+    const watcher = mockJsonlWatcher();
+    const session = makeSession({ id: 'watcher-sess' });
+    const sessions = mockSessionManager([session]);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    monitor.setJsonlWatcher(watcher as unknown as JsonlWatcher);
+
+    (monitor as any).removeSession('watcher-sess');
+
+    expect(watcher.unwatch).toHaveBeenCalledWith('watcher-sess');
+  });
+
+  it('clears all tracking maps while leaving other sessions untouched', () => {
+    const { monitor } = setupMonitorWithState();
+
+    // Verify s2 exists in all maps before removal
+    expect((monitor as any).lastStatus.has('s2')).toBe(true);
+    expect((monitor as any).lastBytesSeen.has('s2')).toBe(true);
+    expect((monitor as any).idleNotified.has('s2')).toBe(true);
+
+    (monitor as any).removeSession('s1');
+
+    // s2 should remain in all maps
+    expect((monitor as any).lastStatus.has('s2')).toBe(true);
+    expect((monitor as any).lastBytesSeen.has('s2')).toBe(true);
+    expect((monitor as any).idleNotified.has('s2')).toBe(true);
+    expect((monitor as any).idleSince.has('s2')).toBe(true);
+    expect((monitor as any).stateSince.has('s2')).toBe(true);
+    expect((monitor as any).prevStatusForStall.has('s2')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deadCheckIntervalMs timing
+// ---------------------------------------------------------------------------
+
+describe('deadCheckIntervalMs timing', () => {
+  it('dead check runs when interval has elapsed since lastDeadCheck', async () => {
+    const session = makeSession({ id: 'timing-1' });
+    const sessions = mockSessionManager([session]);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+      { ...DEFAULT_MONITOR_CONFIG, deadCheckIntervalMs: 10_000 },
+    );
+
+    // Set lastDeadCheck to 11 seconds ago — should fire
+    (monitor as any).lastDeadCheck = Date.now() - 11_000;
+
+    // poll() contains the timing gate. We test by calling poll() and checking
+    // that isWindowAlive was called (meaning checkDeadSessions ran).
+    // But poll() also calls checkSession which needs readMessagesForMonitor.
+    // Instead, let's directly test the timing logic.
+    const now = Date.now();
+    const shouldCheck = now - (monitor as any).lastDeadCheck >= DEFAULT_MONITOR_CONFIG.deadCheckIntervalMs;
+    expect(shouldCheck).toBe(true);
+  });
+
+  it('dead check is skipped if interval has not elapsed since lastDeadCheck', () => {
+    const now = Date.now();
+    const lastDeadCheck = now - 5_000; // 5 seconds ago, interval is 10s
+
+    const shouldCheck = now - lastDeadCheck >= DEFAULT_MONITOR_CONFIG.deadCheckIntervalMs;
+    expect(shouldCheck).toBe(false);
+  });
+
+  it('default deadCheckIntervalMs is 10 seconds', () => {
+    expect(DEFAULT_MONITOR_CONFIG.deadCheckIntervalMs).toBe(10_000);
+  });
+
+  it('fires exactly at the interval boundary', () => {
+    const now = Date.now();
+    const lastDeadCheck = now - 10_000; // exactly 10s ago
+
+    const shouldCheck = now - lastDeadCheck >= DEFAULT_MONITOR_CONFIG.deadCheckIntervalMs;
+    expect(shouldCheck).toBe(true);
+  });
+
+  it('custom deadCheckIntervalMs is respected', () => {
+    const customInterval = 5_000;
+    const now = Date.now();
+    const lastDeadCheck = now - 5_500;
+
+    const shouldCheck = now - lastDeadCheck >= customInterval;
+    expect(shouldCheck).toBe(true);
+
+    const notYet = now - 4_000;
+    const shouldCheck2 = now - notYet >= customInterval;
+    expect(shouldCheck2).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full integration: poll() timing gate
+// ---------------------------------------------------------------------------
+
+describe('poll() dead check timing gate', () => {
+  it('calls checkDeadSessions when deadCheckIntervalMs has elapsed', async () => {
+    const session = makeSession({ id: 'poll-dead' });
+    const sessions = mockSessionManager([session]);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+      { ...DEFAULT_MONITOR_CONFIG, deadCheckIntervalMs: 0 }, // 0 = always fires
+    );
+
+    const checkDeadSpy = vi.spyOn(monitor as any, 'checkDeadSessions').mockResolvedValue(undefined);
+
+    // poll() requires checkSession to not throw
+    await (monitor as any).poll();
+
+    expect(checkDeadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips checkDeadSessions when interval has NOT elapsed', async () => {
+    const session = makeSession({ id: 'poll-skip' });
+    const sessions = mockSessionManager([session]);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+      { ...DEFAULT_MONITOR_CONFIG, deadCheckIntervalMs: 100_000 }, // very long
+    );
+
+    // Set lastDeadCheck to now — interval hasn't elapsed
+    (monitor as any).lastDeadCheck = Date.now();
+
+    const checkDeadSpy = vi.spyOn(monitor as any, 'checkDeadSessions').mockResolvedValue(undefined);
+
+    await (monitor as any).poll();
+
+    expect(checkDeadSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session detail message format
+// ---------------------------------------------------------------------------
+
+describe('dead session detail message', () => {
+  it('includes window name in detail', async () => {
+    const session = makeSession({ id: 'msg-1', windowName: 'my-special-window' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    const payload = channels.statusChange.mock.calls[0][0] as SessionEventPayload;
+    expect(payload.detail).toContain('my-special-window');
+    expect(payload.detail).toContain('died');
+  });
+
+  it('payload timestamp is a valid ISO string', async () => {
+    const session = makeSession({ id: 'msg-ts' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    const payload = channels.statusChange.mock.calls[0][0] as SessionEventPayload;
+    expect(payload.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(new Date(payload.timestamp).getTime()).not.toBeNaN();
+  });
+
+  it('payload contains correct session metadata', async () => {
+    const session = makeSession({
+      id: 'msg-meta',
+      windowName: 'meta-win',
+      workDir: '/home/user/project',
+    });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    await (monitor as any).checkDeadSessions();
+
+    const payload = channels.statusChange.mock.calls[0][0] as SessionEventPayload;
+    expect(payload.session.id).toBe('msg-meta');
+    expect(payload.session.name).toBe('meta-win');
+    expect(payload.session.workDir).toBe('/home/user/project');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Order of operations
+// ---------------------------------------------------------------------------
+
+describe('order of operations in checkDeadSessions', () => {
+  it('calls removeSession before killSession', async () => {
+    const session = makeSession({ id: 'order-1' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+
+    const callOrder: string[] = [];
+    vi.spyOn(monitor as any, 'removeSession').mockImplementation(() => {
+      callOrder.push('removeSession');
+    });
+    sessions.killSession.mockImplementation(async () => {
+      callOrder.push('killSession');
+    });
+
+    await (monitor as any).checkDeadSessions();
+
+    expect(callOrder).toEqual(['removeSession', 'killSession']);
+  });
+
+  it('emits events before removing session', async () => {
+    const session = makeSession({ id: 'emit-order' });
+    const sessions = mockSessionManager([session]);
+    sessions.isWindowAlive.mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const bus = mockEventBus();
+    const monitor = new SessionMonitor(
+      sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+      channels as unknown as ChannelManager,
+    );
+    monitor.setEventBus(bus as unknown as SessionEventBus);
+
+    const callOrder: string[] = [];
+    bus.emitDead.mockImplementation(() => {
+      callOrder.push('emitDead');
+    });
+    channels.statusChange.mockImplementation(async () => {
+      callOrder.push('statusChange');
+    });
+
+    await (monitor as any).checkDeadSessions();
+
+    // emitDead and statusChange should fire before removeSession completes
+    // (removeSession is synchronous so it runs after the awaits)
+    expect(callOrder.indexOf('emitDead')).toBeLessThan(callOrder.indexOf('statusChange') === -1 ? Infinity : callOrder.indexOf('statusChange'));
+    // Both events should have fired
+    expect(callOrder).toContain('emitDead');
+    expect(callOrder).toContain('statusChange');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for removeSession tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up a monitor with internal state populated for session 's1' (and 's2' for
+ * verifying that only the target session is cleaned).
+ */
+function setupMonitorWithState(): { monitor: SessionMonitor; channels: ReturnType<typeof mockChannelManager> } {
+  const s1 = makeSession({ id: 's1', windowName: 'session-1' });
+  const s2 = makeSession({ id: 's2', windowName: 'session-2' });
+  const sessions = mockSessionManager([s1, s2]);
+  const channels = mockChannelManager();
+  const monitor = new SessionMonitor(
+    sessions as unknown as ConstructorParameters<typeof SessionMonitor>[0],
+    channels as unknown as ChannelManager,
+  );
+
+  const now = Date.now();
+
+  // Populate all internal maps for s1
+  (monitor as any).lastStatus.set('s1', 'working');
+  (monitor as any).lastStatus.set('s2', 'idle');
+
+  (monitor as any).lastBytesSeen.set('s1', { bytes: 1024, at: now - 5000 });
+  (monitor as any).lastBytesSeen.set('s2', { bytes: 2048, at: now - 3000 });
+
+  (monitor as any).deadNotified.add('s1');
+
+  (monitor as any).rateLimitedSessions.add('s1');
+
+  // Debounce timer — use a real timer that can be cleared
+  (monitor as any).statusChangeDebounce.set('s1', setTimeout(() => {}, 60_000));
+
+  (monitor as any).stallNotified.add('s1:stall:jsonl');
+  (monitor as any).stallNotified.add('s1:stall:permission');
+  (monitor as any).stallNotified.add('s2:stall:jsonl');
+
+  (monitor as any).idleNotified.add('s1');
+  (monitor as any).idleNotified.add('s2');
+
+  (monitor as any).idleSince.set('s1', now - 10_000);
+  (monitor as any).idleSince.set('s2', now - 5_000);
+
+  (monitor as any).stateSince.set('s1', { state: 'working', since: now - 30_000 });
+  (monitor as any).stateSince.set('s2', { state: 'idle', since: now - 20_000 });
+
+  (monitor as any).prevStatusForStall.set('s1', 'working');
+  (monitor as any).prevStatusForStall.set('s2', 'idle');
+
+  // processedStopSignals uses different keys (claudeSessionId:timestamp)
+  (monitor as any).processedStopSignals.add('claude-xyz:1700000000');
+
+  return { monitor, channels };
+}

--- a/src/__tests__/events.test.ts
+++ b/src/__tests__/events.test.ts
@@ -1,0 +1,1009 @@
+/**
+ * events.test.ts — Comprehensive tests for SessionEventBus (src/events.ts).
+ *
+ * Covers subscribe/emit lifecycle, ring buffer behavior, getEventsSince replay,
+ * emitEnded cleanup timing, subscribeGlobal, emitCreated, event ID incrementing,
+ * destroy(), toGlobalEvent mapping, and all helper emit methods.
+ *
+ * Areas NOT duplicated from sse-events.test.ts are the focus here.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionEventBus, type SessionSSEEvent, type GlobalSSEEvent } from '../events.js';
+
+/** Flush all pending setImmediate callbacks. */
+function flushAsync(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+/** Flush multiple cycles of setImmediate. */
+function flushAsyncN(n: number): Promise<void> {
+  let p = Promise.resolve();
+  for (let i = 0; i < n; i++) {
+    p = p.then(() => new Promise<void>(resolve => setImmediate(resolve)));
+  }
+  return p;
+}
+
+describe('SessionEventBus', () => {
+  let bus: SessionEventBus;
+
+  beforeEach(() => {
+    bus = new SessionEventBus();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    bus.destroy();
+    vi.useRealTimers();
+  });
+
+  // ── 1. Subscribe/emit lifecycle ──────────────────────────────────────
+
+  describe('subscribe/emit lifecycle', () => {
+    it('subscribe returns a function', () => {
+      const unsub = bus.subscribe('sess-1', () => {});
+      expect(typeof unsub).toBe('function');
+      unsub();
+    });
+
+    it('unsubscribe removes handler — emitter deleted when no listeners remain', () => {
+      const unsub = bus.subscribe('sess-1', () => {});
+      expect(bus.hasSubscribers('sess-1')).toBe(true);
+
+      unsub();
+      expect(bus.hasSubscribers('sess-1')).toBe(false);
+      expect(bus.subscriberCount('sess-1')).toBe(0);
+    });
+
+    it('emitter not deleted while at least one listener remains', () => {
+      const unsub1 = bus.subscribe('sess-1', () => {});
+      const unsub2 = bus.subscribe('sess-1', () => {});
+
+      unsub1();
+      expect(bus.hasSubscribers('sess-1')).toBe(true);
+      expect(bus.subscriberCount('sess-1')).toBe(1);
+
+      unsub2();
+      expect(bus.hasSubscribers('sess-1')).toBe(false);
+    });
+
+    it('subscribe to non-existent session creates emitter lazily', () => {
+      expect(bus.hasSubscribers('never-existed')).toBe(false);
+      expect(bus.subscriberCount('never-existed')).toBe(0);
+
+      const unsub = bus.subscribe('never-existed', () => {});
+      expect(bus.hasSubscribers('never-existed')).toBe(true);
+      unsub();
+    });
+
+    it('multiple subscribers on same session all receive events', async () => {
+      const collector1: SessionSSEEvent[] = [];
+      const collector2: SessionSSEEvent[] = [];
+      const collector3: SessionSSEEvent[] = [];
+
+      bus.subscribe('sess-1', e => collector1.push(e));
+      bus.subscribe('sess-1', e => collector2.push(e));
+      bus.subscribe('sess-1', e => collector3.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'test');
+      await flushAsync();
+
+      expect(collector1).toHaveLength(1);
+      expect(collector2).toHaveLength(1);
+      expect(collector3).toHaveLength(1);
+      // All receive the same event object
+      expect(collector1[0].id).toBe(collector2[0].id);
+      expect(collector2[0].id).toBe(collector3[0].id);
+    });
+
+    it('unsubscribe mid-stream stops delivery for that handler only', async () => {
+      const events1: SessionSSEEvent[] = [];
+      const events2: SessionSSEEvent[] = [];
+
+      const unsub1 = bus.subscribe('sess-1', e => events1.push(e));
+      bus.subscribe('sess-1', e => events2.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'first');
+      await flushAsync();
+
+      unsub1();
+
+      bus.emitStatus('sess-1', 'idle', 'second');
+      await flushAsync();
+
+      expect(events1).toHaveLength(1);
+      expect(events2).toHaveLength(2);
+    });
+
+    it('re-subscribing after full unsubscribe works', async () => {
+      const events: SessionSSEEvent[] = [];
+      const unsub = bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'before');
+      await flushAsync();
+      expect(events).toHaveLength(1);
+
+      unsub();
+
+      const unsub2 = bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStatus('sess-1', 'idle', 'after');
+      await flushAsync();
+      expect(events).toHaveLength(2);
+
+      unsub2();
+    });
+  });
+
+  // ── 2. Buffer behavior (ring buffer) ─────────────────────────────────
+
+  describe('buffer behavior (ring buffer)', () => {
+    it('events are buffered up to BUFFER_SIZE (50)', () => {
+      for (let i = 0; i < 50; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const buffered = bus.getEventsSince('sess-1', 0);
+      expect(buffered).toHaveLength(50);
+      expect(buffered[0].id).toBe(1);
+      expect(buffered[49].id).toBe(50);
+    });
+
+    it('events beyond BUFFER_SIZE are trimmed — oldest removed first', () => {
+      for (let i = 0; i < 55; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const buffered = bus.getEventsSince('sess-1', 0);
+      expect(buffered).toHaveLength(50);
+      // First 5 events (ids 1-5) were trimmed
+      expect(buffered[0].id).toBe(6);
+      expect(buffered[49].id).toBe(55);
+    });
+
+    it('trimming preserves the most recent events', () => {
+      for (let i = 0; i < 100; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const buffered = bus.getEventsSince('sess-1', 0);
+      expect(buffered).toHaveLength(50);
+      expect(buffered[0].id).toBe(51);
+      expect(buffered[49].id).toBe(100);
+    });
+
+    it('buffer is per-session — events from one session do not affect another', () => {
+      for (let i = 0; i < 55; i++) {
+        bus.emitStatus('sess-1', 'working', `s1 ${i}`);
+      }
+      for (let i = 0; i < 3; i++) {
+        bus.emitStatus('sess-2', 'working', `s2 ${i}`);
+      }
+
+      const s1 = bus.getEventsSince('sess-1', 0);
+      const s2 = bus.getEventsSince('sess-2', 0);
+
+      // sess-1 was trimmed to 50
+      expect(s1).toHaveLength(50);
+      // sess-2 was not trimmed
+      expect(s2).toHaveLength(3);
+    });
+
+    it('global event buffer is also trimmed at 50', () => {
+      bus.subscribeGlobal(() => {});
+
+      for (let i = 0; i < 60; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const globalBuffered = bus.getGlobalEventsSince(0);
+      expect(globalBuffered).toHaveLength(50);
+      expect(globalBuffered[0].id).toBe(11);
+      expect(globalBuffered[49].id).toBe(60);
+    });
+
+    it('global buffer trims after 100+ events', () => {
+      bus.subscribeGlobal(() => {});
+
+      for (let i = 0; i < 120; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const globalBuffered = bus.getGlobalEventsSince(0);
+      expect(globalBuffered).toHaveLength(50);
+      expect(globalBuffered[0].id).toBe(71);
+      expect(globalBuffered[49].id).toBe(120);
+    });
+  });
+
+  // ── 3. getEventsSince replay ──────────────────────────────────────────
+
+  describe('getEventsSince replay', () => {
+    it('returns events with id strictly greater than lastEventId', () => {
+      for (let i = 0; i < 5; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const since3 = bus.getEventsSince('sess-1', 3);
+      expect(since3).toHaveLength(2);
+      expect(since3[0].id).toBe(4);
+      expect(since3[1].id).toBe(5);
+    });
+
+    it('returns empty array for unknown session', () => {
+      bus.emitStatus('sess-1', 'working', 'exists');
+      expect(bus.getEventsSince('nonexistent', 0)).toEqual([]);
+    });
+
+    it('returns empty array when no new events after lastEventId', () => {
+      for (let i = 0; i < 3; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      // lastEventId equals the latest event id
+      const result = bus.getEventsSince('sess-1', 3);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when lastEventId exceeds all buffered ids', () => {
+      for (let i = 0; i < 3; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const result = bus.getEventsSince('sess-1', 999);
+      expect(result).toEqual([]);
+    });
+
+    it('works after buffer trimming — only recent events available', () => {
+      for (let i = 0; i < 60; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      // Request events since id 5 — but ids 1-10 were trimmed
+      const result = bus.getEventsSince('sess-1', 5);
+      // Buffer starts at id 11, so all 50 events have id > 5
+      expect(result).toHaveLength(50);
+
+      // Request events since id 55 — only ids 56-60 are available
+      const recent = bus.getEventsSince('sess-1', 55);
+      expect(recent).toHaveLength(5);
+      expect(recent[0].id).toBe(56);
+      expect(recent[4].id).toBe(60);
+    });
+
+    it('replayed events are the same objects that were emitted', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'test');
+      await flushAsync();
+
+      const replayed = bus.getEventsSince('sess-1', 0);
+      expect(replayed).toHaveLength(1);
+      expect(replayed[0].event).toBe('status');
+      expect(replayed[0].data.status).toBe('working');
+      expect(replayed[0].data.detail).toBe('test');
+      expect(replayed[0].id).toBe(events[0].id);
+    });
+  });
+
+  // ── 4. Cleanup timing (emitEnded) ────────────────────────────────────
+
+  describe('cleanup timing (emitEnded)', () => {
+    it('emitEnded marks emitter as ending', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitEnded('sess-1', 'completed');
+      await flushAsync();
+
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe('ended');
+      expect(events[0].data.reason).toBe('completed');
+    });
+
+    it('emitter is cleaned up after 1 second', () => {
+      const unsub = bus.subscribe('sess-1', () => {});
+      expect(bus.hasSubscribers('sess-1')).toBe(true);
+
+      bus.emitEnded('sess-1', 'completed');
+      unsub();
+
+      // Before 1s, emitter may still exist (marked as ending)
+      vi.advanceTimersByTime(500);
+
+      // After 1s, cleanup fires
+      vi.advanceTimersByTime(600);
+      expect(bus.hasSubscribers('sess-1')).toBe(false);
+    });
+
+    it('event buffer is deleted after cleanup timeout fires', () => {
+      bus.emitStatus('sess-1', 'working', 'test');
+      expect(bus.getEventsSince('sess-1', 0)).toHaveLength(1);
+
+      bus.emitEnded('sess-1', 'done');
+
+      // Before timeout
+      vi.advanceTimersByTime(500);
+      expect(bus.getEventsSince('sess-1', 0)).toHaveLength(2);
+
+      // After timeout — buffer is deleted regardless
+      vi.advanceTimersByTime(600);
+      expect(bus.getEventsSince('sess-1', 0)).toEqual([]);
+    });
+
+    it('re-subscribing within 1s window creates fresh emitter', async () => {
+      const unsub1 = bus.subscribe('sess-1', () => {});
+      bus.emitEnded('sess-1', 'completed');
+      unsub1();
+
+      // Re-subscribe before the 1s cleanup
+      const events2: SessionSSEEvent[] = [];
+      const unsub2 = bus.subscribe('sess-1', e => events2.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'fresh');
+      await flushAsync();
+
+      expect(events2).toHaveLength(1);
+      expect(events2[0].data.status).toBe('working');
+      unsub2();
+    });
+
+    it('old emitter setTimeout does NOT delete fresh emitter', async () => {
+      const unsub1 = bus.subscribe('sess-1', () => {});
+      bus.emitEnded('sess-1', 'completed');
+      unsub1();
+
+      // Re-subscribe immediately — creates fresh emitter
+      const events2: SessionSSEEvent[] = [];
+      const unsub2 = bus.subscribe('sess-1', e => events2.push(e));
+
+      // Advance past the cleanup timeout for the old emitter
+      vi.advanceTimersByTime(1200);
+      await flushAsync();
+
+      // Fresh emitter should still work
+      bus.emitStatus('sess-1', 'idle', 'after-timeout');
+      await flushAsync();
+
+      expect(events2).toHaveLength(1);
+      expect(events2[0].data.status).toBe('idle');
+
+      unsub2();
+    });
+
+    it('emitEnded with remaining subscribers does not delete emitter immediately', async () => {
+      const events1: SessionSSEEvent[] = [];
+      const events2: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events1.push(e));
+      bus.subscribe('sess-1', e => events2.push(e));
+
+      bus.emitEnded('sess-1', 'completed');
+      await flushAsync();
+
+      // Both should have received the ended event
+      expect(events1).toHaveLength(1);
+      expect(events2).toHaveLength(1);
+    });
+  });
+
+  // ── 5. subscribeGlobal ───────────────────────────────────────────────
+
+  describe('subscribeGlobal', () => {
+    it('lazily creates global emitter on first subscribe', () => {
+      // Before any subscribeGlobal, emitting should not throw
+      bus.emitStatus('sess-1', 'working', 'no-crash');
+
+      const events: GlobalSSEEvent[] = [];
+      const unsub = bus.subscribeGlobal(e => events.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'after-subscribe');
+      // emitCreated is synchronous for global emitter
+      // but per-session emit() uses setImmediate for global forwarding
+      // We need to flush setImmediate
+      vi.advanceTimersByTime(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe('session_status_change');
+      unsub();
+    });
+
+    it('returns unsubscribe function that works', async () => {
+      const events: GlobalSSEEvent[] = [];
+      const unsub = bus.subscribeGlobal(e => events.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'before');
+      vi.advanceTimersByTime(0);
+
+      expect(events).toHaveLength(1);
+
+      unsub();
+
+      bus.emitStatus('sess-1', 'idle', 'after');
+      vi.advanceTimersByTime(0);
+
+      expect(events).toHaveLength(1);
+    });
+
+    it('receives GlobalSSEEvent versions of per-session events', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'status');
+      bus.emitMessage('sess-1', 'assistant', 'hello', 'text');
+      bus.emitApproval('sess-1', 'Allow?');
+      bus.emitStall('sess-1', 'jsonl', 'stalled');
+      bus.emitDead('sess-1', 'died');
+      vi.advanceTimersByTime(0);
+
+      expect(events).toHaveLength(5);
+      expect(events[0].event).toBe('session_status_change');
+      expect(events[1].event).toBe('session_message');
+      expect(events[2].event).toBe('session_approval');
+      expect(events[3].event).toBe('session_stall');
+      expect(events[4].event).toBe('session_dead');
+    });
+
+    it('multiple global subscribers all receive events', async () => {
+      const collector1: GlobalSSEEvent[] = [];
+      const collector2: GlobalSSEEvent[] = [];
+
+      bus.subscribeGlobal(e => collector1.push(e));
+      bus.subscribeGlobal(e => collector2.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'test');
+      vi.advanceTimersByTime(0);
+
+      expect(collector1).toHaveLength(1);
+      expect(collector2).toHaveLength(1);
+    });
+
+    it('global subscriber receives events from multiple sessions', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+
+      bus.emitStatus('sess-a', 'working', 'a');
+      bus.emitStatus('sess-b', 'idle', 'b');
+      bus.emitStatus('sess-c', 'working', 'c');
+      vi.advanceTimersByTime(0);
+
+      expect(events).toHaveLength(3);
+      expect(events[0].sessionId).toBe('sess-a');
+      expect(events[1].sessionId).toBe('sess-b');
+      expect(events[2].sessionId).toBe('sess-c');
+    });
+
+    it('global subscriber can unsubscribe independently', async () => {
+      const collector1: GlobalSSEEvent[] = [];
+      const collector2: GlobalSSEEvent[] = [];
+
+      const unsub1 = bus.subscribeGlobal(e => collector1.push(e));
+      bus.subscribeGlobal(e => collector2.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'first');
+      vi.advanceTimersByTime(0);
+      expect(collector1).toHaveLength(1);
+      expect(collector2).toHaveLength(1);
+
+      unsub1();
+
+      bus.emitStatus('sess-1', 'idle', 'second');
+      vi.advanceTimersByTime(0);
+      expect(collector1).toHaveLength(1);
+      expect(collector2).toHaveLength(2);
+    });
+  });
+
+  // ── 6. emitCreated ───────────────────────────────────────────────────
+
+  describe('emitCreated', () => {
+    it('emits only to global subscribers — not per-session', async () => {
+      const sessionEvents: SessionSSEEvent[] = [];
+      const globalEvents: GlobalSSEEvent[] = [];
+
+      bus.subscribe('sess-new', e => sessionEvents.push(e));
+      bus.subscribeGlobal(e => globalEvents.push(e));
+
+      bus.emitCreated('sess-new', 'my session', '/tmp/work');
+
+      expect(sessionEvents).toHaveLength(0);
+      // emitCreated emits synchronously (no setImmediate)
+      expect(globalEvents).toHaveLength(1);
+    });
+
+    it('has correct event type session_created', () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+
+      bus.emitCreated('sess-new', 'my session', '/tmp/work');
+
+      expect(events[0].event).toBe('session_created');
+      expect(events[0].sessionId).toBe('sess-new');
+      expect(events[0].data.name).toBe('my session');
+      expect(events[0].data.workDir).toBe('/tmp/work');
+    });
+
+    it('does nothing when no global emitter exists', () => {
+      // No subscribeGlobal called — should not throw
+      expect(() => bus.emitCreated('sess-x', 'name', '/dir')).not.toThrow();
+    });
+
+    it('is buffered in global event buffer for replay', () => {
+      bus.subscribeGlobal(() => {});
+
+      bus.emitCreated('sess-new', 'my session', '/tmp');
+
+      const buffered = bus.getGlobalEventsSince(0);
+      expect(buffered).toHaveLength(1);
+      expect(buffered[0].event.event).toBe('session_created');
+    });
+
+    it('emitCreated event gets a unique incrementing id', () => {
+      bus.subscribeGlobal(() => {});
+
+      bus.emitStatus('sess-1', 'working', 'before');
+      bus.emitCreated('sess-new', 'new', '/tmp');
+      bus.emitStatus('sess-1', 'idle', 'after');
+
+      // emitStatus uses setImmediate for global, but emitCreated is sync
+      // The IDs should still be incrementing
+      const buffered = bus.getGlobalEventsSince(0);
+      // emitStatus events are buffered synchronously in emit(), emitCreated also increments
+      // IDs are: 1 (status), 2 (created), 3 (status)
+      expect(buffered.length).toBeGreaterThanOrEqual(1);
+      for (let i = 1; i < buffered.length; i++) {
+        expect(buffered[i].id!).toBeGreaterThan(buffered[i - 1].id!);
+      }
+    });
+  });
+
+  // ── 7. Event ID incrementing ─────────────────────────────────────────
+
+  describe('event ID incrementing', () => {
+    it('IDs are globally incrementing across all sessions', () => {
+      bus.emitStatus('sess-a', 'working', 'a1');
+      bus.emitStatus('sess-b', 'working', 'b1');
+      bus.emitStatus('sess-a', 'idle', 'a2');
+      bus.emitStatus('sess-b', 'idle', 'b2');
+
+      const a = bus.getEventsSince('sess-a', 0);
+      const b = bus.getEventsSince('sess-b', 0);
+
+      expect(a[0].id).toBe(1);
+      expect(b[0].id).toBe(2);
+      expect(a[1].id).toBe(3);
+      expect(b[1].id).toBe(4);
+    });
+
+    it('each event gets a unique id — no collisions across sessions', () => {
+      const allIds: number[] = [];
+
+      for (let s = 0; s < 5; s++) {
+        for (let i = 0; i < 10; i++) {
+          bus.emitStatus(`sess-${s}`, 'working', `event ${i}`);
+        }
+      }
+
+      for (let s = 0; s < 5; s++) {
+        const events = bus.getEventsSince(`sess-${s}`, 0);
+        for (const e of events) {
+          allIds.push(e.id!);
+        }
+      }
+
+      expect(allIds).toHaveLength(50);
+      const uniqueIds = new Set(allIds);
+      expect(uniqueIds.size).toBe(50);
+    });
+
+    it('IDs assigned by helper methods follow the same sequence', () => {
+      bus.emitStatus('sess-1', 'working', 'status');
+      bus.emitMessage('sess-1', 'assistant', 'msg', 'text');
+      bus.emitSystem('sess-1', 'sys msg');
+      bus.emitApproval('sess-1', 'prompt');
+      bus.emitStall('sess-1', 'jsonl', 'stalled');
+      bus.emitDead('sess-1', 'dead');
+      bus.emitHook('sess-1', 'Stop', {});
+
+      const events = bus.getEventsSince('sess-1', 0);
+      expect(events).toHaveLength(7);
+      for (let i = 0; i < 7; i++) {
+        expect(events[i].id).toBe(i + 1);
+      }
+    });
+
+    it('emitCreated IDs participate in the global sequence', () => {
+      bus.subscribeGlobal(() => {});
+
+      bus.emitStatus('sess-1', 'working', 'before'); // id 1
+      bus.emitCreated('sess-new', 'new', '/tmp');     // id 2
+      bus.emitStatus('sess-1', 'idle', 'after');      // id 3
+
+      const globalEvents = bus.getGlobalEventsSince(0);
+      expect(globalEvents).toHaveLength(3);
+      expect(globalEvents[0].id).toBe(1);
+      expect(globalEvents[1].id).toBe(2);
+      expect(globalEvents[2].id).toBe(3);
+    });
+  });
+
+  // ── 8. destroy() ─────────────────────────────────────────────────────
+
+  describe('destroy()', () => {
+    it('removes all listeners from all emitters', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      bus.subscribe('sess-1', handler1);
+      bus.subscribe('sess-2', handler2);
+
+      bus.destroy();
+
+      expect(bus.hasSubscribers('sess-1')).toBe(false);
+      expect(bus.hasSubscribers('sess-2')).toBe(false);
+    });
+
+    it('clears all per-session event buffers', () => {
+      bus.emitStatus('sess-1', 'working', 'a');
+      bus.emitStatus('sess-2', 'working', 'b');
+      expect(bus.getEventsSince('sess-1', 0)).toHaveLength(1);
+      expect(bus.getEventsSince('sess-2', 0)).toHaveLength(1);
+
+      bus.destroy();
+
+      expect(bus.getEventsSince('sess-1', 0)).toEqual([]);
+      expect(bus.getEventsSince('sess-2', 0)).toEqual([]);
+    });
+
+    it('nulls globalEmitter — no events delivered after destroy', async () => {
+      const globalHandler = vi.fn();
+      bus.subscribeGlobal(globalHandler);
+
+      bus.destroy();
+
+      bus.emitStatus('sess-1', 'working', 'post-destroy');
+      vi.advanceTimersByTime(0);
+
+      expect(globalHandler).not.toHaveBeenCalled();
+    });
+
+    it('clears global event buffer', async () => {
+      bus.subscribeGlobal(() => {});
+      bus.emitStatus('sess-1', 'working', 'a');
+      expect(bus.getGlobalEventsSince(0)).toHaveLength(1);
+
+      bus.destroy();
+
+      expect(bus.getGlobalEventsSince(0)).toEqual([]);
+    });
+
+    it('destroy is idempotent — calling twice does not throw', () => {
+      bus.subscribe('sess-1', () => {});
+      bus.subscribeGlobal(() => {});
+      bus.emitStatus('sess-1', 'working', 'test');
+
+      expect(() => {
+        bus.destroy();
+        bus.destroy();
+      }).not.toThrow();
+    });
+  });
+
+  // ── 9. toGlobalEvent mapping ─────────────────────────────────────────
+
+  describe('toGlobalEvent mapping', () => {
+    it('maps status -> session_status_change', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitStatus('sess-1', 'idle', 'done');
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_status_change');
+    });
+
+    it('maps message -> session_message', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitMessage('sess-1', 'assistant', 'text', 'text');
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_message');
+    });
+
+    it('maps system -> session_message', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitSystem('sess-1', 'system note');
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_message');
+    });
+
+    it('maps approval -> session_approval', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitApproval('sess-1', 'Allow file write?');
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_approval');
+    });
+
+    it('maps ended -> session_ended', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitEnded('sess-1', 'timeout');
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_ended');
+    });
+
+    it('maps stall -> session_stall', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitStall('sess-1', 'permission', 'stalled');
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_stall');
+    });
+
+    it('maps dead -> session_dead', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitDead('sess-1', 'process died');
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_dead');
+    });
+
+    it('maps hook -> session_message', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitHook('sess-1', 'Stop', { reason: 'user' });
+      vi.advanceTimersByTime(0);
+      expect(events[0].event).toBe('session_message');
+    });
+
+    it('global event preserves session data from original event', async () => {
+      const events: GlobalSSEEvent[] = [];
+      bus.subscribeGlobal(e => events.push(e));
+      bus.emitMessage('sess-1', 'assistant', 'hello world', 'text');
+      vi.advanceTimersByTime(0);
+
+      const global = events[0];
+      expect(global.sessionId).toBe('sess-1');
+      expect(global.data.role).toBe('assistant');
+      expect(global.data.text).toBe('hello world');
+      expect(global.id).toBeDefined();
+      expect(global.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  // ── 10. Helper emit methods ──────────────────────────────────────────
+
+  describe('emitStatus', () => {
+    it('delegates to emit with correct data structure', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStatus('sess-1', 'idle', 'Session is idle');
+      await flushAsync();
+
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe('status');
+      expect(events[0].sessionId).toBe('sess-1');
+      expect(events[0].data.status).toBe('idle');
+      expect(events[0].data.detail).toBe('Session is idle');
+      expect(events[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(events[0].emittedAt).toBeDefined();
+      expect(events[0].id).toBe(1);
+    });
+
+    it('emits working status correctly', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'Processing');
+      await flushAsync();
+
+      expect(events[0].data.status).toBe('working');
+    });
+  });
+
+  describe('emitMessage', () => {
+    it('delegates with role, text, contentType', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitMessage('sess-1', 'user', 'Do something', 'text');
+      await flushAsync();
+
+      expect(events[0].event).toBe('message');
+      expect(events[0].data.role).toBe('user');
+      expect(events[0].data.text).toBe('Do something');
+      expect(events[0].data.contentType).toBe('text');
+    });
+
+    it('passes tool metadata when provided', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitMessage('sess-1', 'assistant', 'Reading...', 'tool_use', {
+        tool_name: 'Read',
+        tool_id: 'toolu_xyz789',
+      });
+      await flushAsync();
+
+      expect(events[0].data.tool_name).toBe('Read');
+      expect(events[0].data.tool_id).toBe('toolu_xyz789');
+    });
+
+    it('works without contentType', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitMessage('sess-1', 'assistant', 'plain text');
+      await flushAsync();
+
+      expect(events[0].event).toBe('message');
+      expect(events[0].data.text).toBe('plain text');
+      expect(events[0].data.contentType).toBeUndefined();
+    });
+  });
+
+  describe('emitSystem', () => {
+    it('delegates with role=system and isSystem=true', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitSystem('sess-1', 'System initialized', 'info');
+      await flushAsync();
+
+      expect(events[0].event).toBe('system');
+      expect(events[0].data.role).toBe('system');
+      expect(events[0].data.text).toBe('System initialized');
+      expect(events[0].data.contentType).toBe('info');
+      expect(events[0].data.isSystem).toBe(true);
+    });
+
+    it('works without contentType', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitSystem('sess-1', 'No content type');
+      await flushAsync();
+
+      expect(events[0].data.contentType).toBeUndefined();
+    });
+  });
+
+  describe('emitApproval', () => {
+    it('delegates with correct data structure', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitApproval('sess-1', 'Allow bash execution?');
+      await flushAsync();
+
+      expect(events[0].event).toBe('approval');
+      expect(events[0].data.prompt).toBe('Allow bash execution?');
+    });
+  });
+
+  describe('emitStall', () => {
+    it('delegates with stallType and detail', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStall('sess-1', 'jsonl', 'No transcript activity for 5 minutes');
+      await flushAsync();
+
+      expect(events[0].event).toBe('stall');
+      expect(events[0].data.stallType).toBe('jsonl');
+      expect(events[0].data.detail).toBe('No transcript activity for 5 minutes');
+    });
+
+    it('supports various stall types', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStall('sess-1', 'permission', 'Permission prompt unattended');
+      bus.emitStall('sess-1', 'unknown', 'Unknown state for 3 minutes');
+      bus.emitStall('sess-1', 'extended', 'Extended stall detected');
+      await flushAsync();
+
+      expect(events).toHaveLength(3);
+      expect(events[0].data.stallType).toBe('permission');
+      expect(events[1].data.stallType).toBe('unknown');
+      expect(events[2].data.stallType).toBe('extended');
+    });
+  });
+
+  describe('emitDead', () => {
+    it('delegates with reason in data', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitDead('sess-1', 'tmux pane destroyed');
+      await flushAsync();
+
+      expect(events[0].event).toBe('dead');
+      expect(events[0].data.reason).toBe('tmux pane destroyed');
+    });
+  });
+
+  describe('emitHook', () => {
+    it('delegates with hookEvent and merged data', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitHook('sess-1', 'Stop', { exitCode: 0, duration: 120 });
+      await flushAsync();
+
+      expect(events[0].event).toBe('hook');
+      expect(events[0].data.hookEvent).toBe('Stop');
+      expect(events[0].data.exitCode).toBe(0);
+      expect(events[0].data.duration).toBe(120);
+    });
+
+    it('works with empty hookData', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitHook('sess-1', 'SessionStart', {});
+      await flushAsync();
+
+      expect(events[0].event).toBe('hook');
+      expect(events[0].data.hookEvent).toBe('SessionStart');
+    });
+  });
+
+  // ── Cross-cutting: emittedAt timestamp ───────────────────────────────
+
+  describe('emittedAt timestamp (Issue #87)', () => {
+    it('every emitted event has emittedAt set', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      bus.emitStatus('sess-1', 'working', 'a');
+      bus.emitMessage('sess-1', 'assistant', 'b', 'text');
+      bus.emitSystem('sess-1', 'c');
+      bus.emitApproval('sess-1', 'd');
+      bus.emitStall('sess-1', 'jsonl', 'e');
+      bus.emitDead('sess-1', 'f');
+      bus.emitHook('sess-1', 'Stop', {});
+      await flushAsync();
+
+      for (const event of events) {
+        expect(event.emittedAt).toBeDefined();
+        expect(typeof event.emittedAt).toBe('number');
+        expect(event.emittedAt!).toBeGreaterThan(0);
+      }
+    });
+
+    it('emittedAt values are non-decreasing', async () => {
+      const events: SessionSSEEvent[] = [];
+      bus.subscribe('sess-1', e => events.push(e));
+
+      for (let i = 0; i < 5; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+      await flushAsync();
+
+      for (let i = 1; i < events.length; i++) {
+        expect(events[i].emittedAt!).toBeGreaterThanOrEqual(events[i - 1].emittedAt!);
+      }
+    });
+  });
+
+  // ── Cross-cutting: emit() with no emitter ────────────────────────────
+
+  describe('emit() without subscribers', () => {
+    it('emit does not throw when no per-session emitter exists', () => {
+      expect(() => {
+        bus.emitStatus('no-sess', 'working', 'test');
+      }).not.toThrow();
+    });
+
+    it('events are still buffered even with no subscribers', () => {
+      bus.emitStatus('no-sess', 'working', 'buffered');
+
+      const buffered = bus.getEventsSince('no-sess', 0);
+      expect(buffered).toHaveLength(1);
+      expect(buffered[0].data.status).toBe('working');
+    });
+  });
+});

--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -1,0 +1,1235 @@
+/**
+ * pipeline.test.ts — Comprehensive tests for PipelineManager.
+ *
+ * Covers DAG validation, cycle detection, stage advancement,
+ * polling, cleanup timers, batchCreate edge cases, and accessors.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PipelineManager } from '../pipeline.js';
+import type { BatchSessionSpec, PipelineConfig, PipelineState } from '../pipeline.js';
+import type { SessionManager, SessionInfo } from '../session.js';
+import type { SessionEventBus } from '../events.js';
+
+// ---------------------------------------------------------------------------
+// Helpers: mock factories
+// ---------------------------------------------------------------------------
+
+function makeMockSession(id: string, overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id,
+    windowId: `@${id.slice(0, 4)}`,
+    windowName: `cc-${id.slice(0, 8)}`,
+    workDir: '/app',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 0,
+    permissionStallMs: 0,
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+function makeMockSessions(): {
+  mock: SessionManager;
+  createSession: ReturnType<typeof vi.fn>;
+  sendInitialPrompt: ReturnType<typeof vi.fn>;
+  getSession: ReturnType<typeof vi.fn>;
+} {
+  const createSession = vi.fn();
+  const sendInitialPrompt = vi.fn();
+  const getSession = vi.fn();
+  const mock = { createSession, sendInitialPrompt, getSession } as unknown as SessionManager;
+  return { mock, createSession, sendInitialPrompt, getSession };
+}
+
+function makeMockEventBus(): {
+  mock: SessionEventBus;
+  emitEnded: ReturnType<typeof vi.fn>;
+} {
+  const emitEnded = vi.fn();
+  const mock = { emitEnded } as unknown as SessionEventBus;
+  return { mock, emitEnded };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PipelineManager', () => {
+  let sessions: ReturnType<typeof makeMockSessions>;
+  let eventBus: ReturnType<typeof makeMockEventBus>;
+  let manager: PipelineManager;
+
+  beforeEach(() => {
+    sessions = makeMockSessions();
+    eventBus = makeMockEventBus();
+    manager = new PipelineManager(sessions.mock, eventBus.mock);
+  });
+
+  afterEach(() => {
+    manager.destroy();
+    vi.useRealTimers();
+  });
+
+  // =========================================================================
+  // 1. DAG Validation
+  // =========================================================================
+
+  describe('DAG validation', () => {
+    it('accepts valid dependsOn references', async () => {
+      const config: PipelineConfig = {
+        name: 'valid',
+        workDir: '/app',
+        stages: [
+          { name: 'build', prompt: 'build it', dependsOn: [] },
+          { name: 'test', prompt: 'test it', dependsOn: ['build'] },
+          { name: 'deploy', prompt: 'deploy it', dependsOn: ['test'] },
+        ],
+      };
+      sessions.createSession.mockResolvedValue(makeMockSession('sess-1'));
+
+      const pipeline = await manager.createPipeline(config);
+      expect(pipeline.status).toBe('running');
+    });
+
+    it('throws on invalid dependsOn reference', async () => {
+      const config: PipelineConfig = {
+        name: 'bad-dep',
+        workDir: '/app',
+        stages: [
+          { name: 'build', prompt: 'build', dependsOn: ['nonexistent'] },
+        ],
+      };
+
+      await expect(manager.createPipeline(config)).rejects.toThrow(
+        'Stage "build" depends on unknown stage "nonexistent"',
+      );
+    });
+
+    it('accepts empty stages list (no stages, no deps)', async () => {
+      const config: PipelineConfig = {
+        name: 'empty',
+        workDir: '/app',
+        stages: [],
+      };
+
+      const pipeline = await manager.createPipeline(config);
+      // All zero stages are completed trivially
+      expect(pipeline.status).toBe('completed');
+    });
+
+    it('starts stages with no dependsOn immediately', async () => {
+      const config: PipelineConfig = {
+        name: 'immediate',
+        workDir: '/app',
+        stages: [
+          { name: 'alpha', prompt: 'do alpha', dependsOn: [] },
+          { name: 'beta', prompt: 'do beta', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('sess-alpha'))
+        .mockResolvedValueOnce(makeMockSession('sess-beta'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      expect(sessions.createSession).toHaveBeenCalledTimes(2);
+      expect(pipeline.stages.find(s => s.name === 'alpha')?.status).toBe('running');
+      expect(pipeline.stages.find(s => s.name === 'beta')?.status).toBe('running');
+    });
+
+    it('uses pipeline-level workDir when stage has none', async () => {
+      const config: PipelineConfig = {
+        name: 'workdir',
+        workDir: '/global/dir',
+        stages: [
+          { name: 'stage-no-dir', prompt: 'run', dependsOn: [] },
+          { name: 'stage-with-dir', prompt: 'run', dependsOn: [], workDir: '/custom/dir' },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s1'))
+        .mockResolvedValueOnce(makeMockSession('s2'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config);
+
+      // First stage: no workDir, should use pipeline workDir
+      expect(sessions.createSession).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        workDir: '/global/dir',
+      }));
+      // Second stage: has own workDir
+      expect(sessions.createSession).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        workDir: '/custom/dir',
+      }));
+    });
+  });
+
+  // =========================================================================
+  // 2. Cycle Detection (DFS algorithm)
+  // =========================================================================
+
+  describe('cycle detection', () => {
+    it('detects self-referencing stage: A dependsOn ["A"]', async () => {
+      const config: PipelineConfig = {
+        name: 'self-ref',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: ['A'] },
+        ],
+      };
+
+      await expect(manager.createPipeline(config)).rejects.toThrow(
+        'Circular dependency detected involving stage "A"',
+      );
+    });
+
+    it('accepts linear chain: A -> B -> C', async () => {
+      const config: PipelineConfig = {
+        name: 'linear',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+          { name: 'C', prompt: 'c', dependsOn: ['B'] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+
+      const pipeline = await manager.createPipeline(config);
+      // A starts immediately; B and C stay pending
+      expect(pipeline.status).toBe('running');
+      expect(pipeline.stages.find(s => s.name === 'A')?.status).toBe('running');
+      expect(pipeline.stages.find(s => s.name === 'B')?.status).toBe('pending');
+      expect(pipeline.stages.find(s => s.name === 'C')?.status).toBe('pending');
+    });
+
+    it('accepts diamond: A -> B, A -> C -> D', async () => {
+      const config: PipelineConfig = {
+        name: 'diamond',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+          { name: 'C', prompt: 'c', dependsOn: ['A'] },
+          { name: 'D', prompt: 'd', dependsOn: ['C'] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+
+      const pipeline = await manager.createPipeline(config);
+      expect(pipeline.status).toBe('running');
+    });
+
+    it('detects direct cycle: A -> B -> A', async () => {
+      const config: PipelineConfig = {
+        name: 'direct-cycle',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: ['B'] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+        ],
+      };
+
+      await expect(manager.createPipeline(config)).rejects.toThrow(
+        /Circular dependency detected involving stage "[AB]"/,
+      );
+    });
+
+    it('detects indirect cycle: A -> B -> C -> A', async () => {
+      const config: PipelineConfig = {
+        name: 'indirect-cycle',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: ['C'] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+          { name: 'C', prompt: 'c', dependsOn: ['B'] },
+        ],
+      };
+
+      await expect(manager.createPipeline(config)).rejects.toThrow(
+        /Circular dependency detected/,
+      );
+    });
+
+    it('detects cycle in complex multi-component graph', async () => {
+      // Components: X -> Y -> Z (valid), but P -> Q -> P (cycle)
+      const config: PipelineConfig = {
+        name: 'multi-cycle',
+        workDir: '/app',
+        stages: [
+          { name: 'X', prompt: 'x', dependsOn: [] },
+          { name: 'Y', prompt: 'y', dependsOn: ['X'] },
+          { name: 'Z', prompt: 'z', dependsOn: ['Y'] },
+          { name: 'P', prompt: 'p', dependsOn: ['Q'] },
+          { name: 'Q', prompt: 'q', dependsOn: ['P'] },
+        ],
+      };
+
+      await expect(manager.createPipeline(config)).rejects.toThrow(
+        /Circular dependency detected/,
+      );
+    });
+  });
+
+  // =========================================================================
+  // 3. Stage Advancement
+  // =========================================================================
+
+  describe('stage advancement', () => {
+    it('advances stages whose dependencies are all completed', async () => {
+      const config: PipelineConfig = {
+        name: 'advance',
+        workDir: '/app',
+        stages: [
+          { name: 'first', prompt: 'run first', dependsOn: [] },
+          { name: 'second', prompt: 'run second', dependsOn: ['first'] },
+        ],
+      };
+
+      // First stage: starts immediately
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-first'))
+        .mockResolvedValueOnce(makeMockSession('s-second'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+      expect(pipeline.stages[0].status).toBe('running');
+      expect(pipeline.stages[1].status).toBe('pending');
+
+      // Simulate first stage completing (session goes idle)
+      sessions.getSession.mockReturnValue(makeMockSession('s-first', { status: 'idle' }));
+      // Need a fresh mock for the second stage creation
+      sessions.createSession.mockResolvedValue(makeMockSession('s-second'));
+
+      // Trigger polling to detect completion and advance
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('completed');
+      expect(pipeline.stages[1].status).toBe('running');
+    });
+
+    it('keeps stage waiting until all dependencies complete', async () => {
+      const config: PipelineConfig = {
+        name: 'wait-deps',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: [] },
+          { name: 'C', prompt: 'c', dependsOn: ['A', 'B'] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-a'))
+        .mockResolvedValueOnce(makeMockSession('s-b'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // A completes, B still running
+      sessions.getSession.mockImplementation((id: string) => {
+        if (id === 's-a') return makeMockSession('s-a', { status: 'idle' });
+        if (id === 's-b') return makeMockSession('s-b', { status: 'working' });
+        return null;
+      });
+
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // A completed, B still running, C still pending (waiting for B)
+      expect(pipeline.stages.find(s => s.name === 'A')?.status).toBe('completed');
+      expect(pipeline.stages.find(s => s.name === 'B')?.status).toBe('running');
+      expect(pipeline.stages.find(s => s.name === 'C')?.status).toBe('pending');
+    });
+
+    it('fails pipeline when any dependency fails', async () => {
+      const config: PipelineConfig = {
+        name: 'dep-fail',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-a'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Simulate A failing: session disappears
+      sessions.getSession.mockReturnValue(null);
+
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages.find(s => s.name === 'A')?.status).toBe('failed');
+      expect(pipeline.status).toBe('failed');
+    });
+
+    it('advancePipeline is no-op when pipeline is completed', async () => {
+      const config: PipelineConfig = {
+        name: 'already-done',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Simulate the only stage completing
+      sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.status).toBe('completed');
+
+      // Reset call count, then poll again — no new sessions should be created
+      const createCalls = sessions.createSession.mock.calls.length;
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+      expect(sessions.createSession.mock.calls.length).toBe(createCalls);
+    });
+
+    it('advancePipeline is no-op when pipeline is failed', async () => {
+      const config: PipelineConfig = {
+        name: 'already-failed',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Force fail the pipeline
+      sessions.getSession.mockReturnValue(null);
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.status).toBe('failed');
+
+      const createCalls = sessions.createSession.mock.calls.length;
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+      expect(sessions.createSession.mock.calls.length).toBe(createCalls);
+    });
+
+    it('starts stages with no dependencies immediately on createPipeline', async () => {
+      const config: PipelineConfig = {
+        name: 'no-deps',
+        workDir: '/app',
+        stages: [
+          { name: 'solo', prompt: 'fly free', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-solo'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+      expect(pipeline.stages[0].status).toBe('running');
+      expect(pipeline.stages[0].sessionId).toBe('s-solo');
+      expect(pipeline.stages[0].startedAt).toBeGreaterThan(0);
+    });
+
+    it('marks stage failed when createSession throws during advancement', async () => {
+      const config: PipelineConfig = {
+        name: 'create-fails',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+        ],
+      };
+
+      // A starts fine
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-a'))
+        .mockRejectedValueOnce(new Error('tmux full'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Complete A, then advance should try to create B and fail
+      sessions.getSession.mockReturnValue(makeMockSession('s-a', { status: 'idle' }));
+
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages.find(s => s.name === 'A')?.status).toBe('completed');
+      expect(pipeline.stages.find(s => s.name === 'B')?.status).toBe('failed');
+      expect(pipeline.stages.find(s => s.name === 'B')?.error).toBe('tmux full');
+      expect(pipeline.status).toBe('failed');
+    });
+
+    it('marks stage failed when sendInitialPrompt throws during advancement', async () => {
+      const config: PipelineConfig = {
+        name: 'prompt-fails',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-a'));
+      sessions.sendInitialPrompt.mockRejectedValue(new Error('send failed'));
+
+      const pipeline = await manager.createPipeline(config);
+
+      // createSession succeeded but sendInitialPrompt threw
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('send failed');
+      expect(pipeline.status).toBe('failed');
+    });
+  });
+
+  // =========================================================================
+  // 4. Polling-based Completion
+  // =========================================================================
+
+  describe('polling-based completion', () => {
+    it('pollPipelines detects idle session as completed stage', async () => {
+      const config: PipelineConfig = {
+        name: 'poll-idle',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Session is idle = stage done
+      sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
+
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('completed');
+      expect(pipeline.stages[0].completedAt).toBeGreaterThan(0);
+    });
+
+    it('pollPipelines detects disappeared session as failed', async () => {
+      const config: PipelineConfig = {
+        name: 'poll-gone',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Session vanished
+      sessions.getSession.mockReturnValue(null);
+
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('Session disappeared');
+    });
+
+    it('pollPipelines calls advancePipeline after checking running stages', async () => {
+      const config: PipelineConfig = {
+        name: 'poll-advance',
+        workDir: '/app',
+        stages: [
+          { name: 'first', prompt: 'a', dependsOn: [] },
+          { name: 'second', prompt: 'b', dependsOn: ['first'] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s1'))
+        .mockResolvedValueOnce(makeMockSession('s2'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // first goes idle, second should be started by advancePipeline
+      sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
+
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // advancePipeline should have been called (second stage now running)
+      expect(pipeline.stages.find(s => s.name === 'first')?.status).toBe('completed');
+      expect(pipeline.stages.find(s => s.name === 'second')?.status).toBe('running');
+    });
+
+    it('marks pipeline completed when all stages completed', async () => {
+      const config: PipelineConfig = {
+        name: 'all-done',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-a'))
+        .mockResolvedValueOnce(makeMockSession('s-b'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // A completes
+      sessions.getSession.mockImplementation((id: string) => {
+        if (id === 's-a') return makeMockSession('s-a', { status: 'idle' });
+        return null;
+      });
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // B starts and completes
+      sessions.getSession.mockImplementation((id: string) => {
+        if (id === 's-b') return makeMockSession('s-b', { status: 'idle' });
+        return null;
+      });
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.status).toBe('completed');
+    });
+
+    it('emits emitEnded when pipeline completes (eventBus provided)', async () => {
+      const config: PipelineConfig = {
+        name: 'emit-test',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.status).toBe('completed');
+      expect(eventBus.emitEnded).toHaveBeenCalledWith(pipeline.id, 'pipeline_completed');
+    });
+
+    it('does not emit emitEnded when no eventBus is provided', async () => {
+      const managerNoBus = new PipelineManager(sessions.mock);
+
+      const config: PipelineConfig = {
+        name: 'no-bus',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await managerNoBus.createPipeline(config);
+
+      sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
+      await (managerNoBus as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.status).toBe('completed');
+      // No crash, no emitEnded call — just succeeds silently
+      managerNoBus.destroy();
+    });
+  });
+
+  // =========================================================================
+  // 5. Cleanup Timers
+  // =========================================================================
+
+  describe('cleanup timers', () => {
+    it('cleans up completed pipeline after 30 seconds', async () => {
+      vi.useFakeTimers();
+
+      const config: PipelineConfig = {
+        name: 'cleanup-done',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+      const pipelineId = pipeline.id;
+
+      sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.status).toBe('completed');
+      expect(manager.getPipeline(pipelineId)).toBeDefined();
+
+      // Advance 30s — cleanup timer should fire
+      vi.advanceTimersByTime(30_000);
+
+      expect(manager.getPipeline(pipelineId)).toBeNull();
+    });
+
+    it('cleans up failed pipeline after 30 seconds', async () => {
+      vi.useFakeTimers();
+
+      const config: PipelineConfig = {
+        name: 'cleanup-fail',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+      const pipelineId = pipeline.id;
+
+      expect(pipeline.status).toBe('running');
+
+      // Session disappears -> stage fails -> pipeline fails
+      sessions.getSession.mockReturnValue(null);
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.status).toBe('failed');
+      expect(manager.getPipeline(pipelineId)).toBeDefined();
+
+      // Advance 30s — cleanup timer should fire
+      vi.advanceTimersByTime(30_000);
+
+      expect(manager.getPipeline(pipelineId)).toBeNull();
+    });
+
+    it('cleanup removes from both pipelines and pipelineConfigs maps', async () => {
+      vi.useFakeTimers();
+
+      const config: PipelineConfig = {
+        name: 'dual-cleanup',
+        workDir: '/app',
+        stages: [
+          { name: 'only', prompt: 'run', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+      const pipelineId = pipeline.id;
+
+      sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // Access private pipelineConfigs to verify cleanup
+      const configsMap = (manager as unknown as { pipelineConfigs: Map<string, PipelineConfig> }).pipelineConfigs;
+
+      expect(configsMap.has(pipelineId)).toBe(true);
+
+      vi.advanceTimersByTime(30_000);
+
+      expect(configsMap.has(pipelineId)).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // 6. batchCreate edge cases
+  // =========================================================================
+
+  describe('batchCreate', () => {
+    it('returns empty result for empty specs array', async () => {
+      const result = await manager.batchCreate([]);
+
+      expect(result).toEqual({
+        sessions: [],
+        created: 0,
+        failed: 0,
+        errors: [],
+      });
+    });
+
+    it('handles all sessions failing', async () => {
+      sessions.createSession.mockRejectedValue(new Error('no tmux'));
+
+      const specs: BatchSessionSpec[] = [
+        { workDir: '/a', name: 'one', prompt: 'x' },
+        { workDir: '/b', name: 'two', prompt: 'y' },
+      ];
+
+      const result = await manager.batchCreate(specs);
+
+      expect(result.created).toBe(0);
+      expect(result.failed).toBe(2);
+      expect(result.sessions).toHaveLength(0);
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors[0]).toBe('no tmux');
+      expect(result.errors[1]).toBe('no tmux');
+    });
+
+    it('handles partial failure (some succeed, some fail)', async () => {
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-good', { windowName: 'good-session' }))
+        .mockRejectedValueOnce(new Error('timeout'))
+        .mockResolvedValueOnce(makeMockSession('s-also-good', { windowName: 'also-good' }));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const specs: BatchSessionSpec[] = [
+        { workDir: '/a', name: 'one', prompt: 'x' },
+        { workDir: '/b', name: 'two', prompt: 'y' },
+        { workDir: '/c', name: 'three', prompt: 'z' },
+      ];
+
+      const result = await manager.batchCreate(specs);
+
+      expect(result.created).toBe(2);
+      expect(result.failed).toBe(1);
+      expect(result.sessions).toHaveLength(2);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBe('timeout');
+    });
+
+    it('counts sendInitialPrompt failure in failed count', async () => {
+      sessions.createSession.mockResolvedValue(makeMockSession('s1', { windowName: 'session-1' }));
+      sessions.sendInitialPrompt.mockRejectedValue(new Error('prompt failed'));
+
+      const specs: BatchSessionSpec[] = [
+        { workDir: '/a', name: 'one', prompt: 'hello' },
+      ];
+
+      const result = await manager.batchCreate(specs);
+
+      // createSession succeeded but sendInitialPrompt threw, so the whole spec fails
+      expect(result.failed).toBe(1);
+      expect(result.created).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBe('prompt failed');
+    });
+
+    it('skips sendInitialPrompt when no prompt provided', async () => {
+      sessions.createSession.mockResolvedValue(makeMockSession('s1', { windowName: 'no-prompt' }));
+
+      const specs: BatchSessionSpec[] = [
+        { workDir: '/a', name: 'silent' },
+      ];
+
+      const result = await manager.batchCreate(specs);
+
+      expect(result.created).toBe(1);
+      expect(result.sessions[0].id).toBe('s1');
+      expect(result.sessions[0].name).toBe('no-prompt');
+      expect(result.sessions[0].promptDelivery).toBeUndefined();
+      expect(sessions.sendInitialPrompt).not.toHaveBeenCalled();
+    });
+
+    it('includes promptDelivery in result when prompt is sent', async () => {
+      sessions.createSession.mockResolvedValue(makeMockSession('s1', { windowName: 'prompted' }));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 3 });
+
+      const specs: BatchSessionSpec[] = [
+        { workDir: '/a', name: 'with-prompt', prompt: 'Do the thing' },
+      ];
+
+      const result = await manager.batchCreate(specs);
+
+      expect(result.created).toBe(1);
+      expect(result.sessions[0].promptDelivery).toEqual({ delivered: true, attempts: 3 });
+    });
+
+    it('handles unknown error without message', async () => {
+      sessions.createSession.mockRejectedValue(new Error());
+
+      const specs: BatchSessionSpec[] = [
+        { workDir: '/a', name: 'mystery' },
+      ];
+
+      const result = await manager.batchCreate(specs);
+
+      expect(result.failed).toBe(1);
+      // Error() has empty message — falls back to "Unknown error"
+      expect(result.errors[0]).toBe('Unknown error');
+    });
+  });
+
+  // =========================================================================
+  // 7. getPipeline / listPipelines / destroy
+  // =========================================================================
+
+  describe('getPipeline / listPipelines / destroy', () => {
+    it('getPipeline returns null for unknown id', () => {
+      expect(manager.getPipeline('nonexistent')).toBeNull();
+    });
+
+    it('getPipeline returns pipeline state after creation', async () => {
+      const config: PipelineConfig = {
+        name: 'get-test',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const created = await manager.createPipeline(config);
+      const retrieved = manager.getPipeline(created.id);
+
+      expect(retrieved).toBe(created);
+    });
+
+    it('listPipelines returns all pipelines', async () => {
+      const config1: PipelineConfig = {
+        name: 'pipeline-1',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'a', dependsOn: [] }],
+      };
+      const config2: PipelineConfig = {
+        name: 'pipeline-2',
+        workDir: '/app',
+        stages: [{ name: 'B', prompt: 'b', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const p1 = await manager.createPipeline(config1);
+      const p2 = await manager.createPipeline(config2);
+
+      const all = manager.listPipelines();
+      expect(all).toHaveLength(2);
+
+      const ids = all.map(p => p.id);
+      expect(ids).toContain(p1.id);
+      expect(ids).toContain(p2.id);
+    });
+
+    it('listPipelines returns empty array when no pipelines exist', () => {
+      expect(manager.listPipelines()).toEqual([]);
+    });
+
+    it('destroy clears poll interval', async () => {
+      const config: PipelineConfig = {
+        name: 'destroy-test',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'a', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config);
+
+      // pollInterval should be set now
+      const intervalBefore = (manager as unknown as { pollInterval: NodeJS.Timeout | null }).pollInterval;
+      expect(intervalBefore).not.toBeNull();
+
+      manager.destroy();
+
+      const intervalAfter = (manager as unknown as { pollInterval: NodeJS.Timeout | null }).pollInterval;
+      expect(intervalAfter).toBeNull();
+    });
+
+    it('destroy when no poll interval is safe (no-op)', () => {
+      // Never created a pipeline, so no poll interval
+      const intervalBefore = (manager as unknown as { pollInterval: NodeJS.Timeout | null }).pollInterval;
+      expect(intervalBefore).toBeNull();
+
+      // Should not throw
+      expect(() => manager.destroy()).not.toThrow();
+    });
+
+    it('destroy called twice is safe', async () => {
+      const config: PipelineConfig = {
+        name: 'double-destroy',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'a', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config);
+
+      manager.destroy();
+      manager.destroy(); // second call should be safe
+
+      const interval = (manager as unknown as { pollInterval: NodeJS.Timeout | null }).pollInterval;
+      expect(interval).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // 8. Pipeline state shape
+  // =========================================================================
+
+  describe('pipeline state shape', () => {
+    it('returns correct initial PipelineState shape', async () => {
+      const config: PipelineConfig = {
+        name: 'shape-test',
+        workDir: '/project',
+        stages: [
+          { name: 'build', prompt: 'build', dependsOn: [] },
+          { name: 'test', prompt: 'test', dependsOn: ['build'] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Top-level fields
+      expect(pipeline.id).toBeTruthy();
+      expect(pipeline.name).toBe('shape-test');
+      expect(pipeline.status).toBe('running');
+      expect(typeof pipeline.createdAt).toBe('number');
+      expect(pipeline.createdAt).toBeGreaterThan(0);
+
+      // Stage shapes
+      expect(pipeline.stages).toHaveLength(2);
+      expect(pipeline.stages[0]).toEqual({
+        name: 'build',
+        status: 'running',
+        sessionId: 's1',
+        dependsOn: [],
+        startedAt: expect.any(Number),
+      });
+      expect(pipeline.stages[1]).toEqual({
+        name: 'test',
+        status: 'pending',
+        dependsOn: ['build'],
+      });
+    });
+
+    it('preserves per-stage permissionMode and autoApprove', async () => {
+      const config: PipelineConfig = {
+        name: 'perm-test',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [], permissionMode: 'acceptEdits' },
+          { name: 'B', prompt: 'b', dependsOn: ['A'], autoApprove: true },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-a'))
+        .mockResolvedValueOnce(makeMockSession('s-b'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config);
+
+      expect(sessions.createSession).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        permissionMode: 'acceptEdits',
+      }));
+
+      // Complete A to trigger B
+      sessions.getSession.mockReturnValue(makeMockSession('s-a', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(sessions.createSession).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        autoApprove: true,
+      }));
+    });
+  });
+
+  // =========================================================================
+  // 9. Poll interval management
+  // =========================================================================
+
+  describe('poll interval management', () => {
+    it('sets a 5-second poll interval on first pipeline creation', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(global, 'setInterval');
+
+      const config: PipelineConfig = {
+        name: 'interval-test',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'a', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config);
+
+      expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 5000);
+    });
+
+    it('does not create duplicate poll interval for second pipeline', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(global, 'setInterval');
+
+      const config1: PipelineConfig = {
+        name: 'first',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'a', dependsOn: [] }],
+      };
+      const config2: PipelineConfig = {
+        name: 'second',
+        workDir: '/app',
+        stages: [{ name: 'B', prompt: 'b', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config1);
+      await manager.createPipeline(config2);
+
+      // setInterval should have been called only once (for the first pipeline)
+      expect(setInterval).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // =========================================================================
+  // 10. Multi-stage pipeline integration scenarios
+  // =========================================================================
+
+  describe('multi-stage integration', () => {
+    it('advances through full pipeline: A -> B -> C', async () => {
+      const config: PipelineConfig = {
+        name: 'full-run',
+        workDir: '/app',
+        stages: [
+          { name: 'build', prompt: 'build', dependsOn: [] },
+          { name: 'test', prompt: 'test', dependsOn: ['build'] },
+          { name: 'deploy', prompt: 'deploy', dependsOn: ['test'] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-build'))
+        .mockResolvedValueOnce(makeMockSession('s-test'))
+        .mockResolvedValueOnce(makeMockSession('s-deploy'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+      expect(pipeline.stages[0].status).toBe('running');
+      expect(pipeline.stages[1].status).toBe('pending');
+      expect(pipeline.stages[2].status).toBe('pending');
+
+      // Build completes
+      sessions.getSession.mockReturnValue(makeMockSession('s-build', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('completed');
+      expect(pipeline.stages[1].status).toBe('running');
+      expect(pipeline.stages[2].status).toBe('pending');
+
+      // Test completes
+      sessions.getSession.mockReturnValue(makeMockSession('s-test', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[1].status).toBe('completed');
+      expect(pipeline.stages[2].status).toBe('running');
+
+      // Deploy completes
+      sessions.getSession.mockReturnValue(makeMockSession('s-deploy', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[2].status).toBe('completed');
+      expect(pipeline.status).toBe('completed');
+      expect(eventBus.emitEnded).toHaveBeenCalledWith(pipeline.id, 'pipeline_completed');
+    });
+
+    it('handles parallel stages completing independently', async () => {
+      const config: PipelineConfig = {
+        name: 'parallel',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: [] },
+          { name: 'C', prompt: 'c', dependsOn: ['A', 'B'] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-a'))
+        .mockResolvedValueOnce(makeMockSession('s-b'))
+        .mockResolvedValueOnce(makeMockSession('s-c'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Both A and B running, C pending
+      expect(pipeline.stages[0].status).toBe('running');
+      expect(pipeline.stages[1].status).toBe('running');
+      expect(pipeline.stages[2].status).toBe('pending');
+
+      // A completes, B still running
+      sessions.getSession.mockImplementation((id: string) => {
+        if (id === 's-a') return makeMockSession('s-a', { status: 'idle' });
+        if (id === 's-b') return makeMockSession('s-b', { status: 'working' });
+        return null;
+      });
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('completed');
+      expect(pipeline.stages[1].status).toBe('running');
+      expect(pipeline.stages[2].status).toBe('pending'); // Still waiting on B
+
+      // B completes, C can now start
+      sessions.getSession.mockImplementation((id: string) => {
+        if (id === 's-a') return makeMockSession('s-a', { status: 'idle' });
+        if (id === 's-b') return makeMockSession('s-b', { status: 'idle' });
+        return null;
+      });
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[1].status).toBe('completed');
+      expect(pipeline.stages[2].status).toBe('running');
+    });
+
+    it('fails entire pipeline when intermediate stage fails', async () => {
+      const config: PipelineConfig = {
+        name: 'mid-fail',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+          { name: 'C', prompt: 'c', dependsOn: ['B'] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-a'))
+        .mockResolvedValueOnce(makeMockSession('s-b'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // A completes, B starts
+      sessions.getSession.mockReturnValue(makeMockSession('s-a', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // B's session disappears (fails)
+      sessions.getSession.mockImplementation((id: string) => {
+        if (id === 's-b') return null;
+        return makeMockSession('s-a', { status: 'idle' });
+      });
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages.find(s => s.name === 'B')?.status).toBe('failed');
+      expect(pipeline.status).toBe('failed');
+      // C never started
+      expect(pipeline.stages.find(s => s.name === 'C')?.status).toBe('pending');
+    });
+  });
+});

--- a/src/__tests__/stall-detection.test.ts
+++ b/src/__tests__/stall-detection.test.ts
@@ -1,8 +1,14 @@
 /**
  * stall-detection.test.ts — Tests for Issue #4: configurable per-session stall detection.
+ * Extended with comprehensive coverage for 4 stall types, state transitions,
+ * auto-reject behavior, and stateSince tracking via direct SessionMonitor instantiation.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionMonitor, DEFAULT_MONITOR_CONFIG, type MonitorConfig } from '../monitor.js';
+import type { SessionManager, SessionInfo } from '../session.js';
+import type { ChannelManager } from '../channels/index.js';
+import type { SessionEventPayload } from '../channels/types.js';
 
 describe('Configurable stall detection', () => {
   describe('default threshold', () => {
@@ -172,6 +178,700 @@ describe('Configurable stall detection', () => {
       const isRateLimited = stopReason === 'rate_limit' || stopReason === 'overloaded';
       const channelEvent = isRateLimited ? 'status.rate_limited' : 'status.error';
       expect(channelEvent).toBe('status.error');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper factory for creating a SessionMonitor with mocked dependencies.
+// Uses `as any` to set internal private state and call checkForStalls directly.
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: overrides.id ?? 'sess-1',
+    windowId: overrides.windowId ?? '@1',
+    windowName: overrides.windowName ?? 'test-window',
+    workDir: overrides.workDir ?? '/tmp/test',
+    byteOffset: overrides.byteOffset ?? 0,
+    monitorOffset: overrides.monitorOffset ?? 0,
+    status: overrides.status ?? 'idle',
+    createdAt: overrides.createdAt ?? Date.now() - 600_000,
+    lastActivity: overrides.lastActivity ?? Date.now(),
+    stallThresholdMs: overrides.stallThresholdMs ?? 0,
+    permissionStallMs: overrides.permissionStallMs ?? 0,
+    permissionMode: overrides.permissionMode ?? 'default',
+    ...overrides,
+  } as SessionInfo;
+}
+
+function makeMockDeps() {
+  const sessions: Record<string, SessionInfo> = {};
+
+  const mockSessions = {
+    listSessions: vi.fn(() => Object.values(sessions)),
+    readMessagesForMonitor: vi.fn(async () => ({ messages: [], status: 'idle' as const, statusText: null, interactiveContent: null })),
+    getSession: vi.fn((id: string) => sessions[id] ?? null),
+    approve: vi.fn(async () => {}),
+    reject: vi.fn(async () => {}),
+    isWindowAlive: vi.fn(async () => true),
+    killSession: vi.fn(async () => {}),
+  } as unknown as SessionManager;
+
+  const mockChannels = {
+    statusChange: vi.fn(async (_payload: SessionEventPayload) => {}),
+    message: vi.fn(async () => {}),
+  };
+
+  return { sessions, mockSessions, mockChannels };
+}
+
+function makeMonitor(
+  mockSessions: SessionManager,
+  mockChannels: ChannelManager,
+  configOverrides: Partial<MonitorConfig> = {},
+): SessionMonitor {
+  const config = { ...DEFAULT_MONITOR_CONFIG, ...configOverrides };
+  return new SessionMonitor(mockSessions, mockChannels, config);
+}
+
+// ===========================================================================
+// Integration tests: real SessionMonitor with mocked SessionManager/ChannelManager
+// ===========================================================================
+
+describe('SessionMonitor stall detection (integration)', () => {
+  let deps: ReturnType<typeof makeMockDeps>;
+  let monitor: SessionMonitor;
+
+  beforeEach(() => {
+    deps = makeMockDeps();
+    monitor = makeMonitor(deps.mockSessions, deps.mockChannels as unknown as ChannelManager);
+  });
+
+  // Helper: set internal lastStatus for a session
+  function setLastStatus(sessionId: string, status: string): void {
+    (monitor as any).lastStatus.set(sessionId, status);
+  }
+
+  // Helper: set internal prevStatusForStall
+  function setPrevStallStatus(sessionId: string, status: string): void {
+    (monitor as any).prevStatusForStall.set(sessionId, status);
+  }
+
+  // Helper: set internal lastBytesSeen
+  function setLastBytesSeen(sessionId: string, bytes: number, at: number): void {
+    (monitor as any).lastBytesSeen.set(sessionId, { bytes, at });
+  }
+
+  // Helper: add a session to the mock and set its status
+  function addSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+    const s = makeSession(overrides);
+    deps.sessions[s.id] = s;
+    return s;
+  }
+
+  // Helper: call the private checkForStalls
+  async function checkStalls(now: number): Promise<void> {
+    await (monitor as any).checkForStalls(now);
+  }
+
+  // -------------------------------------------------------------------------
+  describe('Type 1: JSONL stall detection', () => {
+    it('should detect JSONL stall when bytes unchanged for stallThresholdMs', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now - 6 * 60 * 1000); // 6 min ago, same bytes
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      const payload = deps.mockChannels.statusChange.mock.calls[0][0];
+      expect(payload.event).toBe('status.stall');
+      expect(payload.detail).toContain('no new output');
+    });
+
+    it('should reset JSONL tracking when bytes increase', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 1000 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now - 6 * 60 * 1000);
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+      const tracking = (monitor as any).lastBytesSeen.get(session.id);
+      expect(tracking.bytes).toBe(1000);
+      expect(tracking.at).toBe(now);
+    });
+
+    it('should reset JSONL tracking when status changes from working to non-working', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stallNotified.add(`${session.id}:stall:jsonl`);
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:jsonl`)).toBe(false);
+    });
+
+    it('should skip JSONL stall detection for rate-limited sessions', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now - 6 * 60 * 1000);
+      (monitor as any).rateLimitedSessions.add(session.id);
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+    });
+
+    it('should use per-session stallThresholdMs override', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500, stallThresholdMs: 10 * 60 * 1000 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now - 7 * 60 * 1000);
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+    });
+
+    it('should stall with per-session threshold when duration exceeds it', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500, stallThresholdMs: 3 * 60 * 1000 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now - 4 * 60 * 1000);
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      const payload = deps.mockChannels.statusChange.mock.calls[0][0];
+      expect(payload.event).toBe('status.stall');
+    });
+
+    it('should only notify once for the same JSONL stall', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now - 6 * 60 * 1000);
+
+      await checkStalls(now);
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not detect JSONL stall when no previous bytes tracking exists', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+      expect((monitor as any).lastBytesSeen.has(session.id)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Type 2: Permission stall with auto-reject', () => {
+    it('should detect permission stall after permissionStallMs', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 6 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      const payload = deps.mockChannels.statusChange.mock.calls[0][0];
+      expect(payload.event).toBe('status.stall');
+      expect(payload.detail).toContain('permission approval');
+    });
+
+    it('should detect bash_approval stall after permissionStallMs', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'bash_approval');
+      (monitor as any).stateSince.set(session.id, { state: 'bash_approval', since: now - 6 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      const payload = deps.mockChannels.statusChange.mock.calls[0][0];
+      expect(payload.event).toBe('status.stall');
+    });
+
+    it('should auto-reject permission after permissionTimeoutMs', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockSessions.reject).toHaveBeenCalledTimes(1);
+      expect(deps.mockSessions.reject).toHaveBeenCalledWith(session.id);
+      // Permission stall notification + auto-reject + extended stall (11min > 10min extended threshold)
+      expect(deps.mockChannels.statusChange.mock.calls.length).toBeGreaterThanOrEqual(2);
+      const timeoutCall = deps.mockChannels.statusChange.mock.calls.find(
+        (c: any[]) => c[0].event === 'status.permission_timeout',
+      );
+      expect(timeoutCall).toBeDefined();
+      expect(timeoutCall![0].detail).toContain('auto-rejected');
+    });
+
+    it('should auto-reject for bash_approval after timeout too', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'bash_approval');
+      (monitor as any).stateSince.set(session.id, { state: 'bash_approval', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockSessions.reject).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT auto-reject when under permissionTimeoutMs', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 7 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      expect(deps.mockSessions.reject).not.toHaveBeenCalled();
+    });
+
+    it('should only auto-reject once per permission stall', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+      await checkStalls(now);
+
+      expect(deps.mockSessions.reject).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit status.permission_timeout via channels on auto-reject', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 12 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      const allCalls = deps.mockChannels.statusChange.mock.calls;
+      const timeoutCall = allCalls.find((c: any[]) => c[0].event === 'status.permission_timeout');
+      expect(timeoutCall).toBeDefined();
+      expect(timeoutCall![0].detail).toContain('auto-rejected');
+    });
+
+    it('should handle auto-reject failure gracefully', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 11 * 60 * 1000 });
+      (deps.mockSessions as any).reject.mockRejectedValueOnce(new Error('reject failed'));
+
+      await expect(checkStalls(now)).resolves.toBeUndefined();
+      expect(deps.mockChannels.statusChange.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Type 3: Unknown stall detection', () => {
+    it('should detect unknown stall after unknownStallMs', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'unknown');
+      (monitor as any).stateSince.set(session.id, { state: 'unknown', since: now - 4 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      const payload = deps.mockChannels.statusChange.mock.calls[0][0];
+      expect(payload.event).toBe('status.stall');
+      expect(payload.detail).toContain('unknown');
+    });
+
+    it('should NOT detect unknown stall when under unknownStallMs', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'unknown');
+      (monitor as any).stateSince.set(session.id, { state: 'unknown', since: now - 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+    });
+
+    it('should only notify once for unknown stall', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'unknown');
+      (monitor as any).stateSince.set(session.id, { state: 'unknown', since: now - 4 * 60 * 1000 });
+
+      await checkStalls(now);
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should transition from unknown to known and clear stall tracking', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'working');
+      setPrevStallStatus(session.id, 'unknown');
+      // Must set lastBytesSeen so the working block does not `continue` at the no-entry guard
+      setLastBytesSeen(session.id, 500, now);
+      session.monitorOffset = 600; // bytes increasing
+      (monitor as any).stallNotified.add(`${session.id}:stall:unknown`);
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:unknown`)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Type 4: Extended stall detection', () => {
+    it('should detect extended stall for plan_mode held for 2x stallThresholdMs', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'plan_mode');
+      (monitor as any).stateSince.set(session.id, { state: 'plan_mode', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      const payload = deps.mockChannels.statusChange.mock.calls[0][0];
+      expect(payload.event).toBe('status.stall');
+      expect(payload.detail).toContain('plan_mode');
+    });
+
+    it('should detect extended stall for ask_question held for 2x threshold', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'ask_question');
+      (monitor as any).stateSince.set(session.id, { state: 'ask_question', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(1);
+      expect(deps.mockChannels.statusChange.mock.calls[0][0].detail).toContain('ask_question');
+    });
+
+    it('should NOT trigger extended stall for idle state', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'idle');
+      (monitor as any).stateSince.set(session.id, { state: 'idle', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+    });
+
+    it('should NOT trigger extended stall for working state', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now);
+      (monitor as any).stateSince.set(session.id, { state: 'working', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      const calls = deps.mockChannels.statusChange.mock.calls;
+      const extendedCall = calls.find((c: any[]) => c[0].detail?.includes('state for'));
+      expect(extendedCall).toBeUndefined();
+    });
+
+    it('should NOT trigger extended stall when under 2x threshold', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'plan_mode');
+      (monitor as any).stateSince.set(session.id, { state: 'plan_mode', since: now - 8 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+    });
+
+    it('should only notify once for extended stall', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'plan_mode');
+      (monitor as any).stateSince.set(session.id, { state: 'plan_mode', since: now - 11 * 60 * 1000 });
+
+      await checkStalls(now);
+      await checkStalls(now);
+
+      const extendedCalls = deps.mockChannels.statusChange.mock.calls.filter(
+        (c: any[]) => c[0].detail?.includes('state for'),
+      );
+      expect(extendedCalls).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('State transition cleanup', () => {
+    it('should clear ALL stall tracking when session goes idle', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'idle');
+      (monitor as any).stallNotified.add(`${session.id}:stall:jsonl`);
+      (monitor as any).stallNotified.add(`${session.id}:stall:permission`);
+      (monitor as any).stallNotified.add(`${session.id}:stall:permission_timeout`);
+      (monitor as any).stallNotified.add(`${session.id}:stall:unknown`);
+      (monitor as any).stallNotified.add(`${session.id}:stall:extended`);
+      (monitor as any).stateSince.set(session.id, { state: 'working', since: now });
+      (monitor as any).rateLimitedSessions.add(session.id);
+
+      await checkStalls(now);
+
+      for (const key of (monitor as any).stallNotified) {
+        expect(key.startsWith(session.id)).toBe(false);
+      }
+      expect((monitor as any).stateSince.has(session.id)).toBe(false);
+      expect((monitor as any).rateLimitedSessions.has(session.id)).toBe(false);
+    });
+
+    it('should use stallNotified key format ${sessionId}:stall:${type}', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 6 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:permission`)).toBe(true);
+    });
+
+    it('should clear permission stall when transitioning from permission_prompt to working', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'working');
+      setPrevStallStatus(session.id, 'permission_prompt');
+      // Must set lastBytesSeen so the working block does not `continue` at the no-entry guard
+      setLastBytesSeen(session.id, 500, now);
+      session.monitorOffset = 600;
+      (monitor as any).stallNotified.add(`${session.id}:stall:permission`);
+      (monitor as any).stallNotified.add(`${session.id}:stall:permission_timeout`);
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:permission`)).toBe(false);
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:permission_timeout`)).toBe(false);
+    });
+
+    it('should clear permission stall when transitioning from bash_approval to working', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'working');
+      setPrevStallStatus(session.id, 'bash_approval');
+      setLastBytesSeen(session.id, 500, now);
+      session.monitorOffset = 600;
+      (monitor as any).stallNotified.add(`${session.id}:stall:permission`);
+      (monitor as any).stallNotified.add(`${session.id}:stall:permission_timeout`);
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:permission`)).toBe(false);
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:permission_timeout`)).toBe(false);
+    });
+
+    it('should clear unknown stall when transitioning from unknown to working', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'working');
+      setPrevStallStatus(session.id, 'unknown');
+      setLastBytesSeen(session.id, 500, now);
+      session.monitorOffset = 600;
+      (monitor as any).stallNotified.add(`${session.id}:stall:unknown`);
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:unknown`)).toBe(false);
+    });
+
+    it('should NOT clear unrelated stall types on transition', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'working');
+      setPrevStallStatus(session.id, 'permission_prompt');
+      (monitor as any).stallNotified.add(`${session.id}:stall:extended`);
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:extended`)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('stateSince tracking', () => {
+    it('should set stateSince when session enters non-idle state for first time', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'working');
+
+      await checkStalls(now);
+
+      const entry = (monitor as any).stateSince.get(session.id);
+      expect(entry).toBeDefined();
+      expect(entry.state).toBe('working');
+      expect(entry.since).toBe(now);
+    });
+
+    it('should update stateSince on state change (non-permission transition)', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'plan_mode');
+      (monitor as any).stateSince.set(session.id, { state: 'working', since: now - 3 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      const entry = (monitor as any).stateSince.get(session.id);
+      expect(entry.state).toBe('plan_mode');
+      expect(entry.since).toBe(now);
+    });
+
+    it('should preserve stateSince timestamp on permission_prompt to bash_approval transition', async () => {
+      const now = Date.now();
+      const originalSince = now - 3 * 60 * 1000;
+      const session = addSession();
+      setLastStatus(session.id, 'bash_approval');
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: originalSince });
+
+      await checkStalls(now);
+
+      const entry = (monitor as any).stateSince.get(session.id);
+      expect(entry.state).toBe('bash_approval');
+      expect(entry.since).toBe(originalSince);
+    });
+
+    it('should preserve stateSince timestamp on bash_approval to permission_prompt transition', async () => {
+      const now = Date.now();
+      const originalSince = now - 2 * 60 * 1000;
+      const session = addSession();
+      setLastStatus(session.id, 'permission_prompt');
+      (monitor as any).stateSince.set(session.id, { state: 'bash_approval', since: originalSince });
+
+      await checkStalls(now);
+
+      const entry = (monitor as any).stateSince.get(session.id);
+      expect(entry.state).toBe('permission_prompt');
+      expect(entry.since).toBe(originalSince);
+    });
+
+    it('should NOT set stateSince for idle sessions', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'idle');
+
+      await checkStalls(now);
+
+      expect((monitor as any).stateSince.has(session.id)).toBe(false);
+    });
+
+    it('should delete stateSince on transition to idle', async () => {
+      const now = Date.now();
+      const session = addSession();
+      setLastStatus(session.id, 'idle');
+      (monitor as any).stateSince.set(session.id, { state: 'working', since: now - 5 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect((monitor as any).stateSince.has(session.id)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Multiple sessions independence', () => {
+    it('should track stalls independently across different sessions', async () => {
+      const now = Date.now();
+      addSession({ id: 'sess-1', monitorOffset: 500 });
+      addSession({ id: 'sess-2' });
+      setLastStatus('sess-1', 'working');
+      setLastStatus('sess-2', 'unknown');
+      setLastBytesSeen('sess-1', 500, now - 6 * 60 * 1000);
+      (monitor as any).stateSince.set('sess-2', { state: 'unknown', since: now - 4 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clean up one session without affecting another', async () => {
+      const now = Date.now();
+      addSession({ id: 'sess-1' });
+      addSession({ id: 'sess-2' });
+      setLastStatus('sess-1', 'idle');
+      setLastStatus('sess-2', 'permission_prompt');
+      (monitor as any).stateSince.set('sess-1', { state: 'working', since: now });
+      (monitor as any).stateSince.set('sess-2', { state: 'permission_prompt', since: now - 6 * 60 * 1000 });
+      (monitor as any).stallNotified.add('sess-1:stall:jsonl');
+      (monitor as any).stallNotified.add('sess-2:stall:permission');
+
+      await checkStalls(now);
+
+      expect((monitor as any).stateSince.has('sess-1')).toBe(false);
+      expect((monitor as any).stateSince.has('sess-2')).toBe(true);
+      expect((monitor as any).stallNotified.has('sess-1:stall:jsonl')).toBe(false);
+      expect((monitor as any).stallNotified.has('sess-2:stall:permission')).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('prevStatusForStall tracking', () => {
+    it('should set prevStatusForStall after each checkForStalls run', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 600 });
+      setLastStatus(session.id, 'working');
+      // Must have lastBytesSeen to avoid `continue` at the no-entry guard
+      setLastBytesSeen(session.id, 500, now);
+
+      await checkStalls(now);
+
+      expect((monitor as any).prevStatusForStall.get(session.id)).toBe('working');
+    });
+
+    it('should delete prevStatusForStall when currentStatus is undefined', async () => {
+      const now = Date.now();
+      const session = addSession();
+      (monitor as any).prevStatusForStall.set(session.id, 'working');
+
+      await checkStalls(now);
+
+      expect((monitor as any).prevStatusForStall.has(session.id)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Extended stall alongside primary stall', () => {
+    it('should fire both permission stall and extended stall when both thresholds met', async () => {
+      const now = Date.now();
+      const dualMonitor = makeMonitor(deps.mockSessions, deps.mockChannels as unknown as ChannelManager, {
+        stallThresholdMs: 3 * 60 * 1000,
+        permissionStallMs: 5 * 60 * 1000,
+        permissionTimeoutMs: 10 * 60 * 1000,
+      });
+      const session = addSession();
+      (dualMonitor as any).lastStatus.set(session.id, 'permission_prompt');
+      (dualMonitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 7 * 60 * 1000 });
+
+      await (dualMonitor as any).checkForStalls(now);
+
+      const calls = (deps.mockChannels.statusChange as ReturnType<typeof vi.fn>).mock.calls;
+      const events = calls.map((c: any[]) => c[0].event);
+      expect(events).toContain('status.stall');
+      expect(calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/src/__tests__/swarm-changes.test.ts
+++ b/src/__tests__/swarm-changes.test.ts
@@ -1,0 +1,778 @@
+/**
+ * swarm-changes.test.ts — Tests for detectChanges event emission in SwarmMonitor.
+ *
+ * Covers teammate_spawned, teammate_finished, no-event-without-parent,
+ * stale socket cleanup, computeAggregatedStatus, handler error isolation,
+ * and event handler registration.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SwarmMonitor } from '../swarm-monitor.js';
+import type { SwarmEvent, SwarmEventHandler, TeammateInfo, SwarmInfo } from '../swarm-monitor.js';
+import type { SessionManager, SessionInfo } from '../session.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'test-session-123',
+    windowId: '@5',
+    windowName: 'cc-test',
+    workDir: '/tmp/test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'working',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+function createMockSessionManager(sessions: SessionInfo[]): SessionManager {
+  return {
+    listSessions: vi.fn().mockReturnValue(sessions),
+    getSession: vi.fn((id: string) => sessions.find(s => s.id === id) ?? null),
+  } as unknown as SessionManager;
+}
+
+function makeTeammate(overrides: Partial<TeammateInfo> = {}): TeammateInfo {
+  return {
+    windowId: '@0',
+    windowName: 'teammate-explore-agent',
+    cwd: '/tmp/project',
+    paneCommand: 'claude',
+    alive: true,
+    status: 'running',
+    ...overrides,
+  };
+}
+
+function makeSwarmInfo(overrides: Partial<SwarmInfo> = {}): SwarmInfo {
+  return {
+    socketName: 'claude-swarm-12345',
+    pid: 12345,
+    parentSession: null,
+    teammates: [],
+    aggregatedStatus: 'no_teammates',
+    lastScannedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+/** Create a monitor with internal state pre-set so detectChanges can be tested directly. */
+function setupMonitor(sessionManager?: SessionManager): SwarmMonitor {
+  const sm = sessionManager ?? createMockSessionManager([]);
+  return new SwarmMonitor(sm);
+}
+
+/** Set the private lastResult field on the monitor. */
+function setLastResult(monitor: SwarmMonitor, result: SwarmInfo[] | null): void {
+  (monitor as unknown as { lastResult: Record<string, unknown> | null }).lastResult = result
+    ? { swarms: result, totalSockets: result.length, totalTeammates: 0, scannedAt: Date.now() }
+    : null;
+}
+
+// ---------------------------------------------------------------------------
+// teammate_spawned
+// ---------------------------------------------------------------------------
+
+describe('detectChanges — teammate_spawned', () => {
+  let monitor: SwarmMonitor;
+  let events: SwarmEvent[];
+
+  beforeEach(() => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    monitor = setupMonitor(createMockSessionManager([session]));
+    events = [];
+    monitor.onEvent(e => events.push(e));
+  });
+
+  it('should emit teammate_spawned when a new teammate window appears', () => {
+    const swarm = makeSwarmInfo({
+      parentSession: makeSession({ id: 'parent-1', ccPid: 12345 }),
+      teammates: [makeTeammate({ windowName: 'teammate-new-agent' })],
+    });
+    setLastResult(monitor, [swarm]);
+
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('teammate_spawned');
+  });
+
+  it('should NOT emit teammate_spawned for a dead teammate', () => {
+    const swarm = makeSwarmInfo({
+      parentSession: makeSession({ id: 'parent-1', ccPid: 12345 }),
+      teammates: [makeTeammate({ windowName: 'teammate-dead-agent', status: 'dead', alive: false })],
+    });
+    setLastResult(monitor, [swarm]);
+
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('should include correct swarm and teammate info in the event', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const teammate = makeTeammate({ windowName: 'teammate-explore-agent', windowId: '@3' });
+    const swarm = makeSwarmInfo({ parentSession: parent, teammates: [teammate] });
+    setLastResult(monitor, [swarm]);
+
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    if (event.type !== 'teammate_spawned') throw new Error('wrong event type');
+    expect(event.swarm.socketName).toBe('claude-swarm-12345');
+    expect(event.teammate.windowName).toBe('teammate-explore-agent');
+    expect(event.teammate.windowId).toBe('@3');
+    expect(event.swarm.parentSession?.id).toBe('parent-1');
+  });
+
+  it('should NOT re-emit spawn for a teammate already in previous snapshot', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const teammate = makeTeammate({ windowName: 'teammate-existing-agent' });
+    const swarm = makeSwarmInfo({ parentSession: parent, teammates: [teammate] });
+
+    // First scan: teammate is new
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(events).toHaveLength(1);
+
+    events.length = 0;
+
+    // Second scan: same teammate, should NOT spawn again
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(events).toHaveLength(0);
+  });
+
+  it('should emit spawn events for multiple new teammates at once', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const swarm = makeSwarmInfo({
+      parentSession: parent,
+      teammates: [
+        makeTeammate({ windowName: 'teammate-alpha' }),
+        makeTeammate({ windowName: 'teammate-beta' }),
+        makeTeammate({ windowName: 'teammate-gamma' }),
+      ],
+    });
+    setLastResult(monitor, [swarm]);
+
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(3);
+    const names = events.map(e => (e as { teammate: TeammateInfo }).teammate.windowName);
+    expect(names).toContain('teammate-alpha');
+    expect(names).toContain('teammate-beta');
+    expect(names).toContain('teammate-gamma');
+  });
+
+  it('should emit spawn only for new teammates when some already existed', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const existing = makeTeammate({ windowName: 'teammate-existing' });
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [existing] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    events.length = 0;
+
+    // Add a new teammate alongside the existing one
+    const newTeammate = makeTeammate({ windowName: 'teammate-new' });
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [existing, newTeammate] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('teammate_spawned');
+    if (events[0]!.type === 'teammate_spawned') {
+      expect(events[0]!.teammate.windowName).toBe('teammate-new');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// teammate_finished
+// ---------------------------------------------------------------------------
+
+describe('detectChanges — teammate_finished', () => {
+  let monitor: SwarmMonitor;
+  let events: SwarmEvent[];
+
+  beforeEach(() => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    monitor = setupMonitor(createMockSessionManager([session]));
+    events = [];
+    monitor.onEvent(e => events.push(e));
+  });
+
+  it('should emit teammate_finished when a teammate disappears entirely', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const teammate = makeTeammate({ windowName: 'teammate-vanished' });
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [teammate] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    events.length = 0;
+
+    // Teammate no longer in the swarm
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('teammate_finished');
+    if (events[0]!.type === 'teammate_finished') {
+      expect(events[0]!.teammate.windowName).toBe('teammate-vanished');
+      expect(events[0]!.teammate.status).toBe('dead');
+      expect(events[0]!.teammate.alive).toBe(false);
+    }
+  });
+
+  it('should emit teammate_finished when status changes from running to dead', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const runningMate = makeTeammate({ windowName: 'teammate-dying', status: 'running', alive: true });
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [runningMate] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    events.length = 0;
+
+    // Same teammate now dead
+    const deadMate = makeTeammate({ windowName: 'teammate-dying', status: 'dead', alive: false });
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [deadMate] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('teammate_finished');
+  });
+
+  it('should NOT emit teammate_finished for an already-dead teammate in previous snapshot', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const deadMate = makeTeammate({ windowName: 'teammate-already-dead', status: 'dead', alive: false });
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [deadMate] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    events.length = 0;
+
+    // Teammate still dead, now disappears
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // prev.status was 'dead', not 'running', so the transition check fails
+    // but the teammate is gone entirely — that still triggers finished
+    // Actually: the teammate window is gone, so the `!current` branch fires.
+    // The check for `prev.status === 'running' && current.status === 'dead'` does not apply.
+    // The teammate_finished for a disappeared teammate is emitted regardless of prev status.
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('teammate_finished');
+  });
+
+  it('should NOT emit finished when teammate is idle then stays idle', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const idleMate = makeTeammate({ windowName: 'teammate-idle', status: 'idle', alive: false });
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [idleMate] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    events.length = 0;
+
+    // Same teammate, still idle
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [idleMate] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('should NOT emit finished when teammate goes from idle to dead (not running to dead)', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const idleMate = makeTeammate({ windowName: 'teammate-idle-to-dead', status: 'idle', alive: false });
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [idleMate] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    events.length = 0;
+
+    // Teammate transitions idle -> dead (not running -> dead)
+    const deadMate = makeTeammate({ windowName: 'teammate-idle-to-dead', status: 'dead', alive: false });
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [deadMate] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // idle -> dead does NOT trigger finished (only running -> dead does)
+    expect(events).toHaveLength(0);
+  });
+
+  it('should emit multiple finished events when several teammates disappear', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const t1 = makeTeammate({ windowName: 'teammate-a' });
+    const t2 = makeTeammate({ windowName: 'teammate-b' });
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [t1, t2] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    events.length = 0;
+
+    // Both disappear
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(2);
+    const names = events.map(e => (e as { teammate: TeammateInfo }).teammate.windowName);
+    expect(names).toContain('teammate-a');
+    expect(names).toContain('teammate-b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No events without parentSession
+// ---------------------------------------------------------------------------
+
+describe('detectChanges — no events without parentSession', () => {
+  let monitor: SwarmMonitor;
+  let events: SwarmEvent[];
+
+  beforeEach(() => {
+    monitor = setupMonitor(createMockSessionManager([]));
+    events = [];
+    monitor.onEvent(e => events.push(e));
+  });
+
+  it('should emit NO events when swarm has no parentSession', () => {
+    const teammate = makeTeammate({ windowName: 'teammate-orphan' });
+    const swarm = makeSwarmInfo({ parentSession: null, teammates: [teammate] });
+    setLastResult(monitor, [swarm]);
+
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(events).toHaveLength(0);
+  });
+
+  it('should not fire duplicate spawn events across repeated scans without parent', () => {
+    const teammate = makeTeammate({ windowName: 'teammate-orphan' });
+    const swarm = makeSwarmInfo({ parentSession: null, teammates: [teammate] });
+
+    // First scan
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(events).toHaveLength(0);
+
+    // Second scan — previousTeammates updated but still no parent
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(events).toHaveLength(0);
+  });
+
+  it('should still update previousTeammates even without parentSession', () => {
+    const previousTeammates = (monitor as unknown as { previousTeammates: Map<string, TeammateInfo[]> }).previousTeammates;
+    expect(previousTeammates.size).toBe(0);
+
+    const teammate = makeTeammate({ windowName: 'teammate-orphan' });
+    const swarm = makeSwarmInfo({ parentSession: null, teammates: [teammate] });
+    setLastResult(monitor, [swarm]);
+
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // previousTeammates should be updated even without a parent session
+    expect(previousTeammates.has('claude-swarm-12345')).toBe(true);
+    expect(previousTeammates.get('claude-swarm-12345')).toHaveLength(1);
+  });
+
+  it('should emit spawn events once parentSession is resolved on a subsequent scan', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+
+    // First: no parent
+    const teammate = makeTeammate({ windowName: 'teammate-delayed' });
+    const swarmNoParent = makeSwarmInfo({ parentSession: null, teammates: [teammate] });
+    setLastResult(monitor, [swarmNoParent]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(events).toHaveLength(0);
+
+    // Second: parent resolved, but teammate was already recorded in previous snapshot
+    const swarmWithParent = makeSwarmInfo({ parentSession: parent, teammates: [teammate] });
+    setLastResult(monitor, [swarmWithParent]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // The teammate was already in previousTeammates from the no-parent scan,
+    // so it should NOT trigger a spawn event (it's not new).
+    expect(events).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale socket cleanup
+// ---------------------------------------------------------------------------
+
+describe('detectChanges — stale socket cleanup', () => {
+  let monitor: SwarmMonitor;
+  let events: SwarmEvent[];
+  let previousTeammates: Map<string, TeammateInfo[]>;
+
+  beforeEach(() => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    monitor = setupMonitor(createMockSessionManager([session]));
+    events = [];
+    monitor.onEvent(e => events.push(e));
+    previousTeammates = (monitor as unknown as { previousTeammates: Map<string, TeammateInfo[]> }).previousTeammates;
+  });
+
+  it('should remove stale sockets from previousTeammates', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const teammate = makeTeammate({ windowName: 'teammate-old' });
+    const swarm = makeSwarmInfo({ parentSession: parent, teammates: [teammate] });
+
+    // First scan: socket exists
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(previousTeammates.has('claude-swarm-12345')).toBe(true);
+
+    // Second scan: socket gone entirely (no swarms at all)
+    setLastResult(monitor, []);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(previousTeammates.has('claude-swarm-12345')).toBe(false);
+  });
+
+  it('should prevent false finished events from stale data after cleanup', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const teammate = makeTeammate({ windowName: 'teammate-stale' });
+    const swarm = makeSwarmInfo({ parentSession: parent, teammates: [teammate] });
+
+    // Scan 1: teammate exists
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // Scan 2: swarm disappears (cleanup)
+    setLastResult(monitor, []);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // No finished event because parentSession is null in the scan with no swarms —
+    // the swarm is not in lastResult.swarms at all, so no comparison happens.
+    // But the stale socket is removed.
+    const finishedEvents = events.filter(e => e.type === 'teammate_finished');
+    // The finished event was emitted on scan 2's previousSwarm comparison.
+    // Since the swarm was in previousTeammates but not in the current scan,
+    // there's no swarm to iterate over, so no finished event fires.
+    expect(finishedEvents).toHaveLength(0);
+    expect(previousTeammates.has('claude-swarm-12345')).toBe(false);
+
+    events.length = 0;
+
+    // Scan 3: swarm reappears with same teammate name — should trigger spawn
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // Because the stale socket was cleaned up, previousTeammates no longer has it,
+    // so the teammate appears as new and triggers a spawn.
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('teammate_spawned');
+  });
+
+  it('should keep non-stale sockets in previousTeammates', () => {
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const swarm1 = makeSwarmInfo({
+      socketName: 'claude-swarm-11111',
+      pid: 11111,
+      parentSession: parent,
+      teammates: [makeTeammate({ windowName: 'teammate-a' })],
+    });
+    const swarm2 = makeSwarmInfo({
+      socketName: 'claude-swarm-22222',
+      pid: 22222,
+      parentSession: null,
+      teammates: [makeTeammate({ windowName: 'teammate-b' })],
+    });
+
+    setLastResult(monitor, [swarm1, swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+    expect(previousTeammates.has('claude-swarm-11111')).toBe(true);
+    expect(previousTeammates.has('claude-swarm-22222')).toBe(true);
+
+    // Only swarm1 remains
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(previousTeammates.has('claude-swarm-11111')).toBe(true);
+    expect(previousTeammates.has('claude-swarm-22222')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAggregatedStatus
+// ---------------------------------------------------------------------------
+
+describe('computeAggregatedStatus', () => {
+  let monitor: SwarmMonitor;
+
+  beforeEach(() => {
+    monitor = setupMonitor();
+  });
+
+  it('should return "no_teammates" for empty teammates list', () => {
+    const result = (monitor as unknown as { computeAggregatedStatus: (t: TeammateInfo[]) => string })
+      .computeAggregatedStatus([]);
+    expect(result).toBe('no_teammates');
+  });
+
+  it('should return "all_dead" when all teammates are dead', () => {
+    const teammates = [
+      makeTeammate({ status: 'dead', alive: false }),
+      makeTeammate({ status: 'dead', alive: false }),
+    ];
+    const result = (monitor as unknown as { computeAggregatedStatus: (t: TeammateInfo[]) => string })
+      .computeAggregatedStatus(teammates);
+    expect(result).toBe('all_dead');
+  });
+
+  it('should return "some_working" when any teammate is running', () => {
+    const teammates = [
+      makeTeammate({ status: 'running', alive: true }),
+      makeTeammate({ status: 'idle', alive: false }),
+    ];
+    const result = (monitor as unknown as { computeAggregatedStatus: (t: TeammateInfo[]) => string })
+      .computeAggregatedStatus(teammates);
+    expect(result).toBe('some_working');
+  });
+
+  it('should return "some_working" when all teammates are running', () => {
+    const teammates = [
+      makeTeammate({ status: 'running', alive: true }),
+      makeTeammate({ status: 'running', alive: true }),
+    ];
+    const result = (monitor as unknown as { computeAggregatedStatus: (t: TeammateInfo[]) => string })
+      .computeAggregatedStatus(teammates);
+    expect(result).toBe('some_working');
+  });
+
+  it('should return "all_idle" when no running and not all dead', () => {
+    const teammates = [
+      makeTeammate({ status: 'idle', alive: false }),
+      makeTeammate({ status: 'idle', alive: false }),
+    ];
+    const result = (monitor as unknown as { computeAggregatedStatus: (t: TeammateInfo[]) => string })
+      .computeAggregatedStatus(teammates);
+    expect(result).toBe('all_idle');
+  });
+
+  it('should return "all_idle" for a mix of idle and dead teammates', () => {
+    const teammates = [
+      makeTeammate({ status: 'idle', alive: false }),
+      makeTeammate({ status: 'dead', alive: false }),
+    ];
+    const result = (monitor as unknown as { computeAggregatedStatus: (t: TeammateInfo[]) => string })
+      .computeAggregatedStatus(teammates);
+    expect(result).toBe('all_idle');
+  });
+
+  it('should return "some_working" even with one running among many dead', () => {
+    const teammates = [
+      makeTeammate({ status: 'running', alive: true }),
+      makeTeammate({ status: 'dead', alive: false }),
+      makeTeammate({ status: 'dead', alive: false }),
+    ];
+    const result = (monitor as unknown as { computeAggregatedStatus: (t: TeammateInfo[]) => string })
+      .computeAggregatedStatus(teammates);
+    expect(result).toBe('some_working');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler error isolation
+// ---------------------------------------------------------------------------
+
+describe('detectChanges — handler error isolation', () => {
+  it('should not prevent other handlers from receiving events when one throws', () => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const monitor = setupMonitor(createMockSessionManager([session]));
+    const events: SwarmEvent[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const badHandler: SwarmEventHandler = () => {
+      throw new Error('handler exploded');
+    };
+    const goodHandler: SwarmEventHandler = (e) => {
+      events.push(e);
+    };
+
+    monitor.onEvent(badHandler);
+    monitor.onEvent(goodHandler);
+
+    const teammate = makeTeammate({ windowName: 'teammate-resilient' });
+    const swarm = makeSwarmInfo({
+      parentSession: session,
+      teammates: [teammate],
+    });
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // Good handler should still receive the event despite bad handler throwing
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('teammate_spawned');
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('should log handler errors to console.error', () => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const monitor = setupMonitor(createMockSessionManager([session]));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    monitor.onEvent(() => { throw new Error('boom'); });
+
+    const teammate = makeTeammate({ windowName: 'teammate-error-test' });
+    const swarm = makeSwarmInfo({
+      parentSession: session,
+      teammates: [teammate],
+    });
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'SwarmMonitor event handler error:',
+      expect.any(Error),
+    );
+
+    errorSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event handler registration
+// ---------------------------------------------------------------------------
+
+describe('onEvent — handler registration', () => {
+  it('should register handlers that receive events', () => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const monitor = setupMonitor(createMockSessionManager([session]));
+    const events: SwarmEvent[] = [];
+
+    monitor.onEvent(e => events.push(e));
+
+    const teammate = makeTeammate({ windowName: 'teammate-registered' });
+    const swarm = makeSwarmInfo({ parentSession: session, teammates: [teammate] });
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(1);
+  });
+
+  it('should deliver events to all registered handlers', () => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const monitor = setupMonitor(createMockSessionManager([session]));
+    const events1: SwarmEvent[] = [];
+    const events2: SwarmEvent[] = [];
+    const events3: SwarmEvent[] = [];
+
+    monitor.onEvent(e => events1.push(e));
+    monitor.onEvent(e => events2.push(e));
+    monitor.onEvent(e => events3.push(e));
+
+    const teammate = makeTeammate({ windowName: 'teammate-multi' });
+    const swarm = makeSwarmInfo({ parentSession: session, teammates: [teammate] });
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events1).toHaveLength(1);
+    expect(events2).toHaveLength(1);
+    expect(events3).toHaveLength(1);
+
+    expect(events1[0]!.type).toBe('teammate_spawned');
+    expect(events2[0]!.type).toBe('teammate_spawned');
+    expect(events3[0]!.type).toBe('teammate_spawned');
+  });
+
+  it('should receive both spawn and finished events on the same handler', () => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const monitor = setupMonitor(createMockSessionManager([session]));
+    const events: SwarmEvent[] = [];
+
+    monitor.onEvent(e => events.push(e));
+
+    const teammate = makeTeammate({ windowName: 'teammate-lifecycle' });
+    const parent = makeSession({ id: 'parent-1', ccPid: 12345 });
+
+    // Spawn
+    const swarm1 = makeSwarmInfo({ parentSession: parent, teammates: [teammate] });
+    setLastResult(monitor, [swarm1]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    // Finish (disappears)
+    const swarm2 = makeSwarmInfo({ parentSession: parent, teammates: [] });
+    setLastResult(monitor, [swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(2);
+    expect(events[0]!.type).toBe('teammate_spawned');
+    expect(events[1]!.type).toBe('teammate_finished');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectChanges — edge cases
+// ---------------------------------------------------------------------------
+
+describe('detectChanges — edge cases', () => {
+  it('should be a no-op when lastResult is null', () => {
+    const monitor = setupMonitor();
+    const events: SwarmEvent[] = [];
+    monitor.onEvent(e => events.push(e));
+
+    (monitor as unknown as { lastResult: null }).lastResult = null;
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('should handle multiple swarms in a single scan', () => {
+    const session1 = makeSession({ id: 'parent-1', ccPid: 11111 });
+    const session2 = makeSession({ id: 'parent-2', ccPid: 22222 });
+    const monitor = setupMonitor(createMockSessionManager([session1, session2]));
+    const events: SwarmEvent[] = [];
+    monitor.onEvent(e => events.push(e));
+
+    const swarm1 = makeSwarmInfo({
+      socketName: 'claude-swarm-11111',
+      pid: 11111,
+      parentSession: session1,
+      teammates: [makeTeammate({ windowName: 'teammate-from-1' })],
+    });
+    const swarm2 = makeSwarmInfo({
+      socketName: 'claude-swarm-22222',
+      pid: 22222,
+      parentSession: session2,
+      teammates: [makeTeammate({ windowName: 'teammate-from-2' })],
+    });
+
+    setLastResult(monitor, [swarm1, swarm2]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(2);
+    const names = events.map(e => (e as { teammate: TeammateInfo }).teammate.windowName);
+    expect(names).toContain('teammate-from-1');
+    expect(names).toContain('teammate-from-2');
+  });
+
+  it('should not emit spawn for teammate with status dead in initial scan', () => {
+    const session = makeSession({ id: 'parent-1', ccPid: 12345 });
+    const monitor = setupMonitor(createMockSessionManager([session]));
+    const events: SwarmEvent[] = [];
+    monitor.onEvent(e => events.push(e));
+
+    const deadMate = makeTeammate({ windowName: 'teammate-born-dead', status: 'dead', alive: false });
+    const swarm = makeSwarmInfo({ parentSession: session, teammates: [deadMate] });
+    setLastResult(monitor, [swarm]);
+    (monitor as unknown as { detectChanges: () => void }).detectChanges();
+
+    expect(events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix typo `statusChangemock` → `statusChange.mock` in stall-detection.test.ts line 498
- Fix premature `ChannelManager` cast hiding `.mock` property — moved cast to call sites
- Fix `Parameters<typeof SessionMonitor>` → `ConstructorParameters` in dead-session.test.ts
- Type `isWindowAlive` mock with `(id: string)` parameter to match implementation
- Add missing required `SessionInfo` fields in pipeline.test.ts

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] All 1414 tests pass (62 test files, 14 skipped)

Generated by Hephaestus (Aegis dev agent)