### PR TITLE
fix: extend paneDead grace period from 5s to 15s

### DIFF
--- a/src/__tests__/pane-exit-detection-390.test.ts
+++ b/src/__tests__/pane-exit-detection-390.test.ts
@@ -65,7 +65,7 @@ describe('Issue #390 pane-exit detection', () => {
     });
 
     const manager = new SessionManager(tmux, makeConfig());
-    (manager as any).state.sessions = { 's-1': makeSession({ id: 's-1', status: 'working' }) };
+    (manager as any).state.sessions = { 's-1': makeSession({ id: 's-1', status: 'working', lastActivity: Date.now() - 20_000 }) };
 
     const alive = await manager.isWindowAlive('s-1');
 
@@ -122,5 +122,41 @@ describe('Issue #390 pane-exit detection', () => {
 
     expect(health.alive).toBe(false);
     expect(health.details).toContain('pane has exited');
+  });
+
+  it('paneDead + working + within 15s grace period = alive (CC still wrapping up)', async () => {
+    const tmux = makeTmux();
+    tmux.getWindowHealth.mockResolvedValue({
+      windowExists: true,
+      paneCommand: 'bash',
+      claudeRunning: false,
+      paneDead: true,
+    });
+
+    const manager = new SessionManager(tmux, makeConfig());
+    const session = makeSession({ id: 's-4', status: 'working', lastActivity: Date.now() - 10_000 });
+    (manager as any).state.sessions = { 's-4': session };
+
+    const alive = await manager.isWindowAlive('s-4');
+
+    expect(alive).toBe(true);
+  });
+
+  it('paneDead + working + outside 15s grace period = dead', async () => {
+    const tmux = makeTmux();
+    tmux.getWindowHealth.mockResolvedValue({
+      windowExists: true,
+      paneCommand: 'bash',
+      claudeRunning: false,
+      paneDead: true,
+    });
+
+    const manager = new SessionManager(tmux, makeConfig());
+    const session = makeSession({ id: 's-5', status: 'working', lastActivity: Date.now() - 20_000 });
+    (manager as any).state.sessions = { 's-5': session };
+
+    const alive = await manager.isWindowAlive('s-5');
+
+    expect(alive).toBe(false);
   });
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -872,7 +872,7 @@ export class SessionManager {
       // This gives CC time to finish writing results before Aegis closes the session.
       if (windowHealth.paneDead && session.status !== 'idle') {
         const msSinceActivity = Date.now() - (session.lastActivity || session.createdAt);
-        const GRACE_PERIOD_MS = 5000; // 5 seconds — enough for CC to finish and write results
+        const GRACE_PERIOD_MS = 15000; // 15 seconds — enough for CC to finish and write results
         if (msSinceActivity < GRACE_PERIOD_MS) {
           // Pane just died right after activity — likely CC is finishing up.
           // Don't mark dead yet — give it 5 seconds to complete.


### PR DESCRIPTION
## Summary\n\nChange paneDead grace period from 5s to 15s. When CC exits, the session stays alive for 15 seconds to allow CC to finish writing results before marking the session dead.\n\n### The Problem\n\nThe 5s grace period was too short for CC to complete file writes after processing.\n\n### The Fix\n\n- `GRACE_PERIOD_MS = 15000` (15 seconds)\n- `paneDead + working + within grace = alive`\n- `paneDead + working + outside grace = dead`\n- `paneDead + idle = alive` (normal exit)\n\n### Tests Added\n\n- `paneDead + working + within 15s grace period = alive`\n- `paneDead + working + outside 15s grace period = dead`\n\n### Quality Gate\n\n- TypeScript: ✅ Zero errors\n- Build: ✅ Success\n- Tests: ✅ 6/6 pass (pane-exit-detection)\n\n**Developed with:** Aegis v2.12.4\n\nFixes #1026