### PR TITLE
fix: tech debt sweep — type safety + build + empty catch blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm ci
 
       - name: Security audit
-        run: npm audit --audit-level=critical
+        run: npm audit --audit-level=high
 
       - name: Lockfile lint
         run: npx lockfile-lint --type npm --path package-lock.json --validate-https

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -59,8 +59,8 @@ function headersToObject(h: HeadersInit | undefined): Record<string, string> {
 function validateResponse<T>(data: unknown, schema: z.ZodType<T>, context: string): T {
   const result = schema.safeParse(data);
   if (result.success) return result.data;
-  console.warn(`[aegis] API validation warning (${context}):`, result.error.issues);
-  return data as T;
+  console.error(`[aegis] API response validation failed (${context}):`, result.error.issues);
+  throw new Error(`API response validation failed for ${context}: ${result.error.issues.map(i => i.message).join(', ')}`);
 }
 
 // ── Error classification ────────────────────────────────────────
@@ -263,7 +263,7 @@ async function createSSETokenWithRetry(
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     try {
       return await createSSEToken(signal);
-    } catch {
+    } catch { /* SSE token creation failed — retry with backoff */
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       if (attempt < SSE_TOKEN_MAX_RETRIES - 1) {
         const delay = SSE_TOKEN_BASE_DELAY_MS * Math.pow(2, attempt);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -72,7 +72,7 @@ export class AuthManager {
         if (parsed.success) {
           this.store = parsed.data;
         }
-      } catch {
+      } catch { /* corrupted or unreadable keys file — start fresh */
         this.store = { keys: [] };
       }
     }

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1159,7 +1159,7 @@ export class TelegramChannel implements Channel {
     try {
       await tgApi(this.config.botToken, 'editMessageText', body);
       return true;
-    } catch {
+    } catch { /* styled edit failed — message deleted or too old */
       return false;
     }
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -97,4 +97,10 @@ export interface Channel {
    * If not implemented, receives all events.
    */
   filter?(event: SessionEvent): boolean;
+
+  /** Return entries from the dead letter queue (failed deliveries). */
+  getDeadLetterQueue?(): Array<{ timestamp: string; endpoint: string; event: SessionEvent; error: string; attempts: number }>;
+
+  /** Return channel health status. */
+  getHealth?(): ChannelHealthStatus;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ function checkDependency(name: string, command: string): boolean {
   try {
     execSync(`${command} 2>/dev/null`, { stdio: 'ignore' });
     return true;
-  } catch {
+  } catch { /* command not found or exited non-zero */
     return false;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -228,7 +228,7 @@ export async function loadConfig(): Promise<Config> {
       config.allowedWorkDirs.map(async (dir) => {
         try {
           return await realpath(resolve(dir));
-        } catch {
+        } catch { /* dir does not exist yet — use unresolved path */
           return resolve(dir);
         }
       }),

--- a/src/events.ts
+++ b/src/events.ts
@@ -59,6 +59,9 @@ function toGlobalEvent(event: SessionSSEEvent): GlobalSSEEvent {
 export class SessionEventBus {
   private emitters = new Map<string, EventEmitter>();
 
+  /** #224: Track emitters that are ending so new subscribers get fresh emitters. */
+  private readonly endingEmitters = new WeakSet<EventEmitter>();
+
   /** Global incrementing event ID counter. */
   private nextEventId = 1;
 
@@ -75,7 +78,7 @@ export class SessionEventBus {
   private getEmitter(sessionId: string): EventEmitter {
     let emitter = this.emitters.get(sessionId);
     // #224: If emitter is ending (session ended), create a fresh one
-    if (emitter && (emitter as any).ending) {
+    if (emitter && this.endingEmitters.has(emitter)) {
       this.emitters.delete(sessionId);
       emitter = undefined;
     }
@@ -94,7 +97,7 @@ export class SessionEventBus {
     return () => {
       emitter.off('event', handler);
       // Clean up emitter if no more listeners and not ending
-      if (emitter.listenerCount('event') === 0 && !(emitter as any).ending) {
+      if (emitter.listenerCount('event') === 0 && !this.endingEmitters.has(emitter)) {
         this.emitters.delete(sessionId);
       }
     };
@@ -190,7 +193,7 @@ export class SessionEventBus {
     // #224: Mark emitter as ending so new subscribers don't get silently deleted
     const emitter = this.emitters.get(sessionId);
     if (emitter) {
-      (emitter as any).ending = true;
+      this.endingEmitters.add(emitter);
     }
     // Clean up after a short delay (let clients receive the event)
     // Capture reference — only delete if it's still the same emitter

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -47,6 +47,16 @@ interface SessionMapEntry {
   written_at: number;
 }
 
+/** Payload fields for Stop/StopFailure events. */
+interface StopHookPayload {
+  error?: string;
+  message?: string;
+  error_details?: unknown;
+  last_assistant_message?: unknown;
+  agent_id?: string;
+  stop_reason?: string;
+}
+
 /** Handle Stop/StopFailure events.
  *  Writes a signal file that the Aegis monitor can detect.
  *  Issue #15: StopFailure fires on API errors (rate limit, auth failure).
@@ -74,11 +84,11 @@ function handleStopEvent(
     event,
     timestamp: Date.now(),
     // StopFailure may include error info in the payload
-    error: (payload as any).error || (payload as any).message || null,
-    error_details: (payload as any).error_details || null,
-    last_assistant_message: (payload as any).last_assistant_message || null,
-    agent_id: (payload as any).agent_id || null,
-    stop_reason: (payload as any).stop_reason || null,
+    error: (payload as StopHookPayload).error || (payload as StopHookPayload).message || null,
+    error_details: (payload as StopHookPayload).error_details ?? null,
+    last_assistant_message: (payload as StopHookPayload).last_assistant_message ?? null,
+    agent_id: (payload as StopHookPayload).agent_id ?? null,
+    stop_reason: (payload as StopHookPayload).stop_reason ?? null,
   };
 
   // Atomic write: write to temp file then rename (prevents partial writes on crash)
@@ -110,7 +120,7 @@ function main(): void {
   try {
     const input = readFileSync(0, 'utf-8'); // stdin = fd 0
     payload = JSON.parse(input);
-  } catch {
+  } catch { /* malformed or empty stdin — nothing to do */
     process.exit(0);
   }
 
@@ -156,7 +166,7 @@ function main(): void {
       ['display-message', '-t', tmuxPane, '-p', '#{session_name}:#{window_id}:#{window_name}'],
       { encoding: 'utf-8' }
     ).trim();
-  } catch {
+  } catch { /* tmux not running or pane not found */
     console.error('Failed to get tmux info');
     process.exit(0);
   }
@@ -211,15 +221,18 @@ function install(): void {
   if (existsSync(settingsPath)) {
     try {
       settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    } catch {
+    } catch { /* corrupted or unreadable settings file */
       console.error(`Failed to read ${settingsPath}`);
       process.exit(1);
     }
   }
 
   const hookCommand = `node ${join(__dirname, 'hook.js')}`;
-  const hooks = (settings.hooks || {}) as Record<string, unknown[]>;
-  const sessionStart = (hooks.SessionStart || []) as Array<{ hooks?: Array<{ command?: string }> }>;
+  interface HookCommand { type: string; command: string; timeout: number }
+  interface HookEntry { hooks?: HookCommand[] }
+
+  const hooks = (settings.hooks || {}) as Record<string, HookEntry[]>;
+  const sessionStart = (hooks.SessionStart || []) as HookEntry[];
 
   // Check if already installed
   const isInstalled = sessionStart.some(entry =>
@@ -232,15 +245,15 @@ function install(): void {
   }
 
   sessionStart.push({
-    hooks: [{ type: 'command', command: hookCommand, timeout: 5 } as any]
+    hooks: [{ type: 'command', command: hookCommand, timeout: 5 }]
   });
 
   hooks.SessionStart = sessionStart;
 
   // Issue #15: Also register Stop and StopFailure hooks
-  const hookEntry = { hooks: [{ type: 'command', command: hookCommand, timeout: 5 } as any] };
+  const hookEntry: HookEntry = { hooks: [{ type: 'command', command: hookCommand, timeout: 5 }] };
   for (const event of ['Stop', 'StopFailure'] as const) {
-    const existing = (hooks[event] || []) as Array<{ hooks?: Array<{ command?: string }> }>;
+    const existing = (hooks[event] || []) as HookEntry[];
     const alreadyInstalled = existing.some(entry =>
       entry.hooks?.some(h => h.command?.includes('aegis') || h.command?.includes('manus') || h.command?.includes('hook.js'))
     );

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -6,14 +6,14 @@
  */
 
 let playwrightAvailable = false;
-let chromium: any = null;
+let chromium: typeof import('playwright').chromium | null = null;
 
 // Lazy-load Playwright — only fails at startup, not import time
 try {
   const pw = await import('playwright');
   chromium = pw.chromium;
   playwrightAvailable = true;
-} catch {
+} catch { /* playwright not installed — screenshot feature disabled */
   playwrightAvailable = false;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -347,7 +347,7 @@ app.get<{ Params: { id: string } }>('/v1/sessions/:id/metrics', async (req, repl
 app.get('/v1/webhooks/dead-letter', async () => {
   for (const ch of channels.getChannels()) {
     if (ch.name === 'webhook' && 'getDeadLetterQueue' in ch) {
-      return (ch as any).getDeadLetterQueue();
+      return ch.getDeadLetterQueue!();
     }
   }
   return [];
@@ -356,7 +356,7 @@ app.get('/v1/webhooks/dead-letter', async () => {
 // Issue #89 L15: Per-channel health reporting
 app.get('/v1/channels/health', async () => {
   return channels.getChannels().map(ch => {
-    const health = (ch as any).getHealth?.();
+    const health = ch.getHealth?.();
     if (health) return health;
     return { channel: ch.name, healthy: true, lastSuccess: null, lastError: null, pendingCount: 0 };
   });
@@ -595,7 +595,7 @@ app.get('/v1/sessions/health', async () => {
   await Promise.all(allSessions.map(async (s) => {
     try {
       results[s.id] = await sessions.getHealth(s.id);
-    } catch {
+    } catch { /* health check failed — report error state */
       results[s.id] = {
         alive: false, windowExists: false, claudeRunning: false,
         paneCommand: null, status: 'unknown', hasTranscript: false,
@@ -1341,7 +1341,7 @@ function readPidFile(): number | null {
     const content = readFileSync(p, 'utf-8').trim();
     const pid = parseInt(content, 10);
     return isNaN(pid) ? null : pid;
-  } catch {
+  } catch { /* pid file missing or unreadable */
     return null;
   }
 }
@@ -1355,7 +1355,7 @@ function pidExists(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch { /* ESRCH — process does not exist */
     return false;
   }
 }
@@ -1370,7 +1370,7 @@ function isAncestorPid(pid: number): boolean {
       if (current === pid) return true;
       try {
         current = parseInt(readFileSync(`/proc/${current}/stat`, 'utf-8').split(' ')[1], 10);
-      } catch {
+      } catch { /* /proc unavailable or process gone — stop walking */
         break;
       }
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -165,14 +165,14 @@ export class SessionManager {
               } else {
                 this.state = { sessions: {} };
               }
-            } catch {
+            } catch { /* backup state file corrupted — start empty */
               this.state = { sessions: {} };
             }
           } else {
             this.state = { sessions: {} };
           }
         }
-      } catch {
+      } catch { /* state file corrupted — start empty */
         this.state = { sessions: {} };
       }
     }
@@ -643,7 +643,7 @@ export class SessionManager {
       const panePid = await this.tmux.listPanePid(session.windowId);
       if (panePid !== null && !this.tmux.isPidAlive(panePid)) return false;
       return true;
-    } catch {
+    } catch { /* tmux query failed — treat as not alive */
       return false;
     }
   }
@@ -685,7 +685,7 @@ export class SessionManager {
         if (panePid !== null) {
           processAlive = this.tmux.isPidAlive(panePid);
         }
-      } catch {
+      } catch { /* cannot list pane PID — assume dead */
         processAlive = false;
       }
     }
@@ -695,7 +695,7 @@ export class SessionManager {
         const paneText = await this.tmux.capturePane(session.windowId);
         status = detectUIState(paneText);
         session.status = status;
-      } catch {
+      } catch { /* pane capture failed — default to unknown */
         status = 'unknown';
       }
     }
@@ -1078,7 +1078,7 @@ export class SessionManager {
       // First read — cache it
       this.parsedEntriesCache.set(session.id, { entries: [...result.entries], offset: result.newOffset });
       return result.entries;
-    } catch {
+    } catch { /* JSONL read failed — return cached entries or empty */
       return cached ? [...cached.entries] : [];
     }
   }

--- a/src/sse-writer.ts
+++ b/src/sse-writer.ts
@@ -45,7 +45,7 @@ export class SSEWriter {
         this.lastWrite = Date.now();
       }
       return true;
-    } catch {
+    } catch { /* write failed — destroy connection */
       this.destroy();
       return false;
     }

--- a/src/ssrf.ts
+++ b/src/ssrf.ts
@@ -71,7 +71,7 @@ export function validateWebhookUrl(rawUrl: string): string | null {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
-  } catch {
+  } catch { /* malformed URL string */
     return 'Invalid URL';
   }
 
@@ -138,7 +138,7 @@ export async function resolveAndCheckIp(
       return `DNS resolution points to a private/internal IP: ${result.address}`;
     }
     return null;
-  } catch {
+  } catch { /* DNS lookup failed — treat as unsafe */
     return `DNS resolution failed for ${hostname}`;
   }
 }
@@ -160,7 +160,7 @@ export function validateScreenshotUrl(rawUrl: string): string | null {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
-  } catch {
+  } catch { /* malformed URL string */
     return 'Invalid URL';
   }
 

--- a/src/swarm-monitor.ts
+++ b/src/swarm-monitor.ts
@@ -248,7 +248,7 @@ export class SwarmMonitor {
       this.cachedSocketNames = socketNames;
       this.cachedSocketAt = now;
       return socketNames;
-    } catch {
+    } catch { /* tmux list-sockets failed — no swarm sockets visible */
       return [];
     }
   }

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -111,7 +111,7 @@ export class TmuxManager {
       await this.tmuxInternal('has-session', '-t', this.sessionName);
       // Session exists — verify it's healthy by listing windows
       await this.tmuxInternal('list-windows', '-t', this.sessionName, '-F', '#{window_id}');
-    } catch {
+    } catch { /* session missing or unhealthy — (re)create below */
       // Session doesn't exist or is unhealthy — (re)create it.
       // KillMode=process in the systemd service ensures only the node server
       // is killed on restart, not tmux or Claude Code processes inside.
@@ -262,7 +262,7 @@ export class TmuxManager {
               // Re-check session health inside the serialize scope
               try {
                 await this.tmuxInternal('has-session', '-t', this.sessionName);
-              } catch {
+              } catch { /* session lost — recreate */
                 try { await this.tmuxInternal('kill-session', '-t', this.sessionName); } catch { /* may not exist */ }
                 await this.tmuxInternal(
                   'new-session', '-d', '-s', this.sessionName,
@@ -527,7 +527,7 @@ export class TmuxManager {
     try {
       process.kill(pid, 0);
       return true;
-    } catch {
+    } catch { /* ESRCH — process does not exist */
       return false;
     }
   }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -56,7 +56,7 @@ function parseLine(line: string): JsonlEntry | null {
   if (!trimmed || trimmed[0] !== '{') return null;
   try {
     return JSON.parse(trimmed) as JsonlEntry;
-  } catch {
+  } catch { /* malformed JSON — skip line */
     return null;
   }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -289,7 +289,7 @@ export async function validateWorkDir(
   let realPath: string;
   try {
     realPath = await fs.realpath(resolved);
-  } catch {
+  } catch { /* path does not exist on disk */
     return { error: `workDir does not exist: ${resolved}`, code: 'INVALID_WORKDIR' };
   }
 

--- a/src/ws-terminal.ts
+++ b/src/ws-terminal.ts
@@ -303,7 +303,7 @@ async function tickPoll(
   let content: string;
   try {
     content = await tmux.capturePane(session.windowId);
-  } catch {
+  } catch { /* pane gone — evict all subscribers */
     for (const [socket, sub] of [...poll.subscribers]) {
       if (!sub.closed) {
         sendError(socket, 'Failed to capture pane — session may have ended');
@@ -345,7 +345,7 @@ async function tickPoll(
       // Send ping
       try {
         socket.ping();
-      } catch {
+      } catch { /* socket already closed */
         evictSubscriber(sessionId, socket, sub);
       }
     }


### PR DESCRIPTION
## Summary
- **#519**: Replace `let chromium: any` with `typeof import('playwright').chromium` in screenshot module
- **#518**: Add explanatory `/* ... */` comments to ~30 empty catch blocks across `src/` that previously swallowed errors silently
- **#517**: `validateResponse` now throws on schema failure instead of silently returning unvalidated data as `T`
- **#516**: Remove `as any` from Channel and EventEmitter — add `getDeadLetterQueue`/`getHealth` as optional methods on Channel interface; use `WeakSet` for emitter ending state instead of `(emitter as any).ending`
- **#515**: Replace hook payload `as any` casts with typed `StopHookPayload` interface and proper `HookCommand`/`HookEntry` types in `install()`
- **#523**: Align ci.yml `--audit-level` from `critical` to `high`, matching release.yml
- **#525**: `@types/dompurify` already in `devDependencies` — no change needed

## Test plan
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm run build` succeeds
- [x] `npm test` — 73 test files, 1691 tests passing

Generated by Hephaestus (Aegis dev agent)