### PR TITLE
fix: clear all session-keyed tracking state on kill

### DIFF
--- a/src/__tests__/session-cleanup-405.test.ts
+++ b/src/__tests__/session-cleanup-405.test.ts
@@ -1,0 +1,77 @@
+/**
+ * session-cleanup-405.test.ts — Regression tests for issue #405.
+ *
+ * Ensures terminated sessions are removed from all server-side
+ * session-keyed tracking maps and stay clean under create/kill churn.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { cleanupTerminatedSessionState } from '../session-cleanup.js';
+
+class MapBackedCleanup {
+  readonly entries = new Map<string, number>();
+
+  track(sessionId: string): void {
+    this.entries.set(sessionId, Date.now());
+  }
+
+  cleanupSession(sessionId: string): void {
+    this.entries.delete(sessionId);
+  }
+}
+
+class MonitorCleanup {
+  readonly entries = new Map<string, number>();
+
+  track(sessionId: string): void {
+    this.entries.set(sessionId, Date.now());
+  }
+
+  removeSession(sessionId: string): void {
+    this.entries.delete(sessionId);
+  }
+}
+
+describe('cleanupTerminatedSessionState (Issue #405)', () => {
+  it('removes the killed session from every tracking map', () => {
+    const monitor = new MonitorCleanup();
+    const metrics = new MapBackedCleanup();
+    const toolRegistry = new MapBackedCleanup();
+
+    monitor.track('sess-1');
+    monitor.track('sess-2');
+    metrics.track('sess-1');
+    metrics.track('sess-2');
+    toolRegistry.track('sess-1');
+    toolRegistry.track('sess-2');
+
+    cleanupTerminatedSessionState('sess-1', { monitor, metrics, toolRegistry });
+
+    expect(monitor.entries.has('sess-1')).toBe(false);
+    expect(metrics.entries.has('sess-1')).toBe(false);
+    expect(toolRegistry.entries.has('sess-1')).toBe(false);
+
+    expect(monitor.entries.has('sess-2')).toBe(true);
+    expect(metrics.entries.has('sess-2')).toBe(true);
+    expect(toolRegistry.entries.has('sess-2')).toBe(true);
+  });
+
+  it('leaves no stale entries after repeated create/kill cycles', () => {
+    const monitor = new MonitorCleanup();
+    const metrics = new MapBackedCleanup();
+    const toolRegistry = new MapBackedCleanup();
+
+    for (let i = 0; i < 200; i++) {
+      const sessionId = `sess-${i}`;
+      monitor.track(sessionId);
+      metrics.track(sessionId);
+      toolRegistry.track(sessionId);
+
+      cleanupTerminatedSessionState(sessionId, { monitor, metrics, toolRegistry });
+    }
+
+    expect(monitor.entries.size).toBe(0);
+    expect(metrics.entries.size).toBe(0);
+    expect(toolRegistry.entries.size).toBe(0);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import { negotiate, type HandshakeRequest } from './handshake.js';
 import { diagnosticsBus } from './diagnostics.js';
 import { setStructuredLogSink } from './logger.js';
 import { MemoryBridge } from './memory-bridge.js';
+import { cleanupTerminatedSessionState } from './session-cleanup.js';
 import { normalizeApiErrorPayload } from './api-error-envelope.js';
 import {
   authKeySchema, sendMessageSchema, commandSchema, bashSchema,
@@ -110,8 +111,7 @@ async function handleInbound(cmd: InboundCommand): Promise<void> {
         // reference a session that is still being destroyed.
         await sessions.killSession(cmd.sessionId);
         await channels.sessionEnded(makePayload('session.ended', cmd.sessionId, 'killed'));
-        monitor.removeSession(cmd.sessionId);
-        metrics.cleanupSession(cmd.sessionId);
+        cleanupTerminatedSessionState(cmd.sessionId, { monitor, metrics, toolRegistry });
         break;
       case 'message':
       case 'command':
@@ -1011,8 +1011,7 @@ async function killSessionHandler(req: IdRequest, reply: FastifyReply): Promise<
     await sessions.killSession(req.params.id);
     eventBus.emitEnded(req.params.id, 'killed');
     await channels.sessionEnded(makePayload('session.ended', req.params.id, 'killed'));
-    monitor.removeSession(req.params.id);
-    metrics.cleanupSession(req.params.id);
+    cleanupTerminatedSessionState(req.params.id, { monitor, metrics, toolRegistry });
     return { ok: true };
   } catch (e: unknown) {
     return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
@@ -1580,9 +1579,7 @@ async function reapStaleSessions(maxAgeMs: number): Promise<void> {
           session: { id: session.id, name: session.windowName, workDir: session.workDir },
           detail: `Auto-killed: exceeded ${maxAgeMs / 3600000}h time limit`,
         });
-        monitor.removeSession(session.id);
-        metrics.cleanupSession(session.id);
-      toolRegistry.cleanupSession(session.id);
+        cleanupTerminatedSessionState(session.id, { monitor, metrics, toolRegistry });
       } catch (e) {
         console.error(`Reaper: failed to kill session ${session.id}:`, e);
       }
@@ -1608,11 +1605,9 @@ async function reapZombieSessions(): Promise<void> {
 
     console.log(`Reaper: removing zombie session ${session.windowName} (${session.id.slice(0, 8)})`);
     try {
-      monitor.removeSession(session.id);
       eventBus.cleanupSession(session.id);
       await sessions.killSession(session.id);
-      metrics.cleanupSession(session.id);
-      toolRegistry.cleanupSession(session.id);
+      cleanupTerminatedSessionState(session.id, { monitor, metrics, toolRegistry });
       await channels.sessionEnded({
         event: 'session.ended',
         timestamp: new Date().toISOString(),

--- a/src/session-cleanup.ts
+++ b/src/session-cleanup.ts
@@ -1,0 +1,21 @@
+/**
+ * session-cleanup.ts — Shared per-session cleanup for terminated sessions.
+ *
+ * Ensures all server-side session-keyed tracking structures are cleaned in
+ * every termination path (API kill, inbound kill, stale reaper, zombie reaper).
+ */
+
+export interface SessionCleanupDeps {
+  monitor: { removeSession(sessionId: string): void };
+  metrics: { cleanupSession(sessionId: string): void };
+  toolRegistry: { cleanupSession(sessionId: string): void };
+}
+
+export function cleanupTerminatedSessionState(
+  sessionId: string,
+  deps: SessionCleanupDeps,
+): void {
+  deps.monitor.removeSession(sessionId);
+  deps.metrics.cleanupSession(sessionId);
+  deps.toolRegistry.cleanupSession(sessionId);
+}


### PR DESCRIPTION
Closes #405

## Aegis version
**Developed with:** v2.11.0

## Summary
- add a shared terminated-session cleanup helper used by all kill paths
- ensure inbound/API/reaper/zombie kill flows all clear monitor, metrics, and tool registry state
- add regression tests for single kill cleanup and repeated create/kill churn

## Validation
- npx tsc --noEmit
- npm run build
- npm test (fails on existing OS-specific tests unrelated to this change)