### PR TITLE
fix: preserve hook env vars for BOM settings files

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -287,6 +287,33 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
     }
   });
 
+  it('should preserve env vars when settings.local.json starts with UTF-8 BOM', async () => {
+    const projectSettings = {
+      env: {
+        ANTHROPIC_AUTH_TOKEN: 'zai-token-bom',
+        ANTHROPIC_BASE_URL: 'https://api.z.ai/api/anthropic',
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5.1',
+      },
+    };
+    writeFileSync(settingsPath, '\uFEFF' + JSON.stringify(projectSettings, null, 2));
+
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'bom-settings', 'test-secret-123', workDir);
+
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+      expect(parsed.env).toEqual({
+        ANTHROPIC_AUTH_TOKEN: 'zai-token-bom',
+        ANTHROPIC_BASE_URL: 'https://api.z.ai/api/anthropic',
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5.1',
+        MCP_CONNECTION_NONBLOCKING: 'true',
+      });
+    } finally {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  });
+
   it('should preserve env vars even if schema validation fails on unrelated fields', async () => {
     const projectSettings = {
       permissions: { defaultMode: 123 },

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -26,7 +26,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parseSettingsWithFallback(raw: string): Record<string, unknown> | undefined {
-  const json = JSON.parse(raw) as unknown;
+  // Windows editors may write UTF-8 BOM; strip it so JSON.parse does not fail.
+  const json = JSON.parse(raw.replace(/^\uFEFF/, '')) as unknown;
   if (!isRecord(json)) return undefined;
 
   const parsed = ccSettingsSchema.safeParse(json);


### PR DESCRIPTION
## Summary
- fix hook settings merge when project .claude/settings.local.json starts with UTF-8 BOM
- keep ZAI/Anthropic env vars from project settings instead of falling back to MCP-only env
- add regression test covering BOM-prefixed settings files

## Validation
- 
pm test -- src/__tests__/hook-settings.test.ts
- 
px tsc --noEmit

## Aegis version
**Developed with:** UNAVAILABLE

Closes #984