### PR TITLE
fix: harden structured logging diagnostics channel

### DIFF
--- a/src/__tests__/logger-diagnostics-881.test.ts
+++ b/src/__tests__/logger-diagnostics-881.test.ts
@@ -1,10 +1,14 @@
 /**
- * logger-diagnostics-881.test.ts — Tests for Issue #881 structured logging and diagnostics.
+ * logger-diagnostics-881.test.ts - Tests for Issue #881 structured logging and diagnostics.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { DiagnosticsBus, sanitizeDiagnosticsAttributes } from '../diagnostics.js';
-import { StructuredLogger } from '../logger.js';
+import {
+  DEFAULT_DIAGNOSTICS_BUFFER_SIZE,
+  DiagnosticsBus,
+  sanitizeDiagnosticsAttributes,
+} from '../diagnostics.js';
+import { StructuredLogger, setStructuredLogSink } from '../logger.js';
 
 describe('Issue #881: structured logger and diagnostics bus', () => {
   const originalLog = console.log;
@@ -15,19 +19,21 @@ describe('Issue #881: structured logger and diagnostics bus', () => {
     console.log = vi.fn();
     console.warn = vi.fn();
     console.error = vi.fn();
+    setStructuredLogSink({});
   });
 
   afterEach(() => {
     console.log = originalLog;
     console.warn = originalWarn;
     console.error = originalError;
+    setStructuredLogSink({});
   });
 
-  it('emits structured JSON logs with core fields', () => {
+  it('emits structured JSON logs with schema fields and diagnostics event', () => {
     const bus = new DiagnosticsBus(10);
-    const logger = new StructuredLogger(bus);
+    const structuredLogger = new StructuredLogger(bus);
 
-    logger.warn({
+    structuredLogger.warn({
       component: 'monitor',
       operation: 'permission_timeout_auto_reject',
       sessionId: 'session-123',
@@ -39,36 +45,50 @@ describe('Issue #881: structured logger and diagnostics bus', () => {
     const payload = (console.warn as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     const record = JSON.parse(payload) as Record<string, unknown>;
 
-    expect(record.level).toBe('warn');
-    expect(record.component).toBe('monitor');
-    expect(record.operation).toBe('permission_timeout_auto_reject');
-    expect(record.sessionId).toBe('session-123');
-    expect(record.errorCode).toBe('PERMISSION_TIMEOUT');
-    expect(record.attributes).toEqual({ timeoutMinutes: 10, windowName: 'cc-test' });
+    expect(record).toEqual(expect.objectContaining({
+      level: 'warn',
+      component: 'monitor',
+      operation: 'permission_timeout_auto_reject',
+      sessionId: 'session-123',
+      errorCode: 'PERMISSION_TIMEOUT',
+      attributes: { timeoutMinutes: 10, windowName: 'cc-test' },
+    }));
+    expect(typeof record.timestamp).toBe('string');
 
-    const events = bus.getRecent();
-    expect(events).toHaveLength(1);
-    expect(events[0].event).toBe('monitor.permission_timeout_auto_reject');
+    const [event] = bus.getRecent();
+    expect(event).toEqual(expect.objectContaining({
+      event: 'monitor.permission_timeout_auto_reject',
+      level: 'warn',
+      component: 'monitor',
+      operation: 'permission_timeout_auto_reject',
+      sessionId: 'session-123',
+      errorCode: 'PERMISSION_TIMEOUT',
+      attributes: { timeoutMinutes: 10, windowName: 'cc-test' },
+    }));
+    expect(typeof event.timestamp).toBe('string');
   });
 
-  it('drops sensitive fields from diagnostics attributes', () => {
+  it('redacts sensitive fields recursively for no-PII diagnostics attributes', () => {
     const sanitized = sanitizeDiagnosticsAttributes({
       timeoutMinutes: 10,
       workDir: '/secret/project',
-      token: 'abc123',
+      nested: {
+        authToken: 'abc123',
+        detail: 'still useful',
+      },
       prompt: 'do something',
-      windowPath: '/tmp/visible',
+      metadata: [
+        { password: 'never' },
+        { safeKey: 'safe-value' },
+      ],
       eventDetail: 'still useful',
-      textContent: 'keep this diagnostic text',
-      safeKey: 'safe-value',
     });
 
     expect(sanitized).toEqual({
       timeoutMinutes: 10,
-      windowPath: '/tmp/visible',
+      nested: { detail: 'still useful' },
+      metadata: [{}, { safeKey: 'safe-value' }],
       eventDetail: 'still useful',
-      textContent: 'keep this diagnostic text',
-      safeKey: 'safe-value',
     });
   });
 
@@ -89,5 +109,31 @@ describe('Issue #881: structured logger and diagnostics bus', () => {
     const events = bus.getRecent();
     expect(events).toHaveLength(3);
     expect(events.map((e) => e.operation)).toEqual(['event_3', 'event_4', 'event_5']);
+  });
+
+  it('uses default bounded diagnostics buffer size and enforces getRecent limit', () => {
+    const bus = new DiagnosticsBus();
+
+    for (let i = 1; i <= DEFAULT_DIAGNOSTICS_BUFFER_SIZE + 25; i += 1) {
+      bus.emit({
+        event: `monitor.event_${i}`,
+        level: 'info',
+        component: 'monitor',
+        operation: `event_${i}`,
+        timestamp: new Date().toISOString(),
+        attributes: { sequence: i },
+      });
+    }
+
+    const recentFive = bus.getRecent(5);
+    expect(bus.getRecent()).toHaveLength(DEFAULT_DIAGNOSTICS_BUFFER_SIZE);
+    expect(recentFive).toHaveLength(5);
+    expect(recentFive.map((e) => e.operation)).toEqual([
+      `event_${DEFAULT_DIAGNOSTICS_BUFFER_SIZE + 21}`,
+      `event_${DEFAULT_DIAGNOSTICS_BUFFER_SIZE + 22}`,
+      `event_${DEFAULT_DIAGNOSTICS_BUFFER_SIZE + 23}`,
+      `event_${DEFAULT_DIAGNOSTICS_BUFFER_SIZE + 24}`,
+      `event_${DEFAULT_DIAGNOSTICS_BUFFER_SIZE + 25}`,
+    ]);
   });
 });

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,5 +1,5 @@
 /**
- * diagnostics.ts — no-PII diagnostics event stream with bounded in-memory buffer.
+ * diagnostics.ts - no-PII diagnostics event stream with bounded in-memory buffer.
  */
 
 import { EventEmitter } from 'node:events';
