### PR TITLE
fix(security): prevent DNS rebinding SSRF in webhook delivery (#822)

### DIFF
--- a/src/__tests__/ssrf.test.ts
+++ b/src/__tests__/ssrf.test.ts
@@ -2,7 +2,7 @@
  * ssrf.test.ts — Tests for shared SSRF validation utility.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { isPrivateIP, validateWebhookUrl, resolveAndCheckIp } from '../ssrf.js';
+import { isPrivateIP, validateWebhookUrl, resolveAndCheckIp, buildConnectionUrl } from '../ssrf.js';
 import type { DnsLookupFn } from '../ssrf.js';
 
 // ── isPrivateIP ──────────────────────────────────────────────────────
@@ -333,5 +333,39 @@ describe('resolveAndCheckIp', () => {
     const result = await resolveAndCheckIp('safe.example.com', mockLookup);
     expect(result.error).toBeNull();
     expect(result.resolvedIp).toBe('::ffff:8.8.8.8');
+  });
+});
+
+// ── buildConnectionUrl ───────────────────────────────────────────────
+describe('buildConnectionUrl', () => {
+  it('substitutes IPv4 into URL and preserves host header', () => {
+    const { connectionUrl, hostHeader } = buildConnectionUrl('https://example.com/path', '93.184.216.34');
+    expect(connectionUrl).toBe('https://93.184.216.34/path');
+    expect(hostHeader).toBe('example.com');
+  });
+
+  it('preserves port in connection URL and host header', () => {
+    const { connectionUrl, hostHeader } = buildConnectionUrl('https://example.com:8443/hook', '1.2.3.4');
+    expect(connectionUrl).toBe('https://1.2.3.4:8443/hook');
+    expect(hostHeader).toBe('example.com:8443');
+  });
+
+  it('wraps IPv6 address in brackets', () => {
+    const { connectionUrl, hostHeader } = buildConnectionUrl('https://example.com/path', '2606:2800:220:1:248:1893:25c8:1946');
+    expect(connectionUrl).toBe('https://[2606:2800:220:1:248:1893:25c8:1946]/path');
+    expect(hostHeader).toBe('example.com');
+  });
+
+  it('preserves query string and fragment', () => {
+    const { connectionUrl, hostHeader } = buildConnectionUrl('https://example.com/path?q=1#frag', '10.0.0.1');
+    expect(connectionUrl).toContain('q=1');
+    expect(connectionUrl).toContain('#frag');
+    expect(hostHeader).toBe('example.com');
+  });
+
+  it('handles URL with no path', () => {
+    const { connectionUrl, hostHeader } = buildConnectionUrl('https://example.com', '1.2.3.4');
+    expect(connectionUrl).toBe('https://1.2.3.4/');
+    expect(hostHeader).toBe('example.com');
   });
 });

--- a/src/__tests__/webhook-dlq.test.ts
+++ b/src/__tests__/webhook-dlq.test.ts
@@ -6,6 +6,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WebhookChannel } from '../channels/webhook.js';
 import type { SessionEventPayload } from '../channels/types.js';
 
+// Mock SSRF DNS check (resolves to public IP so delivery proceeds)
+vi.mock('../ssrf.js', () => ({
+  validateWebhookUrl: vi.fn().mockReturnValue(null),
+  resolveAndCheckIp: vi.fn().mockResolvedValue({ error: null, resolvedIp: null }),
+  buildConnectionUrl: vi.fn(),
+}));
+
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 

