### PR TITLE
fix: add Zod schemas for getSessionMessages and getMetrics

### DIFF
--- a/dashboard/src/__tests__/schemas.test.ts
+++ b/dashboard/src/__tests__/schemas.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+
+import { SessionMessagesSchema, GlobalMetricsSchema } from '../api/schemas';
+
+// ── SessionMessagesSchema ────────────────────────────────────────
+
+describe('SessionMessagesSchema', () => {
+  const validPayload = {
+    messages: [
+      { role: 'user', contentType: 'text', text: 'hello' },
+      { role: 'assistant', contentType: 'tool_use', text: '', toolName: 'bash', toolUseId: 'abc' },
+    ],
+    status: 'idle',
+    statusText: null,
+    interactiveContent: null,
+  };
+
+  it('accepts valid payload', () => {
+    const result = SessionMessagesSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts optional fields omitted', () => {
+    const result = SessionMessagesSchema.safeParse({
+      messages: [{ role: 'system', contentType: 'text', text: 'ok' }],
+      status: 'working',
+      statusText: 'busy',
+      interactiveContent: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid role', () => {
+    const result = SessionMessagesSchema.safeParse({
+      ...validPayload,
+      messages: [{ role: 'bot', contentType: 'text', text: 'hi' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid contentType', () => {
+    const result = SessionMessagesSchema.safeParse({
+      ...validPayload,
+      messages: [{ role: 'user', contentType: 'image', text: '' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid status', () => {
+    const result = SessionMessagesSchema.safeParse({
+      ...validPayload,
+      status: 'flying',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing messages array', () => {
+    const { messages, ...noMessages } = validPayload;
+    const result = SessionMessagesSchema.safeParse(noMessages);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-nullable statusText', () => {
+    const result = SessionMessagesSchema.safeParse({
+      ...validPayload,
+      statusText: 123,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── GlobalMetricsSchema ──────────────────────────────────────────
+
+describe('GlobalMetricsSchema', () => {
+  const validPayload = {
+    uptime: 3600,
+    sessions: {
+      total_created: 10,
+      currently_active: 2,
+      completed: 7,
+      failed: 1,
+      avg_duration_sec: 120,
+      avg_messages_per_session: 5.5,
+    },
+    auto_approvals: 3,
+    webhooks_sent: 20,
+    webhooks_failed: 1,
+    screenshots_taken: 5,
+    pipelines_created: 2,
+    batches_created: 1,
+    prompt_delivery: {
+      sent: 15,
+      delivered: 14,
+      failed: 1,
+      success_rate: 0.93,
+    },
+  };
+
+  it('accepts valid payload', () => {
+    const result = GlobalMetricsSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts null success_rate', () => {
+    const result = GlobalMetricsSchema.safeParse({
+      ...validPayload,
+      prompt_delivery: { ...validPayload.prompt_delivery, success_rate: null },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing sessions block', () => {
+    const { sessions, ...noSessions } = validPayload;
+    const result = GlobalMetricsSchema.safeParse(noSessions);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects string where number expected', () => {
+    const result = GlobalMetricsSchema.safeParse({
+      ...validPayload,
+      uptime: '3600',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing prompt_delivery', () => {
+    const { prompt_delivery, ...noDelivery } = validPayload;
+    const result = GlobalMetricsSchema.safeParse(noDelivery);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects extra unknown field in sessions', () => {
+    const result = GlobalMetricsSchema.safeParse({
+      ...validPayload,
+      sessions: { ...validPayload.sessions, extra: true },
+    });
+    // Zod allows extra keys by default — this should still pass
+    expect(result.success).toBe(true);
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -31,6 +31,8 @@ import {
   SessionsListResponseSchema,
   SessionHealthSchema,
   SessionMetricsSchema,
+  SessionMessagesSchema,
+  GlobalMetricsSchema,
   GlobalSSEEventSchema,
 } from './schemas';
 
@@ -132,9 +134,8 @@ export function getHealth(): Promise<HealthResponse> {
 
 // ── Metrics ─────────────────────────────────────────────────────
 
-// NOTE: unchecked — lower-criticality endpoint
 export function getMetrics(): Promise<GlobalMetrics> {
-  return request('/v1/metrics');
+  return request('/v1/metrics', { schema: GlobalMetricsSchema, schemaContext: 'getMetrics' });
 }
 
 // ── Sessions ────────────────────────────────────────────────────
@@ -182,9 +183,11 @@ export function getAllSessionsHealth(): Promise<Record<string, SessionHealth>> {
 
 // ── Session Messages ────────────────────────────────────────────
 
-// NOTE: unchecked — lower-criticality endpoint
 export function getSessionMessages(id: string): Promise<MessagesResponse> {
-  return request(`/v1/sessions/${encodeURIComponent(id)}/read`);
+  return request(`/v1/sessions/${encodeURIComponent(id)}/read`, {
+    schema: SessionMessagesSchema,
+    schemaContext: 'getSessionMessages',
+  });
 }
 
 // ── Session Metrics ─────────────────────────────────────────────

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -115,6 +115,52 @@ export const SessionMetricsSchema = z.object({
   statusChanges: z.array(z.string()),
 });
 
+// ── ParsedEntry ──────────────────────────────────────────────────
+
+const ParsedEntrySchema = z.object({
+  role: z.enum(['user', 'assistant', 'system']),
+  contentType: z.enum(['text', 'thinking', 'tool_use', 'tool_result', 'permission_request']),
+  text: z.string(),
+  toolName: z.string().optional(),
+  toolUseId: z.string().optional(),
+  timestamp: z.string().optional(),
+});
+
+// ── SessionMessages (Issue #407) ────────────────────────────────
+
+export const SessionMessagesSchema = z.object({
+  messages: z.array(ParsedEntrySchema),
+  status: UIState,
+  statusText: z.string().nullable(),
+  interactiveContent: z.string().nullable(),
+});
+
+// ── GlobalMetrics (Issue #407) ──────────────────────────────────
+
+export const GlobalMetricsSchema = z.object({
+  uptime: z.number(),
+  sessions: z.object({
+    total_created: z.number(),
+    currently_active: z.number(),
+    completed: z.number(),
+    failed: z.number(),
+    avg_duration_sec: z.number(),
+    avg_messages_per_session: z.number(),
+  }),
+  auto_approvals: z.number(),
+  webhooks_sent: z.number(),
+  webhooks_failed: z.number(),
+  screenshots_taken: z.number(),
+  pipelines_created: z.number(),
+  batches_created: z.number(),
+  prompt_delivery: z.object({
+    sent: z.number(),
+    delivered: z.number(),
+    failed: z.number(),
+    success_rate: z.number().nullable(),
+  }),
+});
+
 // ── SSE Event Data (Issue #410) ────────────────────────────────
 
 const SSEEventTypes = z.enum([


### PR DESCRIPTION
## Summary
- Adds `SessionMessagesSchema` (validates `ParsedEntry[]`, status, interactiveContent) and `GlobalMetricsSchema` (validates uptime, sessions stats, prompt_delivery) to `dashboard/src/api/schemas.ts`
- Wires both schemas into `client.ts` via the existing `request()` schema validation pattern, removing the last two unchecked response paths
- Adds 13 tests covering valid payloads, invalid roles/contentTypes/statuses, missing fields, and type mismatches

Fixes #407

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] All 100 dashboard tests pass (including 13 new schema tests)

Generated by Hephaestus (Aegis dev agent)