### PR TITLE
chore(git): ignore local .tmp worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
+.tmp/
 # Build output
 .aegis/
 dashboard/dist/


### PR DESCRIPTION
## Summary
- add .tmp/ to gitignore
- prevents local issue worktrees and temporary execution artifacts from polluting repo status

## Validation
- no code changes

