### PR TITLE
fix(perf): clear pipeline poll interval when no pipelines remain (#578)

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -1096,6 +1096,71 @@ describe('PipelineManager', () => {
       // setInterval should have been called only once (for the first pipeline)
       expect(setInterval).toHaveBeenCalledTimes(1);
     });
+
+    it('#578: clears poll interval when all pipelines are cleaned up', async () => {
+      vi.useFakeTimers();
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+      const config: PipelineConfig = {
+        name: 'auto-clear-test',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'a', dependsOn: [] }],
+      };
+
+      const idleSession = makeMockSession('s1');
+      idleSession.status = 'idle';
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+      sessions.getSession.mockReturnValue(idleSession);
+
+      await manager.createPipeline(config);
+
+      // Fire a poll tick — session is idle so stage completes, pipeline completes,
+      // and the 30s cleanup timer is scheduled
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      // Advance past the 30s cleanup delay — interval should be cleared
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(clearIntervalSpy).toHaveBeenCalled();
+    });
+
+    it('#578: restarts poll interval when pipeline is added after interval cleared', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(global, 'setInterval');
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+      const config1: PipelineConfig = {
+        name: 'first',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'a', dependsOn: [] }],
+      };
+      const config2: PipelineConfig = {
+        name: 'second',
+        workDir: '/app',
+        stages: [{ name: 'B', prompt: 'b', dependsOn: [] }],
+      };
+
+      const idleSession = makeMockSession('s1');
+      idleSession.status = 'idle';
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+      sessions.getSession.mockReturnValue(idleSession);
+
+      // Create first pipeline, let it complete and clean up
+      await manager.createPipeline(config1);
+      expect(setInterval).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(clearIntervalSpy).toHaveBeenCalled();
+
+      // Create second pipeline — interval should be restarted
+      await manager.createPipeline(config2);
+
+      expect(setInterval).toHaveBeenCalledTimes(2);
+    });
   });
 
   // =========================================================================

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -264,6 +264,11 @@ export class PipelineManager {
         setTimeout(() => {
           this.pipelines.delete(pipelineId);
           this.pipelineConfigs.delete(pipelineId); // #219: clean up stored config
+          // #578: Stop polling when no pipelines remain
+          if (this.pipelines.size === 0 && this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
+          }
         }, 30_000);
       }
     }


### PR DESCRIPTION
## Summary
Stop setInterval polling when pipeline count reaches 0 to prevent unnecessary timer overhead.

## Changes
- `src/pipeline.ts`: clear pollInterval when pipelines.size === 0
- `src/__tests__/pipeline.test.ts`: tests for interval cleanup

Fixes #578
## Quality Gate
- [x] tsc --noEmit — zero errors
- [x] npm run build — success
- [x] npm test — 1831 tests passed