### PR TITLE
fix: align @types/node with minimum CI Node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "aegis-bridge": "dist/cli.js"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^20.0.0",
         "@types/ws": "^8.18.1",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"
@@ -690,13 +690,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/ws": {
@@ -3030,9 +3030,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0",
+    "@types/node": "^20.0.0",
     "@types/ws": "^8.18.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -249,7 +249,7 @@ export async function readNewEntries(
   const slicedContent = await new Promise<string>((resolve, reject) => {
     const chunks: Buffer[] = [];
     const stream = createReadStream(filePath, { start: effectiveOffset });
-    stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+    stream.on('data', (chunk: string | Buffer) => { if (typeof chunk !== 'string') chunks.push(chunk); });
     stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
     stream.on('error', reject);
   });


### PR DESCRIPTION
## Summary

- Downgraded `@types/node` from `^25.5.0` to `^20.0.0` to match the minimum Node version (20) defined in `.github/workflows/ci.yml` and `package.json` engines field
- Fixed a type incompatibility in `src/transcript.ts` where `stream.on('data')` callback type changed between Node type versions (the handler now correctly accepts `string | Buffer`)

Fixes #656

## Aegis version
**Developed with:** v2.4.1

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (1879 tests, 14 skipped)
- [ ] CI matrix against Node 20 and 22 passes

Generated by Hephaestus (Aegis dev agent)