### PR TITLE
fix(security): add mutex to validateSSEToken to prevent double-decrement race

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -210,21 +210,21 @@ describe('SSE Token Management (Issue #297)', () => {
   describe('Token validation', () => {
     it('should validate a fresh SSE token', async () => {
       const { token } = await auth.generateSSEToken('master');
-      expect(auth.validateSSEToken(token)).toBe(true);
+      expect(await auth.validateSSEToken(token)).toBe(true);
     });
 
-    it('should reject unknown tokens', () => {
-      expect(auth.validateSSEToken('sse_nonexistent')).toBe(false);
+    it('should reject unknown tokens', async () => {
+      expect(await auth.validateSSEToken('sse_nonexistent')).toBe(false);
     });
 
-    it('should reject tokens without sse_ prefix', () => {
-      expect(auth.validateSSEToken('random-string')).toBe(false);
+    it('should reject tokens without sse_ prefix', async () => {
+      expect(await auth.validateSSEToken('random-string')).toBe(false);
     });
 
     it('should be single-use — second validation fails', async () => {
       const { token } = await auth.generateSSEToken('master');
-      expect(auth.validateSSEToken(token)).toBe(true);
-      expect(auth.validateSSEToken(token)).toBe(false);
+      expect(await auth.validateSSEToken(token)).toBe(true);
+      expect(await auth.validateSSEToken(token)).toBe(false);
     });
 
     it('should reject expired tokens', async () => {
@@ -233,9 +233,9 @@ describe('SSE Token Management (Issue #297)', () => {
       // We test expiry indirectly by generating a token and verifying
       // that only fresh tokens validate. Direct time manipulation would
       // require mocking Date.now which is fragile.
-      expect(auth.validateSSEToken(token)).toBe(true);
+      expect(await auth.validateSSEToken(token)).toBe(true);
       // Token was consumed, so a second call fails
-      expect(auth.validateSSEToken(token)).toBe(false);
+      expect(await auth.validateSSEToken(token)).toBe(false);
     });
   });
 
@@ -260,7 +260,7 @@ describe('SSE Token Management (Issue #297)', () => {
         tokens.push((await auth.generateSSEToken('master')).token);
       }
       // Consume one
-      auth.validateSSEToken(tokens[0]);
+      await auth.validateSSEToken(tokens[0]);
       // Should be able to generate another
       const newToken = await auth.generateSSEToken('master');
       expect(newToken.token).toBeTruthy();
@@ -313,6 +313,61 @@ describe('SSE Token Management (Issue #297)', () => {
 
       // Limit should still be enforced despite the rejected mutex
       await expect(auth.generateSSEToken('master')).rejects.toThrow(/limit reached/);
+    });
+  });
+
+  describe('Concurrent validation race (#826)', () => {
+    it('should not double-decrement when validating concurrently with generation', async () => {
+      // Generate 3 tokens for the same key
+      const tokens = await Promise.all([
+        auth.generateSSEToken('key-A'),
+        auth.generateSSEToken('key-A'),
+        auth.generateSSEToken('key-A'),
+      ]);
+
+      // Fire concurrent validations and a generation — the generation
+      // must see the correct count after validations complete
+      const results = await Promise.all([
+        auth.validateSSEToken(tokens[0].token),
+        auth.validateSSEToken(tokens[1].token),
+        // This generation must succeed: 2 tokens consumed → count = 1, room for more
+        auth.generateSSEToken('key-A'),
+      ]);
+
+      expect(results[0]).toBe(true);
+      expect(results[1]).toBe(true);
+      // The generation should succeed without hitting the limit
+      expect(results[2].token).toBeTruthy();
+
+      // After consuming 2 + generating 1: outstanding = 2 (tokens[2] + new one)
+      // Should still allow up to 3 more (limit is 5)
+      for (let i = 0; i < 3; i++) {
+        const t = await auth.generateSSEToken('key-A');
+        expect(t.token).toBeTruthy();
+      }
+      // 6th token total should fail (5 outstanding: tokens[2] + 4 new)
+      await expect(auth.generateSSEToken('key-A')).rejects.toThrow(/limit reached/);
+    });
+
+    it('should not double-decrement the same token under concurrent validation', async () => {
+      const { token } = await auth.generateSSEToken('key-A');
+
+      // Fire 5 concurrent validations of the SAME token
+      // Only one should succeed; the mutex ensures single-use semantics
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () => auth.validateSSEToken(token))
+      );
+
+      const successCount = results.filter(Boolean).length;
+      expect(successCount).toBe(1);
+
+      // Count should be 0 — the single token was consumed once
+      // Verify by generating up to 5 new tokens (should all succeed)
+      for (let i = 0; i < 5; i++) {
+        const t = await auth.generateSSEToken('key-A');
+        expect(t.token).toBeTruthy();
+      }
+      await expect(auth.generateSSEToken('key-A')).rejects.toThrow(/limit reached/);
     });
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -259,38 +259,52 @@ export class AuthManager {
   /**
    * Validate and consume a short-lived SSE token.
    * Returns true if valid (and marks it as used), false otherwise.
-   * Also cleans up expired tokens as a side effect.
+   * #826: Async with mutex to prevent concurrent validation/generation from
+   * racing on shared state (sseTokens, sseTokenCounts).
    */
-  validateSSEToken(token: string): boolean {
-    const entry = this.sseTokens.get(token);
-    if (!entry) return false;
+  async validateSSEToken(token: string): Promise<boolean> {
+    // Acquire mutex — chain onto the previous operation
+    let release: () => void = () => {};
+    const lock = new Promise<void>((resolve) => { release = resolve; });
+    const previous = this.sseMutex;
+    this.sseMutex = lock;
 
-    // Already used
-    if (entry.used) {
-      this.sseTokens.delete(token);
-      return false;
-    }
+    // #573: catch prior rejection so it doesn't propagate and block subsequent callers
+    try {
+      await previous.catch(() => {});
 
-    // Expired
-    if (Date.now() > entry.expiresAt) {
-      this.sseTokens.delete(token);
-      return false;
-    }
+      const entry = this.sseTokens.get(token);
+      if (!entry) return false;
 
-    // Valid — consume it
-    entry.used = true;
-    const keyId = entry.keyId;
-    this.sseTokens.delete(token);
-    // #357: Decrement outstanding count so generateSSEToken doesn't over-limit
-    const count = this.sseTokenCounts.get(keyId);
-    if (count !== undefined) {
-      if (count <= 1) {
-        this.sseTokenCounts.delete(keyId);
-      } else {
-        this.sseTokenCounts.set(keyId, count - 1);
+      // Already used
+      if (entry.used) {
+        this.sseTokens.delete(token);
+        return false;
       }
+
+      // Expired
+      if (Date.now() > entry.expiresAt) {
+        this.sseTokens.delete(token);
+        return false;
+      }
+
+      // Valid — consume it
+      entry.used = true;
+      const keyId = entry.keyId;
+      this.sseTokens.delete(token);
+      // #357: Decrement outstanding count so generateSSEToken doesn't over-limit
+      const count = this.sseTokenCounts.get(keyId);
+      if (count !== undefined) {
+        if (count <= 1) {
+          this.sseTokenCounts.delete(keyId);
+        } else {
+          this.sseTokenCounts.set(keyId, count - 1);
+        }
+      }
+      return true;
+    } finally {
+      release();
     }
-    return true;
   }
 
   /** Remove expired SSE tokens and recount per-key outstanding. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -258,7 +258,7 @@ function setupAuth(authManager: AuthManager): void {
 
     // #297: Check if this is a short-lived SSE token first
     if (isSSERoute && token.startsWith('sse_')) {
-      if (authManager.validateSSEToken(token)) {
+      if (await authManager.validateSSEToken(token)) {
         return; // authenticated via short-lived SSE token
       }
       return reply.status(401).send({ error: 'Unauthorized — SSE token invalid or expired' });


### PR DESCRIPTION
Fixes #826

## Summary

- `validateSSEToken` modified shared state (`sseTokens`, `sseTokenCounts`) without holding the `sseMutex`, allowing concurrent validation to double-decrement per-key token counts
- Made `validateSSEToken` async and acquire the same promise-chain mutex used by `generateSSEToken`, ensuring atomic read-modify-write on shared state
- Updated `server.ts` call site to `await` the now-async method
- Added two tests for concurrent validation race scenarios

## Changes

| File | Change |
|------|--------|
| `src/auth.ts` | `validateSSEToken` → async, acquires `sseMutex` with try/finally |
| `src/server.ts` | `await authManager.validateSSEToken(token)` |
| `src/__tests__/auth.test.ts` | All calls updated to `await`, 2 new concurrent validation tests |

## Quality gate

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npm test` ✅ (1935 passed, 14 skipped)

## Aegis version
**Developed with:** v2.5.2

Generated by Hephaestus (Aegis dev agent)