### PR TITLE
fix(dashboard): ToolResultCard no longer classifies empty results as errors

### DIFF
--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -108,7 +108,7 @@ function ToolUseCard({ entry }: { entry: ParsedEntry }) {
 // ─── Tool Result Card ────────────────────────────────────────────
 function ToolResultCard({ entry }: { entry: ParsedEntry }) {
   const isError =
-    entry.text.toLowerCase().startsWith('error') || entry.text.length === 0;
+    entry.text.toLowerCase().startsWith('error');
 
   return (
     <div className="flex justify-start mb-3">


### PR DESCRIPTION
Empty tool results were incorrectly styled with red error border. Remove `entry.text.length === 0` from isError check.

Closes #643