### PR TITLE
fix: virtualize dashboard transcript rendering

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "aegis-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.23",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "dompurify": "^3.3.3",
@@ -1587,6 +1588,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.23",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "dompurify": "^3.3.3",

--- a/dashboard/src/__tests__/TranscriptViewer.test.tsx
+++ b/dashboard/src/__tests__/TranscriptViewer.test.tsx
@@ -1,0 +1,217 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { ParsedEntry } from '../types';
+import { TranscriptViewer } from '../components/session/TranscriptViewer';
+import { useStore } from '../store/useStore';
+
+const mockGetSessionMessages = vi.fn();
+const mockSubscribeSSE = vi.fn();
+const originalConsoleError = console.error;
+
+vi.mock('../api/client', () => ({
+  getSessionMessages: (...args: unknown[]) => mockGetSessionMessages(...args),
+  subscribeSSE: (...args: unknown[]) => mockSubscribeSSE(...args),
+}));
+
+vi.mock('../components/session/MessageBubble', () => ({
+  MessageBubble: ({ entry }: { entry: ParsedEntry }) => (
+    <div data-height="48" data-message-bubble data-testid="message-bubble">
+      {entry.text}
+    </div>
+  ),
+}));
+
+function createRect(height: number): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    bottom: height,
+    right: 800,
+    width: 800,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function makeMessage(index: number): ParsedEntry {
+  return {
+    role: index % 4 === 0 ? 'user' : 'assistant',
+    contentType: 'text',
+    text: `message-${index}`,
+    timestamp: new Date(2026, 3, 3, 12, 0, index).toISOString(),
+  };
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+    configurable: true,
+    value(options: ScrollToOptions) {
+      if (typeof options.top === 'number') {
+        Object.defineProperty(this, 'scrollTop', {
+          configurable: true,
+          writable: true,
+          value: options.top,
+        });
+
+        this.dispatchEvent(new Event('scroll'));
+      }
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value() {
+      if (this.getAttribute('data-testid') === 'transcript-scroll-container') {
+        return createRect(480);
+      }
+
+      const height = Number(this.getAttribute('data-height') ?? 0);
+      return createRect(height);
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      if (this.getAttribute('data-testid') === 'transcript-scroll-container') {
+        return 480;
+      }
+
+      return Number(this.getAttribute('data-height') ?? 0);
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return 800;
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return this.clientHeight;
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get() {
+      return this.clientWidth;
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get() {
+      if (this.getAttribute('data-testid') === 'transcript-scroll-container') {
+        const virtualizer = this.querySelector('[data-testid="transcript-virtualizer"]') as HTMLElement | null;
+        return virtualizer ? Number.parseFloat(virtualizer.style.height) : 0;
+      }
+
+      return this.clientHeight;
+    },
+  });
+});
+
+describe('TranscriptViewer virtualization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.spyOn(console, 'error').mockImplementation((message: unknown, ...args: unknown[]) => {
+      if (
+        typeof message === 'string' &&
+        message.includes('flushSync was called from inside a lifecycle method')
+      ) {
+        return;
+      }
+
+      originalConsoleError(message, ...args);
+    });
+
+    useStore.setState({ token: null });
+
+    mockSubscribeSSE.mockReturnValue(() => undefined);
+    mockGetSessionMessages.mockResolvedValue({
+      messages: Array.from({ length: 200 }, (_, index) => makeMessage(index)),
+      status: 'working',
+      statusText: null,
+      interactiveContent: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders only a virtualized subset for large transcripts', async () => {
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('message-bubble').length).toBeGreaterThan(0);
+    });
+
+    const renderedMessages = screen.getAllByTestId('message-bubble');
+    expect(renderedMessages.length).toBeLessThan(60);
+    expect(screen.getByText('message-0')).toBeDefined();
+    expect(screen.queryByText('message-199')).toBeNull();
+  });
+
+  it('keeps the rendered window subset when new live messages arrive', async () => {
+    let sseHandler: ((event: MessageEvent) => void) | null = null;
+    mockSubscribeSSE.mockImplementation((_sessionId: string, handler: (event: MessageEvent) => void) => {
+      sseHandler = handler;
+      return () => undefined;
+    });
+
+    render(<TranscriptViewer sessionId="session-2" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('message-bubble').length).toBeGreaterThan(0);
+    });
+
+    const container = screen.getByTestId('transcript-scroll-container');
+    await act(async () => {
+      Object.defineProperty(container, 'scrollTop', {
+        configurable: true,
+        writable: true,
+        value: container.scrollHeight - container.clientHeight,
+      });
+      container.dispatchEvent(new Event('scroll'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('message-199')).toBeDefined();
+    });
+
+    await act(async () => {
+      sseHandler?.(new MessageEvent('message', {
+        data: JSON.stringify({
+          event: 'message',
+          data: makeMessage(200),
+        }),
+      }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('message-200')).toBeDefined();
+    });
+
+    expect(screen.getAllByTestId('message-bubble').length).toBeLessThan(60);
+    expect(screen.queryByText('message-0')).toBeNull();
+  });
+});

--- a/dashboard/src/components/session/TranscriptViewer.tsx
+++ b/dashboard/src/components/session/TranscriptViewer.tsx
@@ -1,14 +1,24 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import type { ParsedEntry } from '../../types';
 import { getSessionMessages, subscribeSSE } from '../../api/client';
 import { useStore } from '../../store/useStore';
 import { MessageBubble } from './MessageBubble';
 
 const MAX_SESSION_MESSAGES = 1000;
