### PR TITLE
fix: harden session acquisition mutex in findIdleSessionByWorkDir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@fastify/static": "^9.0.0",
         "@fastify/websocket": "^11.2.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
-        "async-mutex": "^0.5.0",
         "fastify": "^5.8.2",
         "zod": "^4.3.6"
       },
@@ -1018,15 +1017,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/atomic-sleep": {
@@ -3659,6 +3649,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.2.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
-    "async-mutex": "^0.5.0",
     "fastify": "^5.8.2",
     "zod": "^4.3.6"
   },

--- a/src/__tests__/session-mutex-880.test.ts
+++ b/src/__tests__/session-mutex-880.test.ts
@@ -75,18 +75,40 @@ describe('Issue #880: session acquisition mutex hardening', () => {
   it('releases the lock when an exception occurs inside the critical section', async () => {
     const session = makeSession({ workDir: '/project/a', status: 'idle' });
     let calls = 0;
+    let releaseFirstWindowCheck!: () => void;
+    const firstWindowCheckGate = new Promise<void>((resolve) => {
+      releaseFirstWindowCheck = resolve;
+    });
+    let firstCallEntered!: () => void;
+    const firstCallEnteredPromise = new Promise<void>((resolve) => {
+      firstCallEntered = resolve;
+    });
+    let secondCallReachedWindowCheck = false;
+
     const sm = createSessionManager({
       windowExists: vi.fn(async () => {
         calls += 1;
-        if (calls === 1) throw new Error('simulated tmux failure');
+        if (calls === 1) {
+          firstCallEntered();
+          await firstWindowCheckGate;
+          throw new Error('simulated tmux failure');
+        }
+        secondCallReachedWindowCheck = true;
         return true;
       }),
     }, [session]);
 
-    await expect(sm.findIdleSessionByWorkDir('/project/a')).rejects.toThrow('simulated tmux failure');
+    const firstCall = sm.findIdleSessionByWorkDir('/project/a');
+    await firstCallEnteredPromise;
 
-    session.status = 'idle';
+    // Start a second contender while the first still holds the lock.
     const secondCall = sm.findIdleSessionByWorkDir('/project/a');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(secondCallReachedWindowCheck).toBe(false);
+
+    releaseFirstWindowCheck();
+    await expect(firstCall).rejects.toThrow('simulated tmux failure');
+
     const result = await Promise.race([
       secondCall,
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('lock not released')), 1000)),

--- a/src/session.ts
+++ b/src/session.ts
@@ -21,7 +21,7 @@ import { persistedStateSchema } from './validation.js';
 import { loadContinuationPointers } from './continuation-pointer.js';
 import type { z } from 'zod';
 import { writeHookSettingsFile, cleanupHookSettingsFile } from './hook-settings.js';
-import { Mutex } from 'async-mutex';
+import { Mutex } from './utils/mutex.js';
 import { maybeInjectFault } from './fault-injection.js';
 
 /** Convert parsed JSON arrays to Sets for activeSubagents (#668). */

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal FIFO async mutex for serializing critical sections.
+ *
+ * runExclusive guarantees the lock is released even if the callback throws.
+ */
+export class Mutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async runExclusive<T>(callback: () => Promise<T> | T): Promise<T> {
+    let release!: () => void;
+    const previous = this.tail;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n- replace external async-mutex usage with a dedicated internal FIFO mutex primitive\n- preserve atomic acquire semantics in findIdleSessionByWorkDir via runExclusive\n- strengthen deterministic contention test for exceptional lock-release path\n\n## Validation\n- npx tsc --noEmit\n- npx vitest run src/__tests__/session-mutex-880.test.ts\n- npx vitest run src/__tests__/session-mutex-880.test.ts src/__tests__/fix-841-840-836.test.ts src/__tests__/fault-injection-harness-901.test.ts\n- npm run build\n- npm test (fails on Windows path/env expectations unrelated to this change)\n\nCloses #880