### PR TITLE
fix: include dashboard in npm package + add types/exports/homepage/bugs (#539)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,8 +13,15 @@ vitest.config.*
 # CI/CD
 .github/
 
-# Dashboard (separate app)
-dashboard/
+# Dashboard source (dist is included via files field)
+dashboard/src/
+dashboard/node_modules/
+dashboard/index.html
+dashboard/package.json
+dashboard/package-lock.json
+dashboard/vite.config.ts
+dashboard/tsconfig.json
+dashboard/tailwind.config.*
 
 # Docs
 docs/

--- a/package.json
+++ b/package.json
@@ -4,11 +4,22 @@
   "type": "module",
   "description": "Orchestrate Claude Code sessions via API. Create, brief, monitor, refine, ship.",
   "main": "dist/server.js",
+  "types": "dist/server.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js"
+    }
+  },
   "bin": {
     "aegis-bridge": "dist/cli.js"
   },
   "files": [
     "dist",
+    "dashboard/dist",
     "!dist/__tests__",
     "!dist/**/*.map"
   ],
@@ -17,7 +28,7 @@
     "build:dashboard": "cd dashboard && npm install && npm run build",
     "start": "node dist/cli.js",
     "dev": "tsc && node dist/cli.js",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build:dashboard && npm run build",
     "test": "vitest run"
   },
   "keywords": [
@@ -42,6 +53,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/OneStepAt4time/aegis.git"
+  },
+  "homepage": "https://github.com/OneStepAt4time/aegis#readme",
+  "bugs": {
+    "url": "https://github.com/OneStepAt4time/aegis/issues"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary
- Replace blanket `dashboard/` exclusion in `.npmignore` with specific source-only exclusions
- Add `dashboard/dist` to `files` whitelist so the built dashboard ships with the npm package
- Update `prepublishOnly` to build dashboard before TypeScript (`build:dashboard && build`)
- Add `types`, `exports`, `homepage`, `bugs` fields to `package.json` for proper npm discoverability

## Why
Without this fix, `npx aegis-bridge` would start the server but serve no dashboard — the built dashboard at `dashboard/dist/` was excluded by `.npmignore` and not listed in `files`. The server silently degrades ("Dashboard directory not found").

Closes #539

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] All 1677 tests pass
- [ ] Verify `npm pack --dry-run` includes dashboard files after `npm run build:dashboard`

Generated by Hephaestus (Aegis dev agent)