### PR TITLE
fix: use timingSafeEqual for token comparison — Issue #402

### DIFF
--- a/src/__tests__/auth-timing-safe.test.ts
+++ b/src/__tests__/auth-timing-safe.test.ts
@@ -1,0 +1,70 @@
+/**
+ * auth-timing-safe.test.ts — Verify timing-safe comparison for token validation.
+ *
+ * Issue #402: token === masterToken was vulnerable to timing attacks.
+ * The fix uses crypto.timingSafeEqual for constant-time comparison.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthManager } from '../auth.js';
+import type { ApiKey } from '../auth.js';
+
+// Capture what timingSafeEqual was called with
+let timingSafeEqualCalls: Array<{ a: string; b: string }> = [];
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  return {
+    ...actual,
+    timingSafeEqual: vi.fn((a: Buffer, b: Buffer) => {
+      timingSafeEqualCalls.push({ a: a.toString(), b: b.toString() });
+      // Delegate to real implementation
+      return actual.timingSafeEqual(a, b);
+    }),
+  };
+});
+
+describe('AuthManager timing-safe token comparison (#402)', () => {
+  let auth: AuthManager;
+  const masterToken = 'test_master_token_value_12345';
+
+  beforeEach(() => {
+    timingSafeEqualCalls = [];
+    auth = new AuthManager('/tmp/test-keys-timing.json', masterToken);
+    auth['store'] = { keys: [] };
+  });
+
+  it('uses timingSafeEqual for master token comparison', () => {
+    auth.validate(masterToken);
+
+    const matchCall = timingSafeEqualCalls.find(
+      (c) => c.a === masterToken && c.b === masterToken,
+    );
+    expect(matchCall).toBeDefined();
+  });
+
+  it('does not use === short-circuit (wrong token fails safely)', () => {
+    // A token that differs only in the last character
+    const wrongToken = masterToken.slice(0, -1) + 'X';
+    // Ensure lengths match so timingSafeEqual is actually called
+    const result = auth.validate(wrongToken);
+
+    expect(result.valid).toBe(false);
+
+    // timingSafeEqual should have been called (not skipped by === check)
+    const matchCall = timingSafeEqualCalls.find(
+      (c) => c.a === wrongToken && c.b === masterToken,
+    );
+    expect(matchCall).toBeDefined();
+  });
+
+  it('rejects tokens of different length without calling timingSafeEqual', () => {
+    const result = auth.validate('short');
+    expect(result.valid).toBe(false);
+
+    // timingSafeEqual should NOT be called for length mismatch
+    const matchCall = timingSafeEqualCalls.find(
+      (c) => c.b === masterToken,
+    );
+    expect(matchCall).toBeUndefined();
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,7 +6,7 @@
  * Backward compatible with single authToken from config.
  */
 
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
@@ -126,8 +126,9 @@ export class AuthManager {
       return { valid: true, keyId: null, rateLimited: false };
     }
 
-    // Check master token (backward compat)
-    if (this.masterToken && token === this.masterToken) {
+    // Check master token (backward compat) — timing-safe comparison (#402)
+    if (this.masterToken && token.length === this.masterToken.length
+      && timingSafeEqual(Buffer.from(token), Buffer.from(this.masterToken))) {
       return { valid: true, keyId: 'master', rateLimited: false };
     }
 


### PR DESCRIPTION
## Summary
Fixes #402. Critical security fix.

## Problem
Master token comparison in auth.ts used `===` which short-circuits on first differing character, leaking timing information to attackers.

## Solution
- Import `timingSafeEqual` from `node:crypto`
- Replace `token === this.masterToken` with constant-time comparison
- Add length check first (timingSafeEqual throws if lengths differ)
- 3 new unit tests verifying timingSafeEqual usage

## Test plan
- [x] tsc --noEmit — clean
- [x] npm run build — clean
- [x] npm test — 1560 tests passing