### PR TITLE
fix: add session summary card to dashboard (#961)

### DIFF
--- a/dashboard/src/__tests__/SessionSummaryCard.test.tsx
+++ b/dashboard/src/__tests__/SessionSummaryCard.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionSummaryCard } from '../components/session/SessionSummaryCard';
+import type { SessionSummary } from '../types';
+
+const fixedNow = new Date('2026-04-03T12:00:00.000Z').valueOf();
+
+const summary: SessionSummary = {
+  sessionId: 'session-1',
+  windowName: 'Alpha Session',
+  status: 'working',
+  totalMessages: 5,
+  messages: [
+    { role: 'user', contentType: 'text', text: 'Start' },
+    { role: 'assistant', contentType: 'text', text: 'Working on it' },
+    { role: 'assistant', contentType: 'tool_result', text: 'Done' },
+    { role: 'system', contentType: 'text', text: 'Reminder' },
+    { role: 'reviewer', contentType: 'text', text: 'Looks good' },
+  ],
+  createdAt: fixedNow - 5 * 60 * 1000,
+  lastActivity: fixedNow - 30 * 1000,
+  permissionMode: 'acceptEdits',
+};
+
+describe('SessionSummaryCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the compact summary metrics and message role breakdown', () => {
+    render(<SessionSummaryCard summary={summary} loading={false} />);
+
+    expect(screen.getByText('Session Summary')).toBeDefined();
+    expect(screen.getByText('working')).toBeDefined();
+    expect(screen.getByText('Started 5m ago')).toBeDefined();
+    expect(screen.getByText('Last active 30s ago')).toBeDefined();
+    expect(screen.getByText('acceptEdits')).toBeDefined();
+    expect(screen.getByText('Total Messages')).toBeDefined();
+    expect(screen.getByText('User')).toBeDefined();
+    expect(screen.getByText('Assistant')).toBeDefined();
+    expect(screen.getByText('System')).toBeDefined();
+    expect(screen.getByText('Other')).toBeDefined();
+    expect(screen.getByText('5')).toBeDefined();
+    expect(screen.getByText('2')).toBeDefined();
+  });
+
+  it('renders a loading skeleton while summary data is pending', () => {
+    const { container } = render(<SessionSummaryCard summary={null} loading={true} />);
+    expect(container.textContent).not.toContain('Session Summary');
+    expect(container.querySelector('.animate-pulse')).not.toBeNull();
+  });
+
+  it('renders nothing when no summary is available after loading', () => {
+    const { container } = render(<SessionSummaryCard summary={null} loading={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/dashboard/src/__tests__/useSessionPolling.test.ts
+++ b/dashboard/src/__tests__/useSessionPolling.test.ts
@@ -12,6 +12,7 @@ vi.mock('../api/client', () => ({
   getSessionHealth: vi.fn(),
   getSessionPane: vi.fn(),
   getSessionMetrics: vi.fn(),
+  getSessionSummary: vi.fn(),
   subscribeSSE: vi.fn(),
 }));
 
@@ -23,7 +24,7 @@ vi.mock('../store/useToastStore', () => ({
   useToastStore: vi.fn(),
 }));
 
-import { getSession, getSessionHealth, getSessionPane, getSessionMetrics, subscribeSSE } from '../api/client';
+import { getSession, getSessionHealth, getSessionPane, getSessionMetrics, getSessionSummary, subscribeSSE } from '../api/client';
 import { useStore } from '../store/useStore';
 import { useToastStore } from '../store/useToastStore';
 
@@ -31,6 +32,7 @@ const mockedGetSession = vi.mocked(getSession);
 const mockedGetSessionHealth = vi.mocked(getSessionHealth);
 const mockedGetSessionPane = vi.mocked(getSessionPane);
 const mockedGetSessionMetrics = vi.mocked(getSessionMetrics);
+const mockedGetSessionSummary = vi.mocked(getSessionSummary);
 
 describe('useSessionPolling', () => {
   let capturedHandler: ((e: MessageEvent) => void) | null = null;
@@ -77,6 +79,19 @@ describe('useSessionPolling', () => {
       approvals: 0,
       autoApprovals: 0,
       statusChanges: [],
+    });
+    mockedGetSessionSummary.mockResolvedValue({
+      sessionId: 'session-a',
+      windowName: 'test',
+      status: 'idle',
+      totalMessages: 2,
+      messages: [
+        { role: 'user', contentType: 'text', text: 'hello' },
+        { role: 'assistant', contentType: 'text', text: 'hi' },
+      ],
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+      permissionMode: 'default',
     });
 
     (subscribeSSE as any).mockImplementation(
@@ -146,6 +161,7 @@ describe('useSessionPolling', () => {
     // Reset after new session load
     mockedGetSessionPane.mockClear();
     mockedGetSessionHealth.mockClear();
+    mockedGetSessionSummary.mockClear();
 
     // Advance past the debounce period
     await act(async () => {
@@ -156,6 +172,7 @@ describe('useSessionPolling', () => {
     // If the fix is missing, getSessionPane would be called with the stale ref
     expect(mockedGetSessionPane).not.toHaveBeenCalled();
     expect(mockedGetSessionHealth).not.toHaveBeenCalled();
+    expect(mockedGetSessionSummary).not.toHaveBeenCalled();
   });
 
   it('discards stale debounce callbacks via generation counter', async () => {
@@ -203,5 +220,20 @@ describe('useSessionPolling', () => {
 
     // No additional calls should have been made by the old debounce
     expect(mockedGetSessionPane.mock.calls.length).toBe(callsAfterSwitch);
+  });
+
+  it('loads session summary during the initial fetch', async () => {
+    const { result } = renderHook(
+      ({ id }) => useSessionPolling(id),
+      { initialProps: { id: 'session-a' } },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockedGetSessionSummary).toHaveBeenCalledWith('session-a');
+    expect(result.current.summary?.totalMessages).toBe(2);
+    expect(result.current.summaryLoading).toBe(false);
   });
 });

--- a/dashboard/src/components/session/SessionSummaryCard.tsx
+++ b/dashboard/src/components/session/SessionSummaryCard.tsx
@@ -1,0 +1,86 @@
+import type { SessionSummary } from '../../types';
+import { formatTimeAgo } from '../../utils/format';
+
+interface SessionSummaryCardProps {
+  summary: SessionSummary | null;
+  loading: boolean;
+}
+
+interface SummaryMetricProps {
+  label: string;
+  value: number | string;
+  accentClassName: string;
+}
+
+function SummaryMetric({ label, value, accentClassName }: SummaryMetricProps) {
+  return (
+    <div className="rounded-md border border-[#1a1a2e] bg-[#111118] px-3 py-2.5">
+      <div className="text-[10px] uppercase tracking-[0.18em] text-[#666]">{label}</div>
+      <div className={`mt-1 font-mono text-lg ${accentClassName}`}>{value}</div>
+    </div>
+  );
+}
+
+function countMessagesByRole(messages: SessionSummary['messages']): Record<string, number> {
+  return messages.reduce<Record<string, number>>((counts, message) => {
+    const role = message.role.trim().toLowerCase();
+    counts[role] = (counts[role] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+export function SessionSummaryCard({ summary, loading }: SessionSummaryCardProps) {
+  if (loading) {
+    return (
+      <section className="rounded-lg border border-[#1a1a2e] bg-[#0d0d14] px-4 py-3 animate-pulse">
+        <div className="h-3 w-28 rounded bg-[#1a1a2e]" />
+        <div className="mt-3 grid gap-3 sm:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-16 rounded-md bg-[#111118]" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (!summary) {
+    return null;
+  }
+
+  const messageCounts = countMessagesByRole(summary.messages);
+  const userMessages = messageCounts.user ?? 0;
+  const assistantMessages = messageCounts.assistant ?? 0;
+  const systemMessages = messageCounts.system ?? 0;
+  const otherMessages = summary.totalMessages - userMessages - assistantMessages - systemMessages;
+  const lastActivityText = formatTimeAgo(summary.lastActivity);
+  const createdText = formatTimeAgo(summary.createdAt);
+
+  return (
+    <section className="rounded-lg border border-[#1a1a2e] bg-[#0d0d14] px-4 py-3 sm:px-5 sm:py-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.22em] text-[#666]">Session Summary</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[#888]">
+            <span className="rounded-full border border-[#00e5ff]/25 bg-[#00e5ff]/10 px-2 py-1 font-semibold uppercase tracking-[0.14em] text-[#00e5ff]">
+              {summary.status.replace(/_/g, ' ')}
+            </span>
+            <span>Started {createdText}</span>
+            <span className="text-[#333]">•</span>
+            <span>Last active {lastActivityText}</span>
+          </div>
+        </div>
+        <div className="text-xs text-[#666]">
+          Permission mode <span className="font-semibold text-[#b8b8c8]">{summary.permissionMode || 'default'}</span>
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        <SummaryMetric label="Total Messages" value={summary.totalMessages} accentClassName="text-[#00e5ff]" />
+        <SummaryMetric label="User" value={userMessages} accentClassName="text-[#7dd3fc]" />
+        <SummaryMetric label="Assistant" value={assistantMessages} accentClassName="text-[#34d399]" />
+        <SummaryMetric label="System" value={systemMessages} accentClassName="text-[#f59e0b]" />
+        <SummaryMetric label="Other" value={Math.max(otherMessages, 0)} accentClassName="text-[#c084fc]" />
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -1,10 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { SessionInfo, SessionHealth, SessionMetrics } from '../types';
+import type { SessionInfo, SessionHealth, SessionMetrics, SessionSummary } from '../types';
 import {
   getSession,
   getSessionHealth,
   getSessionPane,
   getSessionMetrics,
+  getSessionSummary,
   subscribeSSE,
 } from '../api/client';
 import { useStore } from '../store/useStore';
@@ -24,6 +25,8 @@ interface UseSessionPollingReturn {
   paneLoading: boolean;
   metrics: SessionMetrics | null;
   metricsLoading: boolean;
+  summary: SessionSummary | null;
+  summaryLoading: boolean;
   refetchPaneAndMetrics: () => void;
 }
 
@@ -44,6 +47,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   // Metrics state
   const [metrics, setMetrics] = useState<SessionMetrics | null>(null);
   const [metricsLoading, setMetricsLoading] = useState(true);
+  const [summary, setSummary] = useState<SessionSummary | null>(null);
+  const [summaryLoading, setSummaryLoading] = useState(true);
 
   // Refs for stable callbacks
   const sessionIdRef = useRef(sessionId);
@@ -81,7 +86,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   }, [addToast]);
   loadSessionAndHealthRef.current = loadSessionAndHealth;
 
-  // Fetch pane + metrics
+  // Fetch pane + metrics + summary
   const loadPaneAndMetrics = useCallback(async () => {
     if (cancelledRef.current) return;
     const sid = sessionIdRef.current;
@@ -103,6 +108,15 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     } finally {
       if (!cancelledRef.current) setMetricsLoading(false);
     }
+
+    try {
+      const data = await getSessionSummary(sid);
+      if (!cancelledRef.current) setSummary(data);
+    } catch (e: unknown) {
+      addToast('warning', 'Failed to load session summary', e instanceof Error ? e.message : undefined);
+    } finally {
+      if (!cancelledRef.current) setSummaryLoading(false);
+    }
   }, [addToast]);
   loadPaneAndMetricsRef.current = loadPaneAndMetrics;
 
@@ -113,6 +127,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     setLoading(true);
     setPaneLoading(true);
     setMetricsLoading(true);
+    setSummaryLoading(true);
 
     loadSessionAndHealth();
     loadPaneAndMetrics();
@@ -199,6 +214,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     paneLoading,
     metrics,
     metricsLoading,
+    summary,
+    summaryLoading,
     refetchPaneAndMetrics: loadPaneAndMetrics,
   };
 }

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -13,6 +13,7 @@ import { TranscriptViewer } from '../components/session/TranscriptViewer';
 import { LiveTerminal } from '../components/session/LiveTerminal';
 import { SessionMetricsPanel } from '../components/session/SessionMetricsPanel';
 import { ApprovalBanner } from '../components/session/ApprovalBanner';
+import { SessionSummaryCard } from '../components/session/SessionSummaryCard';
 
 type TabId = 'transcript' | 'terminal' | 'metrics';
 
@@ -29,6 +30,7 @@ export default function SessionDetailPage() {
   const {
     session, health, notFound, loading,
     metrics, metricsLoading,
+    summary, summaryLoading,
   } = useSessionPolling(id ?? '');
 
   const [msgInput, setMsgInput] = useState('');
@@ -138,6 +140,8 @@ export default function SessionDetailPage() {
           onInterrupt={handleInterrupt}
           onKill={handleKill}
         />
+
+        <SessionSummaryCard summary={summary} loading={summaryLoading} />
 
         {/* Tab bar — full-width stretch on mobile */}
         <div className="flex border-b border-[#1a1a2e]" role="tablist">


### PR DESCRIPTION
Replaces #961 ÔÇö dashboard session summary card.\n\n**Developed with:** v2.9.1\n**Tested with:** v2.9.1\n\nCloses #961

## Aegis version
**Developed with:** v2.9.0