### PR TITLE
fix: worktree-aware continuation metadata lookup with bounded fanout

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -91,6 +91,24 @@ describe('config', () => {
       const config = getConfig();
       expect(config.webhooks).toEqual(['https://a.com/hook', 'https://b.com/hook']);
     });
+
+    it('toggles worktree-aware continuation via env rollout guard', () => {
+      process.env.AEGIS_WORKTREE_AWARE_CONTINUATION = 'true';
+      const enabled = getConfig();
+      expect(enabled.worktreeAwareContinuation).toBe(true);
+
+      process.env.AEGIS_WORKTREE_AWARE_CONTINUATION = 'false';
+      const disabled = getConfig();
+      expect(disabled.worktreeAwareContinuation).toBe(false);
+    });
+
+    it('parses worktree sibling directories via env list', () => {
+      process.env.AEGIS_WORKTREE_SIBLING_DIRS = '~/wt-a, ~/wt-b';
+      const config = getConfig();
+      expect(config.worktreeSiblingDirs).toHaveLength(2);
+      expect(config.worktreeSiblingDirs[0]).toContain('wt-a');
+      expect(config.worktreeSiblingDirs[1]).toContain('wt-b');
+    });
   });
 
   describe('MANUS_* backward compatibility', () => {

--- a/src/__tests__/worktree-lookup-884.test.ts
+++ b/src/__tests__/worktree-lookup-884.test.ts
@@ -9,7 +9,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { findSessionFileWithFanout } from '../worktree-lookup.js';
+import {
+  findSessionFileWithFanout,
+  selectFreshestValidContinuationCandidates,
+} from '../worktree-lookup.js';
 import { mkdtemp, mkdir, writeFile, rm, utimes } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -103,6 +106,35 @@ describe('findSessionFileWithFanout', () => {
     // With maxCandidates=3 only sibs 0,1,2 are searched — sib-3 is beyond the limit
     const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, siblings, 3);
     expect(result).toBeNull(); // 4th sibling not reached
+  });
+});
+
+describe('selectFreshestValidContinuationCandidates', () => {
+  it('prefers freshest written_at candidate and rejects stale pointers', () => {
+    const now = Date.now();
+    const createdAt = now - 10_000;
+
+    const ordered = selectFreshestValidContinuationCandidates([
+      { key: 'older-valid', sessionId: 's1', writtenAt: now - 2_000, windowName: 'w' },
+      { key: 'stale', sessionId: 's2', writtenAt: now - 20_000, windowName: 'w' },
+      { key: 'newest-valid', sessionId: 's3', writtenAt: now - 1_000, windowName: 'w' },
+    ], createdAt, 5);
+
+    expect(ordered.map(c => c.key)).toEqual(['newest-valid', 'older-valid']);
+  });
+
+  it('applies candidate bound after freshness sorting', () => {
+    const now = Date.now();
+    const createdAt = now - 50_000;
+
+    const ordered = selectFreshestValidContinuationCandidates([
+      { key: 'k1', sessionId: 's1', writtenAt: now - 5_000, windowName: 'w' },
+      { key: 'k2', sessionId: 's2', writtenAt: now - 4_000, windowName: 'w' },
+      { key: 'k3', sessionId: 's3', writtenAt: now - 3_000, windowName: 'w' },
+      { key: 'k4', sessionId: 's4', writtenAt: now - 2_000, windowName: 'w' },
+    ], createdAt, 2);
+
+    expect(ordered.map(c => c.key)).toEqual(['k4', 'k3']);
   });
 });
 

--- a/src/__tests__/worktree-lookup-884.test.ts
+++ b/src/__tests__/worktree-lookup-884.test.ts
@@ -1,0 +1,108 @@
+/**
+ * worktree-lookup-884.test.ts — Tests for worktree-aware session file discovery.
+ *
+ * Issue #884: Verifies that:
+ * 1. Primary directory is found without fanout
+ * 2. Sibling worktree directory is found when primary lacks the file
+ * 3. Fanout is bounded by maxCandidates
+ * 4. Freshest file is returned when both dirs match
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { findSessionFileWithFanout } from '../worktree-lookup.js';
+import { mkdtemp, mkdir, writeFile, rm, utimes } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const SESSION_ID = 'deadbeef-0000-0000-0000-000000000001';
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'wt-884-test-'));
+});
+
+afterEach(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function makeProjectsDir(base: string, projectName: string, withSession: boolean, mtimeOffset = 0): Promise<string> {
+  const dir = join(base, projectName);
+  await mkdir(dir, { recursive: true });
+  if (withSession) {
+    const file = join(dir, `${SESSION_ID}.jsonl`);
+    await writeFile(file, '{"test":true}\n');
+    if (mtimeOffset !== 0) {
+      const now = Date.now();
+      const t = (now + mtimeOffset) / 1000;
+      await utimes(file, t, t);
+    }
+  }
+  return base;
+}
+
+describe('findSessionFileWithFanout', () => {
+  it('returns primary-directory match without fanout', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    await makeProjectsDir(primaryDir, 'proj-a', true);
+    await makeProjectsDir(siblingDir, 'proj-b', false);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).not.toBeNull();
+    expect(result).toContain(primaryDir);
+    expect(result).toContain(SESSION_ID);
+  });
+
+  it('falls back to sibling dir when primary does not contain the file', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    await makeProjectsDir(primaryDir, 'proj-a', false);
+    await makeProjectsDir(siblingDir, 'proj-b', true);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).not.toBeNull();
+    expect(result).toContain(siblingDir);
+  });
+
+  it('returns freshest candidate when both dirs have a match', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    // primary is older (mtime -10s), sibling is newer (mtime +0)
+    await makeProjectsDir(primaryDir, 'proj-a', true, -10_000);
+    await makeProjectsDir(siblingDir, 'proj-b', true, 0);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).not.toBeNull();
+    expect(result).toContain(siblingDir); // sibling is fresher
+  });
+
+  it('returns null when no directories contain the file', async () => {
+    const primaryDir = join(tmpRoot, 'primary');
+    const siblingDir = join(tmpRoot, 'sibling');
+    await makeProjectsDir(primaryDir, 'proj-a', false);
+    await makeProjectsDir(siblingDir, 'proj-b', false);
+
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, [siblingDir]);
+    expect(result).toBeNull();
+  });
+
+  it('respects maxCandidates bound on sibling fanout', async () => {
+    // Create 7 sibling dirs, only the 4th has the file (beyond maxCandidates=3)
+    const primaryDir = join(tmpRoot, 'primary');
+    await mkdir(primaryDir, { recursive: true });
+
+    const siblings: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = join(tmpRoot, `sib-${i}`);
+      const hasFile = i === 3; // only 4th sibling (index 3) has the file
+      await makeProjectsDir(d, 'proj', hasFile);
+      siblings.push(d);
+    }
+
+    // With maxCandidates=3 only sibs 0,1,2 are searched — sib-3 is beyond the limit
+    const result = await findSessionFileWithFanout(SESSION_ID, primaryDir, siblings, 3);
+    expect(result).toBeNull(); // 4th sibling not reached
+  });
+});
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,6 +143,12 @@ async function loadConfigFile(): Promise<Partial<Config>> {
         if (typeof parsed.claudeProjectsDir === 'string') {
           parsed.claudeProjectsDir = expandTilde(parsed.claudeProjectsDir);
         }
+        if (Array.isArray(parsed.worktreeSiblingDirs)) {
+          const siblingDirs = parsed.worktreeSiblingDirs as unknown[];
+          parsed.worktreeSiblingDirs = siblingDirs
+            .filter((dir: unknown): dir is string => typeof dir === 'string')
+            .map(expandTilde);
+        }
         // Log if using legacy path
         if (path.includes('manus')) {
           console.log(`Config: loaded from legacy path ${path} — consider migrating to aegis paths`);
@@ -223,6 +229,23 @@ function applyEnvOverrides(config: Config): Config {
         // Skip complex types (Record<string,string>) that can't be set from a single env var
         break;
     }
+  }
+
+  // Issue #884: rollout guard and fanout path configuration.
+  const worktreeAwareRaw = process.env.AEGIS_WORKTREE_AWARE_CONTINUATION
+    ?? process.env.MANUS_WORKTREE_AWARE_CONTINUATION;
+  if (worktreeAwareRaw !== undefined) {
+    config.worktreeAwareContinuation = worktreeAwareRaw.toLowerCase() === 'true';
+  }
+
+  const siblingDirsRaw = process.env.AEGIS_WORKTREE_SIBLING_DIRS
+    ?? process.env.MANUS_WORKTREE_SIBLING_DIRS;
+  if (siblingDirsRaw !== undefined) {
+    config.worktreeSiblingDirs = siblingDirsRaw
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+      .map(expandTilde);
   }
 
   return config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,13 @@ export interface Config {
    *  Empty array = all directories allowed (backward compatible).
    *  Paths are resolved and symlink-resolved before checking. */
   allowedWorkDirs: string[];
+  /** Issue #884: Enable worktree-aware continuation metadata lookup (default: false).
+   *  When true, Aegis fans out to sibling worktree project dirs when the primary
+   *  directory lookup fails to find a session file. */
+  worktreeAwareContinuation: boolean;
+  /** Issue #884: Additional Claude projects directories to search during worktree fanout.
+   *  Paths are expanded (~) and checked for existence before searching. */
+  worktreeSiblingDirs: string[];
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -93,6 +100,8 @@ const defaults: Config = {
   sseMaxConnections: 100,
   sseMaxPerIp: 10,
   allowedWorkDirs: [],
+  worktreeAwareContinuation: false,
+  worktreeSiblingDirs: [],
 };
 
 /** Parse CLI args for --config flag */

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,6 +11,7 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { TmuxManager, type TmuxWindow } from './tmux.js';
 import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.js';
+import { findSessionFileWithFanout } from './worktree-lookup.js';
 import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState } from './terminal-parser.js';
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
@@ -129,6 +130,22 @@ export class SessionManager {
   ) {
     this.stateFile = join(config.stateDir, 'state.json');
     this.sessionMapFile = join(config.stateDir, 'session_map.json');
+  }
+
+  /**
+   * Issue #884: Worktree-aware session file lookup.
+   * When `worktreeAwareContinuation` is enabled, fans out to sibling worktree
+   * project dirs; otherwise falls back to the existing single-directory search.
+   */
+  private findSessionFileMaybeWorktree(sessionId: string): Promise<string | null> {
+    if (this.config.worktreeAwareContinuation && this.config.worktreeSiblingDirs.length > 0) {
+      return findSessionFileWithFanout(
+        sessionId,
+        this.config.claudeProjectsDir,
+        this.config.worktreeSiblingDirs,
+      );
+    }
+    return findSessionFile(sessionId, this.config.claudeProjectsDir);
   }
 
   /** Validate that parsed data looks like a valid SessionState. */
