### PR TITLE
docs: add examples directory reference templates

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Examples
+
+Reference examples for integrating and orchestrating Aegis.
+
+## Layout
+
+- `openclaw-agent/`
+  - `SOUL.md`: ready-to-adapt dev agent template
+  - `HEARTBEAT.md`: session supervision loop template
+  - `openclaw.json`: example OpenClaw configuration for Aegis workflows
+- `claude-code-skill/`
+  - `aegis-workflow.md`: end-to-end orchestration skill
+  - `aegis-task.md`: single-task execution skill
+- `standalone/`
+  - `simple-agent.ts`: minimal create/read flow (<50 lines)
+  - `ci-runner.ts`: CI-oriented session runner with exit codes
+  - `README.md`: run instructions
+
+## Notes
+
+These examples are based on production patterns already used in this repository's `skill/references` templates and API flow.

--- a/examples/claude-code-skill/aegis-task.md
+++ b/examples/claude-code-skill/aegis-task.md
@@ -1,0 +1,22 @@
+# Aegis Single-Task Skill
+
+Use this skill for one focused implementation task.
+
+## Input
+- Issue number
+- Repo path
+- Explicit acceptance criteria
+
+## Steps
+1. Create a session with a precise prompt.
+2. Poll status until completion.
+3. Handle `permission_prompt`, `bash_approval`, `plan_mode`, and `ask_question` states.
+4. Review touched files for regressions.
+5. Run targeted tests.
+6. Commit and push if checks pass.
+
+## Output Checklist
+- [ ] Requirement implemented
+- [ ] No unrelated changes
+- [ ] Tests executed and passing
+- [ ] Commit message follows conventional commits

--- a/examples/claude-code-skill/aegis-workflow.md
+++ b/examples/claude-code-skill/aegis-workflow.md
@@ -1,0 +1,21 @@
+# Aegis Workflow Skill
+
+Use this skill when you need full lifecycle orchestration for one or more tasks.
+
+## Objective
+Drive tasks from issue selection to validated PR-ready changes with Aegis sessions.
+
+## Workflow
+1. Select non-blocked issue(s) and define acceptance criteria.
+2. Create one Aegis session per issue with explicit scope and constraints.
+3. Supervise each session with heartbeat polling and stall nudges.
+4. Approve safe prompts; reject or escalate risky operations.
+5. Validate changed scope with tests/build.
+6. Commit with conventional commit type.
+7. Push branch and open PR with issue linkage and validation notes.
+
+## Guardrails
+- Never bypass auth/security checks.
+- Never merge with failing quality gate.
+- Keep PRs single-purpose and reviewable.
+- Prefer `fix:` or `refactor:` over `feat:` unless user-visible capability is added.

--- a/examples/openclaw-agent/HEARTBEAT.md
+++ b/examples/openclaw-agent/HEARTBEAT.md
@@ -1,0 +1,57 @@
+# OpenClaw Heartbeat Loop
+
+Use this loop to supervise an Aegis session until completion.
+
+## Loop Policy
+- Poll `GET /v1/sessions/:id/read` every 5 seconds.
+- If status is `permission_prompt` or `bash_approval`, auto-approve in trusted repos.
+- If no new messages for 150 seconds, send a nudge message.
+- If status is `idle`, collect the final transcript and exit success.
+- Hard-timeout after 10 minutes unless overridden.
+
+## Suggested Shell Script
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+SID="$1"
+MAX_WAIT="${2:-600}"
+POLL=5
+ELAPSED=0
+LAST_COUNT=0
+STALL_AT=0
+
+while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+  RESP=$(curl -sf "http://127.0.0.1:9100/v1/sessions/$SID/read")
+  STATUS=$(echo "$RESP" | jq -r '.status')
+  COUNT=$(echo "$RESP" | jq -r '.messages | length')
+
+  if [ "$STATUS" = "idle" ]; then
+    echo "$RESP" | jq '.messages[-5:]'
+    exit 0
+  fi
+
+  if [ "$STATUS" = "permission_prompt" ] || [ "$STATUS" = "bash_approval" ]; then
+    curl -sf -X POST "http://127.0.0.1:9100/v1/sessions/$SID/approve" >/dev/null
+  fi
+
+  if [ "$COUNT" -eq "$LAST_COUNT" ]; then
+    if [ "$STALL_AT" -eq 0 ]; then STALL_AT="$ELAPSED"; fi
+    if [ $((ELAPSED - STALL_AT)) -ge 150 ]; then
+      curl -sf -X POST "http://127.0.0.1:9100/v1/sessions/$SID/send" \
+        -H "Content-Type: application/json" \
+        -d '{"text":"Continue with the best next step and report blockers."}' >/dev/null
+      STALL_AT="$ELAPSED"
+    fi
+  else
+    STALL_AT="$ELAPSED"
+  fi
+
+  LAST_COUNT="$COUNT"
+  sleep "$POLL"
+  ELAPSED=$((ELAPSED + POLL))
+done
+
+echo "Timeout after ${MAX_WAIT}s"
+exit 2
+```

--- a/examples/openclaw-agent/SOUL.md
+++ b/examples/openclaw-agent/SOUL.md
@@ -1,0 +1,34 @@
+# OpenClaw Dev Agent
+
+## Role
+Implement one scoped task end-to-end inside a repository, then validate it with tests.
+
+## Working Directory
+/path/to/repo
+
+## Rules
+- Write code first, then explain only if asked.
+- Keep changes scoped to the current issue.
+- Run targeted tests for touched areas.
+- Do not add `.only` or `.skip` to tests.
+- Do not weaken validation, auth, or security checks.
+- Commit with a clear conventional commit message when done.
+
+## Scope Template
+- Issue: #<number>
+- Goal: <single concrete result>
+- Files expected to change: <paths>
+- Acceptance criteria:
+  - [ ] Behavior implemented
+  - [ ] Tests added or updated
+  - [ ] Quality gate for touched scope passes
+
+## Constraints
+- Avoid unrelated refactors.
+- Prefer small, reviewable commits.
+- Preserve public API shape unless explicitly requested.
+
+## Completion Criteria
+- [ ] Code implemented
+- [ ] Tests pass for touched scope
+- [ ] Commit created

--- a/examples/openclaw-agent/openclaw.json
+++ b/examples/openclaw-agent/openclaw.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://openclaw.dev/schemas/config.json",
+  "name": "aegis-dev-loop",
+  "description": "Reference OpenClaw setup for orchestrating Aegis sessions.",
+  "runner": {
+    "type": "shell",
+    "command": "bash",
+    "args": ["-lc", "./scripts/run-task.sh"]
+  },
+  "env": {
+    "AEGIS_BASE_URL": "http://127.0.0.1:9100",
+    "AEGIS_AUTO_APPROVE": "true",
+    "AEGIS_POLL_INTERVAL_MS": "5000"
+  },
+  "inputs": {
+    "repo": {
+      "type": "string",
+      "required": true,
+      "description": "Absolute path of the repository to work on."
+    },
+    "prompt": {
+      "type": "string",
+      "required": true,
+      "description": "Task prompt sent to the session."
+    }
+  }
+}

--- a/examples/standalone/README.md
+++ b/examples/standalone/README.md
@@ -1,0 +1,25 @@
+# Standalone Examples
+
+These scripts demonstrate direct Aegis API usage from Node.js with no framework dependency.
+
+## Prerequisites
+- Aegis server running locally at `http://127.0.0.1:9100`
+- Node.js 18+
+
+## simple-agent.ts
+Creates a session, waits for completion, and prints the last assistant message.
+
+```bash
+npx tsx examples/standalone/simple-agent.ts /path/to/repo "Implement a tiny change and summarize it"
+```
+
+## ci-runner.ts
+Creates a session for CI-style execution, auto-approves prompts, and exits with code:
+- `0` success
+- `1` task completed but transcript suggests failure
+- `2` session creation failure
+- `3` timeout
+
+```bash
+npx tsx examples/standalone/ci-runner.ts /path/to/repo "Run tests and report result"
+```

