### PR TITLE
fix(security): add bounds validation on WebSocket resize messages (#581)

### DIFF
--- a/src/__tests__/ws-terminal.test.ts
+++ b/src/__tests__/ws-terminal.test.ts
@@ -419,6 +419,62 @@ describe('ws-terminal', () => {
 
       expect(tmux.resizePane).toHaveBeenCalledWith('win-1', 80, 24);
     });
+
+    // Issue #581: Resize bounds validation
+    it('should clamp cols below minimum to 10', () => {
+      sessions.set(SESS1, makeSession());
+      const ws = makeMockWebSocket();
+      const handler = getWsHandler(app);
+      handler(ws, { params: { id: SESS1 } });
+
+      ws._emit('message', Buffer.from(JSON.stringify({ type: 'resize', cols: 3, rows: 24 })));
+
+      expect(tmux.resizePane).toHaveBeenCalledWith('win-1', 10, 24);
+    });
+
+    it('should clamp cols above maximum to 500', () => {
+      sessions.set(SESS1, makeSession());
+      const ws = makeMockWebSocket();
+      const handler = getWsHandler(app);
+      handler(ws, { params: { id: SESS1 } });
+
+      ws._emit('message', Buffer.from(JSON.stringify({ type: 'resize', cols: 9999, rows: 24 })));
+
+      expect(tmux.resizePane).toHaveBeenCalledWith('win-1', 500, 24);
+    });
+
+    it('should clamp rows below minimum to 5', () => {
+      sessions.set(SESS1, makeSession());
+      const ws = makeMockWebSocket();
+      const handler = getWsHandler(app);
+      handler(ws, { params: { id: SESS1 } });
+
+      ws._emit('message', Buffer.from(JSON.stringify({ type: 'resize', cols: 80, rows: 1 })));
+
+      expect(tmux.resizePane).toHaveBeenCalledWith('win-1', 80, 5);
+    });
+
+    it('should clamp rows above maximum to 200', () => {
+      sessions.set(SESS1, makeSession());
+      const ws = makeMockWebSocket();
+      const handler = getWsHandler(app);
+      handler(ws, { params: { id: SESS1 } });
+
+      ws._emit('message', Buffer.from(JSON.stringify({ type: 'resize', cols: 80, rows: 999 })));
+
+      expect(tmux.resizePane).toHaveBeenCalledWith('win-1', 80, 200);
+    });
+
+    it('should pass through valid dimensions within bounds unchanged', () => {
+      sessions.set(SESS1, makeSession());
+      const ws = makeMockWebSocket();
+      const handler = getWsHandler(app);
+      handler(ws, { params: { id: SESS1 } });
+
+      ws._emit('message', Buffer.from(JSON.stringify({ type: 'resize', cols: 120, rows: 40 })));
+
+      expect(tmux.resizePane).toHaveBeenCalledWith('win-1', 120, 40);
+    });
   });
 
   describe('cleanup on disconnect', () => {

--- a/src/ws-terminal.ts
+++ b/src/ws-terminal.ts
@@ -270,8 +270,8 @@ export function registerWsTerminalRoute(
           if (msg.type === 'input' && typeof msg.text === 'string') {
             await sessions.sendMessage(sessionId, msg.text);
           } else if (msg.type === 'resize') {
-            const cols = clamp(msg.cols ?? 80, 1, 1000, 80);
-            const rows = clamp(msg.rows ?? 24, 1, 1000, 24);
+            const cols = clamp(msg.cols ?? 80, 10, 500, 80);
+            const rows = clamp(msg.rows ?? 24, 5, 200, 24);
             await tmux.resizePane(session.windowId, cols, rows);
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
Clamps resize cols to [10, 500] and rows to [5, 200] to prevent tmux resource issues from extreme values.

## Changes
- `src/ws-terminal.ts`: tighten clamp bounds from [1, 1000] to [10, 500] cols, [5, 200] rows
- `src/__tests__/ws-terminal.test.ts`: tests for bounds validation

Fixes #581

## Quality Gate
- [x] tsc --noEmit — zero errors
- [x] npm run build — success
- [x] npm test — 1831 tests passed