### PR TITLE
test(reliability): add deterministic fault-injection integration harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "start": "node dist/cli.js",
     "dev": "tsc && node dist/cli.js",
     "prepublishOnly": "npm run build:dashboard && npm run build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:fault-harness": "vitest run src/__tests__/fault-injection-harness-901.test.ts"
   },
   "keywords": [
     "claude",

--- a/src/__tests__/fault-injection-harness-901.test.ts
+++ b/src/__tests__/fault-injection-harness-901.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionInfo, SessionManager } from '../session.js';
+import type { ChannelManager, SessionEventPayload } from '../channels/index.js';
+import type { JsonlWatcher } from '../jsonl-watcher.js';
+import type { ParsedEntry } from '../transcript.js';
+import type { UIState } from '../terminal-parser.js';
+import { SessionMonitor } from '../monitor.js';
+import {
+  addFaultRule,
+  clearFaultRules,
+  InjectedFatalFaultError,
+  maybeInjectFault,
+  resetFaultInjection,
+  setFaultInjectionEnabledForTest,
+  setFaultInjectionSeedForTest,
+} from '../fault-injection.js';
+import { SessionManager as RealSessionManager } from '../session.js';
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'session-1',
+    windowId: '@0',
+    windowName: 'test-session',
+    workDir: '/tmp/test',
+    claudeSessionId: 'claude-abc',
+    jsonlPath: '/tmp/test/session.jsonl',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now() - 60_000,
+    lastActivity: Date.now() - 10_000,
+    stallThresholdMs: 5 * 60 * 1000,
+    permissionStallMs: 5 * 60 * 1000,
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+function mockSessionManager(sessions: SessionInfo[] = []) {
+  const sessionMap = new Map<string, SessionInfo>();
+  for (const s of sessions) sessionMap.set(s.id, { ...s });
+
+  return {
+    listSessions: vi.fn(() => [...sessionMap.values()]),
+    getSession: vi.fn((id: string) => sessionMap.get(id) ?? null),
+    isWindowAlive: vi.fn<(id: string) => Promise<boolean>>(async () => true),
+    killSession: vi.fn(async () => {}),
+    readMessagesForMonitor: vi.fn(async () => ({
+      messages: [] as ParsedEntry[],
+      status: 'idle' as UIState,
+      statusText: null as string | null,
+      interactiveContent: null as string | null,
+    })),
+    approve: vi.fn(async () => {}),
+    reject: vi.fn(async () => {}),
+  };
+}
+
+function mockChannelManager() {
+  return {
+    statusChange: vi.fn(async (_payload: SessionEventPayload) => {}),
+    message: vi.fn(async (_payload: SessionEventPayload) => {}),
+  };
+}
+
+function makeMessage(overrides: Partial<ParsedEntry> = {}): ParsedEntry {
+  return {
+    role: 'assistant',
+    contentType: 'text',
+    text: 'Hello world',
+    ...overrides,
+  };
+}
+
+async function flushAll(ms = 50): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('Issue #901: deterministic fault-injection integration harness', () => {
+  beforeEach(() => {
+    setFaultInjectionEnabledForTest(true);
+    setFaultInjectionSeedForTest(901);
+    clearFaultRules();
+    resetFaultInjection();
+  });
+
+  afterEach(() => {
+    clearFaultRules();
+    setFaultInjectionEnabledForTest(false);
+    resetFaultInjection();
+    vi.restoreAllMocks();
+  });
+
+  it('injects deterministic transient fault in monitor forwardMessage fire-and-forget path', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    addFaultRule({
+      point: 'monitor.forwardMessage.channels.message',
+      mode: 'transient',
+      every: 1,
+      errorMessage: 'Injected monitor transient',
+    });
+
+    const session = makeSession({ id: 'fi-msg-1' });
+    const sessions = mockSessionManager([session]);
+    const channels = mockChannelManager();
+    const watcher = {
+      watch: vi.fn(),
+      unwatch: vi.fn(),
+      isWatching: vi.fn(() => false),
+      onEntries: vi.fn(),
+    };
+
+    const monitor = new SessionMonitor(
+      sessions as unknown as SessionManager,
+      channels as unknown as ChannelManager,
+    );
+    monitor.setJsonlWatcher(watcher as unknown as JsonlWatcher);
+
+    const onEntries = watcher.onEntries.mock.calls[0][0] as (event: unknown) => void;
+    onEntries({
+      sessionId: 'fi-msg-1',
+      newOffset: 500,
+      messages: [makeMessage()],
+    });
+
+    await flushAll(120);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(channels.message).toHaveBeenCalledTimes(0);
+  });
+
+  it('injects deterministic fatal fault in session acquisition path', async () => {
+    addFaultRule({
+      point: 'session.findIdleSessionByWorkDir.start',
+      mode: 'fatal',
+      every: 1,
+      errorMessage: 'Injected acquisition fatal',
+    });
+
+    const tmux = {
+      windowExists: vi.fn(async () => true),
+    };
+
+    const manager = new RealSessionManager(
+      tmux as any,
+      { stateDir: '/tmp/aegis-test' } as any,
+    );
+
+    (manager as any).state.sessions = {
+      s1: makeSession({ id: 's1', workDir: '/tmp/project', status: 'idle' }),
+    };
+
+    await expect(manager.findIdleSessionByWorkDir('/tmp/project')).rejects.toBeInstanceOf(InjectedFatalFaultError);
+
+    clearFaultRules();
+    const acquired = await manager.findIdleSessionByWorkDir('/tmp/project');
+    expect(acquired?.id).toBe('s1');
+  });
+
+  it('supports deterministic delay injection for CI-friendly timing scenarios', async () => {
+    addFaultRule({
+      point: 'fault.harness.delay.sample',
+      mode: 'delay',
+      every: 1,
+      delayMs: 30,
+    });
+
+    const start = Date.now();
+    await maybeInjectFault('fault.harness.delay.sample');
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(20);
+  });
+
+  it('has zero behavior change when harness is disabled', async () => {
+    setFaultInjectionEnabledForTest(false);
+    addFaultRule({
+      point: 'fault.harness.disabled.sample',
+      mode: 'fatal',
+      every: 1,
+      errorMessage: 'should not throw when disabled',
+    });
+
+    await expect(maybeInjectFault('fault.harness.disabled.sample')).resolves.toBeUndefined();
+  });
+});

