### PR TITLE
ci: use npm ci instead of npm install in build:dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc && npm run build:copy-dashboard",
     "build:copy-dashboard": "node scripts/copy-dashboard.mjs",
-    "build:dashboard": "cd dashboard && npm install && npm run build",
+    "build:dashboard": "cd dashboard && npm ci && npm run build",
     "start": "node dist/cli.js",
     "dev": "tsc && node dist/cli.js",
     "prepublishOnly": "npm run build:dashboard && npm run build",


### PR DESCRIPTION
## Summary
Change `build:dashboard` script to use `npm ci` instead of `npm install` for deterministic, lockfile-respecting builds.

## Changes
- `package.json`: Replace `npm install` with `npm ci` in `build:dashboard` script

## Testing
- Existing tests pass
- TSC: zero errors
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #653