### PR TITLE
feat: move OpenClaw skill into repository for tracked versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,19 @@ jobs:
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-clawhub:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - run: npm install -g clawhub
+      - run: |
+          VERSION=$(node -p "require('./package.json').version")
+          clawhub publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -47,3 +47,6 @@ Thumbs.db
 *.log
 *.jsonl
 .claude/
+
+# OpenClaw skill (published to ClawhHub, not npm)
+skill/

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: aegis
+description: Orchestrate Claude Code sessions via Aegis HTTP/MCP bridge. Use when spawning CC sessions for coding tasks, implementing issues, reviewing PRs, fixing CI, batch tasks, or any multi-agent workflow. Triggers on "aegis", "spawn session", "orchestrate CC", "parallel agents", "create CC session", "send to CC". Requires Aegis server running on localhost:9100.
+---
+
+# Aegis — CC Session Orchestration
+
+Aegis manages interactive Claude Code sessions via HTTP API (port 9100) or MCP tools. Each session runs CC in tmux with JSONL transcript parsing and bidirectional communication.
+
+## Prerequisites
+
+1. Aegis server running: `curl -s http://127.0.0.1:9100/v1/health`
+2. MCP configured (optional, for native tool access): see [scripts/setup-mcp.sh](scripts/setup-mcp.sh)
+3. Verify health: `bash scripts/health-check.sh`
+
+## Core Workflow
+
+```
+create → send prompt → poll status → handle permissions → read result → quality gate → cleanup
+```
+
+### Step 1: Create Session
+
+**MCP**: `create_session(workDir, name?, prompt?)`
+**HTTP**:
+```bash
+SID=$(curl -s -X POST http://127.0.0.1:9100/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"workDir":"/path/to/project","name":"task-name"}' \
+  | jq -r '.id')
+```
+
+> ⚠️ `workDir` must exist on disk or creation fails silently (returns `null` id).
+
+Wait 8-10s for CC to boot. Check `promptDelivery.delivered` in the response — if `false`, resend via `send_message` after CC boots.
+
+### Step 2: Send Prompt
+
+**MCP**: `send_message(sessionId, text)`
+**HTTP**:
+```bash
+curl -s -X POST http://127.0.0.1:9100/v1/sessions/$SID/send \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Your task here"}'
+```
+
+### Step 3: Poll Until Idle
+
+**MCP**: `get_status(sessionId)` — check `status` field
+**HTTP**:
+```bash
+STATUS=$(curl -s http://127.0.0.1:9100/v1/sessions/$SID/read | jq -r '.status')
+```
+
+### Step 4: Handle Permission Prompts
+
+While polling, react to non-idle states:
+
+| Status | Action |
+|--------|--------|
+| `idle` | Done — read result |
+| `working` | Wait (poll every 5s) |
+| `permission_prompt` | `POST .../approve` (trust folder, tool use) |
+| `bash_approval` | `POST .../approve` or `POST .../reject` |
+| `plan_mode` | `POST .../approve` (option 1) or `POST .../escape` |
+| `ask_question` | `POST .../send` with answer |
+| `unknown` | `GET .../pane` for raw terminal output |
+
+### Step 5: Read Transcript
+
+**MCP**: `get_transcript(sessionId)`
+**HTTP**: `curl -s http://127.0.0.1:9100/v1/sessions/$SID/read`
+
+Returns `{ messages[], status, statusText }`. Each message: `{ role, contentType, text, timestamp }`.
+
+### Step 6: Quality Gate
+
+Before accepting output, verify:
+1. Check transcript for tool errors or failed assertions
+2. Run `tsc --noEmit` and build via `send_message` if needed
+3. Confirm tests pass (request CC to run them)
+4. Check for common issues: missing imports, hardcoded values, incomplete implementations
+
+### Step 7: Cleanup
+
+**MCP**: `kill_session(sessionId)`
+**HTTP**: `curl -s -X DELETE http://127.0.0.1:9100/v1/sessions/$SID`
+
+Always cleanup — idle sessions consume tmux windows and memory.
+
+## Common Patterns
+
+### Implement Issue
+
+```
+create_session(workDir=repo, name="impl-#123", prompt="Implement issue #123. Read the issue description first, then write code. Don't explain, just implement. Run tests when done.")
+→ poll → approve permissions → read transcript → verify tests pass → cleanup
+```
+
+### Review PR
+
+```
+create_session(workDir=repo, name="review-PR-456", prompt="Review PR #456. Focus on: security issues, test coverage, API design. Be concise.")
+→ poll → read transcript → extract review comments
+```
+
+### Fix CI
+
+```
+create_session(workDir=repo, name="fix-ci", prompt="CI is failing on main. Run the failing test suite, identify the root cause, and fix it. Don't add skip/only annotations.")
+→ poll → approve bash commands → verify CI green → cleanup
+```
+
+### Batch Tasks
+
+Spawn multiple sessions in parallel, then poll all:
+
+```bash
+for task in "task-a" "task-b" "task-c"; do
+  curl -s -X POST http://127.0.0.1:9100/v1/sessions \
+    -H "Content-Type: application/json" \
+    -d "{\"workDir\":\"$REPO\",\"name\":\"$task\",\"prompt\":\"$task description\"}" \
+    | jq -r '.id' >> /tmp/session-ids.txt
+done
+# Poll all until done
+while read SID; do ... done < /tmp/session-ids.txt
+```
+
+## Stall Detection and Recovery
+
+A session is **stalled** when `working` for >5 minutes with no transcript change.
+
+### Detection
+
+```bash
+HASH1=$(curl -s http://127.0.0.1:9100/v1/sessions/$SID/read | jq -r '.messages | length')
+sleep 30
+HASH2=$(curl -s http://127.0.0.1:9100/v1/sessions/$SID/read | jq -r '.messages | length')
+# If HASH1 == HASH2 and status is still "working", likely stalled
+```
+
+### Recovery Options (in order)
+
+1. **Nudge** — send `send_message("Continue. What's blocking you?")`
+2. **Interrupt** — `POST .../interrupt` then resend the task
+3. **Refine** — send a simplified or decomposed version of the task
+4. **Pivot** — kill session, create new one with a different approach
+5. **Escalate** — abandon automated approach, notify human
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `Connection refused` on 9100 | Aegis not running. Check `scripts/health-check.sh` |
+| Session stuck at `unknown` | `GET .../pane` for raw output. May need `POST .../escape` |
+| Permission loop (approve keeps coming) | Likely bash approval. Check transcript for the command. Reject if unsafe |
+| `promptDelivery: "failed"` | CC didn't boot yet. Wait 10s and resend via `send_message` |
+| Session not appearing in `list_sessions` | Check `workDir` filter. Session may have been killed |
+| High memory usage | Kill idle sessions. Use `list_sessions` to find orphans |
+
+## MCP Tool Reference
+
+When MCP is configured, 21 tools are available natively:
+
+### Session Lifecycle
+| Tool | Description |
+|------|-------------|
+| `create_session` | Spawn new CC session (workDir, name, prompt) |
+| `list_sessions` | List sessions, filter by status/workDir |
+| `get_status` | Detailed session status + health |
+| `kill_session` | Kill session + cleanup resources |
+| `batch_create_sessions` | Spawn multiple sessions at once |
+
+### Communication
+| Tool | Description |
+|------|-------------|
+| `send_message` | Send text to a session |
+| `send_bash` | Execute bash via `!` prefix |
+| `send_command` | Send /slash command |
+| `get_transcript` | Read conversation transcript |
+| `capture_pane` | Raw terminal output |
+| `get_session_summary` | Summary with message counts + duration |
+
+### Permission Handling
+| Tool | Description |
+|------|-------------|
+| `approve_permission` | Approve pending prompt |
+| `reject_permission` | Reject pending prompt |
+| `escape_session` | Send Escape key (dismiss dialogs) |
+| `interrupt_session` | Send Ctrl+C |
+
+### Monitoring
+| Tool | Description |
+|------|-------------|
+| `server_health` | Server version, uptime, session counts |
+| `get_session_metrics` | Per-session performance metrics |
+| `get_session_latency` | Latency measurements |
+
+### Advanced
+| Tool | Description |
+|------|-------------|
+| `list_pipelines` | List multi-step pipelines |
+| `create_pipeline` | Create orchestrated pipeline |
+| `get_swarm` | Swarm status for parallel sessions |
+
+For full API reference, see [references/api-quick-ref.md](references/api-quick-ref.md).
+For agent templates, see [references/agent-template.md](references/agent-template.md).
+For heartbeat/dev-loop templates, see [references/heartbeat-template.md](references/heartbeat-template.md).

--- a/skill/references/agent-template.md
+++ b/skill/references/agent-template.md
@@ -1,0 +1,61 @@
+# Agent Template (SOUL.md)
+
+Use this template to define a dev agent that Aegis orchestrates. Place in the session's working directory as `SOUL.md` or `CLAUDE.md`.
+
+---
+
+## Template
+
+```markdown
+# <Agent Name>
+
+## Role
+<One sentence: what this agent does>
+
+## Working Directory
+<repo path>
+
+## Rules
+- Write code, don't explain
+- Run tests after implementation
+- Don't add skip/only annotations to tests
+- Don't modify files outside scope unless fixing a blocking issue
+- Commit with descriptive messages when done
+
+## Scope
+<What this agent should implement. Be specific: issue numbers, file paths, acceptance criteria.>
+
+## Constraints
+- <Time/complexity limit>
+- <Files not to touch>
+- <Patterns to follow>
+
+## Completion Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+- [ ] Tests pass
+```
+
+## Usage
+
+When spawning a session, include the agent's scope in the initial prompt:
+
+```bash
+curl -s -X POST http://127.0.0.1:9100/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workDir": "/path/to/repo",
+    "name": "agent-name",
+    "prompt": "You are <Agent Name>. Your task: <scope>. Follow rules in CLAUDE.md. Write code, run tests, commit when done."
+  }'
+```
+
+## Agent Archetypes
+
+| Archetype | Prompt Pattern |
+|-----------|---------------|
+| **Implementer** | "Implement X. Don't explain. Run tests." |
+| **Reviewer** | "Review the code in X. Focus on Y. Be concise." |
+| **Fixer** | "Fix failing test X. Root cause first, then fix." |
+| **Scout** | "Investigate X. Report findings. Don't change code." |
+| **Refactorer** | "Refactor X to pattern Y. Keep behavior identical. Run full test suite." |

--- a/skill/references/api-quick-ref.md
+++ b/skill/references/api-quick-ref.md
@@ -1,0 +1,115 @@
+# Aegis API Quick Reference
+
+Base URL: `http://127.0.0.1:9100`
+
+## Sessions
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/v1/sessions` | Create session. Body: `{workDir, name?, prompt?, resumeSessionId?}` |
+| POST | `/v1/sessions/batch` | Batch create. Body: `{sessions: [{workDir, name?, prompt?}]}` |
+| GET | `/v1/sessions` | List all sessions |
+| GET | `/v1/sessions/:id` | Get session details |
+| GET | `/v1/sessions/:id/health` | Health check for session |
+| GET | `/v1/sessions/:id/read` | Read transcript + status |
+| GET | `/v1/sessions/:id/summary` | Summary: message counts, duration, status history |
+| GET | `/v1/sessions/:id/metrics` | Performance metrics |
+| GET | `/v1/sessions/:id/latency` | Latency measurements |
+| DELETE | `/v1/sessions/:id` | Kill session |
+
+## Communication
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/v1/sessions/:id/send` | Send message. Body: `{text}` |
+| POST | `/v1/sessions/:id/command` | Slash command. Body: `{command}` |
+| POST | `/v1/sessions/:id/bash` | Bash command. Body: `{command}` |
+| GET | `/v1/sessions/:id/pane` | Raw terminal output |
+
+## Interactive Prompts
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/v1/sessions/:id/approve` | Approve current prompt |
+| POST | `/v1/sessions/:id/reject` | Reject current prompt |
+| POST | `/v1/sessions/:id/escape` | Escape (exit plan mode, close dialog) |
+| POST | `/v1/sessions/:id/interrupt` | Ctrl+C |
+
+## Advanced
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/v1/pipelines` | List pipelines |
+| POST | `/v1/pipelines` | Create pipeline |
+| GET | `/v1/swarm` | Swarm status |
+
+## Server
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/v1/health` | Server health, version, uptime, session counts |
+
+## Response Formats
+
+### Create Session
+```json
+{
+  "id": "uuid",
+  "windowId": "@N",
+  "windowName": "string",
+  "status": "unknown",
+  "workDir": "path",
+  "claudeSessionId": "uuid",
+  "promptDelivery": { "delivered": true, "attempts": 1 }
+}
+```
+
+> ⚠️ `workDir` must exist on disk. If it doesn't, `id` will be `null`.
+> ⚠️ Check `promptDelivery.delivered` — if `false`, CC didn't boot yet. Wait 10s and resend via `/send`.
+
+### Read Transcript
+```json
+{
+  "messages": [{
+    "role": "user|assistant",
+    "contentType": "text|thinking|tool_use|tool_result",
+    "text": "...",
+    "timestamp": "ISO-8601"
+  }],
+  "status": "idle|working|permission_prompt|bash_approval|plan_mode|ask_question|unknown",
+  "statusText": "..."
+}
+```
+
+### Kill Session
+```json
+{ "ok": true }
+```
+
+Session returns `{ "error": "Session not found" }` after kill.
+
+## MCP Tool Mapping (21 tools)
+
+| MCP Tool | REST Equivalent |
+|----------|----------------|
+| `create_session` | `POST /v1/sessions` |
+| `list_sessions` | `GET /v1/sessions` |
+| `get_status` | `GET /v1/sessions/:id` + `/health` |
+| `get_transcript` | `GET /v1/sessions/:id/read` |
+| `send_message` | `POST /v1/sessions/:id/send` |
+| `kill_session` | `DELETE /v1/sessions/:id` |
+| `approve_permission` | `POST /v1/sessions/:id/approve` |
+| `reject_permission` | `POST /v1/sessions/:id/reject` |
+| `escape_session` | `POST /v1/sessions/:id/escape` |
+| `interrupt_session` | `POST /v1/sessions/:id/interrupt` |
+| `send_bash` | `POST /v1/sessions/:id/bash` |
+| `send_command` | `POST /v1/sessions/:id/command` |
+| `capture_pane` | `GET /v1/sessions/:id/pane` |
+| `get_session_metrics` | `GET /v1/sessions/:id/metrics` |
+| `get_session_latency` | `GET /v1/sessions/:id/latency` |
+| `get_session_summary` | `GET /v1/sessions/:id/summary` |
+| `batch_create_sessions` | `POST /v1/sessions/batch` |
+| `list_pipelines` | `GET /v1/pipelines` |
+| `create_pipeline` | `POST /v1/pipelines` |
+| `get_swarm` | `GET /v1/swarm` |
+| `server_health` | `GET /v1/health` |

--- a/skill/references/heartbeat-template.md
+++ b/skill/references/heartbeat-template.md
@@ -1,0 +1,103 @@
+# Heartbeat Template (Dev Loop)
+
+Use this template to implement a polling loop that drives an Aegis session through completion. Suitable for CI/CD, automated dev loops, or supervised agent workflows.
+
+---
+
+## Basic Loop
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SID="$1"
+MAX_WAIT="${2:-600}"  # 10 minutes default
+POLL_INTERVAL=5
+ELAPSED=0
+LAST_MSG_COUNT=0
+STALL_START=0
+STALL_THRESHOLD=150   # 2.5 minutes with no new messages
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  RESP=$(curl -sf http://127.0.0.1:9100/v1/sessions/$SID/read)
+  STATUS=$(echo "$RESP" | jq -r '.status')
+  MSG_COUNT=$(echo "$RESP" | jq -r '.messages | length')
+
+  case "$STATUS" in
+    idle)
+      echo "Session $SID completed."
+      echo "$RESP" | jq '.messages[-3:]'  # last 3 messages
+      exit 0
+      ;;
+    working)
+      # Stall detection
+      if [ "$MSG_COUNT" -eq "$LAST_MSG_COUNT" ]; then
+        if [ "$STALL_START" -eq 0 ]; then
+          STALL_START=$ELAPSED
+        fi
+        STALLED=$((ELAPSED - STALL_START))
+        if [ "$STALLED" -gt "$STALL_THRESHOLD" ]; then
+          echo "STALL detected (${STALLED}s without progress). Sending nudge."
+          curl -sf -X POST http://127.0.0.1:9100/v1/sessions/$SID/send \
+            -H "Content-Type: application/json" \
+            -d '{"text":"Continue. What is blocking you?"}'
+          STALL_START=$ELAPSED  # reset stall timer
+        fi
+      else
+        STALL_START=$ELAPSED
+      fi
+      LAST_MSG_COUNT=$MSG_COUNT
+      ;;
+    permission_prompt|bash_approval)
+      echo "Approving permission prompt."
+      curl -sf -X POST http://127.0.0.1:9100/v1/sessions/$SID/approve
+      ;;
+    plan_mode)
+      echo "Approving plan (option 1)."
+      curl -sf -X POST http://127.0.0.1:9100/v1/sessions/$SID/approve
+      ;;
+    ask_question)
+      QUESTION=$(echo "$RESP" | jq -r '.messages[-1].text' 2>/dev/null)
+      echo "Agent asks: $QUESTION"
+      # Default: approve. Customize per use case.
+      curl -sf -X POST http://127.0.0.1:9100/v1/sessions/$SID/send \
+        -H "Content-Type: application/json" \
+        -d '{"text":"Proceed with your best judgment."}'
+      ;;
+    *)
+      echo "Unknown status: $STATUS. Checking pane."
+      curl -sf http://127.0.0.1:9100/v1/sessions/$SID/pane | tail -20
+      ;;
+  esac
+
+  sleep $POLL_INTERVAL
+  ELAPSED=$((ELAPSED + POLL_INTERVAL))
+done
+
+echo "TIMEOUT after ${MAX_WAIT}s. Session may still be running."
+exit 2
+```
+
+## Usage
+
+```bash
+# Create session
+SID=$(curl -s -X POST http://127.0.0.1:9100/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"workDir":"/path/to/repo","name":"task","prompt":"Implement X"}' \
+  | jq -r '.id')
+
+# Run heartbeat loop
+bash heartbeat.sh $SID 600
+
+# Check exit code: 0=done, 2=timeout
+```
+
+## Customization Points
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MAX_WAIT` | 600s | Maximum time before timeout |
+| `POLL_INTERVAL` | 5s | How often to check status |
+| `STALL_THRESHOLD` | 150s | Time without progress before nudging |
+| Permission handling | Auto-approve | Change to log/reject for untrusted commands |

--- a/skill/scripts/health-check.sh
+++ b/skill/scripts/health-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Verify Aegis server is running and responsive.
+set -euo pipefail
+
+HOST="${AEGIS_HOST:-127.0.0.1}"
+PORT="${AEGIS_PORT:-9100}"
+URL="http://$HOST:$PORT/v1/health"
+
+echo -n "Aegis health check ($URL)... "
+
+RESPONSE=$(curl -sf --max-time 5 "$URL" 2>/dev/null) && STATUS=$? || STATUS=$?
+
+if [ $STATUS -ne 0 ]; then
+  echo "FAIL (connection refused or timeout)"
+  echo "Start Aegis: aegis-bridge start"
+  exit 1
+fi
+
+STATUS_VAL=$(echo "$RESPONSE" | jq -r '.status // . // empty' 2>/dev/null)
+if [ "$STATUS_VAL" = "ok" ] || [ "$STATUS_VAL" = "healthy" ]; then
+  echo "OK"
+  exit 0
+fi
+
+# If response is valid JSON, assume healthy
+if echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "OK (response received)"
+  exit 0
+fi
+
+echo "FAIL (unexpected response: $RESPONSE)"
+exit 1

--- a/skill/scripts/setup-mcp.sh
+++ b/skill/scripts/setup-mcp.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Configure Aegis MCP server in Claude Code settings.
+# Adds an "aegis" MCP entry to ~/.claude/settings.json or project .mcp.json.
+set -euo pipefail
+
+SCOPE="${1:-user}"
+PORT="${AEGIS_PORT:-9100}"
+
+if [ "$SCOPE" = "project" ]; then
+  CONFIG_FILE=".mcp.json"
+else
+  CONFIG_FILE="$HOME/.claude/settings.json"
+  mkdir -p "$(dirname "$CONFIG_FILE")"
+fi
+
+echo "Configuring Aegis MCP ($SCOPE scope) in $CONFIG_FILE"
+
+# Use claude mcp add if available
+if command -v claude &>/dev/null; then
+  if [ "$SCOPE" = "user" ]; then
+    claude mcp add --scope user aegis -- npx aegis-bridge mcp --port "$PORT"
+  else
+    claude mcp add --scope project aegis -- npx aegis-bridge mcp --port "$PORT"
+  fi
+  echo "Done. MCP server 'aegis' added via claude CLI."
+  exit 0
+fi
+
+# Fallback: write JSON directly
+echo "claude CLI not found. Writing config directly."
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo '{"mcpServers":{}}' > "$CONFIG_FILE"
+fi
+
+# Use jq to add the server entry
+TMP=$(mktemp)
+jq --arg port "$PORT" '
+  .mcpServers = (.mcpServers // {}) |
+  .mcpServers.aegis = {
+    "command": "npx",
+    "args": ["aegis-bridge", "mcp", "--port", $port]
+  }
+' "$CONFIG_FILE" > "$TMP" && mv "$TMP" "$CONFIG_FILE"
+
+echo "Done. Added 'aegis' MCP server to $CONFIG_FILE"
+echo "Restart Claude Code for changes to take effect."


### PR DESCRIPTION
## What

Moves the Aegis OpenClaw skill from local workspace (`~/.openclaw/workspace/skills/aegis/`) into the repository itself (`skill/` directory).

## Why

- **Atomic versioning**: skill updates ship in the same PR as code changes
- **Dual-publish**: release workflow publishes to both npm (package) and ClawhHub (skill)
- **Discoverability**: contributors see the skill, users can install via clawhub
- **No drift**: impossible for skill docs to fall out of sync with the API

## What changed

- New: `skill/` directory with SKILL.md, references, scripts
- Modified: `.npmignore` (excludes skill/ from npm package)
- Modified: `.github/workflows/release.yml` (adds ClawhHub publish step)

## Closes

Partially addresses #446, #447, #448 (M2 — OpenClaw Skill)

Generated by Hephaestus (Aegis dev agent)