### PR TITLE
fix(dashboard): exclude AbortSignal from batchCreateSessions JSON body

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -415,10 +415,11 @@ export interface BatchResult {
 }
 
 export function batchCreateSessions(opts: { sessions: CreateSessionRequest[]; signal?: AbortSignal }): Promise<BatchResult> {
+  const { signal, ...body } = opts;
   return request('/v1/sessions/batch', {
     method: 'POST',
-    signal: opts.signal,
-    body: JSON.stringify(opts),
+    signal,
+    body: JSON.stringify(body),
   });
 }
 


### PR DESCRIPTION
## Summary
- `batchCreateSessions` was passing the entire `opts` object (including `AbortSignal`) to `JSON.stringify`, resulting in `{ signal: {} }` in the request body
- Destructure `signal` out of `opts` before serializing so only `{ sessions: [...] }` is sent

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] All 1865 tests pass (83 test files)

## Aegis version
**Developed with:** v2.4.1

Closes #626

Generated by Hephaestus (Aegis dev agent)