### PR TITLE
fix(dashboard): add token to LiveTerminal WebSocket effect dependencies

### DIFF
--- a/dashboard/src/components/session/LiveTerminal.tsx
+++ b/dashboard/src/components/session/LiveTerminal.tsx
@@ -134,7 +134,7 @@ export function LiveTerminal({ sessionId, status }: LiveTerminalProps) {
       wsRef.current = null;
       ws.close();
     };
-  }, [getWsUrl]);
+  }, [getWsUrl, token]);
 
   // Forward user input to WebSocket
   useEffect(() => {


### PR DESCRIPTION
WS effect used `token` but didn't list it in deps. Token changes (re-auth) would not trigger WS reconnect with new credentials.

Closes #642