### PR TITLE
fix(#587): add error handling to Layout SSE subscription

### DIFF
--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Layout.test.tsx — Tests for Layout SSE error handling (#587).
+ *
+ * Verifies that if subscribeGlobalSSE throws synchronously, the component
+ * survives (no crash) and still renders the UI.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, type RenderResult } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const mockSubscribeGlobalSSE = vi.fn();
+
+vi.mock('../api/client', () => ({
+  subscribeGlobalSSE: (...args: unknown[]) => mockSubscribeGlobalSSE(...args),
+}));
+
+vi.mock('../components/ToastContainer', () => ({
+  default: () => <div data-testid="toast-container" />,
+}));
+
+// Lazy import so mocks are in place
+import Layout from '../components/Layout';
+
+function renderLayout(): RenderResult {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="/" element={<div>Test Content</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('Layout SSE error handling (#587)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders without crashing when subscribeGlobalSSE succeeds', () => {
+    mockSubscribeGlobalSSE.mockReturnValue(() => {});
+    renderLayout();
+    expect(screen.getByText('Aegis Dashboard')).toBeDefined();
+    expect(mockSubscribeGlobalSSE).toHaveBeenCalled();
+  });
+
+  it('renders without crashing when subscribeGlobalSSE throws synchronously', () => {
+    mockSubscribeGlobalSSE.mockImplementation(() => {
+      throw new Error('Invalid URL construction');
+    });
+
+    // Should NOT throw — the component catches the error
+    expect(() => renderLayout()).not.toThrow();
+    expect(screen.getByText('Aegis Dashboard')).toBeDefined();
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to subscribe to global SSE:',
+      expect.any(Error),
+    );
+  });
+
+  it('calls unsubscribe on cleanup', () => {
+    const unsubscribe = vi.fn();
+    mockSubscribeGlobalSSE.mockReturnValue(unsubscribe);
+
+    const { unmount } = renderLayout();
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('does not call unsubscribe on cleanup when subscribeGlobalSSE threw', () => {
+    mockSubscribeGlobalSSE.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const { unmount } = renderLayout();
+    // Unmounting should not throw even though unsubscribe is undefined
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -27,30 +27,36 @@ export default function Layout() {
   const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // #121: Wire up global SSE connection
+  // #587: Wrap in try/catch to prevent app crash on synchronous errors
   useEffect(() => {
-    const unsubscribe = subscribeGlobalSSE((event) => {
-      if (!event.sessionId) return;
-      addActivity(event);
-    }, token, {
-      onOpen: () => {
-        if (disconnectTimerRef.current) {
-          clearTimeout(disconnectTimerRef.current);
-          disconnectTimerRef.current = null;
-        }
-        setSseConnected(true);
-      },
-      onClose: () => {
-        disconnectTimerRef.current = setTimeout(() => {
-          setSseConnected(false);
-        }, 2000);
-      },
-    });
+    let unsubscribe: (() => void) | undefined;
+    try {
+      unsubscribe = subscribeGlobalSSE((event) => {
+        if (!event.sessionId) return;
+        addActivity(event);
+      }, token, {
+        onOpen: () => {
+          if (disconnectTimerRef.current) {
+            clearTimeout(disconnectTimerRef.current);
+            disconnectTimerRef.current = null;
+          }
+          setSseConnected(true);
+        },
+        onClose: () => {
+          disconnectTimerRef.current = setTimeout(() => {
+            setSseConnected(false);
+          }, 2000);
+        },
+      });
+    } catch (err) {
+      console.error('Failed to subscribe to global SSE:', err);
+    }
 
     return () => {
       if (disconnectTimerRef.current) {
         clearTimeout(disconnectTimerRef.current);
       }
-      unsubscribe();
+      unsubscribe?.();
     };
   }, [setSseConnected, addActivity, token]);
 


### PR DESCRIPTION
## Summary
- Wraps `subscribeGlobalSSE()` in `Layout.tsx` `useEffect` with try-catch to prevent dashboard crash on synchronous errors (invalid URL construction, auth errors)
- Uses optional chaining (`unsubscribe?.()`) in cleanup to handle the case where subscribe threw
- Logs caught errors via `console.error('Failed to subscribe to global SSE:', err)`

## Test plan
- [x] `renders without crashing when subscribeGlobalSSE succeeds` — happy path
- [x] `renders without crashing when subscribeGlobalSSE throws synchronously` — the core bug case, verifies no crash + error logged
- [x] `calls unsubscribe on cleanup` — cleanup calls returned function
- [x] `does not call unsubscribe on cleanup when subscribeGlobalSSE threw` — cleanup is safe when unsubscribe is undefined
- [x] All 104 dashboard tests pass

Fixes #587

Generated by Hephaestus (Aegis dev agent)