### PR TITLE
fix(security): set key store file permissions to 0o600

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -89,7 +89,7 @@ export class AuthManager {
     if (!existsSync(dir)) {
       await mkdir(dir, { recursive: true });
     }
-    await writeFile(this.keysFile, JSON.stringify(this.store, null, 2));
+    await writeFile(this.keysFile, JSON.stringify(this.store, null, 2), { mode: 0o600 });
   }
 
   /** Create a new API key. Returns the plaintext key (only shown once). */


### PR DESCRIPTION
## Summary
Write the auth key store file with restrictive `0o600` permissions (owner read/write only) instead of default `0o644`.

## Changes
- `src/auth.ts`: Add `{ mode: 0o600 }` to `writeFile` call in `save()`

## Testing
- 1865 tests pass, 83 test files green
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #682