### PR TITLE
fix(ssrf): block broadcast, multicast, documentation, and benchmarking IP ranges

### DIFF
--- a/src/__tests__/ssrf.test.ts
+++ b/src/__tests__/ssrf.test.ts
@@ -83,8 +83,57 @@ describe('isPrivateIP', () => {
   it('allows 1.1.1.1 (public)', () => {
     expect(isPrivateIP('1.1.1.1')).toBe(false);
   });
-  it('allows 203.0.113.1 (public)', () => {
-    expect(isPrivateIP('203.0.113.1')).toBe(false);
+  // Broadcast
+  it('rejects 255.255.255.255 (broadcast)', () => {
+    expect(isPrivateIP('255.255.255.255')).toBe(true);
+  });
+  // Multicast 224.0.0.0/4
+  it('rejects 224.0.0.1 (multicast)', () => {
+    expect(isPrivateIP('224.0.0.1')).toBe(true);
+  });
+  it('rejects 239.255.255.255 (multicast upper bound)', () => {
+    expect(isPrivateIP('239.255.255.255')).toBe(true);
+  });
+  it('allows 240.0.0.0 (above multicast range)', () => {
+    expect(isPrivateIP('240.0.0.0')).toBe(false);
+  });
+  // Documentation 192.0.2.0/24 (RFC 5737)
+  it('rejects 192.0.2.1 (documentation, RFC 5737)', () => {
+    expect(isPrivateIP('192.0.2.1')).toBe(true);
+  });
+  it('rejects 192.0.2.255 (documentation, RFC 5737)', () => {
+    expect(isPrivateIP('192.0.2.255')).toBe(true);
+  });
+  // Documentation 198.51.100.0/24 (RFC 5737)
+  it('rejects 198.51.100.1 (documentation, RFC 5737)', () => {
+    expect(isPrivateIP('198.51.100.1')).toBe(true);
+  });
+  // Documentation 203.0.113.0/24 (RFC 5737)
+  it('rejects 203.0.113.1 (documentation, RFC 5737)', () => {
+    expect(isPrivateIP('203.0.113.1')).toBe(true);
+  });
+  it('rejects 203.0.113.255 (documentation, RFC 5737)', () => {
+    expect(isPrivateIP('203.0.113.255')).toBe(true);
+  });
+  // Benchmarking 198.18.0.0/15 (RFC 2544)
+  it('rejects 198.18.0.1 (benchmarking, RFC 2544)', () => {
+    expect(isPrivateIP('198.18.0.1')).toBe(true);
+  });
+  it('rejects 198.19.255.255 (benchmarking upper bound)', () => {
+    expect(isPrivateIP('198.19.255.255')).toBe(true);
+  });
+  it('allows 198.17.255.255 (below benchmarking range)', () => {
+    expect(isPrivateIP('198.17.255.255')).toBe(false);
+  });
+  it('allows 198.20.0.0 (above benchmarking range)', () => {
+    expect(isPrivateIP('198.20.0.0')).toBe(false);
+  });
+  // Valid public IPs
+  it('allows 8.8.8.8 (public)', () => {
+    expect(isPrivateIP('8.8.8.8')).toBe(false);
+  });
+  it('allows 1.1.1.1 (public)', () => {
+    expect(isPrivateIP('1.1.1.1')).toBe(false);
   });
 });
 

--- a/src/ssrf.ts
+++ b/src/ssrf.ts
@@ -18,12 +18,16 @@ import net from 'node:net';
  * - Unspecified: ::
  * - IPv6 unique-local: fc00::/7
  * - CGNAT: 100.64.0.0/10 (RFC 6598)
+ * - Broadcast: 255.255.255.255
+ * - Multicast: 224.0.0.0/4 (RFC 5771)
+ * - Documentation: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (RFC 5737)
+ * - Benchmarking: 198.18.0.0/15 (RFC 2544)
  */
 export function isPrivateIP(ip: string): boolean {
   // IPv4
   if (net.isIPv4(ip)) {
     const parts = ip.split('.').map(Number);
-    const [a, b] = parts;
+    const [a, b, c] = parts;
     // 0.0.0.0/8
     if (a === 0) return true;
     // 10.0.0.0/8
@@ -38,6 +42,18 @@ export function isPrivateIP(ip: string): boolean {
     if (a === 192 && b === 168) return true;
     // 100.64.0.0/10 (CGNAT)
     if (a === 100 && b >= 64 && b <= 127) return true;
+    // 255.255.255.255 (broadcast)
+    if (a === 255 && b === 255 && c === 255 && parts[3] === 255) return true;
+    // 224.0.0.0/4 (multicast) — 224.0.0.0 to 239.255.255.255
+    if (a >= 224 && a <= 239) return true;
+    // 192.0.2.0/24 (documentation, RFC 5737)
+    if (a === 192 && b === 0 && c === 2) return true;
+    // 198.51.100.0/24 (documentation, RFC 5737)
+    if (a === 198 && b === 51 && c === 100) return true;
+    // 203.0.113.0/24 (documentation, RFC 5737)
+    if (a === 203 && b === 0 && c === 113) return true;
+    // 198.18.0.0/15 (benchmarking, RFC 2544) — 198.18.0.0 to 198.19.255.255
+    if (a === 198 && b >= 18 && b <= 19) return true;
     return false;
   }
 


### PR DESCRIPTION
## Summary
Expand SSRF protection to block broadcast, multicast, documentation, and benchmarking IP ranges.

## Changes
- `src/ssrf.ts`: Add checks for broadcast (255.255.255.255), multicast (224.0.0.0/4), documentation (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24), and benchmarking (198.18.0.0/15) ranges
- `src/__tests__/ssrf.test.ts`: Add 14 new test cases for all ranges

## Testing
- 1879 tests pass, 83 test files green (+14 new SSRF tests)
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #683