### PR TITLE
fix(security): catch prior mutex rejection in generateSSEToken (#573)

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -287,4 +287,32 @@ describe('SSE Token Management (Issue #297)', () => {
       expect(successes).toHaveLength(5);
     });
   });
+
+  describe('Mutex rejection resilience (#573)', () => {
+    it('should generate token even if previous mutex holder rejected', async () => {
+      // Corrupt the mutex to simulate a rejected promise from a prior holder
+      const rejectedPromise = Promise.reject(new Error('simulated prior rejection'));
+      rejectedPromise.catch(() => {}); // Prevent unhandled rejection warning
+      (auth as any).sseMutex = rejectedPromise;
+
+      // Next caller should still succeed — prior rejection must not propagate
+      const result = await auth.generateSSEToken('master');
+      expect(result.token).toMatch(/^sse_[a-f0-9]{64}$/);
+    });
+
+    it('should maintain per-key limit after mutex rejection', async () => {
+      // Fill up to limit
+      for (let i = 0; i < 5; i++) {
+        await auth.generateSSEToken('master');
+      }
+
+      // Corrupt mutex
+      const rejectedPromise = Promise.reject(new Error('simulated'));
+      rejectedPromise.catch(() => {});
+      (auth as any).sseMutex = rejectedPromise;
+
+      // Limit should still be enforced despite the rejected mutex
+      await expect(auth.generateSSEToken('master')).rejects.toThrow(/limit reached/);
+    });
+  });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -208,8 +208,9 @@ export class AuthManager {
     this.sseMutex = lock;
 
     // #509: await + try/finally together so release() fires even if previous rejects
+    // #573: catch prior rejection so it doesn't propagate and block subsequent callers
     try {
-      await previous;
+      await previous.catch(() => {});
 
       // Cleanup expired tokens first
       this.cleanExpiredSSETokens();


### PR DESCRIPTION
## Summary
Prevents race condition where a rejected prior mutex holder blocks all subsequent SSE token generation callers. Now catches prior rejection instead of propagating it.

## Changes
- `src/auth.ts`: `await previous` → `await previous.catch(() => {})`
- `src/__tests__/auth.test.ts`: test for concurrent token generation under rejection

## Scope
Minimal: 2 files, +30 -1 lines.

Fixes #573

## Quality Gate
- [x] tsc --noEmit — zero errors
- [x] npm run build — success
- [x] npm test — 1815 tests passed