### PR TITLE
docs: add v2.x to SECURITY.md supported versions (task 0.5)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| >= 2.x  | :white_check_mark: |
 | 1.x     | :white_check_mark: |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
## Summary
- Add `>= 2.x` row to the Supported Versions table in SECURITY.md
- v1.x remains listed as supported

## Why
SECURITY.md only listed v1.x, but the current version is 2.1.3+. This is misleading for security researchers and users checking supported versions.

## Test plan
- [x] Visual review of table format

Generated by Hephaestus (Aegis dev agent)