+const ESTIMATED_MESSAGE_HEIGHT_PX = 88;
+const VIRTUAL_OVERSCAN_ROWS = 8;
+const VIRTUAL_ROW_GAP_PX = 12;
+const DEFAULT_VIEWPORT_HEIGHT_PX = 480;
+const SCROLL_BOTTOM_THRESHOLD_PX = 60;
 
 /** Composite dedup key: timestamp + content fingerprint (fixes #512) */
 function dedupKey(m: ParsedEntry): string {
   return `${m.timestamp ?? ''}:${m.role}:${m.contentType}:${m.text.length}:${m.text.slice(0, 80)}`;
+}
+
+function messageKey(entry: ParsedEntry, index: number): string {
+  return entry.toolUseId ?? `${entry.role}:${entry.contentType}:${entry.timestamp ?? index}:${entry.text.slice(0, 80)}`;
 }
 
 interface TranscriptViewerProps {
@@ -95,24 +105,24 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
     return () => unsubscribe();
   }, [sessionId, token]);
 
-  // Auto-scroll when new messages arrive (unless user scrolled up)
-  useEffect(() => {
-    if (!userScrolledRef.current) {
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages]);
-
   const handleScroll = useCallback(() => {
     const el = containerRef.current;
     if (!el) return;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_BOTTOM_THRESHOLD_PX;
     userScrolledRef.current = !atBottom;
     setShowScrollBtn(!atBottom);
   }, []);
 
-  const scrollToBottom = useCallback(() => {
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     userScrolledRef.current = false;
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    setShowScrollBtn(false);
+
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTo({ top: el.scrollHeight, behavior });
+    }
+
+    bottomRef.current?.scrollIntoView({ behavior });
   }, []);
 
   const toggleFilter = useCallback((key: keyof FilterState) => {
@@ -126,6 +136,36 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
     if (entry.contentType === 'tool_result' && !filters.tool_result) return false;
     return true;
   }), [messages, filters]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: filteredMessages.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => ESTIMATED_MESSAGE_HEIGHT_PX,
+    overscan: VIRTUAL_OVERSCAN_ROWS,
+    initialRect: {
+      width: 0,
+      height: DEFAULT_VIEWPORT_HEIGHT_PX,
+    },
+    getItemKey: (index) => messageKey(filteredMessages[index], index),
+    measureElement: (element) => {
+      const bubble = element.firstElementChild as HTMLElement | null;
+      const measuredHeight = bubble?.getBoundingClientRect().height ?? element.getBoundingClientRect().height;
+      return measuredHeight > 0
+        ? measuredHeight + VIRTUAL_ROW_GAP_PX
+        : ESTIMATED_MESSAGE_HEIGHT_PX;
+    },
+  });
+
+  // Auto-scroll when new messages arrive (unless user scrolled up)
+  useEffect(() => {
+    if (userScrolledRef.current) return;
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      scrollToBottom(messages.length > 0 ? 'smooth' : 'auto');
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [messages, scrollToBottom]);
 
   if (loading) {
     return (
@@ -172,22 +212,48 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
         ref={containerRef}
         onScroll={handleScroll}
         className="flex-1 overflow-y-auto px-4 py-3"
+        data-testid="transcript-scroll-container"
       >
         {filteredMessages.length === 0 && (
           <div className="flex items-center justify-center h-full text-[#555] text-sm">
             No messages yet
           </div>
         )}
-        {filteredMessages.map((entry, i) => (
-          <MessageBubble key={entry.toolUseId ?? `${entry.role}-${entry.timestamp ?? i}`} entry={entry} />
-        ))}
-        <div ref={bottomRef} />
+        {filteredMessages.length > 0 && (
+          <div
+            className="relative w-full"
+            data-testid="transcript-virtualizer"
+            style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+          >
+            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+              const entry = filteredMessages[virtualRow.index];
+
+              return (
+                <div
+                  key={virtualRow.key}
+                  ref={rowVirtualizer.measureElement}
+                  data-index={virtualRow.index}
+                  className="absolute left-0 top-0 w-full"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
+                >
+                  <MessageBubble entry={entry} />
+                </div>
+              );
+            })}
+            <div
+              ref={bottomRef}
+              aria-hidden="true"
+              className="absolute left-0 top-0 h-px w-px"
+              style={{ transform: `translateY(${rowVirtualizer.getTotalSize()}px)` }}
+            />
+          </div>
+        )}
       </div>
 
       {/* Scroll to bottom button */}
       {showScrollBtn && (
         <button
-          onClick={scrollToBottom}
+          onClick={() => scrollToBottom()}
           className="absolute bottom-4 right-4 bg-[#1a1a2e] hover:bg-[#2a2a3e] text-[#00e5ff] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[#1a1a2e] transition-colors z-10"
           title="Scroll to bottom"
         >


### PR DESCRIPTION
## Summary - virtualize TranscriptViewer rendering with @tanstack/react-virtual for large transcripts - preserve transcript filtering, live SSE updates, and scroll-to-bottom behavior while rendering only a measured window - add dashboard tests covering initial windowed rendering and live-update behavior near the bottom of the transcript  ## Testing - npm run build - npx vitest run src/__tests__/TranscriptViewer.test.tsx - npx tsc --noEmit  ## Aegis version **Developed with:** v2.9.0