### PR TITLE
perf: replace O(n) event buffer pruning with circular queue

### DIFF
--- a/src/__tests__/circular-buffer.test.ts
+++ b/src/__tests__/circular-buffer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { CircularBuffer } from '../utils/circular-buffer.js';
+
+describe('CircularBuffer', () => {
+  it('stores items until capacity', () => {
+    const buffer = new CircularBuffer<number>(3);
+    buffer.push(1);
+    buffer.push(2);
+    expect(buffer.toArray()).toEqual([1, 2]);
+    expect(buffer.size()).toBe(2);
+  });
+
+  it('evicts oldest item when capacity is exceeded', () => {
+    const buffer = new CircularBuffer<number>(3);
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+    buffer.push(4);
+    expect(buffer.toArray()).toEqual([2, 3, 4]);
+    expect(buffer.size()).toBe(3);
+  });
+
+  it('preserves insertion order through multiple wraparounds', () => {
+    const buffer = new CircularBuffer<number>(4);
+    for (let i = 1; i <= 10; i++) {
+      buffer.push(i);
+    }
+    expect(buffer.toArray()).toEqual([7, 8, 9, 10]);
+  });
+
+  it('clear resets internal state', () => {
+    const buffer = new CircularBuffer<number>(2);
+    buffer.push(1);
+    buffer.push(2);
+    buffer.clear();
+    expect(buffer.toArray()).toEqual([]);
+    expect(buffer.size()).toBe(0);
+    buffer.push(3);
+    expect(buffer.toArray()).toEqual([3]);
+  });
+
+  it('throws on invalid capacity', () => {
+    expect(() => new CircularBuffer<number>(0)).toThrow();
+    expect(() => new CircularBuffer<number>(-1)).toThrow();
+    expect(() => new CircularBuffer<number>(1.5)).toThrow();
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -7,6 +7,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { CircularBuffer } from './utils/circular-buffer.js';
 
 export interface SessionSSEEvent {
   event: 'status' | 'message' | 'system' | 'approval' | 'ended' | 'heartbeat' | 'stall' | 'dead' | 'hook' | 'subagent_start' | 'subagent_stop';
@@ -78,10 +79,10 @@ export class SessionEventBus {
   private static readonly BUFFER_SIZE = 50;
 
   /** Per-session ring buffer for event replay. */
-  private eventBuffers = new Map<string, Array<{ id: number; event: SessionSSEEvent }>>();
+  private eventBuffers = new Map<string, CircularBuffer<{ id: number; event: SessionSSEEvent }>>();
 
   /** Global ring buffer for event replay across all sessions (Issue #301). */
-  private globalEventBuffer: Array<{ id: number; event: GlobalSSEEvent }> = [];
+  private globalEventBuffer = new CircularBuffer<{ id: number; event: GlobalSSEEvent }>(SessionEventBus.BUFFER_SIZE);
 
   /** Get or create the emitter for a session. */
   private getEmitter(sessionId: string): EventEmitter {
@@ -121,13 +122,10 @@ export class SessionEventBus {
     // Push to ring buffer
     let buffer = this.eventBuffers.get(sessionId);
     if (!buffer) {
-      buffer = [];
+      buffer = new CircularBuffer<{ id: number; event: SessionSSEEvent }>(SessionEventBus.BUFFER_SIZE);
       this.eventBuffers.set(sessionId, buffer);
     }
     buffer.push({ id: event.id, event });
-    if (buffer.length > SessionEventBus.BUFFER_SIZE) {
-      buffer.splice(0, buffer.length - SessionEventBus.BUFFER_SIZE);
-    }
     const emitter = this.emitters.get(sessionId);
     if (emitter) {
       const imm = setImmediate(() => {
@@ -141,9 +139,6 @@ export class SessionEventBus {
       const globalEvent = toGlobalEvent(event);
       // Issue #301: push to global ring buffer
       this.globalEventBuffer.push({ id: event.id, event: globalEvent });
-      if (this.globalEventBuffer.length > SessionEventBus.BUFFER_SIZE) {
-        this.globalEventBuffer.splice(0, this.globalEventBuffer.length - SessionEventBus.BUFFER_SIZE);
-      }
       const imm = setImmediate(() => {
         this.pendingTimers.delete(imm);
         this.globalEmitter?.emit('event', globalEvent);
@@ -156,7 +151,7 @@ export class SessionEventBus {
   getEventsSince(sessionId: string, lastEventId: number): SessionSSEEvent[] {
     const buffer = this.eventBuffers.get(sessionId);
     if (!buffer) return [];
-    return buffer.filter(e => e.id > lastEventId).map(e => e.event);
+    return buffer.toArray().filter(e => e.id > lastEventId).map(e => e.event);
   }
 
   /** Emit a status change event. */
@@ -308,15 +303,12 @@ export class SessionEventBus {
     };
     // Issue #301: buffer global-only events
     this.globalEventBuffer.push({ id, event: globalEvent });
-    if (this.globalEventBuffer.length > SessionEventBus.BUFFER_SIZE) {
-      this.globalEventBuffer.splice(0, this.globalEventBuffer.length - SessionEventBus.BUFFER_SIZE);
-    }
     this.globalEmitter.emit('event', globalEvent);
   }
 
   /** Get global events emitted after the given event ID (Issue #301). */
   getGlobalEventsSince(lastEventId: number): Array<{ id: number; event: GlobalSSEEvent }> {
-    return this.globalEventBuffer.filter(e => e.id > lastEventId);
+    return this.globalEventBuffer.toArray().filter(e => e.id > lastEventId);
   }
 
   /** #398: Clean up per-session state (call when session is killed). */
@@ -351,7 +343,7 @@ export class SessionEventBus {
     }
     this.emitters.clear();
     this.eventBuffers.clear();
-    this.globalEventBuffer = [];
+    this.globalEventBuffer.clear();
     this.globalEmitter?.removeAllListeners();
     this.globalEmitter = null;
   }

--- a/src/utils/circular-buffer.ts
+++ b/src/utils/circular-buffer.ts
@@ -1,0 +1,40 @@
+export class CircularBuffer<T> {
+  private readonly items: Array<T | undefined>;
+  private head = 0;
+  private count = 0;
+
+  constructor(private readonly capacity: number) {
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new Error(`CircularBuffer capacity must be a positive integer, got: ${capacity}`);
+    }
+    this.items = new Array<T | undefined>(capacity);
+  }
+
+  push(item: T): void {
+    this.items[this.head] = item;
+    this.head = (this.head + 1) % this.capacity;
+    if (this.count < this.capacity) {
+      this.count++;
+    }
+  }
+
+  toArray(): T[] {
+    if (this.count === 0) {
+      return [];
+    }
+    if (this.count < this.capacity) {
+      return this.items.slice(0, this.count) as T[];
+    }
+    return [...this.items.slice(this.head), ...this.items.slice(0, this.head)] as T[];
+  }
+
+  clear(): void {
+    this.items.fill(undefined);
+    this.head = 0;
+    this.count = 0;
+  }
+
+  size(): number {
+    return this.count;
+  }
+}


### PR DESCRIPTION
## Summary
- replace per-session event replay storage from array+splice pruning to a fixed-capacity circular buffer
- add reusable CircularBuffer utility in src/utils/circular-buffer.ts
- keep replay behavior unchanged while removing O(n) shift/copy overhead on overflow
- add dedicated unit tests for circular buffer behavior

Closes #660

## Validation
- npx vitest run src/__tests__/circular-buffer.test.ts src/__tests__/events.test.ts
- npx tsc --noEmit
- npm run build
- npm test (fails on existing Windows baseline tests unrelated to this change: env-security/path handling suites)

## Aegis version
**Developed with:** v2.6.0
