### PR TITLE
fix: safely parse stop hook payload fields

### DIFF
--- a/src/__tests__/stop-failure.test.ts
+++ b/src/__tests__/stop-failure.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { normalizeStopHookPayload } from '../hook.js';
 
 describe('StopFailure hook support', () => {
   let tmpDir: string;
@@ -78,6 +79,35 @@ describe('StopFailure hook support', () => {
       expect(signal.error_details).toBe('Too many requests, retry after 30s');
       expect(signal.last_assistant_message).toBe('I was working on fixing the bug...');
       expect(signal.agent_id).toBe('agent-123');
+    });
+
+    it('should ignore malformed typed fields while preserving valid payload values', () => {
+      const signal = normalizeStopHookPayload({
+        error: { message: 'Rate limit exceeded' },
+        message: 42,
+        error_details: { retry_after: 30 },
+        last_assistant_message: 'I was working on fixing the bug...',
+        agent_id: ['agent-123'],
+        stop_reason: 'rate_limit',
+      });
+
+      expect(signal.error).toBeNull();
+      expect(signal.error_details).toEqual({ retry_after: 30 });
+      expect(signal.last_assistant_message).toBe('I was working on fixing the bug...');
+      expect(signal.agent_id).toBeNull();
+      expect(signal.stop_reason).toBe('rate_limit');
+    });
+
+    it('should fall back to message when error is absent and message is a valid string', () => {
+      const signal = normalizeStopHookPayload({
+        message: 'Rate limit exceeded',
+        error_details: null,
+        stop_reason: 'rate_limit',
+      });
+
+      expect(signal.error).toBe('Rate limit exceeded');
+      expect(signal.error_details).toBeNull();
+      expect(signal.stop_reason).toBe('rate_limit');
     });
   });
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -58,12 +58,34 @@ interface SessionMapEntry {
 
 /** Payload fields for Stop/StopFailure events. */
 interface StopHookPayload {
-  error?: string;
-  message?: string;
-  error_details?: unknown;
-  last_assistant_message?: unknown;
-  agent_id?: string;
-  stop_reason?: string;
+  error: string | null;
+  error_details: unknown | null;
+  last_assistant_message: unknown | null;
+  agent_id: string | null;
+  stop_reason: string | null;
+}
+
+function getOptionalStringField(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function getOptionalUnknownField(payload: Record<string, unknown>, key: string): unknown | null {
+  if (!Object.prototype.hasOwnProperty.call(payload, key)) {
+    return null;
+  }
+
+  return payload[key] ?? null;
+}
+
+export function normalizeStopHookPayload(payload: Record<string, unknown>): StopHookPayload {
+  return {
+    error: getOptionalStringField(payload, 'error') ?? getOptionalStringField(payload, 'message'),
+    error_details: getOptionalUnknownField(payload, 'error_details'),
+    last_assistant_message: getOptionalUnknownField(payload, 'last_assistant_message'),
+    agent_id: getOptionalStringField(payload, 'agent_id'),
+    stop_reason: getOptionalStringField(payload, 'stop_reason'),
+  };
 }
 
 /** Handle Stop/StopFailure events.
@@ -89,15 +111,16 @@ function handleStopEvent(
     } catch { /* fresh */ }
   }
 
+  const stopPayload = normalizeStopHookPayload(payload);
+
   signals[sessionId] = {
     event,
     timestamp: Date.now(),
-    // StopFailure may include error info in the payload
-    error: (payload as StopHookPayload).error || (payload as StopHookPayload).message || null,
-    error_details: (payload as StopHookPayload).error_details ?? null,
-    last_assistant_message: (payload as StopHookPayload).last_assistant_message ?? null,
-    agent_id: (payload as StopHookPayload).agent_id ?? null,
-    stop_reason: (payload as StopHookPayload).stop_reason ?? null,
+    error: stopPayload.error,
+    error_details: stopPayload.error_details,
+    last_assistant_message: stopPayload.last_assistant_message,
+    agent_id: stopPayload.agent_id,
+    stop_reason: stopPayload.stop_reason,
   };
 
   // Atomic write: write to temp file then rename (prevents partial writes on crash)
@@ -282,4 +305,6 @@ function install(): void {
   console.log(`Aegis hook installed in ${settingsPath}`);
 }
 
-main();
+if (process.argv[1] === __filename) {
+  main();
+}


### PR DESCRIPTION
## Summary - replace unsafe stop hook payload field casts with field-level normalization - preserve valid stop payload fields while nulling malformed typed values - add malformed-payload coverage and message fallback coverage  ## Testing - npx tsc --noEmit - npm test -- src/__tests__/stop-failure.test.ts - npm test -- src/__tests__/hook-injection.test.ts  Closes #515  ## Aegis version **Developed with:** v2.9.0