--- a/src/__tests__/webhook-dns-rebinding.test.ts
+++ b/src/__tests__/webhook-dns-rebinding.test.ts
@@ -1,0 +1,200 @@
+/**
+ * webhook-dns-rebinding.test.ts — Tests for DNS rebinding protection in webhook delivery.
+ *
+ * Validates that deliverWithRetry resolves DNS before each fetch attempt
+ * and blocks delivery when DNS rebinding points to a private/internal IP.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SessionEventPayload } from '../channels/types.js';
+
+// Mock SSRF module — resolveAndCheckIp is forwarded to a controllable mock
+const mockResolveAndCheckIp = vi.fn();
+vi.mock('../ssrf.js', () => ({
+  validateWebhookUrl: vi.fn().mockReturnValue(null),
+  resolveAndCheckIp: (...args: unknown[]) => mockResolveAndCheckIp(...args),
+  buildConnectionUrl: (url: string, ip: string) => {
+    const parsed = new URL(url);
+    const originalHost = parsed.host;
+    parsed.hostname = ip;
+    return { connectionUrl: parsed.toString(), hostHeader: originalHost };
+  },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Import after mocks
+const { WebhookChannel } = await import('../channels/webhook.js');
+
+function makePayload(): SessionEventPayload {
+  return {
+    event: 'session.created',
+    timestamp: new Date().toISOString(),
+    session: { id: 'test-1', name: 'test', workDir: '/tmp' },
+    detail: 'test',
+  };
+}
+
+describe('WebhookChannel DNS rebinding protection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFetch.mockReset();
+    mockResolveAndCheckIp.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function flushTimers(promise: Promise<void>, iterations = 30): Promise<void> {
+    for (let i = 0; i < iterations; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    await promise;
+  }
+
+  it('resolves DNS and uses connection URL with IP substitution', async () => {
+    mockResolveAndCheckIp.mockResolvedValue({
+      error: null,
+      resolvedIp: '93.184.216.34',
+    });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const channel = new WebhookChannel({
+      endpoints: [{ url: 'https://example.com/hook', timeoutMs: 1000 }],
+    });
+
+    await channel.onSessionCreated(makePayload());
+
+    expect(mockResolveAndCheckIp).toHaveBeenCalledWith('example.com');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Fetch URL should contain the resolved IP
+    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    expect(fetchUrl).toContain('93.184.216.34');
+    // Host header should preserve original hostname
+    const fetchOpts = mockFetch.mock.calls[0][1] as RequestInit;
+    expect((fetchOpts.headers as Record<string, string>)['Host']).toBe('example.com');
+  });
+
+  it('blocks delivery when DNS resolves to private IP', async () => {
+    mockResolveAndCheckIp.mockResolvedValue({
+      error: 'DNS resolution points to a private/internal IP: 10.0.0.1',
+      resolvedIp: null,
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const channel = new WebhookChannel({
+      endpoints: [{ url: 'https://example.com/hook', timeoutMs: 1000 }],
+    });
+
+    const promise = channel.onSessionCreated(makePayload());
+    await flushTimers(promise);
+
+    // Fetch should never be called
+    expect(mockFetch).not.toHaveBeenCalled();
+    // DNS check retried MAX_RETRIES times
+    expect(mockResolveAndCheckIp).toHaveBeenCalledTimes(5);
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('detects DNS rebinding on retry: public then private', async () => {
+    // First attempt: DNS resolves to public IP but fetch fails (5xx)
+    mockResolveAndCheckIp.mockResolvedValueOnce({
+      error: null,
+      resolvedIp: '93.184.216.34',
+    });
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+
+    // Second attempt: DNS rebinds to private IP
+    mockResolveAndCheckIp.mockResolvedValueOnce({
+      error: 'DNS resolution points to a private/internal IP: 169.254.169.254',
+      resolvedIp: null,
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const channel = new WebhookChannel({
+      endpoints: [{ url: 'https://example.com/hook', timeoutMs: 1000 }],
+    });
+
+    const promise = channel.onSessionCreated(makePayload());
+    await flushTimers(promise);
+
+    // First fetch was called with the public IP
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    expect(fetchUrl).toContain('93.184.216.34');
+    // DNS checked at least twice: once before first fetch, once before second
+    expect(mockResolveAndCheckIp.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('skips DNS check for localhost (dev mode)', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const channel = new WebhookChannel({
+      endpoints: [{ url: 'http://127.0.0.1:3000/hook' }],
+    });
+
+    await channel.onSessionCreated(makePayload());
+
+    expect(mockResolveAndCheckIp).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe('http://127.0.0.1:3000/hook');
+  });
+
+  it('handles DNS failure gracefully', async () => {
+    mockResolveAndCheckIp.mockResolvedValue({
+      error: 'DNS resolution failed for example.com',
+      resolvedIp: null,
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const channel = new WebhookChannel({
+      endpoints: [{ url: 'https://example.com/hook', timeoutMs: 1000 }],
+    });
+
+    const promise = channel.onSessionCreated(makePayload());
+    await flushTimers(promise);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockResolveAndCheckIp).toHaveBeenCalledTimes(5);
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('re-resolves DNS on each retry attempt', async () => {
+    mockResolveAndCheckIp.mockResolvedValue({
+      error: null,
+      resolvedIp: '93.184.216.34',
+    });
+    mockFetch.mockResolvedValue({ ok: false, status: 503 } as Response);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const channel = new WebhookChannel({
+      endpoints: [{ url: 'https://example.com/hook', timeoutMs: 1000 }],
+    });
+
+    const promise = channel.onSessionCreated(makePayload());
+    await flushTimers(promise);
+
+    // DNS checked before each of the 5 fetch attempts
+    expect(mockResolveAndCheckIp).toHaveBeenCalledTimes(5);
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/__tests__/webhook-retry.test.ts
+++ b/src/__tests__/webhook-retry.test.ts
@@ -6,6 +6,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WebhookChannel } from '../channels/webhook.js';
 import type { SessionEventPayload } from '../channels/types.js';
 
+// Mock SSRF DNS check (resolves to public IP so delivery proceeds)
+vi.mock('../ssrf.js', () => ({
+  validateWebhookUrl: vi.fn().mockReturnValue(null),
+  resolveAndCheckIp: vi.fn().mockResolvedValue({ error: null, resolvedIp: null }),
+  buildConnectionUrl: vi.fn(),
+}));
+
 // Mock global fetch
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -11,7 +11,7 @@ import type {
   SessionEventPayload,
 } from './types.js';
 import { webhookEndpointSchema, getErrorMessage } from '../validation.js';
-import { validateWebhookUrl } from '../ssrf.js';
+import { validateWebhookUrl, resolveAndCheckIp, buildConnectionUrl } from '../ssrf.js';
 import { redactSecretsFromText } from '../utils/redact-headers.js';
 import { RetriableError } from './manager.js';
 
@@ -155,14 +155,42 @@ export class WebhookChannel implements Channel {
     maxRetries: number = WebhookChannel.MAX_RETRIES,
   ): Promise<void> {
     let lastError = '';
+    const hostname = new URL(ep.url).hostname;
+    const bareHost = hostname.replace(/^\[|\]$/g, '');
+
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        const res = await fetch(ep.url, {
+        // DNS rebinding protection: resolve and validate IP before each fetch.
+        // Skip for literal IPs (already validated at config time).
+        let fetchUrl = ep.url;
+        let headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          ...(ep.headers || {}),
+        };
+        if (bareHost !== '127.0.0.1' && bareHost !== '::1' && bareHost !== 'localhost') {
+          const dnsResult = await resolveAndCheckIp(bareHost);
+          if (dnsResult.error) {
+            lastError = dnsResult.error;
+            if (attempt < maxRetries) {
+              const delay = WebhookChannel.backoff(attempt);
+              console.warn(`Webhook ${ep.url} DNS check failed for ${event} (attempt ${attempt}/${maxRetries}): ${lastError}, retrying in ${Math.round(delay)}ms`);
+              await new Promise(r => setTimeout(r, delay));
+              continue;
+            }
+            console.error(`Webhook ${ep.url} DNS check failed after ${maxRetries} attempts for ${event}: ${lastError}`);
+            this.addToDeadLetterQueue(ep.url, event, lastError, maxRetries);
+            throw new RetriableError(lastError);
+          }
+          if (dnsResult.resolvedIp) {
+            const { connectionUrl, hostHeader } = buildConnectionUrl(ep.url, dnsResult.resolvedIp);
+            fetchUrl = connectionUrl;
+            headers['Host'] = hostHeader;
+          }
+        }
+
+        const res = await fetch(fetchUrl, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(ep.headers || {}),
-          },
+          headers,
           body,
           signal: AbortSignal.timeout(ep.timeoutMs || 5000),
         });

--- a/src/ssrf.ts
+++ b/src/ssrf.ts
@@ -217,6 +217,30 @@ export function buildHostResolverRule(hostname: string, resolvedIp: string): str
 }
 
 /**
+ * Build a connection URL where the hostname is replaced by the resolved IP address.
+ *
+ * This prevents DNS rebinding (TOCTOU) attacks in HTTP clients (like Node fetch)
+ * by ensuring the connection goes to the validated IP, not a re-resolved address.
+ * The original hostname is returned separately so callers can set the Host header.
+ *
+ * For IPv6 addresses, wraps the IP in brackets per RFC 2732.
+ *
+ * @param originalUrl - The original URL (e.g. "https://example.com/path")
+ * @param resolvedIp - The validated IP address to connect to
+ * @returns Object with the connection URL and the original hostname for Host header
+ */
+export function buildConnectionUrl(originalUrl: string, resolvedIp: string): { connectionUrl: string; hostHeader: string } {
+  const parsed = new URL(originalUrl);
+  const originalHost = parsed.host; // includes port if non-default
+  // IPv6 literals need brackets in URLs
+  const ipForUrl = parsed.hostname.startsWith('[') || resolvedIp.includes(':')
+    ? `[${resolvedIp}]`
+    : resolvedIp;
+  parsed.hostname = ipForUrl;
+  return { connectionUrl: parsed.toString(), hostHeader: originalHost };
+}
+
+/**
  * Validate a URL for the screenshot endpoint to prevent SSRF attacks.
  *
  * Checks:


### PR DESCRIPTION
## Summary

- Adds runtime DNS resolution check (`resolveAndCheckIp()`) before each `fetch()` attempt in webhook `deliverWithRetry()`, closing the DNS rebinding TOCTOU gap identified in #822
- New `buildConnectionUrl()` helper in `ssrf.ts` substitutes the validated IP into the connection URL while preserving the original hostname in the `Host` header — prevents the HTTP client from re-resolving DNS
- Screenshot endpoint already protected via Chromium `--host-resolver-rules` pinning — no changes needed
- 6 new unit tests covering DNS rebinding scenarios: IP substitution, private IP blocking, rebinding detection on retry, localhost bypass, DNS failure, per-attempt re-resolution

## Aegis version
**Developed with:** v2.5.2

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 1944 tests pass (86 files), including 6 new DNS rebinding tests
- [ ] Verify webhook delivery to external HTTPS endpoint still works (manual)
- [ ] Verify webhook to `http://127.0.0.1` (dev mode) still works without DNS check

Fixes #822