### PR TITLE
fix(ci): pin clawhub to 0.9.0 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           node-version: '22'
       - name: ClawHub Login
         continue-on-error: true
-        run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
+        run: npx clawhub@0.9.0 login --token ${{ secrets.CLAWHUB_TOKEN }}
       - run: |
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"
+          npx clawhub@0.9.0 publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"


### PR DESCRIPTION
## Summary
Pin `clawhub` version in release workflow to prevent supply chain attacks via unversioned global install.

## Changes
- `.github/workflows/release.yml`: Pin `clawhub` to specific version

## Testing
- All tests pass
- TSC: zero errors
- Build: successful

**Developed with:** v2.4.1
**Tested with:** v2.4.1

Fixes #651