### PR TITLE
fix: inject MCP_CONNECTION_NONBLOCKING in hook settings (#931)

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -215,7 +215,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
 
       // Project settings preserved
       expect(parsed.permissions).toEqual({ defaultMode: 'bypassPermissions' });
-      expect(parsed.env).toEqual({ ANTHROPIC_AUTH_TOKEN: 'sk-test-123', ANTHROPIC_BASE_URL: 'https://proxy.example.com' });
+      expect(parsed.env).toEqual({ ANTHROPIC_AUTH_TOKEN: 'sk-test-123', ANTHROPIC_BASE_URL: 'https://proxy.example.com', MCP_CONNECTION_NONBLOCKING: 'true' });
 
       // Hooks also present
       expect(parsed.hooks).toBeDefined();
@@ -238,7 +238,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
       expect(parsed.hooks).toBeDefined();
       // No project-level keys leaked in
       expect(parsed.permissions).toBeUndefined();
-      expect(parsed.env).toBeUndefined();
+      expect(parsed.env).toEqual({ MCP_CONNECTION_NONBLOCKING: 'true' });
     } finally {
       if (existsSync(filePath)) unlinkSync(filePath);
     }
@@ -294,7 +294,7 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
       const parsed = JSON.parse(content) as Record<string, unknown>;
 
       // env preserved
-      expect(parsed.env).toEqual({ FOO: 'bar' });
+      expect(parsed.env).toEqual({ FOO: 'bar', MCP_CONNECTION_NONBLOCKING: 'true' });
       // Both project and Aegis hooks present for Stop
       const hooks = parsed.hooks as Record<string, Array<{ hooks: Array<{ type: string; url?: string; command?: string }> }>>;
       expect(hooks.Stop).toHaveLength(2);

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -155,7 +155,12 @@ export async function writeHookSettingsFile(baseUrl: string, sessionId: string, 
     mergedHooks[event] = [...(existingHooks[event] ?? []), ...entries];
   }
 
-  const combined = { ...merged, hooks: mergedHooks };
+  const combined: Record<string, unknown> = { ...merged, hooks: mergedHooks };
+
+  // Issue #931: Always inject MCP_CONNECTION_NONBLOCKING so CC does not block
+  // on MCP server connections when launched via Aegis orchestration.
+  ((combined as Record<string, unknown>).env = (combined.env || {}) as Record<string, string>);
+  ((combined.env || {}) as Record<string, string>)["MCP_CONNECTION_NONBLOCKING"] = "true";
 
   // Issue #648: Use unpredictable directory name and restrictive permissions
   // to prevent symlink attacks and information disclosure in /tmp.


### PR DESCRIPTION
## Summary

Fixes #931 — CC sessions launched via Aegis were crashing on startup because MCP server connections from project `settings.local.json` would block for up to 5s per server.

## Root Cause

`settings.local.json` enables 7 MCP servers (zai-mcp-server, web-search-prime, web-reader, zread, chrome-devtools, github, supabase). CC 2.1.89+ waits up to 5s per server for MCP connection. With some servers not running, CC would timeout and exit immediately after receiving a prompt.

## Fix

Inject `MCP_CONNECTION_NONBLOCKING=true` into the merged hook settings env in `writeHookSettingsFile()`. This CC 2.1.89+ feature skips MCP connection wait entirely for Aegis sessions.

## Changes
- `src/hook-settings.ts`: Add env injection after settings merge
- `src/__tests__/hook-settings.test.ts`: Update 3 test assertions to expect the new env var

## Test Plan
- [x] tsc --noEmit ✅
- [x] npm run build ✅  
- [x] 2173 tests ✅ (110 test files)
- [x] Manual: Aegis session creation → CC starts, receives prompt, responds ✅

**Developed with:** v2.6.3
**Tested with:** v2.6.3