### PR TITLE
fix(security): redact session metadata from webhook payloads

### DIFF
--- a/src/__tests__/webhook-retry.test.ts
+++ b/src/__tests__/webhook-retry.test.ts
@@ -132,9 +132,13 @@ describe('Webhook delivery with retry', () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.api).toBeDefined();
-    expect(body.api.read).toContain('test-123');
-    expect(body.api.send).toContain('test-123');
-    expect(body.api.kill).toContain('test-123');
+    // Issue #827: session IDs are redacted from webhook payloads
+    expect(body.api.read).toBe('GET /sessions/[REDACTED]/read');
+    expect(body.api.send).toBe('POST /sessions/[REDACTED]/send');
+    expect(body.api.kill).toBe('DELETE /sessions/[REDACTED]');
+    expect(body.session.id).toBe('[REDACTED]');
+    expect(body.session.name).toBe('[REDACTED]');
+    expect(body.session.workDir).toBe('[REDACTED]');
   });
 
   it('should skip endpoint if event filter does not match', async () => {
@@ -183,7 +187,10 @@ describe('Webhook delivery with retry', () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.event).toBe('status.permission');
-    expect(body.session.id).toBe('test-123');
+    // Issue #827: session metadata is redacted
+    expect(body.session.id).toBe('[REDACTED]');
+    expect(body.session.name).toBe('[REDACTED]');
+    expect(body.session.workDir).toBe('[REDACTED]');
   });
 
   it('should have correct MAX_RETRIES constant', () => {

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -117,15 +117,28 @@ export class WebhookChannel implements Channel {
     return base * (0.5 + Math.random() * 0.5);
   }
 
-  private async fire(payload: SessionEventPayload): Promise<void> {
-    const body = JSON.stringify({
-      ...payload,
-      api: {
-        read: `GET /sessions/${payload.session.id}/read`,
-        send: `POST /sessions/${payload.session.id}/send`,
-        kill: `DELETE /sessions/${payload.session.id}`,
+  /** Redact sensitive session metadata from webhook payloads. */
+  private static redactPayload(
+    payload: SessionEventPayload,
+  ): Record<string, unknown> {
+    const { session, ...rest } = payload;
+    return {
+      ...rest,
+      session: {
+        id: '[REDACTED]',
+        name: '[REDACTED]',
+        workDir: '[REDACTED]',
       },
-    });
+      api: {
+        read: 'GET /sessions/[REDACTED]/read',
+        send: 'POST /sessions/[REDACTED]/send',
+        kill: 'DELETE /sessions/[REDACTED]',
+      },
+    };
+  }
+
+  private async fire(payload: SessionEventPayload): Promise<void> {
+    const body = JSON.stringify(WebhookChannel.redactPayload(payload));
 
     const promises = this.endpoints.map(async ep => {
       // Skip if endpoint filters and this event isn't in the list


### PR DESCRIPTION
## Summary

- Redact `session.id`, `session.name`, and `session.workDir` from outgoing webhook payloads by replacing with `[REDACTED]`
- Redact session ID from `api` links (`read`, `send`, `kill`) in webhook body
- Extract redaction into a static `redactPayload()` method for testability

Fixes #827

## Context

Issue #613 previously addressed webhook header leakage in error logs, but the core payload body at `src/channels/webhook.ts:119-127` still spread the full `SessionEventPayload` (including `session.id`, `session.name`, `session.workDir`) verbatim to all configured webhook endpoints.

## Aegis version
**Developed with:** v2.5.2

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (1933 tests, 0 failures)
- [x] Existing webhook tests updated to verify redaction
- [ ] Manual: send a webhook and verify payload body contains `[REDACTED]` for all session fields

Generated by Hephaestus (Aegis dev agent)