### PR TITLE
docs: update PR template with Aegis version gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,15 +2,23 @@
 
 <!-- Brief description of what this PR does and why -->
 
+## Aegis version
+
+<!-- REQUIRED. Call `aegis_server_health` and paste the version here -->
+<!-- Argus will REJECT this PR if the version doesn't match the running server -->
+
+**Developed with:** v<!-- e.g. 2.3.5 -->
+**Tested with:** v<!-- e.g. 2.3.5 -->
+
 ## Change type
 
-- [ ] `feat` — New feature
 - [ ] `fix` — Bug fix
 - [ ] `refactor` — Code restructuring with no behavior change
 - [ ] `perf` — Performance improvement
 - [ ] `test` — Adding or updating tests
 - [ ] `docs` — Documentation only
 - [ ] `chore` — Build, CI, tooling
+- [ ] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)
 
 ## Scope
 


### PR DESCRIPTION
Updated PR template with:
- Mandatory Aegis version field (developed/tested)
- feat: restriction note (user-visible features only)
- Argus will verify version matches server health