### PR TITLE
fix: add retryWithJitter utility and fatal/transient taxonomy for pipeline stages (#886)

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -457,7 +457,7 @@ describe('PipelineManager', () => {
       // A starts fine
       sessions.createSession
         .mockResolvedValueOnce(makeMockSession('s-a'))
-        .mockRejectedValueOnce(new Error('tmux full'));
+        .mockRejectedValue(new Error('tmux full'));
       sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
 
       const pipeline = await manager.createPipeline(config);
@@ -470,6 +470,51 @@ describe('PipelineManager', () => {
       expect(pipeline.stages.find(s => s.name === 'A')?.status).toBe('completed');
       expect(pipeline.stages.find(s => s.name === 'B')?.status).toBe('failed');
       expect(pipeline.stages.find(s => s.name === 'B')?.error).toBe('tmux full');
+      expect(pipeline.status).toBe('failed');
+    });
+
+    it('retries transient createSession failures and recovers', async () => {
+      const config: PipelineConfig = {
+        name: 'create-recovers',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+          { name: 'B', prompt: 'b', dependsOn: ['A'] },
+        ],
+      };
+
+      sessions.createSession
+        .mockResolvedValueOnce(makeMockSession('s-a'))
+        .mockRejectedValueOnce(new Error('tmux failed'))
+        .mockResolvedValueOnce(makeMockSession('s-b'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Complete A so B can start. B should recover after one transient failure.
+      sessions.getSession.mockReturnValue(makeMockSession('s-a', { status: 'idle' }));
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages.find(s => s.name === 'B')?.status).toBe('running');
+      expect(pipeline.status).toBe('running');
+    });
+
+    it('does not retry non-retryable createSession failures', async () => {
+      const config: PipelineConfig = {
+        name: 'create-fatal',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'a', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockRejectedValue(new Error('validation failed'));
+
+      const pipeline = await manager.createPipeline(config);
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('validation failed');
+      expect(sessions.createSession).toHaveBeenCalledTimes(1);
       expect(pipeline.status).toBe('failed');
     });
 

--- a/src/__tests__/retry-886.test.ts
+++ b/src/__tests__/retry-886.test.ts
@@ -1,0 +1,53 @@
+/**
+ * retry-886.test.ts — Tests for Issue #886 shared retryWithJitter utility.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { retryWithJitter } from '../retry.js';
+
+describe('Issue #886: retryWithJitter', () => {
+  it('retries transient errors and eventually succeeds', async () => {
+    let attempts = 0;
+    const result = await retryWithJitter(async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error('ECONNREFUSED');
+      return 'ok';
+    }, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+      shouldRetry: (error) => String((error as Error).message).includes('ECONN'),
+    });
+
+    expect(result).toBe('ok');
+    expect(attempts).toBe(3);
+  });
+
+  it('fails immediately on non-retryable errors', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('validation failed');
+    });
+
+    await expect(retryWithJitter(fn, {
+      maxAttempts: 3,
+      shouldRetry: (error) => String((error as Error).message).includes('ECONN'),
+    })).rejects.toThrow('validation failed');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails after exhausting retries', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('ECONNRESET');
+    });
+
+    await expect(retryWithJitter(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+      shouldRetry: () => true,
+    })).rejects.toThrow('ECONNRESET');
+
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -8,6 +8,8 @@
 import { type SessionManager, type SessionInfo } from './session.js';
 import { type SessionEventBus } from './events.js';
 import { getErrorMessage } from './validation.js';
+import { shouldRetry } from './error-categories.js';
+import { retryWithJitter } from './retry.js';
 
 export interface BatchSessionSpec {
   name?: string;
@@ -65,6 +67,8 @@ export interface PipelineState {
 }
 
 export class PipelineManager {
+  private static readonly PIPELINE_RETRY_MAX_ATTEMPTS = 3;
+
   private pipelines = new Map<string, PipelineState>();
   private pipelineConfigs = new Map<string, PipelineConfig>(); // #219: preserve original stage config
   private pollInterval: NodeJS.Timeout | null = null;
@@ -207,15 +211,27 @@ export class PipelineManager {
       if (!stageConfig) continue;
 
       try {
-        const session = await this.sessions.createSession({
-          workDir: stageConfig.workDir || config.workDir,
-          name: `pipeline-${config.name}-${stage.name}`,
-          permissionMode: stageConfig.permissionMode,
-          autoApprove: stageConfig.autoApprove,
-        });
+        const session = await retryWithJitter(
+          async () => this.sessions.createSession({
+            workDir: stageConfig.workDir || config.workDir,
+            name: `pipeline-${config.name}-${stage.name}`,
+            permissionMode: stageConfig.permissionMode,
+            autoApprove: stageConfig.autoApprove,
+          }),
+          {
+            maxAttempts: PipelineManager.PIPELINE_RETRY_MAX_ATTEMPTS,
+            shouldRetry: (error) => shouldRetry(error),
+          },
+        );
 
         if (stageConfig.prompt) {
-          await this.sessions.sendInitialPrompt(session.id, stageConfig.prompt);
+          await retryWithJitter(
+            async () => this.sessions.sendInitialPrompt(session.id, stageConfig.prompt),
+            {
+              maxAttempts: PipelineManager.PIPELINE_RETRY_MAX_ATTEMPTS,
+              shouldRetry: (error) => shouldRetry(error),
+            },
+          );
         }
 
         stage.sessionId = session.id;

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,48 @@
+/**
+ * retry.ts — shared retry helper with bounded exponential backoff + jitter.
+ */
+
+export interface RetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  onRetry?: (error: unknown, attempt: number, delayMs: number) => void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function computeDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const exponential = Math.min(baseDelayMs * (2 ** (attempt - 1)), maxDelayMs);
+  const jitterMultiplier = 0.5 + (Math.random() * 0.5);
+  return Math.round(exponential * jitterMultiplier);
+}
+
+export async function retryWithJitter<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 250;
+  const maxDelayMs = options.maxDelayMs ?? 3_000;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      const isLastAttempt = attempt >= maxAttempts;
+      const canRetry = options.shouldRetry ? options.shouldRetry(error, attempt) : true;
+      if (isLastAttempt || !canRetry) {
+        throw error;
+      }
+
+      const delayMs = computeDelayMs(attempt, baseDelayMs, maxDelayMs);
+      options.onRetry?.(error, attempt, delayMs);
+      await sleep(delayMs);
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
## Summary

Introduces a shared etryWithJitter utility with bounded exponential backoff and applies it to the two pipeline stages (createSession, sendInitialPrompt) that previously failed fast on any error, including transient ones.

### Changes
- src/retry.ts (new): etryWithJitter(fn, opts) — configurable maxAttempts/baseDelayMs/maxDelayMs/shouldRetry/onRetry with 50–100% jitter
- src/pipeline.ts: import shouldRetry from rror-categories; wrap createSession and sendInitialPrompt in etryWithJitter with PIPELINE_RETRY_MAX_ATTEMPTS = 3
- src/__tests__/retry-886.test.ts: 3 tests — transient recovery, fatal fast-fail, exhaustion
- src/__tests__/pipeline.test.ts: 2 additional tests — transient recovery and fatal fast-fail in pipeline context

### Tests
- 56/56 tests pass (3 retry + 53 existing pipeline)
- Typecheck clean

Closes #886

## Aegis version
**Developed with:** v2.5.3