### PR TITLE
fix(security): read PPid from /proc/<pid>/status instead of stat in isAncestorPid

### DIFF
--- a/src/__tests__/isAncestorPid.test.ts
+++ b/src/__tests__/isAncestorPid.test.ts
@@ -1,0 +1,75 @@
+/**
+ * isAncestorPid.test.ts — Tests for issue #618: isAncestorPid reads wrong field.
+ *
+ * The old code parsed /proc/<pid>/stat and used split(' ')[1] (the comm field),
+ * not index [3] (ppid). The fix reads /proc/<pid>/status and parses the PPid line.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readPpid } from '../server.js';
+
+// Mock readFileSync from node:fs so we control /proc/<pid>/status content
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+const mockReadFileSync = vi.mocked(
+  (await import('node:fs')).readFileSync,
+);
+
+function makeStatus(ppid: number, name = 'bash'): string {
+  return [
+    `Name:\t${name}`,
+    `State:\tS (sleeping)`,
+    `Tgid:\t12345`,
+    `Ngid:\t0`,
+    `Pid:\t12345`,
+    `PPid:\t${ppid}`,
+    `TracerPid:\t0`,
+  ].join('\n');
+}
+
+describe('readPpid', () => {
+  beforeEach(() => {
+    mockReadFileSync.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses PPid from /proc/<pid>/status', () => {
+    mockReadFileSync.mockReturnValue(makeStatus(100));
+    expect(readPpid(12345)).toBe(100);
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      '/proc/12345/status',
+      'utf-8',
+    );
+  });
+
+  it('handles process names with spaces', () => {
+    mockReadFileSync.mockReturnValue(makeStatus(200, 'my process name'));
+    expect(readPpid(12345)).toBe(200);
+  });
+
+  it('handles process names with parentheses', () => {
+    mockReadFileSync.mockReturnValue(makeStatus(300, '(bash)'));
+    expect(readPpid(12345)).toBe(300);
+  });
+
+  it('throws when PPid line is missing', () => {
+    mockReadFileSync.mockReturnValue('Name:\tbash\nPid:\t12345\n');
+    expect(() => readPpid(12345)).toThrow('no PPid line');
+  });
+
+  it('throws when /proc file does not exist', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(() => readPpid(99999)).toThrow('ENOENT');
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1268,6 +1268,18 @@ function pidExists(pid: number): boolean {
 }
 
 /**
+ * Read the parent PID from /proc/<pid>/status.
+ * Uses the PPid line instead of parsing /proc/<pid>/stat,
+ * which breaks when the comm field (process name) contains spaces.
+ */
+export function readPpid(pid: number): number {
+  const status = readFileSync(`/proc/${pid}/status`, 'utf-8');
+  const match = status.match(/^PPid:\s+(\d+)/m);
+  if (!match) throw new Error(`no PPid line in /proc/${pid}/status`);
+  return parseInt(match[1], 10);
+}
+
+/**
  * Check if a PID is an ancestor of the current process.
  */
 function isAncestorPid(pid: number): boolean {
@@ -1276,7 +1288,7 @@ function isAncestorPid(pid: number): boolean {
     for (let depth = 0; depth < 10 && current > 1; depth++) {
       if (current === pid) return true;
       try {
-        current = parseInt(readFileSync(`/proc/${current}/stat`, 'utf-8').split(' ')[1], 10);
+        current = readPpid(current);
       } catch { /* /proc unavailable or process gone — stop walking */
         break;
       }


### PR DESCRIPTION
## Summary

- `isAncestorPid()` parsed `/proc/<pid>/stat` and read `split(' ')[1]`, which is the **comm** field (e.g. `(bash)`), not the parent PID at index `[3]`. `parseInt('(bash)', 10)` returned `NaN`, breaking the ancestor walk after one level.
- This meant EADDRINUSE recovery could kill a grandparent process (e.g. a systemd supervisor) because ancestor detection never traversed beyond `process.ppid`.
- Fix by reading `/proc/<pid>/status` and parsing the `PPid:` line, which is robust against process names containing spaces or parentheses.

Closes #618

## Test plan
- [x] New unit tests in `src/__tests__/isAncestorPid.test.ts` (5 tests):
  - Parses PPid from `/proc/<pid>/status`
  - Handles process names with spaces
  - Handles process names with parentheses
  - Throws when PPid line is missing
  - Throws when `/proc` file does not exist
- [x] Full test suite: **84 files, 1884 tests passing, 0 failures**
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes

## Aegis version
**Developed with:** v2.4.1

Generated by Hephaestus (Aegis dev agent)