### PR TITLE
fix: tmux server crash recovery — health check, reconciliation, re-attach (#397)

### DIFF
--- a/src/__tests__/tmux-crash-recovery.test.ts
+++ b/src/__tests__/tmux-crash-recovery.test.ts
@@ -1,0 +1,522 @@
+/**
+ * tmux-crash-recovery.test.ts — Tests for Issue #397: tmux server crash recovery.
+ *
+ * Covers:
+ * - TmuxManager.isServerHealthy() — healthy / unreachable
+ * - TmuxManager.isTmuxServerError() — crash error patterns vs normal errors
+ * - SessionManager.reconcileTmuxCrash() — recovery, orphaning, re-attach by name
+ * - SessionManager.reconcile() — re-attach by name after tmux restart
+ * - Monitor.checkTmuxHealth() — crash detection, recovery triggers reconciliation
+ * - /health endpoint — includes tmux status
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TmuxManager, TmuxTimeoutError } from '../tmux.js';
+import type { SessionInfo } from '../session.js';
+import type { ChannelManager, SessionEventPayload } from '../channels/index.js';
+import type { SessionEventBus } from '../events.js';
+import { SessionMonitor, DEFAULT_MONITOR_CONFIG } from '../monitor.js';
+
+// ---------------------------------------------------------------------------
+// TmuxManager — isServerHealthy / isTmuxServerError
+// ---------------------------------------------------------------------------
+
+describe('TmuxManager — Issue #397', () => {
+  describe('isServerHealthy', () => {
+    it('returns healthy=true when tmux responds', async () => {
+      const tmux = new TmuxManager('test-session');
+      // Mock the internal method to succeed
+      vi.spyOn(tmux as any, 'tmuxInternal').mockResolvedValue('test-session:1 windows');
+      const result = await tmux.isServerHealthy();
+      expect(result.healthy).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it('returns healthy=false with error message when tmux is unreachable', async () => {
+      const tmux = new TmuxManager('test-session');
+      vi.spyOn(tmux as any, 'tmuxInternal').mockRejectedValue(
+        new Error('no server running on /tmp/tmux-1000/aegis-12345'),
+      );
+      const result = await tmux.isServerHealthy();
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain('no server running');
+    });
+
+    it('returns healthy=false on connection refused', async () => {
+      const tmux = new TmuxManager('test-session');
+      vi.spyOn(tmux as any, 'tmuxInternal').mockRejectedValue(
+        new Error('failed to connect to server'),
+      );
+      const result = await tmux.isServerHealthy();
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain('failed to connect');
+    });
+  });
+
+  describe('isTmuxServerError', () => {
+    it('detects "no server running" as server error', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError(new Error('no server running on /tmp/tmux'))).toBe(true);
+    });
+
+    it('detects "failed to connect to server" as server error', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError(new Error('failed to connect to server'))).toBe(true);
+    });
+
+    it('detects "connection refused" as server error', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError(new Error('connection refused on socket'))).toBe(true);
+    });
+
+    it('detects "no tmux server" as server error', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError(new Error('no tmux server found'))).toBe(true);
+    });
+
+    it('does not flag window-not-found as server error', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError(new Error('can\'t find window @99'))).toBe(false);
+    });
+
+    it('does not flag session-not-found as server error', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError(new Error('session not found: aegis'))).toBe(false);
+    });
+
+    it('handles non-Error values', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError('some string')).toBe(false);
+      expect(tmux.isTmuxServerError(null)).toBe(false);
+      expect(tmux.isTmuxServerError(undefined)).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      const tmux = new TmuxManager('test-session');
+      expect(tmux.isTmuxServerError(new Error('No Server Running'))).toBe(true);
+      expect(tmux.isTmuxServerError(new Error('FAILED TO CONNECT TO SERVER'))).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionManager — reconcileTmuxCrash & reconcile re-attach
+// ---------------------------------------------------------------------------
+
+describe('SessionManager — crash recovery (Issue #397)', () => {
+  /** Create a mock TmuxManager */
+  function mockTmuxManager(windows: Array<{ windowId: string; windowName: string; cwd?: string }> = []) {
+    return {
+      listWindows: vi.fn(async () => windows.map(w => ({
+        windowId: w.windowId,
+        windowName: w.windowName,
+        cwd: w.cwd || '/tmp',
+        paneCommand: 'claude',
+      }))),
+      isServerHealthy: vi.fn(async () => ({ healthy: true, error: null })),
+      isTmuxServerError: vi.fn(() => false),
+      windowExists: vi.fn(async () => true),
+      killWindow: vi.fn(async () => {}),
+      sendKeys: vi.fn(async () => {}),
+      sendKeysVerified: vi.fn(async () => ({ delivered: true, attempts: 1 })),
+      capturePane: vi.fn(async () => ''),
+      sendSpecialKey: vi.fn(async () => {}),
+      listPanePid: vi.fn(async () => null),
+      isPidAlive: vi.fn(() => true),
+      ensureSession: vi.fn(async () => {}),
+      createWindow: vi.fn(async () => ({ windowId: '@1', windowName: 'cc-test' })),
+      killSession: vi.fn(async () => {}),
+      getWindowHealth: vi.fn(async () => ({
+        windowExists: true, paneCommand: 'claude', claudeRunning: true,
+      })),
+    } as any;
+  }
+
+  /** Create a minimal config */
+  function mockConfig() {
+    return {
+      stateDir: '/tmp/aegis-test',
+      host: '127.0.0.1',
+      port: 9100,
+      tmuxSession: 'aegis',
+      claudeProjectsDir: '/tmp/.claude/projects',
+      maxSessionAgeMs: 7200000,
+      reaperIntervalMs: 60000,
+      defaultPermissionMode: 'bypassPermissions',
+      defaultSessionEnv: {},
+      allowedWorkDirs: [],
+      sseMaxConnections: 50,
+      sseMaxPerIp: 5,
+    } as any;
+  }
+
+  describe('reconcile — re-attach by window name', () => {
+    it('re-attaches session when window exists by name but different ID', async () => {
+      const tmux = mockTmuxManager([
+        { windowId: '@5', windowName: 'cc-abc12345' },  // tmux restarted, new ID
+      ]);
+      const config = mockConfig();
+      const { SessionManager } = await import('../session.js');
+      const sessions = new SessionManager(tmux, config);
+
+      // Manually inject a session with old windowId
+      (sessions as any).state.sessions = {
+        'session-1': {
+          id: 'session-1',
+          windowId: '@2',  // old ID from before tmux restart
+          windowName: 'cc-abc12345',
+          workDir: '/tmp/test',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'unknown' as const,
+          createdAt: Date.now() - 60000,
+          lastActivity: Date.now() - 10000,
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+          claudeSessionId: 'claude-xyz',
+          jsonlPath: '/tmp/test/session.jsonl',
+        },
+      };
+
+      await (sessions as any).reconcile();
+
+      // Session should be re-attached with new windowId
+      const session = sessions.getSession('session-1');
+      expect(session).not.toBeNull();
+      expect(session!.windowId).toBe('@5');
+    });
+
+    it('removes session when window is gone by both ID and name', async () => {
+      const tmux = mockTmuxManager([]);  // no windows
+      const config = mockConfig();
+      const { SessionManager } = await import('../session.js');
+      const sessions = new SessionManager(tmux, config);
+
+      (sessions as any).state.sessions = {
+        'session-1': {
+          id: 'session-1',
+          windowId: '@2',
+          windowName: 'cc-gone',
+          workDir: '/tmp/test',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'unknown' as const,
+          createdAt: Date.now() - 60000,
+          lastActivity: Date.now(),
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+        },
+      };
+
+      await (sessions as any).reconcile();
+
+      expect(sessions.getSession('session-1')).toBeNull();
+    });
+  });
+
+  describe('reconcileTmuxCrash', () => {
+    it('recovers sessions by re-attaching to windows with same name', async () => {
+      const tmux = mockTmuxManager([
+        { windowId: '@10', windowName: 'cc-recovered' },  // new ID after restart
+      ]);
+      const config = mockConfig();
+      const { SessionManager } = await import('../session.js');
+      const sessions = new SessionManager(tmux, config);
+
+      (sessions as any).state.sessions = {
+        'session-1': {
+          id: 'session-1',
+          windowId: '@3',  // old ID from before crash
+          windowName: 'cc-recovered',
+          workDir: '/tmp/test',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'working' as const,
+          createdAt: Date.now() - 60000,
+          lastActivity: Date.now(),
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+          claudeSessionId: 'claude-xyz',
+          jsonlPath: '/tmp/test/session.jsonl',
+        },
+      };
+
+      const result = await sessions.reconcileTmuxCrash();
+      expect(result.recovered).toBe(1);
+      expect(result.orphaned).toBe(0);
+
+      const session = sessions.getSession('session-1');
+      expect(session).not.toBeNull();
+      expect(session!.windowId).toBe('@10');
+      expect(session!.status).toBe('unknown');
+    });
+
+    it('marks sessions as orphaned when window is gone', async () => {
+      const tmux = mockTmuxManager([]);  // no windows — all gone
+      const config = mockConfig();
+      const { SessionManager } = await import('../session.js');
+      const sessions = new SessionManager(tmux, config);
+
+      (sessions as any).state.sessions = {
+        'session-1': {
+          id: 'session-1',
+          windowId: '@3',
+          windowName: 'cc-orphaned',
+          workDir: '/tmp/test',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'working' as const,
+          createdAt: Date.now() - 60000,
+          lastActivity: Date.now(),
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+        },
+      };
+
+      const result = await sessions.reconcileTmuxCrash();
+      expect(result.recovered).toBe(0);
+      expect(result.orphaned).toBe(1);
+
+      const session = sessions.getSession('session-1');
+      expect(session).not.toBeNull();
+      expect(session!.lastDeadAt).toBeDefined();
+      expect(session!.status).toBe('unknown');
+    });
+
+    it('handles mixed recovered and orphaned sessions', async () => {
+      const tmux = mockTmuxManager([
+        { windowId: '@20', windowName: 'cc-alive' },
+      ]);
+      const config = mockConfig();
+      const { SessionManager } = await import('../session.js');
+      const sessions = new SessionManager(tmux, config);
+
+      (sessions as any).state.sessions = {
+        'session-1': {
+          id: 'session-1',
+          windowId: '@5',
+          windowName: 'cc-alive',  // exists by name → recovered
+          workDir: '/tmp/test1',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'working' as const,
+          createdAt: Date.now() - 60000,
+          lastActivity: Date.now(),
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+          claudeSessionId: 'c1',
+          jsonlPath: '/tmp/s1.jsonl',
+        },
+        'session-2': {
+          id: 'session-2',
+          windowId: '@6',
+          windowName: 'cc-gone',  // doesn't exist → orphaned
+          workDir: '/tmp/test2',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'working' as const,
+          createdAt: Date.now() - 60000,
+          lastActivity: Date.now(),
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+        },
+      };
+
+      const result = await sessions.reconcileTmuxCrash();
+      expect(result.recovered).toBe(1);
+      expect(result.orphaned).toBe(1);
+    });
+
+    it('skips sessions whose windowId still matches', async () => {
+      const tmux = mockTmuxManager([
+        { windowId: '@5', windowName: 'cc-same' },
+      ]);
+      const config = mockConfig();
+      const { SessionManager } = await import('../session.js');
+      const sessions = new SessionManager(tmux, config);
+
+      (sessions as any).state.sessions = {
+        'session-1': {
+          id: 'session-1',
+          windowId: '@5',  // matches exactly
+          windowName: 'cc-same',
+          workDir: '/tmp/test',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'idle' as const,
+          createdAt: Date.now() - 60000,
+          lastActivity: Date.now(),
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+          claudeSessionId: 'c1',
+          jsonlPath: '/tmp/s1.jsonl',
+        },
+      };
+
+      const result = await sessions.reconcileTmuxCrash();
+      expect(result.recovered).toBe(0);
+      expect(result.orphaned).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Monitor — tmux health check integration
+// ---------------------------------------------------------------------------
+
+describe('Monitor — tmux health check (Issue #397)', () => {
+  function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+    return {
+      id: 'session-1',
+      windowId: '@0',
+      windowName: 'test-session',
+      workDir: '/tmp/test',
+      claudeSessionId: 'claude-abc',
+      jsonlPath: '/tmp/test/session.jsonl',
+      byteOffset: 0,
+      monitorOffset: 0,
+      status: 'idle',
+      createdAt: Date.now() - 60_000,
+      lastActivity: Date.now() - 10_000,
+      stallThresholdMs: 5 * 60 * 1000,
+      permissionStallMs: 5 * 60 * 1000,
+      permissionMode: 'default',
+      ...overrides,
+    };
+  }
+
+  function mockSessionManager(sessions: SessionInfo[] = []) {
+    const sessionMap = new Map<string, SessionInfo>();
+    for (const s of sessions) sessionMap.set(s.id, { ...s });
+
+    return {
+      listSessions: vi.fn(() => [...sessionMap.values()]),
+      getSession: vi.fn((id: string) => sessionMap.get(id) ?? null),
+      isWindowAlive: vi.fn<(id: string) => Promise<boolean>>(async () => true),
+      killSession: vi.fn(async () => {}),
+      readMessagesForMonitor: vi.fn(async () => ({
+        messages: [],
+        status: 'idle' as const,
+        statusText: null,
+        interactiveContent: null,
+      })),
+      approve: vi.fn(async () => {}),
+      reject: vi.fn(async () => {}),
+      reconcileTmuxCrash: vi.fn(async () => ({ recovered: 0, orphaned: 0 })),
+    };
+  }
+
+  function mockChannelManager() {
+    return {
+      statusChange: vi.fn(async (_payload: SessionEventPayload) => {}),
+      message: vi.fn(async (_payload: SessionEventPayload) => {}),
+    };
+  }
+
+  function mockTmux(healthy = true) {
+    return {
+      isServerHealthy: vi.fn(async () => ({
+        healthy,
+        error: healthy ? null : 'no server running',
+      })),
+    };
+  }
+
+  it('detects tmux crash and sets tmuxWasDown flag', async () => {
+    const sessions = mockSessionManager([makeSession()]);
+    const channels = mockChannelManager();
+    const tmux = mockTmux(false);
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+    monitor.setTmuxManager(tmux as any);
+
+    // Simulate a health check with tmux down
+    await (monitor as any).checkTmuxHealth();
+
+    expect((monitor as any).tmuxWasDown).toBe(true);
+  });
+
+  it('triggers reconciliation when tmux recovers', async () => {
+    const sessions = mockSessionManager([makeSession()]);
+    const channels = mockChannelManager();
+    const tmux = mockTmux(true);
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+    monitor.setTmuxManager(tmux as any);
+
+    // Simulate tmux was down
+    (monitor as any).tmuxWasDown = true;
+
+    // Now tmux is back up
+    await (monitor as any).checkTmuxHealth();
+
+    expect((monitor as any).tmuxWasDown).toBe(false);
+    expect(sessions.reconcileTmuxCrash).toHaveBeenCalledOnce();
+  });
+
+  it('does not trigger reconciliation when tmux was never down', async () => {
+    const sessions = mockSessionManager([makeSession()]);
+    const channels = mockChannelManager();
+    const tmux = mockTmux(true);
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+    monitor.setTmuxManager(tmux as any);
+
+    await (monitor as any).checkTmuxHealth();
+
+    expect(sessions.reconcileTmuxCrash).not.toHaveBeenCalled();
+  });
+
+  it('notifies channels on recovery with re-attached sessions', async () => {
+    const sessions = mockSessionManager([makeSession()]);
+    (sessions.reconcileTmuxCrash as any).mockResolvedValue({
+      recovered: 1,
+      orphaned: 0,
+    });
+    const channels = mockChannelManager();
+    const tmux = mockTmux(true);
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+    monitor.setTmuxManager(tmux as any);
+
+    (monitor as any).tmuxWasDown = true;
+    await (monitor as any).checkTmuxHealth();
+
+    expect(channels.statusChange).toHaveBeenCalled();
+    const payload = channels.statusChange.mock.calls[0][0] as SessionEventPayload;
+    expect(payload.event).toBe('status.recovered');
+    expect(payload.detail).toContain('recovered');
+  });
+
+  it('skips health check if TmuxManager not set', async () => {
+    const sessions = mockSessionManager();
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+    // Don't call setTmuxManager — should be a no-op
+
+    await (monitor as any).checkTmuxHealth();
+
+    expect(sessions.reconcileTmuxCrash).not.toHaveBeenCalled();
+  });
+
+  it('continues to report tmux down across multiple checks', async () => {
+    const sessions = mockSessionManager([makeSession()]);
+    const channels = mockChannelManager();
+    const tmux = mockTmux(false);
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+    monitor.setTmuxManager(tmux as any);
+
+    // First check
+    await (monitor as any).checkTmuxHealth();
+    expect((monitor as any).tmuxWasDown).toBe(true);
+
+    // Second check still down
+    await (monitor as any).checkTmuxHealth();
+    expect((monitor as any).tmuxWasDown).toBe(true);
+    // Should NOT call reconcile while still down
+    expect(sessions.reconcileTmuxCrash).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -35,6 +35,7 @@ export type SessionEvent =
   | 'status.error'
   | 'status.rate_limited'
   | 'status.permission_timeout'
+  | 'status.recovered'
   | 'swarm.teammate_spawned'
   | 'swarm.teammate_finished';
 

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -12,6 +12,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { type SessionManager, type SessionInfo } from './session.js';
+import { type TmuxManager } from './tmux.js';
 import { type ParsedEntry } from './transcript.js';
 import { type UIState } from './terminal-parser.js';
 import { type ChannelManager, type SessionEventPayload, type SessionEvent } from './channels/index.js';
@@ -62,6 +63,10 @@ export class SessionMonitor {
   private deadNotified = new Set<string>();  // don't spam dead session events
   private prevStatusForStall = new Map<string, UIState>();  // track previous status for stall transition detection
   private rateLimitedSessions = new Set<string>();  // sessions in rate-limit backoff
+  // Issue #397: Track tmux server health for crash recovery
+  private tmuxWasDown = false;
+  private lastTmuxHealthCheck = 0;
+  private static readonly TMUX_HEALTH_CHECK_INTERVAL_MS = 10_000; // check every 10s
 
   /** Issue #89 L4: Debounce status change broadcasts per session.
    *  If multiple status changes happen within 500ms, only emit the last one.
@@ -85,6 +90,13 @@ export class SessionMonitor {
   /** Issue #32: Set the event bus for SSE streaming. */
   setEventBus(bus: SessionEventBus): void {
     this.eventBus = bus;
+  }
+
+  /** Issue #397: Set the TmuxManager reference for tmux health checks. */
+  private tmux?: TmuxManager;
+
+  setTmuxManager(tmuxManager: TmuxManager): void {
+    this.tmux = tmuxManager;
   }
 
   /** Issue #84: Set the JSONL watcher for fs.watch-based message detection. */
@@ -157,6 +169,12 @@ export class SessionMonitor {
     if (now - this.lastDeadCheck >= this.config.deadCheckIntervalMs) {
       this.lastDeadCheck = now;
       await this.checkDeadSessions();
+    }
+
+    // Issue #397: Tmux server health check (every 10s)
+    if (now - this.lastTmuxHealthCheck >= SessionMonitor.TMUX_HEALTH_CHECK_INTERVAL_MS) {
+      this.lastTmuxHealthCheck = now;
+      await this.checkTmuxHealth();
     }
   }
 
@@ -642,6 +660,38 @@ export class SessionMonitor {
           await this.sessions.killSession(session.id);
         } catch {
           // Window already gone — that's fine, session is dead
+        }
+      }
+    }
+  }
+
+  /** Issue #397: Check tmux server health. Detect crashes and trigger reconciliation. */
+  private async checkTmuxHealth(): Promise<void> {
+    if (!this.tmux) return;
+    const { healthy } = await this.tmux.isServerHealthy();
+
+    if (!healthy) {
+      if (!this.tmuxWasDown) {
+        console.warn('Monitor: tmux server is unreachable — sessions may be orphaned');
+        this.tmuxWasDown = true;
+      }
+      return;
+    }
+
+    // Tmux is healthy now
+    if (this.tmuxWasDown) {
+      console.log('Monitor: tmux server recovered — triggering crash reconciliation');
+      this.tmuxWasDown = false;
+      // Trigger crash reconciliation to re-attach or mark orphaned sessions
+      const result = await this.sessions.reconcileTmuxCrash();
+      if (result.recovered > 0 || result.orphaned > 0) {
+        console.log(`Monitor: crash reconciliation complete — recovered: ${result.recovered}, orphaned: ${result.orphaned}`);
+        // Notify channels about recovery
+        for (const session of this.sessions.listSessions()) {
+          await this.channels.statusChange(
+            this.makePayload('status.recovered', session,
+              `tmux server recovered. Session ${session.windowName} re-attached.`),
+          );
         }
       }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -261,16 +261,19 @@ const createSessionSchema = z.object({
   autoApprove: z.boolean().optional(),
 }).strict();
 
-// Health
+// Health — Issue #397: includes tmux server health check
 app.get('/v1/health', async () => {
   const pkg = await import('../package.json', { with: { type: 'json' } });
   const activeCount = sessions.listSessions().length;
   const totalCount = metrics.getTotalSessionsCreated();
+  const tmuxHealth = await tmux.isServerHealthy();
+  const status = tmuxHealth.healthy ? 'ok' : 'degraded';
   return {
-    status: 'ok',
+    status,
     version: pkg.default.version,
     uptime: process.uptime(),
     sessions: { active: activeCount, total: totalCount },
+    tmux: tmuxHealth,
     timestamp: new Date().toISOString(),
   };
 });
@@ -280,11 +283,14 @@ app.get('/health', async () => {
   const pkg = await import('../package.json', { with: { type: 'json' } });
   const activeCount = sessions.listSessions().length;
   const totalCount = metrics.getTotalSessionsCreated();
+  const tmuxHealth = await tmux.isServerHealthy();
+  const status = tmuxHealth.healthy ? 'ok' : 'degraded';
   return {
-    status: 'ok',
+    status,
     version: pkg.default.version,
     uptime: process.uptime(),
     sessions: { active: activeCount, total: totalCount },
+    tmux: tmuxHealth,
     timestamp: new Date().toISOString(),
   };
 });
@@ -1581,6 +1587,9 @@ async function main(): Promise<void> {
 
   // Wire SSE event bus (Issue #32)
   monitor.setEventBus(eventBus);
+
+  // Issue #397: Wire TmuxManager for tmux health monitoring
+  monitor.setTmuxManager(tmux);
 
   // Issue #84: Wire JSONL watcher for fs.watch-based message detection
   jsonlWatcher = new JsonlWatcher();

--- a/src/session.ts
+++ b/src/session.ts
@@ -9,7 +9,7 @@ import { readFile, writeFile, rename, mkdir, stat, readdir, unlink } from 'node:
 import { existsSync, unlinkSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { TmuxManager } from './tmux.js';
+import { TmuxManager, type TmuxWindow } from './tmux.js';
 import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.js';
 import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState } from './terminal-parser.js';
 import type { Config } from './config.js';
@@ -196,22 +196,38 @@ export class SessionManager {
     await this.reconcile();
   }
 
-  /** Reconcile state with actual tmux windows. Remove dead sessions, restart discovery for live ones. */
+  /** Reconcile state with actual tmux windows. Remove dead sessions, restart discovery for live ones.
+   *  Issue #397: Also handles re-attach by window name when windowId is stale after tmux restart. */
   private async reconcile(): Promise<void> {
     const windows = await this.tmux.listWindows();
     const windowIds = new Set(windows.map(w => w.windowId));
-    const windowNames = new Set(windows.map(w => w.windowName));
+    const windowByName = new Map<string, TmuxWindow>();
+    for (const w of windows) windowByName.set(w.windowName, w);
 
     let changed = false;
     for (const [id, session] of Object.entries(this.state.sessions)) {
-      const alive = windowIds.has(session.windowId) || windowNames.has(session.windowName);
-      if (!alive) {
+      const windowIdAlive = windowIds.has(session.windowId);
+      const windowNameAlive = windowByName.has(session.windowName);
+
+      if (!windowIdAlive && !windowNameAlive) {
         console.log(`Reconcile: session ${session.windowName} (${id.slice(0, 8)}) — tmux window gone, removing`);
         // Restore patched settings before removing dead session
         if (session.settingsPatched) {
           await cleanOrphanedBackup(session.workDir);
         }
         delete this.state.sessions[id];
+        changed = true;
+      } else if (!windowIdAlive && windowNameAlive) {
+        // Issue #397: Window exists with same name but different ID (tmux restarted).
+        // Re-attach by updating the windowId to the new one.
+        const win = windowByName.get(session.windowName)!;
+        const oldWindowId = session.windowId;
+        session.windowId = win.windowId;
+        console.log(`Reconcile: session ${session.windowName} re-attached: ${oldWindowId} → ${win.windowId}`);
+        // Restart discovery if needed
+        if (!session.claudeSessionId || !session.jsonlPath) {
+          this.startSessionIdDiscovery(id);
+        }
         changed = true;
       } else {
         // Session is alive — restart discovery if needed
@@ -225,7 +241,9 @@ export class SessionManager {
     }
 
     // P0 fix: On startup, purge session_map entries that don't correspond to active sessions.
-    await this.purgeStaleSessionMapEntries(windowIds, windowNames);
+    const finalWindowIds = new Set(Object.values(this.state.sessions).map(s => s.windowId));
+    const finalWindowNames = new Set(Object.values(this.state.sessions).map(s => s.windowName));
+    await this.purgeStaleSessionMapEntries(finalWindowIds, finalWindowNames);
 
     // Issue #35: Adopt orphaned tmux windows (cc-* prefix) not in state
     const knownWindowIds = new Set(Object.values(this.state.sessions).map(s => s.windowId));
@@ -260,6 +278,61 @@ export class SessionManager {
     if (changed) {
       await this.save();
     }
+  }
+
+  /** Issue #397: Reconcile after tmux server crash recovery.
+   *  Called when the monitor detects tmux server came back after a crash.
+   *  Returns counts for observability. */
+  async reconcileTmuxCrash(): Promise<{ recovered: number; orphaned: number }> {
+    console.log('Reconcile: tmux crash recovery — checking all sessions');
+    const windows = await this.tmux.listWindows();
+    const windowIds = new Set(windows.map(w => w.windowId));
+    const windowByName = new Map<string, typeof windows[0]>();
+    for (const w of windows) windowByName.set(w.windowName, w);
+
+    let recovered = 0;
+    let orphaned = 0;
+    let changed = false;
+
+    for (const [id, session] of Object.entries(this.state.sessions)) {
+      const windowIdAlive = windowIds.has(session.windowId);
+      const windowNameAlive = windowByName.has(session.windowName);
+
+      if (windowIdAlive) {
+        // Window ID still matches — session survived the crash
+        continue;
+      }
+
+      if (windowNameAlive) {
+        // Window exists by name but ID changed — re-attach
+        const win = windowByName.get(session.windowName)!;
+        const oldWindowId = session.windowId;
+        session.windowId = win.windowId;
+        session.status = 'unknown';
+        session.lastActivity = Date.now();
+        console.log(`Reconcile (crash): session ${session.windowName} re-attached: ${oldWindowId} → ${win.windowId}`);
+        // Restart discovery in case the session state is stale
+        if (!session.claudeSessionId || !session.jsonlPath) {
+          this.startSessionIdDiscovery(id);
+          this.startFilesystemDiscovery(id, session.workDir);
+        }
+        recovered++;
+        changed = true;
+      } else {
+        // Window gone entirely — session is orphaned
+        console.log(`Reconcile (crash): session ${session.windowName} (${id.slice(0, 8)}) — window gone, marking orphaned`);
+        session.status = 'unknown';
+        session.lastDeadAt = Date.now();
+        orphaned++;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await this.save();
+    }
+
+    return { recovered, orphaned };
   }
 
   /** Save state to disk atomically (write to temp, then rename).

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -802,6 +802,32 @@ export class TmuxManager {
     }
   }
 
+  /** Issue #397: Check if the tmux server is reachable and healthy.
+   *  Returns { healthy, error } — does not throw. */
+  async isServerHealthy(): Promise<{ healthy: boolean; error: string | null }> {
+    try {
+      await this.tmuxInternal('list-sessions');
+      return { healthy: true, error: null };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { healthy: false, error: msg };
+    }
+  }
+
+  /** Issue #397: Check if a tmux error indicates the server crashed (vs window-not-found).
+   *  Server crash errors contain specific patterns from tmux CLI. */
+  isTmuxServerError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message.toLowerCase();
+    // "no server running" = tmux server not started
+    // "failed to connect to server" = socket/protocol error
+    // "connection refused" = server died mid-operation
+    return msg.includes('no server running')
+      || msg.includes('failed to connect')
+      || msg.includes('connection refused')
+      || msg.includes('no tmux server');
+  }
+
   /** Kill the entire tmux session. Used for cleanup on shutdown. */
   async killSession(sessionName?: string): Promise<void> {
     const target = sessionName ?? this.sessionName;


### PR DESCRIPTION
## Summary
- Add `TmuxManager.isServerHealthy()` and `isTmuxServerError()` for detecting tmux server crashes vs normal window errors
- Update `/health` and `/v1/health` endpoints to include tmux server status (`ok` / `degraded`)
- Add `SessionManager.reconcileTmuxCrash()` for crash recovery — re-attaches sessions by window name, marks orphans with `lastDeadAt`
- Enhance `SessionManager.reconcile()` to re-attach by window name when `windowId` is stale after tmux restart
- Add periodic tmux health monitoring in `SessionMonitor` (10s interval) with automatic crash detection and reconciliation on recovery
- Add `status.recovered` event type for channel notifications on crash recovery

## Test plan
- [x] 23 new unit tests covering: `isServerHealthy`, `isTmuxServerError`, `reconcileTmuxCrash` (recovered/orphaned/mixed/skip), `reconcile` re-attach by name, monitor health check lifecycle (crash/recovery/no-op)
- [x] Full quality gate passes: `tsc --noEmit` + `npm run build` + `npm test` (1756 tests, 0 failures)

Closes #397

Generated by Hephaestus (Aegis dev agent)