### PR TITLE
fix: align zod major version across monorepo

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,6 +22,9 @@
     "zod": "^4.3.6",
     "zustand": "^5.0.3"
   },
+  "overrides": {
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.7",
     "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "fastify": "^5.8.2",
     "zod": "^4.3.6"
   },
+  "overrides": {
+    "zod": "^4.3.6"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/OneStepAt4time/aegis.git"


### PR DESCRIPTION
## Summary
Align root and dashboard package manifests to a single Zod major strategy (v4), and enforce it with npm overrides to prevent future drift.

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #420

## Test plan
- [x] Root type-check (
px tsc --noEmit)
- [x] Root build (
pm run build)
- [x] Root tests executed (
pm test -- --reporter=dot) *(fails on Windows path expectation in existing tests; unrelated to this change)*
- [x] Dashboard type-check (
pm run typecheck)
- [x] Dashboard build (
pm run build)
- [x] Dashboard tests (
pm test -- --reporter=dot)
