### PR TITLE
fix: add runtime type guards to ActivityStream describeEvent

### DIFF
--- a/dashboard/src/__tests__/ActivityStream.test.ts
+++ b/dashboard/src/__tests__/ActivityStream.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { describeEvent, safeStr } from '../components/ActivityStream';
+import type { GlobalSSEEvent } from '../types';
+
+function makeEvent(
+  event: GlobalSSEEvent['event'],
+  data: Record<string, unknown>,
+): GlobalSSEEvent {
+  return { event, sessionId: 'sess-1', timestamp: '2026-03-29T00:00:00Z', data };
+}
+
+describe('safeStr', () => {
+  it('returns string values unchanged', () => {
+    expect(safeStr('hello')).toBe('hello');
+  });
+
+  it('returns fallback for non-string values', () => {
+    expect(safeStr(123)).toBe('unknown');
+    expect(safeStr(null)).toBe('unknown');
+    expect(safeStr(undefined)).toBe('unknown');
+    expect(safeStr({ foo: 1 })).toBe('unknown');
+    expect(safeStr(true)).toBe('unknown');
+  });
+
+  it('uses custom fallback when provided', () => {
+    expect(safeStr(null, 'fallback')).toBe('fallback');
+    expect(safeStr(42, 'n/a')).toBe('n/a');
+  });
+});
+
+describe('describeEvent — type guards', () => {
+  it('handles session_status_change with valid string status', () => {
+    const e = makeEvent('session_status_change', { status: 'working', detail: 'thinking' });
+    expect(describeEvent(e)).toBe('Status → working: thinking');
+  });
+
+  it('handles session_status_change with non-string status', () => {
+    const e = makeEvent('session_status_change', { status: 42 });
+    expect(describeEvent(e)).toBe('Status → unknown');
+  });
+
+  it('handles session_status_change with non-string detail', () => {
+    const e = makeEvent('session_status_change', { status: 'idle', detail: { nested: true } });
+    expect(describeEvent(e)).toBe('Status → idle');
+  });
+
+  it('handles session_message with string text', () => {
+    const e = makeEvent('session_message', { role: 'user', text: 'hello world' });
+    expect(describeEvent(e)).toBe('User: hello world');
+  });
+
+  it('handles session_message with non-string text (object)', () => {
+    const e = makeEvent('session_message', { role: 'assistant', text: { blocks: [] } });
+    expect(describeEvent(e)).toBe('Claude: {"blocks":[]}');
+  });
+
+  it('handles session_message with null text', () => {
+    const e = makeEvent('session_message', { role: 'assistant', text: null });
+    expect(describeEvent(e)).toBe('Claude: ""');
+  });
+
+  it('handles session_message with undefined text', () => {
+    const e = makeEvent('session_message', { role: 'assistant' });
+    expect(describeEvent(e)).toBe('Claude: ""');
+  });
+
+  it('handles session_approval with string prompt', () => {
+    const e = makeEvent('session_approval', { prompt: 'Allow bash command?' });
+    expect(describeEvent(e)).toBe('Approval needed: Allow bash command?');
+  });
+
+  it('handles session_approval with non-string prompt', () => {
+    const e = makeEvent('session_approval', { prompt: { type: 'tool' } });
+    expect(describeEvent(e)).toBe('Approval needed: {"type":"tool"}');
+  });
+
+  it('handles session_ended with non-string reason', () => {
+    const e = makeEvent('session_ended', { reason: 500 });
+    expect(describeEvent(e)).toBe('Session ended: unknown');
+  });
+
+  it('handles session_created with non-string workDir', () => {
+    const e = makeEvent('session_created', { workDir: null });
+    expect(describeEvent(e)).toBe('Created in unknown dir');
+  });
+
+  it('handles session_stall with non-string stallType', () => {
+    const e = makeEvent('session_stall', { stallType: { kind: 'jsonl' } });
+    expect(describeEvent(e)).toBe('Session stalled: unknown');
+  });
+
+  it('handles session_dead with non-string stallType', () => {
+    const e = makeEvent('session_dead', { stallType: 99 });
+    expect(describeEvent(e)).toBe('Session dead: unknown');
+  });
+
+  it('handles session_subagent_start with non-string name', () => {
+    const e = makeEvent('session_subagent_start', { name: false });
+    expect(describeEvent(e)).toBe('Subagent started: unknown');
+  });
+
+  it('handles session_subagent_stop with non-string name', () => {
+    const e = makeEvent('session_subagent_stop', { name: [1, 2] });
+    expect(describeEvent(e)).toBe('Subagent finished: unknown');
+  });
+});

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -31,27 +31,39 @@ const EVENT_META: Record<GlobalSSEEventType, { icon: typeof Activity; label: str
   session_subagent_stop: { icon: UserCheck, label: 'Subagent Done', color: '#34d399' },
 };
 
