### PR TITLE
fix: filter stale Aegis hook URLs from project settings on session start (#936)

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -460,4 +460,56 @@ describe('writeHookSettingsFile — Issue #847 path validation', () => {
       rmSync(workDir, { recursive: true, force: true });
     }
   });
+
+
+  // Issue #936: Stale Aegis hook URLs from dead sessions should be filtered out
+  it('should filter out stale Aegis hook URLs from project settings', async () => {
+    const workDir = join(tmpdir(), 'aegis-test-stale-hooks-' + process.pid);
+    mkdirSync(join(workDir, '.claude'), { recursive: true });
+    try {
+      // Write a project settings.local.json with STALE Aegis hook URLs
+      // Hook entry shape: { hooks: HttpHookConfig[] } or { command: string }
+      const staleSettings = {
+        hooks: {
+          Stop: [
+            { hooks: [{ type: 'http', url: 'http://localhost:9100/v1/hooks/Stop?sessionId=dead-session-uuid' }] }
+          ],
+          Notification: [
+            { hooks: [{ type: 'http', url: 'http://localhost:9100/v1/hooks/Notification?sessionId=another-dead-session' }] }
+          ],
+          SomeOtherEvent: [
+            { command: 'echo hello' }
+          ]
+        }
+      };
+      writeFileSync(join(workDir, '.claude', 'settings.local.json'), JSON.stringify(staleSettings));
+
+      // Generate hook settings for a new session
+      const filePath = await writeHookSettingsFile('http://localhost:9100', 'new-session-uuid', 'fresh-secret', workDir);
+      try {
+        const { readFile } = await import('node:fs/promises');
+        const content = await readFile(filePath, 'utf-8');
+        const parsed = JSON.parse(content) as unknown as Record<string, Array<{ hooks?: Array<{ url?: string }>; command?: string }>>;
+        const hooks = parsed.hooks as unknown as unknown as Record<string, Array<Record<string, unknown>>>;
+
+        // Stale Aegis URLs should be filtered out
+        const stopHooks = hooks.Stop ?? [];
+        const hasStaleStop = stopHooks.some((h: { hooks?: Array<{ url?: string }>; command?: string }) => h.hooks?.some((hook: { url?: string }) => (hook.url ?? '').includes('dead-session-uuid')));
+        expect(hasStaleStop).toBe(false);
+
+        // New session's Stop hook should be present
+        const hasNewStop = stopHooks.some((h: { hooks?: Array<{ url?: string }>; command?: string }) => h.hooks?.some((hook: { url?: string }) => (hook.url ?? '').includes('new-session-uuid')));
+        expect(hasNewStop).toBe(true);
+
+        // Non-Aegis hooks (command) should be preserved
+        const otherHooks = hooks.SomeOtherEvent ?? [];
+        expect(otherHooks.some((h: { hooks?: Array<{ url?: string }>; command?: string }) => h.command === 'echo hello')).toBe(true);
+      } finally {
+        if (existsSync(filePath)) unlinkSync(filePath);
+      }
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -147,12 +147,32 @@ export async function writeHookSettingsFile(baseUrl: string, sessionId: string, 
     }
   }
 
-  // Deep-merge: project settings as base, hooks merged by event key so both
+  // Deep-merge: project settings as base, Aegis hooks merged by event key so both
   // project-level and Aegis hooks coexist (Issue #635).
-  const existingHooks = (merged.hooks as Record<string, Array<unknown>>) ?? {};
-  const mergedHooks: Record<string, Array<unknown>> = { ...existingHooks };
+  // Issue #936: Filter out existing Aegis hooks from project settings that point to
+  // dead sessions — stale Aegis hook URLs cause CC to crash when callbacks fail.
+  // Hook entry shape: { hooks: HttpHookConfig[] } or { command: string }
+  const existingHooks = (merged.hooks as Record<string, Array<{ matcher?: string; hooks?: Array<{ type?: string; url?: string; command?: string }>; command?: string }>>) ?? {};
+  const aegisBaseUrl = baseUrl.replace('http://', '').replace('https://', '');
+  const mergedHooks: Record<string, Array<{ matcher?: string; hooks?: Array<{ type?: string; url?: string; command?: string }>; command?: string }>> = {};
+  for (const [event, projectEntries] of Object.entries(existingHooks)) {
+    // Only keep non-Aegis hook entries (e.g., user's custom command hooks or HTTP hooks to other servers)
+    const nonAegisEntries = projectEntries.filter(entry => {
+      // Keep command-type hooks (they're not HTTP callbacks to Aegis)
+      if (entry.command) return true;
+      const httpHooks = entry.hooks ?? [];
+      const hasAegisHttpHook = httpHooks.some(h =>
+        h.type === 'http' && h.url?.includes(aegisBaseUrl) && h.url?.includes('/v1/hooks/')
+      );
+      return !hasAegisHttpHook;
+    });
+    if (nonAegisEntries.length > 0) {
+      mergedHooks[event] = nonAegisEntries;
+    }
+  }
+  // Add Aegis hooks for the current session (these are always fresh)
   for (const [event, entries] of Object.entries(hookSettings.hooks)) {
-    mergedHooks[event] = [...(existingHooks[event] ?? []), ...entries];
+    mergedHooks[event] = [...(mergedHooks[event] ?? []), ...entries];
   }
 
   const combined: Record<string, unknown> = { ...merged, hooks: mergedHooks };


### PR DESCRIPTION
## Summary

Before generating hook settings for a new session, filter out existing Aegis HTTP hook URLs from project settings.local.json. Stale Aegis hook URLs (pointing to dead sessions) cause CC to crash when SessionStart callback returns 404.

## Root Cause (Issue #936)

CC deep-merges Aegis hooks into project settings. Old hook URLs accumulate in settings.local.json. When a dead session's hook fires, CC crashes.

## Fix

Filter logic in writeHookSettingsFile():
- Keep non-HTTP hooks (command-type, etc.)
- Keep HTTP hooks to non-Aegis servers
- Filter out Aegis HTTP hooks by URL pattern

## Test
New test: verify stale Aegis URLs are filtered, non-Aegis hooks preserved.

## Test Plan
- [x] tsc --noEmit
- [x] npm run build
- [x] 2174 tests (1 new)

**Developed with:** v2.6.3
**Tested with:** v2.6.3