### PR TITLE
fix: smarter paneDead check — only mark session dead if was actively working (#1026)

### DIFF
--- a/src/__tests__/pane-exit-detection-390.test.ts
+++ b/src/__tests__/pane-exit-detection-390.test.ts
@@ -55,7 +55,7 @@ function makeTmux() {
 }
 
 describe('Issue #390 pane-exit detection', () => {
-  it('paneDead alone does not make isWindowAlive return false when panePid is alive', async () => {
+  it('paneDead while actively working = dead (crash detection)', async () => {
     const tmux = makeTmux();
     tmux.getWindowHealth.mockResolvedValue({
       windowExists: true,
@@ -65,11 +65,28 @@ describe('Issue #390 pane-exit detection', () => {
     });
 
     const manager = new SessionManager(tmux, makeConfig());
-    (manager as any).state.sessions = { 's-1': makeSession({ id: 's-1' }) };
+    (manager as any).state.sessions = { 's-1': makeSession({ id: 's-1', status: 'working' }) };
 
     const alive = await manager.isWindowAlive('s-1');
 
-    expect(alive).toBe(true); // paneDead removed from isWindowAlive check
+    expect(alive).toBe(false); // paneDead + working = crash
+  });
+
+  it('paneDead after going idle = alive (normal CC exit after prompt completion)', async () => {
+    const tmux = makeTmux();
+    tmux.getWindowHealth.mockResolvedValue({
+      windowExists: true,
+      paneCommand: 'bash',
+      claudeRunning: false,
+      paneDead: true,
+    });
+
+    const manager = new SessionManager(tmux, makeConfig());
+    (manager as any).state.sessions = { 's-1': makeSession({ id: 's-1', status: 'idle' }) };
+
+    const alive = await manager.isWindowAlive('s-1');
+
+    expect(alive).toBe(true); // paneDead + idle = normal exit
   });
 
   it('does not produce false positives during normal idle periods', async () => {

--- a/src/session.ts
+++ b/src/session.ts
@@ -866,7 +866,10 @@ export class SessionManager {
 
       const windowHealth = await this.tmux.getWindowHealth(session.windowId);
       if (!windowHealth.windowExists) return false;
-      // Pane exit is a direct crash signal when remain-on-exit keeps dead panes visible.
+      // Pane exit is a crash signal ONLY if the session was actively working (not idle).
+      // Normal CC exit after prompt → session goes idle first, paneDead is expected.
+      // CC crash mid-processing → session still working, paneDead means crash.
+      if (windowHealth.paneDead && session.status !== 'idle') return false;
 
       // Verify the process inside the pane is still alive
       const panePid = await this.tmux.listPanePid(session.windowId);


### PR DESCRIPTION
## Summary

Fixes the session lifecycle bug where sessions were either dying immediately after prompts OR getting stuck in 'working' forever.

### The Problem (Two Failure Modes)

**Failure mode 1 (v2.12.1 regression):**  in  was too aggressive — CC exits after processing, paneDead immediately → session marked dead even though CC completed successfully.

**Failure mode 2 (after naive fix removal):** Removing  check entirely caused sessions to get stuck in 'working' forever. CC exits normally, becomes zombie, but session never transitions.

### The Fix

Combine  with session status to distinguish normal exit from crash:



**Logic:**
- CC exits normally after prompt →  → paneDead but session is alive → ✅
- CC crashes mid-processing →  → paneDead AND not idle → mark dead → ✅

### Testing

- All 117 Aegis test files pass (2244 tests)
- New test: 
- New test: 
- Tested: session stays alive after prompt delivery, CC processes normally

### Impact

- Sessions no longer die prematurely after prompts
- Sessions no longer get stuck in 'working' after CC exits
- Crash detection still works (paneDead + working = dead)
- The  check remains as primary crash detection

Fixes #1026