### PR TITLE
fix(#582): redact sensitive webhook headers from error logs

### DIFF
--- a/src/__tests__/webhook-header-redaction.test.ts
+++ b/src/__tests__/webhook-header-redaction.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { redactHeaders, redactSecretsFromText } from '../utils/redact-headers.js';
+
+describe('redactHeaders', () => {
+  it('redacts Authorization header', () => {
+    const result = redactHeaders({ Authorization: 'Bearer super-secret-token' });
+    expect(result.Authorization).toBe('Bear...[REDACTED]');
+  });
+
+  it('redacts case-insensitively', () => {
+    const result = redactHeaders({ authorization: 'Bearer tok' });
+    expect(result.authorization).toBe('Bear...[REDACTED]');
+  });
+
+  it('redacts Cookie header', () => {
+    const result = redactHeaders({ Cookie: 'session=abc123def456' });
+    expect(result.Cookie).toBe('sess...[REDACTED]');
+  });
+
+  it('redacts X-Api-Key header', () => {
+    const result = redactHeaders({ 'X-Api-Key': 'sk-live-12345678' });
+    expect(result['X-Api-Key']).toBe('sk-l...[REDACTED]');
+  });
+
+  it('redacts api-key header (case-insensitive)', () => {
+    const result = redactHeaders({ 'Api-Key': 'my-api-key-value-here' });
+    expect(result['Api-Key']).toBe('my-a...[REDACTED]');
+  });
+
+  it('passes through non-sensitive headers unchanged', () => {
+    const result = redactHeaders({
+      'Content-Type': 'application/json',
+      'X-Request-Id': 'req-123',
+      Accept: 'application/json',
+    });
+    expect(result).toEqual({
+      'Content-Type': 'application/json',
+      'X-Request-Id': 'req-123',
+      Accept: 'application/json',
+    });
+  });
+
+  it('redacts short values (<=8 chars) completely', () => {
+    const result = redactHeaders({ Authorization: 'short' });
+    expect(result.Authorization).toBe('[REDACTED]');
+  });
+
+  it('handles empty headers object', () => {
+    expect(redactHeaders({})).toEqual({});
+  });
+
+  it('redacts all sensitive headers in a mixed set', () => {
+    const result = redactHeaders({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer my-secret-token',
+      'X-Custom': 'fine',
+      Cookie: 'sid=abcdefghijklmnop',
+      'X-Api-Key': 'sk-1234567890',
+    });
+    expect(result['Content-Type']).toBe('application/json');
+    expect(result['X-Custom']).toBe('fine');
+    expect(result.Authorization).toContain('[REDACTED]');
+    expect(result.Cookie).toContain('[REDACTED]');
+    expect(result['X-Api-Key']).toContain('[REDACTED]');
+  });
+});
+
+describe('redactSecretsFromText', () => {
+  it('removes a bearer token from error text', () => {
+    const text = 'fetch failed: ECONNREFUSED with header Bearer my-secret-token-xyz';
+    const result = redactSecretsFromText(text, { Authorization: 'Bearer my-secret-token-xyz' });
+    expect(result).not.toContain('my-secret-token-xyz');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('removes api key value from error text', () => {
+    const text = 'Request failed for key=sk-live-abcdef123456';
+    const result = redactSecretsFromText(text, { 'X-Api-Key': 'sk-live-abcdef123456' });
+    expect(result).toBe('Request failed for key=[REDACTED]');
+  });
+
+  it('returns text unchanged when headers is undefined', () => {
+    const text = 'some error message';
+    expect(redactSecretsFromText(text, undefined)).toBe(text);
+  });
+
+  it('returns text unchanged when headers has no sensitive entries', () => {
+    const text = 'error with Content-Type application/json';
+    expect(redactSecretsFromText(text, { 'Content-Type': 'application/json' })).toBe(text);
+  });
+
+  it('handles multiple occurrences of the same secret', () => {
+    const text = 'token abc123def456 appeared twice: abc123def456 and abc123def456';
+    const result = redactSecretsFromText(text, { Authorization: 'abc123def456' });
+    expect(result).toBe('token [REDACTED] appeared twice: [REDACTED] and [REDACTED]');
+  });
+
+  it('redacts multiple different secrets', () => {
+    const text = 'auth=Bearer tok123secret and key=sk-abc123key';
+    const result = redactSecretsFromText(text, {
+      Authorization: 'Bearer tok123secret',
+      'X-Api-Key': 'sk-abc123key',
+    });
+    expect(result).not.toContain('tok123secret');
+    expect(result).not.toContain('sk-abc123key');
+  });
+
+  it('skips very short values to avoid false positives', () => {
+    const text = 'error abc in log abc';
+    const result = redactSecretsFromText(text, { Authorization: 'abc' });
+    expect(result).toBe('error abc in log abc');
+  });
+});

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -12,6 +12,7 @@ import type {
 } from './types.js';
 import { webhookEndpointSchema, getErrorMessage } from '../validation.js';
 import { validateWebhookUrl } from '../ssrf.js';
+import { redactSecretsFromText } from '../utils/redact-headers.js';
 
 export interface WebhookEndpoint {
   /** URL to POST to. */
@@ -177,7 +178,7 @@ export class WebhookChannel implements Channel {
           this.addToDeadLetterQueue(ep.url, event, lastError, attempt);
         }
       } catch (e: unknown) {
-        lastError = getErrorMessage(e);
+        lastError = redactSecretsFromText(getErrorMessage(e), ep.headers);
         if (attempt < maxRetries) {
           const delay = WebhookChannel.backoff(attempt);
           console.warn(`Webhook ${ep.url} error for ${event} (attempt ${attempt}/${maxRetries}): ${lastError}, retrying in ${Math.round(delay)}ms`);

--- a/src/utils/redact-headers.ts
+++ b/src/utils/redact-headers.ts
@@ -1,0 +1,55 @@
+/**
+ * redact-headers.ts — Redact sensitive header values for safe logging.
+ *
+ * Issue #582: Prevent webhook custom headers (Authorization, Cookie, etc.)
+ * from leaking into error logs on delivery failures.
+ */
+
+/** Header names whose values should be treated as secrets. Case-insensitive. */
+const SENSITIVE_HEADER_NAMES: ReadonlySet<string> = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+  'api-key',
+  'apikey',
+  'proxy-authorization',
+  'x-csrf-token',
+  'www-authenticate',
+  'proxy-authenticate',
+]);
+
+function isSensitive(headerName: string): boolean {
+  return SENSITIVE_HEADER_NAMES.has(headerName.toLowerCase());
+}
+
+function redactValue(value: string): string {
+  if (value.length <= 8) return '[REDACTED]';
+  return `${value.slice(0, 4)}...[REDACTED]`;
+}
+
+/** Return a copy of `headers` with sensitive values replaced. */
+export function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    result[name] = isSensitive(name) ? redactValue(value) : value;
+  }
+  return result;
+}
+
+/**
+ * Scrub any sensitive header *values* from arbitrary text.
+ * If a fetch error message happens to include a header value, this removes it.
+ */
+export function redactSecretsFromText(text: string, headers: Record<string, string> | undefined): string {
+  if (!headers) return text;
+  let result = text;
+  for (const [name, value] of Object.entries(headers)) {
+    if (!isSensitive(name) || !value) continue;
+    // Skip very short values — too many false positives
+    if (value.length < 4) continue;
+    result = result.replaceAll(value, '[REDACTED]');
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
Redacts sensitive header values (Authorization, Cookie, X-API-Key, etc.) from webhook error logs to prevent secret leakage.

## Changes
- `src/utils/redact-headers.ts` (new) — `redactHeaders()` and `redactSecretsFromText()` utilities
- `src/channels/webhook.ts` — applies header redaction in error catch blocks
- `src/__tests__/webhook-header-redaction.test.ts` — 113 lines of tests covering all sensitive patterns

## Scope
Minimal: 3 files, +170 -1 lines. No unrelated changes.

Fixes #582

## Quality Gate
- [x] `tsc --noEmit` — zero errors
- [x] `npm run build` — success
- [x] `npm test` — 77 files, 1776 tests passed