--- a/examples/standalone/ci-runner.ts
+++ b/examples/standalone/ci-runner.ts
@@ -1,0 +1,35 @@
+type SessionRead = { status: string; messages: Array<{ role: string; text?: string }> };
+
+const BASE_URL = process.env.AEGIS_BASE_URL ?? "http://127.0.0.1:9100";
+
+async function runCiTask(workDir: string, prompt: string): Promise<number> {
+  const created = await fetch(`${BASE_URL}/v1/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ workDir, name: "ci-runner", prompt }),
+  });
+  if (!created.ok) return 2;
+  const { id } = (await created.json()) as { id: string };
+
+  const timeoutAt = Date.now() + 15 * 60_000;
+  while (Date.now() < timeoutAt) {
+    await new Promise((r) => setTimeout(r, 3000));
+    const read = await fetch(`${BASE_URL}/v1/sessions/${id}/read`);
+    const data = (await read.json()) as SessionRead;
+
+    if (data.status === "permission_prompt" || data.status === "bash_approval") {
+      await fetch(`${BASE_URL}/v1/sessions/${id}/approve`, { method: "POST" });
+      continue;
+    }
+    if (data.status === "idle") {
+      const transcript = data.messages.map((m) => `${m.role}: ${m.text ?? ""}`).join("\n");
+      console.log(transcript);
+      return /fail|error/i.test(transcript) ? 1 : 0;
+    }
+  }
+  return 3;
+}
+
+const workDir = process.argv[2] ?? process.cwd();
+const prompt = process.argv[3] ?? "Run tests and report pass/fail summary.";
+runCiTask(workDir, prompt).then((code) => process.exit(code));

--- a/examples/standalone/simple-agent.ts
+++ b/examples/standalone/simple-agent.ts
@@ -1,0 +1,34 @@
+const BASE_URL = process.env.AEGIS_BASE_URL ?? "http://127.0.0.1:9100";
+
+async function main() {
+  const workDir = process.argv[2] ?? process.cwd();
+  const prompt = process.argv[3] ?? "Say hello from Aegis and then stop.";
+
+  const createRes = await fetch(`${BASE_URL}/v1/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ workDir, name: "simple-agent", prompt }),
+  });
+  if (!createRes.ok) throw new Error(`create failed: ${createRes.status}`);
+
+  const { id } = (await createRes.json()) as { id: string };
+
+  for (;;) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const readRes = await fetch(`${BASE_URL}/v1/sessions/${id}/read`);
+    const data = (await readRes.json()) as {
+      status: string;
+      messages: Array<{ role: string; text?: string }>;
+    };
+    if (data.status === "idle") {
+      const lastAssistant = [...data.messages].reverse().find((m) => m.role === "assistant");
+      console.log(lastAssistant?.text ?? "No assistant message found");
+      break;
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary - add a new `examples/` directory with reference templates for OpenClaw agent orchestration - include Claude Code skill templates for full workflow and single-task execution - add standalone Node/TypeScript scripts (`simple-agent.ts`, `ci-runner.ts`) plus run docs  ## Validation - docs/examples and script templates only (no production runtime path changed)  Closes #449  ## Aegis version **Developed with:** UNAVAILABLE

## Aegis version
**Developed with:** v2.9.0