### PR TITLE
feat: register additional CC hook types (#571)

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -40,7 +40,7 @@ describe('generateHookSettings', () => {
     }
   });
 
-  it('should include all 14 registered HTTP hook events', () => {
+  it('should include all 18 registered HTTP hook events', () => {
     const settings = generateHookSettings(baseUrl, sessionId);
     const events = Object.keys(settings.hooks);
 
@@ -58,7 +58,11 @@ describe('generateHookSettings', () => {
     expect(events).toContain('SubagentStop');
     expect(events).toContain('Notification');
     expect(events).toContain('TeammateIdle');
-    expect(events.length).toBe(14);
+    expect(events).toContain('PreCompact');
+    expect(events).toContain('PostCompact');
+    expect(events).toContain('FileChanged');
+    expect(events).toContain('CwdChanged');
+    expect(events.length).toBe(18);
   });
 
   it('should produce valid JSON structure', () => {

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -44,10 +44,9 @@ function validateWorkDirPath(workDir: string): string | undefined {
  * for Aegis status detection and event forwarding.
  *
  * Excluded (low value for Aegis):
- *   - InstructionsLoaded, ConfigChange, CwdChanged, FileChanged (informational)
+ *   - InstructionsLoaded, ConfigChange (informational)
  *   - WorktreeCreate, WorktreeRemove (worktree management)
  *   - Elicitation, ElicitationResult (MCP-specific)
- *   - PreCompact, PostCompact (internal optimization)
  */
 const HTTP_HOOK_EVENTS = [
   // Status detection (highest value)
@@ -65,6 +64,12 @@ const HTTP_HOOK_EVENTS = [
   // Subagent tracking
   'SubagentStart',
   'SubagentStop',
+  // Context management
+  'PreCompact',
+  'PostCompact',
+  // File & directory changes
+  'FileChanged',
+  'CwdChanged',
   // Notifications
   'Notification',
   'TeammateIdle',


### PR DESCRIPTION
## Summary
Register additional Claude Code hook types:
- PreCompact, PostCompact — context management
- FileChanged, CwdChanged — file and directory change tracking

## Changes
- src/hook-settings.ts: Add 4 new hook events to HTTP_HOOK_EVENTS array
- src/__tests__/hook-settings.test.ts: Update test count 14→18, add assertions for new events

## Tests
`npx tsc --noEmit && npm run build && npm test` → 2159 passed

Fixes #571