### PR TITLE
fix(types): remove double-cast escape hatches in production code

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -54,7 +54,7 @@ export class TmuxManager {
   }
 
   /** Promise-chain queue that serializes all tmux CLI calls to prevent race conditions. */
-  private queue: Promise<void> = Promise.resolve(undefined as unknown as void);
+  private queue: Promise<void> = Promise.resolve();
 
   /** #403: Counter of in-flight createWindow calls — direct methods must queue when > 0. */
   private _creatingCount = 0;

--- a/src/ws-terminal.ts
+++ b/src/ws-terminal.ts
@@ -84,7 +84,7 @@ interface WsSubscriber {
 }
 
 interface SessionPoll {
-  timer: ReturnType<typeof setInterval>;
+  timer: ReturnType<typeof setInterval> | null;
   tickCount: number;
   subscribers: Map<WebSocket, WsSubscriber>;
 }
@@ -96,7 +96,7 @@ const sessionPolls = new Map<string, SessionPoll>();
 /** Reset all internal state (for testing). */
 export function _resetForTesting(): void {
   for (const poll of sessionPolls.values()) {
-    clearInterval(poll.timer);
+    if (poll.timer) clearInterval(poll.timer);
   }
   sessionPolls.clear();
 }
@@ -189,7 +189,7 @@ export function registerWsTerminalRoute(
       let poll = sessionPolls.get(sessionId);
       if (!poll) {
         poll = {
-          timer: null as unknown as ReturnType<typeof setInterval>,
+          timer: null,
           tickCount: 0,
           subscribers: new Map(),
         };
@@ -394,7 +394,7 @@ function evictSubscriber(
 
     // If no more subscribers, clean up the poll timer
     if (poll.subscribers.size === 0) {
-      clearInterval(poll.timer);
+      if (poll.timer) clearInterval(poll.timer);
       sessionPolls.delete(sessionId);
     }
   }


### PR DESCRIPTION
## Summary
Remove `as unknown as T` double-cast escape hatches that bypass TypeScript's type system.

## Changes
- `src/tmux.ts`: Replace `Promise.resolve(undefined as unknown as void)` with `Promise.resolve()`
- `src/ws-terminal.ts`: Change `timer: ReturnType<typeof setInterval>` to `timer: ReturnType<typeof setInterval> | null`

## Testing
- 1844 tests pass, 81 test files green
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #585