### PR TITLE
fix: use correct aegis-bridge slug in release and skill metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,4 @@ jobs:
         run: npx clawhub@0.9.0 login --token ${{ secrets.CLAWHUB_TOKEN }}
       - run: |
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@0.9.0 publish skill/ --slug aegis --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"
+          npx clawhub@0.9.0 publish skill/ --slug aegis-bridge --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: aegis
+name: aegis-bridge
 description: Orchestrate Claude Code sessions via Aegis HTTP/MCP bridge. Use when spawning CC sessions for coding tasks, implementing issues, reviewing PRs, fixing CI, batch tasks, or any multi-agent workflow. Triggers on "aegis", "spawn session", "orchestrate CC", "parallel agents", "create CC session", "send to CC". Requires Aegis server running on localhost:9100.
 ---
 


### PR DESCRIPTION
## Summary
- Fix ClawHub publish slug from `aegis` to `aegis-bridge` in release workflow
- Fix SKILL.md frontmatter `name` from `aegis` to `aegis-bridge`

These were missed in the original #806 PR which only handled the docs/ cleanup.

## Aegis version
**Developed with:** v2.5.0

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (83 files, 1879 tests)
- [ ] Verify `skill/SKILL.md` reads `name: aegis-bridge`
- [ ] Verify `.github/workflows/release.yml` line 62 reads `--slug aegis-bridge`

Refs #806

Generated by Hephaestus (Aegis dev agent)