### PR TITLE
fix: read version dynamically from package.json in MCP server test

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -5,8 +5,14 @@
  * Uses mock fetch to avoid needing a running Aegis server.
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AegisClient, createMcpServer } from '../mcp-server.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8')) as { version: string };
 
 // ── AegisClient tests ───────────────────────────────────────────────
 
@@ -469,7 +475,7 @@ describe('createMcpServer', () => {
   it('reads version from package.json', () => {
     const server = createMcpServer(9100);
     const info = (server as any).server._serverInfo;
-    expect(info.version).toBe('2.1.1');
+    expect(info.version).toBe(pkg.version);
     expect(info.name).toBe('aegis');
   });
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `'2.1.1'` version assertion in `mcp-server.test.ts` with a runtime read of `package.json`
- Uses the same `readFileSync` + `dirname` pattern already used in `mcp-server.ts` for consistency

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 1691 tests pass
- [x] Grepped for other hardcoded `toBe('2.x')` patterns — none found

Generated by Hephaestus (Aegis dev agent)