### PR TITLE
fix: validate pipeline stage workDir for path traversal

### DIFF
--- a/src/__tests__/pipeline-stage-workdir-traversal-631.test.ts
+++ b/src/__tests__/pipeline-stage-workdir-traversal-631.test.ts
@@ -1,0 +1,61 @@
+/**
+ * pipeline-stage-workdir-traversal-631.test.ts — Tests for Issue #631.
+ *
+ * Verifies that validateWorkDir rejects path traversal patterns
+ * that could appear in per-stage workDir overrides.
+ * The server route applies validateWorkDir to each stage's workDir
+ * the same way it validates the pipeline-level workDir.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import { validateWorkDir } from '../validation.js';
+
+/** Helper: check result is an error with given code. */
+function isError(result: string | { error: string; code: string }, code: string): boolean {
+  return typeof result === 'object' && result.code === code;
+}
+
+const tmpBase = path.join(os.tmpdir(), 'aegis-test-631');
+
+describe('Pipeline stage workDir path traversal — Issue #631', () => {
+  beforeEach(async () => {
+    await fs.mkdir(tmpBase, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpBase, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('rejects stage workDir with ".." traversing out of /tmp', async () => {
+    const result = await validateWorkDir('/tmp/../../etc/passwd');
+    expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
+  });
+
+  it('rejects stage workDir with ".." appended to a valid path', async () => {
+    const validDir = await fs.mkdtemp(path.join(tmpBase, 'safe-'));
+    const result = await validateWorkDir(validDir + '/../../etc');
+    expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
+  });
+
+  it('rejects stage workDir that is just ".."', async () => {
+    const result = await validateWorkDir('..');
+    expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
+  });
+
+  it('accepts a valid stage workDir under tmp', async () => {
+    const stageDir = await fs.mkdtemp(path.join(tmpBase, 'stage-'));
+    const result = await validateWorkDir(stageDir);
+    expect(typeof result).toBe('string');
+    expect(result).toBe(stageDir);
+  });
+
+  it('accepts a valid stage workDir nested under home', async () => {
+    const stageDir = await fs.mkdtemp(path.join(os.homedir(), '.aegis-test-631-'));
+    const result = await validateWorkDir(stageDir);
+    expect(typeof result).toBe('string');
+    await fs.rm(stageDir, { recursive: true, force: true });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1131,6 +1131,16 @@ app.post('/v1/pipelines', async (req, reply) => {
     return reply.status(400).send({ error: `Invalid workDir: ${safeWorkDir.error}`, code: safeWorkDir.code });
   }
   pipeConfig.workDir = safeWorkDir;
+  // Validate per-stage workDir overrides for path traversal (#631)
+  for (const stage of pipeConfig.stages) {
+    if (stage.workDir) {
+      const safeStageWorkDir = await validateWorkDirWithConfig(stage.workDir);
+      if (typeof safeStageWorkDir === 'object') {
+        return reply.status(400).send({ error: `Invalid workDir for stage "${stage.name}": ${safeStageWorkDir.error}`, code: safeStageWorkDir.code });
+      }
+      stage.workDir = safeStageWorkDir;
+    }
+  }
   try {
     const pipeline = await pipelines.createPipeline(pipeConfig);
     return reply.status(201).send(pipeline);


### PR DESCRIPTION
Fixes #631

## Summary
- Per-stage `workDir` overrides in pipeline creation (`POST /v1/pipelines`) were not validated for path traversal attacks
- Added `validateWorkDirWithConfig` call for each stage's `workDir` in the pipeline route handler (`server.ts`)
- Added 5 unit tests covering traversal patterns (`../..`, `..`, etc.) and valid paths

## Aegis version
**Developed with:** v2.6.0