### PR TITLE
feat: automated release pipeline (npm publish + GitHub Releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run build
+      - run: npm test
+
+  publish-npm:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - name: Generate changelog
+        id: changelog
+        run: |
+          # Get changelog section for this version
+          sed -n "/## \[${{ steps.version.outputs.VERSION }}\]/,/## \[/p" CHANGELOG.md | head -n -1 > release_notes.md
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.md
+          generate_release_notes: false

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,49 @@
+# Source code
+src/
+tsconfig.json
+
+# Tests
+src/__tests__/
+
+# Development
+.eslintrc*
+.prettierrc*
+vitest.config.*
+
+# CI/CD
+.github/
+
+# Dashboard (separate app)
+dashboard/
+
+# Docs
+docs/
+*.md
+!README.md
+!CHANGELOG.md
+!LICENSE
+
+# Build artifacts
+*.tsbuildinfo
+
+# State and config
+.aegis/
+.env
+.env.*
+
+# IDE
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Worktrees
+.worktrees/
+
+# Misc
+.mcp.json
+*.log
+*.jsonl
+.claude/


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` triggered on `v*` tags with 3 jobs: **test**, **publish-npm**, **github-release**
- Add `.npmignore` to ensure clean npm package contents (belt-and-suspenders with existing `files` field in package.json)

Closes #365

## Release workflow details

| Job | Purpose |
|-----|---------|
| `test` | Runs `npm ci` → `tsc --noEmit` → `build` → `npm test` (Node 22) |
| `publish-npm` | `npm publish --provenance --access public` (needs `NPM_TOKEN` secret) |
| `github-release` | Extracts version section from `CHANGELOG.md` → creates GitHub Release via `softprops/action-gh-release@v2` |

## Required secret

- `NPM_TOKEN` — npm access token with publish permissions for `aegis-bridge`

## Release process (after merge)

```bash
npm version patch  # or minor, major
git push --follow-tags
# CI handles the rest
```

## Test plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Confirm `NPM_TOKEN` secret is configured in repo settings
- [ ] Push a test tag (e.g. `v1.3.4-beta.1`) to verify workflow runs end-to-end
- [ ] Verify `.npmignore` produces clean package with `npm pack --dry-run`

Generated by Hephaestus (Aegis dev agent)