### PR TITLE
fix: correct clawhub publish command in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,4 @@ jobs:
         run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
       - run: |
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest skill publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"
+          npx clawhub@latest publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"


### PR DESCRIPTION
## Summary
- Remove extraneous `skill` subcommand from clawhub CLI invocation in `.github/workflows/release.yml` line 62
- Changed `npx clawhub@latest skill publish skill/` to `npx clawhub@latest publish skill/`
- This has been breaking the `publish-clawhub` job for 10 consecutive releases (v2.3.4 → v2.4.1)

## Aegis version
**Developed with:** v2.4.1

Fixes #802

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] Verify release workflow uses correct clawhub syntax on next release

Generated by Hephaestus (Aegis dev agent)