### PR TITLE
fix: disable source maps in tsconfig to match published files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "nodenext",
     "target": "es2022",
     "types": ["node"],
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
Disable `sourceMap` generation in `tsconfig.json` since `.map` files are excluded from the published package and never shipped.

## Changes
- `tsconfig.json`: Set `"sourceMap": false`

## Testing
- 1865 tests pass, 83 test files green
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #685