### PR TITLE
fix: sanitize permission_request content in MessageBubble to prevent XSS

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,8 +8,10 @@
       "name": "aegis-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@types/dompurify": "^3.0.5",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
+        "dompurify": "^3.3.3",
         "lucide-react": "^0.474.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1699,6 +1701,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1725,6 +1736,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2207,6 +2224,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,8 +12,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@types/dompurify": "^3.0.5",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
+    "dompurify": "^3.3.3",
     "lucide-react": "^0.474.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/dashboard/src/__tests__/MessageBubble.test.tsx
+++ b/dashboard/src/__tests__/MessageBubble.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MessageBubble } from '../components/session/MessageBubble';
+import type { ParsedEntry } from '../types';
+
+function makeEntry(overrides: Partial<ParsedEntry> = {}): ParsedEntry {
+  return {
+    role: 'assistant',
+    contentType: 'permission_request',
+    text: 'Bash: echo hello',
+    ...overrides,
+  };
+}
+
+// ── sanitizeText is exercised through MessageBubble ──────────────
+
+describe('MessageBubble — XSS prevention', () => {
+  it('escapes <script> tags in permission_request text', () => {
+    const entry = makeEntry({
+      text: '<script>alert("xss")</script>',
+    });
+    const { container } = render(<MessageBubble entry={entry} />);
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.innerHTML).not.toContain('<script>');
+  });
+
+  it('escapes <img onerror> payloads', () => {
+    const entry = makeEntry({
+      text: '<img src=x onerror="alert(1)">',
+    });
+    const { container } = render(<MessageBubble entry={entry} />);
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.innerHTML).not.toContain('onerror');
+  });
+
+  it('escapes <iframe> payloads', () => {
+    const entry = makeEntry({
+      text: '<iframe src="https://evil.com"></iframe>',
+    });
+    const { container } = render(<MessageBubble entry={entry} />);
+    expect(container.querySelector('iframe')).toBeNull();
+  });
+
+  it('escapes event handler attributes', () => {
+    const entry = makeEntry({
+      text: '<div onmouseover="alert(1)">hover me</div>',
+    });
+    const { container } = render(<MessageBubble entry={entry} />);
+    expect(container.innerHTML).not.toContain('onmouseover');
+  });
+
+  it('renders safe plain text without alteration', () => {
+    const safeText = 'Bash: rm -rf /tmp/old-files';
+    const entry = makeEntry({ text: safeText });
+    const { container } = render(<MessageBubble entry={entry} />);
+    expect(container.textContent).toContain(safeText);
+  });
+
+  it('renders safe text for non-permission_request content types', () => {
+    const entry: ParsedEntry = {
+      role: 'assistant',
+      contentType: 'text',
+      text: '<b>bold</b> is just text',
+    };
+    const { container } = render(<MessageBubble entry={entry} />);
+    // JSX escaping — the <b> should appear as literal text, not a real tag
+    expect(container.querySelector('b')).toBeNull();
+    expect(container.textContent).toContain('<b>bold</b> is just text');
+  });
+});

--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
+import DOMPurify from 'dompurify';
 import type { ParsedEntry } from '../../types';
+
+/** Strip all HTML tags from untrusted text — defense-in-depth against XSS. */
+function sanitizeText(input: string): string {
+  return DOMPurify.sanitize(input, { ALLOWED_TAGS: [] });
+}
 
 const TOOL_ICONS: Record<string, string> = {
   Read: '📖',
@@ -143,7 +149,7 @@ export function MessageBubble({ entry }: { entry: ParsedEntry }) {
     case 'tool_result':
       return <ToolResultCard entry={entry} />;
     case 'permission_request':
-      return <div className="text-red-400 text-sm font-semibold px-3 py-2">Permission Request: {entry.text}</div>;
+      return <div className="text-red-400 text-sm font-semibold px-3 py-2">Permission Request: {sanitizeText(entry.text)}</div>;
     default:
       return <TextMessage entry={entry} />;
   }


### PR DESCRIPTION
## Summary
- Add DOMPurify to strip all HTML tags from `permission_request` text in `MessageBubble.tsx` before rendering
- Defense-in-depth: even if untrusted content (e.g., MCP server tool names) reaches the permission_request text field, XSS payloads are neutralized
- No `dangerouslySetInnerHTML` used — DOMPurify strips tags, React's JSX escaping provides a second layer

## Test plan
- [x] 6 new tests covering `<script>`, `<img onerror>`, `<iframe>`, event handler attributes, safe plain text, and non-permission content types
- [x] All 1694 tests pass (1607 root + 87 dashboard)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean

Fixes #406

Generated by Hephaestus (Aegis dev agent)