### PR TITLE
fix(security): render permission requests as inert text in MessageBubble

### DIFF
--- a/dashboard/src/__tests__/MessageBubble.test.tsx
+++ b/dashboard/src/__tests__/MessageBubble.test.tsx
@@ -30,7 +30,7 @@ describe('MessageBubble — XSS prevention', () => {
     });
     const { container } = render(<MessageBubble entry={entry} />);
     expect(container.querySelector('img')).toBeNull();
-    expect(container.innerHTML).not.toContain('onerror');
+    expect(container.textContent).toContain('<img src=x onerror="alert(1)">');
   });
 
   it('escapes <iframe> payloads', () => {
@@ -39,6 +39,7 @@ describe('MessageBubble — XSS prevention', () => {
     });
     const { container } = render(<MessageBubble entry={entry} />);
     expect(container.querySelector('iframe')).toBeNull();
+    expect(container.textContent).toContain('<iframe src="https://evil.com"></iframe>');
   });
 
   it('escapes event handler attributes', () => {
@@ -46,7 +47,8 @@ describe('MessageBubble — XSS prevention', () => {
       text: '<div onmouseover="alert(1)">hover me</div>',
     });
     const { container } = render(<MessageBubble entry={entry} />);
-    expect(container.innerHTML).not.toContain('onmouseover');
+    expect(container.querySelector('div[onmouseover]')).toBeNull();
+    expect(container.textContent).toContain('<div onmouseover="alert(1)">hover me</div>');
   });
 
   it('renders safe plain text without alteration', () => {
@@ -65,7 +67,20 @@ describe('MessageBubble — XSS prevention', () => {
     const { container } = render(<MessageBubble entry={entry} />);
     // JSX escaping — the <b> should appear as literal text, not a real tag
     expect(container.querySelector('b')).toBeNull();
-    expect(container.textContent).toBe('bold is just text');  // DOMPurify strips <b> tags
+    expect(container.textContent).toContain('<b>bold</b> is just text');
+  });
+
+  it('shows permission_request text with readable formatting and inert content', () => {
+    const entry = makeEntry({
+      role: 'user',
+      text: 'Bash command:\n<svg onload="alert(1)">\nProceed?',
+    });
+
+    const { container } = render(<MessageBubble entry={entry} />);
+
+    expect(screen.getByText('Permission Request')).toBeDefined();
+    expect(container.querySelector('svg')).toBeNull();
+    expect(container.textContent).toContain('Bash command:\n<svg onload="alert(1)">\nProceed?');
   });
 
   it('does not classify ordinary text starting with error as a failed tool result', () => {

--- a/dashboard/src/__tests__/sanitization-all-entry-types.test.tsx
+++ b/dashboard/src/__tests__/sanitization-all-entry-types.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Test for Issue #628: Verify DOMPurify sanitization is applied to ALL entry types.
- * Previously only permission_request entries were sanitized.
+ * Verify XSS payloads are inert for all entry types.
+ * Rendering uses plain React text nodes, which are escaped by default.
  */
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
@@ -18,7 +18,7 @@ const contentTypes: Array<ParsedEntry['contentType']> = [
   'permission_request',
 ];
 
-describe('DOMPurify — all entry types sanitized (#628)', () => {
+describe('Escaped rendering — all entry types are inert', () => {
   it.each(contentTypes)('sanitizes %s entries', (contentType) => {
     const entry: ParsedEntry = {
       role: contentType === 'permission_request' ? 'assistant' : 'assistant',
@@ -44,7 +44,10 @@ describe('DOMPurify — all entry types sanitized (#628)', () => {
     };
     const { container } = render(<MessageBubble entry={entry} />);
     expect(container.querySelector('img')).toBeNull();
-    expect(container.innerHTML).not.toContain('onerror');
+    expect(container.querySelector('[onerror]')).toBeNull();
+    if (contentType !== 'thinking') {
+      expect(container.textContent).toContain('<img src=x onerror="alert(1)">');
+    }
   });
 
   it('sanitizes user role text entries', () => {

--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -1,11 +1,5 @@
 ﻿import { useState } from 'react';
-import DOMPurify from 'dompurify';
 import type { ParsedEntry } from '../../types';
-
-/** Strip all HTML tags from untrusted text â€” defense-in-depth against XSS. */
-function sanitizeText(input: string): string {
-  return DOMPurify.sanitize(input, { ALLOWED_TAGS: [] });
-}
 
 const TOOL_ICONS: Record<string, string> = {
   Read: 'ðŸ“–',
@@ -43,7 +37,7 @@ function TextMessage({ entry }: { entry: ParsedEntry }) {
             : 'bg-[#111118] text-[#e0e0e0] rounded-bl-sm border border-[#1a1a2e]'
         }`}
       >
-        <div className="whitespace-pre-wrap break-words">{sanitizeText(entry.text)}</div>
+        <div className="whitespace-pre-wrap break-words">{entry.text}</div>
         {entry.timestamp && (
           <div className={`text-[10px] mt-1 ${isUser ? 'text-[#555]' : 'text-[#444]'}`}>
             {formatTimestamp(entry.timestamp)}
@@ -75,7 +69,7 @@ function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
         </button>
         {open && (
           <div className="bg-[#0d0d12] border border-[#1a1a2e] rounded-lg px-4 py-3 mt-1 text-sm text-[#555] italic leading-relaxed whitespace-pre-wrap break-words max-h-64 overflow-y-auto">
-            {sanitizeText(entry.text)}
+            {entry.text}
           </div>
         )}
       </div>
@@ -85,7 +79,7 @@ function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
 
 // â”€â”€â”€ Tool Use Card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 function ToolUseCard({ entry }: { entry: ParsedEntry }) {
-  const rawPreview = sanitizeText(entry.text);
+  const rawPreview = entry.text;
   const preview = rawPreview.length > 100 ? rawPreview.slice(0, 100) + 'â€¦' : rawPreview;
 
   return (
@@ -128,8 +122,19 @@ function ToolResultCard({ entry }: { entry: ParsedEntry }) {
           )}
         </div>
         <div className="px-3 py-2 text-xs text-[#666] font-mono whitespace-pre-wrap break-all max-h-32 overflow-y-auto">
-          {sanitizeText(entry.text) || '(empty)'}
+          {entry.text || '(empty)'}
         </div>
+      </div>
+    </div>
+  );
+}
+
+function PermissionRequestMessage({ entry }: { entry: ParsedEntry }) {
+  return (
+    <div className="flex justify-start mb-3">
+      <div className="max-w-[85%] w-full bg-[#2a120f] border border-[#7f1d1d] text-[#fecaca] rounded-lg px-3 py-2">
+        <div className="text-[11px] uppercase tracking-wide font-semibold text-[#fca5a5]">Permission Request</div>
+        <div className="mt-1 text-sm font-mono whitespace-pre-wrap break-words">{entry.text}</div>
       </div>
     </div>
   );
@@ -137,6 +142,10 @@ function ToolResultCard({ entry }: { entry: ParsedEntry }) {
 
 // â”€â”€â”€ MessageBubble (main export) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 export function MessageBubble({ entry }: { entry: ParsedEntry }) {
+  if (entry.contentType === 'permission_request') {
+    return <PermissionRequestMessage entry={entry} />;
+  }
+
   if (entry.role === 'user') {
     return <TextMessage entry={entry} />;
   }
@@ -150,8 +159,6 @@ export function MessageBubble({ entry }: { entry: ParsedEntry }) {
       return <ToolUseCard entry={entry} />;
     case 'tool_result':
       return <ToolResultCard entry={entry} />;
-    case 'permission_request':
-      return <div className="text-red-400 text-sm font-semibold px-3 py-2">Permission Request: {sanitizeText(entry.text)}</div>;
     default:
       return <TextMessage entry={entry} />;
   }


### PR DESCRIPTION
## Summary
- remove HTML-stripping sanitization from MessageBubble and rely on escaped plain-text rendering
- add a dedicated permission_request bubble renderer so permission payloads are displayed consistently and readably
- update XSS tests to prove dangerous payloads remain inert while preserving legitimate text formatting

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #406

## Test plan
- [x] Dashboard tests pass (
pm test in dashboard/)
- [x] Dashboard typecheck passes (
pm run typecheck in dashboard/)
- [x] Dashboard build passes (
pm run build in dashboard/)
- [x] Root typecheck passes (
px tsc --noEmit)
- [x] Root build passes (
pm run build)
- [x] Root tests executed (
pm test) — fails on existing Windows/path-permission baseline tests unrelated to this change
