### PR TITLE
fix(ci): add explicit ClawHub login before skill publish (#724)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
-      - run: npm install -g clawhub
+      - name: ClawHub Login
+        continue-on-error: true
+        run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
       - run: |
           VERSION=$(node -p "require('./package.json').version")
-          clawhub publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          npx clawhub@latest skill publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"


### PR DESCRIPTION
## Summary
ClawHub CLI does not read CLAWHUB_TOKEN from env vars. Add explicit `clawhub login --token` step before publish. Uses `skill publish` instead of legacy `publish` command.

`continue-on-error: true` on login step so CI fails gracefully when CLAWHUB_TOKEN secret does not exist yet.

**Tested with:** 2.3.5

Fixes #724
## Quality Gate
- [x] Only workflow file changed
- [x] Uses correct CLI commands