### PR TITLE
fix: remove unused sessionId prop from PanePreview and ApprovalBanner (#647)

### DIFF
--- a/dashboard/src/components/session/ApprovalBanner.tsx
+++ b/dashboard/src/components/session/ApprovalBanner.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 const AUTO_APPROVE_MODES = new Set(['bypassPermissions', 'dontAsk', 'acceptEdits', 'plan', 'auto']);
 
 interface ApprovalBannerProps {
-  sessionId: string;
   prompt: string;
   permissionMode?: string;
   onApprove?: () => void;

--- a/dashboard/src/components/session/PanePreview.tsx
+++ b/dashboard/src/components/session/PanePreview.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import type { UIState } from '../../types';
 
 interface PanePreviewProps {
-  sessionId: string;
   status: UIState;
   content: string;
   loading: boolean;

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -170,7 +170,6 @@ export default function SessionDetailPage() {
           {needsApproval && (
             <div className="p-3 sm:p-4 pb-0">
               <ApprovalBanner
-                sessionId={s.id}
                 prompt={h.details}
                 permissionMode={s.permissionMode}
                 onApprove={handleApprove}


### PR DESCRIPTION
## Summary

Removes unused `sessionId` prop from `PanePreview` and `ApprovalBanner` components.

## Changes
- `PanePreview.tsx`: Removed `sessionId: string` from `PanePreviewProps`
- `ApprovalBanner.tsx`: Removed `sessionId: string` from `ApprovalBannerProps`
- `SessionDetailPage.tsx`: Removed `sessionId={s.id}` from `ApprovalBanner` usage

## Test Plan
- [x] tsc --noEmit ✅
- [x] npm run build ✅
- [x] 2173 tests ✅

**Developed with:** v2.6.3
**Tested with:** v2.6.3