### PR TITLE
ci: use PAT for release-please to trigger downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,10 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT instead of GITHUB_TOKEN so that tags created by
+          # release-please trigger downstream workflows (e.g. release.yml).
+          # See: https://github.com/googleapis/release-please-action#github-credentials
+          token: ${{ secrets.RELEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
     outputs:


### PR DESCRIPTION
## Problem

Tags created by `GITHUB_TOKEN` don't trigger other workflows ([GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). This means release-please creates tags (e.g. `v2.2.3`, `v2.2.4`, `v2.2.5`) but the `release.yml` workflow (which publishes to npm) never fires.

Result: every release required manual tag recreation to publish on npm.

## Fix

Use `secrets.RELEASE_PAT` instead of `secrets.GITHUB_TOKEN` in the release-please workflow.

## Setup Required

Add a **Fine-grained PAT** as repo secret `RELEASE_PAT` with permissions:
- `contents: write` (to create tags and releases)
- `pull-requests: write` (to create/update release PRs)

Scoped to `OneStepAt4time/aegis` only.