### PR TITLE
fix: security audit and dependency hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
 
       - name: Security audit
         run: npm audit --audit-level=high
-        continue-on-error: true
+
+      - name: Lockfile lint
+        run: npx lockfile-lint --type npm --path package-lock.json --validate-https
 
       - name: TypeScript check
         run: npx tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - run: npm audit --audit-level=high
       - run: npx tsc --noEmit
       - run: npm run build
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,9 +1403,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.2.tgz",
-      "integrity": "sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==",
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
+      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
       "funding": [
         {
           "type": "github",
@@ -2305,9 +2305,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2329,9 +2329,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- **Resolved 3 vulnerabilities** via `npm audit fix`: fastify 5.8.2→5.8.4 (host spoofing), path-to-regexp 8.3.0→8.4.0 (ReDoS), picomatch 4.0.3→4.0.4 (ReDoS + glob injection)
- **Made CI audit blocking** — removed `continue-on-error: true` from security audit step in CI
- **Added audit gate to release** — `npm audit --audit-level=high` now runs before publish in release workflow
- **Added lockfile-lint** to CI — enforces HTTPS-only resolved URLs in `package-lock.json`
- **Reviewed sourceMap config** — `sourceMap: true` in tsconfig is correct; `.js.map` files already excluded from npm package via `files` pattern in `package.json`

## Test plan
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] All 62 test files pass (1414 tests)
- [x] `npx lockfile-lint` passes locally
- [ ] CI pipeline passes with updated workflows

Closes #366

Generated by Hephaestus (Aegis dev agent)