### PR TITLE
fix: atomically check+create tmux window name (#403)

### DIFF
--- a/src/__tests__/tmux-race-403.test.ts
+++ b/src/__tests__/tmux-race-403.test.ts
@@ -1,0 +1,211 @@
+/**
+ * tmux-race-403.test.ts — Test that concurrent createWindow calls with the
+ * same name do not cause duplicate windows (Issue #403).
+ *
+ * The fix moves ensureSession + mkdir + name-check + creation inside a single
+ * serialize() scope and converts _creating boolean to a reference counter.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+/** Replicate the serialize() promise-chain pattern from TmuxManager. */
+function createSerializeQueue() {
+  let queue: Promise<void> = Promise.resolve(undefined as unknown as void);
+
+  const serialize = <T>(fn: () => Promise<T>): Promise<T> => {
+    let resolve!: () => void;
+    const next = new Promise<void>(r => { resolve = r; });
+    const prev = queue;
+    queue = next;
+    return prev.then(async () => {
+      try { return await fn(); }
+      finally { resolve(); }
+    });
+  };
+
+  return { serialize };
+}
+
+describe('createWindow race condition (Issue #403)', () => {
+  it('concurrent createWindow calls with same name produce unique names', async () => {
+    const { serialize } = createSerializeQueue();
+    const windows = new Set<string>();
+    const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+    const createWindow = async (name: string) => {
+      return serialize(async () => {
+        let finalName = name;
+        let counter = 2;
+        while (windows.has(finalName)) {
+          finalName = `${name}-${counter++}`;
+        }
+        await delay(10);
+        windows.add(finalName);
+        return finalName;
+      });
+    };
+
+    const results = await Promise.all([
+      createWindow('task'),
+      createWindow('task'),
+      createWindow('task'),
+    ]);
+
+    expect(new Set(results).size).toBe(3);
+    expect(results).toContain('task');
+    expect(results).toContain('task-2');
+    expect(results).toContain('task-3');
+  });
+
+  it('_creatingCount stays > 0 while multiple createWindow calls are in flight', async () => {
+    const { serialize } = createSerializeQueue();
+    let creatingCount = 0;
+    const snapshots: number[] = [];
+    const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+    const createWindow = async (name: string) => {
+      creatingCount++;
+      try {
+        return await serialize(async () => {
+          snapshots.push(creatingCount);
+          await delay(20);
+          return name;
+        });
+      } finally {
+        creatingCount--;
+      }
+    };
+
+    await Promise.all([
+      createWindow('w1'),
+      createWindow('w2'),
+      createWindow('w3'),
+    ]);
+
+    // Each serialized block should see creatingCount > 0 at the time it runs
+    // (not the stale value from before concurrent calls started)
+    for (const snap of snapshots) {
+      expect(snap).toBeGreaterThanOrEqual(1);
+    }
+
+    // After all complete, counter returns to 0
+    expect(creatingCount).toBe(0);
+  });
+
+  it('boolean _creating flag would be prematurely cleared by first completion', async () => {
+    // Demonstrates the OLD bug: using a boolean flag, the first call to
+    // complete sets _creating = false, even though the second call is still
+    // in flight. This would allow direct methods (capturePaneDirect,
+    // sendKeysDirect) to skip the serialize queue.
+    let creating = false;
+    const snapshots: boolean[] = [];
+    const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+    const createWindowOld = async () => {
+      creating = true;
+      try {
+        await delay(10);
+      } finally {
+        creating = false;
+      }
+    };
+
+    // Start two concurrent calls
+    const p1 = createWindowOld();
+    // Small delay to ensure p1 has started
+    await delay(5);
+    const p2 = createWindowOld();
+
+    // Wait for first to finish — it sets creating = false
+    await p1;
+
+    // Second is still in flight, but creating is now false!
+    snapshots.push(creating);
+
+    await p2;
+
+    // The snapshot taken between p1 finishing and p2 finishing shows false
+    // even though p2 is still "creating" — this is the bug.
+    expect(snapshots[0]).toBe(false);
+  });
+
+  it('_creatingCount correctly reflects in-flight operations after first completes', async () => {
+    // Demonstrates the FIX: counter stays > 0 until ALL createWindow calls finish.
+    let creatingCount = 0;
+    const snapshots: number[] = [];
+    const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+    const createWindowNew = async () => {
+      creatingCount++;
+      try {
+        await delay(10);
+      } finally {
+        creatingCount--;
+      }
+    };
+
+    const p1 = createWindowNew();
+    await delay(5);
+    const p2 = createWindowNew();
+
+    await p1;
+
+    // p2 is still in flight — counter should be 1, not 0
+    snapshots.push(creatingCount);
+
+    await p2;
+
+    expect(snapshots[0]).toBe(1);
+    expect(creatingCount).toBe(0);
+  });
+
+  it('ensureSession + mkdir + name-check inside serialize is atomic', async () => {
+    const { serialize } = createSerializeQueue();
+    const windows = new Set<string>();
+    const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+    const order: string[] = [];
+    let callId = 0;
+
+    const createWindow = async (name: string) => {
+      const id = ++callId;
+      return serialize(async () => {
+        // ensureSession (simulated)
+        order.push(`ensureSession:${id}`);
+        await delay(5);
+
+        // mkdir (simulated)
+        order.push(`mkdir:${id}`);
+        await delay(5);
+
+        // name collision check
+        let finalName = name;
+        let counter = 2;
+        while (windows.has(finalName)) {
+          finalName = `${name}-${counter++}`;
+        }
+
+        // create window
+        order.push(`create:${id}:${finalName}`);
+        await delay(5);
+        windows.add(finalName);
+        return finalName;
+      });
+    };
+
+    const results = await Promise.all([
+      createWindow('task'),
+      createWindow('task'),
+    ]);
+
+    // All steps for call 1 must complete before call 2 starts
+    // (no interleaving of ensureSession/mkdir/check/create between calls)
+    const call1Create = order.indexOf('create:1:task');
+    const call2Ensure = order.indexOf('ensureSession:2');
+
+    // Call 2's ensureSession happens AFTER call 1's create
+    expect(call2Ensure).toBeGreaterThan(call1Create);
+
+    expect(results).toContain('task');
+    expect(results).toContain('task-2');
+  });
+});

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -56,8 +56,8 @@ export class TmuxManager {
   /** Promise-chain queue that serializes all tmux CLI calls to prevent race conditions. */
   private queue: Promise<void> = Promise.resolve(undefined as unknown as void);
 
-  /** #363: True while a window is being created — direct methods must queue. */
-  private _creating = false;
+  /** #403: Counter of in-flight createWindow calls — direct methods must queue when > 0. */
+  private _creatingCount = 0;
 
   /** #357: Short-lived cache for window existence checks to reduce CLI calls. */
   private windowCache = new Map<string, { exists: boolean; timestamp: number }>();
@@ -102,19 +102,24 @@ export class TmuxManager {
    *  We verify by listing windows — if that fails, recreate the session.
    */
   async ensureSession(): Promise<void> {
+    return this.ensureSessionInternal();
+  }
+
+  /** #403: Internal version that calls tmuxInternal directly (safe inside serialize). */
+  private async ensureSessionInternal(): Promise<void> {
     try {
-      await this.tmux('has-session', '-t', this.sessionName);
+      await this.tmuxInternal('has-session', '-t', this.sessionName);
       // Session exists — verify it's healthy by listing windows
-      await this.tmux('list-windows', '-t', this.sessionName, '-F', '#{window_id}');
+      await this.tmuxInternal('list-windows', '-t', this.sessionName, '-F', '#{window_id}');
     } catch {
       // Session doesn't exist or is unhealthy — (re)create it.
       // KillMode=process in the systemd service ensures only the node server
       // is killed on restart, not tmux or Claude Code processes inside.
       try {
         // Kill the broken session first if it exists
-        await this.tmux('kill-session', '-t', this.sessionName);
+        await this.tmuxInternal('kill-session', '-t', this.sessionName);
       } catch { /* session may not exist */ }
-      await this.tmux(
+      await this.tmuxInternal(
         'new-session', '-d', '-s', this.sessionName,
         '-n', '_bridge_main',
         '-x', '220', '-y', '50'
@@ -157,23 +162,27 @@ export class TmuxManager {
     /** @deprecated Use permissionMode instead. Maps true→bypassPermissions, false→default. */
     autoApprove?: boolean;
   }): Promise<{ windowId: string; windowName: string; freshSessionId?: string }> {
-    // Issue #363: Wrap name check + window creation in a single serialize()
-    // scope to prevent name collision races between concurrent createWindow calls.
-    // Without this, two createWindow('task') calls can both pass the name check
-    // before either creates the window.
-    await this.ensureSession();
-
-    // Issue #31: Ensure workDir exists before creating tmux window.
-    // If it doesn't exist, tmux uses $HOME and CC starts in wrong directory.
-    await mkdir(opts.workDir, { recursive: true });
-
-    // #363: Flag — window creation in progress; direct methods must queue.
-    this._creating = true;
+    // #403: Wrap the entire ensureSession + mkdir + name check + window creation
+    // in a single serialize() scope so concurrent createWindow calls cannot
+    // interleave between the name availability check and window creation.
+    // Previous fix (#363) only wrapped name-check+creation but left ensureSession
+    // and mkdir outside — the gap between ensureSession completing and the
+    // serialize block entering allowed concurrent calls to interleave.
+    this._creatingCount++;
     let windowId = '';
     let finalName = '';
 
     try {
       const creationResult = await this.serialize(async () => {
+        // #403: ensureSession and mkdir inside serialize so the whole
+        // sequence is atomic with respect to other createWindow calls.
+        // Uses ensureSessionInternal (tmuxInternal) to avoid re-entering serialize.
+        await this.ensureSessionInternal();
+
+        // Issue #31: Ensure workDir exists before creating tmux window.
+        // If it doesn't exist, tmux uses $HOME and CC starts in wrong directory.
+        await mkdir(opts.workDir, { recursive: true });
+
         // Check for name collision, add suffix if needed
         let name = opts.windowName;
         // #393 fix: use tmuxInternal directly (not listWindows) to avoid
@@ -275,7 +284,7 @@ export class TmuxManager {
       windowId = creationResult.windowId;
       finalName = creationResult.windowName;
     } finally {
-      this._creating = false;
+      this._creatingCount--;
     }
 
     // Set env vars if provided.
@@ -718,11 +727,11 @@ export class TmuxManager {
    *  not be delayed by monitor polls. The queue is for preventing race conditions
    *  in monitor/concurrent reads, but sendInitialPrompt is the ONLY writer at
    *  session creation time.
-   *  #363: During window creation (_creating=true), queues behind serialize
+   *  #403: During window creation (_creatingCount > 0), queues behind serialize
    *  to avoid racing with the creation sequence.
    */
   async capturePaneDirect(windowId: string): Promise<string> {
-    if (this._creating) {
+    if (this._creatingCount > 0) {
       return this.serialize(() => this.capturePaneDirectInternal(windowId));
     }
     return this.capturePaneDirectInternal(windowId);
@@ -747,11 +756,11 @@ export class TmuxManager {
   /** Send keys WITHOUT going through the serialize queue.
    *  Used for critical-path operations (e.g., sendInitialPrompt).
    *  Simplified version: sends literal text + Enter (no ! command mode handling).
-   *  #363: During window creation (_creating=true), queues behind serialize
+   *  #403: During window creation (_creatingCount > 0), queues behind serialize
    *  to avoid racing with the creation sequence.
    */
   async sendKeysDirect(windowId: string, text: string, enter: boolean = true): Promise<void> {
-    if (this._creating) {
+    if (this._creatingCount > 0) {
       return this.serialize(() => this.sendKeysDirectInternal(windowId, text, enter));
     }
     return this.sendKeysDirectInternal(windowId, text, enter);


### PR DESCRIPTION
## Summary
- Move `ensureSession()` and `mkdir()` inside the `serialize()` block so the entire ensureSession + mkdir + name-check + window-creation sequence is atomic with respect to concurrent `createWindow` calls
- Convert `_creating` boolean to `_creatingCount` reference counter so the first call to complete doesn't clear the flag while other createWindow calls are still in flight
- Add `ensureSessionInternal()` that uses `tmuxInternal` directly (avoids re-entering serialize from inside a serialize callback, same pattern as #393)

Fixes #403

## Test plan
- [x] New test file `tmux-race-403.test.ts` with 5 tests verifying serialize atomicity, counter correctness, and demonstrating the old boolean bug
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Full test suite passes (1598 tests, 0 failures)

Generated by Hephaestus (Aegis dev agent)