### PR TITLE
fix: capability handshake schema, feature gates, and fallback warnings

### DIFF
--- a/src/__tests__/api-input-validation.test.ts
+++ b/src/__tests__/api-input-validation.test.ts
@@ -23,6 +23,7 @@ import {
   screenshotSchema,
   batchSessionSchema,
   pipelineSchema,
+  handshakeRequestSchema,
   permissionHookSchema,
   stopHookSchema,
 } from '../validation.js';
@@ -305,6 +306,28 @@ describe('API schema malformed input regression (Issue #506)', () => {
 
     it('rejects missing workDir', () => {
       expect(pipelineSchema.safeParse({ name: 'p', stages: [{ name: 's', prompt: 'p' }] }).success).toBe(false);
+    });
+  });
+
+  describe('handshakeRequestSchema', () => {
+    it('accepts minimal valid handshake request', () => {
+      const result = handshakeRequestSchema.safeParse({ protocolVersion: '1' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing protocolVersion', () => {
+      const result = handshakeRequestSchema.safeParse({ clientCapabilities: ['session.create'] });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-array clientCapabilities', () => {
+      const result = handshakeRequestSchema.safeParse({ protocolVersion: '1', clientCapabilities: 'session.create' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown extra fields (strict)', () => {
+      const result = handshakeRequestSchema.safeParse({ protocolVersion: '1', unknown: true });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/src/__tests__/capability-handshake-885.test.ts
+++ b/src/__tests__/capability-handshake-885.test.ts
@@ -14,6 +14,7 @@ import {
   negotiate,
   AEGIS_CAPABILITIES,
   AEGIS_PROTOCOL_VERSION,
+  isFeatureEnabled,
 } from '../handshake.js';
 
 describe('negotiate', () => {
@@ -27,6 +28,9 @@ describe('negotiate', () => {
     expect(result.negotiatedCapabilities).toEqual([...AEGIS_CAPABILITIES]);
     expect(result.serverCapabilities).toEqual([...AEGIS_CAPABILITIES]);
     expect(result.protocolVersion).toBe(AEGIS_PROTOCOL_VERSION);
+    expect(result.fallbackMode).toBe('none');
+    expect(result.featureGates.cursorReplay).toBe(true);
+    expect(isFeatureEnabled(result, 'hookLifecycle')).toBe(true);
   });
 
   it('partial-capability client gets intersection only', () => {
@@ -37,12 +41,18 @@ describe('negotiate', () => {
     expect(result.compatible).toBe(true);
     expect(result.negotiatedCapabilities).toEqual(['session.create', 'session.approve']);
     expect(result.negotiatedCapabilities).not.toContain('session.transcript');
+    expect(result.fallbackMode).toBe('none');
+    expect(result.featureGates.permissionControl).toBe(true);
+    expect(result.featureGates.transcriptRead).toBe(false);
+    expect(result.featureGates.cursorReplay).toBe(false);
   });
 
   it('client with no declared capabilities gets full server set', () => {
     const result = negotiate({ protocolVersion: AEGIS_PROTOCOL_VERSION });
     expect(result.compatible).toBe(true);
     expect(result.negotiatedCapabilities).toEqual([...AEGIS_CAPABILITIES]);
+    expect(result.fallbackMode).toBe('legacy-defaults');
+    expect(result.warnings.some(w => w.includes('legacy-default'))).toBe(true);
   });
 
   it('unknown client capabilities are ignored with a warning', () => {
@@ -63,6 +73,8 @@ describe('negotiate', () => {
     });
     expect(result.compatible).toBe(false);
     expect(result.negotiatedCapabilities).toHaveLength(0);
+    expect(result.fallbackMode).toBe('incompatible-protocol');
+    expect(result.featureGates.cursorReplay).toBe(false);
     expect(result.warnings.length).toBeGreaterThan(0);
     expect(result.warnings[0]).toContain('below minimum');
   });
@@ -72,11 +84,14 @@ describe('negotiate', () => {
     const result = negotiate({ protocolVersion: futureVersion });
     expect(result.compatible).toBe(true);
     expect(result.warnings.some(w => w.includes('newer than server'))).toBe(true);
+    expect(result.fallbackMode).toBe('legacy-defaults');
   });
 
   it('malformed protocolVersion → not compatible', () => {
     const result = negotiate({ protocolVersion: 'abc-bad' });
     expect(result.compatible).toBe(false);
+    expect(result.fallbackMode).toBe('invalid-protocol');
+    expect(result.featureGates.hookLifecycle).toBe(false);
     expect(result.warnings.some(w => w.includes('Unrecognized'))).toBe(true);
   });
 });

--- a/src/handshake.ts
+++ b/src/handshake.ts
@@ -34,6 +34,27 @@ export const AEGIS_CAPABILITIES = [
 
 export type AegisCapability = (typeof AEGIS_CAPABILITIES)[number];
 
+/**
+ * Feature gates that client integrations should check before enabling
+ * behavior that depends on newer protocol/capability support.
+ */
+export const HANDSHAKE_FEATURE_REQUIREMENTS = {
+  cursorReplay: ['session.transcript.cursor'],
+  transcriptRead: ['session.transcript'],
+  sseEvents: ['session.events.sse'],
+  permissionControl: ['session.approve'],
+  screenshots: ['session.screenshot'],
+  hookLifecycle: ['hooks.pre_tool_use', 'hooks.post_tool_use'],
+} as const satisfies Record<string, readonly AegisCapability[]>;
+
+export type HandshakeFeature = keyof typeof HANDSHAKE_FEATURE_REQUIREMENTS;
+
+export type HandshakeFallbackMode =
+  | 'none'
+  | 'legacy-defaults'
+  | 'incompatible-protocol'
+  | 'invalid-protocol';
+
 /** Request body for POST /v1/handshake */
 export interface HandshakeRequest {
   protocolVersion: string;
@@ -46,8 +67,26 @@ export interface HandshakeResponse {
   protocolVersion: string;
   serverCapabilities: AegisCapability[];
   negotiatedCapabilities: AegisCapability[];
+  featureGates: Record<HandshakeFeature, boolean>;
+  fallbackMode: HandshakeFallbackMode;
   warnings: string[];
   compatible: boolean;
+}
+
+/** Compute boolean feature gates from a negotiated capability set. */
+export function computeFeatureGates(capabilities: readonly AegisCapability[]): Record<HandshakeFeature, boolean> {
+  const enabled = new Set(capabilities);
+  return Object.fromEntries(
+    Object.entries(HANDSHAKE_FEATURE_REQUIREMENTS).map(([feature, required]) => [
+      feature,
+      required.every(capability => enabled.has(capability)),
+    ]),
+  ) as Record<HandshakeFeature, boolean>;
+}
+
+/** Helper for checking one feature gate directly from a handshake response. */
+export function isFeatureEnabled(response: HandshakeResponse, feature: HandshakeFeature): boolean {
+  return response.featureGates[feature] === true;
 }
 
 /**
@@ -68,20 +107,26 @@ export function negotiate(req: HandshakeRequest): HandshakeResponse {
   const minMajor = parseInt(AEGIS_MIN_PROTOCOL_VERSION, 10);
 
   if (isNaN(clientMajor)) {
+    const negotiatedCapabilities: AegisCapability[] = [];
     return {
       protocolVersion: AEGIS_PROTOCOL_VERSION,
       serverCapabilities,
-      negotiatedCapabilities: [],
+      negotiatedCapabilities,
+      featureGates: computeFeatureGates(negotiatedCapabilities),
+      fallbackMode: 'invalid-protocol',
       warnings: [`Unrecognized protocolVersion format: "${req.protocolVersion}". Expected integer string.`],
       compatible: false,
     };
   }
 
   if (clientMajor < minMajor) {
+    const negotiatedCapabilities: AegisCapability[] = [];
     return {
       protocolVersion: AEGIS_PROTOCOL_VERSION,
       serverCapabilities,
-      negotiatedCapabilities: [],
+      negotiatedCapabilities,
+      featureGates: computeFeatureGates(negotiatedCapabilities),
+      fallbackMode: 'incompatible-protocol',
       warnings: [
         `Client protocolVersion ${req.protocolVersion} is below minimum supported version ${AEGIS_MIN_PROTOCOL_VERSION}. Upgrade required.`,
       ],
@@ -98,8 +143,9 @@ export function negotiate(req: HandshakeRequest): HandshakeResponse {
   // Intersect: client declares what it supports; server only enables what it also supports
   let negotiatedCapabilities: AegisCapability[];
   if (!req.clientCapabilities || req.clientCapabilities.length === 0) {
-    // Client omitted capabilities → assume full server capability set
+    // Client omitted capabilities → default to full set for backward compatibility.
     negotiatedCapabilities = serverCapabilities;
+    warnings.push('Client did not provide clientCapabilities; using legacy-default capability negotiation.');
   } else {
     const serverSet = new Set<string>(serverCapabilities);
     const unknown = req.clientCapabilities.filter(c => !serverSet.has(c));
@@ -115,6 +161,8 @@ export function negotiate(req: HandshakeRequest): HandshakeResponse {
     protocolVersion: AEGIS_PROTOCOL_VERSION,
     serverCapabilities,
     negotiatedCapabilities,
+    featureGates: computeFeatureGates(negotiatedCapabilities),
+    fallbackMode: req.clientCapabilities && req.clientCapabilities.length > 0 ? 'none' : 'legacy-defaults',
     warnings,
     compatible: true,
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,7 @@ import { negotiate, type HandshakeRequest } from './handshake.js';
 import {
   authKeySchema, sendMessageSchema, commandSchema, bashSchema,
   screenshotSchema, permissionHookSchema, stopHookSchema,
-  batchSessionSchema, pipelineSchema, parseIntSafe, isValidUUID,
+  batchSessionSchema, pipelineSchema, handshakeRequestSchema, parseIntSafe, isValidUUID,
 } from './validation.js';
 
 
@@ -345,14 +345,11 @@ async function healthHandler(): Promise<Record<string, unknown>> {
 app.get('/v1/health', healthHandler);
 app.get('/health', healthHandler);
 app.post<{ Body: HandshakeRequest }>('/v1/handshake', async (req, reply) => {
-  const { protocolVersion, clientCapabilities, clientVersion } = req.body ?? {};
-  if (typeof protocolVersion !== 'string' || !protocolVersion.trim()) {
-    return reply.status(400).send({ error: 'protocolVersion is required' });
+  const parsed = handshakeRequestSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return reply.status(400).send({ error: 'Invalid handshake request', details: parsed.error.issues });
   }
-  if (clientCapabilities !== undefined && !Array.isArray(clientCapabilities)) {
-    return reply.status(400).send({ error: 'clientCapabilities must be an array' });
-  }
-  const result = negotiate({ protocolVersion, clientCapabilities, clientVersion });
+  const result = negotiate(parsed.data);
   return reply.status(result.compatible ? 200 : 409).send(result);
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -117,6 +117,13 @@ export const pipelineSchema = z.object({
   stages: z.array(pipelineStageSchema).min(1),
 }).strict();
 
+/** POST /v1/handshake */
+export const handshakeRequestSchema = z.object({
+  protocolVersion: z.string().min(1),
+  clientCapabilities: z.array(z.string().min(1)).optional(),
+  clientVersion: z.string().min(1).optional(),
+}).strict();
+
 /** Clamp a numeric value to [min, max]. Returns default if input is NaN. */
 export function clamp(value: number, min: number, max: number, fallback: number): number {
   if (Number.isNaN(value)) return fallback;


### PR DESCRIPTION
## Summary
- harden capability negotiation with explicit feature gates and fallback modes
- add strict handshakeRequestSchema validation on POST /v1/handshake
- preserve backward compatibility via legacy-defaults fallback when clients omit capabilities
- include compatibility warnings for unknown capabilities and protocol mismatches
- expand tests for negotiation success/failure and feature gating behavior

## Validation
- npx tsc --noEmit
- npx vitest run src/__tests__/capability-handshake-885.test.ts
- npx vitest run src/__tests__/api-input-validation.test.ts

Closes #885