### PR TITLE
feat: dynamic permission policy API and sub-agent spawning API (#700 #702)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ import {
 import { loadConfig, type Config } from './config.js';
 import { captureScreenshot, isPlaywrightAvailable } from './screenshot.js';
 import { validateScreenshotUrl, resolveAndCheckIp, buildHostResolverRule } from './ssrf.js';
-import { validateWorkDir } from './validation.js';
+import { validateWorkDir, permissionRuleSchema, type PermissionPolicy } from './validation.js';
 import { SessionEventBus, type SessionSSEEvent, type GlobalSSEEvent } from './events.js';
 import { SSEWriter } from './sse-writer.js';
 import { SSEConnectionLimiter } from './sse-limiter.js';
@@ -375,6 +375,7 @@ const createSessionSchema = z.object({
   stallThresholdMs: z.number().int().positive().max(3_600_000).optional(),
   permissionMode: z.enum(['default', 'bypassPermissions', 'plan', 'acceptEdits', 'dontAsk', 'auto']).optional(),
   autoApprove: z.boolean().optional(),
+  parentId: z.string().uuid().optional(),
 }).strict();
 
 // Health — Issue #397: includes tmux server health check
@@ -661,7 +662,7 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
   if (!parsed.success) {
     return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
   }
-  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove } = parsed.data;
+  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId } = parsed.data;
   if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
 
   // Issue #564: Validate installed Claude Code version
@@ -699,7 +700,7 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
   }
 
   console.time("POST_CREATE_SESSION");
-  const session = await sessions.createSession({ workDir: safeWorkDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove });
+  const session = await sessions.createSession({ workDir: safeWorkDir, name, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId });
   console.timeEnd("POST_CREATE_SESSION"); console.time("POST_CHANNEL_CREATED");
 
   // Issue #625: Track session in metrics so sessionsCreated counter is accurate
@@ -804,6 +805,61 @@ async function sendMessageHandler(req: IdRequest, reply: FastifyReply): Promise<
 }
 app.post<IdParams>('/v1/sessions/:id/send', sendMessageHandler);
 app.post<IdParams>('/sessions/:id/send', sendMessageHandler);
