### PR TITLE
fix: add overflow guard to event ID counter

### DIFF
--- a/src/__tests__/events.test.ts
+++ b/src/__tests__/events.test.ts
@@ -1006,4 +1006,57 @@ describe('SessionEventBus', () => {
       expect(buffered[0].data.status).toBe('working');
     });
   });
+
+  // ── Issue #589: Event ID overflow guard ──────────────────────────────
+
+  describe('event ID overflow guard (#589)', () => {
+    it('resets counter to 1 when approaching MAX_SAFE_INTEGER', async () => {
+      // Force the counter to the edge
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (bus as any).nextEventId = Number.MAX_SAFE_INTEGER - 1;
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const collected: number[] = [];
+      bus.subscribe('sess-1', e => collected.push(e.id!));
+
+      // First allocation: MAX_SAFE_INTEGER - 1 → no reset yet
+      bus.emitStatus('sess-1', 'working', 'edge');
+
+      // Second allocation: counter is now MAX_SAFE_INTEGER → triggers reset, returns 1
+      bus.emitStatus('sess-1', 'idle', 'reset');
+
+      // Third allocation continues from 2
+      bus.emitStatus('sess-1', 'working', 'after-reset');
+
+      await flushAsync();
+
+      expect(collected).toEqual([
+        Number.MAX_SAFE_INTEGER - 1,
+        1,
+        2,
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[SessionEventBus] Event ID counter approaching MAX_SAFE_INTEGER, resetting to 1',
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('emitCreated also triggers overflow reset', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (bus as any).nextEventId = Number.MAX_SAFE_INTEGER;
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      bus.subscribeGlobal(() => {});
+
+      bus.emitCreated('sess-new', 'test', '/tmp');
+
+      expect(warnSpy).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((bus as any).nextEventId).toBe(2);
+
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/src/events.ts
+++ b/src/events.ts
@@ -65,6 +65,15 @@ export class SessionEventBus {
   /** Global incrementing event ID counter. */
   private nextEventId = 1;
 
+  /** #589: Allocate next event ID with overflow guard. */
+  private allocateEventId(): number {
+    if (this.nextEventId >= Number.MAX_SAFE_INTEGER) {
+      console.warn('[SessionEventBus] Event ID counter approaching MAX_SAFE_INTEGER, resetting to 1');
+      this.nextEventId = 1;
+    }
+    return this.nextEventId++;
+  }
+
   /** Maximum events to buffer per session for Last-Event-ID replay. */
   private static readonly BUFFER_SIZE = 50;
 
@@ -108,7 +117,7 @@ export class SessionEventBus {
     // Issue #87: Stamp emittedAt for latency measurement
     event.emittedAt = Date.now();
     // Issue #308: Assign incrementing ID for Last-Event-ID replay
-    event.id = this.nextEventId++;
+    event.id = this.allocateEventId();
     // Push to ring buffer
     let buffer = this.eventBuffers.get(sessionId);
     if (!buffer) {
@@ -268,7 +277,7 @@ export class SessionEventBus {
   /** Emit a session created event to global subscribers. */
   emitCreated(sessionId: string, name: string, workDir: string): void {
     if (!this.globalEmitter) return;
-    const id = this.nextEventId++;
+    const id = this.allocateEventId();
     const globalEvent: GlobalSSEEvent = {
       event: 'session_created',
       sessionId,


### PR DESCRIPTION
Fixes #589

## Summary
- Add `allocateEventId()` private method to `SessionEventBus` that checks for `Number.MAX_SAFE_INTEGER` overflow before incrementing
- Resets counter to 1 (not 0, to avoid falsy confusion) and logs a warning when overflow is imminent
- Applied to both `emit()` and `emitCreated()` ID allocation paths
- Added 2 tests verifying reset behavior for both code paths

## Quality Gate
- `npx tsc --noEmit` — zero errors
- `npm run build` — OK
- `npm test` — 79 files, 1831 passed

## Test plan
- [x] Verify event IDs reset to 1 when counter reaches `MAX_SAFE_INTEGER`
- [x] Verify warning is logged on reset
- [x] Verify `emitCreated` also triggers overflow reset
- [x] All existing tests continue to pass

Generated by Hephaestus (Aegis dev agent)