### PR TITLE
perf: adapt dashboard polling to SSE health

### DIFF
--- a/dashboard/src/__tests__/PipelineDetailPage.test.tsx
+++ b/dashboard/src/__tests__/PipelineDetailPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import PipelineDetailPage from '../pages/PipelineDetailPage';
 import type { PipelineInfo } from '../api/client';
+import { useStore } from '../store/useStore';
 
 const mockGetPipeline = vi.fn();
 
@@ -50,6 +51,7 @@ function renderPage(id = 'pipe-1'): void {
 describe('PipelineDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useStore.setState({ sseConnected: false });
   });
 
   afterEach(() => {
@@ -150,6 +152,44 @@ describe('PipelineDetailPage', () => {
       await vi.runOnlyPendingTimersAsync();
     });
     expect(mockGetPipeline).toHaveBeenCalledTimes(3);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 3_000)).toBe(true);
+  });
+
+  it('backs off polling cadence when SSE is healthy', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    useStore.setState({ sseConnected: true });
+    mockGetPipeline.mockResolvedValue(mockPipeline);
+
+    renderPage();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetPipeline).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 30_000)).toBe(true);
+  });
+
+  it('switches to faster fallback polling when SSE disconnects', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    useStore.setState({ sseConnected: true });
+    mockGetPipeline.mockResolvedValue(mockPipeline);
+
+    renderPage();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 30_000)).toBe(true);
+
+    await act(async () => {
+      useStore.setState({ sseConnected: false });
+      await vi.runAllTicks();
+    });
+
     expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 3_000)).toBe(true);
   });
 });

--- a/dashboard/src/__tests__/PipelinesPage.test.tsx
+++ b/dashboard/src/__tests__/PipelinesPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom';
 import PipelinesPage from '../pages/PipelinesPage';
 import type { PipelineInfo } from '../api/client';
+import { useStore } from '../store/useStore';
 
 const mockGetPipelines = vi.fn();
 
@@ -42,6 +43,7 @@ describe('PipelinesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetPipelines.mockResolvedValue([]);
+    useStore.setState({ sseConnected: false });
   });
 
   afterEach(() => {
@@ -134,6 +136,44 @@ describe('PipelinesPage', () => {
       await vi.runOnlyPendingTimersAsync();
     });
     expect(mockGetPipelines).toHaveBeenCalledTimes(3);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 5_000)).toBe(true);
+  });
+
+  it('backs off polling cadence when SSE is healthy', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    useStore.setState({ sseConnected: true });
+    mockGetPipelines.mockResolvedValue(mockPipelines);
+
+    renderPage();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetPipelines).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 30_000)).toBe(true);
+  });
+
+  it('switches to faster fallback polling when SSE disconnects', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    useStore.setState({ sseConnected: true });
+    mockGetPipelines.mockResolvedValue(mockPipelines);
+
+    renderPage();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 30_000)).toBe(true);
+
+    await act(async () => {
+      useStore.setState({ sseConnected: false });
+      await vi.runAllTicks();
+    });
+
     expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 5_000)).toBe(true);
   });
 });

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -7,12 +7,14 @@ import { useParams, Link } from 'react-router-dom';
 import { getPipeline } from '../api/client';
 import type { PipelineInfo } from '../api/client';
 import type { UIState } from '../types';
+import { useStore } from '../store/useStore';
 import { useToastStore } from '../store/useToastStore';
 import { formatTimeAgo } from '../utils/format';
 import PipelineStatusBadge from '../components/pipeline/PipelineStatusBadge';
 import StatusDot from '../components/overview/StatusDot';
 
 const BASE_POLL_INTERVAL_MS = 3_000;
+const SSE_HEALTHY_POLL_INTERVAL_MS = 30_000;
 const MAX_POLL_INTERVAL_MS = 60_000;
 
 export default function PipelineDetailPage() {
@@ -20,6 +22,7 @@ export default function PipelineDetailPage() {
   const [pipeline, setPipeline] = useState<PipelineInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+  const sseConnected = useStore((s) => s.sseConnected);
   const addToast = useToastStore((t) => t.addToast);
 
   const fetchPipeline = useCallback(async (): Promise<boolean> => {
@@ -51,16 +54,19 @@ export default function PipelineDetailPage() {
       if (cancelled) return;
 
       const isSuccessful = await fetchPipeline();
+      if (cancelled) return;
+
+      const baseDelayMs = sseConnected ? SSE_HEALTHY_POLL_INTERVAL_MS : BASE_POLL_INTERVAL_MS;
+      let nextDelayMs = baseDelayMs;
+
       if (isSuccessful) {
         consecutiveErrors = 0;
       } else {
         consecutiveErrors += 1;
+        const backoffFactor = 2 ** consecutiveErrors;
+        nextDelayMs = Math.min(baseDelayMs * backoffFactor, MAX_POLL_INTERVAL_MS);
       }
 
-      if (cancelled) return;
-
-      const backoffFactor = consecutiveErrors > 0 ? 2 ** consecutiveErrors : 1;
-      const nextDelayMs = Math.min(BASE_POLL_INTERVAL_MS * backoffFactor, MAX_POLL_INTERVAL_MS);
       timeoutId = setTimeout(() => {
         void scheduleNextPoll();
       }, nextDelayMs);
@@ -74,7 +80,7 @@ export default function PipelineDetailPage() {
         clearTimeout(timeoutId);
       }
     };
-  }, [fetchPipeline]);
+  }, [fetchPipeline, sseConnected]);
 
   if (loading) {
     return (

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { Plus } from 'lucide-react';
 import { getPipelines } from '../api/client';
 import type { PipelineInfo } from '../api/client';
+import { useStore } from '../store/useStore';
 import { useToastStore } from '../store/useToastStore';
 import { formatTimeAgo } from '../utils/format';
 import MetricCard from '../components/overview/MetricCard';
@@ -14,12 +15,14 @@ import PipelineStatusBadge from '../components/pipeline/PipelineStatusBadge';
 import CreatePipelineModal from '../components/CreatePipelineModal';
 
 const BASE_POLL_INTERVAL_MS = 5_000;
+const SSE_HEALTHY_POLL_INTERVAL_MS = 30_000;
 const MAX_POLL_INTERVAL_MS = 60_000;
 
 export default function PipelinesPage() {
   const [pipelines, setPipelines] = useState<PipelineInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
+  const sseConnected = useStore((s) => s.sseConnected);
   const addToast = useToastStore((t) => t.addToast);
 
   const fetchPipelines = useCallback(async (): Promise<boolean> => {
@@ -44,16 +47,19 @@ export default function PipelinesPage() {
       if (cancelled) return;
 
       const isSuccessful = await fetchPipelines();
+      if (cancelled) return;
+
+      const baseDelayMs = sseConnected ? SSE_HEALTHY_POLL_INTERVAL_MS : BASE_POLL_INTERVAL_MS;
+      let nextDelayMs = baseDelayMs;
+
       if (isSuccessful) {
         consecutiveErrors = 0;
       } else {
         consecutiveErrors += 1;
+        const backoffFactor = 2 ** consecutiveErrors;
+        nextDelayMs = Math.min(baseDelayMs * backoffFactor, MAX_POLL_INTERVAL_MS);
       }
 
-      if (cancelled) return;
-
-      const backoffFactor = consecutiveErrors > 0 ? 2 ** consecutiveErrors : 1;
-      const nextDelayMs = Math.min(BASE_POLL_INTERVAL_MS * backoffFactor, MAX_POLL_INTERVAL_MS);
       timeoutId = setTimeout(() => {
         void scheduleNextPoll();
       }, nextDelayMs);
@@ -67,7 +73,7 @@ export default function PipelinesPage() {
         clearTimeout(timeoutId);
       }
     };
-  }, [fetchPipelines]);
+  }, [fetchPipelines, sseConnected]);
 
   const counts = {
     total: pipelines.length,


### PR DESCRIPTION
## Summary
- make pipelines polling interval SSE-aware so healthy SSE backs off to a slower cadence
- switch to faster polling when SSE disconnects to preserve fallback freshness
- keep exponential error backoff logic and add tests for healthy/disconnected interval behavior

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #417

## Test plan
- [x] Dashboard targeted tests (
pm test -- src/__tests__/PipelinesPage.test.tsx src/__tests__/PipelineDetailPage.test.tsx)
- [x] Dashboard type-check (
pm run typecheck)
- [x] Dashboard build (
pm run build)
- [x] Dashboard full tests (
pm test)
- [x] Root type-check (
px tsc --noEmit)
- [x] Root build (
pm run build)
- [x] Root tests executed (
pm test) *(fails on existing Windows path/permission expectations unrelated to this change)*
