### PR TITLE
fix(security): harden master token timing-safe comparison

### DIFF
--- a/src/__tests__/auth-timing-safe.test.ts
+++ b/src/__tests__/auth-timing-safe.test.ts
@@ -57,6 +57,22 @@ describe('AuthManager timing-safe token comparison (#402)', () => {
     expect(matchCall).toBeDefined();
   });
 
+  it('uses the same timing-safe comparison path for prefix-style and positional mismatches', () => {
+    const wrongFirst = `X${masterToken.slice(1)}`;
+    const wrongMiddle = `${masterToken.slice(0, 10)}X${masterToken.slice(11)}`;
+    const wrongLast = `${masterToken.slice(0, -1)}X`;
+
+    const cases = [wrongFirst, wrongMiddle, wrongLast];
+    for (const candidate of cases) {
+      timingSafeEqualCalls = [];
+      const result = auth.validate(candidate);
+
+      expect(result.valid).toBe(false);
+      expect(timingSafeEqualCalls).toHaveLength(1);
+      expect(timingSafeEqualCalls[0]).toEqual({ a: candidate, b: masterToken });
+    }
+  });
+
   it('rejects tokens of different length without calling timingSafeEqual', () => {
     const result = auth.validate('short');
     expect(result.valid).toBe(false);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -148,8 +148,7 @@ export class AuthManager {
     }
 
     // Check master token (backward compat) — timing-safe comparison (#402)
-    if (this.masterToken && token.length === this.masterToken.length
-      && timingSafeEqual(Buffer.from(token), Buffer.from(this.masterToken))) {
+    if (this.masterToken && AuthManager.timingSafeStringEqual(token, this.masterToken)) {
       return { valid: true, keyId: 'master', rateLimited: false };
     }
 
@@ -188,6 +187,12 @@ export class AuthManager {
   /** Hash a key with SHA-256. */
   static hashKey(key: string): string {
     return createHash('sha256').update(key).digest('hex');
+  }
+
+  /** Constant-time equality check for secret strings. */
+  private static timingSafeStringEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
   }
 
   /** #583: Check and update batch rate limit for a key. Returns true if rate-limited. */


### PR DESCRIPTION
## Summary
Harden master token verification to use a dedicated timing-safe helper and extend timing-focused unit coverage for same-length mismatch paths (including prefix-style mismatches).

Closes #402

## Aegis version
**Developed with:** v2.11.0

## Test plan
- npx tsc --noEmit
- npm run build
- npm test (full suite has unrelated existing failures on Windows path/permission assertions)
- npm test -- src/__tests__/auth-timing-safe.test.ts src/__tests__/auth.test.ts