### PR TITLE
refactor: deduplicate approve/reject route handlers

### DIFF
--- a/src/__tests__/permission-routes.test.ts
+++ b/src/__tests__/permission-routes.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { registerPermissionRoutes } from '../permission-routes.js';
+
+type RouteHandler = (req: { params: { id: string } }, reply: any) => Promise<unknown>;
+
+function makeMockApp(): FastifyInstance {
+  return {
+    post: vi.fn(),
+  } as unknown as FastifyInstance;
+}
+
+function makeReply() {
+  const send = vi.fn((payload: unknown) => payload);
+  const status = vi.fn(() => ({ send }));
+  return { send, status };
+}
+
+function getHandler(app: FastifyInstance, path: string): RouteHandler {
+  const post = app.post as ReturnType<typeof vi.fn>;
+  const call = post.mock.calls.find((args: unknown[]) => args[0] === path);
+  if (!call) throw new Error(`Missing route registration for ${path}`);
+  return call[1] as RouteHandler;
+}
+
+describe('permission-routes', () => {
+  let app: FastifyInstance;
+  let sessions: {
+    approve: ReturnType<typeof vi.fn>;
+    reject: ReturnType<typeof vi.fn>;
+    getLatencyMetrics: ReturnType<typeof vi.fn>;
+  };
+  let metrics: {
+    recordPermissionResponse: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    app = makeMockApp();
+    sessions = {
+      approve: vi.fn(async () => {}),
+      reject: vi.fn(async () => {}),
+      getLatencyMetrics: vi.fn(() => ({ permission_response_ms: null })),
+    };
+    metrics = {
+      recordPermissionResponse: vi.fn(),
+    };
+  });
+
+  it('registers approve/reject handlers for both v1 and legacy paths', () => {
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+
+    const post = app.post as ReturnType<typeof vi.fn>;
+    expect(post).toHaveBeenCalledWith('/v1/sessions/:id/approve', expect.any(Function));
+    expect(post).toHaveBeenCalledWith('/sessions/:id/approve', expect.any(Function));
+    expect(post).toHaveBeenCalledWith('/v1/sessions/:id/reject', expect.any(Function));
+    expect(post).toHaveBeenCalledWith('/sessions/:id/reject', expect.any(Function));
+  });
+
+  it('approve path calls approve and records permission latency when present', async () => {
+    sessions.getLatencyMetrics.mockReturnValue({ permission_response_ms: 321 });
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    const result = await handler({ params: { id: 's-1' } }, reply);
+
+    expect(result).toEqual({ ok: true });
+    expect(sessions.approve).toHaveBeenCalledWith('s-1');
+    expect(sessions.reject).not.toHaveBeenCalled();
+    expect(metrics.recordPermissionResponse).toHaveBeenCalledWith('s-1', 321);
+  });
+
+  it('reject legacy path calls reject and does not record null latency', async () => {
+    sessions.getLatencyMetrics.mockReturnValue({ permission_response_ms: null });
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+
+    const handler = getHandler(app, '/sessions/:id/reject');
+    const reply = makeReply();
+    const result = await handler({ params: { id: 's-2' } }, reply);
+
+    expect(result).toEqual({ ok: true });
+    expect(sessions.reject).toHaveBeenCalledWith('s-2');
+    expect(sessions.approve).not.toHaveBeenCalled();
+    expect(metrics.recordPermissionResponse).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 with error payload when session operation fails', async () => {
+    sessions.approve.mockRejectedValue(new Error('Session not found'));
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    await handler({ params: { id: 'missing' } }, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(404);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Session not found' });
+  });
+});

--- a/src/permission-routes.ts
+++ b/src/permission-routes.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { SessionManager } from './session.js';
+import type { MetricsCollector } from './metrics.js';
+
+type PermissionAction = 'approve' | 'reject';
+type IdParams = { Params: { id: string } };
+type IdRequest = FastifyRequest<IdParams>;
+
+type PermissionSessions = Pick<SessionManager, 'approve' | 'reject' | 'getLatencyMetrics'>;
+type PermissionMetrics = Pick<MetricsCollector, 'recordPermissionResponse'>;
+
+function createPermissionHandler(
+  action: PermissionAction,
+  sessions: PermissionSessions,
+  metrics: PermissionMetrics,
+): (req: IdRequest, reply: FastifyReply) => Promise<unknown> {
+  return async (req: IdRequest, reply: FastifyReply): Promise<unknown> => {
+    try {
+      if (action === 'approve') {
+        await sessions.approve(req.params.id);
+      } else {
+        await sessions.reject(req.params.id);
+      }
+
+      // Issue #87: Record permission response latency.
+      const lat = sessions.getLatencyMetrics(req.params.id);
+      if (lat !== null && lat.permission_response_ms !== null) {
+        metrics.recordPermissionResponse(req.params.id, lat.permission_response_ms);
+      }
+
+      return { ok: true };
+    } catch (e: unknown) {
+      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
+    }
+  };
+}
+
+export function registerPermissionRoutes(
+  app: FastifyInstance,
+  sessions: PermissionSessions,
+  metrics: PermissionMetrics,
+): void {
+  for (const action of ['approve', 'reject'] as const) {
+    const handler = createPermissionHandler(action, sessions, metrics);
+    app.post<IdParams>(`/v1/sessions/:id/${action}`, handler);
+    app.post<IdParams>(`/sessions/:id/${action}`, handler);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import { SSEConnectionLimiter } from './sse-limiter.js';
 import { PipelineManager, type BatchSessionSpec, type PipelineConfig } from './pipeline.js';
 import { AuthManager } from './auth.js';
 import { MetricsCollector } from './metrics.js';
+import { registerPermissionRoutes } from './permission-routes.js';
 import { registerHookRoutes } from './hooks.js';
 import { registerWsTerminalRoute } from './ws-terminal.js';
 import { SwarmMonitor } from './swarm-monitor.js';
@@ -705,32 +706,17 @@ async function readMessagesHandler(req: IdRequest, reply: FastifyReply): Promise
 app.get<IdParams>('/v1/sessions/:id/read', readMessagesHandler);
 app.get<IdParams>('/sessions/:id/read', readMessagesHandler);
 
-function makePermissionHandler(
-  action: 'approve' | 'reject'
-): (req: IdRequest, reply: FastifyReply) => Promise<unknown> {
-  return async (req: IdRequest, reply: FastifyReply): Promise<unknown> => {
-    try {
-      const op = action === 'approve' ? sessions.approve.bind(sessions) : sessions.reject.bind(sessions);
-      await op(req.params.id);
-      // Issue #87: Record permission response latency
-      const lat = sessions.getLatencyMetrics(req.params.id);
-      if (lat !== null && lat.permission_response_ms !== null) {
-        metrics.recordPermissionResponse(req.params.id, lat.permission_response_ms);
-      }
-      return { ok: true };
-    } catch (e: unknown) {
-      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
-    }
-  };
-}
-
-const approveHandler = makePermissionHandler('approve');
-const rejectHandler = makePermissionHandler('reject');
-
-app.post<IdParams>('/v1/sessions/:id/reject', rejectHandler);
-app.post<IdParams>('/sessions/:id/reject', rejectHandler);
-app.post<IdParams>('/v1/sessions/:id/approve', approveHandler);
-app.post<IdParams>('/sessions/:id/approve', approveHandler);
+registerPermissionRoutes(
+  app,
+  {
+    approve: async (id: string) => sessions.approve(id),
+    reject: async (id: string) => sessions.reject(id),
+    getLatencyMetrics: (id: string) => sessions.getLatencyMetrics(id),
+  },
+  {
+    recordPermissionResponse: (id: string, latencyMs: number) => metrics.recordPermissionResponse(id, latencyMs),
+  },
+);
 
 // Issue #336: Answer pending AskUserQuestion
 app.post<{


### PR DESCRIPTION
## Summary
- extract approve/reject HTTP route registration into a unified factory module
- preserve existing API behavior for both /v1 and legacy /sessions paths
- preserve permission response latency metric semantics
- add focused parity tests for approve/reject routing and error behavior

## Validation
- npx vitest run src/__tests__/permission-routes.test.ts src/__tests__/permission-hints.test.ts src/__tests__/hook-permission-approval.test.ts
- npx tsc --noEmit *(fails in baseline due missing module async-mutex from src/session.ts:24)*

Closes #887