@@ -1198,9 +1215,9 @@ export class SessionManager {
     session.status = status;
     session.lastActivity = Date.now();
 
-    // Try to find JSONL if we don't have it yet
+    // Try to find JSONL if we don't have it yet (Issue #884: worktree-aware)
     if (!session.jsonlPath && session.claudeSessionId) {
-      const path = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+      const path = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
       if (path) {
         session.jsonlPath = path;
         session.byteOffset = 0;
@@ -1249,9 +1266,9 @@ export class SessionManager {
 
     session.status = status;
 
-    // Try to find JSONL if we don't have it yet
+    // Try to find JSONL if we don't have it yet (Issue #884: worktree-aware)
     if (!session.jsonlPath && session.claudeSessionId) {
-      const path = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+      const path = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
       if (path) {
         session.jsonlPath = path;
         session.monitorOffset = 0;
@@ -1358,9 +1375,9 @@ export class SessionManager {
     const session = this.state.sessions[id];
     if (!session) throw new Error(`Session ${id} not found`);
 
-    // Discover JSONL path if not yet known
+    // Discover JSONL path if not yet known (Issue #884: worktree-aware)
     if (!session.jsonlPath && session.claudeSessionId) {
-      const path = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+      const path = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
       if (path) {
         session.jsonlPath = path;
         session.byteOffset = 0;
@@ -1547,9 +1564,9 @@ export class SessionManager {
       try {
         await this.syncSessionMap();
         
-        // If we have claudeSessionId but no jsonlPath, try finding it
+        // If we have claudeSessionId but no jsonlPath, try finding it (Issue #884: worktree-aware)
         if (session.claudeSessionId && !session.jsonlPath) {
-          const jsonlPath = await findSessionFile(session.claudeSessionId, this.config.claudeProjectsDir);
+          const jsonlPath = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
           if (jsonlPath) {
             session.jsonlPath = jsonlPath;
             session.byteOffset = 0;

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,7 +11,12 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { TmuxManager, type TmuxWindow } from './tmux.js';
 import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.js';
-import { findSessionFileWithFanout } from './worktree-lookup.js';
+import {
+  findSessionFileWithFanout,
+  selectFreshestValidContinuationCandidates,
+  WORKTREE_LOOKUP_MAX_CANDIDATES,
+  type ContinuationMapCandidate,
+} from './worktree-lookup.js';
 import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState } from './terminal-parser.js';
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
@@ -1677,8 +1682,10 @@ export class SessionManager {
       for (const session of Object.values(this.state.sessions) as SessionInfo[]) {
         if (session.claudeSessionId) continue;
 
-        // Find matching entry by window ID (exact match to avoid @1 matching @10, @11, etc.)
-        for (const [key, info] of Object.entries(mapData) as [string, any][]) {
+        // Find matching entries by window ID (exact match to avoid @1 matching @10, @11, etc.)
+        type SessionMapEntry = (typeof mapData)[string];
+        const matchingEntries: Array<{ key: string; info: SessionMapEntry }> = [];
+        for (const [key, info] of Object.entries(mapData) as [string, SessionMapEntry][]) {
           // P0 fix: Match by exact windowId suffix (e.g., "aegis:@5"), not substring
           // This prevents @5 from matching @15, @50, etc.
           const keyWindowId = key.includes(':') ? key.split(':').pop() : null;
@@ -1686,6 +1693,25 @@ export class SessionManager {
           const matchesWindowName = info.window_name === session.windowName;
 
           if (matchesWindowId || matchesWindowName) {
+            matchingEntries.push({ key, info });
+          }
+        }
+
+        const orderedEntries = this.config.worktreeAwareContinuation
+          ? selectFreshestValidContinuationCandidates(
+            matchingEntries.map(({ key, info }) => ({
+              key,
+              sessionId: info.session_id,
+              writtenAt: info.written_at || 0,
+              windowName: info.window_name || '',
+            } as ContinuationMapCandidate)),
+            session.createdAt,
+            WORKTREE_LOOKUP_MAX_CANDIDATES,
+          ).map(candidate => matchingEntries.find(entry => entry.key === candidate.key)!)
+          : matchingEntries;
+
+        for (const { key, info } of orderedEntries) {
+          if (!this.config.worktreeAwareContinuation) {
             // GUARD 1: Timestamp — reject session_map entries written before this session was created.
             // After service restarts, old entries survive with stale windowIds that collide
             // with newly assigned tmux window IDs (tmux reuses @N identifiers).
@@ -1696,50 +1722,50 @@ export class SessionManager {
                 `(written_at ${new Date(writtenAt).toISOString()} < createdAt ${new Date(session.createdAt).toISOString()})`);
               continue;
             }
-
-            // Use transcript_path from hook if available (M3: eliminates filesystem scan)
-            // Falls back to findSessionFile for backward compat with old hook versions
-            let jsonlPath: string | null = null;
-            if (info.transcript_path && existsSync(info.transcript_path)) {
-              jsonlPath = info.transcript_path;
-            } else {
-              jsonlPath = await findSessionFile(info.session_id, this.config.claudeProjectsDir);
-            }
-
-            // GUARD 2: Reject paths in _archived/ directory — these are stale sessions
-            if (jsonlPath && (jsonlPath.includes('/_archived/') || jsonlPath.includes('\\_archived\\'))) {
-              console.log(`Discovery: session ${session.windowName} — rejecting archived path: ${jsonlPath}`);
-              continue;
-            }
-
-            if (!jsonlPath) {
-              // No JSONL file found — mapping is stale or CC hasn't written it yet.
-              // Don't break — there may be a fresher entry. Continue searching.
-              continue;
-            }
-
-            // GUARD 3: JSONL mtime — reject if file was last modified before session creation.
-            // Catches cases where session_map has no written_at (old hook without timestamp)
-            // but the JSONL is clearly from a previous session.
-            try {
-              const fileStat = await stat(jsonlPath);
-              if (fileStat.mtimeMs < session.createdAt) {
-                console.log(`Discovery: session ${session.windowName} — rejecting stale JSONL ` +
-                  `(mtime ${new Date(fileStat.mtimeMs).toISOString()} < createdAt ${new Date(session.createdAt).toISOString()})`);
-                continue;
-              }
-            } catch {
-              // stat failed — file removed between find and stat
-              continue;
-            }
-
-            session.claudeSessionId = info.session_id;
-            session.jsonlPath = jsonlPath;
-            session.byteOffset = 0;
-            console.log(`Discovery: session ${session.windowName} mapped to ` +
-              `${info.session_id.slice(0, 8)}... (verified: timestamp + mtime)`);
-            break;
           }
+
+          // Use transcript_path from hook if available (M3: eliminates filesystem scan)
+          // Falls back to worktree-aware file discovery for backward compat with old hook versions
+          let jsonlPath: string | null = null;
+          if (info.transcript_path && existsSync(info.transcript_path)) {
+            jsonlPath = info.transcript_path;
+          } else {
+            jsonlPath = await this.findSessionFileMaybeWorktree(info.session_id);
+          }
+
+          // GUARD 2: Reject paths in _archived/ directory — these are stale sessions
+          if (jsonlPath && (jsonlPath.includes('/_archived/') || jsonlPath.includes('\\_archived\\'))) {
+            console.log(`Discovery: session ${session.windowName} — rejecting archived path: ${jsonlPath}`);
+            continue;
+          }
+
+          if (!jsonlPath) {
+            // No JSONL file found — mapping is stale or CC hasn't written it yet.
+            // Don't break — there may be a fresher entry. Continue searching.
+            continue;
+          }
+
+          // GUARD 3: JSONL mtime — reject if file was last modified before session creation.
+          // Catches cases where session_map has no written_at (old hook without timestamp)
+          // but the JSONL is clearly from a previous session.
+          try {
+            const fileStat = await stat(jsonlPath);
+            if (fileStat.mtimeMs < session.createdAt) {
+              console.log(`Discovery: session ${session.windowName} — rejecting stale JSONL ` +
+                `(mtime ${new Date(fileStat.mtimeMs).toISOString()} < createdAt ${new Date(session.createdAt).toISOString()})`);
+              continue;
+            }
+          } catch {
+            // stat failed — file removed between find and stat
+            continue;
+          }
+
+          session.claudeSessionId = info.session_id;
+          session.jsonlPath = jsonlPath;
+          session.byteOffset = 0;
+          console.log(`Discovery: session ${session.windowName} mapped to ` +
+            `${info.session_id.slice(0, 8)}... (verified: timestamp + mtime via ${key})`);
+          break;
         }
       }
       await this.save();

--- a/src/worktree-lookup.ts
+++ b/src/worktree-lookup.ts
@@ -1,0 +1,79 @@
+/**
+ * worktree-lookup.ts — Worktree-aware session file discovery.
+ *
+ * Issue #884: Extends the single-directory findSessionFile with bounded fanout
+ * across sibling worktree project directories. Returns the freshest (most
+ * recently modified) matching JSONL file across all candidate dirs.
+ */
+
+import { stat, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/** Expand leading ~ to home directory. */
+function expandTilde(p: string): string {
+  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+}
+
+/**
+ * Find the freshest JSONL file for a given sessionId across multiple
+ * Claude projects directories.
+ *
+ * Search order:
+ * 1. Primary directory (existing `claudeProjectsDir` — normal path)
+ * 2. Sibling directories (fanout, bounded by maxCandidates)
+ *
+ * Returns the path with the highest mtime, or null if not found.
+ * Silently ignores unreadable/missing directories.
+ *
+ * @param sessionId     Claude session UUID
+ * @param primaryDir    Primary `~/.claude/projects` directory (searched first)
+ * @param siblingDirs   Additional directories to search (fanout)
+ * @param maxCandidates Upper bound on sibling candidates to evaluate (default: 5)
+ */
+export async function findSessionFileWithFanout(
+  sessionId: string,
+  primaryDir: string,
+  siblingDirs: string[],
+  maxCandidates = 5,
+): Promise<string | null> {
+  const candidates: Array<{ path: string; mtimeMs: number }> = [];
+
+  // Helper: scan one projects dir for sessionId.jsonl files
+  async function scanDir(dir: string): Promise<void> {
+    const expanded = expandTilde(dir);
+    if (!existsSync(expanded)) return;
+    let entries;
+    try {
+      entries = await readdir(expanded, { withFileTypes: true, encoding: 'utf8' });
+    } catch {
+      return; // unreadable directory — skip
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const jsonlPath = join(expanded, entry.name, `${sessionId}.jsonl`);
+      if (existsSync(jsonlPath)) {
+        try {
+          const { mtimeMs } = await stat(jsonlPath);
+          candidates.push({ path: jsonlPath, mtimeMs });
+        } catch {
+          // stat failed — entry may have been deleted between existsSync and stat
+        }
+      }
+    }
+  }
+
+  // Always scan primary first
+  await scanDir(primaryDir);
+
+  // Fanout to siblings (bounded)
+  const bounded = siblingDirs.slice(0, maxCandidates);
+  await Promise.all(bounded.map(d => scanDir(d)));
+
+  if (candidates.length === 0) return null;
+
+  // Return path with the highest mtime (freshest)
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates[0].path;
+}

--- a/src/worktree-lookup.ts
+++ b/src/worktree-lookup.ts
@@ -11,6 +11,15 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
+export const WORKTREE_LOOKUP_MAX_CANDIDATES = 5;
+
+export interface ContinuationMapCandidate {
+  key: string;
+  sessionId: string;
+  writtenAt: number;
+  windowName: string;
+}
+
 /** Expand leading ~ to home directory. */
 function expandTilde(p: string): string {
   return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
@@ -36,7 +45,7 @@ export async function findSessionFileWithFanout(
   sessionId: string,
   primaryDir: string,
   siblingDirs: string[],
-  maxCandidates = 5,
+  maxCandidates = WORKTREE_LOOKUP_MAX_CANDIDATES,
 ): Promise<string | null> {
   const candidates: Array<{ path: string; mtimeMs: number }> = [];
 
@@ -76,4 +85,19 @@ export async function findSessionFileWithFanout(
   // Return path with the highest mtime (freshest)
   candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
   return candidates[0].path;
+}
+
+/**
+ * Select freshest continuation candidates by written_at while rejecting stale
+ * pointers. Returns candidates in selection order (freshest first).
+ */
+export function selectFreshestValidContinuationCandidates(
+  candidates: ContinuationMapCandidate[],
+  sessionCreatedAt: number,
+  maxCandidates = WORKTREE_LOOKUP_MAX_CANDIDATES,
+): ContinuationMapCandidate[] {
+  return candidates
+    .filter(c => c.writtenAt === 0 || c.writtenAt >= sessionCreatedAt)
+    .sort((a, b) => b.writtenAt - a.writtenAt)
+    .slice(0, maxCandidates);
 }


### PR DESCRIPTION
## Summary
- keep worktree-aware continuation lookup behind an explicit rollout flag
- add bounded freshest-valid continuation candidate ordering for session_map matches
- retain no-regression disabled behavior and add env parsing for sibling fanout paths
- add tests for sibling discovery bounds and stale pointer rejection ordering

## Validation
- npx tsc --noEmit
- npx vitest run src/__tests__/worktree-lookup-884.test.ts src/__tests__/config.test.ts

Closes #884