### PR TITLE
fix(security): check all DNS answers and verify TOCTOU-safe IP pinning

### DIFF
--- a/src/__tests__/screenshot-ssrf.test.ts
+++ b/src/__tests__/screenshot-ssrf.test.ts
@@ -64,20 +64,18 @@ describe('validateScreenshotUrl', () => {
 
 describe('resolveAndCheckIp (for screenshot URLs)', () => {
   it('returns error when DNS resolves to 10.x.x.x', async () => {
-    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
-      address: '10.0.0.1',
-      family: 4,
-    });
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '10.0.0.1', family: 4 },
+    ]);
     const result = await resolveAndCheckIp('internal.corp', mockLookup);
     expect(result.error).toContain('private/internal IP');
     expect(result.resolvedIp).toBeNull();
   });
 
   it('returns resolved IP when DNS resolves to public IP', async () => {
-    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
-      address: '93.184.216.34',
-      family: 4,
-    });
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+    ]);
     const result = await resolveAndCheckIp('example.com', mockLookup);
     expect(result.error).toBeNull();
     expect(result.resolvedIp).toBe('93.184.216.34');
@@ -104,6 +102,18 @@ describe('resolveAndCheckIp (for screenshot URLs)', () => {
     const mockLookup: DnsLookupFn = vi.fn().mockRejectedValue(new Error('ENOTFOUND'));
     const result = await resolveAndCheckIp('nonexistent.example', mockLookup);
     expect(result.error).toContain('DNS resolution failed');
+    expect(result.resolvedIp).toBeNull();
+  });
+
+  // ── Multi-answer DNS SSRF bypass prevention (issue #831) ─────────
+  it('rejects when DNS returns public + private addresses (SSRF bypass)', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+    ]);
+    const result = await resolveAndCheckIp('attacker.com', mockLookup);
+    expect(result.error).toContain('private/internal IP');
+    expect(result.error).toContain('169.254.169.254');
     expect(result.resolvedIp).toBeNull();
   });
 });

--- a/src/__tests__/ssrf.test.ts
+++ b/src/__tests__/ssrf.test.ts
@@ -272,20 +272,18 @@ describe('validateWebhookUrl', () => {
 // ── resolveAndCheckIp ───────────────────────────────────────────────
 describe('resolveAndCheckIp', () => {
   it('returns error when DNS resolves to private IP', async () => {
-    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
-      address: '10.0.0.1',
-      family: 4,
-    });
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '10.0.0.1', family: 4 },
+    ]);
     const result = await resolveAndCheckIp('internal.corp', mockLookup);
     expect(result.error).toBe('DNS resolution points to a private/internal IP: 10.0.0.1');
     expect(result.resolvedIp).toBeNull();
   });
 
   it('returns resolved IP when DNS resolves to public IP', async () => {
-    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
-      address: '93.184.216.34',
-      family: 4,
-    });
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+    ]);
     const result = await resolveAndCheckIp('example.com', mockLookup);
     expect(result.error).toBeNull();
     expect(result.resolvedIp).toBe('93.184.216.34');
@@ -316,23 +314,80 @@ describe('resolveAndCheckIp', () => {
   });
 
   it('returns error when DNS resolves to IPv4-mapped private IPv6', async () => {
-    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
-      address: '::ffff:10.0.0.1',
-      family: 6,
-    });
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '::ffff:10.0.0.1', family: 6 },
+    ]);
     const result = await resolveAndCheckIp('evil.corp', mockLookup);
     expect(result.error).toBe('DNS resolution points to a private/internal IP: ::ffff:10.0.0.1');
     expect(result.resolvedIp).toBeNull();
   });
 
-  it('returns null when DNS resolves to IPv4-mapped public IPv6', async () => {
-    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue({
-      address: '::ffff:8.8.8.8',
-      family: 6,
-    });
+  it('returns resolved IP when DNS resolves to IPv4-mapped public IPv6', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '::ffff:8.8.8.8', family: 6 },
+    ]);
     const result = await resolveAndCheckIp('safe.example.com', mockLookup);
     expect(result.error).toBeNull();
     expect(result.resolvedIp).toBe('::ffff:8.8.8.8');
