### PR TITLE
fix: bound event buffer and IP rate-limit maps

### DIFF
--- a/src/__tests__/events.test.ts
+++ b/src/__tests__/events.test.ts
@@ -770,6 +770,60 @@ describe('SessionEventBus', () => {
     });
   });
 
+  describe('bounded session replay buffer map', () => {
+    it('evicts the least recently touched inactive session when cap is exceeded', () => {
+      const cappedBus = new SessionEventBus({ maxSessionBuffers: 3 });
+
+      cappedBus.emitStatus('sess-1', 'working', 'a');
+      cappedBus.emitStatus('sess-2', 'working', 'b');
+      cappedBus.emitStatus('sess-3', 'working', 'c');
+      cappedBus.emitStatus('sess-4', 'working', 'd');
+
+      expect(cappedBus.getEventsSince('sess-1', 0)).toEqual([]);
+      expect(cappedBus.getEventsSince('sess-2', 0)).toHaveLength(1);
+      expect(cappedBus.getEventsSince('sess-3', 0)).toHaveLength(1);
+      expect(cappedBus.getEventsSince('sess-4', 0)).toHaveLength(1);
+
+      cappedBus.destroy();
+    });
+
+    it('does not evict sessions with active subscribers when pruning', () => {
+      const cappedBus = new SessionEventBus({ maxSessionBuffers: 2 });
+      const unsub = cappedBus.subscribe('sess-1', () => {});
+
+      cappedBus.emitStatus('sess-1', 'working', 'a');
+      cappedBus.emitStatus('sess-2', 'working', 'b');
+      cappedBus.emitStatus('sess-3', 'working', 'c');
+
+      expect(cappedBus.getEventsSince('sess-1', 0)).toHaveLength(1);
+      expect(cappedBus.getEventsSince('sess-2', 0)).toEqual([]);
+      expect(cappedBus.getEventsSince('sess-3', 0)).toHaveLength(1);
+
+      unsub();
+      cappedBus.destroy();
+    });
+
+    it('keeps replay buffers bounded under high unique-session churn', () => {
+      const maxBuffers = 5;
+      const cappedBus = new SessionEventBus({ maxSessionBuffers: maxBuffers });
+
+      for (let i = 0; i < 50; i++) {
+        cappedBus.emitStatus(`sess-${i}`, 'working', `evt-${i}`);
+      }
+
+      let retained = 0;
+      for (let i = 0; i < 50; i++) {
+        if (cappedBus.getEventsSince(`sess-${i}`, 0).length > 0) {
+          retained++;
+        }
+      }
+
+      expect(retained).toBeLessThanOrEqual(maxBuffers);
+
+      cappedBus.destroy();
+    });
+  });
+
   // ── 9. toGlobalEvent mapping ─────────────────────────────────────────
 
   describe('toGlobalEvent mapping', () => {

--- a/src/__tests__/trustproxy-rate-limit-633.test.ts
+++ b/src/__tests__/trustproxy-rate-limit-633.test.ts
@@ -68,6 +68,8 @@ describe('Issue #633: IP extraction ignores X-Forwarded-For when trustProxy is o
 // ── rate limit function still works correctly ───────────────────────
 
 describe('Issue #633: Rate limiting still functions with fixed IP logic', () => {
+  const MAX_IP_ENTRIES = 10;
+
   // Copy the checkIpRateLimit logic (simplified) for testing
   function checkIpRateLimit(
     ip: string,
@@ -82,6 +84,18 @@ describe('Issue #633: Rate limiting still functions with fixed IP logic', () => 
     }
     bucket.entries.push(now);
     ipRateLimits.set(ip, bucket);
+    if (ipRateLimits.size > MAX_IP_ENTRIES) {
+      let oldestIp = '';
+      let oldestTime = Infinity;
+      for (const [trackedIp, trackedBucket] of ipRateLimits) {
+        const lastTs = trackedBucket.entries[trackedBucket.entries.length - 1];
+        if (lastTs !== undefined && lastTs < oldestTime) {
+          oldestTime = lastTs;
+          oldestIp = trackedIp;
+        }
+      }
+      if (oldestIp) ipRateLimits.delete(oldestIp);
+    }
     const activeCount = bucket.entries.length - bucket.start;
     const limit = isMaster ? 300 : 120;
     return activeCount > limit;
@@ -113,5 +127,30 @@ describe('Issue #633: Rate limiting still functions with fixed IP logic', () => 
     }
     // 1 request from IP2 — should not be limited
     expect(checkIpRateLimit('10.0.0.2', false, limits)).toBe(false);
+  });
+
+  it('evicts the oldest IP bucket when the map exceeds its cap', () => {
+    const limits = new Map<string, { entries: number[]; start: number }>();
+    for (let i = 0; i < MAX_IP_ENTRIES; i++) {
+      checkIpRateLimit(`10.0.0.${i}`, false, limits);
+    }
+
+    expect(limits.size).toBe(MAX_IP_ENTRIES);
+
+    checkIpRateLimit('10.0.0.250', false, limits);
+
+    expect(limits.size).toBe(MAX_IP_ENTRIES);
+    expect(limits.has('10.0.0.0')).toBe(false);
+    expect(limits.has('10.0.0.250')).toBe(true);
+  });
+
+  it('keeps map size bounded during high unique-IP churn', () => {
+    const limits = new Map<string, { entries: number[]; start: number }>();
+
+    for (let i = 0; i < 500; i++) {
+      checkIpRateLimit(`192.168.0.${i}`, false, limits);
+    }
+
+    expect(limits.size).toBeLessThanOrEqual(MAX_IP_ENTRIES);
   });
 });

--- a/src/events.ts
+++ b/src/events.ts
@@ -42,6 +42,11 @@ export interface GlobalSSEEvent {
   id?: number;
 }
 
+interface SessionEventBusOptions {
+  /** Maximum number of per-session replay buffers retained in memory. */
+  maxSessionBuffers?: number;
+}
+
 /** Map per-session event types to global event types. */
 function toGlobalEvent(event: SessionSSEEvent): GlobalSSEEvent {
   const typeMap: Record<string, GlobalSSEEvent['event']> = {
@@ -95,8 +100,49 @@ export class SessionEventBus {
   /** Per-session ring buffer for event replay. */
   private eventBuffers = new Map<string, CircularBuffer<{ id: number; event: SessionSSEEvent }>>();
 
+  /** Last activity time per session buffer for LRU eviction. */
+  private sessionBufferLastTouched = new Map<string, number>();
+
   /** Global ring buffer for event replay across all sessions (Issue #301). */
   private globalEventBuffer = new CircularBuffer<{ id: number; event: GlobalSSEEvent }>(SessionEventBus.BUFFER_SIZE);
+
+  private readonly maxSessionBuffers: number;
+
+  constructor(options: SessionEventBusOptions = {}) {
+    this.maxSessionBuffers = options.maxSessionBuffers ?? 10_000;
+  }
+
+  private touchSessionBuffer(sessionId: string): void {
+    this.sessionBufferLastTouched.set(sessionId, Date.now());
+  }
+
+  private pruneSessionBufferMap(protectedSessionId?: string): void {
+    if (this.eventBuffers.size <= this.maxSessionBuffers) return;
+
+    let oldestSessionId: string | undefined;
+    let oldestTouched = Infinity;
+
+    for (const [sessionId, touchedAt] of this.sessionBufferLastTouched) {
+      if (sessionId === protectedSessionId) continue;
+      if (!this.eventBuffers.has(sessionId)) {
+        this.sessionBufferLastTouched.delete(sessionId);
+        continue;
+      }
+      const emitter = this.emitters.get(sessionId);
+      if (emitter && emitter.listenerCount('event') > 0) {
+        continue;
+      }
+      if (touchedAt < oldestTouched) {
+        oldestTouched = touchedAt;
+        oldestSessionId = sessionId;
+      }
+    }
+
+    if (oldestSessionId !== undefined) {
+      this.eventBuffers.delete(oldestSessionId);
+      this.sessionBufferLastTouched.delete(oldestSessionId);
+    }
+  }
 
   /** Get or create the emitter for a session. */
   private getEmitter(sessionId: string): EventEmitter {
@@ -140,6 +186,8 @@ export class SessionEventBus {
       this.eventBuffers.set(sessionId, buffer);
     }
     buffer.push({ id: event.id, event });
+    this.touchSessionBuffer(sessionId);
+    this.pruneSessionBufferMap(sessionId);
     const emitter = this.emitters.get(sessionId);
     if (emitter) {
       const imm = setImmediate(() => {
@@ -165,6 +213,7 @@ export class SessionEventBus {
   getEventsSince(sessionId: string, lastEventId: number): SessionSSEEvent[] {
     const buffer = this.eventBuffers.get(sessionId);
     if (!buffer) return [];
+    this.touchSessionBuffer(sessionId);
     return buffer.toArray().filter(e => e.id > lastEventId).map(e => e.event);
   }
 
@@ -196,6 +245,8 @@ export class SessionEventBus {
         newest_id: null,
       };
     }
+
+    this.touchSessionBuffer(sessionId);
 
     const entries = buffer.toArray();
     const clampedLimit = Math.min(SessionEventBus.BUFFER_SIZE, Math.max(1, limit));
@@ -291,6 +342,7 @@ export class SessionEventBus {
         this.emitters.delete(sessionId);
       }
       this.eventBuffers.delete(sessionId);
+      this.sessionBufferLastTouched.delete(sessionId);
     }, 1000);
     this.pendingTimeouts.add(timeout);
   }
@@ -393,6 +445,7 @@ export class SessionEventBus {
       this.pendingTimeouts.delete(timeout);
     }
     this.eventBuffers.delete(sessionId);
+    this.sessionBufferLastTouched.delete(sessionId);
     const emitter = this.emitters.get(sessionId);
     if (emitter) {
       emitter.removeAllListeners();
@@ -417,6 +470,7 @@ export class SessionEventBus {
     }
     this.emitters.clear();
     this.eventBuffers.clear();
+    this.sessionBufferLastTouched.clear();
     this.globalEventBuffer.clear();
     this.globalEmitter?.removeAllListeners();
     this.globalEmitter = null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -217,6 +217,7 @@ interface AuthFailBucket {
 const authFailLimits = new Map<string, AuthFailBucket>();
 const AUTH_FAIL_WINDOW_MS = 60_000;
 const AUTH_FAIL_MAX = 5;
+const MAX_AUTH_FAIL_IP_ENTRIES = 10_000;
 
 function checkAuthFailRateLimit(ip: string): boolean {
   const now = Date.now();
@@ -226,6 +227,18 @@ function checkAuthFailRateLimit(ip: string): boolean {
   bucket.timestamps = bucket.timestamps.filter(t => t >= cutoff);
   bucket.timestamps.push(now);
   authFailLimits.set(ip, bucket);
+  if (authFailLimits.size > MAX_AUTH_FAIL_IP_ENTRIES) {
+    let oldestIp = '';
+    let oldestTime = Infinity;
+    for (const [trackedIp, trackedBucket] of authFailLimits) {
+      const lastTs = trackedBucket.timestamps[trackedBucket.timestamps.length - 1];
+      if (lastTs !== undefined && lastTs < oldestTime) {
+        oldestTime = lastTs;
+        oldestIp = trackedIp;
+      }
+    }
+    if (oldestIp) authFailLimits.delete(oldestIp);
+  }
   return bucket.timestamps.length > AUTH_FAIL_MAX;
 }
 


### PR DESCRIPTION
## Summary
Bound in-memory growth for session replay buffers and IP-based limiter state to prevent unbounded map expansion under high session/IP churn.

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #398

## Test plan
- [x] Targeted tests: 
px vitest run src/__tests__/events.test.ts src/__tests__/trustproxy-rate-limit-633.test.ts --reporter=dot
- [x] Type-check: 
px tsc --noEmit
- [x] Build: 
pm run build
- [x] Full test run attempted: 
pm test -- --reporter=dot *(fails on pre-existing Windows-path and permission expectation tests unrelated to this change)*
