### PR TITLE
fix(type-safety): replace non-null assertion on getDeadLetterQueue

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -371,8 +371,8 @@ app.get<{ Params: { id: string } }>('/v1/sessions/:id/metrics', async (req, repl
 // Issue #89 L14: Webhook dead letter queue
 app.get('/v1/webhooks/dead-letter', async () => {
   for (const ch of channels.getChannels()) {
-    if (ch.name === 'webhook' && 'getDeadLetterQueue' in ch) {
-      return ch.getDeadLetterQueue!();
+    if (ch.name === 'webhook' && typeof ch.getDeadLetterQueue === 'function') {
+      return ch.getDeadLetterQueue();
     }
   }
   return [];


### PR DESCRIPTION
## Summary
Replace non-null assertion (`!`) on optional `getDeadLetterQueue` method with a proper `typeof` type guard.

## Changes
- `src/server.ts`: Replace `ch.getDeadLetterQueue!()` with a `typeof` guard check

## Testing
- 1844 tests pass, 81 test files green
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #584