### PR TITLE
fix: harden tmux crash recovery against false dead-session cleanup

### DIFF
--- a/src/__tests__/tmux-crash-recovery.test.ts
+++ b/src/__tests__/tmux-crash-recovery.test.ts
@@ -420,12 +420,20 @@ describe('Monitor — tmux health check (Issue #397)', () => {
     };
   }
 
-  function mockTmux(healthy = true) {
+  function mockTmux(healthy = true, error: string | null = null) {
     return {
       isServerHealthy: vi.fn(async () => ({
         healthy,
-        error: healthy ? null : 'no server running',
+        error: healthy ? null : (error ?? 'no server running'),
       })),
+      isTmuxServerError: vi.fn((e: unknown) => {
+        if (!(e instanceof Error)) return false;
+        const msg = e.message.toLowerCase();
+        return msg.includes('no server running')
+          || msg.includes('failed to connect')
+          || msg.includes('connection refused')
+          || msg.includes('no tmux server');
+      }),
     };
   }
 
@@ -518,6 +526,34 @@ describe('Monitor — tmux health check (Issue #397)', () => {
     expect((monitor as any).tmuxWasDown).toBe(true);
     // Should NOT call reconcile while still down
     expect(sessions.reconcileTmuxCrash).not.toHaveBeenCalled();
+  });
+
+  it('does not mark tmux down for non-server health errors', async () => {
+    const sessions = mockSessionManager([makeSession()]);
+    const channels = mockChannelManager();
+    const tmux = mockTmux(false, 'can\'t find window @99');
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+    monitor.setTmuxManager(tmux as any);
+
+    await (monitor as any).checkTmuxHealth();
+
+    expect((monitor as any).tmuxWasDown).toBe(false);
+    expect(sessions.reconcileTmuxCrash).not.toHaveBeenCalled();
+  });
+
+  it('skips dead-session cleanup while tmux is down', async () => {
+    const session = makeSession();
+    const sessions = mockSessionManager([session]);
+    (sessions.isWindowAlive as any).mockResolvedValue(false);
+    const channels = mockChannelManager();
+    const monitor = new SessionMonitor(sessions as any, channels as any);
+
+    (monitor as any).tmuxWasDown = true;
+    await (monitor as any).checkDeadSessions();
+
+    expect(sessions.isWindowAlive).not.toHaveBeenCalled();
+    expect(channels.statusChange).not.toHaveBeenCalled();
+    expect(sessions.killSession).not.toHaveBeenCalled();
   });
 });
 

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -184,6 +184,15 @@ export class SessionMonitor {
 
   private async poll(): Promise<void> {
     const now = Date.now();
+
+    // Issue #397: Run tmux health checks before dead-session reaping.
+    // This prevents false "status.dead" events when tmux is temporarily
+    // unreachable and windows still exist once the server recovers.
+    if (now - this.lastTmuxHealthCheck >= SessionMonitor.TMUX_HEALTH_CHECK_INTERVAL_MS) {
+      this.lastTmuxHealthCheck = now;
+      await this.checkTmuxHealth();
+    }
+
     for (const session of this.sessions.listSessions()) {
       try {
         // Issue #84: Start watching when jsonlPath is discovered
@@ -207,12 +216,6 @@ export class SessionMonitor {
     if (now - this.lastDeadCheck >= this.config.deadCheckIntervalMs) {
       this.lastDeadCheck = now;
       await this.checkDeadSessions();
-    }
-
-    // Issue #397: Tmux server health check (every 10s)
-    if (now - this.lastTmuxHealthCheck >= SessionMonitor.TMUX_HEALTH_CHECK_INTERVAL_MS) {
-      this.lastTmuxHealthCheck = now;
-      await this.checkTmuxHealth();
     }
   }
 
@@ -714,6 +717,10 @@ export class SessionMonitor {
 
   /** Check for dead tmux windows and notify via channels. */
   private async checkDeadSessions(): Promise<void> {
+    // Issue #397: While tmux server is down, defer dead-session cleanup.
+    // tmux commands can fail transiently and make healthy sessions look dead.
+    if (this.tmuxWasDown) return;
+
     const sessions = this.sessions.listSessions();
     for (const session of sessions) {
       if (this.deadNotified.has(session.id)) continue;
@@ -744,14 +751,34 @@ export class SessionMonitor {
   /** Issue #397: Check tmux server health. Detect crashes and trigger reconciliation. */
   private async checkTmuxHealth(): Promise<void> {
     if (!this.tmux) return;
-    const { healthy } = await this.tmux.isServerHealthy();
+    let healthy = true;
+    let error: string | null = null;
+    try {
+      ({ healthy, error } = await this.tmux.isServerHealthy());
+    } catch (e: unknown) {
+      healthy = false;
+      error = e instanceof Error ? e.message : String(e);
+    }
 
     if (!healthy) {
+      // Only treat known server/socket failures as "tmux down".
+      // Other tmux errors can be transient command failures.
+      const serverDown = this.tmux.isTmuxServerError(new Error(error ?? 'tmux unavailable'));
+      if (!serverDown) {
+        logger.warn({
+          component: 'monitor',
+          operation: 'tmux_health_check',
+          errorCode: 'TMUX_HEALTH_CHECK_ERROR',
+          attributes: { error: error ?? 'unknown tmux health error' },
+        });
+        return;
+      }
       if (!this.tmuxWasDown) {
         logger.warn({
           component: 'monitor',
           operation: 'tmux_health_check',
           errorCode: 'TMUX_UNREACHABLE',
+          attributes: { error: error ?? 'tmux server unavailable' },
         });
         this.tmuxWasDown = true;
       }


### PR DESCRIPTION
## Summary
Improve tmux crash recovery so temporary tmux outages do not falsely mark active sessions as dead.

### What changed
- Run tmux server health checks before dead-session reaping in monitor polling.
- Skip dead-session cleanup while tmux is known unavailable to avoid orphaning live sessions.
- Classify tmux health failures: only server/socket errors transition monitor into down/recovery mode.
- Add tests for non-server health errors and dead-check suppression while tmux is down.

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #397

## Validation
- [x] Focused tests: 
pm test -- src/__tests__/tmux-crash-recovery.test.ts src/__tests__/dead-session.test.ts
- [x] Type-check: 
px tsc --noEmit
- [x] Build: 
pm run build
- [ ] Full suite: 
pm test *(fails in this worktree; focused crash-recovery coverage passed)*
