### PR TITLE
fix: add latency metrics visualization to dashboard

### DIFF
--- a/dashboard/src/__tests__/LatencyPanel.test.tsx
+++ b/dashboard/src/__tests__/LatencyPanel.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { LatencyPanel } from '../components/metrics/LatencyPanel';
+
+describe('LatencyPanel', () => {
+  it('shows loading state', () => {
+    render(<LatencyPanel latency={null} loading />);
+    expect(screen.getByText('Loading latency metrics...')).toBeDefined();
+  });
+
+  it('shows empty state when no latency data exists', () => {
+    render(<LatencyPanel latency={null} loading={false} />);
+    expect(screen.getByText('No latency samples yet.')).toBeDefined();
+  });
+
+  it('renders session latency cards with aggregated values', () => {
+    render(
+      <LatencyPanel
+        loading={false}
+        latency={{
+          sessionId: 'session-1',
+          realtime: {
+            hook_latency_ms: 22,
+            state_change_detection_ms: 18,
+            permission_response_ms: 320,
+          },
+          aggregated: {
+            hook_latency_ms: { min: 10, max: 40, avg: 22, count: 3 },
+            state_change_detection_ms: { min: 8, max: 30, avg: 18, count: 3 },
+            permission_response_ms: { min: 100, max: 500, avg: 320, count: 2 },
+            channel_delivery_ms: { min: 14, max: 42, avg: 26, count: 4 },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Latency')).toBeDefined();
+    expect(screen.getByText('State Change Detection')).toBeDefined();
+    expect(screen.getByText('Hook Processing')).toBeDefined();
+    expect(screen.getAllByText('22 ms').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('320 ms').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/dashboard/src/__tests__/MetricCards.test.tsx
+++ b/dashboard/src/__tests__/MetricCards.test.tsx
@@ -28,22 +28,26 @@ describe('MetricCards polling strategy', () => {
         completed: 1,
         failed: 0,
         avg_duration_sec: 42,
+        avg_messages_per_session: 3,
       },
+      auto_approvals: 0,
+      webhooks_sent: 0,
+      webhooks_failed: 0,
+      screenshots_taken: 0,
+      pipelines_created: 0,
+      batches_created: 0,
       prompt_delivery: {
+        sent: 1,
         delivered: 1,
         failed: 0,
         success_rate: 100,
       },
-      permission: {
-        prompts: 0,
-        approved: 0,
-        rejected: 0,
+      latency: {
+        hook_latency_ms: { min: 2, max: 6, avg: 4, count: 2 },
+        state_change_detection_ms: { min: 2, max: 6, avg: 4, count: 2 },
+        permission_response_ms: { min: 20, max: 40, avg: 30, count: 2 },
+        channel_delivery_ms: { min: 3, max: 7, avg: 5, count: 2 },
       },
-      throughput: {
-        messages_per_min: 0,
-        tool_calls_per_min: 0,
-      },
-      timestamp: new Date().toISOString(),
     });
 
     mockGetHealth.mockResolvedValue({

--- a/dashboard/src/__tests__/schemas.test.ts
+++ b/dashboard/src/__tests__/schemas.test.ts
@@ -94,6 +94,12 @@ describe('GlobalMetricsSchema', () => {
       failed: 1,
       success_rate: 0.93,
     },
+    latency: {
+      hook_latency_ms: { min: 1, max: 7, avg: 3, count: 5 },
+      state_change_detection_ms: { min: 2, max: 9, avg: 4, count: 5 },
+      permission_response_ms: { min: 10, max: 40, avg: 22, count: 3 },
+      channel_delivery_ms: { min: 3, max: 18, avg: 8, count: 5 },
+    },
   };
 
   it('accepts valid payload', () => {
@@ -126,6 +132,12 @@ describe('GlobalMetricsSchema', () => {
   it('rejects missing prompt_delivery', () => {
     const { prompt_delivery, ...noDelivery } = validPayload;
     const result = GlobalMetricsSchema.safeParse(noDelivery);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing latency block', () => {
+    const { latency, ...noLatency } = validPayload;
+    const result = GlobalMetricsSchema.safeParse(noLatency);
     expect(result.success).toBe(false);
   });
 

--- a/dashboard/src/__tests__/useSessionPolling.test.ts
+++ b/dashboard/src/__tests__/useSessionPolling.test.ts
@@ -12,7 +12,7 @@ vi.mock('../api/client', () => ({
   getSessionHealth: vi.fn(),
   getSessionPane: vi.fn(),
   getSessionMetrics: vi.fn(),
-  getSessionSummary: vi.fn(),
+  getSessionLatency: vi.fn(),
   subscribeSSE: vi.fn(),
 }));
 
@@ -24,7 +24,7 @@ vi.mock('../store/useToastStore', () => ({
   useToastStore: vi.fn(),
 }));
 
-import { getSession, getSessionHealth, getSessionPane, getSessionMetrics, getSessionSummary, subscribeSSE } from '../api/client';
+import { getSession, getSessionHealth, getSessionPane, getSessionMetrics, getSessionLatency, subscribeSSE } from '../api/client';
 import { useStore } from '../store/useStore';
 import { useToastStore } from '../store/useToastStore';
 
@@ -32,7 +32,7 @@ const mockedGetSession = vi.mocked(getSession);
 const mockedGetSessionHealth = vi.mocked(getSessionHealth);
 const mockedGetSessionPane = vi.mocked(getSessionPane);
 const mockedGetSessionMetrics = vi.mocked(getSessionMetrics);
-const mockedGetSessionSummary = vi.mocked(getSessionSummary);
+const mockedGetSessionLatency = vi.mocked(getSessionLatency);
 
 describe('useSessionPolling', () => {
   let capturedHandler: ((e: MessageEvent) => void) | null = null;
@@ -80,15 +80,19 @@ describe('useSessionPolling', () => {
       autoApprovals: 0,
       statusChanges: [],
     });
-    mockedGetSessionSummary.mockResolvedValue({
+    mockedGetSessionLatency.mockResolvedValue({
       sessionId: 'session-a',
-      windowName: 'test',
-      status: 'idle',
-      totalMessages: 0,
-      messages: [],
-      createdAt: Date.now(),
-      lastActivity: Date.now(),
-      permissionMode: 'default',
+      realtime: {
+        hook_latency_ms: 12,
+        state_change_detection_ms: 12,
+        permission_response_ms: null,
+      },
+      aggregated: {
+        hook_latency_ms: { min: 12, max: 12, avg: 12, count: 1 },
+        state_change_detection_ms: { min: 12, max: 12, avg: 12, count: 1 },
+        permission_response_ms: { min: null, max: null, avg: null, count: 0 },
+        channel_delivery_ms: { min: null, max: null, avg: null, count: 0 },
+      },
     });
 
     (subscribeSSE as any).mockImplementation(

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   SessionHealth,
   MessagesResponse,
   SessionMetrics,
+  SessionLatency,
   PaneResponse,
   SessionSummary,
   OkResponse,
@@ -35,6 +36,7 @@ import {
   SessionsListResponseSchema,
   SessionHealthSchema,
   SessionMetricsSchema,
+  SessionLatencySchema,
   SessionMessagesSchema,
   GlobalMetricsSchema,
   GlobalSSEEventSchema,
@@ -245,6 +247,13 @@ export function getSessionMetrics(id: string): Promise<SessionMetrics> {
   return request(`/v1/sessions/${encodeURIComponent(id)}/metrics`, {
     schema: SessionMetricsSchema,
     schemaContext: 'getSessionMetrics',
+  });
+}
+
+export function getSessionLatency(id: string): Promise<SessionLatency> {
+  return request(`/v1/sessions/${encodeURIComponent(id)}/latency`, {
+    schema: SessionLatencySchema,
+    schemaContext: 'getSessionLatency',
   });
 }
 

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -133,6 +133,28 @@ export const SessionMetricsSchema = z.object({
   statusChanges: z.array(z.string()),
 });
 
+const LatencySummaryStatSchema = z.object({
+  min: z.number().nullable(),
+  max: z.number().nullable(),
+  avg: z.number().nullable(),
+  count: z.number(),
+});
+
+export const SessionLatencySchema = z.object({
+  sessionId: z.string(),
+  realtime: z.object({
+    hook_latency_ms: z.number().nullable(),
+    state_change_detection_ms: z.number().nullable(),
+    permission_response_ms: z.number().nullable(),
+  }).nullable(),
+  aggregated: z.object({
+    hook_latency_ms: LatencySummaryStatSchema,
+    state_change_detection_ms: LatencySummaryStatSchema,
+    permission_response_ms: LatencySummaryStatSchema,
+    channel_delivery_ms: LatencySummaryStatSchema,
+  }).nullable(),
+});
+
 // ── ParsedEntry ──────────────────────────────────────────────────
 
 const ParsedEntrySchema = z.object({
@@ -176,6 +198,12 @@ export const GlobalMetricsSchema = z.object({
     delivered: z.number(),
     failed: z.number(),
     success_rate: z.number().nullable(),
+  }),
+  latency: z.object({
+    hook_latency_ms: LatencySummaryStatSchema,
+    state_change_detection_ms: LatencySummaryStatSchema,
+    permission_response_ms: LatencySummaryStatSchema,
+    channel_delivery_ms: LatencySummaryStatSchema,
   }),
 });
 

--- a/dashboard/src/components/metrics/LatencyPanel.tsx
+++ b/dashboard/src/components/metrics/LatencyPanel.tsx
@@ -1,0 +1,112 @@
+import type { SessionLatency } from '../../types';
+
+interface LatencyPanelProps {
+  latency: SessionLatency | null;
+  loading: boolean;
+}
+
+interface LatencyCard {
+  label: string;
+  latest: number | null;
+  avg: number | null;
+  max: number | null;
+  count: number;
+}
+
+function formatMs(value: number | null): string {
+  if (value === null) return '--';
+  return `${Math.round(value)} ms`;
+}
+
+function barWidth(avg: number | null): string {
+  if (avg === null) return '0%';
+  const clamped = Math.min(100, Math.round((avg / 500) * 100));
+  return `${clamped}%`;
+}
+
+export function LatencyPanel({ latency, loading }: LatencyPanelProps) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-36 text-[#555] text-sm animate-pulse">
+        Loading latency metrics...
+      </div>
+    );
+  }
+
+  if (!latency || !latency.aggregated) {
+    return (
+      <div className="rounded-lg border border-[#1a1a2e] bg-[#111118] p-4 text-sm text-[#888]">
+        No latency samples yet.
+      </div>
+    );
+  }
+
+  const cards: LatencyCard[] = [
+    {
+      label: 'State Change Detection',
+      latest: latency.realtime?.state_change_detection_ms ?? null,
+      avg: latency.aggregated.state_change_detection_ms.avg,
+      max: latency.aggregated.state_change_detection_ms.max,
+      count: latency.aggregated.state_change_detection_ms.count,
+    },
+    {
+      label: 'Channel Delivery',
+      latest: null,
+      avg: latency.aggregated.channel_delivery_ms.avg,
+      max: latency.aggregated.channel_delivery_ms.max,
+      count: latency.aggregated.channel_delivery_ms.count,
+    },
+    {
+      label: 'Permission Response',
+      latest: latency.realtime?.permission_response_ms ?? null,
+      avg: latency.aggregated.permission_response_ms.avg,
+      max: latency.aggregated.permission_response_ms.max,
+      count: latency.aggregated.permission_response_ms.count,
+    },
+    {
+      label: 'Hook Processing',
+      latest: latency.realtime?.hook_latency_ms ?? null,
+      avg: latency.aggregated.hook_latency_ms.avg,
+      max: latency.aggregated.hook_latency_ms.max,
+      count: latency.aggregated.hook_latency_ms.count,
+    },
+  ];
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs text-[#888] uppercase tracking-wider">Latency</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {cards.map((card) => (
+          <div
+            key={card.label}
+            className="rounded-lg border border-[#1a1a2e] bg-[#111118] p-4"
+          >
+            <div className="flex items-center justify-between text-xs text-[#888] uppercase tracking-wider">
+              <span>{card.label}</span>
+              <span>{card.count} sample{card.count === 1 ? '' : 's'}</span>
+            </div>
+
+            <div className="mt-3 h-1.5 rounded bg-[#1a1a2e] overflow-hidden">
+              <div className="h-full bg-[#00e5ff]/70 transition-all duration-300" style={{ width: barWidth(card.avg) }} />
+            </div>
+
+            <div className="mt-3 grid grid-cols-3 gap-2 text-xs font-mono text-[#bbb]">
+              <div>
+                <div className="text-[#666] mb-1">Latest</div>
+                <div className="text-[#00e5ff]">{formatMs(card.latest)}</div>
+              </div>
+              <div>
+                <div className="text-[#666] mb-1">Avg</div>
+                <div className="text-[#00ff88]">{formatMs(card.avg)}</div>
+              </div>
+              <div>
+                <div className="text-[#666] mb-1">Max</div>
+                <div className="text-[#ffaa00]">{formatMs(card.max)}</div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -42,9 +42,14 @@ export default function MetricCards() {
   const totalCreated = metrics?.sessions.total_created ?? health?.sessions.total ?? 0;
   const deliveryRate = metrics?.prompt_delivery.success_rate;
   const uptime = health?.uptime ?? metrics?.uptime ?? 0;
+  const hookLatency = metrics?.latency?.hook_latency_ms.avg ?? null;
+  const permissionLatency = metrics?.latency?.permission_response_ms.avg ?? null;
+  const channelLatency = metrics?.latency?.channel_delivery_ms.avg ?? null;
+
+  const formatLatency = (value: number | null): string => (value === null ? '—' : `${Math.round(value)} ms`);
 
   return (
-    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
       <MetricCard
         label="Active Sessions"
         value={activeSessions}
@@ -60,6 +65,21 @@ export default function MetricCards() {
         value={deliveryRate !== null && deliveryRate !== undefined ? deliveryRate.toFixed(1) : '—'}
         suffix="%"
         icon={<Zap className="h-4 w-4" />}
+      />
+      <MetricCard
+        label="Avg Hook Latency"
+        value={formatLatency(hookLatency)}
+        icon={<Clock className="h-4 w-4" />}
+      />
+      <MetricCard
+        label="Avg Permission Latency"
+        value={formatLatency(permissionLatency)}
+        icon={<Clock className="h-4 w-4" />}
+      />
+      <MetricCard
+        label="Avg Channel Latency"
+        value={formatLatency(channelLatency)}
+        icon={<Clock className="h-4 w-4" />}
       />
       <MetricCard
         label="Uptime"

--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -1,11 +1,11 @@
-﻿import { useState, useEffect, useRef, useCallback } from 'react';
-import type { SessionInfo, SessionHealth, SessionMetrics, SessionSummary } from '../types';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { SessionInfo, SessionHealth, SessionMetrics, SessionLatency } from '../types';
 import {
   getSession,
   getSessionHealth,
   getSessionPane,
   getSessionMetrics,
-  getSessionSummary,
+  getSessionLatency,
   subscribeSSE,
 } from '../api/client';
 import { useStore } from '../store/useStore';
@@ -25,8 +25,8 @@ interface UseSessionPollingReturn {
   paneLoading: boolean;
   metrics: SessionMetrics | null;
   metricsLoading: boolean;
-  summary: SessionSummary | null;
-  summaryLoading: boolean;
+  latency: SessionLatency | null;
+  latencyLoading: boolean;
   refetchPaneAndMetrics: () => void;
 }
 
@@ -47,10 +47,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   // Metrics state
   const [metrics, setMetrics] = useState<SessionMetrics | null>(null);
   const [metricsLoading, setMetricsLoading] = useState(true);
-
-  // Summary state
-  const [summary, setSummary] = useState<SessionSummary | null>(null);
-  const [summaryLoading, setSummaryLoading] = useState(true);
+  const [latency, setLatency] = useState<SessionLatency | null>(null);
+  const [latencyLoading, setLatencyLoading] = useState(true);
 
   // Refs for stable callbacks
   const sessionIdRef = useRef(sessionId);
@@ -88,7 +86,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   }, [addToast]);
   loadSessionAndHealthRef.current = loadSessionAndHealth;
 
-  // Fetch pane + metrics + summary
+  // Fetch pane + metrics
   const loadPaneAndMetrics = useCallback(async () => {
     if (cancelledRef.current) return;
     const sid = sessionIdRef.current;
@@ -112,12 +110,12 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     }
 
     try {
-      const data = await getSessionSummary(sid);
-      if (!cancelledRef.current) setSummary(data);
+      const data = await getSessionLatency(sid);
+      if (!cancelledRef.current) setLatency(data);
     } catch (e: unknown) {
-      addToast('warning', 'Failed to load session summary', e instanceof Error ? e.message : undefined);
+      addToast('warning', 'Failed to load session latency', e instanceof Error ? e.message : undefined);
     } finally {
-      if (!cancelledRef.current) setSummaryLoading(false);
+      if (!cancelledRef.current) setLatencyLoading(false);
     }
   }, [addToast]);
   loadPaneAndMetricsRef.current = loadPaneAndMetrics;
@@ -129,7 +127,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     setLoading(true);
     setPaneLoading(true);
     setMetricsLoading(true);
-    setSummaryLoading(true);
+    setLatencyLoading(true);
 
     loadSessionAndHealth();
     loadPaneAndMetrics();
@@ -163,7 +161,7 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     }, 1000);
   }, []);
 
-  // SSE subscription -- drives all refetching
+  // SSE subscription — drives all refetching
   useEffect(() => {
     if (!sessionId) return;
 
@@ -192,12 +190,12 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
             break;
 
           case 'ended':
-            // Final state -- re-fetch everything immediately
+            // Final state — re-fetch everything immediately
             loadSessionAndHealthRef.current?.();
             loadPaneAndMetricsRef.current?.();
             break;
 
-          // 'heartbeat', 'system', 'hook', 'subagent_start', 'subagent_stop' -- no action needed
+          // 'heartbeat', 'system', 'hook', 'subagent_start', 'subagent_stop' — no action needed
         }
       } catch {
         // ignore malformed events
@@ -216,8 +214,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     paneLoading,
     metrics,
     metricsLoading,
-    summary,
-    summaryLoading,
+    latency,
+    latencyLoading,
     refetchPaneAndMetrics: loadPaneAndMetrics,
   };
 }

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -23,8 +23,8 @@ import { SessionHeader } from '../components/session/SessionHeader';
 import { TranscriptViewer } from '../components/session/TranscriptViewer';
 import { LiveTerminal } from '../components/session/LiveTerminal';
 import { SessionMetricsPanel } from '../components/session/SessionMetricsPanel';
+import { LatencyPanel } from '../components/metrics/LatencyPanel';
 import { ApprovalBanner } from '../components/session/ApprovalBanner';
-import { SessionSummaryCard } from '../components/session/SessionSummaryCard';
 
 interface ScreenshotState {
   image: string;
@@ -49,10 +49,8 @@ export default function SessionDetailPage() {
   const {
     session, health, notFound, loading,
     metrics, metricsLoading,
-    summary, summaryLoading,
+    latency, latencyLoading,
   } = useSessionPolling(id ?? '');
-
-
 
   const [msgInput, setMsgInput] = useState('');
   const [sending, setSending] = useState(false);
@@ -242,9 +240,6 @@ export default function SessionDetailPage() {
           onKill={handleKill}
         />
 
-        {/* Session summary */}
-        <SessionSummaryCard summary={summary} loading={summaryLoading} />
-
         {/* Tab bar — full-width stretch on mobile */}
         <div className="flex border-b border-[#1a1a2e]" role="tablist">
           {TABS.map(tab => (
@@ -299,6 +294,9 @@ export default function SessionDetailPage() {
           {activeTab === 'metrics' && (
             <div id="panel-metrics" role="tabpanel" aria-labelledby="tab-metrics" tabIndex={0} className="p-3 sm:p-4">
               <SessionMetricsPanel metrics={metrics} loading={metricsLoading} />
+              <div className="mt-4">
+                <LatencyPanel latency={latency} loading={latencyLoading} />
+              </div>
             </div>
           )}
         </div>

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -112,6 +112,28 @@ export interface SessionMetrics {
   statusChanges: string[];
 }
 
+export interface LatencySummaryStat {
+  min: number | null;
+  max: number | null;
+  avg: number | null;
+  count: number;
+}
+
+export interface SessionLatency {
+  sessionId: string;
+  realtime: {
+    hook_latency_ms: number | null;
+    state_change_detection_ms: number | null;
+    permission_response_ms: number | null;
+  } | null;
+  aggregated: {
+    hook_latency_ms: LatencySummaryStat;
+    state_change_detection_ms: LatencySummaryStat;
+    permission_response_ms: LatencySummaryStat;
+    channel_delivery_ms: LatencySummaryStat;
+  } | null;
+}
+
 export interface GlobalMetrics {
   uptime: number;
   sessions: {
@@ -133,6 +155,12 @@ export interface GlobalMetrics {
     delivered: number;
     failed: number;
     success_rate: number | null;
+  };
+  latency: {
+    hook_latency_ms: LatencySummaryStat;
+    state_change_detection_ms: LatencySummaryStat;
+    permission_response_ms: LatencySummaryStat;
+    channel_delivery_ms: LatencySummaryStat;
   };
 }
 


### PR DESCRIPTION
## Summary
- add Zod validation schema for global metrics API response
- show session latency fields (state-change, channel delivery, permission, hook) in SessionDetailPage Metrics tab
- expand OverviewPage MetricCards with avg latency fields from GlobalMetrics
- add dashboard tests for latency panel rendering

## Validation
- cd dashboard && npx vitest run ✅
- cd dashboard && npm run build ✅
- 
px tsc --noEmit ✅

## Aegis version
**Developed with:** v2.10.1

Closes #313