### PR TITLE
feat: capability handshake contract for Aegis and Claude Code (#885)

### DIFF
--- a/src/__tests__/capability-handshake-885.test.ts
+++ b/src/__tests__/capability-handshake-885.test.ts
@@ -1,0 +1,82 @@
+/**
+ * capability-handshake-885.test.ts — Tests for capability handshake negotiation.
+ *
+ * Issue #885: Verifies that:
+ * 1. Full-capability client gets all negotiated capabilities
+ * 2. Partial-capability client gets only the intersection
+ * 3. Unsupported protocol version → not compatible + warning
+ * 4. Newer client version gets forward-compat warning but remains compatible
+ * 5. Unknown capabilities are ignored with a warning
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  negotiate,
+  AEGIS_CAPABILITIES,
+  AEGIS_PROTOCOL_VERSION,
+} from '../handshake.js';
+
+describe('negotiate', () => {
+  it('full-capability client gets all server capabilities', () => {
+    const result = negotiate({
+      protocolVersion: AEGIS_PROTOCOL_VERSION,
+      clientCapabilities: [...AEGIS_CAPABILITIES],
+    });
+    expect(result.compatible).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.negotiatedCapabilities).toEqual([...AEGIS_CAPABILITIES]);
+    expect(result.serverCapabilities).toEqual([...AEGIS_CAPABILITIES]);
+    expect(result.protocolVersion).toBe(AEGIS_PROTOCOL_VERSION);
+  });
+
+  it('partial-capability client gets intersection only', () => {
+    const result = negotiate({
+      protocolVersion: AEGIS_PROTOCOL_VERSION,
+      clientCapabilities: ['session.create', 'session.approve'],
+    });
+    expect(result.compatible).toBe(true);
+    expect(result.negotiatedCapabilities).toEqual(['session.create', 'session.approve']);
+    expect(result.negotiatedCapabilities).not.toContain('session.transcript');
+  });
+
+  it('client with no declared capabilities gets full server set', () => {
+    const result = negotiate({ protocolVersion: AEGIS_PROTOCOL_VERSION });
+    expect(result.compatible).toBe(true);
+    expect(result.negotiatedCapabilities).toEqual([...AEGIS_CAPABILITIES]);
+  });
+
+  it('unknown client capabilities are ignored with a warning', () => {
+    const result = negotiate({
+      protocolVersion: AEGIS_PROTOCOL_VERSION,
+      clientCapabilities: ['session.create', 'some.future.feature'],
+    });
+    expect(result.compatible).toBe(true);
+    expect(result.negotiatedCapabilities).toContain('session.create');
+    expect(result.negotiatedCapabilities).not.toContain('some.future.feature');
+    expect(result.warnings.some(w => w.includes('some.future.feature'))).toBe(true);
+  });
+
+  it('protocol version below minimum → not compatible + warning', () => {
+    const result = negotiate({
+      protocolVersion: '0',
+      clientCapabilities: ['session.create'],
+    });
+    expect(result.compatible).toBe(false);
+    expect(result.negotiatedCapabilities).toHaveLength(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain('below minimum');
+  });
+
+  it('protocol version newer than server → compatible with forward-compat warning', () => {
+    const futureVersion = String(parseInt(AEGIS_PROTOCOL_VERSION, 10) + 5);
+    const result = negotiate({ protocolVersion: futureVersion });
+    expect(result.compatible).toBe(true);
+    expect(result.warnings.some(w => w.includes('newer than server'))).toBe(true);
+  });
+
+  it('malformed protocolVersion → not compatible', () => {
+    const result = negotiate({ protocolVersion: 'abc-bad' });
+    expect(result.compatible).toBe(false);
+    expect(result.warnings.some(w => w.includes('Unrecognized'))).toBe(true);
+  });
+});

--- a/src/handshake.ts
+++ b/src/handshake.ts
@@ -1,0 +1,121 @@
+/**
+ * handshake.ts — Capability handshake schema and negotiation for Aegis/Claude Code.
+ *
+ * Issue #885: Defines a formal protocolVersion + capabilities negotiation so
+ * that clients and Aegis can agree on supported feature set before using
+ * advanced integration paths. Prevents version-drift breakage.
+ */
+
+/** Current protocol version advertised by this Aegis build. */
+export const AEGIS_PROTOCOL_VERSION = '1';
+
+/** Minimum protocol version this Aegis build still accepts. */
+export const AEGIS_MIN_PROTOCOL_VERSION = '1';
+
+/**
+ * All capabilities Aegis supports in this build.
+ * Capabilities are additive; absence means the feature is unavailable/disabled.
+ */
+export const AEGIS_CAPABILITIES = [
+  'session.create',
+  'session.resume',
+  'session.approve',
+  'session.transcript',
+  'session.transcript.cursor',   // Issue #883: cursor-based replay
+  'session.events.sse',
+  'session.screenshot',
+  'hooks.pre_tool_use',
+  'hooks.post_tool_use',
+  'hooks.notification',
+  'hooks.stop',
+  'swarm',
+  'metrics',
+] as const;
+
+export type AegisCapability = (typeof AEGIS_CAPABILITIES)[number];
+
+/** Request body for POST /v1/handshake */
+export interface HandshakeRequest {
+  protocolVersion: string;
+  clientCapabilities?: string[];
+  clientVersion?: string;
+}
+
+/** Response shape for POST /v1/handshake */
+export interface HandshakeResponse {
+  protocolVersion: string;
+  serverCapabilities: AegisCapability[];
+  negotiatedCapabilities: AegisCapability[];
+  warnings: string[];
+  compatible: boolean;
+}
+
+/**
+ * Negotiate capabilities between a client request and this Aegis build.
+ *
+ * Rules:
+ * - If client protocolVersion < AEGIS_MIN_PROTOCOL_VERSION → not compatible, add warning, return empty negotiatedCapabilities
+ * - If client protocolVersion > AEGIS_PROTOCOL_VERSION → compatible but add forward-compat warning
+ * - negotiatedCapabilities = intersection of server caps and clientCapabilities (or all server caps if client sends none)
+ */
+export function negotiate(req: HandshakeRequest): HandshakeResponse {
+  const warnings: string[] = [];
+  const serverCapabilities = [...AEGIS_CAPABILITIES];
+
+  // Parse major version numbers for comparison
+  const clientMajor = parseInt(req.protocolVersion, 10);
+  const serverMajor = parseInt(AEGIS_PROTOCOL_VERSION, 10);
+  const minMajor = parseInt(AEGIS_MIN_PROTOCOL_VERSION, 10);
+
+  if (isNaN(clientMajor)) {
+    return {
+      protocolVersion: AEGIS_PROTOCOL_VERSION,
+      serverCapabilities,
+      negotiatedCapabilities: [],
+      warnings: [`Unrecognized protocolVersion format: "${req.protocolVersion}". Expected integer string.`],
+      compatible: false,
+    };
+  }
+
+  if (clientMajor < minMajor) {
+    return {
+      protocolVersion: AEGIS_PROTOCOL_VERSION,
+      serverCapabilities,
+      negotiatedCapabilities: [],
+      warnings: [
+        `Client protocolVersion ${req.protocolVersion} is below minimum supported version ${AEGIS_MIN_PROTOCOL_VERSION}. Upgrade required.`,
+      ],
+      compatible: false,
+    };
+  }
+
+  if (clientMajor > serverMajor) {
+    warnings.push(
+      `Client protocolVersion ${req.protocolVersion} is newer than server version ${AEGIS_PROTOCOL_VERSION}. Some client features may be unavailable.`,
+    );
+  }
+
+  // Intersect: client declares what it supports; server only enables what it also supports
+  let negotiatedCapabilities: AegisCapability[];
+  if (!req.clientCapabilities || req.clientCapabilities.length === 0) {
+    // Client omitted capabilities → assume full server capability set
+    negotiatedCapabilities = serverCapabilities;
+  } else {
+    const serverSet = new Set<string>(serverCapabilities);
+    const unknown = req.clientCapabilities.filter(c => !serverSet.has(c));
+    if (unknown.length > 0) {
+      warnings.push(`Unknown client capabilities ignored: ${unknown.join(', ')}`);
+    }
+    negotiatedCapabilities = req.clientCapabilities.filter(
+      (c): c is AegisCapability => serverSet.has(c),
+    );
+  }
+
+  return {
+    protocolVersion: AEGIS_PROTOCOL_VERSION,
+    serverCapabilities,
+    negotiatedCapabilities,
+    warnings,
+    compatible: true,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ import { registerWsTerminalRoute } from './ws-terminal.js';
 import { SwarmMonitor } from './swarm-monitor.js';
 import { killAllSessions } from './signal-cleanup-helper.js';
 import { execFileSync } from 'node:child_process';
+import { negotiate, type HandshakeRequest } from './handshake.js';
 import {
   authKeySchema, sendMessageSchema, commandSchema, bashSchema,
   screenshotSchema, permissionHookSchema, stopHookSchema,
@@ -329,6 +330,19 @@ async function healthHandler(): Promise<Record<string, unknown>> {
 }
 app.get('/v1/health', healthHandler);
 app.get('/health', healthHandler);
+app.post<{ Body: HandshakeRequest }>('/v1/handshake', async (req, reply) => {
+  const { protocolVersion, clientCapabilities, clientVersion } = req.body ?? {};
+  if (typeof protocolVersion !== 'string' || !protocolVersion.trim()) {
+    return reply.status(400).send({ error: 'protocolVersion is required' });
+  }
+  if (clientCapabilities !== undefined && !Array.isArray(clientCapabilities)) {
+    return reply.status(400).send({ error: 'clientCapabilities must be an array' });
+  }
+  const result = negotiate({ protocolVersion, clientCapabilities, clientVersion });
+  return reply.status(result.compatible ? 200 : 409).send(result);
+});
+
+// Issue #81: Swarm awareness
 
 // Issue #81: Swarm awareness — list all detected CC swarms and their teammates
 app.get('/v1/swarm', async () => {


### PR DESCRIPTION
## Summary

Introduces a formal `protocolVersion + capabilities` handshake endpoint so Aegis and Claude Code clients can explicitly negotiate feature support before using advanced integration paths. Prevents version-drift breakage and enables safe feature gating.

### New endpoint

```
POST /v1/handshake
Content-Type: application/json

{
  "protocolVersion": "1",
  "clientCapabilities": ["session.create", "session.transcript.cursor"],
  "clientVersion": "1.0.0"
}
```

**Response (200 when compatible, 409 when not):**
```json
{
  "protocolVersion": "1",
  "serverCapabilities": ["session.create", "session.resume", ...],
  "negotiatedCapabilities": ["session.create", "session.transcript.cursor"],
  "warnings": [],
  "compatible": true
}
```

### Negotiation rules
- `negotiatedCapabilities` = intersection of server and client capabilities (client omits → get full server set)
- `clientVersion < minProtocolVersion` → `compatible: false`, `negotiatedCapabilities: []`
- `clientVersion > serverVersion` → compatible with forward-compat warning
- Unknown client capabilities → ignored with a warning in the response

### Changes
- `src/handshake.ts` (new): `negotiate()`, `AEGIS_CAPABILITIES`, `AEGIS_PROTOCOL_VERSION`, `HandshakeRequest/Response` types
- `src/server.ts`: `POST /v1/handshake` route
- `src/__tests__/capability-handshake-885.test.ts`: 7 tests

### Tests
- 7/7 tests pass
- Typecheck clean

Closes #885

## Aegis version
**Developed with:** v2.5.3
