### PR TITLE
test: add double auth rejection test (#553)

### DIFF
--- a/src/__tests__/ws-terminal.test.ts
+++ b/src/__tests__/ws-terminal.test.ts
@@ -742,6 +742,38 @@ describe('ws-terminal', () => {
       expect(ws.close).toHaveBeenCalled();
     });
 
+    it('should reject second auth attempt with Already authenticated error', () => {
+      const authEnabled = makeAuthManager({ enabled: true, valid: true });
+      const localApp = makeMockFastify();
+      registerWsTerminalRoute(localApp, sessionManager, tmux, authEnabled);
+
+      sessions.set('sess-1', makeSession());
+      const ws = makeMockWebSocket();
+      const handler = getWsHandler(localApp);
+      handler(ws, { params: { id: 'sess-1' } });
+
+      // 1. Authenticate successfully
+      ws._emit('message', Buffer.from(JSON.stringify({ type: 'auth', token: 'valid-token' })));
+      const statusMsg = ws._sent.find(s => {
+        const parsed = JSON.parse(s);
+        return parsed.type === 'status' && parsed.status === 'authenticated';
+      });
+      expect(statusMsg).toBeDefined();
+
+      // 2. Send another auth message
+      ws._emit('message', Buffer.from(JSON.stringify({ type: 'auth', token: 'valid-token' })));
+
+      // 3. Expect "Already authenticated" error
+      const errorMsg = ws._sent.find(s => {
+        const parsed = JSON.parse(s);
+        return parsed.type === 'error' && parsed.message.includes('Already authenticated');
+      });
+      expect(errorMsg).toBeDefined();
+
+      // 4. Connection should NOT be evicted (socket still open)
+      expect(ws.close).not.toHaveBeenCalled();
+    });
+
     it('should not require handshake when auth is disabled', () => {
       const authDisabled = makeAuthManager({ enabled: false });
       const localApp = makeMockFastify();


### PR DESCRIPTION
## Summary
- Adds test for rejecting a second WebSocket auth message after successful authentication
- Verifies the socket receives an "Already authenticated" error but is NOT evicted (stays open)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/__tests__/ws-terminal.test.ts` passes (all 107 tests)
- [x] Full suite passes (pre-existing worktree failures are unrelated)

Closes #553

Generated by Hephaestus (Aegis dev agent)