### PR TITLE
ci: add bundle size check to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,24 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check bundle size
+        run: |
+          THRESHOLD_KB=2048
+          SERVER_SIZE=$(find dist/ -name "*.js" ! -path "*/__tests__/*" -exec du -ck {} + | tail -1 | awk '{print $1}')
+          SERVER_SIZE_KB=$((SERVER_SIZE))
+          echo "## Bundle Size Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Scope | Size (KB) | Threshold (KB) | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-----------|----------------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$SERVER_SIZE_KB" -gt "$THRESHOLD_KB" ]; then
+            echo "| Server (excl. tests) | ${SERVER_SIZE_KB} | ${THRESHOLD_KB} | ❌ Exceeds threshold |" >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Server bundle size ${SERVER_SIZE_KB}KB exceeds ${THRESHOLD_KB}KB threshold"
+            exit 1
+          else
+            echo "| Server (excl. tests) | ${SERVER_SIZE_KB} | ${THRESHOLD_KB} | ✅ Within budget |" >> "$GITHUB_STEP_SUMMARY"
+            echo "Server bundle size: ${SERVER_SIZE_KB}KB (threshold: ${THRESHOLD_KB}KB)"
+          fi
+
       - name: Build dashboard
         run: cd dashboard && npm ci && npm run build
 


### PR DESCRIPTION
## Summary
Add a bundle size check step to the CI pipeline that reports server bundle size as a CI summary and fails if it exceeds a threshold.

## Changes
- `.github/workflows/ci.yml`: Add bundle size check step after build

## Testing
- 1844 tests pass, 81 test files green
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #591