### PR TITLE
fix: include dashboard in npm package (#539)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,8 +13,15 @@ vitest.config.*
 # CI/CD
 .github/
 
-# Dashboard (separate app)
-dashboard/
+# Dashboard source (dist is included via files field)
+dashboard/src/
+dashboard/node_modules/
+dashboard/index.html
+dashboard/package.json
+dashboard/package-lock.json
+dashboard/vite.config.ts
+dashboard/tsconfig.json
+dashboard/tailwind.config.*
 
 # Docs
 docs/

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "!dist/**/*.map"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run build:copy-dashboard",
+    "build:copy-dashboard": "node scripts/copy-dashboard.mjs",
     "build:dashboard": "cd dashboard && npm install && npm run build",
     "start": "node dist/cli.js",
     "dev": "tsc && node dist/cli.js",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build:dashboard && npm run build",
     "test": "vitest run"
   },
   "keywords": [

--- a/scripts/copy-dashboard.mjs
+++ b/scripts/copy-dashboard.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { cpSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const src = join("dashboard", "dist");
+const dst = join("dist", "dashboard");
+
+if (existsSync(src)) {
+  cpSync(src, dst, { recursive: true });
+  console.log("Dashboard copied to dist/dashboard/");
+} else {
+  console.log("No dashboard/dist/ found — skipping dashboard copy");
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1664,7 +1664,8 @@ async function main(): Promise<void> {
 
 
   // #127: Serve dashboard static files (Issue #105) — graceful if missing
-  const dashboardRoot = path.join(__dirname, "..", "dashboard", "dist");
+  // Issue #539: Dashboard is copied into dist/dashboard/ during build
+  const dashboardRoot = path.join(__dirname, "dashboard");
   let dashboardAvailable = false;
   try {
     await fs.access(dashboardRoot);


### PR DESCRIPTION
## Summary
- Dashboard was excluded from npm packages because `files` field only included `dist/` while `dashboard/dist/` is a sibling directory
- Added `build:copy-dashboard` step that copies `dashboard/dist/` into `dist/dashboard/` during build
- Updated `server.ts` to resolve dashboard from `dist/dashboard/` (its new bundled location)
- Updated `prepublishOnly` to build dashboard before the main build
- Updated `.npmignore` to be explicit about which dashboard source files to exclude

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds and copies dashboard to `dist/dashboard/`
- [x] All 1691 tests pass
- [ ] Verify `npm pack` includes `dist/dashboard/` contents
- [ ] Smoke test: install package and confirm dashboard is served at `/dashboard`

Generated by Hephaestus (Aegis dev agent)