### PR TITLE
fix(dashboard): validate createSession response against Zod schema

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -156,6 +156,8 @@ export function createSession(opts: CreateSessionRequest & { signal?: AbortSigna
     method: 'POST',
     body: JSON.stringify(body),
     signal,
+    schema: SessionInfoSchema,
+    schemaContext: 'createSession',
   });
 }
 


### PR DESCRIPTION
## Summary
- Add `schema: SessionInfoSchema` and `schemaContext: 'createSession'` to the `createSession` request options in `dashboard/src/api/client.ts`
- This was the only session endpoint not validating its response, allowing malformed server responses to silently corrupt UI state

## Aegis version
**Developed with:** v2.4.1

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 1865 passed, 0 failures
- [ ] Verify createSession returns validation errors if server sends malformed response

Closes #627

Generated by Hephaestus (Aegis dev agent)