### PR TITLE
feat: REST API routes and session injection for memory bridge (#783)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,8 @@ export interface Config {
    *  Empty array = all directories allowed (backward compatible).
    *  Paths are resolved and symlink-resolved before checking. */
   allowedWorkDirs: string[];
+  /** Memory bridge: key/value store for cross-session context (default: disabled). */
+  memoryBridge: { enabled: boolean; persistPath?: string; reaperIntervalMs?: number };
   /** Issue #884: Enable worktree-aware continuation metadata lookup (default: false).
    *  When true, Aegis fans out to sibling worktree project dirs when the primary
    *  directory lookup fails to find a session file. */
@@ -104,6 +106,7 @@ const defaults: Config = {
   sseMaxPerIp: 10,
   allowedWorkDirs: [],
   worktreeAwareContinuation: false,
+  memoryBridge: { enabled: false },
   worktreeSiblingDirs: [],
 };
 

--- a/src/memory-routes.ts
+++ b/src/memory-routes.ts
@@ -1,0 +1,56 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { MemoryBridge } from './memory-bridge.js';
+import { z } from 'zod';
+
+const setMemorySchema = z.object({
+  key: z.string().max(256),
+  value: z.string().max(100 * 1024),
+  ttlSeconds: z.number().int().positive().max(86400 * 30).optional(),
+}).strict();
+
+const getMemorySchema = z.object({
+  prefix: z.string().optional(),
+});
+
+export function registerMemoryRoutes(app: FastifyInstance, bridge: MemoryBridge): void {
+  // POST /v1/memory — write a memory entry
+  app.post('/v1/memory', async (req: FastifyRequest, reply: FastifyReply) => {
+    const parsed = setMemorySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+    }
+    const { key, value, ttlSeconds } = parsed.data;
+    try {
+      const entry = bridge.set(key, value, ttlSeconds);
+      return { ok: true, entry };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes('Invalid key format')) return reply.status(400).send({ error: msg });
+      if (msg.includes('exceeds maximum size')) return reply.status(413).send({ error: msg });
+      throw e;
+    }
+  });
+
+  // GET /v1/memory/:key — read a memory entry
+  app.get('/v1/memory/:key', async (req: FastifyRequest<{ Params: { key: string } }>, reply: FastifyReply) => {
+    const key = decodeURIComponent(req.params.key);
+    const entry = bridge.get(key);
+    if (!entry) return reply.status(404).send({ error: `Key not found: ${key}` });
+    return { entry };
+  });
+
+  // GET /v1/memory — list entries, optionally filtered by prefix
+  app.get('/v1/memory', async (req: FastifyRequest<{ Querystring: { prefix?: string } }>, reply: FastifyReply) => {
+    const { prefix } = req.query;
+    const entries = bridge.list(prefix);
+    return { entries };
+  });
+
+  // DELETE /v1/memory/:key — delete a memory entry
+  app.delete('/v1/memory/:key', async (req: FastifyRequest<{ Params: { key: string } }>, reply: FastifyReply) => {
+    const key = decodeURIComponent(req.params.key);
+    const deleted = bridge.delete(key);
+    if (!deleted) return reply.status(404).send({ error: `Key not found: ${key}` });
+    return { ok: true };
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,8 @@ import { execFileSync } from 'node:child_process';
 import { negotiate, type HandshakeRequest } from './handshake.js';
 import { diagnosticsBus } from './diagnostics.js';
 import { setStructuredLogSink } from './logger.js';
+import { MemoryBridge } from './memory-bridge.js';
+import { registerMemoryRoutes } from './memory-routes.js';
 import { normalizeApiErrorPayload } from './api-error-envelope.js';
 import {
   authKeySchema, sendMessageSchema, commandSchema, bashSchema,
@@ -80,6 +82,7 @@ let monitor: SessionMonitor;
 let jsonlWatcher: JsonlWatcher;
 const channels = new ChannelManager();
 const eventBus = new SessionEventBus();
+let memoryBridge: MemoryBridge | null = null;
 let sseLimiter: SSEConnectionLimiter;let pipelines: PipelineManager;
 let toolRegistry: ToolRegistry;
 let auth: AuthManager;
@@ -378,6 +381,7 @@ const createSessionSchema = z.object({
   permissionMode: z.enum(['default', 'bypassPermissions', 'plan', 'acceptEdits', 'dontAsk', 'auto']).optional(),
   autoApprove: z.boolean().optional(),
   parentId: z.string().uuid().optional(),
+  memoryKeys: z.array(z.string()).max(50).optional(),
 }).strict();
 
 // Health — Issue #397: includes tmux server health check
@@ -664,7 +668,7 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
   if (!parsed.success) {
     return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
   }
-  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId } = parsed.data;
+  const { workDir, name, prompt, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId, memoryKeys } = parsed.data;
   if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
 
   // Issue #564: Validate installed Claude Code version
@@ -692,7 +696,17 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
       // Send prompt to the existing session if provided
       let promptDelivery: { delivered: boolean; attempts: number } | undefined;
       if (prompt) {
-        promptDelivery = await sessions.sendInitialPrompt(existing.id, prompt);
+        let finalPrompt = prompt;
+        if (memoryKeys && memoryKeys.length > 0 && memoryBridge) {
+          const resolved = memoryBridge.resolveKeys(memoryKeys);
+          if (resolved.size > 0) {
+            const lines = ['[Memory context]'];
+            for (const [k, v] of resolved) lines.push(`${k}: ${v}`);
+            lines.push('', prompt);
+            finalPrompt = lines.join('\n');
+          }
+        }
+        promptDelivery = await sessions.sendInitialPrompt(existing.id, finalPrompt);
         metrics.promptSent(promptDelivery.delivered);
       }
       return reply.status(200).send({ ...existing, reused: true, promptDelivery });
@@ -725,7 +739,18 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
   // Now send the prompt (topic exists, monitor can forward messages)
   let promptDelivery: { delivered: boolean; attempts: number } | undefined;
   if (prompt) {
-    promptDelivery = await sessions.sendInitialPrompt(session.id, prompt);
+    // Issue #783: Inject resolved memory values into prompt
+    let finalPrompt = prompt;
+    if (memoryKeys && memoryKeys.length > 0 && memoryBridge) {
+      const resolved = memoryBridge.resolveKeys(memoryKeys);
+      if (resolved.size > 0) {
+        const lines = ['[Memory context]'];
+        for (const [k, v] of resolved) lines.push(`${k}: ${v}`);
+        lines.push('', prompt);
+        finalPrompt = lines.join('\n');
+      }
+    }
+    promptDelivery = await sessions.sendInitialPrompt(session.id, finalPrompt);
     console.timeEnd("POST_SEND_INITIAL_PROMPT");
     metrics.promptSent(promptDelivery.delivered);
   } else {
@@ -1675,6 +1700,17 @@ async function main(): Promise<void> {
   // Initialize core components with config
   tmux = new TmuxManager(config.tmuxSession);
   sessions = new SessionManager(tmux, config);
+
+  // Memory bridge (Issue #783)
+  if (config.memoryBridge?.enabled) {
+    const persistPath = config.memoryBridge.persistPath ?? path.join(config.stateDir, 'memory.json');
+    memoryBridge = new MemoryBridge(persistPath, config.memoryBridge.reaperIntervalMs);
+    await memoryBridge.load();
+    memoryBridge.startReaper();
+    registerMemoryRoutes(app, memoryBridge);
+    console.error(`Memory bridge enabled, persisted at: ${persistPath}`);
+  }
+
   sseLimiter = new SSEConnectionLimiter({ maxConnections: config.sseMaxConnections, maxPerIp: config.sseMaxPerIp });
   monitor = new SessionMonitor(sessions, channels, { ...DEFAULT_MONITOR_CONFIG, pollIntervalMs: 5000 });
 
@@ -1683,7 +1719,7 @@ async function main(): Promise<void> {
 
   // Setup auth (Issue #39: multi-key + backward compat)
   const { join } = await import('node:path');
-  auth = new AuthManager(join(config.stateDir, 'keys.json'), config.authToken);
+  auth = new AuthManager(path.join(config.stateDir, 'keys.json'), config.authToken);
   await auth.load();
   setupAuth(auth);
 
@@ -1734,7 +1770,7 @@ async function main(): Promise<void> {
   // Initialize batch rate limiter (Issue #583)
 
   // Initialize metrics (Issue #40)
-  metrics = new MetricsCollector(join(config.stateDir, 'metrics.json'));
+  metrics = new MetricsCollector(path.join(config.stateDir, 'metrics.json'));
   await metrics.load();
 
   // Issue #361: Store interval refs so graceful shutdown can clear them


### PR DESCRIPTION
## Summary

Completes #783 — session memory bridge REST API and session injection.

## What's included

**REST API** (`src/memory-routes.ts`):
- `POST /v1/memory` — write key/value with optional TTL
- `GET /v1/memory/:key` — read entry (URL-encoded key)
- `GET /v1/memory?prefix=ns/` — list entries by prefix
- `DELETE /v1/memory/:key` — delete entry

**Session injection** (`src/server.ts`):
- `POST /v1/sessions` accepts `memoryKeys: string[]`
- Resolves keys via MemoryBridge.resolveKeys() and prepends as:
  ```
  [Memory context]
  ns/key1: value1
  ns/key2: value2
  
  <original prompt>
  ```

**Config** (`src/config.ts`):
- `memoryBridge.enabled` (default: false) — opt-in
- `memoryBridge.persistPath` — defaults to `{stateDir}/memory.json`
- `memoryBridge.reaperIntervalMs` — TTL reaper interval

## What's NOT included

This is the final piece — #783 is fully implemented by this PR + #951 (merged).

## Quality Gate

- tsc --noEmit: PASS
- npm run build: PASS
- 2172 tests: PASS

**Developed with:** v2.8.0
**Tested with:** v2.8.0
