### PR TITLE
fix(security): write auth key store with restrictive 0o600 permissions

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -89,7 +89,7 @@ export class AuthManager {
     if (!existsSync(dir)) {
       await mkdir(dir, { recursive: true });
     }
-    await writeFile(this.keysFile, JSON.stringify(this.store, null, 2));
+    await writeFile(this.keysFile, JSON.stringify(this.store, null, 2), { mode: 0o600 });
   }
 
   /** Create a new API key. Returns the plaintext key (only shown once). */


### PR DESCRIPTION
## Summary
- Changed `writeFile` in `AuthManager.save()` to use `{ mode: 0o600 }` so the key store file is created with owner read/write only, preventing other users from reading API key hashes.

Fixes #682

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (82/82 test files, 1855 tests)

Generated by Hephaestus (Aegis dev agent)