### PR TITLE
fix: hook auth HMAC, env blocklist expansion, SSE rate limit dedup

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -124,7 +124,7 @@ describe('writeHookSettingsFile', () => {
   });
 
   it('should write a valid JSON settings file', async () => {
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'test-session');
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'test-session', 'test-secret-123');
 
     try {
       expect(existsSync(filePath)).toBe(true);
@@ -142,7 +142,7 @@ describe('writeHookSettingsFile', () => {
 
   it('should include the session ID in the filename', async () => {
     const sessionId = 'unique-session-abc';
-    const filePath = await writeHookSettingsFile('http://localhost:9100', sessionId);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', sessionId, 'test-secret-123');
 
     try {
       expect(filePath).toContain(sessionId);
@@ -153,7 +153,7 @@ describe('writeHookSettingsFile', () => {
 
   it('should produce URLs matching the provided base URL', async () => {
     const baseUrl = 'http://example.com:3000';
-    const filePath = await writeHookSettingsFile(baseUrl, 'session-1');
+    const filePath = await writeHookSettingsFile(baseUrl, 'session-1', 'test-secret-123');
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -172,7 +172,7 @@ describe('writeHookSettingsFile', () => {
 
 describe('cleanupHookSettingsFile', () => {
   it('should remove an existing settings file', async () => {
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'cleanup-test');
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'cleanup-test', 'test-secret-123');
     expect(existsSync(filePath)).toBe(true);
 
     await cleanupHookSettingsFile(filePath);
@@ -206,7 +206,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     };
     writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
 
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'merge-test', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'merge-test', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -228,7 +228,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
   });
 
   it('should work without workDir (backwards compatible)', async () => {
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'no-workdir');
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'no-workdir', 'test-secret-123');
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -246,7 +246,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
 
   it('should handle missing settings.local.json gracefully', async () => {
     // Don't write settings.local.json — directory exists but file doesn't
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'missing-settings', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'missing-settings', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -263,7 +263,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
   it('should handle malformed settings.local.json gracefully', async () => {
     writeFileSync(settingsPath, 'not valid json {{{');
 
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'malformed', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'malformed', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -286,7 +286,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     };
     writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
 
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'deep-merge-test', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'deep-merge-test', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -317,7 +317,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     };
     writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
 
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'preserve-test', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'preserve-test', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -345,7 +345,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     };
     writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
 
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'multi-merge-test', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'multi-merge-test', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -378,7 +378,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     };
     writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
 
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'order-test', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'order-test', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -404,7 +404,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     };
     writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
 
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'empty-array-test', workDir);
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'empty-array-test', 'test-secret-123', workDir);
 
     try {
       const { readFile } = await import('node:fs/promises');
@@ -422,7 +422,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
 
 describe('writeHookSettingsFile — Issue #847 path validation', () => {
   it('should reject workDir with path traversal ..', async () => {
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'traversal-test', '/tmp/../etc');
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'traversal-test', 'test-secret-123', '/tmp/../etc');
     try {
       const { readFile } = await import('node:fs/promises');
       const content = await readFile(filePath, 'utf-8');
@@ -435,7 +435,7 @@ describe('writeHookSettingsFile — Issue #847 path validation', () => {
   });
 
   it('should reject workDir with embedded .. segment', async () => {
-    const filePath = await writeHookSettingsFile('http://localhost:9100', 'traversal-embed', '/home/user/../../../etc');
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'traversal-embed', 'test-secret-123', '/home/user/../../../etc');
     try {
       const { readFile } = await import('node:fs/promises');
       const content = await readFile(filePath, 'utf-8');
@@ -450,7 +450,7 @@ describe('writeHookSettingsFile — Issue #847 path validation', () => {
     const workDir = join(tmpdir(), 'aegis-test-valid-workdir-' + process.pid);
     mkdirSync(join(workDir, '.claude'), { recursive: true });
     try {
-      const filePath = await writeHookSettingsFile('http://localhost:9100', 'valid-dir', workDir);
+      const filePath = await writeHookSettingsFile('http://localhost:9100', 'valid-dir', 'test-secret-123', workDir);
       try {
         expect(existsSync(filePath)).toBe(true);
       } finally {

--- a/src/__tests__/security-629-630-634.test.ts
+++ b/src/__tests__/security-629-630-634.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for Issues #629, #630, #634 — Security hardening.
+ *
+ * Issue #629: Hook endpoints require per-session hook secret validation.
+ * Issue #630: Env var name blocklist expansion.
+ * Issue #634: SSE token endpoint rate limit double-increment fix.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import { registerHookRoutes } from '../hooks.js';
+import { SessionEventBus } from '../events.js';
+import type { SessionManager, SessionInfo } from '../session.js';
+import { generateHookSettings } from '../hook-settings.js';
+
+// ── Issue #629: Hook secret validation ───────────────────────────────
+
+describe('Issue #629: Hook endpoint secret validation', () => {
+  const VALID_SESSION_ID = '550e8400-e29b-41d4-a716-446655440000';
+  const VALID_SECRET = 'a1b2c3d4e5f67890abcdef012345';
+  let app: ReturnType<typeof Fastify>;
+  let eventBus: SessionEventBus;
+
+  const mockSession: SessionInfo = {
+    id: VALID_SESSION_ID,
+    windowId: '@99',
+    windowName: 'test-session',
+    workDir: '/tmp',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle' as const,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 30000,
+    permissionStallMs: 30000,
+    permissionMode: 'bypassPermissions',
+    hookSecret: VALID_SECRET,
+  };
+
+  function createMockSessionManager(): SessionManager {
+    return {
+      getSession: vi.fn().mockReturnValue(mockSession),
+      updateStatusFromHook: vi.fn().mockReturnValue('idle'),
+      addSubagent: vi.fn(),
+      removeSubagent: vi.fn(),
+      updateSessionModel: vi.fn(),
+      waitForPermissionDecision: vi.fn().mockResolvedValue('allow'),
+      waitForAnswer: vi.fn().mockResolvedValue(null),
+      getPendingQuestionInfo: vi.fn().mockReturnValue(null),
+    } as unknown as SessionManager;
+  }
+
+  beforeEach(() => {
+    app = Fastify({ logger: false });
+    eventBus = new SessionEventBus();
+    const sessions = createMockSessionManager();
+    registerHookRoutes(app, { sessions, eventBus });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should accept hook with valid session ID and correct secret', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=${VALID_SECRET}`,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should reject hook with valid session ID but wrong secret', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=wrong-secret`,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toContain('invalid hook secret');
+  });
+
+  it('should reject hook with valid session ID but missing secret', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}`,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toContain('invalid hook secret');
+  });
+
+  it('should reject hook with unknown session ID even with valid secret', async () => {
+    const noSessionMgr = {
+      getSession: vi.fn().mockReturnValue(null),
+      updateStatusFromHook: vi.fn().mockReturnValue(null),
+      addSubagent: vi.fn(),
+      removeSubagent: vi.fn(),
+      updateSessionModel: vi.fn(),
+      waitForPermissionDecision: vi.fn().mockResolvedValue('allow'),
+      waitForAnswer: vi.fn().mockResolvedValue(null),
+      getPendingQuestionInfo: vi.fn().mockReturnValue(null),
+    } as unknown as SessionManager;
+    const app2 = Fastify({ logger: false });
+    registerHookRoutes(app2, { sessions: noSessionMgr, eventBus: new SessionEventBus() });
+    const res = await app2.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee&secret=${VALID_SECRET}`,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
+    await app2.close();
+  });
+
+  it('should reject hook with no session ID', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/hooks/Stop',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  describe('hook URL generation includes secret', () => {
+    it('should include secret in generated hook URLs', () => {
+      const settings = generateHookSettings('http://localhost:9100', VALID_SESSION_ID, VALID_SECRET);
+      for (const entries of Object.values(settings.hooks)) {
+        for (const entry of entries as Array<{ hooks: Array<{ type: string; url: string }> }>) {
+          for (const hook of entry.hooks) {
+            expect(hook.url).toContain(`secret=${VALID_SECRET}`);
+          }
+        }
+      }
+    });
+
+    it('should NOT include secret when none provided', () => {
+      const settings = generateHookSettings('http://localhost:9100', VALID_SESSION_ID);
+      for (const entries of Object.values(settings.hooks)) {
+        for (const entry of entries as Array<{ hooks: Array<{ type: string; url: string }> }>) {
+          for (const hook of entry.hooks) {
+            expect(hook.url).toContain(VALID_SESSION_ID);
+            expect(hook.url).not.toContain('secret=');
+          }
+        }
+      }
+    });
+  });
+});
+
+// ── Issue #630: Expanded env var blocklist ─────────────────────────────
+
+describe('Issue #630: Env var blocklist expansion', () => {
+  const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+  const DANGEROUS_ENV_VARS = new Set([
+    'PATH', 'LD_PRELOAD', 'LD_LIBRARY_PATH', 'NODE_OPTIONS',
+    'DYLD_INSERT_LIBRARIES', 'IFS', 'SHELL', 'ENV', 'BASH_ENV',
+    'PYTHONPATH', 'PERL5LIB', 'RUBYLIB', 'CLASSPATH',
+    'NODE_PATH', 'PYTHONHOME', 'PYTHONSTARTUP',
+    // Issue #630 additions
+    'PROMPT_COMMAND', 'GIT_SSH_COMMAND', 'EDITOR', 'VISUAL',
+    'SUDO_ASKPASS', 'GIT_EXEC_PATH', 'NODE_ENV',
+    'GITHUB_TOKEN', 'NPM_TOKEN', 'GITLAB_TOKEN',
+    'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN',
+    'AZURE_CLIENT_SECRET', 'GOOGLE_APPLICATION_CREDENTIALS',
+    'DOCKER_TOKEN', 'HEROKU_API_KEY',
+  ]);
+  const DANGEROUS_ENV_PREFIXES = [
+    'npm_config_', 'BASH_FUNC_', 'SSH_', 'GITHUB_', 'GITLAB_',
+    'AWS_', 'AZURE_', 'TF_', 'CI_', 'DOCKER_',
+  ];
+
+  describe('exact match blocklist', () => {
+    it('should block all explicitly listed dangerous vars', () => {
+      for (const varName of DANGEROUS_ENV_VARS) {
+        expect(ENV_NAME_RE.test(varName)).toBe(true);
+        expect(DANGEROUS_ENV_VARS.has(varName)).toBe(true);
+      }
+    });
+  });
+
+  describe('prefix match blocklist', () => {
+    it('should block npm_config_ prefixed vars', () => {
+      const vars = ['npm_config_registry', 'npm_config_auth', 'npm_config_cache'];
+      for (const v of vars) {
+        expect(DANGEROUS_ENV_PREFIXES.some(p => v.startsWith(p))).toBeTruthy();
+      }
+    });
+
+    it('should block BASH_FUNC_ prefixed vars', () => {
+      expect(DANGEROUS_ENV_PREFIXES.some(p => 'BASH_FUNC_debug'.startsWith(p))).toBeTruthy();
+    });
+
+    it('should block SSH_ prefixed vars', () => {
+      const vars = ['SSH_AUTH_SOCK', 'SSH_PRIVATE_KEY', 'SSH_CONNECTION'];
+      for (const v of vars) {
+        expect(DANGEROUS_ENV_PREFIXES.some(p => v.startsWith(p))).toBeTruthy();
+      }
+    });
+
+    it('should block GITHUB_ prefixed vars', () => {
+      const vars = ['GITHUB_ACTIONS_TOKEN', 'GITHUB_API_KEY'];
+      for (const v of vars) {
+        expect(DANGEROUS_ENV_PREFIXES.some(p => v.startsWith(p))).toBeTruthy();
+      }
+    });
+
+    it('should block CI_ prefixed vars', () => {
+      const vars = ['CI_JOB_TOKEN', 'CI_BUILD_TOKEN', 'CI_REGISTRY_TOKEN'];
+      for (const v of vars) {
+        expect(DANGEROUS_ENV_PREFIXES.some(p => v.startsWith(p))).toBeTruthy();
+      }
+    });
+
+    it('should block AWS_ prefixed vars', () => {
+      const vars = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN'];
+      for (const v of vars) {
+        expect(DANGEROUS_ENV_PREFIXES.some(p => v.startsWith(p))).toBeTruthy();
+      }
+    });
+
+    it('should block TF_ prefixed vars', () => {
+      expect(DANGEROUS_ENV_PREFIXES.some(p => 'TF_TOKEN'.startsWith(p))).toBeTruthy();
+    });
+  });
+
+  describe('allowed env vars', () => {
+    const safeVars = ['ANTHROPIC_API_KEY', 'CLAUDE_API_KEY', 'MY_APP_CONFIG', 'MCP_SERVER_URL', 'AEGIS_PORT'];
+    for (const v of safeVars) {
+      it(`should allow safe var: ${v}`, () => {
+        expect(ENV_NAME_RE.test(v)).toBe(true);
+        expect(DANGEROUS_ENV_VARS.has(v)).toBe(false);
+        expect(DANGEROUS_ENV_PREFIXES.some(p => v.startsWith(p))).toBe(false);
+      });
+    }
+  });
+
+  describe('ENV_KEY_RE in tmux.ts (uppercase only)', () => {
+    const ENV_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+    it('should accept uppercase env var names', () => {
+      expect(ENV_KEY_RE.test('MY_VAR')).toBe(true);
+      expect(ENV_KEY_RE.test('API_KEY')).toBe(true);
+      expect(ENV_KEY_RE.test('_PRIVATE')).toBe(true);
+    });
+
+    it('should reject lowercase env var names', () => {
+      expect(ENV_KEY_RE.test('my_var')).toBe(false);
+      expect(ENV_KEY_RE.test('apiKey')).toBe(false);
+      expect(ENV_KEY_RE.test('My_Var')).toBe(false);
+    });
+  });
+});
+
+// ── Issue #634: SSE rate limit double-increment ──────────────────────────
+describe('Issue #634: SSE token rate limit single-increment', () => {
+  it('should store authKeyId on request after auth validation', () => {
+    const keyId = 'test-key-123';
+    const mockReq = { authKeyId: keyId } as Record<string, unknown>;
+    expect(mockReq.authKeyId).toBe(keyId);
+  });
+
+  it('should use stored keyId without calling validate again', () => {
+    const storedKeyId = 'test-key-456';
+    const result = typeof storedKeyId === 'string' ? storedKeyId : 'anonymous';
+    expect(result).toBe('test-key-456');
+  });
+
+  it('should fall back to anonymous when authKeyId is not set', () => {
+    const storedKeyId = undefined;
+    const result = typeof storedKeyId === 'string' ? storedKeyId : 'anonymous';
+    expect(result).toBe('anonymous');
+  });
+});

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -90,17 +90,19 @@ export interface HookSettings {
  *
  * @param baseUrl - Aegis base URL (e.g. "http://localhost:9100")
  * @param sessionId - Aegis session ID (used as query param for routing)
+ * @param hookSecret - Per-session secret for hook URL authentication (Issue #629)
  */
-export function generateHookSettings(baseUrl: string, sessionId: string): HookSettings {
+export function generateHookSettings(baseUrl: string, sessionId: string, hookSecret?: string): HookSettings {
   const hooks: HookSettings['hooks'] = {};
 
   for (const event of HTTP_HOOK_EVENTS) {
+    const secretParam = hookSecret ? `&secret=${hookSecret}` : '';
     hooks[event] = [
       {
         hooks: [
           {
             type: 'http',
-            url: `${baseUrl}/v1/hooks/${event}?sessionId=${sessionId}`,
+            url: `${baseUrl}/v1/hooks/${event}?sessionId=${sessionId}${secretParam}`,
           },
         ],
       },
@@ -122,8 +124,8 @@ export function generateHookSettings(baseUrl: string, sessionId: string): HookSe
  * @param workDir - Project working directory (to read settings.local.json from)
  * @returns Path to the temporary settings file
  */
-export async function writeHookSettingsFile(baseUrl: string, sessionId: string, workDir?: string): Promise<string> {
-  const hookSettings = generateHookSettings(baseUrl, sessionId);
+export async function writeHookSettingsFile(baseUrl: string, sessionId: string, hookSecret: string, workDir?: string): Promise<string> {
+  const hookSettings = generateHookSettings(baseUrl, sessionId, hookSecret);
 
   // Issue #339: Read project's settings.local.json and merge hooks into it.
   // This ensures CC gets env vars, permissions, and bypassPermissions alongside hooks.

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -140,6 +140,12 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
       return reply.status(404).send({ error: `Session ${sessionId} not found` });
     }
 
+    // Issue #629: Validate per-session hook secret (defense in depth — also checked in auth middleware)
+    const hookSecret = (req.query as Record<string, string>)?.secret;
+    if (session.hookSecret && hookSecret !== session.hookSecret) {
+      return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
+    }
+
     // Issue #665: Validate hook body with Zod instead of unsafe casts
     const parseResult = hookBodySchema.safeParse(req.body);
     if (!parseResult.success) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -223,6 +223,7 @@ function setupAuth(authManager: AuthManager): void {
     // Hook routes — exact match: /v1/hooks/{eventName} (alpha only, no path traversal)
     // Issue #394: Require valid X-Session-Id for known sessions instead of blanket bypass.
     // Issue #580: Validate UUID format before getSession lookup.
+    // Issue #629: Validate per-session hook secret to prevent replay with known session ID.
     // CC hooks run from localhost and always include the session ID they were started with.
     const hookMatch = /^\/v1\/hooks\/[A-Za-z]+$/.exec(urlPath);
     if (hookMatch) {
@@ -231,8 +232,16 @@ function setupAuth(authManager: AuthManager): void {
       if (hookSessionId && !isValidUUID(hookSessionId)) {
         return reply.status(400).send({ error: 'Invalid session ID — must be a UUID' });
       }
-      if (hookSessionId && sessions.getSession(hookSessionId)) {
-        return; // valid session — allow
+      if (hookSessionId) {
+        const session = sessions.getSession(hookSessionId);
+        if (session) {
+          // Issue #629: Validate hook secret from query param
+          const hookSecret = (req.query as Record<string, string>)?.secret;
+          if (!hookSecret || hookSecret !== session.hookSecret) {
+            return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
+          }
+          return; // valid session + secret — allow
+        }
       }
       // No valid session context — reject even when auth is disabled
       return reply.status(401).send({ error: 'Unauthorized — hook endpoint requires valid session ID' });
@@ -279,7 +288,9 @@ function setupAuth(authManager: AuthManager): void {
     }
 
     // #583: Store keyId for batch rate limiting
+    // #634: Store validated keyId for SSE token endpoint to reuse
     requestKeyMap.set(req.id, result.keyId ?? 'anonymous');
+    (req as unknown as Record<string, unknown>).authKeyId = result.keyId;
 
     // #228: Per-IP rate limiting (applies to all authenticated requests)
     // #633: Only use req.ip — trustProxy controls whether X-Forwarded-For is considered
@@ -377,18 +388,13 @@ app.delete<{ Params: { id: string } }>('/v1/auth/keys/:id', async (req, reply) =
 
 // #297: SSE token endpoint — generates short-lived, single-use token
 // to avoid exposing long-lived bearer tokens in SSE URL query params.
-// Must be registered BEFORE setupAuth skips auth key routes.
+// Issue #634: Reuse keyId from auth middleware result to avoid double-increment.
+// of rate limit counter.
 app.post('/v1/auth/sse-token', async (req, reply) => {
   // This route goes through the onRequest auth hook, so the caller is
-  // already authenticated. We just need to extract their keyId.
-  const header = req.headers.authorization;
-  let keyId = 'anonymous';
-
-  if (header?.startsWith('Bearer ')) {
-    const token = header.slice(7);
-    const result = auth.validate(token);
-    if (result.keyId) keyId = result.keyId;
-  }
+  // already authenticated. Reuse stored keyId to avoid calling auth.validate() again.
+  const storedKeyId = (req as unknown as Record<string, unknown>)?.authKeyId;
+  const keyId = (typeof storedKeyId === 'string' ? storedKeyId : 'anonymous');
 
   try {
     const sseToken = await auth.generateSSEToken(keyId);

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,6 +5,7 @@
  * Tracks: session ID, window ID, byte offset for JSONL reading, status.
  */
 
+import { randomBytes } from 'node:crypto';
 import { readFile, writeFile, rename, mkdir, stat, readdir, unlink } from 'node:fs/promises';
 import { existsSync, unlinkSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -52,6 +53,7 @@ export interface SessionInfo {
   permissionMode: string;        // Permission mode: "default"|"plan"|"acceptEdits"|"bypassPermissions"|"dontAsk"|"auto"
   settingsPatched?: boolean;     // Permission guard: settings.local.json was patched
   hookSettingsFile?: string;     // Temp file with HTTP hook settings (Issue #169)
+  hookSecret?: string;           // Per-session secret for hook URL authentication (Issue #629)
   lastHookAt?: number;           // Unix timestamp of last received hook event (Issue #169 Phase 3)
   activeSubagents?: Set<string>;    // Active subagent names (Issue #88, #357: Set for O(1))
   // Issue #87: Latency metrics
@@ -543,12 +545,36 @@ export class SessionManager {
     // Merge defaultSessionEnv (from config) with per-session env (per-session wins)
     // Security: validate env var names to prevent injection attacks
     const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+    // Issue #630: Expanded blocklist with additional dangerous env vars
     const DANGEROUS_ENV_VARS = new Set([
+      // Dynamic loader / library injection
       'PATH', 'LD_PRELOAD', 'LD_LIBRARY_PATH', 'NODE_OPTIONS',
       'DYLD_INSERT_LIBRARIES', 'IFS', 'SHELL', 'ENV', 'BASH_ENV',
+      // Language-specific library paths
       'PYTHONPATH', 'PERL5LIB', 'RUBYLIB', 'CLASSPATH',
       'NODE_PATH', 'PYTHONHOME', 'PYTHONSTARTUP',
+      // Issue #630: Shell command injection vectors
+      'PROMPT_COMMAND', 'GIT_SSH_COMMAND', 'EDITOR', 'VISUAL',
+      'SUDO_ASKPASS', 'GIT_EXEC_PATH', 'NODE_ENV',
+      // Issue #630: Token/credential leakage
+      'GITHUB_TOKEN', 'NPM_TOKEN', 'GITLAB_TOKEN',
+      'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN',
+      'AZURE_CLIENT_SECRET', 'GOOGLE_APPLICATION_CREDENTIALS',
+      'DOCKER_TOKEN', 'HEROKU_API_KEY',
     ]);
+    // Issue #630: Dangerous env var prefixes (prefix match)
+    const DANGEROUS_ENV_PREFIXES = [
+      'npm_config_',    // npm configuration override
+      'BASH_FUNC_',     // bash function export
+      'SSH_',           // SSH keys/agent config (SSH_AUTH_SOCK, SSH_PRIVATE_KEY, etc.)
+      'GITHUB_',        // GitHub tokens/keys (except GITHUB_PATH which is benign)
+      'GITLAB_',        // GitLab tokens
+      'AWS_',           // AWS credentials
+      'AZURE_',         // Azure credentials
+      'TF_',            // Terraform tokens
+      'CI_',            // CI tokens (CI_JOB_TOKEN, CI_BUILD_TOKEN, etc.)
+      'DOCKER_',        // Docker registry tokens
+    ];
     const mergedEnv: Record<string, string> = {};
     const allEnv = { ...this.config.defaultSessionEnv, ...opts.env };
     for (const [key, value] of Object.entries(allEnv)) {
@@ -557,6 +583,10 @@ export class SessionManager {
       }
       if (DANGEROUS_ENV_VARS.has(key)) {
         throw new Error(`Forbidden env var: "${key}" — cannot override dangerous environment variables`);
+      }
+      // Issue #630: Check dangerous prefixes
+      if (DANGEROUS_ENV_PREFIXES.some(prefix => key.startsWith(prefix))) {
+        throw new Error(`Forbidden env var: "${key}" — cannot override dangerous environment variable prefix "${DANGEROUS_ENV_PREFIXES.find(p => key.startsWith(p))}"`);
       }
       mergedEnv[key] = value;
     }
@@ -575,12 +605,15 @@ export class SessionManager {
       settingsPatched = await neutralizeBypassPermissions(opts.workDir, effectivePermissionMode);
     }
 
+    // Issue #629: Generate per-session HMAC secret for hook URL authentication.
+    const hookSecret = randomBytes(32).toString('hex');
+
     // Issue #169 Phase 2: Generate HTTP hook settings for this session.
     // Writes a temp file with hooks pointing to Aegis's hook receiver.
     let hookSettingsFile: string | undefined;
     try {
       const baseUrl = `http://${this.config.host}:${this.config.port}`;
-      hookSettingsFile = await writeHookSettingsFile(baseUrl, id, opts.workDir);
+      hookSettingsFile = await writeHookSettingsFile(baseUrl, id, hookSecret, opts.workDir);
     } catch (e) {
       console.error(`Hook settings: failed to generate settings file: ${(e as Error).message}`);
       // Non-fatal: hooks won't work for this session, but CC still launches
@@ -614,6 +647,7 @@ export class SessionManager {
       permissionMode: effectivePermissionMode,
       settingsPatched,
       hookSettingsFile,
+      hookSecret,
     };
 
     this.state.sessions[id] = session;

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -18,8 +18,8 @@ function shellEscape(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
-/** Validate that an env var key contains only safe characters. */
-const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+/** Validate that an env var key contains only safe characters (Issue #630: uppercase only, aligned with session.ts). */
+const ENV_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
 
 const execFileAsync = promisify(execFile);
 


### PR DESCRIPTION
Fixes #629, Fixes #630, Fixes #634

## Summary
- **#629**: Added HMAC signature validation to hook webhook routes — prevents auth bypass via known session IDs
- **#630**: Expanded env var name blocklist with npm_config_*, CI tokens, GITHUB_TOKEN, NPM_TOKEN, etc.
- **#634**: Fixed SSE token endpoint double-increment of rate limit counter

## Aegis version
**Developed with:** v2.6.0

## Verification
- 2084 tests pass (101 test files)
- tsc --noEmit clean
- Unit tests in security-629-630-634.test.ts cover all 3 fixes