### PR TITLE
fix: make tmux createWindow name collision handling race-safe

### DIFF
--- a/src/__tests__/tmux-race-403.test.ts
+++ b/src/__tests__/tmux-race-403.test.ts
@@ -6,7 +6,8 @@
  * serialize() scope and converts _creating boolean to a reference counter.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { TmuxManager } from '../tmux.js';
 
 /** Replicate the serialize() promise-chain pattern from TmuxManager. */
 function createSerializeQueue() {
@@ -207,5 +208,126 @@ describe('createWindow race condition (Issue #403)', () => {
 
     expect(results).toContain('task');
     expect(results).toContain('task-2');
+  });
+
+  it('TmuxManager.createWindow returns deterministic unique names for concurrent calls', async () => {
+    const tmux = new TmuxManager('race-session', 'race-socket');
+    const windows = new Map<string, string>();
+    let nextId = 1;
+
+    vi.spyOn(tmux, 'sendKeys').mockResolvedValue(undefined);
+    vi.spyOn(tmux as any, 'tmuxInternal').mockImplementation(async (...args: unknown[]) => {
+      const [cmd, ...rest] = args as string[];
+
+      if (cmd === 'has-session') return '';
+      if (cmd === 'new-session') return '';
+      if (cmd === 'set-window-option' || cmd === 'select-pane') return '';
+
+      if (cmd === 'list-windows') {
+        return [...windows.entries()]
+          .map(([name, id]) => `${id}\t${name}\t/tmp\tnode`)
+          .join('\n');
+      }
+
+      if (cmd === 'new-window') {
+        const name = rest[rest.indexOf('-n') + 1]!;
+        if (windows.has(name)) {
+          throw new Error(`duplicate window: ${name}`);
+        }
+        windows.set(name, `@${nextId++}`);
+        return '';
+      }
+
+      if (cmd === 'display-message') {
+        const target = rest[rest.indexOf('-t') + 1]!;
+        const name = target.split(':')[1]!;
+        const id = windows.get(name);
+        if (!id) throw new Error(`can't find window: ${name}`);
+        return id;
+      }
+
+      if (cmd === 'kill-window') {
+        const target = rest[rest.indexOf('-t') + 1]!;
+        const name = target.split(':')[1]!;
+        windows.delete(name);
+        return '';
+      }
+
+      throw new Error(`unexpected tmux command in test: ${cmd}`);
+    });
+
+    const [first, second, third] = await Promise.all([
+      tmux.createWindow({ workDir: '/tmp/race', windowName: 'task', claudeCommand: 'claude --version' }),
+      tmux.createWindow({ workDir: '/tmp/race', windowName: 'task', claudeCommand: 'claude --version' }),
+      tmux.createWindow({ workDir: '/tmp/race', windowName: 'task', claudeCommand: 'claude --version' }),
+    ]);
+
+    expect(first.windowName).toBe('task');
+    expect(second.windowName).toBe('task-2');
+    expect(third.windowName).toBe('task-3');
+    expect(new Set([first.windowName, second.windowName, third.windowName]).size).toBe(3);
+  });
+
+  it('TmuxManager.createWindow recovers when duplicate appears between check and create', async () => {
+    const tmux = new TmuxManager('race-session', 'race-socket');
+    const windows = new Map<string, string>();
+    let nextId = 1;
+    let injectExternalCollision = true;
+
+    vi.spyOn(tmux, 'sendKeys').mockResolvedValue(undefined);
+    vi.spyOn(tmux as any, 'tmuxInternal').mockImplementation(async (...args: unknown[]) => {
+      const [cmd, ...rest] = args as string[];
+
+      if (cmd === 'has-session') return '';
+      if (cmd === 'new-session') return '';
+      if (cmd === 'set-window-option' || cmd === 'select-pane') return '';
+
+      if (cmd === 'list-windows') {
+        return [...windows.entries()]
+          .map(([name, id]) => `${id}\t${name}\t/tmp\tnode`)
+          .join('\n');
+      }
+
+      if (cmd === 'new-window') {
+        const name = rest[rest.indexOf('-n') + 1]!;
+        if (injectExternalCollision && name === 'task') {
+          injectExternalCollision = false;
+          windows.set('task', '@999'); // Simulate external creator winning the race.
+          throw new Error('duplicate window: task');
+        }
+        if (windows.has(name)) {
+          throw new Error(`duplicate window: ${name}`);
+        }
+        windows.set(name, `@${nextId++}`);
+        return '';
+      }
+
+      if (cmd === 'display-message') {
+        const target = rest[rest.indexOf('-t') + 1]!;
+        const name = target.split(':')[1]!;
+        const id = windows.get(name);
+        if (!id) throw new Error(`can't find window: ${name}`);
+        return id;
+      }
+
+      if (cmd === 'kill-window') {
+        const target = rest[rest.indexOf('-t') + 1]!;
+        const name = target.split(':')[1]!;
+        windows.delete(name);
+        return '';
+      }
+
+      throw new Error(`unexpected tmux command in test: ${cmd}`);
+    });
+
+    const created = await tmux.createWindow({
+      workDir: '/tmp/race',
+      windowName: 'task',
+      claudeCommand: 'claude --version',
+    });
+
+    expect(created.windowName).toBe('task-2');
+    expect(windows.has('task')).toBe(true);
+    expect(windows.has('task-2')).toBe(true);
   });
 });

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -97,6 +97,35 @@ export class TmuxManager {
     }
   }
 
