### PR TITLE
fix: only count 5xx and network errors as circuit breaker failures

### DIFF
--- a/src/__tests__/channels.test.ts
+++ b/src/__tests__/channels.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ChannelManager } from '../channels/manager.js';
+import { ChannelManager, RetriableError } from '../channels/manager.js';
 import { WebhookChannel } from '../channels/webhook.js';
 import type { Channel, SessionEventPayload } from '../channels/types.js';
 
@@ -42,7 +42,7 @@ describe('ChannelManager circuit breaker (M10)', () => {
   });
 
   it('should skip a disabled channel during cooldown', async () => {
-    const handler = vi.fn().mockRejectedValue(new Error('fail'));
+    const handler = vi.fn().mockRejectedValue(new RetriableError('fail'));
     const ch: Channel = {
       name: 'flaky',
       onStatusChange: handler,
@@ -63,7 +63,7 @@ describe('ChannelManager circuit breaker (M10)', () => {
   });
 
   it('should re-enable channel after cooldown expires', async () => {
-    const handler = vi.fn().mockRejectedValue(new Error('fail'));
+    const handler = vi.fn().mockRejectedValue(new RetriableError('fail'));
     const ch: Channel = {
       name: 'flaky',
       onStatusChange: handler,
@@ -90,7 +90,7 @@ describe('ChannelManager circuit breaker (M10)', () => {
     let callCount = 0;
     const handler = vi.fn().mockImplementation(async () => {
       callCount++;
-      if (callCount <= 3) throw new Error('transient');
+      if (callCount <= 3) throw new RetriableError('transient');
     });
     const ch: Channel = {
       name: 'recovering',
@@ -110,7 +110,7 @@ describe('ChannelManager circuit breaker (M10)', () => {
   });
 
   it('should not affect other channels when one is disabled', async () => {
-    const failHandler = vi.fn().mockRejectedValue(new Error('fail'));
+    const failHandler = vi.fn().mockRejectedValue(new RetriableError('fail'));
     const okHandler = vi.fn().mockResolvedValue(undefined);
 
     const chFail: Channel = { name: 'bad', onStatusChange: failHandler };

--- a/src/__tests__/channels/manager.test.ts
+++ b/src/__tests__/channels/manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { ChannelManager } from '../../channels/manager.js';
+import { ChannelManager, RetriableError } from '../../channels/manager.js';
 import type { Channel, SessionEventPayload, InboundHandler } from '../../channels/types.js';
 
 function createMockChannel(name: string): {
@@ -341,6 +341,138 @@ describe('ChannelManager', () => {
       await expect(manager.sessionEnded(payload)).resolves.toBeUndefined();
       await expect(manager.message(payload)).resolves.toBeUndefined();
       await expect(manager.statusChange(payload)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('circuit breaker — 4xx vs 5xx (#638)', () => {
+    it('does not trip circuit breaker on 4xx errors (plain Error)', async () => {
+      const manager = new ChannelManager();
+      const { channel: ch, onSessionCreated } = createMockChannel('webhook');
+
+      // Simulate 4xx client error — thrown as plain Error
+      onSessionCreated.mockRejectedValue(new Error('HTTP 400'));
+
+      manager.register(ch);
+
+      // Fire more than FAILURE_THRESHOLD events
+      for (let i = 0; i < ChannelManager.FAILURE_THRESHOLD + 2; i++) {
+        await manager.sessionCreated(createPayload('session.created'));
+      }
+
+      // Channel should NOT be disabled — 4xx errors don't count
+      // Fire one more time, it should still be called
+      await manager.sessionCreated(createPayload('session.created'));
+      expect(onSessionCreated).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD + 3);
+    });
+
+    it('trips circuit breaker on 5xx errors (RetriableError)', async () => {
+      const manager = new ChannelManager();
+      const { channel: ch, onSessionCreated } = createMockChannel('webhook');
+
+      // Simulate 5xx server error — thrown as RetriableError
+      onSessionCreated.mockRejectedValue(new RetriableError('HTTP 500'));
+
+      manager.register(ch);
+
+      // Fire FAILURE_THRESHOLD events
+      for (let i = 0; i < ChannelManager.FAILURE_THRESHOLD; i++) {
+        await manager.sessionCreated(createPayload('session.created'));
+      }
+
+      // Channel should be disabled now — next call should be skipped
+      await manager.sessionCreated(createPayload('session.created'));
+      // Called exactly FAILURE_THRESHOLD times, not once more
+      expect(onSessionCreated).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD);
+    });
+
+    it('trips circuit breaker on network errors (RetriableError)', async () => {
+      const manager = new ChannelManager();
+      const { channel: ch, onMessage } = createMockChannel('webhook');
+
+      // Network error — RetriableError
+      onMessage.mockRejectedValue(new RetriableError('fetch failed'));
+
+      manager.register(ch);
+
+      for (let i = 0; i < ChannelManager.FAILURE_THRESHOLD; i++) {
+        await manager.message(createPayload('message.user'));
+      }
+
+      // Channel should be disabled — next call skipped
+      await manager.message(createPayload('message.user'));
+      expect(onMessage).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD);
+    });
+
+    it('resets failure count on success after 4xx errors', async () => {
+      const manager = new ChannelManager();
+      const { channel: ch, onSessionCreated } = createMockChannel('webhook');
+
+      // Throw some 4xx errors — these don't increment failCount
+      onSessionCreated.mockRejectedValueOnce(new Error('HTTP 403'));
+      onSessionCreated.mockRejectedValueOnce(new Error('HTTP 404'));
+
+      manager.register(ch);
+
+      await manager.sessionCreated(createPayload('session.created'));
+      await manager.sessionCreated(createPayload('session.created'));
+
+      // Now succeed — resets failCount to 0
+      onSessionCreated.mockResolvedValueOnce(undefined);
+      await manager.sessionCreated(createPayload('session.created'));
+
+      // Now throw RetriableErrors — need full FAILURE_THRESHOLD to trip
+      onSessionCreated.mockRejectedValue(new RetriableError('HTTP 502'));
+
+      // THRESHOLD-1 retriable failures: failCount = 4, not yet tripped
+      for (let i = 0; i < ChannelManager.FAILURE_THRESHOLD - 1; i++) {
+        await manager.sessionCreated(createPayload('session.created'));
+      }
+
+      // 5th retriable failure: failCount = 5 = THRESHOLD → breaker trips
+      await manager.sessionCreated(createPayload('session.created'));
+
+      // Next call should be skipped (channel disabled)
+      await manager.sessionCreated(createPayload('session.created'));
+      // 3 initial (2x 4xx + 1 success) + 5 retriable failures = 8 total calls
+      expect(onSessionCreated).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD + 3);
+    });
+
+    it('mixed 4xx and 5xx — only 5xx counts toward threshold', async () => {
+      const manager = new ChannelManager();
+      const { channel: ch, onStatusChange } = createMockChannel('webhook');
+
+      manager.register(ch);
+
+      // Alternate 4xx and 5xx errors
+      for (let i = 0; i < ChannelManager.FAILURE_THRESHOLD; i++) {
+        onStatusChange.mockRejectedValueOnce(new Error('HTTP 429'));
+        await manager.statusChange(createPayload('status.idle'));
+
+        onStatusChange.mockRejectedValueOnce(new RetriableError('HTTP 500'));
+        await manager.statusChange(createPayload('status.idle'));
+      }
+
+      // 5xx failCount = FAILURE_THRESHOLD, channel should be disabled
+      await manager.statusChange(createPayload('status.idle'));
+      // The last call should have been skipped
+      expect(onStatusChange).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD * 2);
+    });
+
+    it('does not trip breaker for plain Error even after many failures', async () => {
+      const manager = new ChannelManager();
+      const { channel: ch, onMessage } = createMockChannel('webhook');
+
+      onMessage.mockRejectedValue(new Error('HTTP 401'));
+
+      manager.register(ch);
+
+      // Fire way more than threshold
+      for (let i = 0; i < ChannelManager.FAILURE_THRESHOLD * 3; i++) {
+        await manager.message(createPayload('message.user'));
+      }
+
+      // Channel still not disabled — all calls went through
+      expect(onMessage).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD * 3);
     });
   });
 });

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -14,6 +14,18 @@ import type {
   InboundHandler,
 } from './types.js';
 
+/**
+ * Thrown for retriable failures (5xx server errors, network timeouts).
+ * Only these increment the circuit breaker failure count.
+ * 4xx client errors are thrown as plain Error and do NOT trip the breaker.
+ */
+export class RetriableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RetriableError';
+  }
+}
+
 interface ChannelHealth {
   failCount: number;
   disabledUntil: number;
@@ -112,6 +124,9 @@ export class ChannelManager {
         this.health.set(ch.name, { failCount: 0, disabledUntil: 0 });
       } catch (e) {
         console.error(`Channel ${ch.name} error on ${payload.event}:`, e);
+        // Only count retriable errors (5xx, network) toward circuit breaker.
+        // 4xx client errors are non-retriable — the server is healthy.
+        if (!(e instanceof RetriableError)) return;
         const h = this.health.get(ch.name) ?? { failCount: 0, disabledUntil: 0 };
         h.failCount++;
         if (h.failCount >= ChannelManager.FAILURE_THRESHOLD) {

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -13,6 +13,7 @@ import type {
 import { webhookEndpointSchema, getErrorMessage } from '../validation.js';
 import { validateWebhookUrl } from '../ssrf.js';
 import { redactSecretsFromText } from '../utils/redact-headers.js';
+import { RetriableError } from './manager.js';
 
 export interface WebhookEndpoint {
   /** URL to POST to. */
@@ -193,8 +194,13 @@ export class WebhookChannel implements Channel {
         console.error(`Webhook ${ep.url} failed after ${maxRetries} attempts for ${event}: ${lastError}`);
         this.addToDeadLetterQueue(ep.url, event, lastError, maxRetries);
       }
-      // Final failure (HTTP or network) — throw so fire() can aggregate
-      throw new Error(lastError);
+      // Final failure — throw so fire() can aggregate.
+      // Use RetriableError for 5xx/network (circuit breaker counts these),
+      // plain Error for 4xx (circuit breaker ignores these).
+      if (lastError.startsWith('HTTP ') && parseInt(lastError.slice(5)) < 500) {
+        throw new Error(lastError);
+      }
+      throw new RetriableError(lastError);
     }
   }
 


### PR DESCRIPTION
## Summary
- Circuit breaker now distinguishes 4xx client errors from 5xx/network failures
- Only 5xx and network errors increment the circuit breaker fail count
- 4xx errors (malformed payload, auth issues) do NOT trigger circuit breaker

Fixes #638

## Test plan
- Added unit tests for 4xx vs 5xx circuit breaker behavior
- Quality gate: tsc + build + npm test all green

**Developed with:** v2.5.2