### PR TITLE
fix: correctly report sendMessage delivery failures without masking

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -947,8 +947,14 @@ export class SessionManager {
     if (!session) throw new Error(`Session ${id} not found`);
 
     const result = await this.tmux.sendKeysVerified(session.windowId, text);
-    session.lastActivity = Date.now();
-    await this.save();
+    if (result.delivered) {
+      session.lastActivity = Date.now();
+      try {
+        await this.save();
+      } catch {
+        // Message was delivered — don't let a save failure mask the success
+      }
+    }
     return result;
   }
 
@@ -968,8 +974,14 @@ export class SessionManager {
 
     // Issue #285: Use verified sending with retry for reliability
     const result = await this.tmux.sendKeysVerified(session.windowId, text, 3);
-    session.lastActivity = Date.now();
-    await this.save();
+    if (result.delivered) {
+      session.lastActivity = Date.now();
+      try {
+        await this.save();
+      } catch {
+        // Message was delivered — don't let a save failure mask the success
+      }
+    }
     return result;
   }
 


### PR DESCRIPTION
## Summary

- **P1 bug fix**: `sendMessage` and `sendMessageDirect` in `src/session.ts` masked delivery failures by unconditionally updating `lastActivity` and calling `save()` even when `sendKeysVerified` returned `{ delivered: false }`
- Only update `lastActivity` and persist state when delivery actually succeeded
- Wrap `save()` in try/catch so a persistence failure after a successful send doesn't throw an error that hides the successful delivery from the caller

## Bug report

Severity P1 — `sendMessage` delivery masking in `src/session.ts` (lines 930-933, 951-953).

Two issues:
1. **Delivery failure masked**: `lastActivity` was updated and saved even when `sendKeysVerified` returned `{ delivered: false }`, making failed deliveries look successful
2. **Save failure overwrites success**: if `save()` threw after a successful send, the caller got an error despite the message being delivered

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 1933 passed, 14 skipped (85 files)
- [ ] Manual: verify `{ delivered: false }` is returned without updating `lastActivity` when tmux delivery fails
- [ ] Manual: verify message delivery succeeds even if `save()` throws

## Aegis version
**Developed with:** v2.5.2

Generated by Hephaestus (Aegis dev agent)