### PR TITLE
fix(parser): recognize CC ≥2.1.92 workspace trust dialog

### DIFF
--- a/src/__tests__/terminal-parser.test.ts
+++ b/src/__tests__/terminal-parser.test.ts
@@ -107,6 +107,24 @@ Do you want to trust this workspace?
 
 `;
 
+// CC ≥2.1.92 new workspace trust dialog format (issue #1045)
+const PERMISSION_WORKSPACE_TRUST_V2 = `
+ Accessing workspace:
+
+ /home/bubuntu/projects/aegis
+
+ Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source project, or work from your team). If not, take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel
+`;
+
 const PERMISSION_CONTINUE = `
 Continue?
 
@@ -568,6 +586,10 @@ describe('detectUIState', () => {
 
     it('detects workspace trust permission prompt', () => {
       expect(detectUIState(PERMISSION_WORKSPACE_TRUST)).toBe('permission_prompt');
+    });
+
+    it('detects workspace trust permission prompt (CC ≥2.1.92 format, issue #1045)', () => {
+      expect(detectUIState(PERMISSION_WORKSPACE_TRUST_V2)).toBe('permission_prompt');
     });
 
     it('detects continuation permission prompt', () => {

--- a/src/terminal-parser.ts
+++ b/src/terminal-parser.ts
@@ -54,7 +54,9 @@ const UI_PATTERNS: UIPattern[] = [
       /^\s*Do you want to delete \S/,
       /^\s*Do you want to allow Claude to make these changes/,  // batch edit
       /^\s*Do you want to allow Claude to use/,                 // MCP tool
-      /^\s*Do you want to trust this (project|workspace)/,      // workspace trust
+      /^\s*Do you want to trust this (project|workspace)/,      // workspace trust (old)
+      /^\s*Quick safety check/,                                  // workspace trust (CC ≥2.1.92)
+      /^\s*Is this a project you created/,                       // workspace trust alt text
       /^\s*Do you want to allow (reading|writing)/,             // file scope
       /^\s*Do you want to run this command/,                    // alt bash approval
       /^\s*Do you want to allow writing to/,                    // file write scope


### PR DESCRIPTION
## Summary

CC v2.1.92 changed the workspace trust prompt text. Sessions were silently dying because the terminal parser didn't recognize the new format, so auto-approve never triggered.

### Root cause

**Old format** (matched):
```
Do you want to trust this workspace?
```

**New format** (CC ≥2.1.92, not matched):
```
Quick safety check: Is this a project you created or one you trust?
❯ 1. Yes, I trust this folder
  2. No, exit
```

### Fix

Added two regex patterns to `terminal-parser.ts`:
- `/Quick safety check/`
- `/Is this a project you created/`

### Testing

- Added test fixture with exact CC v2.1.92 pane output
- 74/74 terminal-parser tests pass
- TSC clean, build clean

### Impact

**All sessions** targeting workDirs not previously trusted by CC were affected. This was the root cause of the ~50-70% session failure rate observed on 2026-04-04.

Closes #1045

Developed with: Aegis v2.13.1