### PR TITLE
fix: add missing compiler flags to root tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Add `forceConsistentCasingInFileNames` and `noFallthroughCasesInSwitch` to root `tsconfig.json` for stricter type checking.

## Changes
- `tsconfig.json`: Add two compiler flags

## Testing
- All tests pass (Node 20 + 22)
- TSC: zero errors with new flags
- Build: successful

**Developed with:** v2.3.10
**Tested with:** v2.3.10

Fixes #652