### PR TITLE
fix: complete cursor replay contract for transcript/events

### DIFF
--- a/src/__tests__/cursor-replay-883.test.ts
+++ b/src/__tests__/cursor-replay-883.test.ts
@@ -20,6 +20,7 @@ function cursorWindow(
   limit: number,
 ): {
   messages: EntryWithCursor[];
+  before_id: number | null;
   has_more: boolean;
   oldest_id: number | null;
   newest_id: number | null;
@@ -30,11 +31,14 @@ function cursorWindow(
   const lowerInclusive = Math.max(0, upperExclusive - clampedLimit);
   const slice = allEntries.slice(lowerInclusive, upperExclusive);
   const messages = slice.map((entry, i) => ({ ...entry, _cursor_id: lowerInclusive + i + 1 }));
+  const oldestId = messages.length > 0 ? messages[0]._cursor_id : null;
+  const newestId = messages.length > 0 ? messages[messages.length - 1]._cursor_id : null;
   return {
     messages,
+    before_id: oldestId,
     has_more: lowerInclusive > 0,
-    oldest_id: messages.length > 0 ? messages[0]._cursor_id : null,
-    newest_id: messages.length > 0 ? messages[messages.length - 1]._cursor_id : null,
+    oldest_id: oldestId,
+    newest_id: newestId,
   };
 }
 
@@ -53,6 +57,7 @@ describe('cursor-based transcript window', () => {
     expect(result.messages[0].text).toBe('msg-16');
     expect(result.messages[9].text).toBe('msg-25');
     expect(result.has_more).toBe(true);
+    expect(result.before_id).toBe(16);
     expect(result.oldest_id).toBe(16);
     expect(result.newest_id).toBe(25);
   });

--- a/src/__tests__/events.test.ts
+++ b/src/__tests__/events.test.ts
@@ -288,7 +288,59 @@ describe('SessionEventBus', () => {
     });
   });
 
-  // ── 4. Cleanup timing (emitEnded) ────────────────────────────────────
+  // ── 4. getEventsBefore cursor replay ─────────────────────────────────
+
+  describe('getEventsBefore cursor replay', () => {
+    it('returns newest window when before_id is omitted', () => {
+      for (let i = 0; i < 8; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const result = bus.getEventsBefore('sess-1', undefined, 3);
+      expect(result.events).toHaveLength(3);
+      expect(result.events[0].id).toBe(6);
+      expect(result.events[2].id).toBe(8);
+      expect(result.before_id).toBe(6);
+      expect(result.oldest_id).toBe(6);
+      expect(result.newest_id).toBe(8);
+      expect(result.has_more).toBe(true);
+    });
+
+    it('uses before_id as an exclusive upper bound with no overlap', () => {
+      for (let i = 0; i < 10; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const newest = bus.getEventsBefore('sess-1', undefined, 4);
+      const older = bus.getEventsBefore('sess-1', newest.before_id ?? undefined, 4);
+
+      expect(newest.events.map(e => e.id)).toEqual([7, 8, 9, 10]);
+      expect(older.events.map(e => e.id)).toEqual([3, 4, 5, 6]);
+      expect(older.has_more).toBe(true);
+    });
+
+    it('returns has_more=false when there are no earlier events', () => {
+      for (let i = 0; i < 5; i++) {
+        bus.emitStatus('sess-1', 'working', `event ${i}`);
+      }
+
+      const result = bus.getEventsBefore('sess-1', 3, 10);
+      expect(result.events.map(e => e.id)).toEqual([1, 2]);
+      expect(result.before_id).toBe(1);
+      expect(result.has_more).toBe(false);
+    });
+
+    it('returns empty window metadata for unknown session', () => {
+      const result = bus.getEventsBefore('missing', undefined, 10);
+      expect(result.events).toEqual([]);
+      expect(result.before_id).toBeNull();
+      expect(result.oldest_id).toBeNull();
+      expect(result.newest_id).toBeNull();
+      expect(result.has_more).toBe(false);
+    });
+  });
+
+  // ── 5. Cleanup timing (emitEnded) ────────────────────────────────────
 
   describe('cleanup timing (emitEnded)', () => {
     it('emitEnded marks emitter as ending', async () => {

--- a/src/events.ts
+++ b/src/events.ts
@@ -154,6 +154,56 @@ export class SessionEventBus {
     return buffer.toArray().filter(e => e.id > lastEventId).map(e => e.event);
   }
 
+  /**
+   * Cursor-based replay window for session events.
+   *
+   * - `beforeId` is an exclusive upper bound on event ID.
+   * - If omitted, returns the newest `limit` buffered events.
+   * - Returns events in ascending ID order.
+   */
+  getEventsBefore(
+    sessionId: string,
+    beforeId?: number,
+    limit = 50,
+  ): {
+    events: SessionSSEEvent[];
+    before_id: number | null;
+    has_more: boolean;
+    oldest_id: number | null;
+    newest_id: number | null;
+  } {
+    const buffer = this.eventBuffers.get(sessionId);
+    if (!buffer) {
+      return {
+        events: [],
+        before_id: null,
+        has_more: false,
+        oldest_id: null,
+        newest_id: null,
+      };
+    }
+
+    const entries = buffer.toArray();
+    const clampedLimit = Math.min(SessionEventBus.BUFFER_SIZE, Math.max(1, limit));
+    const upperExclusive = beforeId !== undefined
+      ? entries.findIndex(e => e.id >= beforeId)
+      : entries.length;
+    const resolvedUpperExclusive = upperExclusive === -1 ? entries.length : upperExclusive;
+    const lowerInclusive = Math.max(0, resolvedUpperExclusive - clampedLimit);
+    const window = entries.slice(lowerInclusive, resolvedUpperExclusive);
+    const events = window.map(e => e.event);
+    const oldestId = window.length > 0 ? window[0].id : null;
+    const newestId = window.length > 0 ? window[window.length - 1].id : null;
+
+    return {
+      events,
+      before_id: oldestId,
+      has_more: lowerInclusive > 0,
+      oldest_id: oldestId,
+      newest_id: newestId,
+    };
+  }
+
   /** Emit a status change event. */
   emitStatus(sessionId: string, status: string, detail: string): void {
     this.emit(sessionId, {

--- a/src/handshake.ts
+++ b/src/handshake.ts
@@ -23,6 +23,7 @@ export const AEGIS_CAPABILITIES = [
   'session.transcript',
   'session.transcript.cursor',   // Issue #883: cursor-based replay
   'session.events.sse',
+  'session.events.cursor',
   'session.screenshot',
   'hooks.pre_tool_use',
   'hooks.post_tool_use',


### PR DESCRIPTION
## Summary
- complete Issue #883 replay contract by adding event-buffer cursor replay semantics (efore_id, has_more, oldest_id, 
ewest_id)
- expose event cursor capability in handshake for migration-safe client negotiation
- extend cursor replay tests to validate response metadata and no-overlap windowing behavior

## Validation
- npx tsc --noEmit *(fails in current origin/main baseline: src/session.ts imports sync-mutex without dependency present)*
- npx vitest run src/__tests__/cursor-replay-883.test.ts src/__tests__/events.test.ts src/__tests__/api-pagination-transcript.test.ts src/__tests__/capability-handshake-885.test.ts

Closes #883