-function describeEvent(event: GlobalSSEEvent): string {
+export function safeStr(val: unknown, fallback: string = 'unknown'): string {
+  return typeof val === 'string' ? val : fallback;
+}
+
+export function describeEvent(event: GlobalSSEEvent): string {
   const d = event.data;
   switch (event.event) {
-    case 'session_status_change':
-      return `Status → ${d.status ?? 'unknown'}${d.detail ? `: ${d.detail}` : ''}`;
-    case 'session_message':
-      return `${d.role === 'user' ? 'User' : d.role === 'assistant' ? 'Claude' : 'System'}: ${truncate((d.text as string) ?? '', 80)}`;
-    case 'session_approval':
-      return `Approval needed: ${truncate((d.prompt as string) ?? '', 80)}`;
+    case 'session_status_change': {
+      const status = safeStr(d.status);
+      const detail = typeof d.detail === 'string' ? `: ${d.detail}` : '';
+      return `Status → ${status}${detail}`;
+    }
+    case 'session_message': {
+      const role = d.role === 'user' ? 'User' : d.role === 'assistant' ? 'Claude' : 'System';
+      const text = typeof d.text === 'string' ? d.text : JSON.stringify(d.text ?? '');
+      return `${role}: ${truncate(text, 80)}`;
+    }
+    case 'session_approval': {
+      const prompt = typeof d.prompt === 'string' ? d.prompt : JSON.stringify(d.prompt ?? '');
+      return `Approval needed: ${truncate(prompt, 80)}`;
+    }
     case 'session_ended':
-      return `Session ended: ${d.reason ?? 'unknown'}`;
+      return `Session ended: ${safeStr(d.reason)}`;
     case 'session_created':
-      return `Created in ${(d.workDir as string) ?? 'unknown dir'}`;
+      return `Created in ${safeStr(d.workDir, 'unknown dir')}`;
     case 'session_stall':
-      return `Session stalled: ${(d.stallType as string) ?? 'unknown'}`;
+      return `Session stalled: ${safeStr(d.stallType)}`;
     case 'session_dead':
-      return `Session dead: ${(d.stallType as string) ?? 'unknown'}`;
+      return `Session dead: ${safeStr(d.stallType)}`;
     case 'session_subagent_start':
-      return `Subagent started: ${(d.name as string) ?? 'unknown'}`;
+      return `Subagent started: ${safeStr(d.name)}`;
     case 'session_subagent_stop':
-      return `Subagent finished: ${(d.name as string) ?? 'unknown'}`;
+      return `Subagent finished: ${safeStr(d.name)}`;
     default:
       return JSON.stringify(d);
   }


### PR DESCRIPTION
## Summary
- Replaces unsafe `as string` type casts in `describeEvent()` with runtime `typeof` checks
- Adds `safeStr()` helper for string-or-fallback pattern
- For `text` and `prompt` fields, uses `JSON.stringify()` fallback so objects render as their JSON representation instead of `[object Object]`

Fixes #423

## Test plan
- [x] 18 new unit tests covering all event types with non-string field values
- [x] Dashboard type-check passes (`tsc --noEmit`)
- [x] Main project build + 1583 tests pass

Generated by Hephaestus (Aegis dev agent)