### PR TITLE
perf: memoize SessionTable rows to reduce rerenders

### DIFF
--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -11,9 +11,10 @@ const mockApprove = vi.fn();
 const mockInterrupt = vi.fn();
 const mockKillSession = vi.fn();
 const mockAddToast = vi.fn();
+const mockStatusDot = vi.fn(({ status }: { status: string }) => <span data-testid={`status-dot-${status}`} />);
 
 vi.mock('../components/overview/StatusDot', () => ({
-  default: ({ status }: { status: string }) => <span data-testid={`status-dot-${status}`} />,
+  default: (props: { status: string }) => mockStatusDot(props),
 }));
 
 vi.mock('../api/client', () => ({
@@ -217,5 +218,50 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     expect(mockKillSession).toHaveBeenCalledWith('s1');
     expect(mockKillSession).toHaveBeenCalledWith('s3');
     expect(globalThis.confirm).toHaveBeenCalled();
+  });
+
+  it('does not rerender unchanged rows on unrelated table state changes', async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('bravo').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('charlie').length).toBeGreaterThan(0);
+    });
+
+    const baselineRenders = mockStatusDot.mock.calls.length;
+
+    // Whitespace-only input keeps the deferred search query as an empty string,
+    // so visible rows should remain unchanged.
+    fireEvent.change(screen.getByLabelText('Search sessions'), {
+      target: { value: '   ' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+    });
+
+    expect(mockStatusDot.mock.calls.length).toBe(baselineRenders);
+  });
+
+  it('rerenders only affected rows when a single session selection changes', async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Select session alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText('Select session bravo').length).toBeGreaterThan(0);
+    });
+
+    const baselineRenders = mockStatusDot.mock.calls.length;
+
+    fireEvent.click(screen.getAllByLabelText('Select session alpha')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 session selected/i)).toBeTruthy();
+    });
+
+    // Alpha appears in both mobile and desktop row trees, so selecting alpha should
+    // rerender exactly those two row instances.
+    expect(mockStatusDot.mock.calls.length - baselineRenders).toBe(2);
   });
 });

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -2,7 +2,7 @@
  * components/overview/SessionTable.tsx — Live session table with filtering, search, and bulk actions.
  */
 
-import { memo, useCallback, useDeferredValue, useEffect, useState } from 'react';
+import { memo, useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import type { MouseEvent } from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -78,6 +78,13 @@ interface SessionsPaginationState {
   limit: number;
   total: number;
   totalPages: number;
+}
+
+interface SessionRowViewModel {
+  session: SessionInfo;
+  isAlive: boolean;
+  selected: boolean;
+  currentAction: string | null;
 }
 
 const needsApproval = (session: SessionInfo): boolean =>
@@ -509,7 +516,21 @@ export default function SessionTable() {
     }
   }, [addToast, fetchSessions, selectedIds]);
 
-  const allVisibleSelected = sessions.length > 0 && sessions.every((session) => selectedIds.includes(session.id));
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const rowViewModels = useMemo<SessionRowViewModel[]>(() => {
+    return sessions.map((session) => {
+      const health = healthMap[session.id];
+      return {
+        session,
+        isAlive: health ? health.alive : true,
+        selected: selectedIdSet.has(session.id),
+        currentAction: actionLoading[session.id] ?? null,
+      };
+    });
+  }, [actionLoading, healthMap, selectedIdSet, sessions]);
+
+  const allVisibleSelected = sessions.length > 0 && sessions.every((session) => selectedIdSet.has(session.id));
   const hasActiveFilters = statusFilter !== 'all' || deferredSearch.length > 0;
 
   if (isLoading && sessions.length === 0) {
@@ -656,17 +677,14 @@ export default function SessionTable() {
               <span>{sessions.length} visible</span>
             </div>
 
-            {sessions.map((session) => {
-              const health = healthMap[session.id];
-              const isAlive = health ? health.alive : true;
-
+            {rowViewModels.map((row) => {
               return (
                 <SessionMobileCard
-                  key={session.id}
-                  session={session}
-                  isAlive={isAlive}
-                  selected={selectedIds.includes(session.id)}
-                  currentAction={actionLoading[session.id] ?? null}
+                  key={row.session.id}
+                  session={row.session}
+                  isAlive={row.isAlive}
+                  selected={row.selected}
+                  currentAction={row.currentAction}
                   onToggleSelect={handleToggleSelect}
                   onApprove={handleApprove}
                   onInterrupt={handleInterrupt}
@@ -699,17 +717,14 @@ export default function SessionTable() {
                 </tr>
               </thead>
               <tbody>
-                {sessions.map((session) => {
-                  const health = healthMap[session.id];
-                  const isAlive = health ? health.alive : true;
-
+                {rowViewModels.map((row) => {
                   return (
                     <SessionDesktopRow
-                      key={session.id}
-                      session={session}
-                      isAlive={isAlive}
-                      selected={selectedIds.includes(session.id)}
-                      currentAction={actionLoading[session.id] ?? null}
+                      key={row.session.id}
+                      session={row.session}
+                      isAlive={row.isAlive}
+                      selected={row.selected}
+                      currentAction={row.currentAction}
                       onToggleSelect={handleToggleSelect}
                       onApprove={handleApprove}
                       onInterrupt={handleInterrupt}


### PR DESCRIPTION
## Summary
Memoize SessionTable row derivation (selected-state/action-state/alive-state) so row props remain stable across unrelated parent updates, reducing unnecessary row rerenders while preserving filtering/search/bulk-action behavior.

Added focused tests to verify:
- Unchanged rows do not rerender on unrelated table state updates
- Only affected row instances rerender when a single selection changes

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #418

## Test plan
- [x] Dashboard tests (cd dashboard && npm test)
- [x] Dashboard typecheck (cd dashboard && npm run typecheck)
- [x] Dashboard build (cd dashboard && npm run build)
- [x] Root type-check (
px tsc --noEmit)
- [x] Root build (
pm run build)
- [x] Root tests executed (
pm test) *(fails on existing Windows/path-permission expectations in unrelated tests)*
