### PR TITLE
feat: worktree-aware continuation metadata lookup (#884)

### DIFF
--- a/src/__tests__/worktree-lookup-884.test.ts
+++ b/src/__tests__/worktree-lookup-884.test.ts
@@ -1,0 +1,108 @@
+/**
+ * worktree-lookup-884.test.ts — Tests for worktree-aware session file discovery.
+ *
+ * Issue #884: Verifies that:
+ * 1. Primary directory is found without fanout
+ * 2. Sibling worktree directory is found when primary lacks the file
+ * 3. Fanout is bounded by maxCandidates
+ * 4. Freshest file is returned when both dirs match
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { findSessionFileWithFanout } from '../worktree-lookup.js';
+import { mkdtemp, mkdir, writeFile, rm, utimes } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const SESSION_ID = 'deadbeef-0000-0000-0000-000000000001';
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'wt-884-test-'));
+});
+
+afterEach(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function makeProjectsDir(base: string, projectName: string, withSession: boolean, mtimeOffset = 0): Promise<string> {
+  const dir = join(base, projectName);
+  await mkdir(dir, { recursive: true });
+  if (withSession) {
+    const file = join(dir, `${SESSION_ID}.jsonl`);
+    await writeFile(file, '{"test":true}\n');
+    if (mtimeOffset !== 0) {
+      const now = Date.now();
+      const t = (now + mtimeOffset) / 1000;
+      await utimes(file, t, t);
+    }
+  }
+  return base;
+}
+
+describe('findSessionFileWithFanout', () => {
+  it('returns primary-directory match without fanout', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    await makeProjectsDir(primaryDir, 'proj-a', true);
+    await makeProjectsDir(siblingDir, 'proj-b', false);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).not.toBeNull();
+    expect(result).toContain(primaryDir);
+    expect(result).toContain(SESSION_ID);
+  });
+
+  it('falls back to sibling dir when primary does not contain the file', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    await makeProjectsDir(primaryDir, 'proj-a', false);
+    await makeProjectsDir(siblingDir, 'proj-b', true);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).not.toBeNull();
+    expect(result).toContain(siblingDir);
+  });
+
+  it('returns freshest candidate when both dirs have a match', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    // primary is older (mtime -10s), sibling is newer (mtime +0)
+    await makeProjectsDir(primaryDir, 'proj-a', true, -10_000);
+    await makeProjectsDir(siblingDir, 'proj-b', true, 0);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).not.toBeNull();
+    expect(result).toContain(siblingDir); // sibling is fresher
+  });
+
+  it('returns null when no directories contain the file', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    await makeProjectsDir(primaryDir, 'proj-a', false);
+    await makeProjectsDir(siblingDir, 'proj-b', false);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).toBeNull();
+  });
+
+  it('respects maxCandidates bound on sibling fanout', async () => {
+    // Create 7 sibling dirs, only the 4th has the file (beyond maxCandidates=3)
+    const primaryDir = join(tmpRoot, 'primary');
+    await mkdir(primaryDir, { recursive: true });
+
+    const siblings: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = join(tmpRoot, `sib-${i}`);
+      const hasFile = i === 3; // only 4th sibling (index 3) has the file
+      await makeProjectsDir(d, 'proj', hasFile);
+      siblings.push(d);
+    }
+
+    // With maxCandidates=3 only sibs 0,1,2 are searched — sib-3 is beyond the limit
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, siblings, 3);
+    expect(result).toBeNull(); // 4th sibling not reached
+  });
+});
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,13 @@ export interface Config {
    *  Empty array = all directories allowed (backward compatible).
    *  Paths are resolved and symlink-resolved before checking. */
   allowedWorkDirs: string[];
+  /** Issue #884: Enable worktree-aware continuation metadata lookup (default: false).
+   *  When true, Aegis fans out to sibling worktree project dirs when the primary
+   *  directory lookup fails to find a session file. */
+  worktreeAwareContinuation: boolean;
+  /** Issue #884: Additional Claude projects directories to search during worktree fanout.
+   *  Paths are expanded (~) and checked for existence before searching. */
+  worktreeSiblingDirs: string[];
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -93,6 +100,8 @@ const defaults: Config = {
   sseMaxConnections: 100,
   sseMaxPerIp: 10,
   allowedWorkDirs: [],
+  worktreeAwareContinuation: false,
+  worktreeSiblingDirs: [],
 };
 
 /** Parse CLI args for --config flag */

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,6 +11,7 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { TmuxManager, type TmuxWindow } from './tmux.js';
 import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.js';
+import { findSessionFileWithFanout } from './worktree-lookup.js';
 import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState } from './terminal-parser.js';
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
@@ -130,6 +131,22 @@ export class SessionManager {
   ) {
     this.stateFile = join(config.stateDir, 'state.json');
     this.sessionMapFile = join(config.stateDir, 'session_map.json');
+  }
+
+  /**
+   * Issue #884: Worktree-aware session file lookup.
+   * When `worktreeAwareContinuation` is enabled, fans out to sibling worktree
+   * project dirs; otherwise falls back to the existing single-directory search.
+   */
+  private findSessionFileMaybeWorktree(sessionId: string): Promise<string | null> {
+    if (this.config.worktreeAwareContinuation && this.config.worktreeSiblingDirs.length > 0) {
+      return findSessionFileWithFanout(
+        sessionId,
+        this.config.claudeProjectsDir,
+        this.config.worktreeSiblingDirs,
+      );
+    }
+    return findSessionFile(sessionId, this.config.claudeProjectsDir);
   }
 
   /** Validate that parsed data looks like a valid SessionState. */
@@ -1190,9 +1207,9 @@ export class SessionManager {
     session.status = status;
     session.lastActivity = Date.now();
 
-    // Try to find JSONL if we don't have it yet
+    // Try to find JSONL if we don't have it yet (Issue #884: worktree-aware)
     if (!session.jsonlPath && session.claudeSessionId) {
-      const path = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+      const path = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
       if (path) {
         session.jsonlPath = path;
         session.byteOffset = 0;
@@ -1241,9 +1258,9 @@ export class SessionManager {
 
     session.status = status;
 
-    // Try to find JSONL if we don't have it yet
+    // Try to find JSONL if we don't have it yet (Issue #884: worktree-aware)
     if (!session.jsonlPath && session.claudeSessionId) {
-      const path = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+      const path = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
       if (path) {
         session.jsonlPath = path;
         session.monitorOffset = 0;
@@ -1350,9 +1367,9 @@ export class SessionManager {
     const session = this.state.sessions[id];
     if (!session) throw new Error(`Session ${id} not found`);
 
-    // Discover JSONL path if not yet known
+    // Discover JSONL path if not yet known (Issue #884: worktree-aware)
     if (!session.jsonlPath && session.claudeSessionId) {
-      const path = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+      const path = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
       if (path) {
         session.jsonlPath = path;
         session.byteOffset = 0;
@@ -1601,9 +1618,9 @@ export class SessionManager {
       try {
         await this.syncSessionMap();
         
-        // If we have claudeSessionId but no jsonlPath, try finding it
+        // If we have claudeSessionId but no jsonlPath, try finding it (Issue #884: worktree-aware)
         if (session.claudeSessionId && !session.jsonlPath) {
-          const jsonlPath = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+          const jsonlPath = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
           if (jsonlPath) {
             session.jsonlPath = jsonlPath;
             session.byteOffset = 0;

--- a/src/worktree-lookup.ts
+++ b/src/worktree-lookup.ts
@@ -1,0 +1,79 @@
+/**
+ * worktree-lookup.ts — Worktree-aware session file discovery.
+ *
+ * Issue #884: Extends the single-directory findSessionFile with bounded fanout
+ * across sibling worktree project directories. Returns the freshest (most
+ * recently modified) matching JSONL file across all candidate dirs.
+ */
+
+import { stat, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/** Expand leading ~ to home directory. */
+function expandTilde(p: string): string {
+  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+}
+
+/**
+ * Find the freshest JSONL file for a given sessionId across multiple
+ * Claude projects directories.
+ *
+ * Search order:
+ * 1. Primary directory (existing `claudeProjectsDir` — normal path)
+ * 2. Sibling directories (fanout, bounded by maxCandidates)
+ *
+ * Returns the path with the highest mtime, or null if not found.
+ * Silently ignores unreadable/missing directories.
+ *
+ * @param sessionId     Claude session UUID
+ * @param primaryDir    Primary `~/.claude/projects` directory (searched first)
+ * @param siblingDirs   Additional directories to search (fanout)
+ * @param maxCandidates Upper bound on sibling candidates to evaluate (default: 5)
+ */
+export async function findSessionFileWithFanout(
+  sessionId: string,
+  primaryDir: string,
+  siblingDirs: string[],
+  maxCandidates = 5,
+): Promise<string | null> {
+  const candidates: Array<{ path: string; mtimeMs: number }> = [];
+
+  // Helper: scan one projects dir for sessionId.jsonl files
+  async function scanDir(dir: string): Promise<void> {
+    const expanded = expandTilde(dir);
+    if (!existsSync(expanded)) return;
+    let entries;
+    try {
+      entries = await readdir(expanded, { withFileTypes: true, encoding: 'utf8' });
+    } catch {
+      return; // unreadable directory — skip
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const jsonlPath = join(expanded, entry.name, `${sessionId}.jsonl`);
+      if (existsSync(jsonlPath)) {
+        try {
+          const { mtimeMs } = await stat(jsonlPath);
+          candidates.push({ path: jsonlPath, mtimeMs });
+        } catch {
+          // stat failed — entry may have been deleted between existsSync and stat
+        }
+      }
+    }
+  }
+
+  // Always scan primary first
+  await scanDir(primaryDir);
+
+  // Fanout to siblings (bounded)
+  const bounded = siblingDirs.slice(0, maxCandidates);
+  await Promise.all(bounded.map(d => scanDir(d)));
+
+  if (candidates.length === 0) return null;
+
+  // Return path with the highest mtime (freshest)
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates[0].path;
+}


### PR DESCRIPTION
## Summary

Extends session file discovery to fan out across sibling worktree project directories when the primary `~/.claude/projects` directory lookup fails. The feature is opt-in via a config flag for safe rollout.

### Problem

`findSessionFile()` was scoped to a single configured projects directory. In multi-worktree Git repositories, valid continuation metadata may exist in sibling worktrees' project directories but was not discovered, causing failed resumes.

### Changes

- `src/worktree-lookup.ts` (new): `findSessionFileWithFanout(sessionId, primaryDir, siblingDirs, maxCandidates=5)` — scans primary dir first, then fans out to sibling dirs (bounded by `maxCandidates`). Returns the freshest (highest mtime) matching JSONL file across all candidates.
- `src/config.ts`: new fields `worktreeAwareContinuation: boolean` (default: `false`) and `worktreeSiblingDirs: string[]` (default: `[]`)
- `src/session.ts`: new private helper `findSessionFileMaybeWorktree()` wires the config flag into the 4 session-file discovery call sites (`readMessages`, `readMessagesForMonitor`, `readTranscript`, poll-timer discovery)
- `src/__tests__/worktree-lookup-884.test.ts`: 5 tests using real temp directories

### Config example

```json
{
  "worktreeAwareContinuation": true,
  "worktreeSiblingDirs": [
    "~/.claude/projects-worktree-feature",
    "/home/user/.claude/projects-main"
  ]
}
```

### Tests
- 5/5 tests pass (real filesystem, no mocks)
- Typecheck clean

Closes #884

## Aegis version
**Developed with:** v2.5.3
