### PR TITLE
fix: add pane-exit crash detection for tmux sessions

### DIFF
--- a/src/__tests__/pane-exit-detection-390.test.ts
+++ b/src/__tests__/pane-exit-detection-390.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SessionManager, type SessionInfo } from '../session.js';
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 's-1',
+    windowId: '@1',
+    windowName: 'cc-test',
+    workDir: '/tmp/test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'working',
+    createdAt: Date.now() - 60_000,
+    lastActivity: Date.now() - 10_000,
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+function makeConfig() {
+  return {
+    stateDir: '/tmp/aegis-test',
+    host: '127.0.0.1',
+    port: 9100,
+    tmuxSession: 'aegis',
+    claudeProjectsDir: '/tmp/.claude/projects',
+    maxSessionAgeMs: 7200000,
+    reaperIntervalMs: 60000,
+    defaultPermissionMode: 'default',
+    defaultSessionEnv: {},
+    allowedWorkDirs: [],
+    sseMaxConnections: 50,
+    sseMaxPerIp: 5,
+    worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+  } as any;
+}
+
+function makeTmux() {
+  return {
+    listWindows: vi.fn(async () => []),
+    windowExists: vi.fn(async () => true),
+    listPanePid: vi.fn(async () => 1234),
+    isPidAlive: vi.fn(() => true),
+    getWindowHealth: vi.fn(async () => ({
+      windowExists: true,
+      paneCommand: 'claude',
+      claudeRunning: true,
+      paneDead: false,
+    })),
+    capturePane: vi.fn(async () => ''),
+  } as any;
+}
+
+describe('Issue #390 pane-exit detection', () => {
+  it('treats pane_dead as immediate dead signal in isWindowAlive', async () => {
+    const tmux = makeTmux();
+    tmux.getWindowHealth.mockResolvedValue({
+      windowExists: true,
+      paneCommand: 'bash',
+      claudeRunning: false,
+      paneDead: true,
+    });
+
+    const manager = new SessionManager(tmux, makeConfig());
+    (manager as any).state.sessions = { 's-1': makeSession({ id: 's-1' }) };
+
+    const alive = await manager.isWindowAlive('s-1');
+
+    expect(alive).toBe(false);
+    expect(tmux.listPanePid).not.toHaveBeenCalled();
+  });
+
+  it('does not produce false positives during normal idle periods', async () => {
+    const tmux = makeTmux();
+    tmux.getWindowHealth.mockResolvedValue({
+      windowExists: true,
+      paneCommand: 'claude',
+      claudeRunning: true,
+      paneDead: false,
+    });
+
+    const manager = new SessionManager(tmux, makeConfig());
+    (manager as any).state.sessions = { 's-2': makeSession({ id: 's-2', status: 'idle' }) };
+
+    const alive = await manager.isWindowAlive('s-2');
+
+    expect(alive).toBe(true);
+  });
+
+  it('surfaces pane exit in session health details', async () => {
+    const tmux = makeTmux();
+    tmux.getWindowHealth.mockResolvedValue({
+      windowExists: true,
+      paneCommand: 'bash',
+      claudeRunning: false,
+      paneDead: true,
+    });
+
+    const manager = new SessionManager(tmux, makeConfig());
+    (manager as any).state.sessions = { 's-3': makeSession({ id: 's-3' }) };
+
+    const health = await manager.getHealth('s-3');
+
+    expect(health.alive).toBe(false);
+    expect(health.details).toContain('pane has exited');
+  });
+});

--- a/src/__tests__/stall-detection.test.ts
+++ b/src/__tests__/stall-detection.test.ts
@@ -341,6 +341,18 @@ describe('SessionMonitor stall detection (integration)', () => {
       expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
     });
 
