### PR TITLE
refactor: centralize shared API contract types

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -6,6 +6,18 @@
  */
 
 import { z } from 'zod';
+import type {
+  HealthResponse,
+  SessionInfo,
+  SessionsListResponse,
+  SessionHealth,
+  SessionMetrics,
+  SessionLatency,
+  MessagesResponse,
+  GlobalMetrics,
+  SessionSSEEvent,
+  GlobalSSEEvent,
+} from '../types';
 
 // ── Primitives ──────────────────────────────────────────────────
 
@@ -53,7 +65,7 @@ export const SendResponseSchema = OkResponseSchema.extend({
 
 // ── HealthResponse ──────────────────────────────────────────────
 
-export const HealthResponseSchema = z.object({
+export const HealthResponseSchema: z.ZodType<HealthResponse> = z.object({
   status: z.string(),
   version: z.string(),
   uptime: z.number(),
@@ -66,7 +78,7 @@ export const HealthResponseSchema = z.object({
 
 // ── SessionInfo ─────────────────────────────────────────────────
 
-export const SessionInfoSchema = z.object({
+export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
   id: z.string(),
   windowId: z.string(),
   windowName: z.string(),
@@ -92,7 +104,7 @@ export const SessionInfoSchema = z.object({
 
 // ── SessionsListResponse ────────────────────────────────────────
 
-export const SessionsListResponseSchema = z.object({
+export const SessionsListResponseSchema: z.ZodType<SessionsListResponse> = z.object({
   sessions: z.array(SessionInfoSchema),
   pagination: z.object({
     page: z.number(),
@@ -104,7 +116,7 @@ export const SessionsListResponseSchema = z.object({
 
 // ── SessionHealth ──────────────────────────────────────────────
 
-export const SessionHealthSchema = z.object({
+export const SessionHealthSchema: z.ZodType<SessionHealth> = z.object({
   alive: z.boolean(),
   windowExists: z.boolean(),
   claudeRunning: z.boolean(),
@@ -124,7 +136,7 @@ export const SessionHealthSchema = z.object({
 
 // ── SessionMetrics ─────────────────────────────────────────────
 
-export const SessionMetricsSchema = z.object({
+export const SessionMetricsSchema: z.ZodType<SessionMetrics> = z.object({
   durationSec: z.number(),
   messages: z.number(),
   toolCalls: z.number(),
@@ -140,7 +152,7 @@ const LatencySummaryStatSchema = z.object({
   count: z.number(),
 });
 
-export const SessionLatencySchema = z.object({
+export const SessionLatencySchema: z.ZodType<SessionLatency> = z.object({
   sessionId: z.string(),
   realtime: z.object({
     hook_latency_ms: z.number().nullable(),
@@ -159,7 +171,7 @@ export const SessionLatencySchema = z.object({
 
 const ParsedEntrySchema = z.object({
   role: z.enum(['user', 'assistant', 'system']),
-  contentType: z.enum(['text', 'thinking', 'tool_use', 'tool_result', 'permission_request']),
+  contentType: z.enum(['text', 'thinking', 'tool_use', 'tool_result', 'tool_error', 'permission_request', 'progress']),
   text: z.string(),
   toolName: z.string().optional(),
   toolUseId: z.string().optional(),
@@ -168,7 +180,7 @@ const ParsedEntrySchema = z.object({
 
 // ── SessionMessages (Issue #407) ────────────────────────────────
 
-export const SessionMessagesSchema = z.object({
+export const SessionMessagesSchema: z.ZodType<MessagesResponse> = z.object({
   messages: z.array(ParsedEntrySchema),
   status: UIState,
   statusText: z.string().nullable(),
@@ -177,7 +189,7 @@ export const SessionMessagesSchema = z.object({
 
 // ── GlobalMetrics (Issue #407) ──────────────────────────────────
 
-export const GlobalMetricsSchema = z.object({
+export const GlobalMetricsSchema: z.ZodType<GlobalMetrics> = z.object({
   uptime: z.number(),
   sessions: z.object({
     total_created: z.number(),
@@ -221,13 +233,14 @@ const SSEEventTypes = z.enum([
   'hook',
   'subagent_start',
   'subagent_stop',
+  'verification',
 ]);
 
-export const SessionSSEEventDataSchema = z.object({
+export const SessionSSEEventDataSchema: z.ZodType<SessionSSEEvent> = z.object({
   event: SSEEventTypes,
   sessionId: z.string(),
   timestamp: z.string(),
-  data: z.record(z.string(), z.unknown()).optional(),
+  data: z.record(z.string(), z.unknown()),
 });
 
 // ── Global SSE Event (Issue #410) ──────────────────────────────
@@ -242,9 +255,10 @@ const GlobalSSEEventType = z.enum([
   'session_dead',
   'session_subagent_start',
   'session_subagent_stop',
+  'session_verification',
 ]);
 
-export const GlobalSSEEventSchema = z.object({
+export const GlobalSSEEventSchema: z.ZodType<GlobalSSEEvent> = z.object({
   event: GlobalSSEEventType,
   sessionId: z.string(),
   timestamp: z.string(),

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -29,6 +29,7 @@ const EVENT_META: Record<GlobalSSEEventType, { icon: typeof Activity; label: str
   session_dead: { icon: Skull, label: 'Dead', color: '#dc2626' },
   session_subagent_start: { icon: Users, label: 'Subagent', color: '#3b82f6' },
   session_subagent_stop: { icon: UserCheck, label: 'Subagent Done', color: '#10b981' },
+  session_verification: { icon: ShieldAlert, label: 'Verification', color: '#0891b2' },
 };
 
 export function safeStr(val: unknown, fallback: string = 'unknown'): string {
@@ -64,6 +65,8 @@ export function describeEvent(event: GlobalSSEEvent): string {
       return `Subagent started: ${safeStr(d.name)}`;
     case 'session_subagent_stop':
       return `Subagent finished: ${safeStr(d.name)}`;
+    case 'session_verification':
+      return `Verification: ${safeStr(d.summary ?? d.status, 'completed')}`;
     default:
       return JSON.stringify(d);
   }

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -1,51 +1,35 @@
 /**
- * types/index.ts — Aegis API type definitions.
+ * types/index.ts — Dashboard-facing types.
  *
- * Mirrors the backend types from session.ts, metrics.ts, events.ts, and server.ts.
+ * API contract types are re-exported from src/api-contracts.ts so backend and
+ * dashboard read the same source of truth.
  */
 
-// ── Session ─────────────────────────────────────────────────────
-
-export type UIState =
-  | 'idle'
-  | 'working'
-  | 'compacting'
-  | 'context_warning'
-  | 'waiting_for_input'
-  | 'permission_prompt'
-  | 'plan_mode'
-  | 'ask_question'
-  | 'bash_approval'
-  | 'settings'
-  | 'error'
-  | 'unknown';
-
-export type SessionStatusFilter = 'all' | UIState;
-
-export interface SessionInfo {
-  id: string;
-  windowId: string;
-  windowName: string;
-  workDir: string;
-  claudeSessionId?: string;
-  jsonlPath?: string;
-  byteOffset: number;
-  monitorOffset: number;
-  status: UIState;
-  createdAt: number;
-  lastActivity: number;
-  stallThresholdMs: number;
-  permissionMode: string;
-  /** @deprecated Use permissionMode. */
-  autoApprove?: boolean;
-  settingsPatched?: boolean;
-  promptDelivery?: { delivered: boolean; attempts: number };
-  actionHints?: Record<string, {
-    method: string;
-    url: string;
-    description: string;
-  }>;
-}
+export type {
+  UIState,
+  SessionStatusFilter,
+  SessionInfo,
+  SessionHealth,
+  HealthResponse,
+  ParsedEntry,
+  MessagesResponse,
+  SessionMetrics,
+  LatencySummaryStat,
+  SessionLatency,
+  GlobalMetrics,
+  SSEEventType,
+  SessionSSEEvent,
+  GlobalSSEEventType,
+  GlobalSSEEvent,
+  CreateSessionRequest,
+  PaneResponse,
+  SessionSummary,
+  OkResponse,
+  SendResponse,
+  ApiError,
+  SessionsListResponse,
+  SessionStatusCounts,
+} from '../../../src/api-contracts';
 
 // ── Session Templates ───────────────────────────────────────────
 
@@ -66,210 +50,9 @@ export interface SessionTemplate {
   updatedAt: number;
 }
 
-// ── Health ──────────────────────────────────────────────────────
-
-export interface SessionHealth {
-  alive: boolean;
-  windowExists: boolean;
-  claudeRunning: boolean;
-  paneCommand: string | null;
-  status: UIState;
-  hasTranscript: boolean;
-  lastActivity: number;
-  lastActivityAgo: number;
-  sessionAge: number;
-  details: string;
-  actionHints?: Record<string, {
-    method: string;
-    url: string;
-    description: string;
-  }>;
-}
-
 export interface RowHealth {
   alive: boolean;
   loading: boolean;
-}
-
-export interface HealthResponse {
-  status: string;
-  version: string;
-  uptime: number;
-  sessions: {
-    active: number;
-    total: number;
-  };
-  timestamp: string;
-}
-
-// ── Messages ────────────────────────────────────────────────────
-
-export interface ParsedEntry {
-  role: 'user' | 'assistant' | 'system';
-  contentType: 'text' | 'thinking' | 'tool_use' | 'tool_result' | 'permission_request';
-  text: string;
-  toolName?: string;
-  toolUseId?: string;
-  timestamp?: string;
-}
-
-export interface MessagesResponse {
-  messages: ParsedEntry[];
-  status: UIState;
-  statusText: string | null;
-  interactiveContent: string | null;
-}
-
-// ── Metrics ─────────────────────────────────────────────────────
-
-export interface SessionMetrics {
-  durationSec: number;
-  messages: number;
-  toolCalls: number;
-  approvals: number;
-  autoApprovals: number;
-  statusChanges: string[];
-}
-
-export interface LatencySummaryStat {
-  min: number | null;
-  max: number | null;
-  avg: number | null;
-  count: number;
-}
-
-export interface SessionLatency {
-  sessionId: string;
-  realtime: {
-    hook_latency_ms: number | null;
-    state_change_detection_ms: number | null;
-    permission_response_ms: number | null;
-  } | null;
-  aggregated: {
-    hook_latency_ms: LatencySummaryStat;
-    state_change_detection_ms: LatencySummaryStat;
-    permission_response_ms: LatencySummaryStat;
-    channel_delivery_ms: LatencySummaryStat;
-  } | null;
-}
-
-export interface GlobalMetrics {
-  uptime: number;
-  sessions: {
-    total_created: number;
-    currently_active: number;
-    completed: number;
-    failed: number;
-    avg_duration_sec: number;
-    avg_messages_per_session: number;
-  };
-  auto_approvals: number;
-  webhooks_sent: number;
-  webhooks_failed: number;
-  screenshots_taken: number;
-  pipelines_created: number;
-  batches_created: number;
-  prompt_delivery: {
-    sent: number;
-    delivered: number;
-    failed: number;
-    success_rate: number | null;
-  };
-  latency: {
-    hook_latency_ms: LatencySummaryStat;
-    state_change_detection_ms: LatencySummaryStat;
-    permission_response_ms: LatencySummaryStat;
-    channel_delivery_ms: LatencySummaryStat;
-  };
-}
-
-// ── SSE Events ──────────────────────────────────────────────────
-
-export type SSEEventType =
-  | 'status'
-  | 'message'
-  | 'approval'
-  | 'ended'
-  | 'heartbeat'
-  | 'stall'
-  | 'dead'
-  | 'system'
-  | 'hook'
-  | 'subagent_start'
-  | 'subagent_stop';
-
-export interface SessionSSEEvent {
-  event: SSEEventType;
-  sessionId: string;
-  timestamp: string;
-  emittedAt?: number;
-  data: Record<string, unknown>;
-}
-
-// ── Global SSE Events ──────────────────────────────────────────
-
-export type GlobalSSEEventType =
-  | 'session_status_change'
-  | 'session_message'
-  | 'session_approval'
-  | 'session_ended'
-  | 'session_created'
-  | 'session_stall'
-  | 'session_dead'
-  | 'session_subagent_start'
-  | 'session_subagent_stop';
-
-export interface GlobalSSEEvent {
-  event: GlobalSSEEventType;
-  sessionId: string;
-  timestamp: string;
-  data: Record<string, unknown>;
-}
-
-// ── Create Session ──────────────────────────────────────────────
-
-export interface CreateSessionRequest {
-  workDir: string;
-  name?: string;
-  prompt?: string;
-  resumeSessionId?: string;
-  claudeCommand?: string;
-  env?: Record<string, string>;
-  stallThresholdMs?: number;
-  permissionMode?: string;
-  /** @deprecated Use permissionMode. */
-  autoApprove?: boolean;
-  ttl_seconds?: number;
-}
-
-// ── Pane ────────────────────────────────────────────────────────
-
-export interface PaneResponse {
-  pane: string;
-}
-
-// ── Summary ─────────────────────────────────────────────────────
-
-export interface SessionSummary {
-  sessionId: string;
-  windowName: string;
-  status: UIState;
-  totalMessages: number;
-  messages: Array<{ role: string; contentType: string; text: string }>;
-  createdAt: number;
-  lastActivity: number;
-  permissionMode: string;
-}
-
-// ── Simple OK response ──────────────────────────────────────────
-
-export interface OkResponse {
-  ok: boolean;
-}
-
-export interface SendResponse extends OkResponse {
-  delivered: boolean;
-  attempts: number;
 }
 
 // ── WebSocket Terminal Messages ─────────────────────────────────
@@ -304,21 +87,3 @@ export interface WsResizeMessage {
 
 export type WsOutboundMessage = WsInputMessage | WsResizeMessage;
 
-// ── API Error ───────────────────────────────────────────────────
-
-export interface ApiError {
-  error: string;
-}
-
-// #120: Paginated sessions list response
-export interface SessionsListResponse {
-  sessions: SessionInfo[];
-  pagination: {
-    page: number;
-    limit: number;
-    total: number;
-    totalPages: number;
-  };
-}
-
-export type SessionStatusCounts = Record<SessionStatusFilter, number>;

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -1,0 +1,247 @@
+/**
+ * api-contracts.ts — Shared API contract types for backend and dashboard.
+ *
+ * Keep this file runtime-free (types only) so both packages can import it
+ * without bundling backend implementation code into the frontend.
+ */
+
+export type UIState =
+  | 'idle'
+  | 'working'
+  | 'compacting'
+  | 'context_warning'
+  | 'waiting_for_input'
+  | 'permission_prompt'
+  | 'plan_mode'
+  | 'ask_question'
+  | 'bash_approval'
+  | 'settings'
+  | 'error'
+  | 'unknown';
+
+export type SessionStatusFilter = 'all' | UIState;
+
+export interface SessionInfo {
+  id: string;
+  windowId: string;
+  windowName: string;
+  workDir: string;
+  claudeSessionId?: string;
+  jsonlPath?: string;
+  byteOffset: number;
+  monitorOffset: number;
+  status: UIState;
+  createdAt: number;
+  lastActivity: number;
+  stallThresholdMs: number;
+  permissionMode: string;
+  autoApprove?: boolean;
+  settingsPatched?: boolean;
+  promptDelivery?: { delivered: boolean; attempts: number };
+  actionHints?: Record<string, {
+    method: string;
+    url: string;
+    description: string;
+  }>;
+}
+
+export interface SessionHealth {
+  alive: boolean;
+  windowExists: boolean;
+  claudeRunning: boolean;
+  paneCommand: string | null;
+  status: UIState;
+  hasTranscript: boolean;
+  lastActivity: number;
+  lastActivityAgo: number;
+  sessionAge: number;
+  details: string;
+  actionHints?: Record<string, {
+    method: string;
+    url: string;
+    description: string;
+  }>;
+}
+
+export interface HealthResponse {
+  status: string;
+  version: string;
+  uptime: number;
+  sessions: {
+    active: number;
+    total: number;
+  };
+  timestamp: string;
+}
+
+export interface ParsedEntry {
+  role: 'user' | 'assistant' | 'system';
+  contentType: 'text' | 'thinking' | 'tool_use' | 'tool_result' | 'tool_error' | 'permission_request' | 'progress';
+  text: string;
+  toolName?: string;
+  toolUseId?: string;
+  timestamp?: string;
+}
+
+export interface MessagesResponse {
+  messages: ParsedEntry[];
+  status: UIState;
+  statusText: string | null;
+  interactiveContent: string | null;
+}
+
+export interface SessionMetrics {
+  durationSec: number;
+  messages: number;
+  toolCalls: number;
+  approvals: number;
+  autoApprovals: number;
+  statusChanges: string[];
+}
+
+export interface LatencySummaryStat {
+  min: number | null;
+  max: number | null;
+  avg: number | null;
+  count: number;
+}
+
+export interface SessionLatency {
+  sessionId: string;
+  realtime: {
+    hook_latency_ms: number | null;
+    state_change_detection_ms: number | null;
+    permission_response_ms: number | null;
+  } | null;
+  aggregated: {
+    hook_latency_ms: LatencySummaryStat;
+    state_change_detection_ms: LatencySummaryStat;
+    permission_response_ms: LatencySummaryStat;
+    channel_delivery_ms: LatencySummaryStat;
+  } | null;
+}
+
+export interface GlobalMetrics {
+  uptime: number;
+  sessions: {
+    total_created: number;
+    currently_active: number;
+    completed: number;
+    failed: number;
+    avg_duration_sec: number;
+    avg_messages_per_session: number;
+  };
+  auto_approvals: number;
+  webhooks_sent: number;
+  webhooks_failed: number;
+  screenshots_taken: number;
+  pipelines_created: number;
+  batches_created: number;
+  prompt_delivery: {
+    sent: number;
+    delivered: number;
+    failed: number;
+    success_rate: number | null;
+  };
+  latency: {
+    hook_latency_ms: LatencySummaryStat;
+    state_change_detection_ms: LatencySummaryStat;
+    permission_response_ms: LatencySummaryStat;
+    channel_delivery_ms: LatencySummaryStat;
+  };
+}
+
+export type SSEEventType =
+  | 'status'
+  | 'message'
+  | 'approval'
+  | 'ended'
+  | 'heartbeat'
+  | 'stall'
+  | 'dead'
+  | 'system'
+  | 'hook'
+  | 'subagent_start'
+  | 'subagent_stop'
+  | 'verification';
+
+export interface SessionSSEEvent {
+  event: SSEEventType;
+  sessionId: string;
+  timestamp: string;
+  emittedAt?: number;
+  data: Record<string, unknown>;
+}
+
+export type GlobalSSEEventType =
+  | 'session_status_change'
+  | 'session_message'
+  | 'session_approval'
+  | 'session_ended'
+  | 'session_created'
+  | 'session_stall'
+  | 'session_dead'
+  | 'session_subagent_start'
+  | 'session_subagent_stop'
+  | 'session_verification';
+
+export interface GlobalSSEEvent {
+  event: GlobalSSEEventType;
+  sessionId: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+export interface CreateSessionRequest {
+  workDir: string;
+  name?: string;
+  prompt?: string;
+  resumeSessionId?: string;
+  claudeCommand?: string;
+  env?: Record<string, string>;
+  stallThresholdMs?: number;
+  permissionMode?: string;
+  autoApprove?: boolean;
+  parentId?: string;
+  memoryKeys?: string[];
+}
+
+export interface PaneResponse {
+  pane: string;
+}
+
+export interface SessionSummary {
+  sessionId: string;
+  windowName: string;
+  status: UIState;
+  totalMessages: number;
+  messages: Array<{ role: string; contentType: string; text: string }>;
+  createdAt: number;
+  lastActivity: number;
+  permissionMode: string;
+}
+
+export interface OkResponse {
+  ok: boolean;
+}
+
+export interface SendResponse extends OkResponse {
+  delivered: boolean;
+  attempts: number;
+}
+
+export interface ApiError {
+  error: string;
+}
+
+export interface SessionsListResponse {
+  sessions: SessionInfo[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export type SessionStatusCounts = Record<SessionStatusFilter, number>;

--- a/src/api-contracts.typecheck.ts
+++ b/src/api-contracts.typecheck.ts
@@ -1,0 +1,37 @@
+import type { SessionInfo as InternalSessionInfo, SessionManager } from './session.js';
+import type { MetricsCollector, SessionLatencySummary } from './metrics.js';
+import type {
+  SessionSSEEvent as InternalSessionSSEEvent,
+  GlobalSSEEvent as InternalGlobalSSEEvent,
+} from './events.js';
+import type {
+  SessionInfo,
+  MessagesResponse,
+  SessionSummary,
+  SessionMetrics,
+  SessionLatency,
+  GlobalMetrics,
+  SessionSSEEvent,
+  GlobalSSEEvent,
+} from './api-contracts.js';
+
+type Assert<T extends true> = T;
+
+export type SessionInfoContractCompat = Assert<InternalSessionInfo extends SessionInfo ? true : false>;
+export type SessionReadMessagesContractCompat = Assert<
+  Awaited<ReturnType<SessionManager['readMessages']>> extends MessagesResponse ? true : false
+>;
+export type SessionSummaryContractCompat = Assert<
+  Awaited<ReturnType<SessionManager['getSummary']>> extends SessionSummary ? true : false
+>;
+export type SessionMetricsContractCompat = Assert<
+  NonNullable<ReturnType<MetricsCollector['getSessionMetrics']>> extends SessionMetrics ? true : false
+>;
+export type SessionLatencySummaryContractCompat = Assert<
+  SessionLatencySummary extends NonNullable<SessionLatency['aggregated']> ? true : false
+>;
+export type GlobalMetricsContractCompat = Assert<
+  ReturnType<MetricsCollector['getGlobalMetrics']> extends GlobalMetrics ? true : false
+>;
+export type SessionSSEContractCompat = Assert<InternalSessionSSEEvent extends SessionSSEEvent ? true : false>;
+export type GlobalSSEContractCompat = Assert<InternalGlobalSSEEvent extends GlobalSSEEvent ? true : false>;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -9,6 +9,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { metricsFileSchema } from './validation.js';
+import type { GlobalMetrics as GlobalMetricsResponse } from './api-contracts.js';
 
 export interface GlobalMetrics {
   sessionsCreated: number;
@@ -246,7 +247,7 @@ export class MetricsCollector {
     this.latency.delete(sessionId);
   }
 
-  getGlobalMetrics(activeSessionCount: number): Record<string, unknown> {
+  getGlobalMetrics(activeSessionCount: number): GlobalMetricsResponse {
     const avgMessages = this.global.sessionsCreated > 0
       ? Math.round(this.global.totalMessages / this.global.sessionsCreated) : 0;
 


### PR DESCRIPTION
## Summary
- add a shared backend-owned API contract module at src/api-contracts.ts
- re-export dashboard API types from the shared contract source instead of manually duplicating contracts
- bind dashboard Zod schemas to shared contract types for compile-time drift detection
- add backend compile-time compatibility assertions in src/api-contracts.typecheck.ts
- include latest SSE contract variants (erification, session_verification) and align related dashboard handling

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #425

## Validation
- [x] Root typecheck: 
px tsc --noEmit
- [x] Root build: 
pm run build
- [x] Dashboard typecheck: 
pm run typecheck (in dashboard/)
- [x] Dashboard build: 
pm run build (in dashboard/)
- [x] Targeted backend tests: 
pm test -- src/__tests__/events.test.ts
- [x] Targeted dashboard tests: 
pm test -- src/__tests__/schemas.test.ts src/__tests__/client.test.ts src/__tests__/ActivityStream.test.ts

## Notes
- Running full root 
pm test in this Windows environment reports existing OS-path expectation failures unrelated to this change (workdir-not-found-458.test.ts).