### PR TITLE
fix(#588): aggregate Promise.allSettled errors in webhook fire()

### DIFF
--- a/src/__tests__/webhook-retry.test.ts
+++ b/src/__tests__/webhook-retry.test.ts
@@ -186,4 +186,90 @@ describe('Webhook delivery with retry', () => {
   it('should have correct BASE_DELAY_MS constant', () => {
     expect(WebhookChannel.BASE_DELAY_MS).toBe(1000);
   });
+
+  describe('Issue #588: Promise.allSettled error aggregation', () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should log aggregated errors when all endpoints fail', async () => {
+      vi.useFakeTimers();
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const channel = new WebhookChannel({
+        endpoints: [
+          { url: 'https://example.com/hook1' },
+          { url: 'https://example.com/hook2' },
+          { url: 'https://example.com/hook3' },
+        ],
+      });
+
+      const deliveryPromise = channel.onSessionCreated!(makePayload());
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+      await deliveryPromise;
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Webhook: 3/3 endpoint(s) failed'),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ECONNREFUSED'),
+      );
+
+      vi.useRealTimers();
+    });
+
+    it('should log partial failures with correct count', async () => {
+      vi.useFakeTimers();
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200 })
+        .mockRejectedValue(new Error('timeout'));
+
+      const channel = new WebhookChannel({
+        endpoints: [
+          { url: 'https://example.com/hook1' },
+          { url: 'https://example.com/hook2' },
+        ],
+      });
+
+      const deliveryPromise = channel.onSessionCreated!(makePayload());
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+      await deliveryPromise;
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Webhook: 1/2 endpoint(s) failed'),
+      );
+
+      vi.useRealTimers();
+    });
+
+    it('should NOT log when all endpoints succeed', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200 })
+        .mockResolvedValueOnce({ ok: true, status: 200 });
+
+      const channel = new WebhookChannel({
+        endpoints: [
+          { url: 'https://example.com/hook1' },
+          { url: 'https://example.com/hook2' },
+        ],
+      });
+
+      await channel.onSessionCreated!(makePayload());
+
+      const aggregationCalls = consoleErrorSpy.mock.calls.filter(
+        (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('endpoint(s) failed'),
+      );
+      expect(aggregationCalls).toHaveLength(0);
+    });
+  });
 });

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -132,7 +132,12 @@ export class WebhookChannel implements Channel {
       await this.deliverWithRetry(ep, body, payload.event);
     });
 
-    await Promise.allSettled(promises);
+    const results = await Promise.allSettled(promises);
+    const failed = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (failed.length > 0) {
+      const reasons = failed.map(r => String(r.reason)).join('; ');
+      console.error(`Webhook: ${failed.length}/${promises.length} endpoint(s) failed: ${reasons}`);
+    }
   }
 
   /** Issue #25: Deliver webhook with retry + exponential backoff. */
@@ -171,7 +176,6 @@ export class WebhookChannel implements Channel {
         if (res.status >= 500) {
           this.addToDeadLetterQueue(ep.url, event, lastError, attempt);
         }
-        return;
       } catch (e: unknown) {
         lastError = getErrorMessage(e);
         if (attempt < maxRetries) {
@@ -183,6 +187,8 @@ export class WebhookChannel implements Channel {
         console.error(`Webhook ${ep.url} failed after ${maxRetries} attempts for ${event}: ${lastError}`);
         this.addToDeadLetterQueue(ep.url, event, lastError, maxRetries);
       }
+      // Final failure (HTTP or network) — throw so fire() can aggregate
+      throw new Error(lastError);
     }
   }
 


### PR DESCRIPTION
Fixes #588

Webhook retry used `Promise.allSettled` without aggregating errors from failed attempts, making debugging difficult when multiple retries fail.

**Fix**: Aggregate all rejection reasons into a single error message when all retries are exhausted.

```
tsc: ✅ zero errors
build: ✅ passed
test: 75 files, 1737 tests passed
```