### PR TITLE
fix(security): cap per-IP rate-limit map at 10k entries (#844)

### DIFF
--- a/src/__tests__/memory-leaks-398-424-511.test.ts
+++ b/src/__tests__/memory-leaks-398-424-511.test.ts
@@ -4,6 +4,7 @@
  * #398: Event buffer cleanup + AuthManager rate limit sweep
  * #424: parsedEntriesCache eviction (sliding window cap)
  * #511: Monitor debounce timer ghost callbacks guard
+ * #844: Per-IP rate-limit map cap (LRU eviction at 10k entries)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -227,5 +228,116 @@ describe('#511: Monitor debounce ghost callback guard', () => {
     await new Promise(resolve => setTimeout(resolve, 50));
 
     expect(broadcastCalled).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #844: Per-IP rate-limit map cap (evict oldest when >10k entries)
+// ---------------------------------------------------------------------------
+
+describe('#844: IP rate-limit map cap', () => {
+  // Replicate the eviction logic from server.ts inline (same pattern as #424 tests)
+  const MAX_IP_ENTRIES = 10;
+
+  it('evicts the IP with the oldest last-seen timestamp when cap exceeded', () => {
+    const ipMap = new Map<string, number[]>(); // ip → timestamps
+    let now = 1000;
+
+    // Fill to cap
+    for (let i = 0; i < MAX_IP_ENTRIES; i++) {
+      ipMap.set(`ip-${i}`, [now++]);
+    }
+    expect(ipMap.size).toBe(MAX_IP_ENTRIES);
+
+    // Add one more — should trigger eviction of ip-0 (oldest)
+    ipMap.set('ip-new', [now++]);
+    if (ipMap.size > MAX_IP_ENTRIES) {
+      let oldestIp = '';
+      let oldestTime = Infinity;
+      for (const [ip, timestamps] of ipMap) {
+        const last = timestamps[timestamps.length - 1]!;
+        if (last < oldestTime) {
+          oldestTime = last;
+          oldestIp = ip;
+        }
+      }
+      if (oldestIp) ipMap.delete(oldestIp);
+    }
+
+    expect(ipMap.size).toBe(MAX_IP_ENTRIES);
+    expect(ipMap.has('ip-0')).toBe(false); // oldest evicted
+    expect(ipMap.has('ip-new')).toBe(true);
+  });
+
+  it('does not evict when map is at or below cap', () => {
+    const ipMap = new Map<string, number[]>();
+    for (let i = 0; i < MAX_IP_ENTRIES; i++) {
+      ipMap.set(`ip-${i}`, [Date.now()]);
+    }
+    expect(ipMap.size).toBe(MAX_IP_ENTRIES);
+    // No eviction at exact cap
+    if (ipMap.size > MAX_IP_ENTRIES) {
+      // would evict — but shouldn't reach here
+      throw new Error('Should not evict at cap');
+    }
+    expect(ipMap.size).toBe(MAX_IP_ENTRIES);
+  });
+
+  it('evicts oldest across multiple overflows', () => {
+    const ipMap = new Map<string, number[]>();
+    let now = 1000;
+
+    // Add 30 entries with cap of 10 — should keep only 10 newest
+    for (let i = 0; i < 30; i++) {
+      ipMap.set(`ip-${i}`, [now++]);
+      if (ipMap.size > MAX_IP_ENTRIES) {
+        let oldestIp = '';
+        let oldestTime = Infinity;
+        for (const [ip, timestamps] of ipMap) {
+          const last = timestamps[timestamps.length - 1]!;
+          if (last < oldestTime) {
+            oldestTime = last;
+            oldestIp = ip;
+          }
+        }
+        if (oldestIp) ipMap.delete(oldestIp);
+      }
+    }
+
+    expect(ipMap.size).toBe(MAX_IP_ENTRIES);
+    // Oldest 20 should be evicted, newest 10 remain
+    expect(ipMap.has('ip-0')).toBe(false);
+    expect(ipMap.has('ip-19')).toBe(false);
+    expect(ipMap.has('ip-20')).toBe(true);
+    expect(ipMap.has('ip-29')).toBe(true);
+  });
+
+  it('preserves recently-accessed IPs over stale ones', () => {
+    const ipMap = new Map<string, number[]>();
+    // Fill to cap
+    for (let i = 0; i < MAX_IP_ENTRIES; i++) {
+      ipMap.set(`ip-${i}`, [1000 + i]); // older timestamps
+    }
+    // Touch ip-0 to make it recent
+    ipMap.set('ip-0', [9999]);
+
+    // Overflow
+    ipMap.set('ip-new', [10000]);
+    if (ipMap.size > MAX_IP_ENTRIES) {
+      let oldestIp = '';
+      let oldestTime = Infinity;
+      for (const [ip, timestamps] of ipMap) {
+        const last = timestamps[timestamps.length - 1]!;
+        if (last < oldestTime) {
+          oldestTime = last;
+          oldestIp = ip;
+        }
+      }
+      if (oldestIp) ipMap.delete(oldestIp);
+    }
+
+    expect(ipMap.has('ip-0')).toBe(true); // recently touched — preserved
+    expect(ipMap.has('ip-1')).toBe(false); // oldest untouched — evicted
+    expect(ipMap.has('ip-new')).toBe(true);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,6 +153,7 @@ const ipRateLimits = new Map<string, IpRateBucket>();
 const IP_WINDOW_MS = 60_000;
 const IP_LIMIT_NORMAL = 120;   // per minute for regular keys
 const IP_LIMIT_MASTER = 300;   // per minute for master token
+const MAX_IP_ENTRIES = 10_000; // #844: Cap tracked IPs to prevent memory exhaustion
 
 function checkIpRateLimit(ip: string, isMaster: boolean): boolean {
   const now = Date.now();
@@ -169,6 +170,19 @@ function checkIpRateLimit(ip: string, isMaster: boolean): boolean {
   }
   bucket.entries.push(now);
   ipRateLimits.set(ip, bucket);
+  // #844: Evict oldest IPs when map exceeds cap to prevent unbounded memory growth
+  if (ipRateLimits.size > MAX_IP_ENTRIES) {
+    let oldestIp = '';
+    let oldestTime = Infinity;
+    for (const [trackedIp, trackedBucket] of ipRateLimits) {
+      const lastTs = trackedBucket.entries[trackedBucket.entries.length - 1];
+      if (lastTs !== undefined && lastTs < oldestTime) {
+        oldestTime = lastTs;
+        oldestIp = trackedIp;
+      }
+    }
+    if (oldestIp) ipRateLimits.delete(oldestIp);
+  }
   const activeCount = bucket.entries.length - bucket.start;
   const limit = isMaster ? IP_LIMIT_MASTER : IP_LIMIT_NORMAL;
   return activeCount > limit;


### PR DESCRIPTION
## Summary
- The `ipRateLimits` Map in `server.ts` grew without bound as unique client IPs were tracked for per-IP rate limiting
- Under a distributed attack or high-traffic scenario with many unique IPs, this could exhaust server memory and crash the process
- Added a `MAX_IP_ENTRIES = 10,000` cap — when exceeded, the IP with the oldest last-seen timestamp is evicted (preserving recently-active entries)

## Changes
- `src/server.ts`: Added `MAX_IP_ENTRIES` constant and eviction logic in `checkIpRateLimit()` that removes the stalest IP when the cap is breached
- `src/__tests__/memory-leaks-398-424-511.test.ts`: Added test suite for #844 covering eviction at cap, preservation of recently-accessed IPs, and multi-overflow behavior

Closes #844

## Aegis version
**Developed with:** v2.5.2

Generated by Hephaestus (Aegis dev agent)