+
+// Issue #702: GET children sessions
+async function getChildrenHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
+  const session = sessions.getSession(req.params.id);
+  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const children = (session.children ?? []).map(id => {
+    const child = sessions.getSession(id);
+    if (!child) return null;
+    return { id: child.id, windowName: child.windowName, status: child.status, createdAt: child.createdAt };
+  }).filter(Boolean);
+  return { children };
+}
+app.get<IdParams>('/v1/sessions/:id/children', getChildrenHandler);
+app.get<IdParams>('/sessions/:id/children', getChildrenHandler);
+
+// Issue #702: Spawn child session
+interface SpawnBody { name?: string; prompt?: string; workDir?: string; permissionMode?: string; }
+type SpawnRequest = FastifyRequest<{ Params: { id: string }; Body: SpawnBody | undefined }>;
+async function spawnChildHandler(req: SpawnRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
+  const parentId = req.params.id;
+  const parent = sessions.getSession(parentId);
+  if (!parent) return reply.status(404).send({ error: 'Parent session not found' });
+  const { name, prompt, workDir, permissionMode } = req.body ?? {};
+  const childName = name ?? `${parent.windowName ?? 'session'}-child`;
+  const childWorkDir = workDir ?? parent.workDir;
+  const childPermMode = permissionMode ?? parent.permissionMode ?? 'bypassPermissions';
+  const childSession = await sessions.createSession({ workDir: childWorkDir, name: childName, parentId, permissionMode: childPermMode });
+  let promptDelivery: { delivered: boolean; attempts: number } | undefined;
+  if (prompt) { promptDelivery = await sessions.sendInitialPrompt(childSession.id, prompt); }
+  return reply.status(201).send({ ...childSession, promptDelivery });
+}
+app.post('/v1/sessions/:id/spawn', spawnChildHandler);
+app.post('/sessions/:id/spawn', spawnChildHandler);
+
+// Issue #700: Permission policy endpoints
+type PermissionRequest = FastifyRequest<{ Params: { id: string }; Body: PermissionPolicy | undefined }>;
+async function getPermissionPolicyHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
+  const session = sessions.getSession(req.params.id);
+  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  return { permissionPolicy: session.permissionPolicy ?? [] };
+}
+async function updatePermissionPolicyHandler(req: PermissionRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
+  const session = sessions.getSession(req.params.id);
+  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const policy = req.body ?? [];
+  const result = permissionRuleSchema.array().safeParse(policy);
+  if (!result.success) return reply.status(400).send({ error: 'Invalid permission policy', details: result.error.issues });
+  session.permissionPolicy = policy;
+  await sessions.save();
+  return { permissionPolicy: policy };
+}
+app.get<IdParams>('/v1/sessions/:id/permissions', getPermissionPolicyHandler);
+app.put('/v1/sessions/:id/permissions', updatePermissionPolicyHandler);
+app.get<IdParams>('/sessions/:id/permissions', getPermissionPolicyHandler);
+app.put('/sessions/:id/permissions', updatePermissionPolicyHandler);
 
 // Read messages
 async function readMessagesHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,7 +17,7 @@ import { detectUIState, extractInteractiveContent, parseStatusLine, type UIState
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
 import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
-import { persistedStateSchema } from './validation.js';
+import { persistedStateSchema, type PermissionPolicy } from './validation.js';
 import { loadContinuationPointers } from './continuation-pointer.js';
 import type { z } from 'zod';
 import { writeHookSettingsFile, cleanupHookSettingsFile, cleanupStaleSessionHooks } from './hook-settings.js';
@@ -65,6 +65,9 @@ export interface SessionInfo {
   model?: string;                // Issue #89 L25: Model name from hook payload (e.g. "claude-sonnet-4-6")
   lastDeadAt?: number;           // Unix timestamp when session was detected as dead (Issue #283)
   ccPid?: number;                // PID of the CC process in the tmux pane (Issue #353: swarm parent matching)
+  parentId?: string;             // Issue #702: Parent session ID for sub-agent hierarchy
+  children?: string[];          // Issue #702: Child session IDs for sub-agent hierarchy
+  permissionPolicy?: PermissionPolicy;  // Issue #700: Dynamic permission rules
 }
 
 export interface SessionState {
@@ -546,6 +549,8 @@ export class SessionManager {
     permissionMode?: string;
     /** @deprecated Use permissionMode instead. Maps true→bypassPermissions, false→default. */
     autoApprove?: boolean;
+    /** Issue #702: Parent session ID for sub-agent hierarchy */
+    parentId?: string;
   }): Promise<SessionInfo> {
     const id = crypto.randomUUID();
     const windowName = opts.name || `cc-${id.slice(0, 8)}`;
@@ -673,6 +678,15 @@ export class SessionManager {
     this.invalidateSessionsListCache();
     await this.save();
 
+        // Issue #702: Register child with parent
+    if (opts.parentId) {
+      const parent = this.state.sessions[opts.parentId];
+      if (parent) {
+        if (!parent.children) parent.children = [];
+        parent.children.push(id);
+        await this.save();
+      }
+    }
     // Issue #353: Fetch CC process PID for swarm parent matching.
     // Fire-and-forget — PID is not needed synchronously.
     // Issue #574: Add .catch() to prevent unhandled rejection if tmux fails mid-lookup.

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -151,6 +151,15 @@ const UIStateEnum = z.enum([
   'settings', 'error', 'unknown',
 ]);
 
+/** Issue #700: Permission Policy Schema */
+export const permissionRuleSchema = z.object({
+  source: z.enum(['userSettings', 'projectSettings', 'localSettings', 'flagSettings', 'aegisApi']),
+  ruleBehavior: z.enum(['allow', 'deny', 'ask']),
+  toolName: z.string().optional(),
+  commandPattern: z.string().optional(),
+});
+export type PermissionPolicy = z.infer<typeof permissionRuleSchema>[];
+
 /** Schema for persisted SessionState (sessions: { [id]: SessionInfo }). */
 export const persistedStateSchema = z.record(
   z.string(),
@@ -180,6 +189,14 @@ export const persistedStateSchema = z.record(
     model: z.string().optional(),
     lastDeadAt: z.number().optional(),
     ccPid: z.number().optional(),
+    parentId: z.string().uuid().optional(),
+    children: z.array(z.string().uuid()).optional(),
+    permissionPolicy: z.array(z.object({
+      source: z.enum(['userSettings', 'projectSettings', 'localSettings', 'flagSettings', 'aegisApi']),
+      ruleBehavior: z.enum(['allow', 'deny', 'ask']),
+      toolName: z.string().optional(),
+      commandPattern: z.string().optional(),
+    })).optional(),
   }),
 );
 


### PR DESCRIPTION
Adds PermissionPolicy schema and per-session permission rule management API.

GET /v1/sessions/:id/permissions — get session permission policy
PUT /v1/sessions/:id/permissions — update session permission rules

PermissionPolicy: allow/deny/ask rules per tool/command pattern with 5 rule sources.

Quality gate: tsc ✅ build ✅ 2173 tests ✅