### PR TITLE
fix(ci): add typecheck step to publish-npm job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - run: npx tsc --noEmit
       - run: npm run build
       - run: npm run build:dashboard
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
Add `npx tsc --noEmit` step to the publish-npm job so published code is always type-checked, even if the job is rerun independently.

## Changes
- `.github/workflows/release.yml`: Add tsc typecheck step before build

## Testing
- Existing tests pass
- TSC: zero errors

**Developed with:** v2.4.1
**Tested with:** v2.4.1

Fixes #655