### PR TITLE
fix: replace unsafe (e as Error).message with instanceof guard

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -275,7 +275,7 @@ export class SessionMonitor {
                 this.makePayload('status.permission_timeout', session, detail),
               );
             } catch (e: unknown) {
-              console.error(`Monitor: auto-reject failed for session ${session.id}: ${(e as Error).message}`);
+              console.error(`Monitor: auto-reject failed for session ${session.id}: ${e instanceof Error ? e.message : String(e)}`);
             }
           }
         }


### PR DESCRIPTION
## Summary
Replace unsafe `(e as Error).message` cast in monitor.ts catch block with proper `instanceof` guard.

## Changes
- `src/monitor.ts`: Use `e instanceof Error ? e.message : String(e)`

## Testing
- 1844 tests pass, TSC zero errors, build successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #667