### PR TITLE
fix: track untracked setTimeout timers in event bus and session discovery

### DIFF
--- a/src/__tests__/events.test.ts
+++ b/src/__tests__/events.test.ts
@@ -386,6 +386,20 @@ describe('SessionEventBus', () => {
       expect(events1).toHaveLength(1);
       expect(events2).toHaveLength(1);
     });
+
+    // #834: cleanupSession cancels pending emitEnded timeout
+    it('cleanupSession cancels pending emitEnded timeout — no stale deletion', () => {
+      const unsub = bus.subscribe('sess-1', () => {});
+      bus.emitEnded('sess-1', 'completed');
+      unsub();
+
+      // cleanupSession before the 1s timeout fires
+      bus.cleanupSession('sess-1');
+
+      // Advance well past the timeout — nothing should throw
+      vi.advanceTimersByTime(5000);
+      expect(bus.hasSubscribers('sess-1')).toBe(false);
+    });
   });
 
   // ── 5. subscribeGlobal ───────────────────────────────────────────────
@@ -687,6 +701,20 @@ describe('SessionEventBus', () => {
         bus.destroy();
         bus.destroy();
       }).not.toThrow();
+    });
+
+    // #834: destroy() cancels pending emitEnded setTimeout
+    it('destroy cancels pending emitEnded timeout — callback does not fire', () => {
+      const unsub = bus.subscribe('sess-1', () => {});
+      bus.emitEnded('sess-1', 'completed');
+      unsub();
+
+      // Destroy before the 1s timeout fires
+      bus.destroy();
+
+      // Advance well past the timeout — nothing should throw or error
+      vi.advanceTimersByTime(5000);
+      expect(bus.hasSubscribers('sess-1')).toBe(false);
     });
   });
 

--- a/src/__tests__/timer-tracking-834-835.test.ts
+++ b/src/__tests__/timer-tracking-834-835.test.ts
@@ -1,0 +1,193 @@
+/**
+ * timer-tracking-834-835.test.ts — Tests for issues #834 and #835.
+ *
+ * #834: emitEnded setTimeout is tracked and cancelled by cleanupSession/destroy.
+ * #835: Discovery timeout timers are tracked and cancelled by cleanupSession.
+ *
+ * For #834 we test SessionEventBus directly (public API).
+ * For #835 we test the discovery timeout logic via the guard patterns
+ * that the timers implement, and verify cleanup prevents stale callbacks.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionEventBus } from '../events.js';
+
+function flushAsync(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+// ── #834: SessionEventBus emitEnded timer tracking ────────────────────
+
+describe('#834: emitEnded setTimeout tracking', () => {
+  let bus: SessionEventBus;
+
+  beforeEach(() => {
+    bus = new SessionEventBus();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    bus.destroy();
+    vi.useRealTimers();
+  });
+
+  it('destroy() cancels emitEnded timeout — no error after timer would have fired', () => {
+    const unsub = bus.subscribe('sess-1', () => {});
+    bus.emitEnded('sess-1', 'completed');
+    unsub();
+
+    // Destroy before the 1s timeout fires
+    bus.destroy();
+
+    // Advance well past 1s — should not throw
+    expect(() => vi.advanceTimersByTime(5000)).not.toThrow();
+  });
+
+  it('cleanupSession() cancels emitEnded timeout — emitter not stale-deleted', () => {
+    const unsub = bus.subscribe('sess-1', () => {});
+    bus.emitEnded('sess-1', 'completed');
+    unsub();
+
+    // cleanupSession before timeout fires
+    bus.cleanupSession('sess-1');
+
+    // Now subscribe again — fresh emitter
+    const events: unknown[] = [];
+    const unsub2 = bus.subscribe('sess-1', (e) => events.push(e));
+
+    // Advance past the original 1s timeout
+    vi.advanceTimersByTime(5000);
+
+    // Fresh emitter should still be intact (not deleted by stale timeout)
+    bus.emitStatus('sess-1', 'working', 'after-cleanup');
+    vi.advanceTimersByTime(0);
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    unsub2();
+  });
+
+  it('multiple emitEnded timers are all cancelled on destroy', () => {
+    const unsub1 = bus.subscribe('sess-1', () => {});
+    const unsub2 = bus.subscribe('sess-2', () => {});
+    const unsub3 = bus.subscribe('sess-3', () => {});
+
+    bus.emitEnded('sess-1', 'done');
+    bus.emitEnded('sess-2', 'done');
+    bus.emitEnded('sess-3', 'done');
+    unsub1();
+    unsub2();
+    unsub3();
+
+    bus.destroy();
+
+    // Advance past all timeouts
+    expect(() => vi.advanceTimersByTime(10000)).not.toThrow();
+  });
+});
+
+// ── #835: Discovery timeout timer logic ───────────────────────────────
+
+describe('#835: Discovery timeout cleanup logic', () => {
+  it('cleanupSession should clear both poll timer and discovery timeout for regular discovery', () => {
+    // Simulate the logic: when cleanupSession is called with a session ID,
+    // it should clear both the interval (pollTimers) and the timeout (discoveryTimeouts)
+    // for both `id` and `fs-${id}` keys.
+
+    // We test the pattern: cleanupSession iterates [id, `fs-${id}`]
+    // and clears both pollTimers and discoveryTimeouts maps.
+    const pollTimers = new Map<string, NodeJS.Timeout>();
+    const discoveryTimeouts = new Map<string, NodeJS.Timeout>();
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    // Simulate startSessionIdDiscovery: creates interval + timeout
+    const interval = setInterval(() => {}, 2000);
+    const timeout = setTimeout(() => {}, 5 * 60 * 1000);
+    pollTimers.set('sess-1', interval);
+    discoveryTimeouts.set('sess-1', timeout);
+
+    // Simulate cleanupSession logic
+    for (const key of ['sess-1', 'fs-sess-1']) {
+      const t = pollTimers.get(key);
+      if (t) {
+        clearInterval(t);
+        pollTimers.delete(key);
+      }
+    }
+    for (const key of ['sess-1', 'fs-sess-1']) {
+      const t = discoveryTimeouts.get(key);
+      if (t) {
+        clearTimeout(t);
+        discoveryTimeouts.delete(key);
+      }
+    }
+
+    expect(pollTimers.has('sess-1')).toBe(false);
+    expect(discoveryTimeouts.has('sess-1')).toBe(false);
+
+    // Advance past the timeout — callback should NOT fire
+    // (cleared above, so this is safe)
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    vi.useRealTimers();
+  });
+
+  it('cleanupSession should clear filesystem discovery timers', () => {
+    const pollTimers = new Map<string, NodeJS.Timeout>();
+    const discoveryTimeouts = new Map<string, NodeJS.Timeout>();
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    // Simulate startFilesystemDiscovery: creates interval + timeout with fs- prefix
+    const interval = setInterval(() => {}, 3000);
+    const timeout = setTimeout(() => {}, 5 * 60 * 1000);
+    pollTimers.set('fs-sess-2', interval);
+    discoveryTimeouts.set('fs-sess-2', timeout);
+
+    // Simulate cleanupSession logic for id=sess-2
+    for (const key of ['sess-2', 'fs-sess-2']) {
+      const t = pollTimers.get(key);
+      if (t) {
+        clearInterval(t);
+        pollTimers.delete(key);
+      }
+    }
+    for (const key of ['sess-2', 'fs-sess-2']) {
+      const t = discoveryTimeouts.get(key);
+      if (t) {
+        clearTimeout(t);
+        discoveryTimeouts.delete(key);
+      }
+    }
+
+    expect(pollTimers.has('fs-sess-2')).toBe(false);
+    expect(discoveryTimeouts.has('fs-sess-2')).toBe(false);
+
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    vi.useRealTimers();
+  });
+
+  it('discovery timeout self-deletes from map when it fires (no cleanup needed)', () => {
+    const discoveryTimeouts = new Map<string, NodeJS.Timeout>();
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const timeout = setTimeout(() => {
+      discoveryTimeouts.delete('sess-3');
+    }, 5 * 60 * 1000);
+    discoveryTimeouts.set('sess-3', timeout);
+
+    // Before timeout fires, it's in the map
+    expect(discoveryTimeouts.has('sess-3')).toBe(true);
+
+    // Advance past timeout
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    // After timeout fires, it removes itself
+    expect(discoveryTimeouts.has('sess-3')).toBe(false);
+
+    clearTimeout(timeout);
+    vi.useRealTimers();
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -215,12 +215,15 @@ export class SessionEventBus {
     // Clean up after a short delay (let clients receive the event)
     // Capture reference — only delete if it's still the same emitter
     // #357: Also delete the per-session event buffer to prevent unbounded map growth
-    setTimeout(() => {
+    // #834: Track the timer so cleanupSession/destroy can cancel it
+    const timeout = setTimeout(() => {
+      this.pendingTimeouts.delete(timeout);
       if (this.emitters.get(sessionId) === emitter) {
         this.emitters.delete(sessionId);
       }
       this.eventBuffers.delete(sessionId);
     }, 1000);
+    this.pendingTimeouts.add(timeout);
   }
 
   /** Emit a stall event. */
@@ -273,6 +276,9 @@ export class SessionEventBus {
   /** #689: Pending setImmediate timers for cleanup on destroy. */
   private pendingTimers = new Set<NodeJS.Immediate>();
 
+  /** #834: Pending setTimeout timers for cleanup on destroy/cleanupSession. */
+  private pendingTimeouts = new Set<NodeJS.Timeout>();
+
   /** Subscribe to events from ALL sessions (new and existing). Returns unsubscribe function. */
   subscribeGlobal(handler: (event: GlobalSSEEvent) => void): () => void {
     if (!this.globalEmitter) {
@@ -315,6 +321,11 @@ export class SessionEventBus {
 
   /** #398: Clean up per-session state (call when session is killed). */
   cleanupSession(sessionId: string): void {
+    // #834: Clear pending setTimeout for this session's emitEnded cleanup
+    for (const timeout of this.pendingTimeouts) {
+      clearTimeout(timeout);
+      this.pendingTimeouts.delete(timeout);
+    }
     this.eventBuffers.delete(sessionId);
     const emitter = this.emitters.get(sessionId);
     if (emitter) {
@@ -330,6 +341,11 @@ export class SessionEventBus {
       clearImmediate(imm);
     }
     this.pendingTimers.clear();
+    // #834: Clear pending setTimeout timers
+    for (const timeout of this.pendingTimeouts) {
+      clearTimeout(timeout);
+    }
+    this.pendingTimeouts.clear();
     for (const emitter of this.emitters.values()) {
       emitter.removeAllListeners();
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -108,6 +108,8 @@ export class SessionManager {
   private stateFile: string;
   private sessionMapFile: string;
   private pollTimers: Map<string, NodeJS.Timeout> = new Map();
+  /** #835: Discovery timeout timers — cleared in cleanupSession to prevent orphan callbacks. */
+  private discoveryTimeouts: Map<string, NodeJS.Timeout> = new Map();
   private saveQueue: Promise<void> = Promise.resolve(); // #218: serialize concurrent saves
   private saveDebounceTimer: NodeJS.Timeout | null = null;
   private static readonly SAVE_DEBOUNCE_MS = 5_000; // #357: debounce offset-only saves
@@ -1345,6 +1347,15 @@ export class SessionManager {
       }
     }
 
+    // #835: Clear discovery timeout timers to prevent orphan callbacks
+    for (const key of [id, `fs-${id}`]) {
+      const timeout = this.discoveryTimeouts.get(key);
+      if (timeout) {
+        clearTimeout(timeout);
+        this.discoveryTimeouts.delete(key);
+      }
+    }
+
     this.cleanupPendingPermission(id);
     this.cleanupPendingQuestion(id);
     this.parsedEntriesCache.delete(id);
@@ -1498,7 +1509,9 @@ export class SessionManager {
     this.pollTimers.set(id, interval);
 
     // P3 fix: Stop after 5 minutes if not found, log timeout
-    setTimeout(() => {
+    // #835: Track the timeout so cleanupSession can cancel it
+    const discoveryTimeout = setTimeout(() => {
+      this.discoveryTimeouts.delete(id);
       const timer = this.pollTimers.get(id);
       const session = this.state.sessions[id];
       if (timer) {
@@ -1510,6 +1523,7 @@ export class SessionManager {
         }
       }
     }, 5 * 60 * 1000);
+    this.discoveryTimeouts.set(id, discoveryTimeout);
   }
 
   /** Issue #16: Filesystem-based discovery for --bare mode (no hooks).
@@ -1565,13 +1579,16 @@ export class SessionManager {
     this.pollTimers.set(`fs-${id}`, interval);
 
     // Timeout after 5 minutes
-    setTimeout(() => {
+    // #835: Track the timeout so cleanupSession can cancel it
+    const fsDiscoveryTimeout = setTimeout(() => {
+      this.discoveryTimeouts.delete(`fs-${id}`);
       const timer = this.pollTimers.get(`fs-${id}`);
       if (timer) {
         clearInterval(timer);
         this.pollTimers.delete(`fs-${id}`);
       }
     }, 5 * 60 * 1000);
+    this.discoveryTimeouts.set(`fs-${id}`, fsDiscoveryTimeout);
   }
 
   /** Sync CC session IDs from the hook-written session_map.json. */


### PR DESCRIPTION
## Summary
- Store emitEnded timer in event bus so cleanupSession()/destroy() can cancel it (#834)
- Store discovery timeout timers in session so cleanupSession() can cancel them (#835)
- Prevents orphan timers and memory leaks

Fixes #834, Fixes #835

## Test plan
- Added unit tests for timer tracking and cleanup