### PR TITLE
fix: add dashboard latency metrics visualization (#962)

### DIFF
--- a/dashboard/src/__tests__/MetricCards.test.tsx
+++ b/dashboard/src/__tests__/MetricCards.test.tsx
@@ -63,49 +63,28 @@ describe('MetricCards polling strategy', () => {
   });
 
   afterEach(() => {
-<<<<<<< HEAD
-    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
 
   it('uses fallback polling when SSE is disconnected', async () => {
-
-    it('uses fallback polling when SSE is disconnected', async () => {
-      vi.useFakeTimers();
-
-      render(<MetricCards />);
-
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      expect(mockGetMetrics).toHaveBeenCalledTimes(1);
-      expect(mockGetHealth).toHaveBeenCalledTimes(1);
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(30_000);
-        await Promise.resolve();
-      });
-
-      expect(mockGetMetrics).toHaveBeenCalledTimes(4);
-      expect(mockGetHealth).toHaveBeenCalledTimes(4);
-    });
-
-    it('renders expanded overview cards and latency comparison', async () => {
-      render(<MetricCards />);
-
-      expect(await screen.findByText('Auto-approvals')).toBeDefined();
-      expect(screen.getByText('Webhooks')).toBeDefined();
-      expect(screen.getByText('Pipelines')).toBeDefined();
-      expect(screen.getByText('Latency Comparison')).toBeDefined();
-      expect(screen.getByLabelText('Global latency comparison')).toBeDefined();
-      expect(screen.getByText('3 delivered / 1 failed')).toBeDefined();
-    });
-
-    it('does not run interval polling when SSE is connected', async () => {
-      vi.useFakeTimers();
+    vi.useFakeTimers();
 
     render(<MetricCards />);
 
     await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+      await Promise.resolve();
+    });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(4);
+    expect(mockGetHealth).toHaveBeenCalledTimes(4);
   });
 
   it('renders expanded overview cards and latency comparison', async () => {
@@ -121,24 +100,10 @@ describe('MetricCards polling strategy', () => {
 
   it('does not run interval polling when SSE is connected', async () => {
     vi.useFakeTimers();
->>>>>>> 6cdbbc4 (fix: add dashboard latency metrics visualization)
     useStore.setState({ sseConnected: true });
 
     render(<MetricCards />);
 
-<<<<<<< HEAD
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(1);
-      expect(mockGetHealth).toHaveBeenCalledTimes(1);
-    });
-
-    const pollingCall = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
-    expect(pollingCall).toBeUndefined();
-    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
-    expect(mockGetHealth).toHaveBeenCalledTimes(1);
-  });
-});
-=======
     await act(async () => {
       await Promise.resolve();
     });

--- a/dashboard/src/__tests__/MetricCards.test.tsx
+++ b/dashboard/src/__tests__/MetricCards.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import MetricCards from '../components/overview/MetricCards';
 import { useStore } from '../store/useStore';
 
@@ -28,22 +28,26 @@ describe('MetricCards polling strategy', () => {
         completed: 1,
         failed: 0,
         avg_duration_sec: 42,
+        avg_messages_per_session: 3,
       },
+      auto_approvals: 2,
+      webhooks_sent: 5,
+      webhooks_failed: 1,
+      screenshots_taken: 4,
+      pipelines_created: 2,
+      batches_created: 1,
       prompt_delivery: {
-        delivered: 1,
-        failed: 0,
-        success_rate: 100,
+        sent: 4,
+        delivered: 3,
+        failed: 1,
+        success_rate: 75,
       },
-      permission: {
-        prompts: 0,
-        approved: 0,
-        rejected: 0,
+      latency: {
+        hook_latency_ms: { min: 10, max: 40, avg: 25, count: 3 },
+        state_change_detection_ms: { min: 12, max: 38, avg: 24, count: 3 },
+        permission_response_ms: { min: 100, max: 300, avg: 180, count: 2 },
+        channel_delivery_ms: { min: 20, max: 60, avg: 35, count: 4 },
       },
-      throughput: {
-        messages_per_min: 0,
-        tool_calls_per_min: 0,
-      },
-      timestamp: new Date().toISOString(),
     });
 
     mockGetHealth.mockResolvedValue({
@@ -59,41 +63,70 @@ describe('MetricCards polling strategy', () => {
   });
 
   afterEach(() => {
+<<<<<<< HEAD
     vi.restoreAllMocks();
-  });
 
   it('uses fallback polling when SSE is disconnected', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
 
-    render(<MetricCards />);
+    it('uses fallback polling when SSE is disconnected', async () => {
+      vi.useFakeTimers();
 
-    await waitFor(() => {
+      render(<MetricCards />);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
       expect(mockGetMetrics).toHaveBeenCalledTimes(1);
       expect(mockGetHealth).toHaveBeenCalledTimes(1);
-    });
 
-    const pollingCall = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
-    expect(pollingCall).toBeDefined();
-    const intervalCallback = pollingCall?.[0] as () => void | Promise<void>;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+        await Promise.resolve();
+      });
 
-    await act(async () => {
-      await intervalCallback?.();
-      await intervalCallback?.();
-      await intervalCallback?.();
-    });
-
-    await waitFor(() => {
       expect(mockGetMetrics).toHaveBeenCalledTimes(4);
       expect(mockGetHealth).toHaveBeenCalledTimes(4);
     });
+
+    it('renders expanded overview cards and latency comparison', async () => {
+      render(<MetricCards />);
+
+      expect(await screen.findByText('Auto-approvals')).toBeDefined();
+      expect(screen.getByText('Webhooks')).toBeDefined();
+      expect(screen.getByText('Pipelines')).toBeDefined();
+      expect(screen.getByText('Latency Comparison')).toBeDefined();
+      expect(screen.getByLabelText('Global latency comparison')).toBeDefined();
+      expect(screen.getByText('3 delivered / 1 failed')).toBeDefined();
+    });
+
+    it('does not run interval polling when SSE is connected', async () => {
+      vi.useFakeTimers();
+
+    render(<MetricCards />);
+
+    await act(async () => {
+  });
+
+  it('renders expanded overview cards and latency comparison', async () => {
+    render(<MetricCards />);
+
+    expect(await screen.findByText('Auto-approvals')).toBeDefined();
+    expect(screen.getByText('Webhooks')).toBeDefined();
+    expect(screen.getByText('Pipelines')).toBeDefined();
+    expect(screen.getByText('Latency Comparison')).toBeDefined();
+    expect(screen.getByLabelText('Global latency comparison')).toBeDefined();
+    expect(screen.getByText('3 delivered / 1 failed')).toBeDefined();
   });
 
   it('does not run interval polling when SSE is connected', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    vi.useFakeTimers();
+>>>>>>> 6cdbbc4 (fix: add dashboard latency metrics visualization)
     useStore.setState({ sseConnected: true });
 
     render(<MetricCards />);
 
+<<<<<<< HEAD
     await waitFor(() => {
       expect(mockGetMetrics).toHaveBeenCalledTimes(1);
       expect(mockGetHealth).toHaveBeenCalledTimes(1);
@@ -103,5 +136,57 @@ describe('MetricCards polling strategy', () => {
     expect(pollingCall).toBeUndefined();
     expect(mockGetMetrics).toHaveBeenCalledTimes(1);
     expect(mockGetHealth).toHaveBeenCalledTimes(1);
+  });
+});
+=======
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a latency empty state when metrics have no latency samples', async () => {
+    mockGetMetrics.mockResolvedValue({
+      uptime: 1,
+      sessions: {
+        total_created: 2,
+        currently_active: 1,
+        completed: 1,
+        failed: 0,
+        avg_duration_sec: 42,
+        avg_messages_per_session: 3,
+      },
+      auto_approvals: 0,
+      webhooks_sent: 0,
+      webhooks_failed: 0,
+      screenshots_taken: 0,
+      pipelines_created: 0,
+      batches_created: 0,
+      prompt_delivery: {
+        sent: 0,
+        delivered: 0,
+        failed: 0,
+        success_rate: null,
+      },
+      latency: {
+        hook_latency_ms: { min: null, max: null, avg: null, count: 0 },
+        state_change_detection_ms: { min: null, max: null, avg: null, count: 0 },
+        permission_response_ms: { min: null, max: null, avg: null, count: 0 },
+        channel_delivery_ms: { min: null, max: null, avg: null, count: 0 },
+      },
+    });
+
+    render(<MetricCards />);
+
+    expect(await screen.findByText('Latency samples will appear after hooks, approvals, and deliveries are recorded.')).toBeDefined();
   });
 });

--- a/dashboard/src/__tests__/SessionMetricsPanel.test.tsx
+++ b/dashboard/src/__tests__/SessionMetricsPanel.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { SessionMetricsPanel } from '../components/session/SessionMetricsPanel';
+
+describe('SessionMetricsPanel', () => {
+  it('renders latency snapshot and aggregated chart data', () => {
+    render(
+      <SessionMetricsPanel
+        metrics={{
+          durationSec: 120,
+          messages: 8,
+          toolCalls: 5,
+          approvals: 2,
+          autoApprovals: 1,
+          statusChanges: ['working', 'permission_prompt', 'idle'],
+        }}
+        loading={false}
+        latencyLoading={false}
+        latency={{
+          sessionId: 'session-1',
+          realtime: {
+            hook_latency_ms: 120,
+            state_change_detection_ms: 118,
+            permission_response_ms: 780,
+          },
+          aggregated: {
+            hook_latency_ms: { min: 80, max: 140, avg: 110, count: 3 },
+            state_change_detection_ms: { min: 78, max: 138, avg: 108, count: 3 },
+            permission_response_ms: { min: 600, max: 900, avg: 780, count: 2 },
+            channel_delivery_ms: { min: 25, max: 60, avg: 40, count: 5 },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Latency Snapshot')).toBeDefined();
+    expect(screen.getByText('Hook Latency')).toBeDefined();
+    expect(screen.getByText('120 ms')).toBeDefined();
+    expect(screen.getByText('Channel Delivery Avg')).toBeDefined();
+    expect(screen.getByLabelText('Session latency averages')).toBeDefined();
+    expect(screen.getAllByText('Status Changes')).toHaveLength(2);
+  });
+
+  it('shows an empty state when no latency samples exist yet', () => {
+    render(
+      <SessionMetricsPanel
+        metrics={{
+          durationSec: 10,
+          messages: 1,
+          toolCalls: 0,
+          approvals: 0,
+          autoApprovals: 0,
+          statusChanges: [],
+        }}
+        loading={false}
+        latencyLoading={false}
+        latency={{
+          sessionId: 'session-2',
+          realtime: null,
+          aggregated: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('No latency samples yet for this session.')).toBeDefined();
+  });
+});

--- a/dashboard/src/__tests__/schemas.test.ts
+++ b/dashboard/src/__tests__/schemas.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { SessionMessagesSchema, GlobalMetricsSchema } from '../api/schemas';
+import { GlobalMetricsSchema, SessionLatencyResponseSchema, SessionMessagesSchema } from '../api/schemas';
 
 // ── SessionMessagesSchema ────────────────────────────────────────
 
@@ -94,6 +94,12 @@ describe('GlobalMetricsSchema', () => {
       failed: 1,
       success_rate: 0.93,
     },
+    latency: {
+      hook_latency_ms: { min: 20, max: 60, avg: 35, count: 4 },
+      state_change_detection_ms: { min: 18, max: 55, avg: 32, count: 4 },
+      permission_response_ms: { min: 200, max: 800, avg: 410, count: 2 },
+      channel_delivery_ms: { min: 25, max: 110, avg: 58, count: 3 },
+    },
   };
 
   it('accepts valid payload', () => {
@@ -129,12 +135,49 @@ describe('GlobalMetricsSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects missing latency block', () => {
+    const { latency, ...noLatency } = validPayload;
+    const result = GlobalMetricsSchema.safeParse(noLatency);
+    expect(result.success).toBe(false);
+  });
+
   it('rejects extra unknown field in sessions', () => {
     const result = GlobalMetricsSchema.safeParse({
       ...validPayload,
       sessions: { ...validPayload.sessions, extra: true },
     });
     // Zod allows extra keys by default — this should still pass
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('SessionLatencyResponseSchema', () => {
+  it('accepts aggregated latency payloads even when realtime delivery latency is absent', () => {
+    const result = SessionLatencyResponseSchema.safeParse({
+      sessionId: 'session-1',
+      realtime: {
+        hook_latency_ms: 44,
+        state_change_detection_ms: 44,
+        permission_response_ms: 220,
+      },
+      aggregated: {
+        hook_latency_ms: { min: 20, max: 60, avg: 35, count: 4 },
+        state_change_detection_ms: { min: 18, max: 55, avg: 32, count: 4 },
+        permission_response_ms: { min: 200, max: 800, avg: 410, count: 2 },
+        channel_delivery_ms: { min: 25, max: 110, avg: 58, count: 3 },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty latency payloads', () => {
+    const result = SessionLatencyResponseSchema.safeParse({
+      sessionId: 'session-2',
+      realtime: null,
+      aggregated: null,
+    });
+
     expect(result.success).toBe(true);
   });
 });

--- a/dashboard/src/__tests__/useSessionPolling.test.ts
+++ b/dashboard/src/__tests__/useSessionPolling.test.ts
@@ -12,6 +12,7 @@ vi.mock('../api/client', () => ({
   getSessionHealth: vi.fn(),
   getSessionPane: vi.fn(),
   getSessionMetrics: vi.fn(),
+  getSessionLatency: vi.fn(),
   subscribeSSE: vi.fn(),
 }));
 
@@ -23,7 +24,7 @@ vi.mock('../store/useToastStore', () => ({
   useToastStore: vi.fn(),
 }));
 
-import { getSession, getSessionHealth, getSessionPane, getSessionMetrics, subscribeSSE } from '../api/client';
+import { getSession, getSessionHealth, getSessionLatency, getSessionMetrics, getSessionPane, subscribeSSE } from '../api/client';
 import { useStore } from '../store/useStore';
 import { useToastStore } from '../store/useToastStore';
 
@@ -31,6 +32,7 @@ const mockedGetSession = vi.mocked(getSession);
 const mockedGetSessionHealth = vi.mocked(getSessionHealth);
 const mockedGetSessionPane = vi.mocked(getSessionPane);
 const mockedGetSessionMetrics = vi.mocked(getSessionMetrics);
+const mockedGetSessionLatency = vi.mocked(getSessionLatency);
 
 describe('useSessionPolling', () => {
   let capturedHandler: ((e: MessageEvent) => void) | null = null;
@@ -78,6 +80,11 @@ describe('useSessionPolling', () => {
       autoApprovals: 0,
       statusChanges: [],
     });
+    mockedGetSessionLatency.mockResolvedValue({
+      sessionId: 'session-a',
+      realtime: null,
+      aggregated: null,
+    });
 
     (subscribeSSE as any).mockImplementation(
       (_sessionId: string, handler: (e: MessageEvent) => void): (() => void) => {
@@ -106,6 +113,7 @@ describe('useSessionPolling', () => {
     // Reset call counts after initial load
     mockedGetSessionPane.mockClear();
     mockedGetSessionHealth.mockClear();
+    mockedGetSessionLatency.mockClear();
 
     // Simulate an SSE event that triggers debounced refetch
     act(() => {
@@ -146,6 +154,7 @@ describe('useSessionPolling', () => {
     // Reset after new session load
     mockedGetSessionPane.mockClear();
     mockedGetSessionHealth.mockClear();
+    mockedGetSessionLatency.mockClear();
 
     // Advance past the debounce period
     await act(async () => {
@@ -156,6 +165,7 @@ describe('useSessionPolling', () => {
     // If the fix is missing, getSessionPane would be called with the stale ref
     expect(mockedGetSessionPane).not.toHaveBeenCalled();
     expect(mockedGetSessionHealth).not.toHaveBeenCalled();
+    expect(mockedGetSessionLatency).not.toHaveBeenCalled();
   });
 
   it('discards stale debounce callbacks via generation counter', async () => {
@@ -170,6 +180,7 @@ describe('useSessionPolling', () => {
     });
 
     mockedGetSessionPane.mockClear();
+    mockedGetSessionLatency.mockClear();
 
     // Simulate SSE event triggering debounce
     act(() => {
@@ -195,6 +206,7 @@ describe('useSessionPolling', () => {
 
     // Clear counters after new session load
     const callsAfterSwitch = mockedGetSessionPane.mock.calls.length;
+    mockedGetSessionLatency.mockClear();
 
     // Advance past debounce period
     await act(async () => {
@@ -203,5 +215,6 @@ describe('useSessionPolling', () => {
 
     // No additional calls should have been made by the old debounce
     expect(mockedGetSessionPane.mock.calls.length).toBe(callsAfterSwitch);
+    expect(mockedGetSessionLatency).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   SessionHealth,
   MessagesResponse,
   SessionMetrics,
+  SessionLatencyResponse,
   PaneResponse,
   SessionSummary,
   OkResponse,
@@ -31,6 +32,7 @@ import {
   SessionsListResponseSchema,
   SessionHealthSchema,
   SessionMetricsSchema,
+  SessionLatencyResponseSchema,
   SessionMessagesSchema,
   GlobalMetricsSchema,
   GlobalSSEEventSchema,
@@ -198,6 +200,13 @@ export function getSessionMetrics(id: string): Promise<SessionMetrics> {
   return request(`/v1/sessions/${encodeURIComponent(id)}/metrics`, {
     schema: SessionMetricsSchema,
     schemaContext: 'getSessionMetrics',
+  });
+}
+
+export function getSessionLatency(id: string): Promise<SessionLatencyResponse> {
+  return request(`/v1/sessions/${encodeURIComponent(id)}/latency`, {
+    schema: SessionLatencyResponseSchema,
+    schemaContext: 'getSessionLatency',
   });
 }
 

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -119,6 +119,33 @@ export const SessionMetricsSchema = z.object({
   statusChanges: z.array(z.string()),
 });
 
+const LatencyStatSummarySchema = z.object({
+  min: z.number().nullable(),
+  max: z.number().nullable(),
+  avg: z.number().nullable(),
+  count: z.number(),
+});
+
+const LatencySummarySetSchema = z.object({
+  hook_latency_ms: LatencyStatSummarySchema,
+  state_change_detection_ms: LatencyStatSummarySchema,
+  permission_response_ms: LatencyStatSummarySchema,
+  channel_delivery_ms: LatencyStatSummarySchema,
+});
+
+const SessionLatencyRealtimeSchema = z.object({
+  hook_latency_ms: z.number().nullable(),
+  state_change_detection_ms: z.number().nullable(),
+  permission_response_ms: z.number().nullable(),
+  channel_delivery_ms: z.number().nullable().optional(),
+});
+
+export const SessionLatencyResponseSchema = z.object({
+  sessionId: z.string(),
+  realtime: SessionLatencyRealtimeSchema.nullable(),
+  aggregated: LatencySummarySetSchema.nullable(),
+});
+
 // ── ParsedEntry ──────────────────────────────────────────────────
 
 const ParsedEntrySchema = z.object({
@@ -163,6 +190,7 @@ export const GlobalMetricsSchema = z.object({
     failed: z.number(),
     success_rate: z.number().nullable(),
   }),
+  latency: LatencySummarySetSchema,
 });
 
 // ── SSE Event Data (Issue #410) ────────────────────────────────

--- a/dashboard/src/components/metrics/LatencyBarChart.tsx
+++ b/dashboard/src/components/metrics/LatencyBarChart.tsx
@@ -1,0 +1,62 @@
+interface LatencyBarDatum {
+  label: string;
+  value: number | null | undefined;
+  color: string;
+}
+
+interface LatencyBarChartProps {
+  ariaLabel: string;
+  items: LatencyBarDatum[];
+  emptyText?: string;
+  formatValue?: (value: number) => string;
+}
+
+function defaultFormatter(value: number): string {
+  return `${Math.round(value)} ms`;
+}
+
+export function LatencyBarChart({
+  ariaLabel,
+  items,
+  emptyText = 'No latency samples yet.',
+  formatValue = defaultFormatter,
+}: LatencyBarChartProps) {
+  const visibleItems = items.filter((item) => item.value !== null && item.value !== undefined);
+
+  if (visibleItems.length === 0) {
+    return (
+      <div className="flex h-44 items-center justify-center rounded-lg border border-dashed border-[#1a1a2e] bg-[#0a0a0f] text-sm text-[#666]">
+        {emptyText}
+      </div>
+    );
+  }
+
+  const maxValue = Math.max(...visibleItems.map((item) => item.value ?? 0), 1);
+
+  return (
+    <div role="img" aria-label={ariaLabel} className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {items.map((item) => {
+        const hasValue = item.value !== null && item.value !== undefined;
+        const height = hasValue ? Math.max(((item.value ?? 0) / maxValue) * 100, 12) : 0;
+
+        return (
+          <div key={item.label} className="rounded-lg border border-[#1a1a2e] bg-[#0a0a0f] p-3">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[#666]">{item.label}</div>
+            <div className="mt-1 h-5 font-mono text-sm tabular-nums text-[#d7d7df]">
+              {hasValue ? formatValue(item.value ?? 0) : '—'}
+            </div>
+            <div className="mt-3 flex h-24 items-end rounded-md bg-[#111118] px-2 pb-2 pt-1">
+              <div
+                className="w-full rounded-sm transition-all duration-300"
+                style={{
+                  height: `${height}%`,
+                  background: `linear-gradient(180deg, ${item.color}, ${item.color}55)`,
+                }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/components/overview/MetricCard.tsx
+++ b/dashboard/src/components/overview/MetricCard.tsx
@@ -9,19 +9,22 @@ interface MetricCardProps {
   value: string | number;
   icon?: ReactNode;
   suffix?: string;
+  detail?: ReactNode;
+  valueClassName?: string;
 }
 
-export default function MetricCard({ label, value, icon, suffix }: MetricCardProps) {
+export default function MetricCard({ label, value, icon, suffix, detail, valueClassName }: MetricCardProps) {
   return (
     <div className="rounded-lg border border-void-lighter bg-[#111118] p-4">
       <div className="mb-2 flex items-center gap-2 text-sm text-[#888]">
         {icon}
         {label}
       </div>
-      <div className="font-mono text-2xl text-[#00e5ff]">
+      <div className={`font-mono text-2xl ${valueClassName ?? 'text-[#00e5ff]'}`}>
         {value}
         {suffix && <span className="ml-1 text-base text-[#666]">{suffix}</span>}
       </div>
+      {detail ? <div className="mt-3 text-xs text-[#888]">{detail}</div> : null}
     </div>
   );
 }

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -3,13 +3,21 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Activity, Clock, Layers, Zap } from 'lucide-react';
-import { getHealth, getMetrics } from '../../api/client';
+import { Activity, CheckCircle2, Clock, Layers, Zap } from 'lucide-react';
+import { getMetrics, getHealth } from '../../api/client';
+import { LatencyBarChart } from '../metrics/LatencyBarChart';
 import { useStore } from '../../store/useStore';
 import { useToastStore } from '../../store/useToastStore';
 import type { HealthResponse } from '../../types';
-import { formatUptime } from '../../utils/format';
+import { formatLatencyMs, formatUptime } from '../../utils/format';
 import MetricCard from './MetricCard';
+
+const LATENCY_META = [
+  { key: 'hook_latency_ms', label: 'Hook', color: '#00e5ff' },
+  { key: 'state_change_detection_ms', label: 'State Change', color: '#7c82ff' },
+  { key: 'permission_response_ms', label: 'Permission', color: '#ffaa00' },
+  { key: 'channel_delivery_ms', label: 'Delivery', color: '#00ff88' },
+] as const;
 
 export default function MetricCards() {
   const metrics = useStore((s) => s.metrics);
@@ -42,30 +50,106 @@ export default function MetricCards() {
   const totalCreated = metrics?.sessions.total_created ?? health?.sessions.total ?? 0;
   const deliveryRate = metrics?.prompt_delivery.success_rate;
   const uptime = health?.uptime ?? metrics?.uptime ?? 0;
+  const delivered = metrics?.prompt_delivery.delivered ?? 0;
+  const deliveryFailed = metrics?.prompt_delivery.failed ?? 0;
+  const webhookFailures = metrics?.webhooks_failed ?? 0;
+  const webhookSuccesses = Math.max((metrics?.webhooks_sent ?? 0) - webhookFailures, 0);
+  const latencyItems = LATENCY_META.map(({ key, label, color }) => ({
+    label,
+    color,
+    value: metrics?.latency[key].avg ?? null,
+  }));
+  const latencySummaries = LATENCY_META.map(({ key, label, color }) => ({
+    label,
+    color,
+    stats: metrics?.latency[key],
+  }));
 
   return (
-    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-      <MetricCard
-        label="Active Sessions"
-        value={activeSessions}
-        icon={<Activity className="h-4 w-4" />}
-      />
-      <MetricCard
-        label="Total Created"
-        value={totalCreated}
-        icon={<Layers className="h-4 w-4" />}
-      />
-      <MetricCard
-        label="Delivery Rate"
-        value={deliveryRate !== null && deliveryRate !== undefined ? deliveryRate.toFixed(1) : '—'}
-        suffix="%"
-        icon={<Zap className="h-4 w-4" />}
-      />
-      <MetricCard
-        label="Uptime"
-        value={formatUptime(uptime)}
-        icon={<Clock className="h-4 w-4" />}
-      />
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          label="Active Sessions"
+          value={activeSessions}
+          icon={<Activity className="h-4 w-4" />}
+          detail={`${metrics?.sessions.completed ?? 0} completed / ${metrics?.sessions.failed ?? 0} failed`}
+        />
+        <MetricCard
+          label="Total Created"
+          value={totalCreated}
+          icon={<Layers className="h-4 w-4" />}
+          detail={`${metrics?.sessions.avg_messages_per_session ?? 0} avg messages/session`}
+        />
+        <MetricCard
+          label="Prompt Delivery"
+          value={deliveryRate !== null && deliveryRate !== undefined ? deliveryRate.toFixed(1) : '—'}
+          suffix={deliveryRate !== null && deliveryRate !== undefined ? '%' : undefined}
+          icon={<Zap className="h-4 w-4" />}
+          detail={`${delivered} delivered / ${deliveryFailed} failed`}
+        />
+        <MetricCard
+          label="Webhooks"
+          value={metrics?.webhooks_sent ?? 0}
+          icon={<CheckCircle2 className="h-4 w-4" />}
+          detail={`${webhookSuccesses} ok / ${webhookFailures} failed`}
+          valueClassName="font-mono text-2xl text-[#00ff88]"
+        />
+        <MetricCard
+          label="Auto-approvals"
+          value={metrics?.auto_approvals ?? 0}
+          detail={`${metrics?.screenshots_taken ?? 0} screenshots captured`}
+          valueClassName="font-mono text-2xl text-[#ffaa00]"
+        />
+        <MetricCard
+          label="Pipelines"
+          value={metrics?.pipelines_created ?? 0}
+          detail={`${metrics?.batches_created ?? 0} batches created`}
+        />
+        <MetricCard
+          label="Avg Session Duration"
+          value={formatUptime(metrics?.sessions.avg_duration_sec ?? 0)}
+          detail={`${metrics?.sessions.avg_messages_per_session ?? 0} avg messages/session`}
+        />
+        <MetricCard
+          label="Uptime"
+          value={formatUptime(uptime)}
+          icon={<Clock className="h-4 w-4" />}
+          detail={sseConnected ? 'Live via SSE' : 'Polling every 10s'}
+        />
+      </div>
+
+      <div className="rounded-lg border border-[#1a1a2e] bg-[#111118] p-4">
+        <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h3 className="text-sm font-semibold text-[#e6e6ee]">Latency Comparison</h3>
+            <p className="text-xs text-[#777]">Average rolling latency across all active session samples.</p>
+          </div>
+        </div>
+
+        <LatencyBarChart
+          ariaLabel="Global latency comparison"
+          items={latencyItems}
+          emptyText="Latency samples will appear after hooks, approvals, and deliveries are recorded."
+          formatValue={formatLatencyMs}
+        />
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {latencySummaries.map((item) => (
+            <div key={item.label} className="rounded-lg border border-[#1a1a2e] bg-[#0a0a0f] p-3">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-[#666]">{item.label}</div>
+              <div className="mt-2 font-mono text-lg tabular-nums" style={{ color: item.color }}>
+                {formatLatencyMs(item.stats?.avg ?? null)}
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-[#888]">
+                <span>min {formatLatencyMs(item.stats?.min ?? null)}</span>
+                <span>max {formatLatencyMs(item.stats?.max ?? null)}</span>
+                <span>samples</span>
+                <span className="font-mono text-[#cfd2df]">{item.stats?.count ?? 0}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/components/session/SessionMetricsPanel.tsx
+++ b/dashboard/src/components/session/SessionMetricsPanel.tsx
@@ -1,9 +1,12 @@
-import type { SessionMetrics } from '../../types';
-import { formatDuration } from '../../utils/format';
+import { LatencyBarChart } from '../metrics/LatencyBarChart';
+import type { SessionLatencyResponse, SessionMetrics } from '../../types';
+import { formatDuration, formatLatencyMs } from '../../utils/format';
 
 interface SessionMetricsPanelProps {
   metrics: SessionMetrics | null;
   loading: boolean;
+  latency: SessionLatencyResponse | null;
+  latencyLoading: boolean;
 }
 
 interface MetricCardData {
@@ -11,10 +14,18 @@ interface MetricCardData {
   value: string;
   icon: string;
   color: string;
+  detail?: string;
 }
 
-export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelProps) {
-  if (loading || !metrics) {
+const LATENCY_META = [
+  { key: 'hook_latency_ms', label: 'Hook', color: '#00e5ff' },
+  { key: 'state_change_detection_ms', label: 'State Change', color: '#7c82ff' },
+  { key: 'permission_response_ms', label: 'Permission', color: '#ffaa00' },
+  { key: 'channel_delivery_ms', label: 'Channel Delivery', color: '#00ff88' },
+] as const;
+
+export function SessionMetricsPanel({ metrics, loading, latency, latencyLoading }: SessionMetricsPanelProps) {
+  if ((loading && latencyLoading) || !metrics) {
     return (
       <div className="flex items-center justify-center h-48 text-[#555] text-sm animate-pulse">
         Loading metrics…
@@ -30,6 +41,46 @@ export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelPro
     { label: 'Auto-approvals', value: metrics.autoApprovals.toString(), icon: '⚡', color: '#ffaa00' },
     { label: 'Status Changes', value: metrics.statusChanges.length.toString(), icon: '🔄', color: '#8888ff' },
   ];
+  const latencySnapshotCards: MetricCardData[] = [
+    {
+      label: 'Hook Latency',
+      value: formatLatencyMs(latency?.realtime?.hook_latency_ms),
+      icon: '🪝',
+      color: '#00e5ff',
+      detail: 'Latest hook-to-receive measurement',
+    },
+    {
+      label: 'State Detection',
+      value: formatLatencyMs(latency?.realtime?.state_change_detection_ms),
+      icon: '👁',
+      color: '#7c82ff',
+      detail: 'Latest Claude state change detection',
+    },
+    {
+      label: 'Permission Response',
+      value: formatLatencyMs(latency?.realtime?.permission_response_ms),
+      icon: '✋',
+      color: '#ffaa00',
+      detail: 'Latest prompt-to-decision response',
+    },
+    {
+      label: 'Channel Delivery Avg',
+      value: formatLatencyMs(latency?.aggregated?.channel_delivery_ms.avg ?? null),
+      icon: '📡',
+      color: '#00ff88',
+      detail: `${latency?.aggregated?.channel_delivery_ms.count ?? 0} rolling samples`,
+    },
+  ];
+  const latencyChartItems = LATENCY_META.map(({ key, label, color }) => ({
+    label,
+    color,
+    value: latency?.aggregated?.[key]?.avg ?? null,
+  }));
+  const latencySummaries = LATENCY_META.map(({ key, label, color }) => ({
+    label,
+    color,
+    stats: latency?.aggregated?.[key] ?? null,
+  }));
 
   return (
     <div className="space-y-4">
@@ -50,8 +101,73 @@ export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelPro
             >
               {card.value}
             </div>
+            {card.detail ? <div className="mt-2 text-xs text-[#777]">{card.detail}</div> : null}
           </div>
         ))}
+      </div>
+
+      <div className="rounded-lg border border-[#1a1a2e] bg-[#111118] p-4">
+        <div className="mb-3">
+          <h3 className="text-xs text-[#888] uppercase tracking-wider">Latency Snapshot</h3>
+          <p className="mt-1 text-xs text-[#666]">Realtime latency where available, plus delivery averages from the rolling session window.</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {latencySnapshotCards.map((card) => (
+            <div
+              key={card.label}
+              className="rounded-lg border border-[#1a1a2e] bg-[#0a0a0f] p-4"
+            >
+              <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider text-[#888]">
+                <span className="text-sm">{card.icon}</span>
+                <span>{card.label}</span>
+              </div>
+              <div className="mt-2 text-2xl font-semibold font-mono tabular-nums" style={{ color: card.color }}>
+                {card.value}
+              </div>
+              <div className="mt-2 text-xs text-[#666]">{card.detail}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-[#1a1a2e] bg-[#111118] p-4">
+        <div className="mb-4">
+          <h3 className="text-xs text-[#888] uppercase tracking-wider">Aggregated Latency</h3>
+          <p className="mt-1 text-xs text-[#666]">Rolling min/max/average latency samples for this session.</p>
+        </div>
+
+        <LatencyBarChart
+          ariaLabel="Session latency averages"
+          items={latencyChartItems}
+          emptyText="No latency samples yet for this session."
+          formatValue={formatLatencyMs}
+        />
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {latencySummaries.map((item) => (
+            <div key={item.label} className="rounded-lg border border-[#1a1a2e] bg-[#0a0a0f] p-3">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-[#666]">{item.label}</div>
+              <div className="mt-2 font-mono text-lg tabular-nums" style={{ color: item.color }}>
+                {formatLatencyMs(item.stats?.avg ?? null)}
+              </div>
+              <div className="mt-2 space-y-1 text-xs text-[#888]">
+                <div className="flex items-center justify-between gap-3">
+                  <span>min</span>
+                  <span className="font-mono text-[#cfd2df]">{formatLatencyMs(item.stats?.min ?? null)}</span>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span>max</span>
+                  <span className="font-mono text-[#cfd2df]">{formatLatencyMs(item.stats?.max ?? null)}</span>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span>samples</span>
+                  <span className="font-mono text-[#cfd2df]">{item.stats?.count ?? 0}</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
 
       {/* Status changes timeline */}

--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { SessionInfo, SessionHealth, SessionMetrics } from '../types';
+import type { SessionInfo, SessionHealth, SessionLatencyResponse, SessionMetrics } from '../types';
 import {
   getSession,
   getSessionHealth,
+  getSessionLatency,
   getSessionPane,
   getSessionMetrics,
   subscribeSSE,
@@ -24,6 +25,8 @@ interface UseSessionPollingReturn {
   paneLoading: boolean;
   metrics: SessionMetrics | null;
   metricsLoading: boolean;
+  latency: SessionLatencyResponse | null;
+  latencyLoading: boolean;
   refetchPaneAndMetrics: () => void;
 }
 
@@ -44,6 +47,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   // Metrics state
   const [metrics, setMetrics] = useState<SessionMetrics | null>(null);
   const [metricsLoading, setMetricsLoading] = useState(true);
+  const [latency, setLatency] = useState<SessionLatencyResponse | null>(null);
+  const [latencyLoading, setLatencyLoading] = useState(true);
 
   // Refs for stable callbacks
   const sessionIdRef = useRef(sessionId);
@@ -86,22 +91,34 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     if (cancelledRef.current) return;
     const sid = sessionIdRef.current;
 
-    try {
-      const data = await getSessionPane(sid);
-      if (!cancelledRef.current) setPaneContent(data.pane ?? '');
-    } catch (e: unknown) {
-      addToast('warning', 'Failed to load terminal pane', e instanceof Error ? e.message : undefined);
-    } finally {
-      if (!cancelledRef.current) setPaneLoading(false);
+    const [paneResult, metricsResult, latencyResult] = await Promise.allSettled([
+      getSessionPane(sid),
+      getSessionMetrics(sid),
+      getSessionLatency(sid),
+    ]);
+
+    if (paneResult.status === 'fulfilled') {
+      if (!cancelledRef.current) setPaneContent(paneResult.value.pane ?? '');
+    } else {
+      addToast('warning', 'Failed to load terminal pane', paneResult.reason instanceof Error ? paneResult.reason.message : undefined);
     }
 
-    try {
-      const data = await getSessionMetrics(sid);
-      if (!cancelledRef.current) setMetrics(data);
-    } catch (e: unknown) {
-      addToast('warning', 'Failed to load session metrics', e instanceof Error ? e.message : undefined);
-    } finally {
-      if (!cancelledRef.current) setMetricsLoading(false);
+    if (metricsResult.status === 'fulfilled') {
+      if (!cancelledRef.current) setMetrics(metricsResult.value);
+    } else {
+      addToast('warning', 'Failed to load session metrics', metricsResult.reason instanceof Error ? metricsResult.reason.message : undefined);
+    }
+
+    if (latencyResult.status === 'fulfilled') {
+      if (!cancelledRef.current) setLatency(latencyResult.value);
+    } else {
+      addToast('warning', 'Failed to load session latency', latencyResult.reason instanceof Error ? latencyResult.reason.message : undefined);
+    }
+
+    if (!cancelledRef.current) {
+      setPaneLoading(false);
+      setMetricsLoading(false);
+      setLatencyLoading(false);
     }
   }, [addToast]);
   loadPaneAndMetricsRef.current = loadPaneAndMetrics;
@@ -113,6 +130,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     setLoading(true);
     setPaneLoading(true);
     setMetricsLoading(true);
+    setLatencyLoading(true);
 
     loadSessionAndHealth();
     loadPaneAndMetrics();
@@ -199,6 +217,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     paneLoading,
     metrics,
     metricsLoading,
+    latency,
+    latencyLoading,
     refetchPaneAndMetrics: loadPaneAndMetrics,
   };
 }

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -28,7 +28,7 @@ export default function SessionDetailPage() {
   const [activeTab, setActiveTab] = useState<TabId>('transcript');
   const {
     session, health, notFound, loading,
-    metrics, metricsLoading,
+    metrics, metricsLoading, latency, latencyLoading,
   } = useSessionPolling(id ?? '');
 
   const [msgInput, setMsgInput] = useState('');
@@ -192,7 +192,7 @@ export default function SessionDetailPage() {
 
           {activeTab === 'metrics' && (
             <div id="panel-metrics" role="tabpanel" aria-labelledby="tab-metrics" tabIndex={0} className="p-3 sm:p-4">
-              <SessionMetricsPanel metrics={metrics} loading={metricsLoading} />
+              <SessionMetricsPanel metrics={metrics} loading={metricsLoading} latency={latency} latencyLoading={latencyLoading} />
             </div>
           )}
         </div>

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -110,6 +110,33 @@ export interface SessionMetrics {
   statusChanges: string[];
 }
 
+export interface LatencyStatSummary {
+  min: number | null;
+  max: number | null;
+  avg: number | null;
+  count: number;
+}
+
+export interface SessionLatencyRealtime {
+  hook_latency_ms: number | null;
+  state_change_detection_ms: number | null;
+  permission_response_ms: number | null;
+  channel_delivery_ms?: number | null;
+}
+
+export interface LatencySummarySet {
+  hook_latency_ms: LatencyStatSummary;
+  state_change_detection_ms: LatencyStatSummary;
+  permission_response_ms: LatencyStatSummary;
+  channel_delivery_ms: LatencyStatSummary;
+}
+
+export interface SessionLatencyResponse {
+  sessionId: string;
+  realtime: SessionLatencyRealtime | null;
+  aggregated: LatencySummarySet | null;
+}
+
 export interface GlobalMetrics {
   uptime: number;
   sessions: {
@@ -132,6 +159,7 @@ export interface GlobalMetrics {
     failed: number;
     success_rate: number | null;
   };
+  latency: LatencySummarySet;
 }
 
 // ── SSE Events ──────────────────────────────────────────────────

--- a/dashboard/src/utils/format.ts
+++ b/dashboard/src/utils/format.ts
@@ -40,3 +40,11 @@ export function formatDuration(ms: number): string {
   const rm = m % 60;
   return `${h}h ${rm.toString().padStart(2, '0')}m`;
 }
+
+export function formatLatencyMs(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  if (value < 1000) return `${Math.round(value)} ms`;
+  const seconds = value / 1000;
+  if (seconds < 10) return `${seconds.toFixed(1)} s`;
+  return `${Math.round(seconds)} s`;
+}


### PR DESCRIPTION
Replaces #962 ÔÇö dashboard latency metrics.\n\n**Developed with:** v2.9.1\n**Tested with:** v2.9.1\n\nCloses #962

## Aegis version
**Developed with:** v2.9.0