### PR TITLE
fix: add TTL cleanup for Telegram forum topics

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -46,6 +46,7 @@ describe('config', () => {
       expect(config.webhooks).toEqual([]);
       expect(config.tgBotToken).toBe('');
       expect(config.tgGroupId).toBe('');
+      expect(config.tgTopicTtlMs).toBe(24 * 60 * 60 * 1000);
     });
   });
 
@@ -96,6 +97,12 @@ describe('config', () => {
       process.env.AEGIS_WEBHOOKS = 'https://a.com/hook, https://b.com/hook';
       const config = getConfig();
       expect(config.webhooks).toEqual(['https://a.com/hook', 'https://b.com/hook']);
+    });
+
+    it('overrides Telegram topic TTL via AEGIS_TG_TOPIC_TTL_MS', () => {
+      process.env.AEGIS_TG_TOPIC_TTL_MS = '60000';
+      const config = getConfig();
+      expect(config.tgTopicTtlMs).toBe(60000);
     });
   });
 

--- a/src/__tests__/telegram-topic-ttl-cleanup.test.ts
+++ b/src/__tests__/telegram-topic-ttl-cleanup.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelegramChannel } from '../channels/telegram.js';
+import type { SessionEventPayload } from '../channels/types.js';
+
+function makePayload(sessionId = 'sess-ttl-1'): SessionEventPayload {
+  return {
+    event: 'session.ended',
+    timestamp: new Date().toISOString(),
+    session: {
+      id: sessionId,
+      name: 'ttl-session',
+      workDir: '/tmp',
+    },
+    detail: 'done',
+  };
+}
+
+describe('Telegram topic TTL cleanup (#287)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('schedules cleanup on session end and deletes only after TTL', async () => {
+    const channel = new TelegramChannel({
+      botToken: 'test-token',
+      groupChatId: '-1000',
+      allowedUserIds: [],
+      topicTtlMs: 500,
+    });
+
+    const sessionId = 'sess-ttl-1';
+    const internal = channel as any;
+    internal.topics.set(sessionId, {
+      sessionId,
+      topicId: 42,
+      windowName: 'ttl-session',
+      endedAt: null,
+      cleanupScheduledAt: null,
+      deleting: false,
+    });
+    internal.progress.set(sessionId, {
+      totalMessages: 1,
+      reads: 0,
+      edits: 0,
+      creates: 0,
+      commands: 0,
+      searches: 0,
+      errors: 0,
+      filesRead: [],
+      filesEdited: [],
+      startedAt: Date.now(),
+      lastMessage: '',
+      currentStatus: 'idle',
+      progressMessageId: null,
+    });
+
+    vi.spyOn(channel, 'sendStyled').mockResolvedValue(null);
+    const tgApi = vi.fn(async (method: string) => {
+      if (method === 'closeForumTopic') return true;
+      if (method === 'deleteForumTopic') return true;
+      return true;
+    });
+    internal.tgApi = tgApi;
+
+    await channel.onSessionEnded(makePayload(sessionId));
+
+    expect(internal.progress.has(sessionId)).toBe(false);
+    expect(internal.topics.has(sessionId)).toBe(true);
+    expect(internal.topicCleanupTimers.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(tgApi).not.toHaveBeenCalledWith('deleteForumTopic', expect.any(Object));
+    expect(internal.topics.has(sessionId)).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(tgApi).toHaveBeenCalledWith('closeForumTopic', {
+      chat_id: '-1000',
+      message_thread_id: 42,
+    });
+    expect(tgApi).toHaveBeenCalledWith('deleteForumTopic', {
+      chat_id: '-1000',
+      message_thread_id: 42,
+    });
+    expect(internal.topics.has(sessionId)).toBe(false);
+  });
+
+  it('is idempotent when cleanup is scheduled multiple times', async () => {
+    const channel = new TelegramChannel({
+      botToken: 'test-token',
+      groupChatId: '-1000',
+      allowedUserIds: [],
+      topicTtlMs: 100,
+    });
+
+    const sessionId = 'sess-ttl-2';
+    const internal = channel as any;
+    internal.topics.set(sessionId, {
+      sessionId,
+      topicId: 77,
+      windowName: 'ttl-session-2',
+      endedAt: null,
+      cleanupScheduledAt: null,
+      deleting: false,
+    });
+
+    const tgApi = vi.fn(async () => true);
+    internal.tgApi = tgApi;
+
+    internal.scheduleTopicCleanup(sessionId);
+    internal.scheduleTopicCleanup(sessionId);
+
+    expect(internal.topicCleanupTimers.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(tgApi).toHaveBeenCalledTimes(2);
+    expect(tgApi).toHaveBeenNthCalledWith(1, 'closeForumTopic', {
+      chat_id: '-1000',
+      message_thread_id: 77,
+    });
+    expect(tgApi).toHaveBeenNthCalledWith(2, 'deleteForumTopic', {
+      chat_id: '-1000',
+      message_thread_id: 77,
+    });
+  });
+
+  it('treats Telegram not-found delete errors as successful cleanup', async () => {
+    const channel = new TelegramChannel({
+      botToken: 'test-token',
+      groupChatId: '-1000',
+      allowedUserIds: [],
+      topicTtlMs: 0,
+    });
+
+    const sessionId = 'sess-ttl-3';
+    const internal = channel as any;
+    internal.topics.set(sessionId, {
+      sessionId,
+      topicId: 99,
+      windowName: 'ttl-session-3',
+      endedAt: Date.now() - 1,
+      cleanupScheduledAt: Date.now() - 1,
+      deleting: false,
+    });
+
+    internal.tgApi = vi.fn(async (method: string) => {
+      if (method === 'closeForumTopic') return true;
+      throw new Error('Telegram API deleteForumTopic: message thread not found');
+    });
+
+    await internal.runTopicCleanup(sessionId);
+    expect(internal.topics.has(sessionId)).toBe(false);
+  });
+});

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -33,12 +33,16 @@ export interface TelegramChannelConfig {
   botToken: string;
   groupChatId: string;
   allowedUserIds: number[];
+  topicTtlMs?: number;
 }
 
 interface SessionTopic {
   sessionId: string;
   topicId: number;
   windowName: string;
+  endedAt: number | null;
+  cleanupScheduledAt: number | null;
+  deleting: boolean;
 }
 
 interface SessionProgress {
@@ -585,6 +589,8 @@ function formatProgressCard(progress: SessionProgress): string {
 
 export class TelegramChannel implements Channel {
   readonly name = 'telegram';
+  static readonly DEFAULT_TOPIC_TTL_MS = 24 * 60 * 60 * 1000;
+  private static readonly TOPIC_CLEANUP_RETRY_MS = 60_000;
 
   private topics = new Map<string, SessionTopic>();
   private progress = new Map<string, SessionProgress>();
@@ -593,6 +599,9 @@ export class TelegramChannel implements Channel {
   private rateLimitUntil = 0;
   private pollBackoffMs = 1_000; // Exponential backoff for poll errors
   private onInbound: InboundHandler | null = null;
+  private topicCleanupTimers = new Map<string, NodeJS.Timeout>();
+  private topicCleanupSweepTimer: NodeJS.Timeout | null = null;
+  private readonly topicTtlMs: number;
 
   // Rate limiting & batching
   private messageQueue = new Map<string, QueuedItem[]>();
@@ -622,7 +631,12 @@ export class TelegramChannel implements Channel {
     this.swarmMonitor = monitor;
   }
 
-  constructor(private config: TelegramChannelConfig) {}
+  constructor(private config: TelegramChannelConfig) {
+    const configuredTtlMs = config.topicTtlMs ?? TelegramChannel.DEFAULT_TOPIC_TTL_MS;
+    this.topicTtlMs = Number.isFinite(configuredTtlMs)
+      ? Math.max(0, configuredTtlMs)
+      : TelegramChannel.DEFAULT_TOPIC_TTL_MS;
+  }
 
   /** Call Telegram Bot API with retry on 429. Instance method so it can access rateLimitUntil. */
   private async tgApi(
@@ -677,6 +691,7 @@ export class TelegramChannel implements Channel {
   async init(onInbound: InboundHandler): Promise<void> {
     this.onInbound = onInbound;
     this.polling = true;
+    this.startTopicCleanupSweep();
     this.pollLoopPromise = this.pollLoop(); // store promise for graceful shutdown
     console.log(`Telegram channel: polling started, group ${this.config.groupChatId}`);
   }
@@ -691,8 +706,14 @@ export class TelegramChannel implements Channel {
     ]);
     for (const timer of this.flushTimers.values()) clearTimeout(timer);
     for (const timer of this.readTimer.values()) clearTimeout(timer);
+    for (const timer of this.topicCleanupTimers.values()) clearTimeout(timer);
+    if (this.topicCleanupSweepTimer) {
+      clearInterval(this.topicCleanupSweepTimer);
+      this.topicCleanupSweepTimer = null;
+    }
     this.flushTimers.clear();
     this.readTimer.clear();
+    this.topicCleanupTimers.clear();
   }
 
   async onSessionCreated(payload: SessionEventPayload): Promise<void> {
@@ -703,10 +724,14 @@ export class TelegramChannel implements Channel {
     })) as { message_thread_id: number };
 
     const topicId = result.message_thread_id;
+    this.clearTopicCleanupTimer(payload.session.id);
     this.topics.set(payload.session.id, {
       sessionId: payload.session.id,
       topicId,
       windowName: payload.session.name,
+      endedAt: null,
+      cleanupScheduledAt: null,
+      deleting: false,
     });
 
     this.progress.set(payload.session.id, {
@@ -774,7 +799,8 @@ export class TelegramChannel implements Channel {
       await this.sendStyled(payload.session.id, styled);
     }
 
-    this.cleanup(payload.session.id);
+    this.scheduleTopicCleanup(payload.session.id);
+    this.cleanupSessionRuntimeState(payload.session.id);
   }
 
   async onMessage(payload: SessionEventPayload): Promise<void> {
@@ -1303,8 +1329,7 @@ export class TelegramChannel implements Channel {
     }
   }
 
-  private cleanup(sessionId: string): void {
-    this.topics.delete(sessionId);
+  private cleanupSessionRuntimeState(sessionId: string): void {
     this.progress.delete(sessionId);
     this.lastSent.delete(sessionId);
     this.pendingTool.delete(sessionId);
@@ -1316,6 +1341,112 @@ export class TelegramChannel implements Channel {
     if (ft) { clearTimeout(ft); this.flushTimers.delete(sessionId); }
     const rt = this.readTimer.get(sessionId);
     if (rt) { clearTimeout(rt); this.readTimer.delete(sessionId); }
+  }
+
+  private startTopicCleanupSweep(): void {
+    if (this.topicCleanupSweepTimer) return;
+    const sweepMs = Math.min(60_000, Math.max(5_000, this.topicTtlMs || 5_000));
+    this.topicCleanupSweepTimer = setInterval(() => {
+      for (const [sessionId, topic] of this.topics) {
+        if (topic.endedAt === null) continue;
+        if (topic.deleting) continue;
+        if (Date.now() >= topic.endedAt + this.topicTtlMs) {
+          void this.runTopicCleanup(sessionId);
+        }
+      }
+    }, sweepMs);
+    if (typeof this.topicCleanupSweepTimer.unref === 'function') {
+      this.topicCleanupSweepTimer.unref();
+    }
+  }
+
+  private clearTopicCleanupTimer(sessionId: string): void {
+    const timer = this.topicCleanupTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.topicCleanupTimers.delete(sessionId);
+    }
+  }
+
+  private scheduleTopicCleanup(sessionId: string): void {
+    const topic = this.topics.get(sessionId);
+    if (!topic) return;
+
+    if (topic.endedAt === null) {
+      topic.endedAt = Date.now();
+    }
+
+    if (topic.cleanupScheduledAt !== null) {
+      return;
+    }
+
+    const cleanupAt = topic.endedAt + this.topicTtlMs;
+    topic.cleanupScheduledAt = cleanupAt;
+
+    const delayMs = Math.max(0, cleanupAt - Date.now());
+    if (delayMs === 0) {
+      void this.runTopicCleanup(sessionId);
+      return;
+    }
+
+    this.clearTopicCleanupTimer(sessionId);
+    const timer = setTimeout(() => {
+      void this.runTopicCleanup(sessionId);
+    }, delayMs);
+    this.topicCleanupTimers.set(sessionId, timer);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+  }
+
+  private async runTopicCleanup(sessionId: string): Promise<void> {
+    const topic = this.topics.get(sessionId);
+    if (!topic || topic.endedAt === null || topic.deleting) return;
+
+    if (Date.now() < topic.endedAt + this.topicTtlMs) {
+      return;
+    }
+
+    topic.deleting = true;
+    this.clearTopicCleanupTimer(sessionId);
+
+    const body = {
+      chat_id: this.config.groupChatId,
+      message_thread_id: topic.topicId,
+    };
+
+    try {
+      try {
+        await this.tgApi('closeForumTopic', body);
+      } catch (e) {
+        if (!this.isIgnorableTopicDeleteError(e)) {
+          throw e;
+        }
+      }
+
+      await this.tgApi('deleteForumTopic', body);
+      this.topics.delete(sessionId);
+    } catch (e) {
+      if (this.isIgnorableTopicDeleteError(e)) {
+        this.topics.delete(sessionId);
+      } else {
+        console.error(`Telegram: failed to cleanup topic for session ${sessionId}:`, this.redactError(e));
+        topic.deleting = false;
+        topic.cleanupScheduledAt = null;
+        const timer = setTimeout(() => {
+          void this.runTopicCleanup(sessionId);
+        }, TelegramChannel.TOPIC_CLEANUP_RETRY_MS);
+        this.topicCleanupTimers.set(sessionId, timer);
+        if (typeof timer.unref === 'function') {
+          timer.unref();
+        }
+      }
+    }
+  }
+
+  private isIgnorableTopicDeleteError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return /not found|message thread|topic.*(?:closed|deleted)|forum topic/i.test(message);
   }
 
   // ── /swarm command ──────────────────────────────────────────────────

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,8 @@ export interface Config {
   tgGroupId: string;
   /** Allowed Telegram user IDs for inbound commands (empty = allow all) */
   tgAllowedUsers: number[];
+  /** TTL for Telegram forum topics after session end, in milliseconds. */
+  tgTopicTtlMs: number;
   /** Webhook URLs (comma-separated or array) */
   webhooks: string[];
   /** Default env vars injected into every CC session (e.g. model overrides, API keys).
@@ -107,6 +109,7 @@ const defaults: Config = {
   tgBotToken: '',
   tgGroupId: '',
   tgAllowedUsers: [],
+  tgTopicTtlMs: 24 * 60 * 60 * 1000,
   webhooks: [],
   defaultSessionEnv: {},
   defaultPermissionMode: 'bypassPermissions',
@@ -199,6 +202,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_TG_TOKEN', manus: 'MANUS_TG_TOKEN', key: 'tgBotToken' },
     { aegis: 'AEGIS_TG_GROUP', manus: 'MANUS_TG_GROUP', key: 'tgGroupId' },
     { aegis: 'AEGIS_TG_ALLOWED_USERS', manus: 'MANUS_TG_ALLOWED_USERS', key: 'tgAllowedUsers' },
+    { aegis: 'AEGIS_TG_TOPIC_TTL_MS', manus: 'MANUS_TG_TOPIC_TTL_MS', key: 'tgTopicTtlMs' },
     { aegis: 'AEGIS_WEBHOOKS', manus: 'MANUS_WEBHOOKS', key: 'webhooks' },
     { aegis: 'AEGIS_SSE_MAX_CONNECTIONS', manus: 'MANUS_SSE_MAX_CONNECTIONS', key: 'sseMaxConnections' },
     { aegis: 'AEGIS_SSE_MAX_PER_IP', manus: 'MANUS_SSE_MAX_PER_IP', key: 'sseMaxPerIp' },
@@ -214,6 +218,7 @@ function applyEnvOverrides(config: Config): Config {
       case 'maxSessionAgeMs':
       case 'reaperIntervalMs':
       case 'continuationPointerTtlMs':
+      case 'tgTopicTtlMs':
       case 'sseMaxConnections':
       case 'sseMaxPerIp':
         config[key] = parseIntSafe(value, config[key]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1713,6 +1713,7 @@ function registerChannels(cfg: Config): void {
       botToken: cfg.tgBotToken,
       groupChatId: cfg.tgGroupId,
       allowedUserIds: cfg.tgAllowedUsers,
+      topicTtlMs: cfg.tgTopicTtlMs,
     }));
   }
 


### PR DESCRIPTION
## Summary
Implement TTL-based Telegram forum-topic cleanup tied to session lifecycle.

### What changed
- Add TTL topic lifecycle state and cleanup scheduling in TelegramChannel.
- On session end, schedule forum-topic cleanup after TTL while immediately cleaning in-memory runtime state.
- Add safe and idempotent deletion flow using closeForumTopic + deleteForumTopic, with retry on transient failures and ignore-not-found handling.
- Add config key/env override for topic TTL (	gTopicTtlMs, AEGIS_TG_TOPIC_TTL_MS / MANUS_TG_TOPIC_TTL_MS) and wire into channel registration.
- Add tests for TTL expiry behavior, idempotent scheduling, safe deletion semantics, and config override parsing.

## Aegis version
**Developed with:** v2.11.0

## Linked issue
Closes #287

## Test plan
- [x] Focused tests: 
pm test -- src/__tests__/telegram-topic-ttl-cleanup.test.ts src/__tests__/config.test.ts
- [x] Type-check: 
px tsc --noEmit
- [x] Build: 
pm run build
- [x] Full test run executed: 
pm test *(fails on existing Windows path/permission expectation tests unrelated to this change)*
