### PR TITLE
fix: clean up dashboard SSE subscriptions on unmount

### DIFF
--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -238,6 +238,43 @@ describe('SSE unmount race condition (#416)', () => {
     expect(capturedSignal?.aborted).toBe(true);
   });
 
+  it('subscribeSSE: repeated async mount/unmount cycles do not leak EventSource listeners', async () => {
+    const pendingFetches: Array<{
+      resolve: (response: Response) => void;
+      signal?: AbortSignal;
+    }> = [];
+
+    fetchMock.mockImplementation((_url: string, opts?: RequestInit) => {
+      return new Promise<Response>((resolve) => {
+        pendingFetches.push({
+          resolve,
+          signal: opts?.signal as AbortSignal | undefined,
+        });
+      });
+    });
+
+    const { subscribeSSE } = await import('../api/client');
+
+    const unsubscribeA = subscribeSSE('session-1', () => {}, BEARER_TOKEN);
+    const unsubscribeB = subscribeSSE('session-1', () => {}, BEARER_TOKEN);
+
+    unsubscribeA();
+    unsubscribeB();
+
+    expect(pendingFetches).toHaveLength(2);
+    expect(pendingFetches[0].signal?.aborted).toBe(true);
+    expect(pendingFetches[1].signal?.aborted).toBe(true);
+
+    pendingFetches[0].resolve(mockSSERequest(SSE_TOKEN));
+    pendingFetches[1].resolve(mockSSERequest(SSE_TOKEN));
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(MockRES).not.toHaveBeenCalled();
+  });
+
   it('subscribeGlobalSSE: cleanup before token fetch resolves prevents ResilientEventSource creation', async () => {
     fetchMock.mockReturnValue(new Promise(() => {}));
 

--- a/dashboard/src/__tests__/useSessionPolling.test.ts
+++ b/dashboard/src/__tests__/useSessionPolling.test.ts
@@ -41,7 +41,7 @@ describe('useSessionPolling', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     capturedHandler = null;
-    unsubscribeFn = vi.fn() as any;
+    unsubscribeFn = vi.fn();
 
     vi.mocked(useStore).mockReturnValue({ token: 'test-token' });
     vi.mocked(useToastStore).mockReturnValue({ addToast: vi.fn() });
@@ -219,5 +219,65 @@ describe('useSessionPolling', () => {
 
     // No additional calls should have been made by the old debounce
     expect(mockedGetSessionPane.mock.calls.length).toBe(callsAfterSwitch);
+  });
+
+  it('cleans up prior SSE subscription when sessionId changes', async () => {
+    const unsubscribeA = vi.fn();
+    const unsubscribeB = vi.fn();
+
+    let subscribeCount = 0;
+    (subscribeSSE as any).mockImplementation(() => {
+      subscribeCount++;
+      return subscribeCount === 1 ? unsubscribeA : unsubscribeB;
+    });
+
+    const { rerender, unmount } = renderHook(
+      ({ id }) => useSessionPolling(id),
+      { initialProps: { id: 'session-a' } },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    rerender({ id: 'session-b' });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(unsubscribeA).toHaveBeenCalledTimes(1);
+    expect(unsubscribeB).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsubscribeB).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leave dangling SSE subscriptions across mount/unmount cycles', async () => {
+    let activeSubscriptions = 0;
+    let maxActiveSubscriptions = 0;
+
+    (subscribeSSE as any).mockImplementation(() => {
+      activeSubscriptions++;
+      maxActiveSubscriptions = Math.max(maxActiveSubscriptions, activeSubscriptions);
+      return () => {
+        activeSubscriptions--;
+      };
+    });
+
+    const first = renderHook(() => useSessionPolling('session-a'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    first.unmount();
+
+    const second = renderHook(() => useSessionPolling('session-a'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    second.unmount();
+
+    expect(activeSubscriptions).toBe(0);
+    expect(maxActiveSubscriptions).toBe(1);
   });
 });

--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -120,6 +120,21 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   }, [addToast]);
   loadPaneAndMetricsRef.current = loadPaneAndMetrics;
 
+  // Debounced refetch timers
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const sessionDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const clearDebounceTimers = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = undefined;
+    }
+    if (sessionDebounceRef.current) {
+      clearTimeout(sessionDebounceRef.current);
+      sessionDebounceRef.current = undefined;
+    }
+  }, []);
+
   // Initial load
   useEffect(() => {
     cancelledRef.current = false;
@@ -134,14 +149,9 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
 
     return () => {
       cancelledRef.current = true;
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      if (sessionDebounceRef.current) clearTimeout(sessionDebounceRef.current);
+      clearDebounceTimers();
     };
-  }, [sessionId, loadSessionAndHealth, loadPaneAndMetrics]);
-
-  // Debounced refetch timers
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const sessionDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  }, [sessionId, loadSessionAndHealth, loadPaneAndMetrics, clearDebounceTimers]);
 
   const schedulePaneAndMetricsRefetch = useCallback(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -164,8 +174,10 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
   // SSE subscription — drives all refetching
   useEffect(() => {
     if (!sessionId) return;
+    let active = true;
 
     const unsubscribe = subscribeSSE(sessionId, (e) => {
+      if (!active) return;
       try {
         const result = SessionSSEEventDataSchema.safeParse(JSON.parse(e.data as string));
         if (!result.success) {
@@ -202,8 +214,12 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
       }
     }, token);
 
-    return () => unsubscribe();
-  }, [sessionId, token, scheduleSessionAndHealthRefetch, schedulePaneAndMetricsRefetch]);
+    return () => {
+      active = false;
+      clearDebounceTimers();
+      unsubscribe();
+    };
+  }, [sessionId, token, scheduleSessionAndHealthRefetch, schedulePaneAndMetricsRefetch, clearDebounceTimers]);
 
   return {
     session,


### PR DESCRIPTION
## Summary
- harden dashboard session SSE effect cleanup in useSessionPolling for unmount and dependency changes
- clear pending debounce timers during SSE teardown to prevent stale callbacks after unmount/rerender
- add regression coverage for repeated async mount/unmount cycles to ensure no dangling EventSource listeners
- add hook-level tests verifying one active subscription at a time and balanced unsubscribe behavior

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #416

## Test plan
- [x] Dashboard typecheck (npm run typecheck)
- [x] Dashboard build (npm run build)
- [x] Dashboard tests (npm test)
- [x] Root typecheck (npx tsc --noEmit)
- [x] Root build (npm run build)
- [x] Root tests executed (npm test -- --reporter=dot) *(fails on existing Windows path/permission expectations in unrelated tests: env-security, path-traversal-workdir-435, permission-guard, workdir-not-found-458)*