### PR TITLE
fix: replace silent catches with explicit suppressible-error policy (#882)

### DIFF
--- a/src/__tests__/suppress-882.test.ts
+++ b/src/__tests__/suppress-882.test.ts
@@ -1,0 +1,80 @@
+/**
+ * suppress-882.test.ts — Tests for the explicit suppression predicate.
+ *
+ * Issue #882: Verifies that:
+ * 1. Expected transient races are suppressed (no warn, only debug)
+ * 2. Unexpected exceptions surface a visible warning
+ * 3. Rate limiting suppresses debug noise beyond the per-minute cap
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isSuppressible, suppressedCatch, _resetSuppressRateLimit } from '../suppress.js';
+
+beforeEach(() => {
+  _resetSuppressRateLimit();
+  vi.restoreAllMocks();
+});
+
+describe('isSuppressible', () => {
+  it('suppresses session-not-found messages', () => {
+    expect(isSuppressible(new Error('session not found'), 'monitor.checkSession')).toBe(true);
+    expect(isSuppressible(new Error('No session with id abc123'), 'monitor.checkSession')).toBe(true);
+  });
+
+  it('suppresses ENOENT (file removed after session kill)', () => {
+    const err = Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
+    expect(isSuppressible(err, 'monitor.checkSession')).toBe(true);
+  });
+
+  it('suppresses tmux pane/window-gone errors', () => {
+    expect(isSuppressible(new Error("tmux: can't find window"), 'tmux.capturePane')).toBe(true);
+    expect(isSuppressible(new Error('no such pane: %42'), 'tmux.capturePane')).toBe(true);
+    expect(isSuppressible(new Error('no such window'), 'tmux.capturePane')).toBe(true);
+    expect(isSuppressible(new Error('window already dead'), 'monitor.checkDeadSessions.killSession')).toBe(true);
+  });
+
+  it('suppresses SyntaxError (truncated JSONL reads)', () => {
+    expect(isSuppressible(new SyntaxError('Unexpected end of JSON'), 'monitor.checkStopSignals.parseEntry')).toBe(true);
+  });
+
+  it('does NOT suppress generic internal errors', () => {
+    expect(isSuppressible(new Error('Something totally unexpected'), 'monitor.checkSession')).toBe(false);
+    expect(isSuppressible(new TypeError('Cannot read property x of undefined'), 'monitor.checkSession')).toBe(false);
+  });
+});
+
+describe('suppressedCatch', () => {
+  it('emits console.debug (not warn) for suppressible errors', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    suppressedCatch(new Error('session not found'), 'monitor.checkSession');
+
+    expect(debug).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug.mock.calls[0][0]).toContain('[suppress] monitor.checkSession');
+  });
+
+  it('emits console.warn for non-suppressible errors', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    suppressedCatch(new TypeError('unexpected internal failure'), 'monitor.checkSession');
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(debug).not.toHaveBeenCalled();
+    expect(warn.mock.calls[0][0]).toContain('[unexpected] monitor.checkSession');
+  });
+
+  it('rate-limits debug output beyond SUPPRESS_MAX_PER_MINUTE', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    const err = new Error('session not found');
+    for (let i = 0; i < 20; i++) {
+      suppressedCatch(err, 'monitor.checkSession');
+    }
+
+    // Should stop at 10, not emit all 20
+    expect(debug.mock.calls.length).toBe(10);
+  });
+});

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -20,6 +20,7 @@ import { type ChannelManager, type SessionEventPayload, type SessionEvent } from
 import { type SessionEventBus } from './events.js';
 import { type JsonlWatcher, type JsonlWatcherEvent } from './jsonl-watcher.js';
 import { stopSignalsSchema } from './validation.js';
+import { suppressedCatch } from './suppress.js';
 
 export interface MonitorConfig {
   pollIntervalMs: number;       // Base poll interval (default: 30000 — hooks are primary signal)
@@ -154,8 +155,8 @@ export class SessionMonitor {
           this.jsonlWatcher.watch(session.id, session.jsonlPath, session.monitorOffset);
         }
         await this.checkSession(session);
-      } catch {
-        // Session may have been killed during poll
+      } catch (e) {
+        suppressedCatch(e, 'monitor.checkSession');
       }
     }
 
@@ -440,7 +441,7 @@ export class SessionMonitor {
           );
         }
       }
-    } catch { /* ignore parse errors */ }
+    } catch (e) { suppressedCatch(e, 'monitor.checkStopSignals.parseEntry'); }
   }
 
   /** Issue #84: Handle new entries from the fs.watch-based JSONL watcher.
@@ -659,8 +660,8 @@ export class SessionMonitor {
         // #262: Also remove from SessionManager so dead sessions don't linger
         try {
           await this.sessions.killSession(session.id);
-        } catch {
-          // Window already gone — that's fine, session is dead
+        } catch (e) {
+          suppressedCatch(e, 'monitor.checkDeadSessions.killSession');
         }
       }
     }

--- a/src/suppress.ts
+++ b/src/suppress.ts
@@ -1,0 +1,84 @@
+/**
+ * suppress.ts — Explicit suppression predicate for expected runtime races.
+ *
+ * Issue #882: Replaces silent empty catches with a documented, testable
+ * suppression contract. Suppressible errors (expected races, killed sessions,
+ * missing tmux panes) are forwarded as rate-limited diagnostics events.
+ * Non-suppressible errors are surfaced at warn level.
+ */
+
+/** Contexts where suppressible races may occur. */
+export type SuppressContext =
+  | 'monitor.checkSession'
+  | 'monitor.checkDeadSessions.killSession'
+  | 'monitor.checkStopSignals.parseEntry'
+  | 'session.cleanup'
+  | 'tmux.capturePane'
+  | string;
+
+/** Rate-limit state: max N suppressed debug events per context per minute. */
+const suppressRateLimit = new Map<string, { count: number; resetAt: number }>();
+/** Exported for tests — clears all rate-limit counters. */
+export function _resetSuppressRateLimit(): void {
+  suppressRateLimit.clear();
+}
+
+const SUPPRESS_MAX_PER_MINUTE = 10;
+
+/**
+ * Returns true if the error is an expected transient race that
+ * should be swallowed without surfacing a warning.
+ *
+ * Categories of suppressible errors:
+ * - Session killed while in-flight (SESSION_NOT_FOUND-class messages)
+ * - File not found (ENOENT) — session JSONL removed after kill
+ * - Tmux pane/window gone — dead-session race
+ * - SyntaxError from truncated JSONL reads during rotation
+ */
+export function isSuppressible(error: unknown, _context: SuppressContext): boolean {
+  if (error instanceof SyntaxError) return true;
+
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return true;
+
+    const msg = error.message.toLowerCase();
+    if (msg.includes('session not found')) return true;
+    if (msg.includes('no session with id')) return true;
+    if (msg.includes('no such window')) return true;
+    if (msg.includes('no such pane')) return true;
+    if (msg.includes('no such session')) return true;
+    if (msg.includes("can't find window")) return true;
+    if (msg.includes('window already dead')) return true;
+  }
+  return false;
+}
+
+/**
+ * Handle a caught error using the explicit suppression policy.
+ *
+ * - Suppressible errors: console.debug with rate limiting (max 10/min per context).
+ * - Non-suppressible errors: console.warn — always visible.
+ *
+ * Does NOT rethrow. Call isSuppressible() directly if you need rethrow control.
+ */
+export function suppressedCatch(error: unknown, context: SuppressContext): void {
+  if (isSuppressible(error, context)) {
+    const now = Date.now();
+    const state = suppressRateLimit.get(context);
+    if (!state || now >= state.resetAt) {
+      suppressRateLimit.set(context, { count: 1, resetAt: now + 60_000 });
+      console.debug(`[suppress] ${context}: ${_errorMessage(error)}`);
+    } else if (state.count < SUPPRESS_MAX_PER_MINUTE) {
+      state.count++;
+      console.debug(`[suppress] ${context}: ${_errorMessage(error)}`);
+    }
+    // rate limit exceeded for this window — drop silently
+  } else {
+    console.warn(`[unexpected] ${context}: ${_errorMessage(error)}`, error);
+  }
+}
+
+export function _errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary

Replaces empty/comment-only \catch {}\ blocks in runtime-critical monitor paths with an explicit suppression predicate and rate-limited diagnostics.

### Changes
- \src/suppress.ts\ (new): \isSuppressible(error, context)\ covering session-killed races, ENOENT, tmux pane/window-gone errors, and SyntaxError from truncated JSONL reads. \suppressedCatch()\ logs suppressible errors at \console.debug\ (rate-limited, max 10/min per context) and non-suppressible at \console.warn\.
- \src/monitor.ts\: 3 silent catches replaced:
  - Poll loop \catch { // Session may have been killed }\ → \suppressedCatch(e, 'monitor.checkSession')\
  - \checkStopSignals\ \catch { /* ignore parse errors */ }\ → \suppressedCatch(e, 'monitor.checkStopSignals.parseEntry')\
  - \checkDeadSessions\ killSession catch → \suppressedCatch(e, 'monitor.checkDeadSessions.killSession')\
- \src/__tests__/suppress-882.test.ts\: 8 tests

### Tests
- 8/8 tests pass
- Typecheck clean

Closes #882

## Aegis version
**Developed with:** v2.5.3