### PR TITLE
fix(security): add rate limiting for batch session creation (#583)

### DIFF
--- a/src/__tests__/batch-limiter.test.ts
+++ b/src/__tests__/batch-limiter.test.ts
@@ -1,0 +1,117 @@
+/**
+ * batch-limiter.test.ts — Tests for Issue #583: batch rate limiting.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BatchRateLimiter } from '../batch-limiter.js';
+
+describe('BatchRateLimiter (Issue #583)', () => {
+  describe('per-key cooldown', () => {
+    it('allows the first batch request for a key', () => {
+      const limiter = new BatchRateLimiter({ cooldownMs: 5000 });
+      const result = limiter.check('key-1', 0, 10);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('rejects a second request within cooldown period', () => {
+      const limiter = new BatchRateLimiter({ cooldownMs: 5000 });
+      limiter.check('key-1', 0, 10);
+      limiter.record('key-1');
+
+      const result = limiter.check('key-1', 10, 5);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toBe('cooldown');
+        expect(result.detail).toContain('retry after');
+      }
+    });
+
+    it('allows requests from different keys independently', () => {
+      const limiter = new BatchRateLimiter({ cooldownMs: 5000 });
+      limiter.check('key-1', 0, 10);
+      limiter.record('key-1');
+
+      const result = limiter.check('key-2', 10, 5);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows a request after cooldown expires', () => {
+      const limiter = new BatchRateLimiter({ cooldownMs: 100 });
+      limiter.record('key-1');
+
+      // Simulate time passing
+      const originalNow = Date.now;
+      let fakeTime = originalNow();
+      Date.now = () => fakeTime;
+
+      fakeTime += 150; // Past the 100ms cooldown
+      const result = limiter.check('key-1', 0, 5);
+      expect(result.allowed).toBe(true);
+
+      Date.now = originalNow;
+    });
+  });
+
+  describe('global concurrent session cap', () => {
+    it('rejects batch that would exceed session cap', () => {
+      const limiter = new BatchRateLimiter({ maxConcurrentSessions: 200 });
+      const result = limiter.check('key-1', 195, 10);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toBe('session_cap');
+        expect(result.detail).toContain('195');
+        expect(result.detail).toContain('10');
+        expect(result.detail).toContain('200');
+      }
+    });
+
+    it('allows batch that fits within session cap', () => {
+      const limiter = new BatchRateLimiter({ maxConcurrentSessions: 200 });
+      const result = limiter.check('key-1', 195, 5);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows batch that exactly fills session cap', () => {
+      const limiter = new BatchRateLimiter({ maxConcurrentSessions: 200 });
+      const result = limiter.check('key-1', 190, 10);
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('cooldown vs session cap priority', () => {
+    it('checks cooldown before session cap', () => {
+      const limiter = new BatchRateLimiter({ cooldownMs: 5000, maxConcurrentSessions: 10 });
+      limiter.record('key-1');
+
+      // Cooldown should trigger first, even if session cap would also fail
+      const result = limiter.check('key-1', 0, 100);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toBe('cooldown');
+      }
+    });
+  });
+
+  describe('reset', () => {
+    it('clears cooldown for a specific key', () => {
+      const limiter = new BatchRateLimiter({ cooldownMs: 5000 });
+      limiter.record('key-1');
+
+      limiter.reset('key-1');
+      const result = limiter.check('key-1', 0, 5);
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('defaults', () => {
+    it('uses default cooldown of 5000ms', () => {
+      const limiter = new BatchRateLimiter();
+      expect(limiter.cooldown).toBe(5000);
+    });
+
+    it('uses default session cap of 200', () => {
+      const limiter = new BatchRateLimiter();
+      expect(limiter.sessionCap).toBe(200);
+    });
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -45,6 +45,9 @@ const SSE_TOKEN_TTL_MS = 60_000;
 /** Max SSE tokens per bearer token to prevent abuse. */
 const SSE_TOKEN_MAX_PER_KEY = 5;
 
+/** #583: Minimum interval between batch creation requests per key (5 seconds). */
+const BATCH_COOLDOWN_MS = 5_000;
+
 export class AuthManager {
   private store: ApiKeyStore = { keys: [] };
   private rateLimits = new Map<string, RateLimitBucket>();
@@ -55,6 +58,8 @@ export class AuthManager {
   private sseTokenCounts = new Map<string, number>();
   /** #414: Mutex to prevent concurrent SSE token generation from exceeding per-key limits. */
   private sseMutex: Promise<void> = Promise.resolve();
+  /** #583: Last batch creation timestamp per key ID. */
+  private batchRateLimits = new Map<string, number>();
 
   constructor(
     private keysFile: string,
@@ -176,6 +181,18 @@ export class AuthManager {
     return createHash('sha256').update(key).digest('hex');
   }
 
+  /** #583: Check and update batch rate limit for a key. Returns true if rate-limited. */
+  checkBatchRateLimit(keyId: string | null): boolean {
+    const id = keyId ?? 'anonymous';
+    const now = Date.now();
+    const lastBatch = this.batchRateLimits.get(id);
+    if (lastBatch !== undefined && now - lastBatch < BATCH_COOLDOWN_MS) {
+      return true;
+    }
+    this.batchRateLimits.set(id, now);
+    return false;
+  }
+
   /** #398: Sweep stale rate limit buckets. Prune entries with expired windows. */
   sweepStaleRateLimits(): void {
     const now = Date.now();
@@ -183,6 +200,12 @@ export class AuthManager {
     for (const [keyId, bucket] of this.rateLimits) {
       if (now - bucket.windowStart > windowMs) {
         this.rateLimits.delete(keyId);
+      }
+    }
+    // #583: Prune expired batch rate limit entries
+    for (const [keyId, ts] of this.batchRateLimits) {
+      if (now - ts > BATCH_COOLDOWN_MS) {
+        this.batchRateLimits.delete(keyId);
       }
     }
   }

--- a/src/batch-limiter.ts
+++ b/src/batch-limiter.ts
@@ -1,0 +1,90 @@
+/**
+ * batch-limiter.ts — Rate limiter for batch session creation (Issue #583).
+ *
+ * Enforces:
+ * - Per-key cooldown: 1 batch request per configurable interval per API key
+ * - Global concurrent session cap: reject batch if total active sessions would exceed limit
+ */
+
+export interface BatchLimiterConfig {
+  /** Minimum milliseconds between batch requests per API key. Default: 5000 */
+  cooldownMs?: number;
+  /** Maximum total concurrent sessions across all keys. Default: 200 */
+  maxConcurrentSessions?: number;
+}
+
+export interface BatchCheckAllowed {
+  allowed: true;
+}
+
+export interface BatchCheckDenied {
+  allowed: false;
+  reason: 'cooldown' | 'session_cap';
+  /** Human-readable detail */
+  detail: string;
+}
+
+export type BatchCheckResult = BatchCheckAllowed | BatchCheckDenied;
+
+export class BatchRateLimiter {
+  private readonly cooldownMs: number;
+  private readonly maxConcurrentSessions: number;
+  /** Per-key last batch timestamp. */
+  private lastBatch = new Map<string, number>();
+
+  constructor(config?: BatchLimiterConfig) {
+    this.cooldownMs = config?.cooldownMs ?? 5000;
+    this.maxConcurrentSessions = config?.maxConcurrentSessions ?? 200;
+  }
+
+  /**
+   * Check whether a batch creation request is allowed.
+   * @param keyId - Authenticated API key ID (or 'master' / 'anonymous')
+   * @param currentSessionCount - Number of currently active sessions
+   * @param requestedCount - Number of sessions this batch would create
+   */
+  check(keyId: string, currentSessionCount: number, requestedCount: number): BatchCheckResult {
+    // Per-key cooldown
+    const now = Date.now();
+    const lastTime = this.lastBatch.get(keyId);
+    if (lastTime !== undefined && now - lastTime < this.cooldownMs) {
+      const retryAfter = Math.ceil((this.cooldownMs - (now - lastTime)) / 1000);
+      return {
+        allowed: false,
+        reason: 'cooldown',
+        detail: `Batch cooldown active — retry after ${retryAfter}s`,
+      };
+    }
+
+    // Global concurrent session cap
+    if (currentSessionCount + requestedCount > this.maxConcurrentSessions) {
+      return {
+        allowed: false,
+        reason: 'session_cap',
+        detail: `Session cap exceeded — ${currentSessionCount} active, ${requestedCount} requested, limit ${this.maxConcurrentSessions}`,
+      };
+    }
+
+    return { allowed: true };
+  }
+
+  /** Record that a batch was accepted for the given key. */
+  record(keyId: string): void {
+    this.lastBatch.set(keyId, Date.now());
+  }
+
+  /** Remove a key's cooldown entry. */
+  reset(keyId: string): void {
+    this.lastBatch.delete(keyId);
+  }
+
+  /** Current configured cooldown in ms. */
+  get cooldown(): number {
+    return this.cooldownMs;
+  }
+
+  /** Current configured max concurrent sessions. */
+  get sessionCap(): number {
+    return this.maxConcurrentSessions;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ import { PipelineManager, type BatchSessionSpec, type PipelineConfig } from './p
 import { AuthManager } from './auth.js';
 import { MetricsCollector } from './metrics.js';
 import { registerHookRoutes } from './hooks.js';
+import { BatchRateLimiter } from './batch-limiter.js';
 import { registerWsTerminalRoute } from './ws-terminal.js';
 import { SwarmMonitor } from './swarm-monitor.js';
 import { killAllSessions } from './signal-cleanup-helper.js';
@@ -70,6 +71,7 @@ let jsonlWatcher: JsonlWatcher;
 const channels = new ChannelManager();
 const eventBus = new SessionEventBus();
 let sseLimiter: SSEConnectionLimiter;let pipelines: PipelineManager;
+let batchLimiter: BatchRateLimiter;
 let auth: AuthManager;
 let metrics: MetricsCollector;
 let swarmMonitor: SwarmMonitor;
@@ -169,6 +171,9 @@ function pruneIpRateLimits(): void {
   }
 }
 
+/** #583: Track keyId per request for batch rate limiting. */
+const requestKeyMap = new Map<string, string>();
+
 function setupAuth(authManager: AuthManager): void {
   app.addHook('onRequest', async (req, reply) => {
     // Skip auth for health endpoint and dashboard (Issue #349: exact path matching)
@@ -233,6 +238,9 @@ function setupAuth(authManager: AuthManager): void {
     if (result.rateLimited) {
       return reply.status(429).send({ error: 'Rate limit exceeded — 100 req/min per key' });
     }
+
+    // #583: Store keyId for batch rate limiting
+    requestKeyMap.set(req.id, result.keyId ?? 'anonymous');
 
     // #228: Per-IP rate limiting (applies to all authenticated requests)
     const clientIp = req.ip ?? req.headers['x-forwarded-for'] as string ?? 'unknown';
@@ -1196,11 +1204,25 @@ app.post<{
   return reply.status(200).send({});
 });
 
-// Batch create (Issue #36)
+// Batch create (Issue #36, #583: per-key batch rate limit + global session cap)
+const MAX_CONCURRENT_SESSIONS = 200;
 app.post('/v1/sessions/batch', async (req, reply) => {
   const parsed = batchSessionSchema.safeParse(req.body);
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
   const specs = parsed.data.sessions;
+
+  // #583: Per-key batch rate limit (max 1 batch per 5 seconds)
+  const keyId = requestKeyMap.get(req.id) ?? 'anonymous';
+  if (auth.checkBatchRateLimit(keyId)) {
+    return reply.status(429).send({ error: 'Batch rate limit exceeded — 1 batch per 5 seconds per key' });
+  }
+
+  // #583: Global concurrent session cap
+  const currentCount = sessions.listSessions().length;
+  if (currentCount + specs.length > MAX_CONCURRENT_SESSIONS) {
+    return reply.status(429).send({ error: `Session cap exceeded — ${currentCount} active, max ${MAX_CONCURRENT_SESSIONS}` });
+  }
+
   for (const spec of specs) {
     const safeWorkDir = await validateWorkDirWithConfig(spec.workDir);
     if (typeof safeWorkDir === 'object') {
@@ -1208,6 +1230,7 @@ app.post('/v1/sessions/batch', async (req, reply) => {
     }
     spec.workDir = safeWorkDir;
   }
+  batchLimiter.record(keyId);
   const result = await pipelines.batchCreate(specs);
   return reply.status(201).send(result);
 });
@@ -1635,6 +1658,9 @@ async function main(): Promise<void> {
 
   // Initialize pipeline manager (Issue #36)
   pipelines = new PipelineManager(sessions, eventBus);
+
+  // Initialize batch rate limiter (Issue #583)
+  batchLimiter = new BatchRateLimiter();
 
   // Initialize metrics (Issue #40)
   metrics = new MetricsCollector(join(config.stateDir, 'metrics.json'));


### PR DESCRIPTION
## Summary
Per-key cooldown (1 batch/5s) and global concurrent session cap (200) for batch creation endpoint.

## Changes
- `src/batch-limiter.ts` (new): BatchRateLimiter class
- `src/auth.ts`: checkBatchRateLimit method
- `src/server.ts`: integrate limiter in batch endpoint
- `src/__tests__/batch-limiter.test.ts` (new): tests

Fixes #583
## Quality Gate
- [x] tsc --noEmit — zero errors
- [x] npm run build — success
- [x] npm test — 1861 passed (4 pre-existing failures in .claude-internals/)