### PR TITLE
perf: replace O(n) shift() with O(1) index-based pruning in IP rate limiter

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -144,30 +144,43 @@ app.addHook('onSend', (req, reply, payload, done) => {
 
 // Auth middleware setup (Issue #39: multi-key auth with rate limiting)
 // #228: Per-IP rate limiting (applies even with master token, with higher limits)
-const ipRateLimits = new Map<string, number[]>();
+// #622: Circular buffer — O(1) prune via index advancement instead of O(n) shift()
+interface IpRateBucket {
+  entries: number[];
+  start: number;
+}
+const ipRateLimits = new Map<string, IpRateBucket>();
 const IP_WINDOW_MS = 60_000;
 const IP_LIMIT_NORMAL = 120;   // per minute for regular keys
 const IP_LIMIT_MASTER = 300;   // per minute for master token
 
 function checkIpRateLimit(ip: string, isMaster: boolean): boolean {
   const now = Date.now();
-  const timestamps = ipRateLimits.get(ip) || [];
-  // Prune old entries
-  while (timestamps.length > 0 && timestamps[0] < now - IP_WINDOW_MS) {
-    timestamps.shift();
+  const cutoff = now - IP_WINDOW_MS;
+  const bucket = ipRateLimits.get(ip) || { entries: [], start: 0 };
+  // O(1) prune: advance start index past expired entries
+  while (bucket.start < bucket.entries.length && bucket.entries[bucket.start]! < cutoff) {
+    bucket.start++;
   }
-  timestamps.push(now);
-  ipRateLimits.set(ip, timestamps);
+  // Compact when the leading garbage exceeds 50% of the allocated array
+  if (bucket.start > bucket.entries.length >>> 1) {
+    bucket.entries = bucket.entries.slice(bucket.start);
+    bucket.start = 0;
+  }
+  bucket.entries.push(now);
+  ipRateLimits.set(ip, bucket);
+  const activeCount = bucket.entries.length - bucket.start;
   const limit = isMaster ? IP_LIMIT_MASTER : IP_LIMIT_NORMAL;
-  return timestamps.length > limit;
+  return activeCount > limit;
 }
 
 /** #357: Prune IPs whose timestamp arrays are entirely outside the rate-limit window. */
 function pruneIpRateLimits(): void {
   const cutoff = Date.now() - IP_WINDOW_MS;
-  for (const [ip, timestamps] of ipRateLimits) {
+  for (const [ip, bucket] of ipRateLimits) {
     // All timestamps are old — remove the entry entirely
-    if (timestamps.length === 0 || timestamps[timestamps.length - 1]! < cutoff) {
+    const last = bucket.entries[bucket.entries.length - 1];
+    if (bucket.entries.length - bucket.start === 0 || (last !== undefined && last < cutoff)) {
       ipRateLimits.delete(ip);
     }
   }


### PR DESCRIPTION
## Summary

- Replaces `Array.shift()` loop in `checkIpRateLimit()` with an O(1) index-advancement approach using a circular buffer (`IpRateBucket` with `entries[]` + `start` index)
- Adds periodic compaction (`slice`) when leading garbage exceeds 50% of the array, bounded by the existing 60s `pruneIpRateLimits` sweep
- Updates `pruneIpRateLimits` to work with the new bucket structure

## Fixes

Closes #622

### Before
```typescript
while (timestamps.length > 0 && timestamps[0] < now - IP_WINDOW_MS) {
  timestamps.shift();  // O(n) — reindexes entire array
}
```

### After
```typescript
while (bucket.start < bucket.entries.length && bucket.entries[bucket.start]! < cutoff) {
  bucket.start++;  // O(1) — just increment an index
}
```

## Aegis version
**Developed with:** v2.4.1

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (1879 tests, 1 pre-existing flaky test unrelated to this change)
- [ ] Manual: send >300 requests from a single IP in 60s and verify rate limiting still triggers correctly

Generated by Hephaestus (Aegis dev agent)