### PR TITLE
fix: replace `as any` cast in applyEnvOverrides with type-safe string-key cases

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -200,11 +200,19 @@ function applyEnvOverrides(config: Config): Config {
       case 'tgAllowedUsers':
         config[key] = value.split(',').map(s => Number(s.trim())).filter(n => !isNaN(n) && n > 0);
         break;
+      // All remaining env-mapped keys are string-typed — assign directly.
+      case 'host':
+      case 'authToken':
+      case 'tmuxSession':
+      case 'stateDir':
+      case 'claudeProjectsDir':
+      case 'tgBotToken':
+      case 'tgGroupId':
+        config[key] = value;
+        break;
       default:
         // Skip complex types (Record<string,string>) that can't be set from a single env var
-        if (typeof config[key] === 'object' && config[key] !== null && !Array.isArray(config[key])) break;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (config as any)[key] = value;
+        break;
     }
   }
 


### PR DESCRIPTION
## Summary
Replace `as any` cast in `applyEnvOverrides` with explicit per-key type-safe env variable handling.

## Changes
- `src/config.ts`: Replace `as any` with typed key mapping (11 insertions, 3 deletions)

## Testing
- 1844 tests pass, 81 test files green
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #666