### PR TITLE
refactor: deduplicate approve/reject route handlers (#887)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -683,38 +683,32 @@ async function readMessagesHandler(req: IdRequest, reply: FastifyReply): Promise
 app.get<IdParams>('/v1/sessions/:id/read', readMessagesHandler);
 app.get<IdParams>('/sessions/:id/read', readMessagesHandler);
 
-// Approve
-async function approveHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
-  try {
-    await sessions.approve(req.params.id);
-    // Issue #87: Record permission response latency
-    const lat = sessions.getLatencyMetrics(req.params.id);
-    if (lat !== null && lat.permission_response_ms !== null) {
-      metrics.recordPermissionResponse(req.params.id, lat.permission_response_ms);
+function makePermissionHandler(
+  action: 'approve' | 'reject'
+): (req: IdRequest, reply: FastifyReply) => Promise<unknown> {
+  return async (req: IdRequest, reply: FastifyReply): Promise<unknown> => {
+    try {
+      const op = action === 'approve' ? sessions.approve.bind(sessions) : sessions.reject.bind(sessions);
+      await op(req.params.id);
+      // Issue #87: Record permission response latency
+      const lat = sessions.getLatencyMetrics(req.params.id);
+      if (lat !== null && lat.permission_response_ms !== null) {
+        metrics.recordPermissionResponse(req.params.id, lat.permission_response_ms);
+      }
+      return { ok: true };
+    } catch (e: unknown) {
+      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
-    return { ok: true };
-  } catch (e: unknown) {
-    return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
-  }
+  };
 }
-app.post<IdParams>('/v1/sessions/:id/approve', approveHandler);
-app.post<IdParams>('/sessions/:id/approve', approveHandler);
 
-// Reject
-async function rejectHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
-  try {
-    await sessions.reject(req.params.id);
-    const lat = sessions.getLatencyMetrics(req.params.id);
-    if (lat !== null && lat.permission_response_ms !== null) {
-      metrics.recordPermissionResponse(req.params.id, lat.permission_response_ms);
-    }
-    return { ok: true };
-  } catch (e: unknown) {
-    return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
-  }
-}
+const approveHandler = makePermissionHandler('approve');
+const rejectHandler = makePermissionHandler('reject');
+
 app.post<IdParams>('/v1/sessions/:id/reject', rejectHandler);
 app.post<IdParams>('/sessions/:id/reject', rejectHandler);
+app.post<IdParams>('/v1/sessions/:id/approve', approveHandler);
+app.post<IdParams>('/sessions/:id/approve', approveHandler);
 
 // Issue #336: Answer pending AskUserQuestion
 app.post<{


### PR DESCRIPTION
## Summary

Extracts a unified handler factory for the overlapping approve and reject route handlers, eliminating code duplication while preserving identical API behaviour and centralising latency metric recording.

### Changes
- src/server.ts: replace duplicated pprove/eject route bodies with a shared makeApprovalHandler(action) factory
- Preserved: all API surface, error handling, latency metric recording

### Tests
- All existing tests pass
- Typecheck clean

Closes #887

## Aegis version
**Developed with:** v2.5.3