### PR TITLE
fix: replace sync readFileSync with async I/O in transcript scanning

### DIFF
--- a/src/__tests__/transcript.test.ts
+++ b/src/__tests__/transcript.test.ts
@@ -492,4 +492,69 @@ describe('readNewEntries mid-offset', () => {
     expect(result.entries).toHaveLength(0);
     expect(result.newOffset).toBe(content.length);
   });
+
+  // Issue #409: async I/O should not block event loop
+  it('uses async I/O and does not read the entire file', async () => {
+    // Create a large file (>4096 bytes) to ensure the windowed scan
+    // only reads a small portion, not the whole file
+    const line1 = JSON.stringify({ type: 'user', message: { role: 'user', content: 'x'.repeat(5000) }, timestamp: '2024-01-01T00:00:00Z' });
+    const line2 = JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'y'.repeat(5000) }, timestamp: '2024-01-01T00:00:01Z' });
+    const line3 = JSON.stringify({ type: 'user', message: { role: 'user', content: 'Target' }, timestamp: '2024-01-01T00:00:02Z' });
+    const content = `${line1}\n${line2}\n${line3}\n`;
+    const filePath = join(tmpDir, 'large.jsonl');
+    writeFileSync(filePath, content);
+
+    // Set offset to middle of line3 — should scan back to newline before line3
+    const line3Start = line1.length + 1 + line2.length + 1;
+    const midLine3 = line3Start + Math.floor(line3.length / 2);
+    const result = await readNewEntries(filePath, midLine3);
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].text).toBe('Target');
+  });
+
+  it('handles offset at start of file (no backward scan needed)', async () => {
+    const line1 = JSON.stringify({ type: 'user', message: { role: 'user', content: 'First' }, timestamp: '2024-01-01T00:00:00Z' });
+    const content = `${line1}\n`;
+    const filePath = join(tmpDir, 'start.jsonl');
+    writeFileSync(filePath, content);
+
+    const result = await readNewEntries(filePath, 0);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].text).toBe('First');
+  });
+
+  it('scans across multiple newlines in the 4096-byte window', async () => {
+    // Create lines small enough that multiple fit in the 4096-byte window
+    const lines: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      lines.push(JSON.stringify({ type: 'user', message: { role: 'user', content: `Line${i}` }, timestamp: '2024-01-01T00:00:00Z' }));
+    }
+    const content = lines.join('\n') + '\n';
+    const filePath = join(tmpDir, 'multi.jsonl');
+    writeFileSync(filePath, content);
+
+    // Find offset for the middle of line 5
+    let offset = 0;
+    for (let i = 0; i < 5; i++) {
+      offset += lines[i].length + 1; // +1 for newline
+    }
+    offset += Math.floor(lines[5].length / 2);
+
+    const result = await readNewEntries(filePath, offset);
+    // Should get lines 5-9 (scanning back finds newline before line 5)
+    expect(result.entries.length).toBeGreaterThanOrEqual(4);
+    expect(result.entries[0].text).toBe('Line5');
+  });
+
+  it('handles file truncation by resetting offset to 0', async () => {
+    const content = JSON.stringify({ type: 'user', message: { role: 'user', content: 'Only' }, timestamp: '2024-01-01T00:00:00Z' }) + '\n';
+    const filePath = join(tmpDir, 'truncated.jsonl');
+    writeFileSync(filePath, content);
+
+    // Offset larger than file size
+    const result = await readNewEntries(filePath, 99999);
+    expect(result.entries).toHaveLength(0);
+    expect(result.newOffset).toBe(0);
+  });
 });

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -5,8 +5,8 @@
  * Reads CC session JSONL files and extracts structured messages.
  */
 
-import { stat, readFile } from 'node:fs/promises';
-import { createReadStream, existsSync, readFileSync } from 'node:fs';
+import { stat, readFile, open } from 'node:fs/promises';
+import { createReadStream, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { readdir } from 'node:fs/promises';
@@ -217,11 +217,19 @@ export async function readNewEntries(
   // Read from byte offset to end using createReadStream to avoid loading entire file
   // Issue #222: Only read from offset forward, not the whole file
   // Issue #259: If offset lands mid-entry, scan backwards to previous newline
+  // Issue #409: Use async I/O instead of readFileSync to avoid blocking the event loop
   let effectiveOffset = fromOffset;
   if (effectiveOffset > 0) {
-    // Read a small window before the offset to find the previous newline
-    const scanStart = Math.max(0, effectiveOffset - 4096);
-    const scanBuf = readFileSync(filePath).subarray(scanStart, effectiveOffset);
+    const scanSize = 4096;
+    const scanStart = Math.max(0, effectiveOffset - scanSize);
+    const scanLen = effectiveOffset - scanStart;
+    const scanBuf = Buffer.alloc(scanLen);
+    const fd = await open(filePath, 'r');
+    try {
+      await fd.read(scanBuf, 0, scanLen, scanStart);
+    } finally {
+      await fd.close();
+    }
     for (let i = scanBuf.length - 1; i >= 0; i--) {
       if (scanBuf[i] === 0x0a) { // '\n'
         effectiveOffset = scanStart + i + 1;


### PR DESCRIPTION
## Summary
- Replaced `readFileSync()` in `transcript.ts` with async `open()`+`read()` using a 4096-byte buffer
- The sync call was reading the **entire JSONL file** into memory just to scan a small window for newlines, blocking the event loop and scaling O(n) with file size
- Added 4 new tests covering large files, start-of-file, multi-line window scanning, and file truncation

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 69 files, 1587 tests passing
- [ ] Verify with a long-running session that transcript polling is non-blocking

Fixes #409

Generated by Hephaestus (Aegis dev agent)