### PR TITLE
fix: preserve hook env vars and normalize callback host

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -287,6 +287,32 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     }
   });
 
+  it('should preserve env vars even if schema validation fails on unrelated fields', async () => {
+    const projectSettings = {
+      permissions: { defaultMode: 123 },
+      env: {
+        ANTHROPIC_AUTH_TOKEN: 'zai-token',
+        ANTHROPIC_BASE_URL: 'https://zai.example.com',
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
+
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'schema-fallback', 'test-secret-123', workDir);
+
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+      expect(parsed.env).toEqual({
+        ANTHROPIC_AUTH_TOKEN: 'zai-token',
+        ANTHROPIC_BASE_URL: 'https://zai.example.com',
+        MCP_CONNECTION_NONBLOCKING: 'true',
+      });
+    } finally {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  });
+
   it('should deep-merge project and Aegis hooks for the same event (Issue #635)', async () => {
     const projectSettings = {
       hooks: {
@@ -469,5 +495,15 @@ describe('writeHookSettingsFile — Issue #847 path validation', () => {
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('generateHookSettings — Issue #979 callback host normalization', () => {
+  it('should normalize 0.0.0.0 to 127.0.0.1 for hook callback URLs', () => {
+    const generated = generateHookSettings('http://0.0.0.0:9100', 'session-979', 'secret-979');
+    const stopHooks = generated.hooks.Stop;
+    expect(stopHooks).toBeDefined();
+    expect(stopHooks[0].hooks[0].url).toContain('http://127.0.0.1:9100/');
+    expect(stopHooks[0].hooks[0].url).toContain('sessionId=session-979');
   });
 });

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -21,6 +21,33 @@ import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { ccSettingsSchema } from './validation.js';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseSettingsWithFallback(raw: string): Record<string, unknown> | undefined {
+  const json = JSON.parse(raw) as unknown;
+  if (!isRecord(json)) return undefined;
+
+  const parsed = ccSettingsSchema.safeParse(json);
+  if (parsed.success) return parsed.data;
+
+  // Preserve unknown/extra fields (including env vars) even when schema validation fails.
+  return json;
+}
+
+function normalizeHookBaseUrl(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    if (url.hostname === '0.0.0.0' || url.hostname === '::' || url.hostname === '[::]') {
+      url.hostname = '127.0.0.1';
+    }
+    return url.origin;
+  } catch {
+    return baseUrl.replace('0.0.0.0', '127.0.0.1');
+  }
+}
+
 /**
  * Validate a workDir path for use in hook settings resolution.
  * Defense-in-depth against path traversal: rejects paths containing ".." segments
@@ -107,6 +134,7 @@ export interface HookSettings {
  */
 export function generateHookSettings(baseUrl: string, sessionId: string, hookSecret?: string): HookSettings {
   const hooks: HookSettings['hooks'] = {};
+  const callbackBaseUrl = normalizeHookBaseUrl(baseUrl);
 
   for (const event of HTTP_HOOK_EVENTS) {
     const secretParam = hookSecret ? `&secret=${hookSecret}` : '';
@@ -115,7 +143,7 @@ export function generateHookSettings(baseUrl: string, sessionId: string, hookSec
         hooks: [
           {
             type: 'http',
-            url: `${baseUrl}/v1/hooks/${event}?sessionId=${sessionId}${secretParam}`,
+            url: `${callbackBaseUrl}/v1/hooks/${event}?sessionId=${sessionId}${secretParam}`,
           },
         ],
       },
@@ -150,10 +178,7 @@ export async function writeHookSettingsFile(baseUrl: string, sessionId: string, 
     if (existsSync(projectSettingsPath)) {
       try {
         const raw = await readFile(projectSettingsPath, 'utf-8');
-        const parsed = ccSettingsSchema.safeParse(JSON.parse(raw));
-        if (parsed.success) {
-          merged = parsed.data;
-        }
+        merged = parseSettingsWithFallback(raw) ?? {};
       } catch {
         // Malformed settings file — use empty base, hooks will still work
       }


### PR DESCRIPTION
## Summary
- preserve project env vars from `.claude/settings.local.json` even when schema validation fails on unrelated fields
- normalize hook callback base URL from `0.0.0.0` / `::` to `127.0.0.1` so CC can reach Aegis callbacks
- add regression tests for both env preservation and callback host normalization

## Validation
- `npx vitest run src/__tests__/hook-settings.test.ts`
- `npx tsc --noEmit`

Closes #979

## Aegis version
**Developed with:** v2.9.2