### PR TITLE
fix: add auth key management page

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "test -d dist || echo '\\033[33mWarning: dist/ not found — run \"npm run build\" first if tests depend on built artifacts.\\033[0m' >&2; vitest run",
+    "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -5,6 +5,7 @@
 import { Routes, Route } from 'react-router-dom';
 import ErrorBoundary from './components/ErrorBoundary';
 import Layout from './components/Layout';
+import AuthKeysPage from './pages/AuthKeysPage';
 import OverviewPage from './pages/OverviewPage';
 import SessionDetailPage from './pages/SessionDetailPage';
 import PipelinesPage from './pages/PipelinesPage';
@@ -17,6 +18,7 @@ export default function App() {
       <Routes>
         <Route element={<Layout />}>
           <Route path="/" element={<OverviewPage />} />
+          <Route path="/auth/keys" element={<AuthKeysPage />} />
           <Route path="/sessions/:id" element={<SessionDetailPage />} />
           <Route path="/pipelines" element={<PipelinesPage />} />
           <Route path="/pipelines/:id" element={<PipelineDetailPage />} />

--- a/dashboard/src/__tests__/AuthKeysPage.test.tsx
+++ b/dashboard/src/__tests__/AuthKeysPage.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AuthKeysPage from '../pages/AuthKeysPage';
+
+const mockCreateAuthKey = vi.fn();
+const mockGetAuthKeys = vi.fn();
+const mockRevokeAuthKey = vi.fn();
+const mockAddToast = vi.fn();
+
+vi.mock('../api/client', () => ({
+  createAuthKey: (...args: unknown[]) => mockCreateAuthKey(...args),
+  getAuthKeys: (...args: unknown[]) => mockGetAuthKeys(...args),
+  revokeAuthKey: (...args: unknown[]) => mockRevokeAuthKey(...args),
+}));
+
+vi.mock('../store/useToastStore', () => ({
+  useToastStore: (selector: (store: { addToast: typeof mockAddToast }) => unknown) => selector({ addToast: mockAddToast }),
+}));
+
+describe('AuthKeysPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-04-03T14:00:00.000Z'));
+    mockGetAuthKeys.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function renderPage(): void {
+    render(<AuthKeysPage />);
+  }
+
+  it('lists existing auth keys', async () => {
+    mockGetAuthKeys.mockResolvedValueOnce([
+      {
+        id: 'key-1',
+        name: 'ops-primary',
+        createdAt: Date.parse('2026-04-03T13:00:00.000Z'),
+        lastUsedAt: 0,
+        rateLimit: 100,
+      },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('ops-primary')).toBeDefined();
+      expect(screen.getByText('1h ago')).toBeDefined();
+    });
+  });
+
+  it('creates a key, refreshes the list, and keeps the secret hidden by default', async () => {
+    mockGetAuthKeys
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 'key-1',
+          name: 'ops-primary',
+          createdAt: Date.parse('2026-04-03T13:59:00.000Z'),
+          lastUsedAt: 0,
+          rateLimit: 100,
+        },
+      ]);
+    mockCreateAuthKey.mockResolvedValueOnce({
+      id: 'key-1',
+      name: 'ops-primary',
+      key: 'aegis_super_secret_key_1234567890',
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No auth keys yet')).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText('Key Name'), { target: { value: 'ops-primary' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Auth Key' }));
+
+    await waitFor(() => {
+      expect(mockCreateAuthKey).toHaveBeenCalledWith('ops-primary');
+      expect(screen.getByText('Store this key now')).toBeDefined();
+      expect(screen.getAllByText('ops-primary').length).toBeGreaterThan(0);
+      expect(screen.queryByText('aegis_super_secret_key_1234567890')).toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reveal secret' }));
+
+    expect(screen.getByText('aegis_super_secret_key_1234567890')).toBeDefined();
+    expect(mockGetAuthKeys).toHaveBeenCalledTimes(2);
+    expect(mockAddToast).toHaveBeenCalledWith(
+      'success',
+      'Auth key created',
+      'Store the secret now. It is only shown once.',
+    );
+  });
+
+  it('revokes a key after confirmation', async () => {
+    mockGetAuthKeys.mockResolvedValueOnce([
+      {
+        id: 'key-1',
+        name: 'ops-primary',
+        createdAt: Date.parse('2026-04-03T13:00:00.000Z'),
+        lastUsedAt: 0,
+        rateLimit: 100,
+      },
+    ]);
+    mockRevokeAuthKey.mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('confirm', vi.fn(() => true));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('ops-primary')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+
+    await waitFor(() => {
+      expect(mockRevokeAuthKey).toHaveBeenCalledWith('key-1');
+      expect(screen.queryByText('ops-primary')).toBeNull();
+    });
+
+    expect(mockAddToast).toHaveBeenCalledWith('success', 'Auth key revoked');
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -24,6 +24,8 @@ import type {
   ApiError,
 } from '../types';
 import {
+  AuthKeySummarySchema,
+  CreatedAuthKeySchema,
   HealthResponseSchema,
   SessionInfoSchema,
   SendResponseSchema,
@@ -480,23 +482,37 @@ export function createSSEToken(signal?: AbortSignal): Promise<SSETokenResponse> 
 export interface AuthKey {
   id: string;
   name: string;
-  key: string;
-  createdAt: string;
+  createdAt: number;
+  lastUsedAt: number;
+  rateLimit: number;
 }
 
-export function createAuthKey(name: string): Promise<AuthKey> {
+export interface CreatedAuthKey {
+  id: string;
+  name: string;
+  key: string;
+}
+
+export function createAuthKey(name: string): Promise<CreatedAuthKey> {
   return request('/v1/auth/keys', {
     method: 'POST',
     body: JSON.stringify({ name }),
+    schema: CreatedAuthKeySchema,
+    schemaContext: 'createAuthKey',
   });
 }
 
 export function getAuthKeys(): Promise<AuthKey[]> {
-  return request('/v1/auth/keys');
+  return request('/v1/auth/keys', {
+    schema: z.array(AuthKeySummarySchema),
+    schemaContext: 'getAuthKeys',
+  });
 }
 
 export function revokeAuthKey(id: string): Promise<OkResponse> {
   return request(`/v1/auth/keys/${encodeURIComponent(id)}`, {
     method: 'DELETE',
+    schema: OkResponseSchema,
+    schemaContext: 'revokeAuthKey',
   });
 }

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -30,6 +30,20 @@ export const OkResponseSchema = z.object({
   ok: z.boolean(),
 });
 
+export const AuthKeySummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.number(),
+  lastUsedAt: z.number(),
+  rateLimit: z.number(),
+});
+
+export const CreatedAuthKeySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  key: z.string(),
+});
+
 // ── SendResponse ────────────────────────────────────────────────
 
 export const SendResponseSchema = OkResponseSchema.extend({

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
+  KeyRound,
   LayoutDashboard,
   Shield,
   Terminal,
@@ -18,6 +19,7 @@ import ToastContainer from './ToastContainer';
 const NAV_ITEMS = [
   { to: '/', label: 'Overview', icon: LayoutDashboard },
   { to: '/pipelines', label: 'Pipelines', icon: Activity },
+  { to: '/auth/keys', label: 'Auth Keys', icon: KeyRound },
 ];
 
 const MAX_SSE_RETRIES = 5;

--- a/dashboard/src/pages/AuthKeysPage.tsx
+++ b/dashboard/src/pages/AuthKeysPage.tsx
@@ -1,0 +1,327 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Copy,
+  Eye,
+  EyeOff,
+  KeyRound,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
+import {
+  createAuthKey,
+  getAuthKeys,
+  revokeAuthKey,
+  type AuthKey,
+  type CreatedAuthKey,
+} from '../api/client';
+import { useToastStore } from '../store/useToastStore';
+import { formatTimeAgo } from '../utils/format';
+
+const REFRESH_INTERVAL_MS = 15_000;
+const SECRET_CLEAR_MS = 60_000;
+
+function formatCreatedAt(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+function maskKey(key: string): string {
+  if (key.length <= 12) return '•'.repeat(key.length);
+  return `${key.slice(0, 8)}${'•'.repeat(Math.max(8, key.length - 12))}${key.slice(-4)}`;
+}
+
+export default function AuthKeysPage() {
+  const [keys, setKeys] = useState<AuthKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [createdKey, setCreatedKey] = useState<CreatedAuthKey | null>(null);
+  const [secretVisible, setSecretVisible] = useState(false);
+  const addToast = useToastStore((store) => store.addToast);
+
+  const fetchKeys = useCallback(async (silent = false) => {
+    if (silent) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+
+    try {
+      const data = await getAuthKeys();
+      setKeys(data.slice().sort((left, right) => right.createdAt - left.createdAt));
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load auth keys';
+      setError(message);
+      addToast('error', 'Failed to load auth keys', message);
+    } finally {
+      if (silent) {
+        setRefreshing(false);
+      } else {
+        setLoading(false);
+      }
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    fetchKeys();
+    const interval = setInterval(() => {
+      void fetchKeys(true);
+    }, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchKeys]);
+
+  useEffect(() => {
+    if (!createdKey) return;
+    const timer = setTimeout(() => {
+      setCreatedKey(null);
+      setSecretVisible(false);
+    }, SECRET_CLEAR_MS);
+    return () => clearTimeout(timer);
+  }, [createdKey]);
+
+  async function handleCreate(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+
+    setCreating(true);
+    try {
+      const result = await createAuthKey(trimmedName);
+      setCreatedKey(result);
+      setSecretVisible(false);
+      setName('');
+      addToast('success', 'Auth key created', 'Store the secret now. It is only shown once.');
+      await fetchKeys(true);
+    } catch (err) {
+      addToast(
+        'error',
+        'Failed to create auth key',
+        err instanceof Error ? err.message : undefined,
+      );
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleCopySecret(): Promise<void> {
+    if (!createdKey) return;
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('Clipboard access is unavailable in this browser');
+      }
+      await navigator.clipboard.writeText(createdKey.key);
+      addToast('success', 'Auth key copied');
+    } catch (err) {
+      addToast('warning', 'Failed to copy auth key', err instanceof Error ? err.message : undefined);
+    }
+  }
+
+  async function handleRevoke(id: string, keyName: string): Promise<void> {
+    if (!window.confirm(`Revoke auth key "${keyName}"? This cannot be undone.`)) {
+      return;
+    }
+
+    setRevokingId(id);
+    try {
+      await revokeAuthKey(id);
+      setKeys((current) => current.filter((key) => key.id !== id));
+      if (createdKey?.id === id) {
+        setCreatedKey(null);
+        setSecretVisible(false);
+      }
+      addToast('success', 'Auth key revoked');
+    } catch (err) {
+      addToast('error', 'Failed to revoke auth key', err instanceof Error ? err.message : undefined);
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-100">Auth Keys</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Create, review, and revoke dashboard API keys without exposing stored secrets.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void fetchKeys(true)}
+          disabled={refreshing}
+          className="flex min-h-[44px] items-center justify-center gap-2 rounded border border-[#1a1a2e] bg-[#111118] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[#00e5ff]/30 hover:text-[#00e5ff] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+        <section className="rounded-lg border border-[#1a1a2e] bg-[#111118] p-5">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-100">
+            <Plus className="h-4 w-4 text-[#00e5ff]" />
+            Create Key
+          </div>
+          <p className="mt-2 text-sm text-gray-500">
+            New secrets are never persisted in the dashboard and are cleared from view after one minute.
+          </p>
+
+          <form className="mt-4 space-y-4" onSubmit={handleCreate}>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-gray-400" htmlFor="auth-key-name">
+                Key Name
+              </label>
+              <input
+                id="auth-key-name"
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="ops-primary"
+                className="min-h-[44px] w-full rounded border border-[#1a1a2e] bg-[#0a0a0f] px-3 py-2.5 text-sm text-gray-200 placeholder-gray-600 focus:border-[#00e5ff] focus:outline-none"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={creating || !name.trim()}
+              className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded border border-[#00e5ff]/30 bg-[#00e5ff]/10 px-3 py-2 text-sm font-medium text-[#00e5ff] transition-colors hover:bg-[#00e5ff]/20 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <KeyRound className="h-4 w-4" />
+              {creating ? 'Creating…' : 'Create Auth Key'}
+            </button>
+          </form>
+
+          {createdKey ? (
+            <div className="mt-5 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4" role="status">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-semibold text-emerald-300">Store this key now</h3>
+                  <p className="mt-1 text-xs text-emerald-200/80">
+                    This secret is shown once and is hidden by default.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCreatedKey(null);
+                    setSecretVisible(false);
+                  }}
+                  className="text-xs font-medium text-emerald-200/80 transition-colors hover:text-emerald-200"
+                >
+                  Dismiss
+                </button>
+              </div>
+
+              <dl className="mt-4 space-y-3 text-sm text-gray-200">
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-gray-500">Name</dt>
+                  <dd className="mt-1 font-medium text-gray-100">{createdKey.name}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-gray-500">Secret</dt>
+                  <dd className="mt-1 rounded border border-[#1a1a2e] bg-[#0a0a0f] px-3 py-2 font-mono text-xs text-[#9af5ff]">
+                    {secretVisible ? createdKey.key : maskKey(createdKey.key)}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => setSecretVisible((current) => !current)}
+                  className="flex min-h-[40px] items-center gap-2 rounded border border-[#1a1a2e] bg-[#0a0a0f] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[#00e5ff]/30 hover:text-[#00e5ff]"
+                >
+                  {secretVisible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                  {secretVisible ? 'Hide secret' : 'Reveal secret'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleCopySecret()}
+                  className="flex min-h-[40px] items-center gap-2 rounded border border-[#1a1a2e] bg-[#0a0a0f] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[#00e5ff]/30 hover:text-[#00e5ff]"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                  Copy secret
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="rounded-lg border border-[#1a1a2e] bg-[#111118] p-5">
+          <div className="flex items-center justify-between gap-3 border-b border-[#1a1a2e] pb-4">
+            <div>
+              <h3 className="text-sm font-semibold text-gray-100">Existing Keys</h3>
+              <p className="mt-1 text-xs text-gray-500">
+                {keys.length} key{keys.length === 1 ? '' : 's'} configured
+              </p>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="flex min-h-[240px] items-center justify-center text-sm text-gray-500">
+              <div className="animate-pulse">Loading auth keys…</div>
+            </div>
+          ) : error ? (
+            <div className="mt-4 rounded-lg border border-amber-500/20 bg-amber-500/5 p-4 text-sm text-amber-200">
+              <p className="font-medium">Unable to load auth keys</p>
+              <p className="mt-1 text-amber-200/80">{error}</p>
+              <button
+                type="button"
+                onClick={() => void fetchKeys()}
+                className="mt-4 rounded border border-amber-500/30 px-3 py-2 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-500/10"
+              >
+                Retry
+              </button>
+            </div>
+          ) : keys.length === 0 ? (
+            <div className="flex min-h-[240px] flex-col items-center justify-center rounded-lg border border-dashed border-[#1a1a2e] bg-[#0a0a0f] px-6 text-center">
+              <KeyRound className="h-8 w-8 text-gray-600" />
+              <p className="mt-4 text-sm font-medium text-gray-300">No auth keys yet</p>
+              <p className="mt-1 max-w-md text-sm text-gray-500">
+                Create a key to grant API access without sharing the dashboard bearer token.
+              </p>
+            </div>
+          ) : (
+            <div className="mt-4 space-y-3">
+              {keys.map((key) => (
+                <article
+                  key={key.id}
+                  className="rounded-lg border border-[#1a1a2e] bg-[#0a0a0f] p-4"
+                >
+                  <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate font-medium text-gray-100">{key.name}</span>
+                        <span className="rounded-full border border-[#1a1a2e] bg-[#111118] px-2 py-0.5 font-mono text-[11px] text-gray-500">
+                          {key.id}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm text-gray-400">
+                        Created <span title={formatCreatedAt(key.createdAt)}>{formatTimeAgo(key.createdAt)}</span>
+                      </p>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => void handleRevoke(key.id, key.name)}
+                      disabled={revokingId === key.id}
+                      className="flex min-h-[40px] items-center justify-center gap-2 rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      {revokingId === key.id ? 'Revoking…' : 'Revoke'}
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/types/lucide-react.d.ts
+++ b/dashboard/src/types/lucide-react.d.ts
@@ -1,0 +1,1 @@
+declare module 'lucide-react';


### PR DESCRIPTION
## Summary - add a dashboard auth key management page for listing, creating, and revoking keys - add typed client helpers and routing/navigation for the new auth key workflow - cover the page with dashboard tests for listing, create flow, and revoke flow  ## Validation - npx tsc --noEmit - cd dashboard && npx tsc --noEmit - cd dashboard && npm run build - cd dashboard && npx vitest run src/__tests__/AuthKeysPage.test.tsx  ## Aegis version **Developed with:** v2.9.0