### PR TITLE
ci: extract dashboard tests into separate job with explicit dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
 
-# ⚠️ Branch protection requires these exact check names: "lint-pr-title", "test (20)", "test (22)"
+# ⚠️ Branch protection requires these exact check names: "lint-pr-title", "test (20)", "test (22)", "dashboard-test"
 # If you rename jobs or change the matrix, update required status checks in repo settings.
 jobs:
   lint-pr-title:
@@ -85,9 +85,6 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Run dashboard tests
-        run: cd dashboard && npx vitest run
-
       - name: Audit tracked files
         run: |
           FOUND=$(git ls-files | grep -E '(^should$|results\.tsv|^state/|\.tsbuildinfo$|\.env$|\.log$|\.tmp$|\.bak$|\.swp$)' || true)
@@ -97,3 +94,21 @@ jobs:
             exit 1
           fi
           echo "Audit passed - no blacklisted files found"
+
+  dashboard-test:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dashboard dependencies
+        run: cd dashboard && npm ci
+
+      - name: Run dashboard tests
+        run: cd dashboard && npx vitest run


### PR DESCRIPTION
## Summary

- Extracts the "Run dashboard tests" step from the `test` job into its own `dashboard-test` job with `needs: [test]`
- The new job installs its own dashboard deps via `npm ci`, removing the implicit reliance on the "Build dashboard" step having already installed them
- Updates the branch protection comment to include `"dashboard-test"` as a required check name

Fixes #654

## Aegis version
**Developed with:** v2.4.1

## Test plan
- [ ] Verify `dashboard-test` job runs after `test` completes
- [ ] Verify `dashboard-test` installs its own deps and passes independently
- [ ] Update required status checks in repo settings to include `dashboard-test`

Generated by Hephaestus (Aegis dev agent)