### PR TITLE
fix: aggregate and log webhook delivery failures

### DIFF
--- a/src/__tests__/webhook-retry.test.ts
+++ b/src/__tests__/webhook-retry.test.ts
@@ -189,16 +189,19 @@ describe('Webhook delivery with retry', () => {
 
   describe('Issue #588: Promise.allSettled error aggregation', () => {
     let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
       consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     });
 
     afterEach(() => {
       consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
-    it('should log aggregated errors when all endpoints fail', async () => {
+    it('should log at error level when all endpoints fail', async () => {
       vi.useFakeTimers();
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
 
@@ -217,7 +220,7 @@ describe('Webhook delivery with retry', () => {
       await deliveryPromise;
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Webhook: 3/3 endpoint(s) failed'),
+        expect.stringContaining('Webhook: 3/3 endpoint(s) failed (total)'),
       );
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('ECONNREFUSED'),
@@ -226,7 +229,7 @@ describe('Webhook delivery with retry', () => {
       vi.useRealTimers();
     });
 
-    it('should log partial failures with correct count', async () => {
+    it('should log at warn level for partial failures', async () => {
       vi.useFakeTimers();
       mockFetch
         .mockResolvedValueOnce({ ok: true, status: 200 })
@@ -245,7 +248,7 @@ describe('Webhook delivery with retry', () => {
       }
       await deliveryPromise;
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Webhook: 1/2 endpoint(s) failed'),
       );
 
@@ -266,7 +269,10 @@ describe('Webhook delivery with retry', () => {
 
       await channel.onSessionCreated!(makePayload());
 
-      const aggregationCalls = consoleErrorSpy.mock.calls.filter(
+      const aggregationCalls = [
+        ...consoleErrorSpy.mock.calls,
+        ...consoleWarnSpy.mock.calls,
+      ].filter(
         (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('endpoint(s) failed'),
       );
       expect(aggregationCalls).toHaveLength(0);

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -137,7 +137,12 @@ export class WebhookChannel implements Channel {
     const failed = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
     if (failed.length > 0) {
       const reasons = failed.map(r => String(r.reason)).join('; ');
-      console.error(`Webhook: ${failed.length}/${promises.length} endpoint(s) failed: ${reasons}`);
+      const allFailed = failed.length === results.length;
+      if (allFailed) {
+        console.error(`Webhook: ${failed.length}/${results.length} endpoint(s) failed (total): ${reasons}`);
+      } else {
+        console.warn(`Webhook: ${failed.length}/${results.length} endpoint(s) failed: ${reasons}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #588

- Differentiate total vs partial webhook delivery failures in `fire()` method
- All endpoints fail → `console.error` with `(total)` marker for high visibility
- Some endpoints fail → `console.warn` for operational awareness
- Updated existing tests to verify correct log levels

## Changes

- `src/channels/webhook.ts`: `fire()` now checks if all endpoints failed and selects appropriate log level
- `src/__tests__/webhook-retry.test.ts`: Added `console.warn` spy; updated test expectations for new behavior

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — success
- [x] `npx vitest run src/__tests__/webhook-retry.test.ts` — 14/14 pass
- [x] `npm test` — no new regressions (1 pre-existing flaky SSE test failure)

Generated by Hephaestus (Aegis dev agent)