### PR TITLE
fix(security): harden unsafe JSON.parse boundaries

### DIFF
--- a/src/__tests__/continuation-pointer-900.test.ts
+++ b/src/__tests__/continuation-pointer-900.test.ts
@@ -71,6 +71,17 @@ describe('Issue #900: continuation pointer storage', () => {
     expect(readFileSync(mapFile, 'utf-8')).toBe('{}');
   });
 
+  it('self-heals non-object top-level JSON by resetting to empty map', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-pointer-test-'));
+    const mapFile = join(tmpDir, 'session_map.json');
+    writeFileSync(mapFile, JSON.stringify(['not', 'a', 'map']));
+
+    const result = await loadContinuationPointers(mapFile, 10_000, 2_000);
+
+    expect(result).toEqual({});
+    expect(readFileSync(mapFile, 'utf-8')).toBe('{}');
+  });
+
   function setupMapFile(data: Record<string, unknown>): string {
     tmpDir = mkdtempSync(join(tmpdir(), 'aegis-pointer-test-'));
     mkdirSync(tmpDir, { recursive: true });

--- a/src/__tests__/memory-bridge.test.ts
+++ b/src/__tests__/memory-bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MemoryBridge } from "../memory-bridge.js";
-import { existsSync, unlinkSync } from "fs";
+import { existsSync, unlinkSync, writeFileSync } from "fs";
 
 describe("MemoryBridge", () => {
   const tmpPath = "/tmp/aegis-memory-test.json";
@@ -95,5 +95,27 @@ describe("MemoryBridge", () => {
     const bridge2 = new MemoryBridge(tmpPath);
     await bridge2.load();
     expect(bridge2.get("ns/k")?.value).toBe("v");
+  });
+
+  it("ignores malformed persisted JSON", async () => {
+    writeFileSync(tmpPath, '{not-json');
+
+    await bridge.load();
+
+    expect(bridge.list()).toEqual([]);
+  });
+
+  it("ignores persisted entries with invalid structure", async () => {
+    writeFileSync(tmpPath, JSON.stringify([
+      { key: 'ok/key', value: 'v', namespace: 'ok', created_at: 1, updated_at: 2 },
+      { key: 'bad/key', value: 123, namespace: 'bad', created_at: 1, updated_at: 2 },
+      { key: 99, value: 'v', namespace: 'bad', created_at: 1, updated_at: 2 },
+    ]));
+
+    await bridge.load();
+
+    expect(bridge.get('ok/key')?.value).toBe('v');
+    expect(bridge.get('bad/key')).toBeNull();
+    expect(bridge.list()).toHaveLength(1);
   });
 });

--- a/src/continuation-pointer.ts
+++ b/src/continuation-pointer.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import type { z } from 'zod';
 import { sessionMapEntrySchema } from './validation.js';
+import { safeJsonParse } from './safe-json.js';
 
 export type ContinuationPointerEntry = z.infer<typeof sessionMapEntrySchema>;
 