@@ -17,45 +17,83 @@ export interface DiagnosticsEvent {
   attributes: Record<string, unknown>;
 }
 
-const FORBIDDEN_KEYS = new Set([
+export const DEFAULT_DIAGNOSTICS_BUFFER_SIZE = 100;
+const MAX_DIAGNOSTICS_STRING_LENGTH = 200;
+const MAX_SANITIZE_DEPTH = 4;
+
+const FORBIDDEN_KEY_FRAGMENTS = [
   'token',
   'password',
   'secret',
   'authorization',
-  'workdir',
+  'cookie',
+  'auth',
+  'api_key',
+  'apikey',
   'prompt',
-]);
+  'transcript',
+  'payload',
+  'workdir',
+];
 
 function isForbiddenAttribute(key: string): boolean {
-  return FORBIDDEN_KEYS.has(key.toLowerCase());
+  const normalized = key.toLowerCase();
+  return FORBIDDEN_KEY_FRAGMENTS.some(fragment => normalized.includes(fragment));
+}
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (depth > MAX_SANITIZE_DEPTH) return '[TRUNCATED]';
+  if (typeof value === 'string') {
+    return value.length > MAX_DIAGNOSTICS_STRING_LENGTH
+      ? `${value.slice(0, MAX_DIAGNOSTICS_STRING_LENGTH)}...`
+      : value;
+  }
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeValue(item, depth + 1));
+  }
+  if (typeof value === 'object') {
+    const sanitizedObject: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (isForbiddenAttribute(key)) continue;
+      sanitizedObject[key] = sanitizeValue(nested, depth + 1);
+    }
+    return sanitizedObject;
+  }
+  if (value === undefined) return undefined;
+  return String(value);
 }
 
 export function sanitizeDiagnosticsAttributes(attributes: Record<string, unknown> | undefined): Record<string, unknown> {
   if (!attributes) return {};
-  const sanitized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(attributes)) {
-    if (isForbiddenAttribute(key)) continue;
-    if (typeof value === 'string') {
-      sanitized[key] = value.length > 200 ? `${value.slice(0, 200)}...` : value;
-      continue;
-    }
-    sanitized[key] = value;
-  }
-  return sanitized;
+  const sanitized = sanitizeValue(attributes);
+  return (typeof sanitized === 'object' && sanitized !== null && !Array.isArray(sanitized))
+    ? (sanitized as Record<string, unknown>)
+    : {};
+}
+
+function sanitizeDiagnosticsEvent(event: DiagnosticsEvent): DiagnosticsEvent {
+  return {
+    ...event,
+    attributes: sanitizeDiagnosticsAttributes(event.attributes),
+  };
 }
 
 export class DiagnosticsBus {
   private readonly emitter = new EventEmitter();
   private readonly buffer: DiagnosticsEvent[] = [];
 
-  constructor(private readonly maxEntries: number = 200) {}
+  constructor(private readonly maxEntries: number = DEFAULT_DIAGNOSTICS_BUFFER_SIZE) {}
 
   emit(event: DiagnosticsEvent): void {
-    this.buffer.push(event);
+    const sanitizedEvent = sanitizeDiagnosticsEvent(event);
+    this.buffer.push(sanitizedEvent);
     if (this.buffer.length > this.maxEntries) {
       this.buffer.splice(0, this.buffer.length - this.maxEntries);
     }
-    this.emitter.emit('event', event);
+    this.emitter.emit('event', sanitizedEvent);
   }
 
   subscribe(handler: (event: DiagnosticsEvent) => void): () => void {
@@ -63,8 +101,9 @@ export class DiagnosticsBus {
     return () => this.emitter.off('event', handler);
   }
 
-  getRecent(): DiagnosticsEvent[] {
-    return [...this.buffer];
+  getRecent(limit = this.maxEntries): DiagnosticsEvent[] {
+    if (limit <= 0) return [];
+    return this.buffer.slice(-Math.min(limit, this.maxEntries));
   }
 
   clear(): void {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 /**
- * logger.ts — structured logger that also emits sanitized diagnostics events.
+ * logger.ts - structured logger that also emits sanitized diagnostics events.
  */
 
 import {
@@ -17,7 +17,7 @@ export interface LogContext {
   attributes?: Record<string, unknown>;
 }
 
-interface StructuredLogRecord {
+export interface StructuredLogRecord {
   timestamp: string;
   level: DiagnosticsLevel;
   component: string;
@@ -25,6 +25,28 @@ interface StructuredLogRecord {
   sessionId?: string;
   errorCode?: string;
   attributes: Record<string, unknown>;
+}
+
+export interface StructuredLogSink {
+  info?: (record: StructuredLogRecord) => void;
+  warn?: (record: StructuredLogRecord) => void;
+  error?: (record: StructuredLogRecord) => void;
+}
+
+const defaultSink: Required<StructuredLogSink> = {
+  info: (record) => console.log(JSON.stringify(record)),
+  warn: (record) => console.warn(JSON.stringify(record)),
+  error: (record) => console.error(JSON.stringify(record)),
+};
+
+let sink: StructuredLogSink = defaultSink;
+
+export function setStructuredLogSink(nextSink: StructuredLogSink): void {
+  sink = {
+    info: nextSink.info ?? defaultSink.info,
+    warn: nextSink.warn ?? defaultSink.warn,
+    error: nextSink.error ?? defaultSink.error,
+  };
 }
 
 export class StructuredLogger {
@@ -55,13 +77,12 @@ export class StructuredLogger {
       attributes,
     };
 
-    const payload = JSON.stringify(record);
     if (level === 'error') {
-      console.error(payload);
+      sink.error?.(record);
     } else if (level === 'warn') {
-      console.warn(payload);
+      sink.warn?.(record);
     } else {
-      console.log(payload);
+      sink.info?.(record);
     }
 
     this.bus.emit({

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -408,7 +408,11 @@ export class SessionMonitor {
       const raw = await readFile(signalFile, 'utf-8');
       const parsed = stopSignalsSchema.safeParse(JSON.parse(raw));
       if (!parsed.success) {
-        console.warn('stop_signals.json failed validation in checkStopSignals');
+        logger.warn({
+          component: 'monitor',
+          operation: 'check_stop_signals',
+          errorCode: 'STOP_SIGNALS_INVALID',
+        });
         return;
       }
       const signals = parsed.data;

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,8 @@ import { SwarmMonitor } from './swarm-monitor.js';
 import { killAllSessions } from './signal-cleanup-helper.js';
 import { execFileSync } from 'node:child_process';
 import { negotiate, type HandshakeRequest } from './handshake.js';
+import { diagnosticsBus } from './diagnostics.js';
+import { setStructuredLogSink } from './logger.js';
 import {
   authKeySchema, sendMessageSchema, commandSchema, bashSchema,
   screenshotSchema, permissionHookSchema, stopHookSchema,
@@ -132,6 +134,12 @@ const app = Fastify({
       },
     },
   },
+});
+
+setStructuredLogSink({
+  info: (record) => app.log.info(record),
+  warn: (record) => app.log.warn(record),
+  error: (record) => app.log.error(record),
 });
 
 // #227: Security headers on all API responses (skip SSE)
@@ -402,8 +410,27 @@ app.post('/v1/auth/sse-token', async (req, reply) => {
   }
 });
 
+const diagnosticsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
 // Global metrics (Issue #40)
 app.get('/v1/metrics', async () => metrics.getGlobalMetrics(sessions.listSessions().length));
+
+// Bounded no-PII diagnostics channel (Issue #881)
+app.get('/v1/diagnostics', async (req, reply) => {
+  const parsed = diagnosticsQuerySchema.safeParse(req.query ?? {});
+  if (!parsed.success) {
+    return reply.status(400).send({
+      error: 'Invalid diagnostics query params',
+      details: parsed.error.issues,
+    });
+  }
+
+  const limit = parsed.data.limit ?? 50;
+  const events = diagnosticsBus.getRecent(limit);
+  return { count: events.length, events };
+});
 
 // Per-session metrics (Issue #40)
 app.get<{ Params: { id: string } }>('/v1/sessions/:id/metrics', async (req, reply) => {


### PR DESCRIPTION
## Summary
- tighten no-PII diagnostics sanitization (recursive key filtering + string truncation)
- make diagnostics buffer explicitly bounded by default (100 entries) with query-time limits
- route structured logger output into Fastify logger and add /v1/diagnostics API for bounded diagnostics retrieval
- migrate remaining monitor stop-signal validation warning to structured logger
- expand tests for diagnostics schema fields, recursive PII redaction, and buffer bounds behavior

## Validation
- npx tsc --noEmit (fails in baseline: missing async-mutex module import in src/session.ts)
- npx vitest run src/__tests__/logger-diagnostics-881.test.ts src/__tests__/monitor-fixes.test.ts

Closes #881
