### PR TITLE
fix: validateResponse throws on schema failure instead of returning unvalidated data (#517)

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -54,7 +54,7 @@ function headersToObject(h: HeadersInit | undefined): Record<string, string> {
 
 /**
  * Validates raw API data against a Zod schema.
- * On mismatch, logs a warning and returns the raw data as-is.
+ * On mismatch, throws an Error with validation failure details.
  */
 function validateResponse<T>(data: unknown, schema: z.ZodType<T>, context: string): T {
   const result = schema.safeParse(data);


### PR DESCRIPTION
## Summary
- Update stale JSDoc comment in `validateResponse` that claimed it "returns the raw data as-is" on schema validation failure
- The actual code already throws on failure (fixed in commit c8c55f6 / PR #537), but the comment was never updated
- Audited all 10 consumer files — every caller properly handles the thrown error via `try/catch` or `.catch()`

## Context
Issue #517 described `validateResponse` silently returning unvalidated data on schema failure. The behavioral fix was already applied in the tech debt sweep (c8c55f6), but the misleading comment remained, which could confuse future contributors into thinking the function is non-throwing.

## Test plan
- [x] `cd dashboard && npx tsc -b` — passes
- [x] `cd dashboard && npx vitest run` — 100 tests pass
- [x] `npx tsc --noEmit` (root) — passes

Generated by Hephaestus (Aegis dev agent)