### PR TITLE
fix(session): resilient pointer storage schema + TTL (#900)

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -80,6 +80,12 @@ describe('config', () => {
       expect(config.stateDir).toBe('/custom/state');
     });
 
+    it('overrides continuation pointer TTL via AEGIS_CONTINUATION_POINTER_TTL_MS', () => {
+      process.env.AEGIS_CONTINUATION_POINTER_TTL_MS = '120000';
+      const config = getConfig();
+      expect(config.continuationPointerTtlMs).toBe(120000);
+    });
+
     it('overrides webhooks via AEGIS_WEBHOOKS', () => {
       process.env.AEGIS_WEBHOOKS = 'https://example.com/hook';
       const config = getConfig();

--- a/src/__tests__/continuation-pointer-900.test.ts
+++ b/src/__tests__/continuation-pointer-900.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadContinuationPointers } from '../continuation-pointer.js';
+
+describe('Issue #900: continuation pointer storage', () => {
+  let tmpDir: string;
+
+  const validEntry = {
+    session_id: '00000000-0000-0000-0000-000000000001',
+    cwd: '/tmp/project',
+    window_name: 'cc-test',
+    written_at: 1_000,
+  };
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+    tmpDir = '';
+  });
+
+  it('drops invalid entries and keeps valid pointers', async () => {
+    const mapFile = setupMapFile({
+      'aegis:@1': validEntry,
+      'aegis:@2': { broken: true },
+    });
+
+    const result = await loadContinuationPointers(mapFile, 10_000, 2_000);
+
+    expect(Object.keys(result)).toEqual(['aegis:@1']);
+    expect(result['aegis:@1'].schema_version).toBe(1);
+    expect(result['aegis:@1'].expires_at).toBe(11_000);
+  });
+
+  it('drops stale legacy pointer using written_at + TTL', async () => {
+    const mapFile = setupMapFile({
+      'aegis:@1': {
+        ...validEntry,
+        written_at: 1_000,
+      },
+    });
+
+    const result = await loadContinuationPointers(mapFile, 5_000, 6_500);
+
+    expect(result).toEqual({});
+  });
+
+  it('honors expires_at when provided', async () => {
+    const mapFile = setupMapFile({
+      'aegis:@1': {
+        ...validEntry,
+        expires_at: 5_000,
+      },
+    });
+
+    const result = await loadContinuationPointers(mapFile, 100_000, 6_000);
+
+    expect(result).toEqual({});
+  });
+
+  it('self-heals corrupted JSON by resetting to empty map', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-pointer-test-'));
+    const mapFile = join(tmpDir, 'session_map.json');
+    writeFileSync(mapFile, '{ not-valid-json');
+
+    const result = await loadContinuationPointers(mapFile, 10_000, 2_000);
+
+    expect(result).toEqual({});
+    expect(readFileSync(mapFile, 'utf-8')).toBe('{}');
+  });
+
+  function setupMapFile(data: Record<string, unknown>): string {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-pointer-test-'));
+    mkdirSync(tmpDir, { recursive: true });
+    const mapFile = join(tmpDir, 'session_map.json');
+    writeFileSync(mapFile, JSON.stringify(data, null, 2));
+    return mapFile;
+  }
+});

--- a/src/__tests__/json-parse-validation.test.ts
+++ b/src/__tests__/json-parse-validation.test.ts
@@ -117,6 +117,16 @@ describe('sessionMapSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts resilient pointer metadata fields', () => {
+    const full = {
+      ...validEntry,
+      schema_version: 1,
+      expires_at: Date.now() + 60_000,
+    };
+    const result = sessionMapSchema.safeParse({ 'aegis:@1': full });
+    expect(result.success).toBe(true);
+  });
+
   it('accepts empty record', () => {
     const result = sessionMapSchema.safeParse({});
     expect(result.success).toBe(true);

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,8 @@ export interface Config {
   maxSessionAgeMs: number;
   /** Reaper check interval in milliseconds */
   reaperIntervalMs: number;
+  /** Continuation pointer TTL in milliseconds (Issue #900). */
+  continuationPointerTtlMs: number;
   /** Telegram bot token */
   tgBotToken: string;
   /** Telegram group chat ID */
@@ -90,6 +92,7 @@ const defaults: Config = {
   claudeProjectsDir: join(homedir(), '.claude', 'projects'),
   maxSessionAgeMs: 2 * 60 * 60 * 1000, // 2 hours
   reaperIntervalMs: 5 * 60 * 1000, // 5 minutes
+  continuationPointerTtlMs: 24 * 60 * 60 * 1000, // 24 hours
   tgBotToken: '',
   tgGroupId: '',
   tgAllowedUsers: [],
@@ -179,6 +182,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_CLAUDE_PROJECTS_DIR', manus: 'MANUS_CLAUDE_PROJECTS_DIR', key: 'claudeProjectsDir' },
     { aegis: 'AEGIS_MAX_SESSION_AGE_MS', manus: 'MANUS_MAX_SESSION_AGE_MS', key: 'maxSessionAgeMs' },
     { aegis: 'AEGIS_REAPER_INTERVAL_MS', manus: 'MANUS_REAPER_INTERVAL_MS', key: 'reaperIntervalMs' },
+    { aegis: 'AEGIS_CONTINUATION_POINTER_TTL_MS', manus: 'MANUS_CONTINUATION_POINTER_TTL_MS', key: 'continuationPointerTtlMs' },
     { aegis: 'AEGIS_TG_TOKEN', manus: 'MANUS_TG_TOKEN', key: 'tgBotToken' },
     { aegis: 'AEGIS_TG_GROUP', manus: 'MANUS_TG_GROUP', key: 'tgGroupId' },
     { aegis: 'AEGIS_TG_ALLOWED_USERS', manus: 'MANUS_TG_ALLOWED_USERS', key: 'tgAllowedUsers' },
@@ -196,6 +200,7 @@ function applyEnvOverrides(config: Config): Config {
       case 'port':
       case 'maxSessionAgeMs':
       case 'reaperIntervalMs':
+      case 'continuationPointerTtlMs':
       case 'sseMaxConnections':
       case 'sseMaxPerIp':
         config[key] = parseIntSafe(value, config[key]);

--- a/src/continuation-pointer.ts
+++ b/src/continuation-pointer.ts
@@ -1,0 +1,84 @@
+import { existsSync } from 'node:fs';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import type { z } from 'zod';
+import { sessionMapEntrySchema } from './validation.js';
+
+export type ContinuationPointerEntry = z.infer<typeof sessionMapEntrySchema>;
+
+function computeExpiresAt(entry: ContinuationPointerEntry, ttlMs: number): number {
+  if (typeof entry.expires_at === 'number') {
+    return entry.expires_at;
+  }
+  return entry.written_at + ttlMs;
+}
+
+async function persistPointerMap(
+  sessionMapFile: string,
+  mapData: Record<string, ContinuationPointerEntry>,
+): Promise<void> {
+  const tmpFile = `${sessionMapFile}.tmp`;
+  await writeFile(tmpFile, JSON.stringify(mapData, null, 2));
+  await rename(tmpFile, sessionMapFile);
+}
+
+/**
+ * Read continuation pointers with schema validation + TTL cleanup.
+ *
+ * Backward compatible behavior:
+ * - Legacy entries without expires_at are accepted and normalized.
+ * - Corrupt files do not throw; they are reset to an empty map.
+ */
+export async function loadContinuationPointers(
+  sessionMapFile: string,
+  ttlMs: number,
+  nowMs = Date.now(),
+): Promise<Record<string, ContinuationPointerEntry>> {
+  if (!existsSync(sessionMapFile)) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(sessionMapFile, 'utf-8'));
+  } catch {
+    await persistPointerMap(sessionMapFile, {});
+    return {};
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    await persistPointerMap(sessionMapFile, {});
+    return {};
+  }
+
+  const cleaned: Record<string, ContinuationPointerEntry> = {};
+  let changed = false;
+
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    const entryResult = sessionMapEntrySchema.safeParse(value);
+    if (!entryResult.success) {
+      changed = true;
+      continue;
+    }
+
+    const entry = entryResult.data;
+    const expiresAt = computeExpiresAt(entry, ttlMs);
+    if (expiresAt <= nowMs) {
+      changed = true;
+      continue;
+    }
+
+    if (entry.expires_at !== expiresAt || entry.schema_version !== 1) {
+      changed = true;
+    }
+
+    cleaned[key] = {
+      ...entry,
+      schema_version: 1,
+      expires_at: expiresAt,
+    };
+  }
+
+  if (changed) {
+    await persistPointerMap(sessionMapFile, cleaned);
+  }
+
+  return cleaned;
+}

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -33,6 +33,13 @@ const BRIDGE_DIR = existsSync(AEGIS_DIR) ? AEGIS_DIR : MANUS_DIR;
 const MAP_FILE = join(BRIDGE_DIR, 'session_map.json');
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const TMUX_PANE_RE = /^%\d+$/;
+const DEFAULT_POINTER_TTL_MS = 24 * 60 * 60 * 1000;
+
+function getPointerTtlMs(): number {
+  const raw = process.env.AEGIS_CONTINUATION_POINTER_TTL_MS ?? process.env.MANUS_CONTINUATION_POINTER_TTL_MS;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_POINTER_TTL_MS;
+}
 
 interface SessionMapEntry {
   session_id: string;
@@ -45,6 +52,8 @@ interface SessionMapEntry {
   agent_type: string | null;
   model: string | null;
   written_at: number;
+  schema_version?: number;
+  expires_at?: number;
 }
 
 /** Payload fields for Stop/StopFailure events. */
@@ -194,6 +203,7 @@ function main(): void {
     } catch { /* fresh map */ }
   }
 
+  const writtenAt = Date.now();
   sessionMap[key] = {
     session_id: sessionId,
     cwd,
@@ -204,7 +214,9 @@ function main(): void {
     source: payload.source || null,
     agent_type: payload.agent_type || null,
     model: payload.model || null,
-    written_at: Date.now(),
+    written_at: writtenAt,
+    schema_version: 1,
+    expires_at: writtenAt + getPointerTtlMs(),
   };
 
   // Atomic write: write to temp file then rename (prevents race-condition data loss)

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,7 +17,8 @@ import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
 import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
-import { persistedStateSchema, sessionMapSchema } from './validation.js';
+import { persistedStateSchema } from './validation.js';
+import { loadContinuationPointers } from './continuation-pointer.js';
 import type { z } from 'zod';
 import { writeHookSettingsFile, cleanupHookSettingsFile } from './hook-settings.js';
 import { Mutex } from 'async-mutex';
@@ -1562,13 +1563,10 @@ export class SessionManager {
   private async cleanSessionMapForWindow(windowName: string, windowId?: string): Promise<void> {
     if (!existsSync(this.sessionMapFile)) return;
     try {
-      const raw = await readFile(this.sessionMapFile, 'utf-8');
-      const parsed = sessionMapSchema.safeParse(JSON.parse(raw));
-      if (!parsed.success) {
-        console.warn('session_map.json failed validation in cleanSessionMapForWindow');
-        return;
-      }
-      const mapData = parsed.data;
+      const mapData = await loadContinuationPointers(
+        this.sessionMapFile,
+        this.config.continuationPointerTtlMs,
+      );
       let changed = false;
       for (const [key, info] of Object.entries(mapData) as [string, any][]) {
         // Clean by window_name (original behavior)
@@ -1602,13 +1600,10 @@ export class SessionManager {
   ): Promise<void> {
     if (!existsSync(this.sessionMapFile)) return;
     try {
-      const raw = await readFile(this.sessionMapFile, 'utf-8');
-      const parsed = sessionMapSchema.safeParse(JSON.parse(raw));
-      if (!parsed.success) {
-        console.warn('session_map.json failed validation in purgeStaleSessionMapEntries');
-        return;
-      }
-      const mapData = parsed.data;
+      const mapData = await loadContinuationPointers(
+        this.sessionMapFile,
+        this.config.continuationPointerTtlMs,
+      );
       let changed = false;
       const activeNamesLower = new Set([...activeWindowNames].map(n => n.toLowerCase()));
 
@@ -1757,13 +1752,10 @@ export class SessionManager {
     if (!existsSync(this.sessionMapFile)) return;
 
     try {
-      const mapRaw = await readFile(this.sessionMapFile, 'utf-8');
-      const mapParsed = sessionMapSchema.safeParse(JSON.parse(mapRaw));
-      if (!mapParsed.success) {
-        console.warn('session_map.json failed validation in syncSessionMap');
-        return;
-      }
-      const mapData = mapParsed.data;
+      const mapData = await loadContinuationPointers(
+        this.sessionMapFile,
+        this.config.continuationPointerTtlMs,
+      );
 
       for (const session of Object.values(this.state.sessions) as SessionInfo[]) {
         if (session.claudeSessionId) continue;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -176,22 +176,24 @@ export const persistedStateSchema = z.record(
   }),
 );
 
+/** Schema for a single continuation pointer entry in session_map.json (Issue #900). */
+export const sessionMapEntrySchema = z.object({
+  session_id: z.string(),
+  cwd: z.string(),
+  window_name: z.string(),
+  transcript_path: z.string().nullable().optional(),
+  permission_mode: z.string().nullable().optional(),
+  agent_id: z.string().nullable().optional(),
+  source: z.string().nullable().optional(),
+  agent_type: z.string().nullable().optional(),
+  model: z.string().nullable().optional(),
+  written_at: z.number(),
+  schema_version: z.number().int().positive().optional(),
+  expires_at: z.number().optional(),
+});
+
 /** Schema for session_map.json entries. */
-export const sessionMapSchema = z.record(
-  z.string(),
-  z.object({
-    session_id: z.string(),
-    cwd: z.string(),
-    window_name: z.string(),
-    transcript_path: z.string().nullable().optional(),
-    permission_mode: z.string().nullable().optional(),
-    agent_id: z.string().nullable().optional(),
-    source: z.string().nullable().optional(),
-    agent_type: z.string().nullable().optional(),
-    model: z.string().nullable().optional(),
-    written_at: z.number(),
-  }),
-);
+export const sessionMapSchema = z.record(z.string(), sessionMapEntrySchema);
 
 /** Schema for stop_signals.json entries. */
 export const stopSignalsSchema = z.record(


### PR DESCRIPTION
## Summary\n- add resilient continuation pointer loader with schema validation and TTL self-healing\n- normalize legacy pointer entries and auto-prune stale/invalid pointers\n- write explicit pointer metadata (schema_version, ^[xpires_at) from SessionStart hook\n- use TTL-aware pointer read path in session discovery and cleanup flows\n\n## Tests\n- npx vitest run src/__tests__/continuation-pointer-900.test.ts src/__tests__/json-parse-validation.test.ts src/__tests__/config.test.ts\n- npx tsc --noEmit\n- npm run build\n\nCloses #900\n\n## Aegis version\n**Developed with:** v2.6.0