### PR TITLE
fix(security): detect IPv4-mapped IPv6 addresses in SSRF protection (#621)

### DIFF
--- a/src/__tests__/ssrf.test.ts
+++ b/src/__tests__/ssrf.test.ts
@@ -135,6 +135,79 @@ describe('isPrivateIP', () => {
   it('allows 1.1.1.1 (public)', () => {
     expect(isPrivateIP('1.1.1.1')).toBe(false);
   });
+
+  // ── IPv4-mapped IPv6 (::ffff:x.x.x.x) — SSRF bypass vector (#621) ────
+  it('rejects ::ffff:127.0.0.1 (mapped loopback)', () => {
+    expect(isPrivateIP('::ffff:127.0.0.1')).toBe(true);
+  });
+  it('rejects ::ffff:10.0.0.1 (mapped RFC 1918)', () => {
+    expect(isPrivateIP('::ffff:10.0.0.1')).toBe(true);
+  });
+  it('rejects ::ffff:172.16.0.1 (mapped RFC 1918)', () => {
+    expect(isPrivateIP('::ffff:172.16.0.1')).toBe(true);
+  });
+  it('rejects ::ffff:192.168.1.1 (mapped RFC 1918)', () => {
+    expect(isPrivateIP('::ffff:192.168.1.1')).toBe(true);
+  });
+  it('rejects ::ffff:169.254.0.1 (mapped link-local)', () => {
+    expect(isPrivateIP('::ffff:169.254.0.1')).toBe(true);
+  });
+  it('rejects ::ffff:0.0.0.0 (mapped unspecified)', () => {
+    expect(isPrivateIP('::ffff:0.0.0.0')).toBe(true);
+  });
+  it('rejects ::ffff:100.64.0.1 (mapped CGNAT)', () => {
+    expect(isPrivateIP('::ffff:100.64.0.1')).toBe(true);
+  });
+  it('rejects ::ffff:255.255.255.255 (mapped broadcast)', () => {
+    expect(isPrivateIP('::ffff:255.255.255.255')).toBe(true);
+  });
+  it('rejects ::ffff:224.0.0.1 (mapped multicast)', () => {
+    expect(isPrivateIP('::ffff:224.0.0.1')).toBe(true);
+  });
+  it('allows ::ffff:8.8.8.8 (mapped public)', () => {
+    expect(isPrivateIP('::ffff:8.8.8.8')).toBe(false);
+  });
+  it('allows ::ffff:1.1.1.1 (mapped public)', () => {
+    expect(isPrivateIP('::ffff:1.1.1.1')).toBe(false);
+  });
+  // Case-insensitive ::FFFF:
+  it('rejects ::FFFF:127.0.0.1 (uppercase mapped loopback)', () => {
+    expect(isPrivateIP('::FFFF:127.0.0.1')).toBe(true);
+  });
+
+  // ── IPv4-mapped IPv6 hex form (::ffff:XXXX:XXXX) — URL-normalized ──
+  it('rejects ::ffff:7f00:1 (hex form of ::ffff:127.0.0.1)', () => {
+    expect(isPrivateIP('::ffff:7f00:1')).toBe(true);
+  });
+  it('rejects ::ffff:a00:1 (hex form of ::ffff:10.0.0.1)', () => {
+    expect(isPrivateIP('::ffff:a00:1')).toBe(true);
+  });
+  it('rejects ::ffff:ac10:1 (hex form of ::ffff:172.16.0.1)', () => {
+    expect(isPrivateIP('::ffff:ac10:1')).toBe(true);
+  });
+  it('rejects ::ffff:c0a8:101 (hex form of ::ffff:192.168.1.1)', () => {
+    expect(isPrivateIP('::ffff:c0a8:101')).toBe(true);
+  });
+  it('allows ::ffff:808:808 (hex form of ::ffff:8.8.8.8, public)', () => {
+    expect(isPrivateIP('::ffff:808:808')).toBe(false);
+  });
+
+  // ── IPv4-compatible IPv6 (::x.x.x.x) — deprecated bypass vector ──────
+  it('rejects ::127.0.0.1 (compat loopback)', () => {
+    expect(isPrivateIP('::127.0.0.1')).toBe(true);
+  });
+  it('rejects ::10.0.0.1 (compat RFC 1918)', () => {
+    expect(isPrivateIP('::10.0.0.1')).toBe(true);
+  });
+  it('rejects ::192.168.1.1 (compat RFC 1918)', () => {
+    expect(isPrivateIP('::192.168.1.1')).toBe(true);
+  });
+  it('rejects ::0.0.0.0 (compat unspecified)', () => {
+    expect(isPrivateIP('::0.0.0.0')).toBe(true);
+  });
+  it('allows ::8.8.8.8 (compat public)', () => {
+    expect(isPrivateIP('::8.8.8.8')).toBe(false);
+  });
 });
 
 // ── validateWebhookUrl ──────────────────────────────────────────────
@@ -173,6 +246,22 @@ describe('validateWebhookUrl', () => {
 
   it('rejects private IP in URL', () => {
     expect(validateWebhookUrl('https://10.0.0.1/hook')).toBe('Private/internal IP addresses are not allowed');
+  });
+
+  it('rejects IPv4-mapped IPv6 loopback in URL', () => {
+    expect(validateWebhookUrl('https://[::ffff:127.0.0.1]/hook')).toBe('Private/internal IP addresses are not allowed');
+  });
+
+  it('rejects IPv4-mapped IPv6 private in URL', () => {
+    expect(validateWebhookUrl('https://[::ffff:10.0.0.1]/hook')).toBe('Private/internal IP addresses are not allowed');
+  });
+
+  it('allows IPv6 loopback via HTTPS (local dev)', () => {
+    expect(validateWebhookUrl('https://[::1]/hook')).toBeNull();
+  });
+
+  it('rejects IPv6 unique-local in URL', () => {
+    expect(validateWebhookUrl('https://[fc00::1]/hook')).toBe('Private/internal IP addresses are not allowed');
   });
 
   it('rejects .local hostname', () => {
@@ -219,5 +308,23 @@ describe('resolveAndCheckIp', () => {
     const result = await resolveAndCheckIp('192.168.1.1', mockLookup);
     expect(result).toBe('DNS resolution points to a private/internal IP: 192.168.1.1');
     expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('returns error when DNS resolves to IPv4-mapped private IPv6', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
+      address: '::ffff:10.0.0.1',
+      family: 6,
+    });
+    const result = await resolveAndCheckIp('evil.corp', mockLookup);
+    expect(result).toBe('DNS resolution points to a private/internal IP: ::ffff:10.0.0.1');
+  });
+
+  it('returns null when DNS resolves to IPv4-mapped public IPv6', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
+      address: '::ffff:8.8.8.8',
+      family: 6,
+    });
+    const result = await resolveAndCheckIp('safe.example.com', mockLookup);
+    expect(result).toBeNull();
   });
 });

--- a/src/ssrf.ts
+++ b/src/ssrf.ts
@@ -17,6 +17,8 @@ import net from 'node:net';
  * - Current network: 0.0.0.0/8
  * - Unspecified: ::
  * - IPv6 unique-local: fc00::/7
+ * - IPv4-mapped IPv6: ::ffff:x.x.x.x (RFC 4291)
+ * - IPv4-compatible IPv6: ::x.x.x.x (deprecated)
  * - CGNAT: 100.64.0.0/10 (RFC 6598)
  * - Broadcast: 255.255.255.255
  * - Multicast: 224.0.0.0/4 (RFC 5771)
@@ -59,6 +61,32 @@ export function isPrivateIP(ip: string): boolean {
 
   // IPv6
   const lower = ip.toLowerCase();
+
+  // IPv4-mapped IPv6 (::ffff:x.x.x.x, RFC 4291 §2.5.5)
+  // Handles dotted-quad form (::ffff:127.0.0.1) and hex form (::ffff:7f00:1).
+  // Also handles IPv4-compatible IPv6 (::x.x.x.x, deprecated).
+  if (lower.startsWith('::ffff:')) {
+    const suffix = lower.slice(7);
+    // Dotted quad form: ::ffff:127.0.0.1
+    if (net.isIPv4(suffix)) {
+      return isPrivateIP(suffix);
+    }
+    // Hex form: ::ffff:7f00:1 → parse last 32 bits as IPv4
+    const hexGroups = suffix.split(':').map(h => parseInt(h, 16));
+    if (hexGroups.length === 2 && hexGroups.every(n => !isNaN(n))) {
+      const embedded = `${(hexGroups[0] >> 8) & 0xff}.${hexGroups[0] & 0xff}.${(hexGroups[1] >> 8) & 0xff}.${hexGroups[1] & 0xff}`;
+      if (net.isIPv4(embedded)) {
+        return isPrivateIP(embedded);
+      }
+    }
+  }
+
+  // IPv4-compatible IPv6 (::x.x.x.x, deprecated RFC 4291 §2.5.5)
+  const afterPrefix = lower.startsWith('::') && lower !== '::' && lower !== '::1' ? lower.slice(2) : null;
+  if (afterPrefix !== null && net.isIPv4(afterPrefix)) {
+    return isPrivateIP(afterPrefix);
+  }
+
   // ::1 (loopback)
   if (lower === '::1') return true;
   // :: (unspecified)
@@ -93,8 +121,11 @@ export function validateWebhookUrl(rawUrl: string): string | null {
 
   const hostname = parsed.hostname;
 
+  // Strip brackets from IPv6 URLs: [::1] → ::1
+  const bareHost = hostname.replace(/^\[|\]$/g, '');
+
   // Scheme check — must be HTTPS, or HTTP only for local dev
-  const isLocalDev = hostname === '127.0.0.1' || hostname === '::1' || hostname === 'localhost';
+  const isLocalDev = bareHost === '127.0.0.1' || bareHost === '::1' || bareHost === 'localhost';
   if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLocalDev)) {
     if (parsed.protocol === 'http:') {
       return 'Only HTTPS URLs are allowed for external hosts';
@@ -103,12 +134,12 @@ export function validateWebhookUrl(rawUrl: string): string | null {
   }
 
   // Reject *.local hostnames (but allow literal localhost for dev)
-  if (hostname.endsWith('.local')) {
+  if (bareHost.endsWith('.local')) {
     return 'Localhost URLs are not allowed';
   }
 
   // Reject private/internal IPs (except 127.0.0.1/::1 which are allowed for dev over HTTP)
-  if (net.isIP(hostname) && isPrivateIP(hostname) && !isLocalDev) {
+  if (net.isIP(bareHost) && isPrivateIP(bareHost) && !isLocalDev) {
     return 'Private/internal IP addresses are not allowed';
   }
 
@@ -186,13 +217,16 @@ export function validateScreenshotUrl(rawUrl: string): string | null {
 
   const hostname = parsed.hostname;
 
+  // Strip brackets from IPv6 URLs: [::1] → ::1
+  const bareHost = hostname.replace(/^\[|\]$/g, '');
+
   // Reject localhost / *.local hostnames
-  if (hostname === 'localhost' || hostname.endsWith('.local')) {
+  if (bareHost === 'localhost' || bareHost.endsWith('.local')) {
     return 'Localhost URLs are not allowed';
   }
 
   // Reject private/internal IPs
-  if (net.isIP(hostname) && isPrivateIP(hostname)) {
+  if (net.isIP(bareHost) && isPrivateIP(bareHost)) {
     return 'Private/internal IP addresses are not allowed';
   }
 


### PR DESCRIPTION
## Summary

- Fixes critical SSRF bypass in `isPrivateIP()` where IPv4-mapped IPv6 addresses (`::ffff:127.0.0.1`) and IPv4-compatible addresses (`::127.0.0.1`) were not detected as private
- Handles both dotted-quad form (`::ffff:127.0.0.1`) and hex-normalized form (`::ffff:7f00:1`) — the form browsers/URL parsers produce
- Fixes bracket stripping for IPv6 URLs in `validateWebhookUrl` and `validateScreenshotUrl` — all `[::x]` hostnames bypassed IP checks because `net.isIP()` returns 0 for bracketed addresses
- Adds 27 new test cases covering all bypass vectors

## Attack scenario prevented

An attacker could configure a webhook URL with hostname resolving to `::ffff:127.0.0.1`. The `isPrivateIP()` check passed (not recognized as private), and the webhook fired to localhost.

## Files changed

- `src/ssrf.ts` — IPv4-mapped/compatible IPv6 detection + bracket stripping
- `src/__tests__/ssrf.test.ts` — 27 new tests

## Aegis version

**Developed with:** v2.4.1

Closes #621

Generated by Hephaestus (Aegis dev agent)