### PR TITLE
feat: MCP Prompts — workflow templates for common tasks — Issue #443

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -702,4 +702,95 @@ describe('MCP Resources', () => {
       expect(getText(result.contents)).toContain('Error:');
     });
   });
+
+  describe('MCP Prompts', () => {
+  // ── MCP Prompts tests (Issue #443) ──
+
+  it('registers 3 prompts', () => {
+    const server = createMcpServer(9100);
+    const prompts = (server as any)._registeredPrompts;
+    const names = Object.keys(prompts);
+    expect(names).toContain('implement_issue');
+    expect(names).toContain('review_pr');
+    expect(names).toContain('debug_session');
+    expect(names).toHaveLength(3);
+  });
+
+  it('implement_issue prompt returns structured message', async () => {
+    const server = createMcpServer(9100);
+    const prompts = (server as any)._registeredPrompts;
+    const result = await prompts.implement_issue.callback({
+      issueNumber: '443',
+      workDir: '/home/user/aegis',
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+    const text = result.messages[0].content.text;
+    expect(text).toContain('OneStepAt4time/aegis#443');
+    expect(text).toContain('/home/user/aegis');
+    expect(text).toContain('implementing');
+    expect(text).toContain('create_session');
+  });
+
+  it('implement_issue prompt uses custom repo owner/name', async () => {
+    const server = createMcpServer(9100);
+    const prompts = (server as any)._registeredPrompts;
+    const result = await prompts.implement_issue.callback({
+      issueNumber: '99',
+      workDir: '/tmp',
+      repoOwner: 'myorg',
+      repoName: 'myrepo',
+    });
+    const text = result.messages[0].content.text;
+    expect(text).toContain('myorg/myrepo#99');
+    expect(text).toContain('https://github.com/myorg/myrepo/issues/99');
+  });
+
+  it('review_pr prompt returns structured message', async () => {
+    const server = createMcpServer(9100);
+    const prompts = (server as any)._registeredPrompts;
+    const result = await prompts.review_pr.callback({
+      prNumber: '123',
+      workDir: '/home/user/aegis',
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+    const text = result.messages[0].content.text;
+    expect(text).toContain('OneStepAt4time/aegis#123');
+    expect(text).toContain('reviewing');
+    expect(text).toContain('gh pr view 123');
+    expect(text).toContain('gh pr diff 123');
+  });
+
+  it('review_pr prompt uses custom repo owner/name', async () => {
+    const server = createMcpServer(9100);
+    const prompts = (server as any)._registeredPrompts;
+    const result = await prompts.review_pr.callback({
+      prNumber: '42',
+      workDir: '/tmp',
+      repoOwner: 'other',
+      repoName: 'project',
+    });
+    const text = result.messages[0].content.text;
+    expect(text).toContain('other/project#42');
+    expect(text).toContain('https://github.com/other/project/pull/42');
+  });
+
+  it('debug_session prompt returns structured message', async () => {
+    const server = createMcpServer(9100);
+    const prompts = (server as any)._registeredPrompts;
+    const UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const result = await prompts.debug_session.callback({
+      sessionId: UUID,
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+    const text = result.messages[0].content.text;
+    expect(text).toContain(UUID);
+    expect(text).toContain('diagnosing');
+    expect(text).toContain('get_status');
+    expect(text).toContain('get_transcript');
+    expect(text).toContain('capture_pane');
+  });
+});
 });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -783,6 +783,139 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     },
   );
 
+  // ── MCP Prompts (Issue #443) ────────────────────────────────────────
+
+  server.prompt(
+    'implement_issue',
+    'Create a session and generate a structured implementation prompt for a GitHub issue.',
+    {
+      issueNumber: z.string().describe('GitHub issue number'),
+      workDir: z.string().describe('Working directory for the new session'),
+      repoOwner: z.string().optional().describe('Repository owner (e.g., "OneStepAt4time")'),
+      repoName: z.string().optional().describe('Repository name (e.g., "aegis")'),
+    },
+    async ({ issueNumber, workDir, repoOwner, repoName }) => {
+      const owner = repoOwner || 'OneStepAt4time';
+      const repo = repoName || 'aegis';
+      const issueUrl = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+
+      return {
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: [
+                'You are tasked with implementing a GitHub issue.',
+                '',
+                `Issue: ${owner}/${repo}#${issueNumber}`,
+                `URL: ${issueUrl}`,
+                `Working directory: ${workDir}`,
+                '',
+                'Steps:',
+                `1. Create a new Aegis session in ${workDir}`,
+                `2. Read the GitHub issue at ${issueUrl} to understand the requirements`,
+                '3. Analyze the codebase to understand the current architecture',
+                '4. Plan the implementation approach',
+                '5. Implement the changes following project conventions',
+                '6. Run the quality gate: npx tsc --noEmit && npm run build && npm test',
+                '7. If tests pass, commit with a conventional commit message',
+                '',
+                'Use the create_session tool to start, then send_message for each step.',
+              ].join('\n'),
+            },
+          },
+        ],
+      };
+    },
+  );
+
+  server.prompt(
+    'review_pr',
+    'Create a session and generate a structured code review prompt for a GitHub pull request.',
+    {
+      prNumber: z.string().describe('GitHub pull request number'),
+      workDir: z.string().describe('Working directory for the new session'),
+      repoOwner: z.string().optional().describe('Repository owner (e.g., "OneStepAt4time")'),
+      repoName: z.string().optional().describe('Repository name (e.g., "aegis")'),
+    },
+    async ({ prNumber, workDir, repoOwner, repoName }) => {
+      const owner = repoOwner || 'OneStepAt4time';
+      const repo = repoName || 'aegis';
+      const prUrl = `https://github.com/${owner}/${repo}/pull/${prNumber}`;
+
+      return {
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: [
+                'You are tasked with reviewing a GitHub pull request.',
+                '',
+                `PR: ${owner}/${repo}#${prNumber}`,
+                `URL: ${prUrl}`,
+                `Working directory: ${workDir}`,
+                '',
+                'Steps:',
+                `1. Create a new Aegis session in ${workDir}`,
+                `2. Fetch the PR details: gh pr view ${prNumber} --repo ${owner}/${repo}`,
+                `3. Fetch the PR diff: gh pr diff ${prNumber} --repo ${owner}/${repo}`,
+                '4. Review the changes for:',
+                '   - Correctness and edge cases',
+                '   - Adherence to project coding conventions (see CLAUDE.md)',
+                '   - Security vulnerabilities (injection, XSS, etc.)',
+                '   - Test coverage for new code',
+                '   - Breaking changes or backwards compatibility',
+                '5. Post the review as a PR comment using gh api',
+                '',
+                'Use the create_session tool to start, then send_message for each step.',
+              ].join('\n'),
+            },
+          },
+        ],
+      };
+    },
+  );
+
+  server.prompt(
+    'debug_session',
+    'Generate a diagnostic summary for an Aegis session by reading its transcript and status.',
+    {
+      sessionId: z.string().describe('The Aegis session ID to debug'),
+    },
+    async ({ sessionId }) => {
+      return {
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: [
+                'You are diagnosing an Aegis session that may be stuck or misbehaving.',
+                '',
+                `Session ID: ${sessionId}`,
+                '',
+                'Steps:',
+                `1. Get the session status using get_status for session ${sessionId}`,
+                `2. Read the transcript using get_transcript for session ${sessionId}`,
+                `3. Capture the current terminal pane using capture_pane for session ${sessionId}`,
+                '4. Analyze the findings:',
+                '   - Is the session in an unexpected state (permission_prompt, unknown)?',
+                '   - Are there error messages in the transcript?',
+                '   - Is the session stalled (no recent activity)?',
+                '   - Are there repeated permission requests?',
+                '5. Provide a diagnostic summary with recommended actions',
+                '',
+                'Use get_status, get_transcript, and capture_pane tools to gather data.',
+              ].join('\n'),
+            },
+          },
+        ],
+      };
+    },
+  );
+
   return server;
 }
 


### PR DESCRIPTION
## Summary
Fixes #443. M1.3 milestone.

Implements 3 MCP prompts using the MCP SDK server.prompt() API:

## Prompts
| Prompt | Args | Purpose |
|--------|------|---------|
| implement_issue | issueNumber, workDir, repoOwner?, repoName? | Create session + implement a GitHub issue |
| review_pr | prNumber, workDir, repoOwner?, repoName? | Create session + review a PR |
| debug_session | sessionId | Diagnostic workflow for stuck sessions |

## Test plan
- [x] tsc --noEmit — clean
- [x] npm run build — clean
- [x] npm test — 64 files, 1466 tests passing