### PR TITLE
fix(security): redact session metadata from webhook payloads

### DIFF
--- a/src/__tests__/webhook-retry.test.ts
+++ b/src/__tests__/webhook-retry.test.ts
@@ -125,9 +125,13 @@ describe('Webhook delivery with retry', () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.api).toBeDefined();
-    expect(body.api.read).toContain('test-123');
-    expect(body.api.send).toContain('test-123');
-    expect(body.api.kill).toContain('test-123');
+    // Issue #827: session IDs are redacted from webhook payloads
+    expect(body.api.read).toBe('GET /sessions/[REDACTED]/read');
+    expect(body.api.send).toBe('POST /sessions/[REDACTED]/send');
+    expect(body.api.kill).toBe('DELETE /sessions/[REDACTED]');
+    expect(body.session.id).toBe('[REDACTED]');
+    expect(body.session.name).toBe('[REDACTED]');
+    expect(body.session.workDir).toBe('[REDACTED]');
   });
 
   it('should skip endpoint if event filter does not match', async () => {
@@ -176,7 +180,10 @@ describe('Webhook delivery with retry', () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.event).toBe('status.permission');
-    expect(body.session.id).toBe('test-123');
+    // Issue #827: session metadata is redacted
+    expect(body.session.id).toBe('[REDACTED]');
+    expect(body.session.name).toBe('[REDACTED]');
+    expect(body.session.workDir).toBe('[REDACTED]');
   });
 
   it('should have correct MAX_RETRIES constant', () => {

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -117,15 +117,28 @@ export class WebhookChannel implements Channel {
     return base * (0.5 + Math.random() * 0.5);
   }
 
-  private async fire(payload: SessionEventPayload): Promise<void> {
-    const body = JSON.stringify({
-      ...payload,
-      api: {
-        read: `GET /sessions/${payload.session.id}/read`,
-        send: `POST /sessions/${payload.session.id}/send`,
-        kill: `DELETE /sessions/${payload.session.id}`,
+  /** Redact sensitive session metadata from webhook payloads. */
+  private static redactPayload(
+    payload: SessionEventPayload,
+  ): Record<string, unknown> {
+    const { session, ...rest } = payload;
+    return {
+      ...rest,
+      session: {
+        id: '[REDACTED]',
+        name: '[REDACTED]',
+        workDir: '[REDACTED]',
       },
-    });
+      api: {
+        read: 'GET /sessions/[REDACTED]/read',
+        send: 'POST /sessions/[REDACTED]/send',
+        kill: 'DELETE /sessions/[REDACTED]',
+      },
+    };
+  }
+
+  private async fire(payload: SessionEventPayload): Promise<void> {
+    const body = JSON.stringify(WebhookChannel.redactPayload(payload));
 
     const promises = this.endpoints.map(async ep => {
       // Skip if endpoint filters and this event isn't in the list


### PR DESCRIPTION
## Summary\n- Redact id, name, workDir from webhook payloads before sending\n- Prevents session metadata leakage to external endpoints\n\nFixes #827\n\n## Test plan\n- Added unit tests for metadata redaction