### PR TITLE
fix: remove redundant includes check in swarm socket discovery

### DIFF
--- a/src/swarm-monitor.ts
+++ b/src/swarm-monitor.ts
@@ -231,11 +231,10 @@ export class SwarmMonitor {
       }
 
       const entries = await readdir(tmpdir());
-      const pattern = this.config.socketGlobPattern.replace('tmux-', '');
       // Match "tmux-<socketName>" directories (tmux socket dirs start with "tmux-")
       const socketNames: string[] = [];
       for (const entry of entries) {
-        if (entry.startsWith('tmux-') && entry.includes(pattern)) {
+        if (entry.startsWith('tmux-')) {
           // Extract socket name: tmux-<socketName> → <socketName>
           const socketName = entry.slice(5); // remove "tmux-"
           // Verify it's a claude-swarm-* socket


### PR DESCRIPTION
## Summary
Remove redundant `includes()` check in swarm socket discovery. The `startsWith('tmux-')` check is sufficient; the subsequent socket name extraction and verification handle filtering.

## Changes
- `src/swarm-monitor.ts`: Remove redundant `entry.includes(pattern)` check

## Testing
- 1864 tests pass, 82 test files green (2 flaky hook-answer-question tests unrelated to this change)
- All swarm-monitor tests pass
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #676