### PR TITLE
fix(security): enforce short-lived SSE token scope on event streams

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { AuthManager } from '../auth.js';
+import { AuthManager, classifyBearerTokenForRoute } from '../auth.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { rm } from 'node:fs/promises';
@@ -369,5 +369,19 @@ describe('SSE Token Management (Issue #297)', () => {
       }
       await expect(auth.generateSSEToken('key-A')).rejects.toThrow(/limit reached/);
     });
+  });
+});
+
+describe('SSE route bearer-token policy (#408)', () => {
+  it('rejects master bearer tokens on SSE routes', () => {
+    expect(classifyBearerTokenForRoute('master-token', true)).toBe('reject');
+  });
+
+  it('accepts short-lived SSE tokens on SSE routes', () => {
+    expect(classifyBearerTokenForRoute('sse_abc123', true)).toBe('sse');
+  });
+
+  it('keeps regular bearer auth on non-SSE routes', () => {
+    expect(classifyBearerTokenForRoute('master-token', false)).toBe('bearer');
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -48,6 +48,15 @@ const SSE_TOKEN_MAX_PER_KEY = 5;
 /** #583: Minimum interval between batch creation requests per key (5 seconds). */
 const BATCH_COOLDOWN_MS = 5_000;
 
+/** Route-level auth policy for bearer tokens. */
+export function classifyBearerTokenForRoute(
+  token: string,
+  isSSERoute: boolean,
+): 'bearer' | 'sse' | 'reject' {
+  if (!isSSERoute) return 'bearer';
+  return token.startsWith('sse_') ? 'sse' : 'reject';
+}
+
 export class AuthManager {
   private store: ApiKeyStore = { keys: [] };
   private rateLimits = new Map<string, RateLimitBucket>();

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,7 +39,7 @@ import { SSEWriter } from './sse-writer.js';
 import { SSEConnectionLimiter } from './sse-limiter.js';
 import { PipelineManager, type BatchSessionSpec, type PipelineConfig } from './pipeline.js';
 import { ToolRegistry } from './tool-registry.js';
-import { AuthManager } from './auth.js';
+import { AuthManager, classifyBearerTokenForRoute } from './auth.js';
 import { MetricsCollector } from './metrics.js';
 import { registerPermissionRoutes } from './permission-routes.js';
 import { registerHookRoutes } from './hooks.js';
@@ -327,13 +327,21 @@ function setupAuth(authManager: AuthManager): void {
       return reply.status(429).send({ error: 'Too many auth failures — try again later' });
     }
 
-    // #297: Check if this is a short-lived SSE token first
-    if (isSSERoute && token.startsWith('sse_')) {
+    const tokenMode = classifyBearerTokenForRoute(token, !!isSSERoute);
+
+    // #408: SSE endpoints require short-lived single-use SSE tokens.
+    // Do not fall back to validating long-lived bearer/master tokens on /events.
+    if (tokenMode === 'sse') {
       if (await authManager.validateSSEToken(token)) {
         return; // authenticated via short-lived SSE token
       }
       recordAuthFailure(clientIp);
       return reply.status(401).send({ error: 'Unauthorized — SSE token invalid or expired' });
+    }
+
+    if (tokenMode === 'reject') {
+      recordAuthFailure(clientIp);
+      return reply.status(401).send({ error: 'Unauthorized — SSE token required for event streams' });
     }
 
     const result = authManager.validate(token);


### PR DESCRIPTION
Closes #408

## Summary
- remove SSE auth fallback that accepted long-lived bearer/master tokens on event-stream routes
- enforce short-lived sse_ token scope for /events authentication
- add regression tests for token classification policy to prevent fallback regressions

## Aegis version
**Developed with:** v2.11.0