+    it('should not emit stall notifications during normal idle periods', async () => {
+      const now = Date.now();
+      const session = addSession({ monitorOffset: 500, status: 'idle' });
+      setLastStatus(session.id, 'idle');
+      setLastBytesSeen(session.id, 500, now - 10 * 60 * 1000);
+
+      await checkStalls(now);
+
+      expect(deps.mockChannels.statusChange).not.toHaveBeenCalled();
+      expect((monitor as any).stallHas(session.id, 'jsonl')).toBe(false);
+    });
+
     it('should use per-session stallThresholdMs override', async () => {
       const now = Date.now();
       const session = addSession({ monitorOffset: 500, stallThresholdMs: 10 * 60 * 1000 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -864,7 +864,11 @@ export class SessionManager {
       // Issue #390: Fast crash detection via stored CC PID
       if (session.ccPid && !this.tmux.isPidAlive(session.ccPid)) return false;
 
-      if (!(await this.tmux.windowExists(session.windowId))) return false;
+      const windowHealth = await this.tmux.getWindowHealth(session.windowId);
+      if (!windowHealth.windowExists) return false;
+      // Pane exit is a direct crash signal when remain-on-exit keeps dead panes visible.
+      if (windowHealth.paneDead) return false;
+
       // Verify the process inside the pane is still alive
       const panePid = await this.tmux.listPanePid(session.windowId);
       if (panePid !== null && !this.tmux.isPidAlive(panePid)) return false;
@@ -949,14 +953,19 @@ export class SessionManager {
     let status: UIState = 'unknown';
     // Issue #69: Also check if the pane PID is alive (zombie window detection)
     let processAlive = true;
+    const paneExited = !!windowHealth.paneDead;
     if (windowHealth.windowExists) {
-      try {
-        const panePid = await this.tmux.listPanePid(session.windowId);
-        if (panePid !== null) {
-          processAlive = this.tmux.isPidAlive(panePid);
-        }
-      } catch { /* cannot list pane PID — assume dead */
+      if (paneExited) {
         processAlive = false;
+      } else {
+        try {
+          const panePid = await this.tmux.listPanePid(session.windowId);
+          if (panePid !== null) {
+            processAlive = this.tmux.isPidAlive(panePid);
+          }
+        } catch { /* cannot list pane PID — assume dead */
+          processAlive = false;
+        }
       }
     }
 
@@ -983,6 +992,8 @@ export class SessionManager {
     let details: string;
     if (!windowHealth.windowExists) {
       details = 'Tmux window does not exist — session is dead';
+    } else if (paneExited) {
+      details = 'Tmux pane has exited — session is dead';
     } else if (!processAlive) {
       details = 'Tmux window exists but pane process is dead — session is dead (zombie window)';
     } else if (!windowHealth.claudeRunning && !recentlyActive) {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -39,8 +39,21 @@ export interface TmuxWindow {
   windowName: string;
   cwd: string;
   paneCommand: string;   // current process in active pane
+  paneDead?: boolean;    // true when pane has exited (requires remain-on-exit)
 }
 
+const WINDOW_LIST_FORMAT = '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{pane_current_command}\t#{pane_dead}';
+
+function parseWindowListLine(line: string): TmuxWindow {
+  const [windowId, windowName, cwd, paneCommand, paneDeadRaw] = line.split('\t');
+  return {
+    windowId,
+    windowName,
+    cwd,
+    paneCommand,
+    paneDead: paneDeadRaw === '1',
+  };
+}
 export class TmuxManager {
   /** tmux socket name (-L flag). Isolates sessions from other tmux instances. */
   readonly socketName: string;
@@ -110,12 +123,10 @@ export class TmuxManager {
   private async resolveAvailableWindowName(baseName: string): Promise<string> {
     const rawWindows = await this.tmuxInternal(
       'list-windows', '-t', this.sessionName,
-      '-F', '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{pane_current_command}'
+      '-F', WINDOW_LIST_FORMAT,
     );
-    const existing = (rawWindows ?? '').split('\n').filter(Boolean).map(line => {
-      const [windowId, windowName, cwd, paneCommand] = line.split('\t');
-      return { windowId, windowName, cwd, paneCommand };
-    }).filter((w: { windowName: string }) => w.windowName !== '_bridge_main');
+    const existing = (rawWindows ?? '').split('\n').filter(Boolean).map(parseWindowListLine)
+      .filter((w: { windowName: string }) => w.windowName !== '_bridge_main');
 
     const existingNames = new Set(existing.map(w => w.windowName));
     let name = baseName;
@@ -163,13 +174,11 @@ export class TmuxManager {
     try {
       const raw = await this.tmux(
         'list-windows', '-t', this.sessionName,
-        '-F', '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{pane_current_command}'
+        '-F', WINDOW_LIST_FORMAT,
       );
       if (!raw) return [];
-      return raw.split('\n').filter(Boolean).map(line => {
-        const [windowId, windowName, cwd, paneCommand] = line.split('\t');
-        return { windowId, windowName, cwd, paneCommand };
-      }).filter(w => w.windowName !== '_bridge_main');
+      return raw.split('\n').filter(Boolean).map(parseWindowListLine)
+        .filter(w => w.windowName !== '_bridge_main');
     } catch (e: unknown) {
       console.warn(`Tmux: listWindows failed: ${(e as Error).message}`);
       return [];
@@ -237,6 +246,12 @@ export class TmuxManager {
               'allow-rename', 'off',
             );
 
+            // Keep exited panes visible so pane_dead can signal Claude crashes quickly.
+            await this.tmuxInternal(
+              'set-window-option', '-t', `${this.sessionName}:${name}`,
+              'remain-on-exit', 'on',
+            );
+
             // Issue #82: Set pane title to session name
             await this.tmuxInternal(
               'select-pane', '-t', `${this.sessionName}:${name}`,
@@ -253,7 +268,7 @@ export class TmuxManager {
             // Verify the window actually exists after creation
             const verifyRaw = await this.tmuxInternal(
               'list-windows', '-t', this.sessionName,
-              '-F', '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{pane_current_command}',
+              '-F', WINDOW_LIST_FORMAT,
             );
             const verified = verifyRaw.split('\n').filter(Boolean).some(line => {
               const [wid] = line.split('\t');
@@ -375,7 +390,7 @@ export class TmuxManager {
     //   - Color capabilities reduced to 256
     //   - Clipboard passthrough via tmux load-buffer instead of OSC 52
     // Prefixing with 'unset' ensures CC gets a clean environment.
-    cmd = `unset TMUX TMUX_PANE && ${cmd}`;
+    cmd = `unset TMUX TMUX_PANE && exec ${cmd}`;
 
     // Send the command to start Claude
     await this.sendKeys(windowId, cmd, true);
@@ -573,20 +588,21 @@ export class TmuxManager {
     windowExists: boolean;
     paneCommand: string | null;
     claudeRunning: boolean;
+    paneDead: boolean;
   }> {
     try {
       const windows = await this.listWindows();
       const win = windows.find(w => w.windowId === windowId);
       if (!win) {
-        return { windowExists: false, paneCommand: null, claudeRunning: false };
+        return { windowExists: false, paneCommand: null, claudeRunning: false, paneDead: false };
       }
       const paneCmd = win.paneCommand.toLowerCase();
       // Claude runs as 'claude' or 'node' process
       const claudeRunning = paneCmd === 'claude' || paneCmd === 'node';
-      return { windowExists: true, paneCommand: win.paneCommand, claudeRunning };
+      return { windowExists: true, paneCommand: win.paneCommand, claudeRunning, paneDead: win.paneDead ?? false };
     } catch (e: unknown) {
       console.warn(`Tmux: getWindowHealth failed for ${windowId}: ${(e as Error).message}`);
-      return { windowExists: false, paneCommand: null, claudeRunning: false };
+      return { windowExists: false, paneCommand: null, claudeRunning: false, paneDead: false };
     }
   }
 


### PR DESCRIPTION
## Summary
Integrate tmux pane-exit signal into session liveness checks so crashed/exited panes are marked dead immediately rather than relying only on stall timers.

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #390

## Test plan
- [x] Focused tests pass (
pm test -- src/__tests__/pane-exit-detection-390.test.ts src/__tests__/stall-detection.test.ts src/__tests__/dead-session.test.ts)
- [x] Type-check passes (
px tsc --noEmit)
- [x] Build succeeds (
pm run build)
- [x] Full test run executed (
pm test) *(fails on existing Windows/path-permission expectations unrelated to this change)*
