### PR TITLE
fix: verify tmux window exists before returning idle session (#636)

### DIFF
--- a/src/__tests__/session-dedup-607.test.ts
+++ b/src/__tests__/session-dedup-607.test.ts
@@ -129,7 +129,7 @@ describe('Issue #607: findIdleSessionByWorkDir logic', () => {
 describe('Issue #607: POST /v1/sessions route reuse', () => {
   function createMockSessionManager(existingSession: SessionInfo | null): SessionManager {
     return {
-      findIdleSessionByWorkDir: vi.fn((_workDir: string) => existingSession),
+      findIdleSessionByWorkDir: vi.fn(async (_workDir: string) => existingSession),
       createSession: vi.fn(async () => { throw new Error('should not create session'); }),
       sendInitialPrompt: vi.fn(async () => ({ delivered: true, attempts: 1 })),
       listSessions: vi.fn(() => []),
@@ -162,7 +162,7 @@ describe('Issue #607: POST /v1/sessions route reuse', () => {
       if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
 
       // Issue #607: Check for an existing idle session with the same workDir
-      const existing = sessions.findIdleSessionByWorkDir(workDir);
+      const existing = await sessions.findIdleSessionByWorkDir(workDir);
       if (existing) {
         let promptDelivery: { delivered: boolean; attempts: number } | undefined;
         if (prompt) {
@@ -225,7 +225,7 @@ describe('Issue #607: POST /v1/sessions route reuse', () => {
     const sessions = sm;
 
     app.post('/v1/sessions', async (_req, reply) => {
-      const existing = sessions.findIdleSessionByWorkDir('/project/a');
+      const existing = await sessions.findIdleSessionByWorkDir('/project/a');
       if (existing) {
         return reply.status(200).send({ ...existing, reused: true });
       }

--- a/src/__tests__/session-dedup-636.test.ts
+++ b/src/__tests__/session-dedup-636.test.ts
@@ -1,0 +1,128 @@
+/**
+ * session-dedup-636.test.ts — Tests for Issue #636: verify tmux window alive
+ * in findIdleSessionByWorkDir.
+ *
+ * When a tmux window is killed externally (user ran `tmux kill-window`, tmux
+ * crashed, etc.) the in-memory session state still marks it as idle.
+ * findIdleSessionByWorkDir must call tmux.windowExists() to filter out dead
+ * sessions before returning a candidate.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionManager } from '../session.js';
+import type { SessionInfo } from '../session.js';
+
+function makeSession(overrides: Partial<SessionInfo> & { workDir: string; status: SessionInfo['status']; windowId?: string }): SessionInfo {
+  return {
+    id: crypto.randomUUID(),
+    windowId: '@1',
+    windowName: 'test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    createdAt: Date.now() - 60_000,
+    lastActivity: Date.now(),
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+function mockTmuxManager(windowExistsMap: Record<string, boolean> = {}) {
+  return {
+    windowExists: vi.fn(async (windowId: string) => windowExistsMap[windowId] ?? false),
+    listWindows: vi.fn(async () => []),
+    isServerHealthy: vi.fn(async () => ({ healthy: true, error: null })),
+    isTmuxServerError: vi.fn(() => false),
+    killWindow: vi.fn(async () => {}),
+    sendKeys: vi.fn(async () => {}),
+    sendKeysVerified: vi.fn(async () => ({ delivered: true, attempts: 1 })),
+    capturePane: vi.fn(async () => ''),
+    sendSpecialKey: vi.fn(async () => {}),
+    listPanePid: vi.fn(async () => null),
+    isPidAlive: vi.fn(() => true),
+    ensureSession: vi.fn(async () => {}),
+    createWindow: vi.fn(async () => ({ windowId: '@1', windowName: 'cc-test' })),
+    killSession: vi.fn(async () => {}),
+    getWindowHealth: vi.fn(async () => ({
+      windowExists: true, paneCommand: 'claude', claudeRunning: true,
+    })),
+  } as any;
+}
+
+function mockConfig() {
+  return { stateDir: '/tmp/aegis-test-636' } as any;
+}
+
+/**
+ * Create a SessionManager with sessions pre-loaded into its internal state.
+ * We use Object.assign to inject sessions without going through createSession.
+ */
+function createSessionManagerWithSessions(
+  sessions: SessionInfo[],
+  windowExistsMap: Record<string, boolean>,
+): SessionManager {
+  const tmux = mockTmuxManager(windowExistsMap);
+  const config = mockConfig();
+  const sm = new SessionManager(tmux, config);
+  // Inject sessions directly into internal state
+  (sm as any).state = { sessions: Object.fromEntries(sessions.map(s => [s.id, s])) };
+  return sm;
+}
+
+describe('Issue #636: findIdleSessionByWorkDir verifies tmux window', () => {
+  it('should return null when the idle session has a dead tmux window', async () => {
+    const session = makeSession({ workDir: '/project/a', status: 'idle', windowId: '@99' });
+    const sm = createSessionManagerWithSessions([session], { '@99': false });
+
+    const result = await sm.findIdleSessionByWorkDir('/project/a');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return the session when the tmux window is alive', async () => {
+    const session = makeSession({ workDir: '/project/a', status: 'idle', windowId: '@1' });
+    const sm = createSessionManagerWithSessions([session], { '@1': true });
+
+    const result = await sm.findIdleSessionByWorkDir('/project/a');
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(session.id);
+  });
+
+  it('should skip dead windows and return the first alive one', async () => {
+    const deadSession = makeSession({ workDir: '/project/a', status: 'idle', windowId: '@10', lastActivity: 3000 });
+    const aliveSession = makeSession({ workDir: '/project/a', status: 'idle', windowId: '@11', lastActivity: 2000 });
+    const sm = createSessionManagerWithSessions(
+      [deadSession, aliveSession],
+      { '@10': false, '@11': true },
+    );
+
+    const result = await sm.findIdleSessionByWorkDir('/project/a');
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(aliveSession.id);
+  });
+
+  it('should return null when all idle sessions have dead windows', async () => {
+    const s1 = makeSession({ workDir: '/project/a', status: 'idle', windowId: '@20' });
+    const s2 = makeSession({ workDir: '/project/a', status: 'idle', windowId: '@21' });
+    const sm = createSessionManagerWithSessions(
+      [s1, s2],
+      { '@20': false, '@21': false },
+    );
+
+    const result = await sm.findIdleSessionByWorkDir('/project/a');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when no sessions match workDir', async () => {
+    const session = makeSession({ workDir: '/project/b', status: 'idle', windowId: '@1' });
+    const sm = createSessionManagerWithSessions([session], { '@1': true });
+
+    const result = await sm.findIdleSessionByWorkDir('/project/a');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -531,7 +531,7 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
   if (typeof safeWorkDir === 'object') return reply.status(400).send({ error: safeWorkDir.error, code: safeWorkDir.code });
 
   // Issue #607: Check for an existing idle session with the same workDir
-  const existing = sessions.findIdleSessionByWorkDir(safeWorkDir);
+  const existing = await sessions.findIdleSessionByWorkDir(safeWorkDir);
   if (existing) {
     // Send prompt to the existing session if provided
     let promptDelivery: { delivered: boolean; attempts: number } | undefined;

--- a/src/session.ts
+++ b/src/session.ts
@@ -804,15 +804,22 @@ export class SessionManager {
 
   /** Issue #607: Find an idle session for the given workDir.
    *  Returns the most recently active idle session, or null if none found.
-   *  Used to resume existing sessions instead of creating duplicates. */
-  findIdleSessionByWorkDir(workDir: string): SessionInfo | null {
+   *  Used to resume existing sessions instead of creating duplicates.
+   *  Issue #636: Verifies tmux window is still alive before returning. */
+  async findIdleSessionByWorkDir(workDir: string): Promise<SessionInfo | null> {
     const candidates = Object.values(this.state.sessions).filter(
       (s) => s.workDir === workDir && s.status === 'idle',
     );
     if (candidates.length === 0) return null;
     // Return the most recently active session
     candidates.sort((a, b) => b.lastActivity - a.lastActivity);
-    return candidates[0];
+    // Issue #636: verify tmux window exists before returning
+    for (const candidate of candidates) {
+      if (await this.tmux.windowExists(candidate.windowId)) {
+        return candidate;
+      }
+    }
+    return null;
   }
 
   /** Get health info for a session.


### PR DESCRIPTION
## Summary
- `findIdleSessionByWorkDir` now calls `tmux.windowExists()` before returning a candidate session, preventing reuse of sessions whose tmux windows were killed externally
- Method signature changed from sync to `async` — single caller in `server.ts` updated with `await`
- Existing `session-dedup-607` test updated for async signature; new `session-dedup-636` test covers 5 scenarios (dead window, alive window, skip-to-alive, all-dead, no-match)

Closes #636

## Aegis version
**Developed with:** v2.5.1

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 1889 passed, 0 failed
- [ ] Manual: create a session, `tmux kill-window` its window, then POST `/v1/sessions` with the same `workDir` — should create a new session instead of reusing the dead one

Generated by Hephaestus (Aegis dev agent)