### PR TITLE
docs: add v2.12.4 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [2.12.4](https://github.com/OneStepAt4time/aegis/compare/v2.12.3...v2.12.4) (2026-04-04)
+
+### Bug Fixes
+
+* extend paneDead grace period from 5s to 15s for session lifecycle ([#1026](https://github.com/OneStepAt4time/aegis/issues/1026)) ([505b8a0](https://github.com/OneStepAt4time/aegis/commit/505b8a0))
+* add test coverage for paneDead grace period scenarios ([505b8a0](https://github.com/OneStepAt4time/aegis/commit/505b8a0))
+
 
 ## [2.12.3](https://github.com/OneStepAt4time/aegis/compare/v2.12.2...v2.12.3) (2026-04-04)
 


### PR DESCRIPTION
## Summary\n\nAdd CHANGELOG.md entry for v2.12.4 release.\n\n### Changes\n- Added `## [2.12.4]` section with paneDead grace period fix\n\n### Quality Gate\n- TypeScript: ✅\n- Build: ✅\n- Tests: ✅ (core tests pass)\n\n**Developed with:** Aegis v2.12.3\n\nRequired for: v2.12.4 GitHub Release + tag