### PR TITLE
fix(ci): remove master branch from CodeQL trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   schedule:
     - cron: "17 3 * * 1"
 


### PR DESCRIPTION
## Summary
Remove dead `master` branch trigger from CodeQL workflow — the project only uses `main`.

## Changes
- `.github/workflows/codeql.yml`: Remove `master` from push branches

## Testing
- CI-only change, no code impact
- Existing tests: 1865 pass

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #686