### PR TITLE
fix: pass build artifacts from test to publish job in release workflow (#649)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,16 @@ jobs:
       - run: npm run build:dashboard
       - run: npm test
       - run: cd dashboard && npx vitest run
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            dist/
+            dashboard/dist/
+            package.json
+            package-lock.json
+          retention-days: 1
 
   publish-npm:
     needs: test
@@ -37,10 +47,11 @@ jobs:
           node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npx tsc --noEmit
-      - run: npm run build
-      - run: npm run build:dashboard
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - run: npm ci --omit=dev
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes TOCTOU gap in `release.yml` where the `test` job and `publish-npm` job both ran `npm ci` + full build independently. The published artifact could differ from the tested artifact.

## Fix

1. **test job**: Uploads `dist/`, `dashboard/dist/`, `package.json`, `package-lock.json` as build artifacts
2. **publish-npm job**: Downloads artifacts and runs `npm ci --omit=dev` (no rebuild)

This ensures the exact same built artifacts that passed tests are what gets published.

## Changes
- Added `actions/upload-artifact@v4` step in test job
- Replaced `npm ci` + build steps in publish-npm with `actions/download-artifact@v4`

## Test Plan
- [x] tsc --noEmit ✅
- [x] npm run build ✅
- [x] 2173 tests ✅
- [x] Workflow syntax validated (workflow file only, not executed)

**Developed with:** v2.6.3
**Tested with:** v2.6.3