--- a/src/fault-injection.ts
+++ b/src/fault-injection.ts
@@ -1,0 +1,151 @@
+/**
+ * fault-injection.ts — deterministic fault injection harness for integration tests.
+ *
+ * Disabled by default in production. Enable with AEGIS_FAULT_INJECTION=1
+ * or via test helpers.
+ */
+
+export type FaultMode = 'transient' | 'fatal' | 'delay';
+
+export interface FaultRule {
+  point: string;
+  mode: FaultMode;
+  every?: number;
+  probability?: number;
+  delayMs?: number;
+  errorMessage?: string;
+}
+
+export class InjectedTransientFaultError extends Error {
+  readonly point: string;
+
+  constructor(point: string, message?: string) {
+    super(message ?? `Injected transient fault at ${point}`);
+    this.name = 'InjectedTransientFaultError';
+    this.point = point;
+  }
+}
+
+export class InjectedFatalFaultError extends Error {
+  readonly point: string;
+
+  constructor(point: string, message?: string) {
+    super(message ?? `Injected fatal fault at ${point}`);
+    this.name = 'InjectedFatalFaultError';
+    this.point = point;
+  }
+}
+
+class FaultInjector {
+  private readonly rules: FaultRule[] = [];
+  private readonly hitCounts = new Map<string, number>();
+  private enabledOverride: boolean | null = null;
+  private seed = 1;
+  private rngState = 1;
+
+  constructor() {
+    this.reset();
+  }
+
+  private readSeedFromEnv(): number {
+    const parsed = Number.parseInt(process.env.AEGIS_FAULT_SEED ?? '1', 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+  }
+
+  private nextRandom(): number {
+    // LCG constants from Numerical Recipes, deterministic and fast.
+    this.rngState = (1664525 * this.rngState + 1013904223) >>> 0;
+    return this.rngState / 0x100000000;
+  }
+
+  private isEnabled(): boolean {
+    if (this.enabledOverride !== null) {
+      return this.enabledOverride;
+    }
+    return process.env.AEGIS_FAULT_INJECTION === '1';
+  }
+
+  reset(): void {
+    this.seed = this.readSeedFromEnv();
+    this.rngState = this.seed;
+    this.hitCounts.clear();
+  }
+
+  clearRules(): void {
+    this.rules.length = 0;
+    this.hitCounts.clear();
+  }
+
+  setEnabledForTest(enabled: boolean): void {
+    this.enabledOverride = enabled;
+  }
+
+  setSeedForTest(seed: number): void {
+    this.seed = seed > 0 ? Math.floor(seed) : 1;
+    this.rngState = this.seed;
+  }
+
+  addRule(rule: FaultRule): void {
+    this.rules.push(rule);
+  }
+
+  async inject(point: string): Promise<void> {
+    if (!this.isEnabled()) return;
+
+    for (const rule of this.rules) {
+      if (rule.point !== point) continue;
+
+      const count = (this.hitCounts.get(point) ?? 0) + 1;
+      this.hitCounts.set(point, count);
+
+      let shouldTrigger = true;
+      if (rule.every && rule.every > 0) {
+        shouldTrigger = count % rule.every === 0;
+      } else if (typeof rule.probability === 'number') {
+        shouldTrigger = this.nextRandom() < Math.max(0, Math.min(1, rule.probability));
+      }
+
+      if (!shouldTrigger) continue;
+
+      if (rule.mode === 'delay') {
+        const ms = Math.max(0, rule.delayMs ?? 0);
+        if (ms > 0) {
+          await new Promise<void>(resolve => setTimeout(resolve, ms));
+        }
+        return;
+      }
+
+      if (rule.mode === 'transient') {
+        throw new InjectedTransientFaultError(point, rule.errorMessage);
+      }
+
+      throw new InjectedFatalFaultError(point, rule.errorMessage);
+    }
+  }
+}
+
+const injector = new FaultInjector();
+
+export function maybeInjectFault(point: string): Promise<void> {
+  return injector.inject(point);
+}
+
+export function resetFaultInjection(): void {
+  injector.reset();
+}
+
+export function clearFaultRules(): void {
+  injector.clearRules();
+}
+
+export function setFaultInjectionEnabledForTest(enabled: boolean): void {
+  injector.setEnabledForTest(enabled);
+}
+
+export function setFaultInjectionSeedForTest(seed: number): void {
+  injector.setSeedForTest(seed);
+}
+
+export function addFaultRule(rule: FaultRule): void {
+  injector.addRule(rule);
+}

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -22,6 +22,7 @@ import { type JsonlWatcher, type JsonlWatcherEvent } from './jsonl-watcher.js';
 import { stopSignalsSchema } from './validation.js';
 import { suppressedCatch } from './suppress.js';
 import { logger } from './logger.js';
+import { maybeInjectFault } from './fault-injection.js';
 
 export interface MonitorConfig {
   pollIntervalMs: number;       // Base poll interval (default: 30000 — hooks are primary signal)
@@ -589,6 +590,7 @@ export class SessionMonitor {
     this.eventBus?.emitMessage(session.id, msg.role, msg.text, msg.contentType,
       msg.toolName || msg.toolUseId ? { tool_name: msg.toolName, tool_id: msg.toolUseId } : undefined);
 
+    await maybeInjectFault('monitor.forwardMessage.channels.message');
     await this.channels.message(this.makePayload(event, session, msg.text));
   }
 
@@ -598,6 +600,8 @@ export class SessionMonitor {
     prevStatus: UIState | undefined,
     result: { statusText: string | null; interactiveContent: string | null },
   ): Promise<void> {
+    await maybeInjectFault('monitor.broadcastStatusChange.start');
+
     if (status === 'permission_prompt' || status === 'bash_approval') {
       // Issue #32: Emit SSE approval event
       this.eventBus?.emitApproval(session.id, result.interactiveContent || 'Permission requested');
@@ -686,6 +690,7 @@ export class SessionMonitor {
     for (const session of sessions) {
       if (this.deadNotified.has(session.id)) continue;
 
+      await maybeInjectFault('monitor.checkDeadSessions.isWindowAlive');
       const alive = await this.sessions.isWindowAlive(session.id);
       if (!alive) {
         this.deadNotified.add(session.id);

--- a/src/session.ts
+++ b/src/session.ts
@@ -20,6 +20,7 @@ import { persistedStateSchema, sessionMapSchema } from './validation.js';
 import type { z } from 'zod';
 import { writeHookSettingsFile, cleanupHookSettingsFile } from './hook-settings.js';
 import { Mutex } from 'async-mutex';
+import { maybeInjectFault } from './fault-injection.js';
 
 /** Convert parsed JSON arrays to Sets for activeSubagents (#668). */
 function hydrateSessions(raw: z.infer<typeof persistedStateSchema>): Record<string, SessionInfo> {
@@ -839,6 +840,7 @@ export class SessionManager {
    *  Issue #840/#880: Atomically acquires the session under a mutex to prevent TOCTOU race. */
   async findIdleSessionByWorkDir(workDir: string): Promise<SessionInfo | null> {
     return this.sessionAcquireMutex.runExclusive(async () => {
+      await maybeInjectFault('session.findIdleSessionByWorkDir.start');
       const candidates = Object.values(this.state.sessions).filter(
         (s) => s.workDir === workDir && s.status === 'idle',
       );
@@ -847,6 +849,7 @@ export class SessionManager {
       candidates.sort((a, b) => b.lastActivity - a.lastActivity);
       // Issue #636: verify tmux window exists before returning
       for (const candidate of candidates) {
+        await maybeInjectFault('session.findIdleSessionByWorkDir.windowExists');
         if (await this.tmux.windowExists(candidate.windowId)) {
           // Issue #840: Mark session as acquired immediately to prevent
           // concurrent callers from grabbing the same session


### PR DESCRIPTION
## Summary
- add deterministic fault-injection module with seeded, test-gated rules for transient/fatal/delay scenarios
- integrate minimal opt-in hooks at reliability boundaries in monitor/session paths
- add integration harness tests for transient, fatal, delay, and disabled-mode behavior
- add CI-friendly test profile: npm run test:fault-harness

Closes #901

## Validation
- npx vitest run src/__tests__/fault-injection-harness-901.test.ts src/__tests__/dead-session.test.ts src/__tests__/fire-and-forget-rejections.test.ts
- npx tsc --noEmit
- npm run build
- npm test (known Windows baseline failures on env/path suites, unchanged by this PR)

## Aegis version
**Developed with:** v2.6.0
