### PR TITLE
fix(dashboard): adaptive polling backoff for pipeline pages

### DIFF
--- a/dashboard/src/__tests__/PipelineDetailPage.test.tsx
+++ b/dashboard/src/__tests__/PipelineDetailPage.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import PipelineDetailPage from '../pages/PipelineDetailPage';
 import type { PipelineInfo } from '../api/client';
@@ -50,6 +50,10 @@ function renderPage(id = 'pipe-1'): void {
 describe('PipelineDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('renders pipeline name and status', async () => {
@@ -116,5 +120,36 @@ describe('PipelineDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByText('No steps yet')).toBeDefined();
     });
+  });
+
+  it('uses exponential backoff on fetch failures and resets on success', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    mockGetPipeline
+      .mockRejectedValueOnce(new Error('temporary outage'))
+      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockResolvedValueOnce(mockPipeline)
+      .mockResolvedValue(mockPipeline);
+
+    renderPage();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+    expect(mockGetPipeline).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 6_000)).toBe(true);
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(mockGetPipeline).toHaveBeenCalledTimes(2);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 12_000)).toBe(true);
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(mockGetPipeline).toHaveBeenCalledTimes(3);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 3_000)).toBe(true);
   });
 });

--- a/dashboard/src/__tests__/PipelinesPage.test.tsx
+++ b/dashboard/src/__tests__/PipelinesPage.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import PipelinesPage from '../pages/PipelinesPage';
 import type { PipelineInfo } from '../api/client';
@@ -42,6 +42,10 @@ describe('PipelinesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetPipelines.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('renders the Pipelines heading', async () => {
@@ -100,5 +104,36 @@ describe('PipelinesPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/2 steps/)).toBeDefined();
     });
+  });
+
+  it('uses exponential backoff on fetch failures and resets on success', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    mockGetPipelines
+      .mockRejectedValueOnce(new Error('temporary outage'))
+      .mockRejectedValueOnce(new Error('still down'))
+      .mockResolvedValueOnce(mockPipelines)
+      .mockResolvedValue(mockPipelines);
+
+    renderPage();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+    expect(mockGetPipelines).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 10_000)).toBe(true);
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(mockGetPipelines).toHaveBeenCalledTimes(2);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 20_000)).toBe(true);
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(mockGetPipelines).toHaveBeenCalledTimes(3);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 5_000)).toBe(true);
   });
 });

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -12,6 +12,9 @@ import { formatTimeAgo } from '../utils/format';
 import PipelineStatusBadge from '../components/pipeline/PipelineStatusBadge';
 import StatusDot from '../components/overview/StatusDot';
 
+const BASE_POLL_INTERVAL_MS = 3_000;
+const MAX_POLL_INTERVAL_MS = 60_000;
+
 export default function PipelineDetailPage() {
   const { id } = useParams<{ id: string }>();
   const [pipeline, setPipeline] = useState<PipelineInfo | null>(null);
@@ -19,12 +22,13 @@ export default function PipelineDetailPage() {
   const [notFound, setNotFound] = useState(false);
   const addToast = useToastStore((t) => t.addToast);
 
-  const fetchPipeline = useCallback(async () => {
-    if (!id) return;
+  const fetchPipeline = useCallback(async (): Promise<boolean> => {
+    if (!id) return false;
     try {
       const data = await getPipeline(id);
       setPipeline(data);
       setNotFound(false);
+      return true;
     } catch (e: unknown) {
       const err = e as Error & { statusCode?: number };
       if (err.statusCode === 404) {
@@ -32,15 +36,44 @@ export default function PipelineDetailPage() {
       } else {
         addToast('error', 'Failed to fetch pipeline', err.message);
       }
+      return false;
     } finally {
       setLoading(false);
     }
   }, [id, addToast]);
 
   useEffect(() => {
-    fetchPipeline();
-    const interval = setInterval(fetchPipeline, 3_000);
-    return () => clearInterval(interval);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+    let consecutiveErrors = 0;
+
+    const scheduleNextPoll = async () => {
+      if (cancelled) return;
+
+      const isSuccessful = await fetchPipeline();
+      if (isSuccessful) {
+        consecutiveErrors = 0;
+      } else {
+        consecutiveErrors += 1;
+      }
+
+      if (cancelled) return;
+
+      const backoffFactor = consecutiveErrors > 0 ? 2 ** consecutiveErrors : 1;
+      const nextDelayMs = Math.min(BASE_POLL_INTERVAL_MS * backoffFactor, MAX_POLL_INTERVAL_MS);
+      timeoutId = setTimeout(() => {
+        void scheduleNextPoll();
+      }, nextDelayMs);
+    };
+
+    void scheduleNextPoll();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [fetchPipeline]);
 
   if (loading) {

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -13,27 +13,60 @@ import MetricCard from '../components/overview/MetricCard';
 import PipelineStatusBadge from '../components/pipeline/PipelineStatusBadge';
 import CreatePipelineModal from '../components/CreatePipelineModal';
 
+const BASE_POLL_INTERVAL_MS = 5_000;
+const MAX_POLL_INTERVAL_MS = 60_000;
+
 export default function PipelinesPage() {
   const [pipelines, setPipelines] = useState<PipelineInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const addToast = useToastStore((t) => t.addToast);
 
-  const fetchPipelines = useCallback(async () => {
+  const fetchPipelines = useCallback(async (): Promise<boolean> => {
     try {
       const data = await getPipelines();
       setPipelines(data);
+      return true;
     } catch (e: unknown) {
       addToast('error', 'Failed to fetch pipelines', e instanceof Error ? e.message : undefined);
+      return false;
     } finally {
       setLoading(false);
     }
   }, [addToast]);
 
   useEffect(() => {
-    fetchPipelines();
-    const interval = setInterval(fetchPipelines, 5_000);
-    return () => clearInterval(interval);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+    let consecutiveErrors = 0;
+
+    const scheduleNextPoll = async () => {
+      if (cancelled) return;
+
+      const isSuccessful = await fetchPipelines();
+      if (isSuccessful) {
+        consecutiveErrors = 0;
+      } else {
+        consecutiveErrors += 1;
+      }
+
+      if (cancelled) return;
+
+      const backoffFactor = consecutiveErrors > 0 ? 2 ** consecutiveErrors : 1;
+      const nextDelayMs = Math.min(BASE_POLL_INTERVAL_MS * backoffFactor, MAX_POLL_INTERVAL_MS);
+      timeoutId = setTimeout(() => {
+        void scheduleNextPoll();
+      }, nextDelayMs);
+    };
+
+    void scheduleNextPoll();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [fetchPipelines]);
 
   const counts = {


### PR DESCRIPTION
## Summary
- replace fixed interval polling in dashboard pipeline pages with adaptive timeout polling
- apply exponential backoff on repeated fetch failures and reset to base interval after successful fetch
- add targeted tests for backoff growth and reset behavior

## Aegis version
**Developed with:** v2.8.0
**Tested with:** v2.8.0

Closes #513