### PR TITLE
feat: session forking — create new from parent context

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -298,6 +298,21 @@ export function escape(id: string): Promise<OkResponse> {
   });
 }
 
+// Issue #468: Fork session
+interface ForkSessionRequest {
+  name?: string;
+  prompt?: string;
+}
+
+export function forkSession(id: string, opts: ForkSessionRequest = {}): Promise<SessionInfo & { forkedFrom: string }> {
+  return request(`/v1/sessions/${encodeURIComponent(id)}/fork`, {
+    method: 'POST',
+    body: JSON.stringify(opts),
+    schema: SessionInfoSchema,
+    schemaContext: 'forkSession',
+  });
+}
+
 // ── Summary ─────────────────────────────────────────────────────
 
 export function getSessionSummary(id: string): Promise<SessionSummary> {

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -8,6 +8,7 @@ interface SessionHeaderProps {
   onApprove?: () => void;
   onReject?: () => void;
   onInterrupt?: () => void;
+  onFork?: () => void;
   onKill?: () => void;
 }
 
@@ -43,7 +44,7 @@ function formatDate(ts: number): string {
   });
 }
 
-export function SessionHeader({ session, health, onApprove, onReject, onInterrupt, onKill }: SessionHeaderProps) {
+export function SessionHeader({ session, health, onApprove, onReject, onInterrupt, onFork, onKill }: SessionHeaderProps) {
   const [confirmKill, setConfirmKill] = useState(false);
   const needsApproval = health.status === 'permission_prompt' || health.status === 'bash_approval';
 
@@ -118,6 +119,13 @@ export function SessionHeader({ session, health, onApprove, onReject, onInterrup
           className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[#1a1a2e] hover:bg-[#2a2a3e] text-[#e0e0e0] border border-[#1a1a2e] transition-colors"
         >
           Interrupt
+        </button>
+
+        <button
+          onClick={onFork}
+          className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[#1a1a2e] hover:bg-[#2a2a3e] text-[#e0e0e0] border border-[#1a1a2e] transition-colors"
+        >
+          Fork
         </button>
 
         {!confirmKill ? (

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   escape,
   killSession,
   getScreenshot,
+  forkSession,
 } from '../api/client';
 import { useToastStore } from '../store/useToastStore';
 import { useSessionPolling } from '../hooks/useSessionPolling';
@@ -104,6 +105,15 @@ export default function SessionDetailPage() {
     interrupt(s.id).catch((e: unknown) =>
       addToast('error', 'Interrupt failed', e instanceof Error ? e.message : undefined),
     );
+  }
+  async function handleFork() {
+    try {
+      const forked = await forkSession(s.id, { name: undefined });
+      addToast('success', 'Session forked', `New session ${forked.id.slice(0, 8)} created`);
+      navigate(`/session/${forked.id}`);
+    } catch (e: unknown) {
+      addToast('error', 'Fork failed', e instanceof Error ? e.message : undefined);
+    }
   }
   function handleEscape() {
     escape(s.id).catch((e: unknown) =>
@@ -237,6 +247,7 @@ export default function SessionDetailPage() {
           onApprove={handleApprove}
           onReject={handleReject}
           onInterrupt={handleInterrupt}
+          onFork={handleFork}
           onKill={handleKill}
         />
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -871,6 +871,36 @@ async function spawnChildHandler(req: SpawnRequest, reply: FastifyReply): Promis
 app.post('/v1/sessions/:id/spawn', spawnChildHandler);
 app.post('/sessions/:id/spawn', spawnChildHandler);
 
+// Issue #468: Fork session — create independent session inheriting environment
+interface ForkBody { name?: string; prompt?: string; clearPanes?: boolean; }
+type ForkRequest = FastifyRequest<{ Params: { id: string }; Body: ForkBody | undefined }>;
+async function forkSessionHandler(req: ForkRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
+  const parentId = req.params.id;
+  const parent = sessions.getSession(parentId);
+  if (!parent) return reply.status(404).send({ error: 'Parent session not found' });
+  const { name, prompt } = req.body ?? {};
+  const forkName = name ?? `${parent.windowName ?? 'session'}-fork`;
+  // Inherit: workDir, permissionMode, env (collect from parent's env vars if stored)
+  // Note: Parent's env vars are passed during creation but not stored in SessionInfo
+  // For now, we inherit structural settings (workDir, permissionMode)
+  const forkedSession = await sessions.createSession({
+    workDir: parent.workDir,
+    name: forkName,
+    permissionMode: parent.permissionMode,
+  });
+  let promptDelivery: { delivered: boolean; attempts: number } | undefined;
+  if (prompt) { promptDelivery = await sessions.sendInitialPrompt(forkedSession.id, prompt); }
+  await channels.sessionCreated({
+    event: 'session.created',
+    timestamp: new Date().toISOString(),
+    session: { id: forkedSession.id, name: forkedSession.windowName, workDir: parent.workDir },
+    detail: `Session forked from ${parentId}`,
+  });
+  return reply.status(201).send({ ...forkedSession, forkedFrom: parentId, promptDelivery });
+}
+app.post('/v1/sessions/:id/fork', forkSessionHandler);
+app.post('/sessions/:id/fork', forkSessionHandler);
+
 // Issue #700: Permission policy endpoints
 type PermissionRequest = FastifyRequest<{ Params: { id: string }; Body: PermissionPolicy | undefined }>;
 async function getPermissionPolicyHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary
- Implement fork session endpoint (POST /v1/sessions/:id/fork)
- Add fork button to SessionDetailPage
- Fork creates independent session inheriting parent's workDir and permissionMode
- Redirect to new forked session on successful fork

## Quality gates
- TypeScript: ✅
- Dashboard build: ✅
- Dashboard tests: ✅ (153 tests passed)
- Root build: ✅

Closes #468