### PR TITLE
chore: enforce always-bump-patch versioning strategy

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
+      "versioning-strategy": "always-bump-patch",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
## Summary
Prevent feat: commits from auto-bumping minor version. All release-please bumps go to patch only.

## Aegis version
**Developed with:** v2.4.1
**Tested with:** v2.4.1

## Change type
- [x] `chore` — Build, CI, tooling

## Linked issue
None — process improvement

## Test plan
- [x] Config change only, no code affected

## Security impact
None