### PR TITLE
fix(perf): align stall detection with CLAUDE_STREAM_IDLE_TIMEOUT_MS (#392)

### DIFF
--- a/src/__tests__/stall-detection.test.ts
+++ b/src/__tests__/stall-detection.test.ts
@@ -245,7 +245,10 @@ describe('SessionMonitor stall detection (integration)', () => {
 
   beforeEach(() => {
     deps = makeMockDeps();
-    monitor = makeMonitor(deps.mockSessions, deps.mockChannels as unknown as ChannelManager);
+    // Issue #392: Use 5min stall threshold for integration tests calibrated to that value
+    monitor = makeMonitor(deps.mockSessions, deps.mockChannels as unknown as ChannelManager, {
+      stallThresholdMs: 5 * 60 * 1000,
+    });
   });
 
   // Helper: set internal lastStatus for a session

--- a/src/__tests__/stall-threshold-392.test.ts
+++ b/src/__tests__/stall-threshold-392.test.ts
@@ -1,0 +1,57 @@
+/**
+ * stall-threshold-392.test.ts — Tests for Issue #392:
+ * Reduce default stall threshold from 5min to 2min, add env var override.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('Issue #392: stall threshold defaults and env var override', () => {
+  const originalEnv = process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS;
+
+  beforeEach(() => {
+    delete process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = originalEnv;
+    } else {
+      delete process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS;
+    }
+    vi.resetModules();
+  });
+
+  describe('default threshold', () => {
+    it('SessionManager.DEFAULT_STALL_THRESHOLD_MS should be 120000 (2 minutes)', async () => {
+      const { SessionManager } = await import('../session.js');
+      expect(SessionManager.DEFAULT_STALL_THRESHOLD_MS).toBe(120_000);
+    });
+
+    it('DEFAULT_MONITOR_CONFIG.stallThresholdMs should be 120000 (2 minutes)', async () => {
+      const { DEFAULT_MONITOR_CONFIG } = await import('../monitor.js');
+      expect(DEFAULT_MONITOR_CONFIG.stallThresholdMs).toBe(120_000);
+    });
+  });
+
+  describe('CLAUDE_STREAM_IDLE_TIMEOUT_MS env var override', () => {
+    it('should use env var * 1.5 when result >= 120000', async () => {
+      process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '100000';
+      // 100000 * 1.5 = 150000, which is >= 120000
+      const { SessionManager } = await import('../session.js');
+      expect(SessionManager.DEFAULT_STALL_THRESHOLD_MS).toBe(150_000);
+    });
+
+    it('should clamp to 120000 when env var * 1.5 < 120000', async () => {
+      process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '50000';
+      // 50000 * 1.5 = 75000, but Math.max(120000, 75000) = 120000
+      const { SessionManager } = await import('../session.js');
+      expect(SessionManager.DEFAULT_STALL_THRESHOLD_MS).toBe(120_000);
+    });
+
+    it('should handle env var equal to 80000 (80000 * 1.5 = 120000)', async () => {
+      process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '80000';
+      const { SessionManager } = await import('../session.js');
+      expect(SessionManager.DEFAULT_STALL_THRESHOLD_MS).toBe(120_000);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,17 @@ export interface Config {
   allowedWorkDirs: string[];
 }
 
+/** Compute stall threshold from env var or default (Issue #392).
+ *  If CLAUDE_STREAM_IDLE_TIMEOUT_MS is set, uses Math.max(120000, parseInt(val) * 1.5).
+ *  Otherwise defaults to 2 minutes (120000ms). */
+export function computeStallThreshold(): number {
+  const env = process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS;
+  if (env) {
+    return Math.max(120_000, Math.round(parseInt(env, 10) * 1.5));
+  }
+  return 2 * 60 * 1000;
+}
+
 /** Default configuration values */
 const defaults: Config = {
   port: 9100,
@@ -78,7 +89,7 @@ const defaults: Config = {
   webhooks: [],
   defaultSessionEnv: {},
   defaultPermissionMode: 'bypassPermissions',
-  stallThresholdMs: 5 * 60 * 1000,
+  stallThresholdMs: computeStallThreshold(),
   sseMaxConnections: 100,
   sseMaxPerIp: 10,
   allowedWorkDirs: [],

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { type SessionManager, type SessionInfo } from './session.js';
 import { type TmuxManager } from './tmux.js';
+import { computeStallThreshold } from './config.js';
 import { type ParsedEntry } from './transcript.js';
 import { type UIState } from './terminal-parser.js';
 import { type ChannelManager, type SessionEventPayload, type SessionEvent } from './channels/index.js';
@@ -39,7 +40,7 @@ export const DEFAULT_MONITOR_CONFIG: MonitorConfig = {
   pollIntervalMs: 30_000,               // 30s base — hooks are the primary signal (Issue #169 Phase 3)
   fastPollIntervalMs: 5_000,            // 5s when hooks are quiet — fallback safety net
   hookQuietMs: 60_000,                  // 60s without a hook → switch to fast polling
-  stallThresholdMs: 5 * 60 * 1000,        // 5 minutes (Issue #4: reduced from 60 min)
+  stallThresholdMs: 2 * 60 * 1000,          // 2 minutes (Issue #392: reduced from 5 min)
   stallCheckIntervalMs: 30 * 1000,        // check every 30 seconds (faster for shorter thresholds)
   deadCheckIntervalMs: 10 * 1000,         // check every 10 seconds (Issue M19: faster dead detection)
   permissionStallMs: 5 * 60 * 1000,       // 5 min waiting for permission = stalled

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,6 +13,7 @@ import { TmuxManager, type TmuxWindow } from './tmux.js';
 import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.js';
 import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState } from './terminal-parser.js';
 import type { Config } from './config.js';
+import { computeStallThreshold } from './config.js';
 import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
 import { persistedStateSchema, sessionMapSchema } from './validation.js';
 import { writeHookSettingsFile, cleanupHookSettingsFile } from './hook-settings.js';
@@ -366,8 +367,8 @@ export class SessionManager {
     await rename(tmpFile, this.stateFile);
   }
 
-  /** Default stall threshold: 5 minutes (Issue #4: reduced from 60 min). */
-  static readonly DEFAULT_STALL_THRESHOLD_MS = 5 * 60 * 1000;
+  /** Default stall threshold: 2 min (Issue #392: 1.5x CC's 90s default, configurable via CLAUDE_STREAM_IDLE_TIMEOUT_MS). */
+  static readonly DEFAULT_STALL_THRESHOLD_MS = computeStallThreshold();
   static readonly DEFAULT_PERMISSION_STALL_MS = 5 * 60 * 1000;
 
   /** Create a new CC session. */


### PR DESCRIPTION
## Summary
Default stall threshold from 5min → 2min (1.5x CC 90s default). Reads CLAUDE_STREAM_IDLE_TIMEOUT_MS env var for dynamic override.

Fixes #392
## Quality Gate
- [x] tsc --noEmit — zero errors
- [x] npm run build — success
- [x] npm test — 1856 passed