### PR TITLE
fix: standardize API error response envelope

### DIFF
--- a/src/__tests__/api-error-envelope.test.ts
+++ b/src/__tests__/api-error-envelope.test.ts
@@ -1,0 +1,73 @@
+import Fastify, { type FastifyReply, type FastifyRequest } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { normalizeApiErrorPayload } from '../api-error-envelope.js';
+
+describe('API error envelope normalization (Issue #399)', () => {
+  let app: ReturnType<typeof Fastify> | null = null;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+      app = null;
+    }
+  });
+
+  it('normalizes JSON error responses with code, message, details, requestId, and legacy error', async () => {
+    app = Fastify({ logger: false });
+    app.addHook('onSend', (req: FastifyRequest, reply: FastifyReply, payload: unknown, done: (err?: Error | null, payload?: unknown) => void) => {
+      const contentType = reply.getHeader('content-type');
+      const normalized = normalizeApiErrorPayload({
+        payload,
+        statusCode: reply.statusCode,
+        requestId: req.id,
+        contentType: typeof contentType === 'string' ? contentType : undefined,
+      });
+      done(null, normalized as any);
+    });
+
+    app.post('/v1/example', async (_req: FastifyRequest, reply: FastifyReply) => {
+      return reply.status(400).send({
+        error: 'Invalid request body',
+        details: [{ field: 'workDir', issue: 'Required' }],
+      });
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/example',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body.code).toBe('VALIDATION_ERROR');
+    expect(body.message).toBe('Invalid request body');
+    expect(body.error).toBe('Invalid request body');
+    expect(body.details).toEqual([{ field: 'workDir', issue: 'Required' }]);
+    expect(typeof body.requestId).toBe('string');
+    expect(body.requestId.length).toBeGreaterThan(0);
+  });
+
+  it('does not normalize SSE payloads', async () => {
+    app = Fastify({ logger: false });
+    app.addHook('onSend', (req: FastifyRequest, reply: FastifyReply, payload: unknown, done: (err?: Error | null, payload?: unknown) => void) => {
+      const contentType = reply.getHeader('content-type');
+      const normalized = normalizeApiErrorPayload({
+        payload,
+        statusCode: reply.statusCode,
+        requestId: req.id,
+        contentType: typeof contentType === 'string' ? contentType : undefined,
+      });
+      done(null, normalized as any);
+    });
+
+    app.get('/v1/sse', async (_req: FastifyRequest, reply: FastifyReply) => {
+      reply.header('content-type', 'text/event-stream');
+      return reply.status(400).send('data: keep-original\n\n');
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/v1/sse' });
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toBe('data: keep-original\n\n');
+  });
+});

--- a/src/api-error-envelope.ts
+++ b/src/api-error-envelope.ts
@@ -1,0 +1,87 @@
+export interface ApiErrorEnvelope {
+  code: string;
+  message: string;
+  details?: unknown;
+  requestId: string;
+  error: string;
+}
+
+interface NormalizeApiErrorInput {
+  payload: unknown;
+  statusCode: number;
+  requestId: string;
+  contentType?: string;
+}
+
+function defaultErrorMessage(statusCode: number): string {
+  if (statusCode >= 500) return 'Internal server error';
+  if (statusCode === 404) return 'Not found';
+  if (statusCode === 401) return 'Unauthorized';
+  if (statusCode === 403) return 'Forbidden';
+  if (statusCode === 429) return 'Rate limit exceeded';
+  return 'Request failed';
+}
+
+function mapStatusToCode(statusCode: number): string {
+  if (statusCode === 400) return 'VALIDATION_ERROR';
+  if (statusCode === 401) return 'UNAUTHORIZED';
+  if (statusCode === 403) return 'FORBIDDEN';
+  if (statusCode === 404) return 'NOT_FOUND';
+  if (statusCode === 409) return 'CONFLICT';
+  if (statusCode === 429) return 'RATE_LIMITED';
+  if (statusCode === 501) return 'NOT_IMPLEMENTED';
+  if (statusCode >= 500) return 'INTERNAL_ERROR';
+  return `HTTP_${statusCode}`;
+}
+
+function parseJsonObjectString(payload: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isJsonContentType(contentType?: string): boolean {
+  return typeof contentType === 'string' && contentType.toLowerCase().includes('application/json');
+}
+
+export function normalizeApiErrorPayload(input: NormalizeApiErrorInput): unknown {
+  const { payload, statusCode, requestId, contentType } = input;
+  if (statusCode < 400) return payload;
+  if (typeof contentType === 'string' && contentType.includes('text/event-stream')) return payload;
+
+  let source: Record<string, unknown> | null = null;
+  if (payload && typeof payload === 'object' && !Array.isArray(payload) && !(payload instanceof Buffer)) {
+    source = payload as Record<string, unknown>;
+  } else if (typeof payload === 'string' && isJsonContentType(contentType)) {
+    source = parseJsonObjectString(payload);
+  }
+
+  if (!source) return payload;
+
+  const legacyError = typeof source.error === 'string' ? source.error : undefined;
+  const sourceMessage = typeof source.message === 'string' ? source.message : undefined;
+  const message = sourceMessage ?? legacyError ?? defaultErrorMessage(statusCode);
+  const code = typeof source.code === 'string' ? source.code : mapStatusToCode(statusCode);
+  const envelope: ApiErrorEnvelope = {
+    code,
+    message,
+    requestId,
+    error: legacyError ?? message,
+  };
+
+  if (source.details !== undefined) {
+    envelope.details = source.details;
+  }
+
+  if (typeof payload === 'string') {
+    return JSON.stringify(envelope);
+  }
+
+  return envelope;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,7 @@ import { execFileSync } from 'node:child_process';
 import { negotiate, type HandshakeRequest } from './handshake.js';
 import { diagnosticsBus } from './diagnostics.js';
 import { setStructuredLogSink } from './logger.js';
+import { normalizeApiErrorPayload } from './api-error-envelope.js';
 import {
   authKeySchema, sendMessageSchema, commandSchema, bashSchema,
   screenshotSchema, permissionHookSchema, stopHookSchema,
@@ -155,7 +156,7 @@ app.addHook('onSend', (req, reply, payload, done) => {
   reply.header('X-Frame-Options', 'DENY');
   reply.header('Referrer-Policy', 'strict-origin-when-cross-origin');
   reply.header('Permissions-Policy', 'camera=(), microphone=()');
-  done();
+  const normalizedPayload = normalizeApiErrorPayload({ payload, statusCode: reply.statusCode, requestId: req.id, contentType: typeof contentType === "string" ? contentType : undefined }); done(null, normalizedPayload as any);
 });
 
 // Auth middleware setup (Issue #39: multi-key auth with rate limiting)
@@ -250,6 +251,7 @@ function pruneIpRateLimits(): void {
 
 /** #583: Track keyId per request for batch rate limiting. */
 const requestKeyMap = new Map<string, string>();
+
 
 // #839: Clean up requestKeyMap entries after response to prevent unbounded memory leak.
 app.addHook('onResponse', (req, _reply, done) => {


### PR DESCRIPTION
## Summary
- add centralized JSON error-envelope normalizer for API responses
- include standard fields: code, message, optional details, requestId
- preserve backward compatibility by keeping legacy error field
- wire normalizer once in server onSend hook (no per-route rewrites)
- skip normalization for SSE payloads to avoid stream behavior changes

Closes #399

## Test Evidence
- npx tsc --noEmit
- npm test -- src/__tests__/api-error-envelope.test.ts
- npm run build