@@ -36,12 +37,13 @@ export async function loadContinuationPointers(
   if (!existsSync(sessionMapFile)) return {};
 
   let parsed: unknown;
-  try {
-    parsed = JSON.parse(await readFile(sessionMapFile, 'utf-8'));
-  } catch {
+  const raw = await readFile(sessionMapFile, 'utf-8');
+  const parsedResult = safeJsonParse(raw, 'Continuation pointer map');
+  if (!parsedResult.ok) {
     await persistPointerMap(sessionMapFile, {});
     return {};
   }
+  parsed = parsedResult.data;
 
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     await persistPointerMap(sessionMapFile, {});

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -22,6 +22,7 @@ import { homedir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { stopSignalsSchema, sessionMapSchema } from './validation.js';
+import { safeJsonParse, safeJsonParseSchema } from './safe-json.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -79,14 +80,12 @@ function handleStopEvent(
 
   let signals: Record<string, unknown> = {};
   if (existsSync(signalFile)) {
-    try {
-      const parsed = stopSignalsSchema.safeParse(JSON.parse(readFileSync(signalFile, 'utf-8')));
-      if (parsed.success) {
-        signals = parsed.data;
-      } else {
-        console.warn('stop_signals.json failed validation, starting fresh');
-      }
-    } catch { /* fresh */ }
+    const parsed = safeJsonParseSchema(readFileSync(signalFile, 'utf-8'), stopSignalsSchema, 'stop_signals.json');
+    if (parsed.ok) {
+      signals = parsed.data;
+    } else {
+      console.warn(`${parsed.error}; starting fresh`);
+    }
   }
 
   signals[sessionId] = {
@@ -128,7 +127,11 @@ function main(): void {
   };
   try {
     const input = readFileSync(0, 'utf-8'); // stdin = fd 0
-    payload = JSON.parse(input);
+    const parsed = safeJsonParse(input, 'Hook stdin payload');
+    if (!parsed.ok || typeof parsed.data !== 'object' || parsed.data === null || Array.isArray(parsed.data)) {
+      process.exit(0);
+    }
+    payload = parsed.data as typeof payload;
   } catch { /* malformed or empty stdin — nothing to do */
     process.exit(0);
   }
@@ -193,14 +196,12 @@ function main(): void {
 
   let sessionMap: Record<string, SessionMapEntry> = {};
   if (existsSync(MAP_FILE)) {
-    try {
-      const parsed = sessionMapSchema.safeParse(JSON.parse(readFileSync(MAP_FILE, 'utf-8')));
-      if (parsed.success) {
-        sessionMap = parsed.data as Record<string, SessionMapEntry>;
-      } else {
-        console.warn('session_map.json failed validation, starting fresh');
-      }
-    } catch { /* fresh map */ }
+    const parsed = safeJsonParseSchema(readFileSync(MAP_FILE, 'utf-8'), sessionMapSchema, 'session_map.json');
+    if (parsed.ok) {
+      sessionMap = parsed.data as Record<string, SessionMapEntry>;
+    } else {
+      console.warn(`${parsed.error}; starting fresh`);
+    }
   }
 
   const writtenAt = Date.now();
@@ -231,12 +232,12 @@ function install(): void {
   
   let settings: Record<string, unknown> = {};
   if (existsSync(settingsPath)) {
-    try {
-      settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    } catch { /* corrupted or unreadable settings file */
+    const parsed = safeJsonParse(readFileSync(settingsPath, 'utf-8'), settingsPath);
+    if (!parsed.ok || typeof parsed.data !== 'object' || parsed.data === null || Array.isArray(parsed.data)) {
       console.error(`Failed to read ${settingsPath}`);
       process.exit(1);
     }
+    settings = parsed.data as Record<string, unknown>;
   }
 
   const hookCommand = `node ${join(__dirname, 'hook.js')}`;

--- a/src/memory-bridge.ts
+++ b/src/memory-bridge.ts
@@ -1,4 +1,5 @@
 import { existsSync, renameSync, writeFileSync, readFileSync } from "fs";
+import { safeJsonParse } from './safe-json.js';
 
 interface MemoryEntry {
   value: string;
@@ -7,6 +8,18 @@ interface MemoryEntry {
   created_at: number;
   updated_at: number;
   expires_at?: number;
+}
+
+function isMemoryEntry(value: unknown): value is MemoryEntry {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  if (typeof entry.key !== 'string') return false;
+  if (typeof entry.value !== 'string') return false;
+  if (typeof entry.namespace !== 'string') return false;
+  if (typeof entry.created_at !== 'number') return false;
+  if (typeof entry.updated_at !== 'number') return false;
+  if (entry.expires_at !== undefined && typeof entry.expires_at !== 'number') return false;
+  return true;
 }
 
 const KEY_REGEX = /^(.+?)\/(.+)$/;
@@ -77,14 +90,13 @@ export class MemoryBridge {
 
   async load(): Promise<void> {
     if (!this.persistPath || !existsSync(this.persistPath)) return;
-    try {
-      const raw = JSON.parse(readFileSync(this.persistPath, "utf-8"));
-      if (Array.isArray(raw)) {
-        for (const e of raw) {
-          if (e.key && e.value) this.store.set(e.key, e);
-        }
-      }
-    } catch { /* ignore corrupt file */ }
+    const parsed = safeJsonParse(readFileSync(this.persistPath, 'utf-8'), 'Memory bridge store');
+    if (!parsed.ok) return;
+    if (!Array.isArray(parsed.data)) return;
+    for (const rawEntry of parsed.data) {
+      if (!isMemoryEntry(rawEntry)) continue;
+      this.store.set(rawEntry.key, rawEntry);
+    }
   }
 
   async save(): Promise<void> {

--- a/src/safe-json.ts
+++ b/src/safe-json.ts
@@ -1,0 +1,33 @@
+import type { ZodType } from 'zod';
+import { getErrorMessage } from './validation.js';
+
+export type SafeJsonResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+
+/** Parse JSON without throwing and return a contextual error message. */
+export function safeJsonParse(raw: string, context = 'JSON payload'): SafeJsonResult<unknown> {
+  try {
+    return { ok: true, data: JSON.parse(raw) as unknown };
+  } catch (err) {
+    return { ok: false, error: `${context} is not valid JSON: ${getErrorMessage(err)}` };
+  }
+}
+
+/** Parse JSON and validate the resulting structure with a Zod schema. */
+export function safeJsonParseSchema<T>(
+  raw: string,
+  schema: ZodType<T>,
+  context = 'JSON payload',
+): SafeJsonResult<T> {
+  const parsed = safeJsonParse(raw, context);
+  if (!parsed.ok) return parsed;
+
+  const validated = schema.safeParse(parsed.data);
+  if (!validated.success) {
+    const reason = validated.error.issues.map(i => i.message).join(', ');
+    return { ok: false, error: `${context} has invalid structure: ${reason}` };
+  }
+
+  return { ok: true, data: validated.data };
+}

--- a/src/template-store.ts
+++ b/src/template-store.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { safeJsonParse } from './safe-json.js';
 
 export interface SessionTemplate {
   id: string;
@@ -32,6 +33,28 @@ export interface TemplateStore {
   templates: Record<string, SessionTemplate>;
 }
 
+function isSessionTemplate(value: unknown): value is SessionTemplate {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.id === 'string' &&
+    typeof t.name === 'string' &&
+    typeof t.workDir === 'string' &&
+    typeof t.createdAt === 'number' &&
+    typeof t.updatedAt === 'number'
+  );
+}
+
+function isTemplateStore(value: unknown): value is TemplateStore {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (!record.templates || typeof record.templates !== 'object' || Array.isArray(record.templates)) return false;
+  for (const tmpl of Object.values(record.templates as Record<string, unknown>)) {
+    if (!isSessionTemplate(tmpl)) return false;
+  }
+  return true;
+}
+
 const CONFIG_DIR = join(homedir(), '.config', 'aegis');
 const TEMPLATES_FILE = join(CONFIG_DIR, 'templates.json');
 
@@ -47,8 +70,13 @@ async function loadTemplates(): Promise<Record<string, SessionTemplate>> {
   try {
     if (existsSync(TEMPLATES_FILE)) {
       const content = await readFile(TEMPLATES_FILE, 'utf-8');
-      const store = JSON.parse(content) as TemplateStore;
-      cachedTemplates = store.templates || {};
+      const parsed = safeJsonParse(content, 'templates.json');
+      if (!parsed.ok || !isTemplateStore(parsed.data)) {
+        console.warn(`Failed to parse templates store: ${parsed.ok ? 'invalid structure' : parsed.error}`);
+        cachedTemplates = {};
+      } else {
+        cachedTemplates = parsed.data.templates || {};
+      }
     } else {
       cachedTemplates = {};
     }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { readdir } from 'node:fs/promises';
 import { sessionsIndexSchema } from './validation.js';
+import { safeJsonParse, safeJsonParseSchema } from './safe-json.js';
 
 /** Default Claude projects directory */
 const DEFAULT_CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects');
@@ -58,13 +59,13 @@ function parseLine(line: string): JsonlEntry | null {
     // Lines that are blank or don't start with '{' are expected (separators, comments)
     return null;
   }
-  try {
-    return JSON.parse(trimmed) as JsonlEntry;
-  } catch (err) {
+  const parsed = safeJsonParse(trimmed, 'JSONL line');
+  if (!parsed.ok) {
     // Issue #823: Log malformed JSON lines so data loss is visible
-    console.error(`parseLine: dropping malformed JSONL line (${(err as Error).message}): ${trimmed.slice(0, 200)}`);
+    console.error(`parseLine: dropping malformed JSONL line (${parsed.error}): ${trimmed.slice(0, 200)}`);
     return null;
   }
+  return parsed.data as JsonlEntry;
 }
 
 /** Summarize a tool_use block. */
@@ -308,8 +309,8 @@ export async function findSessionFile(
     if (await pathExists(indexPath)) {
       try {
         const indexRaw = await readFile(indexPath, 'utf-8');
-        const indexParsed = sessionsIndexSchema.safeParse(JSON.parse(indexRaw));
-        if (!indexParsed.success) continue;
+        const indexParsed = safeJsonParseSchema(indexRaw, sessionsIndexSchema, 'sessions-index.json');
+        if (!indexParsed.ok) continue;
         const entries = indexParsed.data.entries || [];
         for (const entry of entries) {
           if (entry.sessionId === sessionId && entry.fullPath && (await pathExists(entry.fullPath))) {

--- a/src/ws-terminal.ts
+++ b/src/ws-terminal.ts
@@ -26,6 +26,7 @@ import type { TmuxManager } from './tmux.js';
 import type { AuthManager } from './auth.js';
 import type WebSocket from 'ws';
 import { clamp, wsInboundMessageSchema, isValidUUID } from './validation.js';
+import { safeJsonParse } from './safe-json.js';
 
 const POLL_INTERVAL_MS = 500;
 const KEEPALIVE_INTERVAL_TICKS = 60; // 30s at 500ms intervals
@@ -220,14 +221,21 @@ export function registerWsTerminalRoute(
           return;
         }
 
-        try {
-          const parsed = wsInboundMessageSchema.safeParse(JSON.parse(data.toString()));
-          if (!parsed.success) {
-            sendError(socket, `Invalid message: ${parsed.error.issues.map(i => i.message).join(', ')}`);
-            return;
-          }
-          const msg = parsed.data;
+        const jsonParsed = safeJsonParse(data.toString(), 'WebSocket message');
+        if (!jsonParsed.ok) {
+          sendError(socket, `Invalid message: ${jsonParsed.error}`);
+          return;
+        }
 
+        const parsed = wsInboundMessageSchema.safeParse(jsonParsed.data);
+        if (!parsed.success) {
+          sendError(socket, `Invalid message: ${parsed.error.issues.map(i => i.message).join(', ')}`);
+          return;
+        }
+
+        const msg = parsed.data;
+
+        try {
           // Handle auth handshake (Issue #503)
           if (msg.type === 'auth') {
             if (subscriber.authenticated) {
@@ -275,7 +283,7 @@ export function registerWsTerminalRoute(
             await tmux.resizePane(session.windowId, cols, rows);
           }
         } catch (e) {
-          sendError(socket, `Invalid message: ${e instanceof Error ? e.message : String(e)}`);
+          sendError(socket, `Failed to process message: ${e instanceof Error ? e.message : String(e)}`);
         }
       });
 


### PR DESCRIPTION
## Summary
Harden critical runtime JSON parsing paths by replacing raw parse flows with safe parsing plus validation/type guards.

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #410

## Test plan
- npx tsc --noEmit
- npm run build
- npm test -- --run src/__tests__/continuation-pointer-900.test.ts src/__tests__/memory-bridge.test.ts src/__tests__/ws-terminal.test.ts
- npm test -- --maxWorkers=1 (full suite attempted; environment exited non-zero without concise failure summary in terminal output)