### PR TITLE
fix: MCP kill_session 400 + extended working stall detection

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -214,6 +214,21 @@ describe('AegisClient', () => {
     );
   });
 
+  it('killSession does NOT send Content-Type header (Issue #560)', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+
+    await client.killSession(UUID);
+
+    const call = (fetch as any).mock.calls[0];
+    const headers = call[1]?.headers as Record<string, string> | undefined;
+    // Must NOT contain Content-Type — bodyless DELETE with Content-Type: application/json
+    // causes Fastify to reject with 400 Bad Request
+    expect(headers?.['Content-Type']).toBeUndefined();
+  });
+
   it('approvePermission sends POST /v1/sessions/:id/approve', async () => {
     (fetch as any).mockResolvedValue({
       ok: true,

--- a/src/__tests__/stall-detection.test.ts
+++ b/src/__tests__/stall-detection.test.ts
@@ -874,4 +874,148 @@ describe('SessionMonitor stall detection (integration)', () => {
       expect(calls.length).toBeGreaterThanOrEqual(2);
     });
   });
+
+  // -------------------------------------------------------------------------
+  describe('Type 5: Extended working stall (Issue #562)', () => {
+    it('should detect extended_working stall when working for 3x stallThresholdMs', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now);
+      // 16 min > 3 * 5min = 15min threshold
+      (monitor as any).stateSince.set(session.id, { state: 'working', since: now - 16 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      const calls = deps.mockChannels.statusChange.mock.calls;
+      const extendedWorkingCall = calls.find((c: any[]) =>
+        c[0].detail?.includes('working') && c[0].detail?.includes('internal loop'),
+      );
+      expect(extendedWorkingCall).toBeDefined();
+    });
+
+    it('should NOT detect extended_working stall when working for under 3x threshold', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now);
+      // 14 min < 3 * 5min = 15min threshold
+      (monitor as any).stateSince.set(session.id, { state: 'working', since: now - 14 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      const calls = deps.mockChannels.statusChange.mock.calls;
+      const extendedWorkingCall = calls.find((c: any[]) =>
+        c[0].detail?.includes('internal loop'),
+      );
+      expect(extendedWorkingCall).toBeUndefined();
+    });
+
+    it('should only notify once for extended_working stall', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now);
+      (monitor as any).stateSince.set(session.id, { state: 'working', since: now - 16 * 60 * 1000 });
+
+      await checkStalls(now);
+      await checkStalls(now);
+
+      const calls = deps.mockChannels.statusChange.mock.calls;
+      const extendedWorkingCalls = calls.filter((c: any[]) =>
+        c[0].detail?.includes('internal loop'),
+      );
+      expect(extendedWorkingCalls).toHaveLength(1);
+    });
+
+    it('should NOT detect extended_working stall when state entry is not working', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'working');
+      setLastBytesSeen(session.id, 500, now);
+      // stateSince exists but state is not 'working'
+      (monitor as any).stateSince.set(session.id, { state: 'permission_prompt', since: now - 16 * 60 * 1000 });
+
+      await checkStalls(now);
+
+      const calls = deps.mockChannels.statusChange.mock.calls;
+      const extendedWorkingCall = calls.find((c: any[]) =>
+        c[0].detail?.includes('internal loop'),
+      );
+      expect(extendedWorkingCall).toBeUndefined();
+    });
+
+    it('should clear extended_working stall when session goes idle', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500 });
+      setLastStatus(session.id, 'idle');
+      (monitor as any).stallNotified.add(`${session.id}:stall:extended_working`);
+
+      await checkStalls(now);
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:extended_working`)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('handleWatcherEvent stall timer (Issue #562)', () => {
+    it('should NOT reset stall timer when file grew but no messages parsed', () => {
+      const session = addSession();
+      const originalAt = Date.now() - 3 * 60 * 1000;
+      (monitor as any).lastBytesSeen.set(session.id, { bytes: 100, at: originalAt });
+
+      (monitor as any).handleWatcherEvent({
+        sessionId: session.id,
+        newOffset: 200,
+        messages: [],
+      });
+
+      const tracking = (monitor as any).lastBytesSeen.get(session.id);
+      expect(tracking.bytes).toBe(200);
+      expect(tracking.at).toBe(originalAt);
+    });
+
+    it('should reset stall timer when real messages arrive', () => {
+      const session = addSession();
+      const originalAt = Date.now() - 3 * 60 * 1000;
+      (monitor as any).lastBytesSeen.set(session.id, { bytes: 100, at: originalAt });
+
+      (monitor as any).handleWatcherEvent({
+        sessionId: session.id,
+        newOffset: 200,
+        messages: [{ role: 'assistant', contentType: 'text', text: 'hello' }],
+      });
+
+      const tracking = (monitor as any).lastBytesSeen.get(session.id);
+      expect(tracking.bytes).toBe(200);
+      expect(tracking.at).not.toBe(originalAt);
+      expect(tracking.at).toBeGreaterThan(originalAt);
+    });
+
+    it('should clear jsonl stall notification when real messages arrive', () => {
+      const session = addSession();
+      (monitor as any).stallNotified.add(`${session.id}:stall:jsonl`);
+
+      (monitor as any).handleWatcherEvent({
+        sessionId: session.id,
+        newOffset: 200,
+        messages: [{ role: 'assistant', contentType: 'text', text: 'hello' }],
+      });
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:jsonl`)).toBe(false);
+    });
+
+    it('should NOT clear jsonl stall notification when no messages arrive', () => {
+      const session = addSession();
+      (monitor as any).stallNotified.add(`${session.id}:stall:jsonl`);
+
+      (monitor as any).handleWatcherEvent({
+        sessionId: session.id,
+        newOffset: 200,
+        messages: [],
+      });
+
+      expect((monitor as any).stallNotified.has(`${session.id}:stall:jsonl`)).toBe(true);
+    });
+  });
 });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -39,8 +39,9 @@ export class AegisClient {
   }
 
   private async request<T = unknown>(path: string, opts?: RequestInit): Promise<T> {
+    const hasBody = opts?.body !== undefined;
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
       ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
     };
     let res: Response;

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -299,6 +299,26 @@ export class SessionMonitor {
         }
       }
 
+      // --- Type 5: Extended working stall (working too long regardless of byte changes, ---
+      // Catches CC stuck in "Misting" state where internal loop detection
+      if (currentStatus === 'working') {
+        const entry = this.stateSince.get(session.id);
+        if (entry && entry.state === 'working') {
+          const workingDuration = now - entry.since;
+          const maxWorkingMs = this.config.stallThresholdMs * 3; // 15 min default
+          if (workingDuration >= maxWorkingMs && !this.stallNotified.has(`${session.id}:stall:extended_working`)) {
+            this.stallNotified.add(`${session.id}:stall:extended_working`);
+            const minutes = Math.round(workingDuration / 60000);
+            const detail = `Session stalled: in "working" state for ${minutes}min. ` +
+              `CC may be stuck in an internal loop (e.g., Misting). Consider: POST /v1/sessions/${session.id}/interrupt or /kill`;
+            this.eventBus?.emitStall(session.id, 'extended_working', detail);
+            await this.channels.statusChange(
+              this.makePayload('status.stall', session, detail),
+            );
+          }
+        }
+      }
+
       // Clean up stall notifications on state transitions (using prevStallStatus)
       if (prevStallStatus && prevStallStatus !== currentStatus) {
         const exitedPermission = prevStallStatus === 'permission_prompt' || prevStallStatus === 'bash_approval';
@@ -428,12 +448,19 @@ export class SessionMonitor {
       session.lastActivity = Date.now();
     }
 
-    // Update JSONL stall tracking — always initialize on watcher events
+    // Update JSONL stall tracking — only reset stall timer when real messages arrive
+    // When no messages, only update bytes tracking (keep timestamp)
     const now = Date.now();
     const prev = this.lastBytesSeen.get(event.sessionId);
     if (event.newOffset > (prev?.bytes ?? -1)) {
-      this.lastBytesSeen.set(event.sessionId, { bytes: event.newOffset, at: now });
-      this.stallNotified.delete(`${event.sessionId}:stall:jsonl`);
+      if (event.messages.length > 0) {
+        // Real output — reset stall timer
+        this.lastBytesSeen.set(event.sessionId, { bytes: event.newOffset, at: now });
+        this.stallNotified.delete(`${event.sessionId}:stall:jsonl`);
+      } else {
+        // File grew but no messages — only update bytes, keep timestamp
+        this.lastBytesSeen.set(event.sessionId, { bytes: event.newOffset, at: prev?.at ?? now });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **Fix #560**: MCP `kill_session` tool no longer sends `Content-Type: application/json` on bodyless DELETE requests, which caused Fastify to return 400 Bad Request
- **Fix #562**: Two-part stall detection fix for sessions stuck in CC's internal "Misting" loop:
  - `handleWatcherEvent` now only resets stall timer when real messages arrive (not just on file offset changes from CC internal writes)
  - New Type 5 "extended_working" stall detection triggers at 3x stallThresholdMs (15 min default) for sessions continuously in "working" state

## Changes

### `src/mcp-server.ts`
- `AegisClient.request()`: Only set `Content-Type: application/json` when `opts.body` is defined (DELETE requests have no body)

### `src/monitor.ts`
- `handleWatcherEvent()`: Stall timer only resets when `event.messages.length > 0`; file-only growth updates bytes but preserves timestamp
- `checkForStalls()`: New Type 5 extended working stall — triggers when session has been continuously `working` for `stallThresholdMs * 3` regardless of byte changes

## Test plan

- [x] New test: `killSession` does NOT send `Content-Type` header (mcp-server.test.ts)
- [x] New tests: Type 5 extended working stall detection (5 tests in stall-detection.test.ts)
- [x] New tests: handleWatcherEvent stall timer behavior (4 tests in stall-detection.test.ts)
- [x] All 187 relevant tests pass (stall-detection + mcp-server)
- [x] TypeScript compilation clean (`npx tsc --noEmit`)

Generated by Hephaestus (Aegis dev agent)