+  });
+
+  // ── Multi-answer DNS (issue #831) ──────────────────────────────────
+  it('returns first resolved IP when all DNS answers are public', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '93.184.216.35', family: 4 },
+    ]);
+    const result = await resolveAndCheckIp('cdn.example.com', mockLookup);
+    expect(result.error).toBeNull();
+    expect(result.resolvedIp).toBe('93.184.216.34');
+  });
+
+  it('rejects when first DNS answer is public but second is private (SSRF bypass)', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '127.0.0.1', family: 4 },
+    ]);
+    const result = await resolveAndCheckIp('evil-dual.corp', mockLookup);
+    expect(result.error).toBe('DNS resolution points to a private/internal IP: 127.0.0.1');
+    expect(result.resolvedIp).toBeNull();
+  });
+
+  it('rejects when first DNS answer is private even if second is public', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '10.0.0.1', family: 4 },
+      { address: '93.184.216.34', family: 4 },
+    ]);
+    const result = await resolveAndCheckIp('evil-first.corp', mockLookup);
+    expect(result.error).toBe('DNS resolution points to a private/internal IP: 10.0.0.1');
+    expect(result.resolvedIp).toBeNull();
+  });
+
+  it('rejects when all DNS answers are private', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '10.0.0.1', family: 4 },
+      { address: '192.168.1.1', family: 4 },
+      { address: '172.16.0.1', family: 4 },
+    ]);
+    const result = await resolveAndCheckIp('all-internal.corp', mockLookup);
+    expect(result.error).toBe('DNS resolution points to a private/internal IP: 10.0.0.1');
+    expect(result.resolvedIp).toBeNull();
+  });
+
+  it('returns error when DNS returns empty answer list', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([]);
+    const result = await resolveAndCheckIp('empty.example.com', mockLookup);
+    expect(result.error).toBe('DNS resolution returned no addresses for empty.example.com');
+    expect(result.resolvedIp).toBeNull();
+  });
+
+  it('rejects when mixed IPv4 public + IPv6 private in multi-answer', async () => {
+    const mockLookup: DnsLookupFn = vi.fn().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '::ffff:127.0.0.1', family: 6 },
+    ]);
+    const result = await resolveAndCheckIp('mixed-evil.corp', mockLookup);
+    expect(result.error).toBe('DNS resolution points to a private/internal IP: ::ffff:127.0.0.1');
+    expect(result.resolvedIp).toBeNull();
   });
 });
 

--- a/src/ssrf.ts
+++ b/src/ssrf.ts
@@ -152,11 +152,11 @@ export interface DnsLookupResult {
   family: number;
 }
 
-/** DNS lookup function type for dependency injection. */
-export type DnsLookupFn = (hostname: string) => Promise<DnsLookupResult>;
+/** DNS lookup function type for dependency injection. Returns ALL addresses. */
+export type DnsLookupFn = (hostname: string) => Promise<DnsLookupResult[]>;
 
-/** Default DNS lookup using node:dns/promises. */
-const defaultLookup: DnsLookupFn = (hostname: string) => dns.lookup(hostname);
+/** Default DNS lookup using node:dns/promises with { all: true } to resolve all addresses. */
+const defaultLookup: DnsLookupFn = (hostname: string) => dns.lookup(hostname, { all: true });
 
 /**
  * Result of DNS resolution with SSRF check.
@@ -192,11 +192,22 @@ export async function resolveAndCheckIp(
   }
 
   try {
-    const result = await lookupFn(hostname);
-    if (isPrivateIP(result.address)) {
-      return { error: `DNS resolution points to a private/internal IP: ${result.address}`, resolvedIp: null };
+    const results = await lookupFn(hostname);
+    if (results.length === 0) {
+      return { error: `DNS resolution returned no addresses for ${hostname}`, resolvedIp: null };
     }
-    return { error: null, resolvedIp: result.address };
+
+    // Check ALL resolved addresses — reject if ANY is private/internal.
+    // An attacker can configure DNS to return both public and private IPs;
+    // the HTTP client may connect to any of them.
+    for (const result of results) {
+      if (isPrivateIP(result.address)) {
+        return { error: `DNS resolution points to a private/internal IP: ${result.address}`, resolvedIp: null };
+      }
+    }
+
+    // All addresses safe — return first for TOCTOU-safe pinning via --host-resolver-rules.
+    return { error: null, resolvedIp: results[0].address };
   } catch { /* DNS lookup failed — treat as unsafe */
     return { error: `DNS resolution failed for ${hostname}`, resolvedIp: null };
   }


### PR DESCRIPTION
## Summary

- **Issue #831**: `resolveAndCheckIp()` now uses `dns.lookup({ all: true })` to resolve ALL DNS answers instead of only the first. If ANY answer resolves to a private/internal IP, the request is rejected. Prevents SSRF bypass via multi-answer DNS (safe IP first, malicious IP second).
- **Issue #829**: Verified the existing `--host-resolver-rules` pinning flow is correct — the validated IP from `resolveAndCheckIp` is atomically pinned to Chromium via `MAP hostname ip`. The multi-answer fix strengthens this by ensuring no unsafe IP slips through unchecked.

## Changes

- `src/ssrf.ts`: Changed `DnsLookupFn` to return `DnsLookupResult[]`, updated `defaultLookup` to use `dns.lookup(hostname, { all: true })`, iterated ALL DNS answers in `resolveAndCheckIp`
- `src/__tests__/ssrf.test.ts`: Updated mocks to return arrays, added 6 new tests for multi-answer DNS scenarios
- `src/__tests__/screenshot-ssrf.test.ts`: Updated mocks, added multi-answer SSRF bypass test

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 1940 passed, 0 failures
- [x] New tests cover: all public multi-answer, public+private mix, all private, empty results, mixed IPv4/IPv6

Closes #829, Closes #831

## Aegis version
**Developed with:** v2.5.2