### PR TITLE
fix: enhance global metrics dashboard

### DIFF
--- a/dashboard/src/__tests__/MetricCards.test.tsx
+++ b/dashboard/src/__tests__/MetricCards.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MetricCards from '../components/overview/MetricCards';
 import { useStore } from '../store/useStore';
 
@@ -11,60 +11,48 @@ vi.mock('../api/client', () => ({
   getHealth: (...args: unknown[]) => mockGetHealth(...args),
 }));
 
-describe('MetricCards polling strategy', () => {
+describe('MetricCards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    useStore.setState({
-      metrics: null,
-      sseConnected: false,
-    });
+    useStore.setState({ metrics: null });
 
     mockGetMetrics.mockResolvedValue({
-      uptime: 1,
+      uptime: 7200,
       sessions: {
-        total_created: 2,
-        currently_active: 1,
-        completed: 1,
-        failed: 0,
-        avg_duration_sec: 42,
+        total_created: 12,
+        currently_active: 3,
+        completed: 8,
+        failed: 1,
+        avg_duration_sec: 240,
+        avg_messages_per_session: 6,
       },
+      auto_approvals: 9,
+      webhooks_sent: 20,
+      webhooks_failed: 5,
+      screenshots_taken: 4,
+      pipelines_created: 7,
+      batches_created: 2,
       prompt_delivery: {
-        delivered: 1,
-        failed: 0,
-        success_rate: 100,
+        sent: 40,
+        delivered: 34,
+        failed: 6,
+        success_rate: 85,
       },
-      permission: {
-        prompts: 0,
-        approved: 0,
-        rejected: 0,
-      },
-      throughput: {
-        messages_per_min: 0,
-        tool_calls_per_min: 0,
-      },
-      timestamp: new Date().toISOString(),
     });
 
     mockGetHealth.mockResolvedValue({
       status: 'ok',
       version: 'test',
-      uptime: 1,
+      uptime: 5400,
       sessions: {
-        active: 1,
-        total: 2,
+        active: 2,
+        total: 10,
       },
       timestamp: new Date().toISOString(),
     });
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('uses fallback polling when SSE is disconnected', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
-
+  it('renders enriched overview metrics from the global metrics payload', async () => {
     render(<MetricCards />);
 
     await waitFor(() => {
@@ -72,36 +60,28 @@ describe('MetricCards polling strategy', () => {
       expect(mockGetHealth).toHaveBeenCalledTimes(1);
     });
 
-    const pollingCall = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
-    expect(pollingCall).toBeDefined();
-    const intervalCallback = pollingCall?.[0] as () => void | Promise<void>;
+    expect(await screen.findByText('Prompt Delivery')).toBeTruthy();
+    expect(screen.getByText('Webhooks')).toBeTruthy();
+    expect(screen.getByText('Automation')).toBeTruthy();
 
-    await act(async () => {
-      await intervalCallback?.();
-      await intervalCallback?.();
-      await intervalCallback?.();
-    });
+    expect(screen.getByText('Active Sessions')).toBeTruthy();
+    expect(screen.getByText('Total Created')).toBeTruthy();
+    expect(screen.getByText('Delivery Rate')).toBeTruthy();
+    expect(screen.getByText('Uptime')).toBeTruthy();
 
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(4);
-      expect(mockGetHealth).toHaveBeenCalledTimes(4);
-    });
-  });
+    expect(screen.getByText('Delivered')).toBeTruthy();
+    expect(screen.getAllByText('Failed')).toHaveLength(2);
+    expect(screen.getByText('Success Rate')).toBeTruthy();
+    expect(screen.getAllByText('Failure Rate')).toHaveLength(2);
+    expect(screen.getByText('Auto Approvals')).toBeTruthy();
+    expect(screen.getByText('Pipelines')).toBeTruthy();
+    expect(screen.getByText('Batches')).toBeTruthy();
 
-  it('does not run interval polling when SSE is connected', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
-    useStore.setState({ sseConnected: true });
-
-    render(<MetricCards />);
-
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(1);
-      expect(mockGetHealth).toHaveBeenCalledTimes(1);
-    });
-
-    const pollingCall = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
-    expect(pollingCall).toBeUndefined();
-    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
-    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Delivery rate trend')).toBeTruthy();
+    expect(screen.getAllByTestId('delivery-rate-bar')).toHaveLength(1);
+    expect(screen.getByText('34')).toBeTruthy();
+    expect(screen.getByText('85.0%')).toBeTruthy();
+    expect(screen.getByText('15')).toBeTruthy();
+    expect(screen.getByText('7')).toBeTruthy();
   });
 });

--- a/dashboard/src/__tests__/metricsOverview.test.ts
+++ b/dashboard/src/__tests__/metricsOverview.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { appendDeliveryRateSample, buildMetricsOverviewModel } from '../utils/metricsOverview';
+import type { GlobalMetrics, HealthResponse } from '../types';
+
+function makeMetrics(overrides: Partial<GlobalMetrics> = {}): GlobalMetrics {
+  return {
+    uptime: 7200,
+    sessions: {
+      total_created: 12,
+      currently_active: 3,
+      completed: 8,
+      failed: 1,
+      avg_duration_sec: 240,
+      avg_messages_per_session: 6,
+    },
+    auto_approvals: 9,
+    webhooks_sent: 20,
+    webhooks_failed: 5,
+    screenshots_taken: 4,
+    pipelines_created: 7,
+    batches_created: 2,
+    prompt_delivery: {
+      sent: 40,
+      delivered: 34,
+      failed: 6,
+      success_rate: 85,
+    },
+    ...overrides,
+  };
+}
+
+function makeHealth(overrides: Partial<HealthResponse> = {}): HealthResponse {
+  return {
+    status: 'ok',
+    version: 'test',
+    uptime: 5400,
+    sessions: {
+      active: 2,
+      total: 10,
+    },
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('appendDeliveryRateSample', () => {
+  it('appends numeric samples and trims to the most recent values', () => {
+    const history = [70, 72, 74];
+    expect(appendDeliveryRateSample(history, 88, 4)).toEqual([70, 72, 74, 88]);
+    expect(appendDeliveryRateSample([70, 72, 74, 88], 91, 4)).toEqual([72, 74, 88, 91]);
+  });
+
+  it('ignores missing success rates', () => {
+    const history = [70, 72, 74];
+    expect(appendDeliveryRateSample(history, null)).toEqual(history);
+    expect(appendDeliveryRateSample(history, undefined)).toEqual(history);
+  });
+});
+
+describe('buildMetricsOverviewModel', () => {
+  it('maps summary and detail sections from metrics payloads', () => {
+    const model = buildMetricsOverviewModel(makeMetrics(), makeHealth(), [78, 82, 85]);
+
+    expect(model.summaryCards).toEqual([
+      { label: 'Active Sessions', value: 3 },
+      { label: 'Total Created', value: 12 },
+      { label: 'Delivery Rate', value: '85.0', suffix: '%' },
+      { label: 'Uptime', value: '1h 30m' },
+    ]);
+
+    expect(model.promptDelivery).toEqual([
+      { label: 'Delivered', value: '34', tone: 'success' },
+      { label: 'Failed', value: '6', tone: 'danger' },
+      { label: 'Success Rate', value: '85.0%', tone: 'success' },
+      { label: 'Failure Rate', value: '15.0%', tone: 'warning' },
+    ]);
+
+    expect(model.webhooks).toEqual([
+      { label: 'Succeeded', value: '15', tone: 'success' },
+      { label: 'Failed', value: '5', tone: 'danger' },
+      { label: 'Sent', value: '20' },
+      { label: 'Failure Rate', value: '25.0%', tone: 'warning' },
+    ]);
+
+    expect(model.automation).toEqual([
+      { label: 'Auto Approvals', value: '9', tone: 'success' },
+      { label: 'Pipelines', value: '7' },
+      { label: 'Batches', value: '2' },
+      { label: 'Screenshots', value: '4' },
+    ]);
+
+    expect(model.deliveryRateTrend).toEqual([78, 82, 85]);
+  });
+
+  it('falls back to health data and empty placeholders when metrics are unavailable', () => {
+    const model = buildMetricsOverviewModel(null, makeHealth(), []);
+
+    expect(model.summaryCards).toEqual([
+      { label: 'Active Sessions', value: 2 },
+      { label: 'Total Created', value: 10 },
+      { label: 'Delivery Rate', value: '—' },
+      { label: 'Uptime', value: '1h 30m' },
+    ]);
+
+    expect(model.promptDelivery[2]).toEqual({ label: 'Success Rate', value: '—', tone: 'success' });
+    expect(model.webhooks[3]).toEqual({ label: 'Failure Rate', value: '—', tone: 'default' });
+    expect(model.automation[0]).toEqual({ label: 'Auto Approvals', value: '0', tone: 'success' });
+  });
+});

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -1,71 +1,174 @@
 /**
- * components/overview/MetricCards.tsx — Grid of metric cards with fallback polling.
+ * components/overview/MetricCards.tsx — Grid of metric cards with polling.
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Activity, Clock, Layers, Zap } from 'lucide-react';
-import { getHealth, getMetrics } from '../../api/client';
+import { Activity, Clock, Layers, Orbit, Send, Webhook, Zap } from 'lucide-react';
+import { getMetrics, getHealth } from '../../api/client';
 import { useStore } from '../../store/useStore';
 import { useToastStore } from '../../store/useToastStore';
-import type { HealthResponse } from '../../types';
-import { formatUptime } from '../../utils/format';
+import { appendDeliveryRateSample, buildMetricsOverviewModel } from '../../utils/metricsOverview';
 import MetricCard from './MetricCard';
+import type { HealthResponse } from '../../types';
+
+interface MetricsDetailPanelProps {
+  title: string;
+  icon: React.ReactNode;
+  description: string;
+  stats: Array<{
+    label: string;
+    value: string;
+    tone?: 'default' | 'success' | 'warning' | 'danger';
+  }>;
+  children?: React.ReactNode;
+}
+
+function detailToneClass(tone?: 'default' | 'success' | 'warning' | 'danger'): string {
+  if (tone === 'success') return 'text-emerald-300';
+  if (tone === 'warning') return 'text-amber-300';
+  if (tone === 'danger') return 'text-rose-300';
+  return 'text-[#f4f7fb]';
+}
+
+function MetricsDetailPanel({ title, icon, description, stats, children }: MetricsDetailPanelProps) {
+  return (
+    <section className="rounded-xl border border-void-lighter bg-[#111118] p-4">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-sm font-medium text-[#d8d8df]">
+            <span className="text-[#00e5ff]">{icon}</span>
+            {title}
+          </div>
+          <p className="mt-1 text-xs text-[#7f8192]">{description}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        {stats.map((stat) => (
+          <div key={`${title}-${stat.label}`} className="rounded-lg border border-white/5 bg-black/10 px-3 py-2">
+            <div className="text-[11px] uppercase tracking-[0.16em] text-[#6e7387]">{stat.label}</div>
+            <div className={`mt-1 font-mono text-lg ${detailToneClass(stat.tone)}`}>{stat.value}</div>
+          </div>
+        ))}
+      </div>
+
+      {children ? <div className="mt-4">{children}</div> : null}
+    </section>
+  );
+}
+
+function DeliveryRateTrend({ values }: { values: number[] }) {
+  if (values.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-white/10 px-3 py-4 text-xs text-[#6e7387]">
+        Trend appears after a few metric refreshes.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between text-[11px] uppercase tracking-[0.16em] text-[#6e7387]">
+        <span>Delivery Trend</span>
+        <span>{values.length} samples</span>
+      </div>
+      <div aria-label="Delivery rate trend" className="flex h-20 items-end gap-1 rounded-lg border border-white/5 bg-black/10 px-3 py-3">
+        {values.map((value, index) => {
+          const height = Math.max(10, Math.round((value / 100) * 52));
+          return (
+            <div key={`delivery-rate-${index}`} className="flex min-w-0 flex-1 flex-col items-center justify-end">
+              <div
+                data-testid="delivery-rate-bar"
+                className="w-full rounded-t bg-gradient-to-t from-[#0ea5e9] via-[#22d3ee] to-[#a7f3d0]"
+                style={{ height: `${height}px` }}
+                title={`${value.toFixed(1)}%`}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 export default function MetricCards() {
   const metrics = useStore((s) => s.metrics);
-  const sseConnected = useStore((s) => s.sseConnected);
   const setMetrics = useStore((s) => s.setMetrics);
   const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [deliveryRateTrend, setDeliveryRateTrend] = useState<number[]>([]);
 
   const fetchData = useCallback(async () => {
     try {
-      const [nextMetrics, nextHealth] = await Promise.all([getMetrics(), getHealth()]);
-      setMetrics(nextMetrics);
-      setHealth(nextHealth);
+      const [m, h] = await Promise.all([getMetrics(), getHealth()]);
+      setMetrics(m);
+      setHealth(h);
+      setDeliveryRateTrend((currentTrend) => appendDeliveryRateSample(currentTrend, m.prompt_delivery.success_rate));
     } catch (e: unknown) {
       useToastStore.getState().addToast('error', 'Failed to load metrics', e instanceof Error ? e.message : undefined);
     }
-  }, [setMetrics]);
+  }, [setMetrics, setHealth]);
 
   useEffect(() => {
     fetchData();
-
-    if (sseConnected) {
-      return;
-    }
-
     const interval = setInterval(fetchData, 10_000);
     return () => clearInterval(interval);
-  }, [fetchData, sseConnected]);
+  }, [fetchData]);
 
-  const activeSessions = metrics?.sessions.currently_active ?? health?.sessions.active ?? 0;
-  const totalCreated = metrics?.sessions.total_created ?? health?.sessions.total ?? 0;
-  const deliveryRate = metrics?.prompt_delivery.success_rate;
-  const uptime = health?.uptime ?? metrics?.uptime ?? 0;
+  const model = buildMetricsOverviewModel(metrics, health, deliveryRateTrend);
 
   return (
-    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-      <MetricCard
-        label="Active Sessions"
-        value={activeSessions}
-        icon={<Activity className="h-4 w-4" />}
-      />
-      <MetricCard
-        label="Total Created"
-        value={totalCreated}
-        icon={<Layers className="h-4 w-4" />}
-      />
-      <MetricCard
-        label="Delivery Rate"
-        value={deliveryRate !== null && deliveryRate !== undefined ? deliveryRate.toFixed(1) : '—'}
-        suffix="%"
-        icon={<Zap className="h-4 w-4" />}
-      />
-      <MetricCard
-        label="Uptime"
-        value={formatUptime(uptime)}
-        icon={<Clock className="h-4 w-4" />}
-      />
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <MetricCard
+          label={model.summaryCards[0].label}
+          value={model.summaryCards[0].value}
+          icon={<Activity className="h-4 w-4" />}
+          suffix={model.summaryCards[0].suffix}
+        />
+        <MetricCard
+          label={model.summaryCards[1].label}
+          value={model.summaryCards[1].value}
+          icon={<Layers className="h-4 w-4" />}
+          suffix={model.summaryCards[1].suffix}
+        />
+        <MetricCard
+          label={model.summaryCards[2].label}
+          value={model.summaryCards[2].value}
+          icon={<Zap className="h-4 w-4" />}
+          suffix={model.summaryCards[2].suffix}
+        />
+        <MetricCard
+          label={model.summaryCards[3].label}
+          value={model.summaryCards[3].value}
+          icon={<Clock className="h-4 w-4" />}
+          suffix={model.summaryCards[3].suffix}
+        />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <MetricsDetailPanel
+          title="Prompt Delivery"
+          icon={<Send className="h-4 w-4" />}
+          description="Success and failure signals from the prompt delivery pipeline."
+          stats={model.promptDelivery}
+        >
+          <DeliveryRateTrend values={model.deliveryRateTrend} />
+        </MetricsDetailPanel>
+
+        <MetricsDetailPanel
+          title="Webhooks"
+          icon={<Webhook className="h-4 w-4" />}
+          description="Outbound webhook reliability and failure pressure."
+          stats={model.webhooks}
+        />
+
+        <MetricsDetailPanel
+          title="Automation"
+          icon={<Orbit className="h-4 w-4" />}
+          description="Auto-approvals and workflow creation volume across the system."
+          stats={model.automation}
+        />
+      </div>
     </div>
   );
 }

--- a/dashboard/src/utils/metricsOverview.ts
+++ b/dashboard/src/utils/metricsOverview.ts
@@ -1,0 +1,98 @@
+import { formatUptime } from './format';
+import type { GlobalMetrics, HealthResponse } from '../types';
+
+export interface OverviewSummaryCard {
+  label: string;
+  value: string | number;
+  suffix?: string;
+}
+
+export interface OverviewStatItem {
+  label: string;
+  value: string;
+  tone?: 'default' | 'success' | 'warning' | 'danger';
+}
+
+export interface MetricsOverviewModel {
+  summaryCards: OverviewSummaryCard[];
+  promptDelivery: OverviewStatItem[];
+  webhooks: OverviewStatItem[];
+  automation: OverviewStatItem[];
+  deliveryRateTrend: number[];
+}
+
+const DEFAULT_TREND_POINTS = 12;
+
+function formatPercent(value: number | null | undefined): string {
+  return value === null || value === undefined ? '—' : `${value.toFixed(1)}%`;
+}
+
+function computeFailureRate(failed: number, total: number): number | null {
+  return total > 0 ? (failed / total) * 100 : null;
+}
+
+export function appendDeliveryRateSample(
+  history: number[],
+  successRate: number | null | undefined,
+  maxPoints = DEFAULT_TREND_POINTS,
+): number[] {
+  if (successRate === null || successRate === undefined) {
+    return history;
+  }
+
+  const nextHistory = [...history, successRate];
+  return nextHistory.length > maxPoints
+    ? nextHistory.slice(nextHistory.length - maxPoints)
+    : nextHistory;
+}
+
+export function buildMetricsOverviewModel(
+  metrics: GlobalMetrics | null,
+  health: HealthResponse | null,
+  deliveryRateTrend: number[],
+): MetricsOverviewModel {
+  const activeSessions = metrics?.sessions.currently_active ?? health?.sessions.active ?? 0;
+  const totalCreated = metrics?.sessions.total_created ?? health?.sessions.total ?? 0;
+  const delivered = metrics?.prompt_delivery.delivered ?? 0;
+  const failedDeliveries = metrics?.prompt_delivery.failed ?? 0;
+  const sentDeliveries = metrics?.prompt_delivery.sent ?? 0;
+  const deliverySuccessRate = metrics?.prompt_delivery.success_rate ?? null;
+  const webhookSent = metrics?.webhooks_sent ?? 0;
+  const webhookFailed = metrics?.webhooks_failed ?? 0;
+  const webhookSucceeded = Math.max(webhookSent - webhookFailed, 0);
+  const uptime = health?.uptime ?? metrics?.uptime ?? 0;
+  const deliveryFailureRate = computeFailureRate(failedDeliveries, sentDeliveries);
+  const webhookFailureRate = computeFailureRate(webhookFailed, webhookSent);
+
+  return {
+    summaryCards: [
+      { label: 'Active Sessions', value: activeSessions },
+      { label: 'Total Created', value: totalCreated },
+      {
+        label: 'Delivery Rate',
+        value: deliverySuccessRate === null ? '—' : deliverySuccessRate.toFixed(1),
+        suffix: deliverySuccessRate === null ? undefined : '%',
+      },
+      { label: 'Uptime', value: formatUptime(uptime) },
+    ],
+    promptDelivery: [
+      { label: 'Delivered', value: String(delivered), tone: 'success' },
+      { label: 'Failed', value: String(failedDeliveries), tone: failedDeliveries > 0 ? 'danger' : 'default' },
+      { label: 'Success Rate', value: formatPercent(deliverySuccessRate), tone: 'success' },
+      { label: 'Failure Rate', value: formatPercent(deliveryFailureRate), tone: deliveryFailureRate && deliveryFailureRate > 0 ? 'warning' : 'default' },
+    ],
+    webhooks: [
+      { label: 'Succeeded', value: String(webhookSucceeded), tone: 'success' },
+      { label: 'Failed', value: String(webhookFailed), tone: webhookFailed > 0 ? 'danger' : 'default' },
+      { label: 'Sent', value: String(webhookSent) },
+      { label: 'Failure Rate', value: formatPercent(webhookFailureRate), tone: webhookFailureRate && webhookFailureRate > 0 ? 'warning' : 'default' },
+    ],
+    automation: [
+      { label: 'Auto Approvals', value: String(metrics?.auto_approvals ?? 0), tone: 'success' },
+      { label: 'Pipelines', value: String(metrics?.pipelines_created ?? 0) },
+      { label: 'Batches', value: String(metrics?.batches_created ?? 0) },
+      { label: 'Screenshots', value: String(metrics?.screenshots_taken ?? 0) },
+    ],
+    deliveryRateTrend,
+  };
+}


### PR DESCRIPTION
## Summary- expand the overview metrics section with prompt delivery, webhook, and automation panels- add a lightweight delivery-rate trend chart using existing /v1/metrics polling data- add dashboard tests for overview rendering and metrics adapter mapping## Validation- dashboard: npx vitest run- dashboard: npm run build- repo: npx tsc --noEmitCloses #318

## Aegis version
**Developed with:** v2.9.0