### PR TITLE
refactor: consolidate tmux discovery polling per session

### DIFF
--- a/src/__tests__/memory-leak-405.test.ts
+++ b/src/__tests__/memory-leak-405.test.ts
@@ -2,7 +2,7 @@
  * memory-leak-405.test.ts — Tests for Issue #405: session kill must clear all tracking maps.
  *
  * Covers:
- * - cleanupSession clears pollTimers (regular + fs- prefixed keys)
+ * - cleanupSession clears pollTimers (single coordinated key)
  * - cleanupSession clears pendingPermissions (with timer cleanup)
  * - cleanupSession clears pendingQuestions (with timer cleanup)
  * - cleanupSession clears parsedEntriesCache
@@ -27,7 +27,6 @@ function createManagerWithSession(sessionId: string) {
 
   // Populate maps for the given session
   pollTimers.set(sessionId, setTimeout(() => {}, 60_000));
-  pollTimers.set(`fs-${sessionId}`, setTimeout(() => {}, 60_000));
   pendingPermissions.set(sessionId, {
     resolve: () => {},
     timer: setTimeout(() => {}, 60_000),
@@ -60,13 +59,11 @@ function createManagerWithSession(sessionId: string) {
   };
 
   const cleanupSession = (id: string): void => {
-    for (const key of [id, `fs-${id}`]) {
-      const timer = pollTimers.get(key);
-      if (timer) {
-        clearInterval(timer);
-        clearedTimers.push(key);
-        pollTimers.delete(key);
-      }
+    const timer = pollTimers.get(id);
+    if (timer) {
+      clearInterval(timer);
+      clearedTimers.push(id);
+      pollTimers.delete(id);
     }
     cleanupPendingPermission(id);
     cleanupPendingQuestion(id);
@@ -97,27 +94,17 @@ describe('cleanupSession clears pollTimers', () => {
     expect(mgr.pollTimers.has('sess-1')).toBe(false);
   });
 
-  it('clears the fs-prefixed timer key', () => {
-    const mgr = createManagerWithSession('sess-1');
-    expect(mgr.pollTimers.has('fs-sess-1')).toBe(true);
-
-    mgr.cleanupSession('sess-1');
-
-    expect(mgr.pollTimers.has('fs-sess-1')).toBe(false);
-  });
-
-  it('calls clearInterval for both timer variants', () => {
+  it('calls clearInterval for the coordinated timer', () => {
     const mgr = createManagerWithSession('sess-1');
 
     mgr.cleanupSession('sess-1');
 
-    expect(mgr.clearedTimers).toEqual(['sess-1', 'fs-sess-1']);
+    expect(mgr.clearedTimers).toEqual(['sess-1']);
   });
 
   it('does not throw when timer keys do not exist', () => {
     const mgr = createManagerWithSession('sess-1');
     mgr.pollTimers.delete('sess-1');
-    mgr.pollTimers.delete('fs-sess-1');
 
     expect(() => mgr.cleanupSession('sess-1')).not.toThrow();
     expect(mgr.clearedTimers).toEqual([]);
@@ -246,7 +233,6 @@ describe('cleanupSession only affects the target session', () => {
 
     // sess-1 should be fully cleaned
     expect(mgr.pollTimers.has('sess-1')).toBe(false);
-    expect(mgr.pollTimers.has('fs-sess-1')).toBe(false);
     expect(mgr.pendingPermissions.has('sess-1')).toBe(false);
     expect(mgr.pendingQuestions.has('sess-1')).toBe(false);
     expect(mgr.parsedEntriesCache.has('sess-1')).toBe(false);
@@ -266,7 +252,6 @@ describe('session churn does not leak maps', () => {
     for (let i = 0; i < 100; i++) {
       const id = `sess-${i}`;
       mgr.pollTimers.set(id, setTimeout(() => {}, 60_000));
-      mgr.pollTimers.set(`fs-${id}`, setTimeout(() => {}, 60_000));
       mgr.pendingPermissions.set(id, {
         resolve: () => {},
         timer: setTimeout(() => {}, 60_000),

--- a/src/__tests__/timer-tracking-834-835.test.ts
+++ b/src/__tests__/timer-tracking-834-835.test.ts
@@ -88,13 +88,8 @@ describe('#834: emitEnded setTimeout tracking', () => {
 // ── #835: Discovery timeout timer logic ───────────────────────────────
 
 describe('#835: Discovery timeout cleanup logic', () => {
-  it('cleanupSession should clear both poll timer and discovery timeout for regular discovery', () => {
-    // Simulate the logic: when cleanupSession is called with a session ID,
-    // it should clear both the interval (pollTimers) and the timeout (discoveryTimeouts)
-    // for both `id` and `fs-${id}` keys.
-
-    // We test the pattern: cleanupSession iterates [id, `fs-${id}`]
-    // and clears both pollTimers and discoveryTimeouts maps.
+  it('cleanupSession clears coordinated poll timer + discovery timeout', () => {
+    // Simulate cleanupSession with a single coordinated timer per session.
     const pollTimers = new Map<string, NodeJS.Timeout>();
     const discoveryTimeouts = new Map<string, NodeJS.Timeout>();
 
@@ -107,19 +102,15 @@ describe('#835: Discovery timeout cleanup logic', () => {
     discoveryTimeouts.set('sess-1', timeout);
 
     // Simulate cleanupSession logic
-    for (const key of ['sess-1', 'fs-sess-1']) {
-      const t = pollTimers.get(key);
-      if (t) {
-        clearInterval(t);
-        pollTimers.delete(key);
-      }
+    const intervalToClear = pollTimers.get('sess-1');
+    if (intervalToClear) {
+      clearInterval(intervalToClear);
+      pollTimers.delete('sess-1');
     }
-    for (const key of ['sess-1', 'fs-sess-1']) {
-      const t = discoveryTimeouts.get(key);
-      if (t) {
-        clearTimeout(t);
-        discoveryTimeouts.delete(key);
-      }
+    const timeoutToClear = discoveryTimeouts.get('sess-1');
+    if (timeoutToClear) {
+      clearTimeout(timeoutToClear);
+      discoveryTimeouts.delete('sess-1');
     }
 
     expect(pollTimers.has('sess-1')).toBe(false);
@@ -127,42 +118,6 @@ describe('#835: Discovery timeout cleanup logic', () => {
 
     // Advance past the timeout — callback should NOT fire
     // (cleared above, so this is safe)
-    vi.advanceTimersByTime(6 * 60 * 1000);
-
-    vi.useRealTimers();
-  });
-
-  it('cleanupSession should clear filesystem discovery timers', () => {
-    const pollTimers = new Map<string, NodeJS.Timeout>();
-    const discoveryTimeouts = new Map<string, NodeJS.Timeout>();
-
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-
-    // Simulate startFilesystemDiscovery: creates interval + timeout with fs- prefix
-    const interval = setInterval(() => {}, 3000);
-    const timeout = setTimeout(() => {}, 5 * 60 * 1000);
-    pollTimers.set('fs-sess-2', interval);
-    discoveryTimeouts.set('fs-sess-2', timeout);
-
-    // Simulate cleanupSession logic for id=sess-2
-    for (const key of ['sess-2', 'fs-sess-2']) {
-      const t = pollTimers.get(key);
-      if (t) {
-        clearInterval(t);
-        pollTimers.delete(key);
-      }
-    }
-    for (const key of ['sess-2', 'fs-sess-2']) {
-      const t = discoveryTimeouts.get(key);
-      if (t) {
-        clearTimeout(t);
-        discoveryTimeouts.delete(key);
-      }
-    }
-
-    expect(pollTimers.has('fs-sess-2')).toBe(false);
-    expect(discoveryTimeouts.has('fs-sess-2')).toBe(false);
-
     vi.advanceTimersByTime(6 * 60 * 1000);
 
     vi.useRealTimers();

--- a/src/__tests__/tmux-polling-395.test.ts
+++ b/src/__tests__/tmux-polling-395.test.ts
@@ -1,0 +1,128 @@
+/**
+ * tmux-polling-395.test.ts — Tests for Issue #395.
+ *
+ * Validates that session discovery uses a single coordinated poller per session,
+ * and that discovery still updates session mapping data correctly.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionManager, type SessionInfo } from '../session.js';
+import type { TmuxManager } from '../tmux.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+
+function flushAsync(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+function makeSession(overrides: Partial<SessionInfo>): SessionInfo {
+  return {
+    id: overrides.id ?? 'sess-1',
+    windowId: overrides.windowId ?? '@1',
+    windowName: overrides.windowName ?? 'cc-sess-1',
+    workDir: overrides.workDir ?? '/tmp/work-395',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'unknown',
+    createdAt: overrides.createdAt ?? Date.now(),
+    lastActivity: overrides.lastActivity ?? Date.now(),
+    stallThresholdMs: 120_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    claudeSessionId: overrides.claudeSessionId,
+    jsonlPath: overrides.jsonlPath,
+  };
+}
+
+describe('Issue #395: consolidated tmux discovery polling', () => {
+  let rootTmpDir: string;
+
+  beforeEach(() => {
+    rootTmpDir = mkdtempSync(join(tmpdir(), 'aegis-395-'));
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(rootTmpDir, { recursive: true, force: true });
+  });
+
+  it('keeps only one active discovery poller per session', () => {
+    const stateDir = join(rootTmpDir, 'state');
+    const claudeProjectsDir = join(rootTmpDir, 'projects');
+    const tmux = {} as TmuxManager;
+
+    const sm = new SessionManager(tmux, {
+      stateDir,
+      claudeProjectsDir,
+      continuationPointerTtlMs: 60_000,
+      worktreeAwareContinuation: false,
+      worktreeSiblingDirs: [],
+    } as any);
+
+    (sm as any).state = {
+      sessions: {
+        'sess-1': makeSession({ id: 'sess-1', createdAt: Date.now() - 1_000 }),
+      },
+    };
+
+    (sm as any).startDiscoveryPolling('sess-1', '/tmp/work-395');
+    expect((sm as any).pollTimers.size).toBe(1);
+    expect((sm as any).pollTimers.has('sess-1')).toBe(true);
+
+    // Starting again should replace, not duplicate.
+    (sm as any).startDiscoveryPolling('sess-1', '/tmp/work-395');
+    expect((sm as any).pollTimers.size).toBe(1);
+    expect((sm as any).pollTimers.has('sess-1')).toBe(true);
+    expect((sm as any).discoveryTimeouts.size).toBe(1);
+
+    (sm as any).cleanupSession('sess-1');
+    expect((sm as any).pollTimers.size).toBe(0);
+    expect((sm as any).discoveryTimeouts.size).toBe(0);
+    expect((sm as any).discoveryNextFilesystemScanAt.size).toBe(0);
+  });
+
+  it('still updates claudeSessionId/jsonlPath through coordinated poller', async () => {
+    const stateDir = join(rootTmpDir, 'state');
+    const claudeProjectsDir = join(rootTmpDir, 'projects');
+    const tmux = {} as TmuxManager;
+
+    const sm = new SessionManager(tmux, {
+      stateDir,
+      claudeProjectsDir,
+      continuationPointerTtlMs: 60_000,
+      worktreeAwareContinuation: false,
+      worktreeSiblingDirs: [],
+    } as any);
+
+    const workDir = '/tmp/work-395';
+    const projectHash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
+    const projectDir = join(claudeProjectsDir, projectHash);
+    mkdirSync(projectDir, { recursive: true });
+
+    const claudeSessionId = '11111111-2222-3333-4444-555555555555';
+    const jsonlPath = join(projectDir, `${claudeSessionId}.jsonl`);
+    writeFileSync(jsonlPath, '{"type":"user","message":{"role":"user","content":"hi"}}\n');
+
+    const session = makeSession({
+      id: 'sess-2',
+      windowId: '@2',
+      windowName: 'cc-sess-2',
+      workDir,
+      createdAt: Date.now() - 2_000,
+    });
+
+    (sm as any).state = { sessions: { 'sess-2': session } };
+
+    (sm as any).startDiscoveryPolling('sess-2', workDir);
+
+    vi.advanceTimersByTime(2_100);
+    await flushAsync();
+    await flushAsync();
+
+    expect(session.claudeSessionId).toBe(claudeSessionId);
+    expect(session.jsonlPath).toBe(jsonlPath);
+    expect((sm as any).pollTimers.has('sess-2')).toBe(false);
+  });
+});

--- a/src/session.ts
+++ b/src/session.ts
@@ -103,6 +103,8 @@ export class SessionManager {
   private stateFile: string;
   private sessionMapFile: string;
   private pollTimers: Map<string, NodeJS.Timeout> = new Map();
+  /** Next filesystem-scan time (ms epoch) for each discovery poller. */
+  private discoveryNextFilesystemScanAt: Map<string, number> = new Map();
   /** #835: Discovery timeout timers — cleared in cleanupSession to prevent orphan callbacks. */
   private discoveryTimeouts: Map<string, NodeJS.Timeout> = new Map();
   private saveQueue: Promise<void> = Promise.resolve(); // #218: serialize concurrent saves
@@ -255,14 +257,14 @@ export class SessionManager {
         console.log(`Reconcile: session ${session.windowName} re-attached: ${oldWindowId} → ${win.windowId}`);
         // Restart discovery if needed
         if (!session.claudeSessionId || !session.jsonlPath) {
-          this.startSessionIdDiscovery(id);
+          this.startDiscoveryPolling(id, session.workDir);
         }
         changed = true;
       } else {
         // Session is alive — restart discovery if needed
         if (!session.claudeSessionId || !session.jsonlPath) {
           console.log(`Reconcile: session ${session.windowName} — restarting JSONL discovery`);
-          this.startSessionIdDiscovery(id);
+          this.startDiscoveryPolling(id, session.workDir);
         } else {
           console.log(`Reconcile: session ${session.windowName} — alive, JSONL ready`);
         }
@@ -300,8 +302,7 @@ export class SessionManager {
       this.state.sessions[id] = session;
       this.invalidateSessionsListCache();
       console.log(`Reconcile: adopted orphaned window ${win.windowName} (${win.windowId}) as ${id.slice(0, 8)}`);
-      this.startSessionIdDiscovery(id);
-      this.startFilesystemDiscovery(id, session.workDir);
+      this.startDiscoveryPolling(id, session.workDir);
       changed = true;
     }
 
@@ -343,8 +344,7 @@ export class SessionManager {
         console.log(`Reconcile (crash): session ${session.windowName} re-attached: ${oldWindowId} → ${win.windowId}`);
         // Restart discovery in case the session state is stale
         if (!session.claudeSessionId || !session.jsonlPath) {
-          this.startSessionIdDiscovery(id);
-          this.startFilesystemDiscovery(id, session.workDir);
+          this.startDiscoveryPolling(id, session.workDir);
         }
         recovered++;
         changed = true;
@@ -682,24 +682,17 @@ export class SessionManager {
       }
     }).catch(e => console.error(`Session: failed to list pane PID for ${id}:`, e));
 
-    // Start BOTH discovery methods in parallel:
-    // 1. Hook-based: fast, relies on SessionStart hook writing session_map.json
-    // 2. Filesystem-based: slower, scans for new .jsonl files — works when hooks fail
-    // Issue #16: --bare flag skips hooks entirely
+    // Start coordinated discovery polling:
+    // - Hook/session_map sync: fast path
+    // - Filesystem scan fallback: works when hooks fail or are skipped (Issue #16)
     // Field bug (Zeus 2026-03-22): hooks may not fire even without --bare
-    //
-    // If we already have the claudeSessionId (from --session-id), filesystem discovery
-    // will just find the JSONL path. Hook discovery may still run but won't override.
-    this.startFilesystemDiscovery(id, opts.workDir);
+    this.startDiscoveryPolling(id, opts.workDir);
 
     // P0 fix: Clean stale entries from session_map.json for BOTH window name AND id.
     // After archiving old .jsonl files, stale session_map entries would point
     // to moved files, causing discovery to pick up ghost session IDs.
     // Also cleans stale windowId entries that could collide after restart.
     await this.cleanSessionMapForWindow(finalName, windowId);
-
-    // Start watching for the CC session ID via hook
-    this.startSessionIdDiscovery(id);
 
     return session;
   }
@@ -1482,23 +1475,7 @@ export class SessionManager {
 
   /** #405: Clean up all tracking maps for a session to prevent memory leaks. */
   private cleanupSession(id: string): void {
-    // Clear polling timers (both regular and filesystem discovery variants)
-    for (const key of [id, `fs-${id}`]) {
-      const timer = this.pollTimers.get(key);
-      if (timer) {
-        clearInterval(timer);
-        this.pollTimers.delete(key);
-      }
-    }
-
-    // #835: Clear discovery timeout timers to prevent orphan callbacks
-    for (const key of [id, `fs-${id}`]) {
-      const timeout = this.discoveryTimeouts.get(key);
-      if (timeout) {
-        clearTimeout(timeout);
-        this.discoveryTimeouts.delete(key);
-      }
-    }
+    this.stopDiscoveryPolling(id);
 
     this.cleanupPendingPermission(id);
     this.cleanupPendingQuestion(id);
@@ -1613,27 +1590,83 @@ export class SessionManager {
     } catch { /* ignore parse/write errors */ }
   }
 
-  /** Try to discover the CC session ID and JSONL path. */
-  private startSessionIdDiscovery(id: string): void {
+  /** Stop and remove the coordinated discovery poller/timer for a session. */
+  private stopDiscoveryPolling(id: string): void {
+    const timer = this.pollTimers.get(id);
+    if (timer) {
+      clearInterval(timer);
+      this.pollTimers.delete(id);
+    }
+
+    const timeout = this.discoveryTimeouts.get(id);
+    if (timeout) {
+      clearTimeout(timeout);
+      this.discoveryTimeouts.delete(id);
+    }
+
+    this.discoveryNextFilesystemScanAt.delete(id);
+  }
+
+  /** Attempt filesystem-based discovery for a single session poll tick. */
+  private async maybeDiscoverFromFilesystem(session: SessionInfo, workDir: string): Promise<boolean> {
+    const projectHash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
+    const projectDir = join(this.config.claudeProjectsDir, projectHash);
+    if (!existsSync(projectDir)) return false;
+
+    const files = await readdir(projectDir);
+    const jsonlFiles = files.filter(f =>
+      f.endsWith('.jsonl') && !f.startsWith('.'),
+    );
+
+    for (const file of jsonlFiles) {
+      const filePath = join(projectDir, file);
+      const fileStat = await stat(filePath);
+
+      // Only consider files created after the session.
+      if (fileStat.mtimeMs < session.createdAt) continue;
+
+      // Extract session ID from filename (filename = sessionId.jsonl).
+      const sessionId = file.replace('.jsonl', '');
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(sessionId)) continue;
+
+      session.claudeSessionId = sessionId;
+      session.jsonlPath = filePath;
+      session.byteOffset = 0;
+      console.log(`Discovery (filesystem): session ${session.windowName} mapped to ${sessionId.slice(0, 8)}...`);
+      await this.save();
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Coordinated discovery poller for a session.
+   *
+   * Consolidates hook/session_map sync and filesystem fallback into a single
+   * interval loop per session, reducing duplicate independent pollers.
+   */
+  private startDiscoveryPolling(id: string, workDir: string): void {
+    // If a poller already exists, replace it to ensure only one active poller/session.
+    this.stopDiscoveryPolling(id);
+
     const interval = setInterval(async () => {
       const session = this.state.sessions[id];
       if (!session) {
-        clearInterval(interval);
-        this.pollTimers.delete(id);
+        this.stopDiscoveryPolling(id);
         return;
       }
 
-      // Stop when we have both session ID and JSONL path
+      // Stop when we have both session ID and JSONL path.
       if (session.claudeSessionId && session.jsonlPath) {
-        clearInterval(interval);
-        this.pollTimers.delete(id);
+        this.stopDiscoveryPolling(id);
         return;
       }
 
       try {
         await this.syncSessionMap();
-        
-        // If we have claudeSessionId but no jsonlPath, try finding it (Issue #884: worktree-aware)
+
+        // If we have claudeSessionId but no jsonlPath, try finding it (Issue #884: worktree-aware).
         if (session.claudeSessionId && !session.jsonlPath) {
           const jsonlPath = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
           if (jsonlPath) {
@@ -1642,92 +1675,36 @@ export class SessionManager {
             await this.save();
           }
         }
-      } catch { /* ignore */ }
-    }, 2000);
+
+        // Filesystem fallback scan cadence (originally every 3s).
+        const now = Date.now();
+        const nextFsScanAt = this.discoveryNextFilesystemScanAt.get(id) ?? 0;
+        if (now >= nextFsScanAt && (!session.claudeSessionId || !session.jsonlPath)) {
+          this.discoveryNextFilesystemScanAt.set(id, now + 3_000);
+          await this.maybeDiscoverFromFilesystem(session, workDir);
+        }
+
+        if (session.claudeSessionId && session.jsonlPath) {
+          this.stopDiscoveryPolling(id);
+        }
+      } catch {
+        // best-effort polling; ignore transient errors
+      }
+    }, 2_000);
 
     this.pollTimers.set(id, interval);
+    this.discoveryNextFilesystemScanAt.set(id, Date.now());
 
-    // P3 fix: Stop after 5 minutes if not found, log timeout
-    // #835: Track the timeout so cleanupSession can cancel it
+    // P3 fix: Stop after 5 minutes if not found, log timeout.
+    // #835: Track the timeout so cleanupSession can cancel it.
     const discoveryTimeout = setTimeout(() => {
-      this.discoveryTimeouts.delete(id);
-      const timer = this.pollTimers.get(id);
       const session = this.state.sessions[id];
-      if (timer) {
-        clearInterval(timer);
-        this.pollTimers.delete(id);
-        // P3 fix: Log when discovery times out
-        if (session && !session.claudeSessionId) {
-          console.log(`Discovery: session ${session.windowName} — timed out after 5min, no session_id found`);
-        }
+      this.stopDiscoveryPolling(id);
+      if (session && !session.claudeSessionId) {
+        console.log(`Discovery: session ${session.windowName} — timed out after 5min, no session_id found`);
       }
     }, 5 * 60 * 1000);
     this.discoveryTimeouts.set(id, discoveryTimeout);
-  }
-
-  /** Issue #16: Filesystem-based discovery for --bare mode (no hooks).
-   *  Scans the Claude projects directory for new .jsonl files created after the session.
-   */
-  private startFilesystemDiscovery(id: string, workDir: string): void {
-    const projectHash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
-    const projectDir = join(this.config.claudeProjectsDir, projectHash);
-
-    const interval = setInterval(async () => {
-      const session = this.state.sessions[id];
-      if (!session) {
-        clearInterval(interval);
-        this.pollTimers.delete(`fs-${id}`);
-        return;
-      }
-
-      if (session.claudeSessionId && session.jsonlPath) {
-        clearInterval(interval);
-        this.pollTimers.delete(`fs-${id}`);
-        return;
-      }
-
-      try {
-        if (!existsSync(projectDir)) return;
-        const { readdir } = await import('node:fs/promises');
-        const files = await readdir(projectDir);
-        const jsonlFiles = files.filter(f =>
-          f.endsWith('.jsonl') && !f.startsWith('.')
-        );
-
-        for (const file of jsonlFiles) {
-          const filePath = join(projectDir, file);
-          const fileStat = await stat(filePath);
-
-          // Only consider files created after the session
-          if (fileStat.mtimeMs < session.createdAt) continue;
-
-          // Extract session ID from filename (filename = sessionId.jsonl)
-          const sessionId = file.replace('.jsonl', '');
-          if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(sessionId)) continue;
-
-          session.claudeSessionId = sessionId;
-          session.jsonlPath = filePath;
-          session.byteOffset = 0;
-          console.log(`Discovery (filesystem): session ${session.windowName} mapped to ${sessionId.slice(0, 8)}...`);
-          await this.save();
-          break;
-        }
-      } catch { /* ignore */ }
-    }, 3000);
-
-    this.pollTimers.set(`fs-${id}`, interval);
-
-    // Timeout after 5 minutes
-    // #835: Track the timeout so cleanupSession can cancel it
-    const fsDiscoveryTimeout = setTimeout(() => {
-      this.discoveryTimeouts.delete(`fs-${id}`);
-      const timer = this.pollTimers.get(`fs-${id}`);
-      if (timer) {
-        clearInterval(timer);
-        this.pollTimers.delete(`fs-${id}`);
-      }
-    }, 5 * 60 * 1000);
-    this.discoveryTimeouts.set(`fs-${id}`, fsDiscoveryTimeout);
   }
 
   /** Sync CC session IDs from the hook-written session_map.json. */


### PR DESCRIPTION
## Summary
Consolidate session discovery from two independent per-session loops (session_map and filesystem fallback) into one coordinated poller.

- Replaced dual timers (id + s-id) with a single discovery timer per session.
- Kept hook/session_map sync and filesystem fallback behavior in the same poll tick.
- Preserved discovery timeout behavior and cleanup semantics.
- Added tests to assert single poller operation and successful session data updates.

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #395

## Test plan
- [x] Targeted tests: 
pm test -- src/__tests__/tmux-polling-395.test.ts src/__tests__/memory-leak-405.test.ts src/__tests__/timer-tracking-834-835.test.ts
- [x] Type-check: 
px tsc --noEmit
- [x] Build: 
pm run build
- [x] Full test run executed: 
pm test -- --reporter=dot *(fails on existing unrelated tests in this workspace state)*