+  /** Determine whether an error indicates tmux rejected a duplicate window name. */
+  private isDuplicateWindowNameError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message.toLowerCase();
+    return msg.includes('duplicate window')
+      || msg.includes('window name already exists')
+      || msg.includes('duplicate session');
+  }
+
+  /** Compute an available window name by suffixing -2, -3, ... when needed. */
+  private async resolveAvailableWindowName(baseName: string): Promise<string> {
+    const rawWindows = await this.tmuxInternal(
+      'list-windows', '-t', this.sessionName,
+      '-F', '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{pane_current_command}'
+    );
+    const existing = (rawWindows ?? '').split('\n').filter(Boolean).map(line => {
+      const [windowId, windowName, cwd, paneCommand] = line.split('\t');
+      return { windowId, windowName, cwd, paneCommand };
+    }).filter((w: { windowName: string }) => w.windowName !== '_bridge_main');
+
+    const existingNames = new Set(existing.map(w => w.windowName));
+    let name = baseName;
+    let counter = 2;
+    while (existingNames.has(name)) {
+      name = `${baseName}-${counter++}`;
+    }
+    return name;
+  }
+
   /** Ensure our tmux session exists and is healthy.
    *  Issue #7: After prolonged uptime, tmux session may exist but be degraded.
    *  We verify by listing windows — if that fails, recreate the session.
@@ -183,23 +212,9 @@ export class TmuxManager {
         // If it doesn't exist, tmux uses $HOME and CC starts in wrong directory.
         await mkdir(opts.workDir, { recursive: true });
 
-        // Check for name collision, add suffix if needed
-        let name = opts.windowName;
-        // #393 fix: use tmuxInternal directly (not listWindows) to avoid
-        // re-entering serialize() from inside a serialize() callback → deadlock.
-        const rawWindows = await this.tmuxInternal(
-          'list-windows', '-t', this.sessionName,
-          '-F', '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{pane_current_command}'
-        );
-        const existing = (rawWindows ?? '').split('\n').filter(Boolean).map(line => {
-          const [windowId, windowName, cwd, paneCommand] = line.split('\t');
-          return { windowId, windowName, cwd, paneCommand };
-        }).filter((w: { windowName: string }) => w.windowName !== '_bridge_main');
-        const existingNames = new Set(existing.map(w => w.windowName));
-        let counter = 2;
-        while (existingNames.has(name)) {
-          name = `${opts.windowName}-${counter++}`;
-        }
+        // #403: Resolve a free name inside the serialize block. If tmux still
+        // reports a duplicate at create time, we recompute and retry.
+        let name = await this.resolveAvailableWindowName(opts.windowName);
 
         // Issue #7: Retry window creation up to 3 times.
         const MAX_RETRIES = 3;
@@ -255,6 +270,10 @@ export class TmuxManager {
             break;
           } catch (e) {
             lastError = e as Error;
+            if (this.isDuplicateWindowNameError(e)) {
+              name = await this.resolveAvailableWindowName(opts.windowName);
+              continue;
+            }
             console.error(`Tmux: createWindow attempt ${attempt}/${MAX_RETRIES} failed: ${(e as Error).message}`);
 
             if (attempt < MAX_RETRIES) {


### PR DESCRIPTION
## Summary
- make tmux window-name collision handling resilient to concurrent/external creators by recomputing an available name when tmux reports a duplicate-name race
- keep createWindow deterministic under concurrent calls and preserve non-colliding suffix behavior
- add race-focused tests that exercise concurrent createWindow calls and duplicate-name recovery on the real TmuxManager flow

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #403

## Test plan
- npx tsc --noEmit
- npm run build
- npm test -- src/__tests__/tmux-race-403.test.ts
- npm test (fails in this Windows environment due existing unrelated path/permissions expectations in other tests)