### PR TITLE
fix(security): cap tracked IPs in rate limiter to prevent memory exhaustion

### DIFF
--- a/src/__tests__/ip-rate-limiter.test.ts
+++ b/src/__tests__/ip-rate-limiter.test.ts
@@ -1,0 +1,172 @@
+/**
+ * ip-rate-limiter.test.ts — Tests for Issue #844: max-IP cap on ipRateLimits map.
+ *
+ * Also covers the core per-IP rate limiting logic (#228, #622) extracted from server.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IpRateLimiter, MAX_TRACKED_IPS, IP_LIMIT_NORMAL, IP_LIMIT_MASTER, IP_WINDOW_MS } from '../ip-rate-limiter.js';
+
+describe('IpRateLimiter', () => {
+  let limiter: IpRateLimiter;
+
+  beforeEach(() => {
+    limiter = new IpRateLimiter();
+  });
+
+  // ── Core rate limiting (#228, #622) ──────────────────────────────────
+  describe('basic rate limiting', () => {
+    it('allows requests under the limit', () => {
+      for (let i = 0; i < IP_LIMIT_NORMAL; i++) {
+        expect(limiter.check('1.2.3.4', false)).toBe(false);
+      }
+    });
+
+    it('blocks requests over the normal limit', () => {
+      for (let i = 0; i < IP_LIMIT_NORMAL; i++) {
+        limiter.check('1.2.3.4', false);
+      }
+      expect(limiter.check('1.2.3.4', false)).toBe(true);
+    });
+
+    it('allows higher limit for master token', () => {
+      for (let i = 0; i < IP_LIMIT_NORMAL; i++) {
+        limiter.check('1.2.3.4', true);
+      }
+      // Normal limit would block, but master has higher limit
+      expect(limiter.check('1.2.3.4', false)).toBe(true); // normal limit exceeded
+      expect(limiter.check('1.2.3.4', true)).toBe(false);  // master limit not yet reached
+    });
+
+    it('blocks requests over the master limit', () => {
+      for (let i = 0; i < IP_LIMIT_MASTER; i++) {
+        limiter.check('1.2.3.4', true);
+      }
+      expect(limiter.check('1.2.3.4', true)).toBe(true);
+    });
+
+    it('tracks IPs independently', () => {
+      for (let i = 0; i < IP_LIMIT_NORMAL; i++) {
+        limiter.check('1.2.3.4', false);
+      }
+      expect(limiter.check('1.2.3.4', false)).toBe(true);
+      expect(limiter.check('5.6.7.8', false)).toBe(false);
+    });
+
+    it('resets after the window expires', () => {
+      vi.useFakeTimers();
+      for (let i = 0; i < IP_LIMIT_NORMAL; i++) {
+        limiter.check('1.2.3.4', false);
+      }
+      expect(limiter.check('1.2.3.4', false)).toBe(true);
+
+      // Advance past the window
+      vi.advanceTimersByTime(IP_WINDOW_MS + 1);
+      expect(limiter.check('1.2.3.4', false)).toBe(false);
+      vi.useRealTimers();
+    });
+  });
+
+  // ── #844: Max tracked IPs cap ───────────────────────────────────────
+  describe('max tracked IPs cap (#844)', () => {
+    it('enforces MAX_TRACKED_IPS cap', () => {
+      // Fill up to the cap
+      for (let i = 0; i < MAX_TRACKED_IPS; i++) {
+        limiter.check(`${i}.0.0.1`, false);
+      }
+      expect(limiter.size).toBe(MAX_TRACKED_IPS);
+
+      // Adding one more should NOT exceed the cap
+      limiter.check('255.0.0.1', false);
+      expect(limiter.size).toBe(MAX_TRACKED_IPS);
+    });
+
+    it('evicts least-recently-used IP when cap is reached', () => {
+      // Add IP "1.0.0.1" first (it should be evicted)
+      limiter.check('1.0.0.1', false);
+      // Fill the rest with other IPs
+      for (let i = 1; i < MAX_TRACKED_IPS; i++) {
+        limiter.check(`${i + 1}.0.0.1`, false);
+      }
+      expect(limiter.size).toBe(MAX_TRACKED_IPS);
+
+      // Adding a new IP should evict "1.0.0.1" (oldest lastUsedAt)
+      limiter.check('255.0.0.1', false);
+      expect(limiter.size).toBe(MAX_TRACKED_IPS);
+
+      // "1.0.0.1" should have been evicted, so it starts fresh
+      // It should only have 1 entry now, well under the limit
+      expect(limiter.check('1.0.0.1', false)).toBe(false);
+    });
+
+    it('does not evict existing IPs when updating', () => {
+      // Add an IP, then re-check it — size should not grow
+      limiter.check('1.2.3.4', false);
+      expect(limiter.size).toBe(1);
+      limiter.check('1.2.3.4', false);
+      expect(limiter.size).toBe(1);
+    });
+
+    it('evicts the correct LRU IP when multiple candidates exist', () => {
+      // Add IPs in order: first will have oldest lastUsedAt
+      const ips = ['10.0.0.1', '10.0.0.2', '10.0.0.3'];
+      for (const ip of ips) {
+        limiter.check(ip, false);
+      }
+      // Update lastUsedAt for 10.0.0.2 and 10.0.0.3 but not 10.0.0.1
+      limiter.check('10.0.0.2', false);
+      limiter.check('10.0.0.3', false);
+
+      // Fill to cap
+      for (let i = 4; i <= MAX_TRACKED_IPS; i++) {
+        limiter.check(`10.0.0.${i}`, false);
+      }
+
+      // Add one more — should evict 10.0.0.1 (least recently used)
+      limiter.check('10.1.0.1', false);
+      expect(limiter.size).toBe(MAX_TRACKED_IPS);
+
+      // 10.0.0.1 was evicted — fresh start, under limit
+      expect(limiter.check('10.0.0.1', false)).toBe(false);
+    });
+  });
+
+  // ── Prune stale entries (#357) ──────────────────────────────────────
+  describe('prune', () => {
+    it('removes IPs with no recent activity', () => {
+      vi.useFakeTimers();
+      limiter.check('1.2.3.4', false);
+      expect(limiter.size).toBe(1);
+
+      // Advance past the window
+      vi.advanceTimersByTime(IP_WINDOW_MS + 1);
+      limiter.prune();
+      expect(limiter.size).toBe(0);
+      vi.useRealTimers();
+    });
+
+    it('keeps IPs with recent activity', () => {
+      vi.useFakeTimers();
+      limiter.check('1.2.3.4', false);
+      vi.advanceTimersByTime(IP_WINDOW_MS / 2);
+      limiter.check('1.2.3.4', false); // refresh activity
+
+      vi.advanceTimersByTime(IP_WINDOW_MS / 2 + 1);
+      limiter.prune();
+      expect(limiter.size).toBe(1); // still active
+      vi.useRealTimers();
+    });
+
+    it('prunes multiple stale IPs', () => {
+      vi.useFakeTimers();
+      limiter.check('1.2.3.4', false);
+      limiter.check('5.6.7.8', false);
+      limiter.check('9.10.11.12', false);
+      expect(limiter.size).toBe(3);
+
+      vi.advanceTimersByTime(IP_WINDOW_MS + 1);
+      limiter.prune();
+      expect(limiter.size).toBe(0);
+      vi.useRealTimers();
+    });
+  });
+});

--- a/src/ip-rate-limiter.ts
+++ b/src/ip-rate-limiter.ts
@@ -1,0 +1,78 @@
+/**
+ * ip-rate-limiter.ts — Per-IP HTTP request rate limiting.
+ *
+ * #228: Sliding-window rate limiter with circular buffer.
+ * #622: O(1) prune via index advancement instead of O(n) shift().
+ * #844: Max tracked IPs cap with LRU eviction to prevent memory exhaustion.
+ */
+
+interface IpRateBucket {
+  entries: number[];
+  start: number;
+  /** Timestamp of the last rate-limit check for this IP (used for LRU eviction). */
+  lastUsedAt: number;
+}
+
+export const IP_WINDOW_MS = 60_000;
+export const IP_LIMIT_NORMAL = 120;   // per minute for regular keys
+export const IP_LIMIT_MASTER = 300;   // per minute for master token
+/** #844: Max tracked IPs to prevent unbounded memory growth. */
+export const MAX_TRACKED_IPS = 10_000;
+
+export class IpRateLimiter {
+  private buckets = new Map<string, IpRateBucket>();
+
+  /** Check and record a request from the given IP. Returns true if rate-limited. */
+  check(ip: string, isMaster: boolean): boolean {
+    const now = Date.now();
+    const cutoff = now - IP_WINDOW_MS;
+    const existing = this.buckets.get(ip);
+    const bucket = existing || { entries: [], start: 0, lastUsedAt: now };
+    bucket.lastUsedAt = now;
+    // O(1) prune: advance start index past expired entries
+    while (bucket.start < bucket.entries.length && bucket.entries[bucket.start]! < cutoff) {
+      bucket.start++;
+    }
+    // Compact when the leading garbage exceeds 50% of the allocated array
+    if (bucket.start > bucket.entries.length >>> 1) {
+      bucket.entries = bucket.entries.slice(bucket.start);
+      bucket.start = 0;
+    }
+    bucket.entries.push(now);
+    // #844: Enforce max tracked IPs cap to prevent memory exhaustion.
+    // Evict the least-recently-used IP when the map exceeds capacity.
+    if (!existing && this.buckets.size >= MAX_TRACKED_IPS) {
+      let oldestIp: string | null = null;
+      let oldestTime = Infinity;
+      for (const [trackedIp, trackedBucket] of this.buckets) {
+        if (trackedBucket.lastUsedAt < oldestTime) {
+          oldestTime = trackedBucket.lastUsedAt;
+          oldestIp = trackedIp;
+        }
+      }
+      if (oldestIp !== null) {
+        this.buckets.delete(oldestIp);
+      }
+    }
+    this.buckets.set(ip, bucket);
+    const activeCount = bucket.entries.length - bucket.start;
+    const limit = isMaster ? IP_LIMIT_MASTER : IP_LIMIT_NORMAL;
+    return activeCount > limit;
+  }
+
+  /** #357: Prune IPs whose timestamp arrays are entirely outside the rate-limit window. */
+  prune(): void {
+    const cutoff = Date.now() - IP_WINDOW_MS;
+    for (const [ip, bucket] of this.buckets) {
+      const last = bucket.entries[bucket.entries.length - 1];
+      if (bucket.entries.length - bucket.start === 0 || (last !== undefined && last < cutoff)) {
+        this.buckets.delete(ip);
+      }
+    }
+  }
+
+  /** Number of currently tracked IPs. */
+  get size(): number {
+    return this.buckets.size;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import { validateWorkDir } from './validation.js';
 import { SessionEventBus, type SessionSSEEvent, type GlobalSSEEvent } from './events.js';
 import { SSEWriter } from './sse-writer.js';
 import { SSEConnectionLimiter } from './sse-limiter.js';
+import { IpRateLimiter } from './ip-rate-limiter.js';
 import { PipelineManager, type BatchSessionSpec, type PipelineConfig } from './pipeline.js';
 import { AuthManager } from './auth.js';
 import { MetricsCollector } from './metrics.js';
@@ -145,46 +146,8 @@ app.addHook('onSend', (req, reply, payload, done) => {
 // Auth middleware setup (Issue #39: multi-key auth with rate limiting)
 // #228: Per-IP rate limiting (applies even with master token, with higher limits)
 // #622: Circular buffer — O(1) prune via index advancement instead of O(n) shift()
-interface IpRateBucket {
-  entries: number[];
-  start: number;
-}
-const ipRateLimits = new Map<string, IpRateBucket>();
-const IP_WINDOW_MS = 60_000;
-const IP_LIMIT_NORMAL = 120;   // per minute for regular keys
-const IP_LIMIT_MASTER = 300;   // per minute for master token
-
-function checkIpRateLimit(ip: string, isMaster: boolean): boolean {
-  const now = Date.now();
-  const cutoff = now - IP_WINDOW_MS;
-  const bucket = ipRateLimits.get(ip) || { entries: [], start: 0 };
-  // O(1) prune: advance start index past expired entries
-  while (bucket.start < bucket.entries.length && bucket.entries[bucket.start]! < cutoff) {
-    bucket.start++;
-  }
-  // Compact when the leading garbage exceeds 50% of the allocated array
-  if (bucket.start > bucket.entries.length >>> 1) {
-    bucket.entries = bucket.entries.slice(bucket.start);
-    bucket.start = 0;
-  }
-  bucket.entries.push(now);
-  ipRateLimits.set(ip, bucket);
-  const activeCount = bucket.entries.length - bucket.start;
-  const limit = isMaster ? IP_LIMIT_MASTER : IP_LIMIT_NORMAL;
-  return activeCount > limit;
-}
-
-/** #357: Prune IPs whose timestamp arrays are entirely outside the rate-limit window. */
-function pruneIpRateLimits(): void {
-  const cutoff = Date.now() - IP_WINDOW_MS;
-  for (const [ip, bucket] of ipRateLimits) {
-    // All timestamps are old — remove the entry entirely
-    const last = bucket.entries[bucket.entries.length - 1];
-    if (bucket.entries.length - bucket.start === 0 || (last !== undefined && last < cutoff)) {
-      ipRateLimits.delete(ip);
-    }
-  }
-}
+// #844: Max tracked IPs cap with LRU eviction to prevent memory exhaustion.
+const ipRateLimiter = new IpRateLimiter();
 
 /** #583: Track keyId per request for batch rate limiting. */
 const requestKeyMap = new Map<string, string>();
@@ -260,7 +223,7 @@ function setupAuth(authManager: AuthManager): void {
     // #228: Per-IP rate limiting (applies to all authenticated requests)
     const clientIp = req.ip ?? req.headers['x-forwarded-for'] as string ?? 'unknown';
     const isMaster = result.keyId === 'master';
-    if (checkIpRateLimit(clientIp, isMaster)) {
+    if (ipRateLimiter.check(clientIp, isMaster)) {
       return reply.status(429).send({ error: 'Rate limit exceeded — IP throttled' });
     }
   });
@@ -1501,7 +1464,7 @@ async function main(): Promise<void> {
   const zombieReaperInterval = setInterval(() => reapZombieSessions(), ZOMBIE_REAP_INTERVAL_MS);
   const metricsSaveInterval = setInterval(() => { void metrics.save(); }, 5 * 60 * 1000);
   // #357: Prune stale IP rate-limit entries every minute
-  const ipPruneInterval = setInterval(pruneIpRateLimits, 60_000);
+  const ipPruneInterval = setInterval(() => ipRateLimiter.prune(), 60_000);
   // #398: Sweep stale API key rate limit buckets every 5 minutes
   const authSweepInterval = setInterval(() => auth.sweepStaleRateLimits(), 5 * 60_000);
 


### PR DESCRIPTION
## Summary

- Extracts the per-IP rate limiter from inline code in `server.ts` into `src/ip-rate-limiter.ts` (follows the pattern of `sse-limiter.ts`)
- Adds a **10,000 IP cap** with **LRU eviction** — when the cap is reached, the least-recently-used IP entry is evicted before a new one is inserted
- Adds `lastUsedAt` tracking to each bucket for efficient LRU ordering
- Adds 13 unit tests covering basic rate limiting, max-IP cap enforcement, LRU eviction behavior, and stale entry pruning

## Problem

The `ipRateLimits` map in `server.ts` grew without bound. An attacker sending requests from many source IPs (e.g., via a botnet or proxy rotation) could exhaust server memory, as each IP's timestamp array was retained for the full 60-second window with no upper bound on the number of tracked IPs.

## Fix

- **`MAX_TRACKED_IPS = 10_000`** — hard cap on the number of tracked IPs
- When a new IP arrives and the map is at capacity, the entry with the oldest `lastUsedAt` timestamp is evicted
- Existing IPs (re-checked) simply update their `lastUsedAt` without growing the map
- The existing `prune()` method continues to clean up stale entries every 60 seconds

## Aegis version
**Developed with:** v2.5.2

Closes #844

Generated by Hephaestus (Aegis dev agent)