### PR TITLE
feat(metrics): per-session token usage tracking and cost estimation

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -143,6 +143,13 @@ export const SessionMetricsSchema: z.ZodType<SessionMetrics> = z.object({
   approvals: z.number(),
   autoApprovals: z.number(),
   statusChanges: z.array(z.string()),
+  tokenUsage: z.object({
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheCreationTokens: z.number(),
+    cacheReadTokens: z.number(),
+    estimatedCostUsd: z.number(),
+  }).optional(),
 });
 
 const LatencySummaryStatSchema = z.object({

--- a/dashboard/src/components/session/SessionMetricsPanel.tsx
+++ b/dashboard/src/components/session/SessionMetricsPanel.tsx
@@ -13,23 +13,31 @@ interface MetricCardData {
   color: string;
 }
 
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toString();
+}
+
 export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelProps) {
   if (loading || !metrics) {
     return (
       <div className="flex items-center justify-center h-48 text-[#555] text-sm animate-pulse">
-        Loading metricsâ€¦
+        Loading metrics...
       </div>
     );
   }
 
   const cards: MetricCardData[] = [
-    { label: 'Duration', value: formatDuration(metrics.durationSec * 1000), icon: 'â±', color: '#3b82f6' },
-    { label: 'Messages', value: metrics.messages.toString(), icon: 'ðŸ’¬', color: '#3b82f6' },
-    { label: 'Tool Calls', value: metrics.toolCalls.toString(), icon: 'ðŸ”§', color: '#3b82f6' },
-    { label: 'Approvals', value: metrics.approvals.toString(), icon: 'âœ…', color: '#10b981' },
-    { label: 'Auto-approvals', value: metrics.autoApprovals.toString(), icon: 'âš¡', color: '#f59e0b' },
-    { label: 'Status Changes', value: metrics.statusChanges.length.toString(), icon: 'ðŸ”„', color: '#8888ff' },
+    { label: 'Duration', value: formatDuration(metrics.durationSec * 1000), icon: '\u23f1', color: '#3b82f6' },
+    { label: 'Messages', value: metrics.messages.toString(), icon: '\ud83d\udcac', color: '#3b82f6' },
+    { label: 'Tool Calls', value: metrics.toolCalls.toString(), icon: '\ud83d\udd27', color: '#3b82f6' },
+    { label: 'Approvals', value: metrics.approvals.toString(), icon: '\u2705', color: '#10b981' },
+    { label: 'Auto-approvals', value: metrics.autoApprovals.toString(), icon: '\u26a1', color: '#f59e0b' },
+    { label: 'Status Changes', value: metrics.statusChanges.length.toString(), icon: '\ud83d\udd04', color: '#8888ff' },
   ];
+
+  const tu = metrics.tokenUsage;
 
   return (
     <div className="space-y-4">
@@ -54,6 +62,40 @@ export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelPro
         ))}
       </div>
 
+      {/* Issue #488: Token usage + cost panel */}
+      {tu && (
+        <div className="bg-[#111118] border border-[#1a1a2e] rounded-lg p-4">
+          <h3 className="text-xs text-[#888] uppercase tracking-wider mb-3">Token Usage</h3>
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+            <div className="rounded border border-[#1a1a2e] bg-[#0a0a0f] p-3">
+              <div className="text-[10px] text-[#888] uppercase tracking-wider mb-1">Input</div>
+              <div className="text-lg font-mono font-semibold text-[#3b82f6]">{formatTokens(tu.inputTokens)}</div>
+            </div>
+            <div className="rounded border border-[#1a1a2e] bg-[#0a0a0f] p-3">
+              <div className="text-[10px] text-[#888] uppercase tracking-wider mb-1">Output</div>
+              <div className="text-lg font-mono font-semibold text-[#10b981]">{formatTokens(tu.outputTokens)}</div>
+            </div>
+            <div className="rounded border border-[#1a1a2e] bg-[#0a0a0f] p-3">
+              <div className="text-[10px] text-[#888] uppercase tracking-wider mb-1">Cache Write</div>
+              <div className="text-lg font-mono font-semibold text-[#f59e0b]">{formatTokens(tu.cacheCreationTokens)}</div>
+            </div>
+            <div className="rounded border border-[#1a1a2e] bg-[#0a0a0f] p-3">
+              <div className="text-[10px] text-[#888] uppercase tracking-wider mb-1">Cache Read</div>
+              <div className="text-lg font-mono font-semibold text-[#f59e0b]">{formatTokens(tu.cacheReadTokens)}</div>
+            </div>
+            <div className="rounded border border-[#1a1a2e] bg-[#001a1f] p-3">
+              <div className="text-[10px] text-[#888] uppercase tracking-wider mb-1">Est. Cost</div>
+              <div className="text-lg font-mono font-semibold text-[#00e5ff]">
+                {`$${tu.estimatedCostUsd < 0.01 ? tu.estimatedCostUsd.toFixed(4) : tu.estimatedCostUsd.toFixed(3)}`}
+              </div>
+            </div>
+          </div>
+          <div className="mt-2 text-[11px] text-[#444]">
+            Cost estimate uses Anthropic list prices (sonnet tier by default). Actual cost may vary by model and plan.
+          </div>
+        </div>
+      )}
+
       {/* Status changes timeline */}
       {metrics.statusChanges.length > 0 && (
         <div className="bg-[#111118] border border-[#1a1a2e] rounded-lg p-4">
@@ -73,4 +115,3 @@ export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelPro
     </div>
   );
 }
-

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -97,6 +97,14 @@ export interface SessionMetrics {
   approvals: number;
   autoApprovals: number;
   statusChanges: string[];
+  /** Issue #488: Cumulative token usage and estimated cost. Present once tokens are first observed. */
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    estimatedCostUsd: number;
+  };
 }
 
 export interface LatencySummaryStat {

--- a/src/jsonl-watcher.ts
+++ b/src/jsonl-watcher.ts
@@ -11,7 +11,7 @@
 import { watch, type FSWatcher } from 'node:fs';
 import { readFile, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { readNewEntries, type ParsedEntry } from './transcript.js';
+import { readNewEntries, extractTokenDelta, type ParsedEntry, type TokenUsageDelta } from './transcript.js';
 
 export interface JsonlWatcherEvent {
   sessionId: string;
@@ -19,6 +19,8 @@ export interface JsonlWatcherEvent {
   newOffset: number;
   /** True if the file was truncated (e.g. after /clear). */
   truncated: boolean;
+  /** Issue #488: Aggregated token usage delta from this batch of entries. */
+  tokenUsageDelta: TokenUsageDelta;
 }
 
 export interface JsonlWatcherConfig {
@@ -195,6 +197,7 @@ export class JsonlWatcher {
           messages: result.entries,
           newOffset: result.newOffset,
           truncated,
+          tokenUsageDelta: extractTokenDelta(result.raw),
         };
 
         for (const listener of this.listeners) {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { metricsFileSchema } from './validation.js';
 import type { GlobalMetrics as GlobalMetricsResponse } from './api-contracts.js';
+import type { TokenUsageDelta } from './transcript.js';
 
 export interface GlobalMetrics {
   sessionsCreated: number;
@@ -28,6 +29,15 @@ export interface GlobalMetrics {
   promptsFailed: number;
 }
 
+/** Issue #488: Cumulative token usage + estimated cost for a session. */
+export interface SessionTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  estimatedCostUsd: number;
+}
+
 export interface SessionMetrics {
   durationSec: number;
   messages: number;
@@ -35,6 +45,8 @@ export interface SessionMetrics {
   approvals: number;
   autoApprovals: number;
   statusChanges: string[];
+  /** Issue #488: Cumulative token usage and estimated cost. Present once tokens are first observed. */
+  tokenUsage?: SessionTokenUsage;
 }
 
 /** Issue #87: Per-session latency samples (rolling window). */
@@ -77,6 +89,32 @@ export class MetricsCollector {
 
   /** Maximum samples per latency type per session (rolling window). */
   static readonly MAX_LATENCY_SAMPLES = 100;
+
+  /**
+   * Issue #488: Cost per million tokens by model family.
+   * Rates: [input $/M, output $/M, cacheWrite $/M, cacheRead $/M].
+   */
+  private static readonly COST_TABLE: Record<string, [number, number, number, number]> = {
+    'haiku':  [0.80,   4.00,  1.00,  0.08],
+    'sonnet': [3.00,  15.00,  3.75,  0.30],
+    'opus':   [15.00, 75.00, 18.75,  1.50],
+  };
+
+  private static estimateCost(delta: TokenUsageDelta, model?: string): number {
+    let tier: [number, number, number, number] = MetricsCollector.COST_TABLE['sonnet'];
+    if (model) {
+      const lower = model.toLowerCase();
+      if (lower.includes('haiku')) tier = MetricsCollector.COST_TABLE['haiku'];
+      else if (lower.includes('opus')) tier = MetricsCollector.COST_TABLE['opus'];
+    }
+    const [inRate, outRate, cwRate, crRate] = tier;
+    return (
+      (delta.inputTokens * inRate +
+       delta.outputTokens * outRate +
+       delta.cacheCreationTokens * cwRate +
+       delta.cacheReadTokens * crRate) / 1_000_000
+    );
+  }
 
   constructor(private metricsFile: string) {}
 
@@ -154,6 +192,28 @@ export class MetricsCollector {
       this.global.promptsDelivered++;
     } else {
       this.global.promptsFailed++;
+    }
+  }
+
+  /** Issue #488: Accumulate token usage for a session. */
+  recordTokenUsage(sessionId: string, delta: TokenUsageDelta, model?: string): void {
+    const m = this.perSession.get(sessionId);
+    if (!m) return;
+    const addedCost = MetricsCollector.estimateCost(delta, model);
+    if (!m.tokenUsage) {
+      m.tokenUsage = {
+        inputTokens: delta.inputTokens,
+        outputTokens: delta.outputTokens,
+        cacheCreationTokens: delta.cacheCreationTokens,
+        cacheReadTokens: delta.cacheReadTokens,
+        estimatedCostUsd: addedCost,
+      };
+    } else {
+      m.tokenUsage.inputTokens += delta.inputTokens;
+      m.tokenUsage.outputTokens += delta.outputTokens;
+      m.tokenUsage.cacheCreationTokens += delta.cacheCreationTokens;
+      m.tokenUsage.cacheReadTokens += delta.cacheReadTokens;
+      m.tokenUsage.estimatedCostUsd += addedCost;
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1796,6 +1796,17 @@ async function main(): Promise<void> {
   jsonlWatcher = new JsonlWatcher();
   monitor.setJsonlWatcher(jsonlWatcher);
 
+  // Issue #488: Accumulate token usage from JSONL events into per-session metrics.
+  jsonlWatcher.onEntries((event) => {
+    const { tokenUsageDelta } = event;
+    if (tokenUsageDelta.inputTokens > 0 || tokenUsageDelta.outputTokens > 0) {
+      if (metrics) {
+        const model = sessions.getSession(event.sessionId)?.model;
+        metrics.recordTokenUsage(event.sessionId, tokenUsageDelta, model);
+      }
+    }
+  });
+
   // Start watching JSONL files for already-discovered sessions
   for (const session of sessions.listSessions()) {
     if (session.jsonlPath) {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -37,12 +37,27 @@ interface ContentBlock {
   is_error?: boolean;
 }
 
-interface JsonlEntry {
+/** Issue #488: Cumulative token usage extracted from a batch of JSONL entries. */
+export interface TokenUsageDelta {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+}
+
+export interface JsonlEntry {
   type: string;         // "user" | "assistant" | "progress" | "system" | etc.
   message?: {
     role: string;
     content: string | ContentBlock[];
     stop_reason?: string;
+    /** Token usage reported by the model (present on assistant messages). */
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
   };
   timestamp?: string;
   // Tool result entries
@@ -204,6 +219,23 @@ export function parseEntries(entries: JsonlEntry[]): ParsedEntry[] {
   }
 
   return results;
+}
+
+/** Issue #488: Sum token usage across a batch of raw JSONL entries. */
+export function extractTokenDelta(raw: JsonlEntry[]): TokenUsageDelta {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheCreationTokens = 0;
+  let cacheReadTokens = 0;
+  for (const entry of raw) {
+    const u = entry.message?.usage;
+    if (!u) continue;
+    inputTokens += u.input_tokens ?? 0;
+    outputTokens += u.output_tokens ?? 0;
+    cacheCreationTokens += u.cache_creation_input_tokens ?? 0;
+    cacheReadTokens += u.cache_read_input_tokens ?? 0;
+  }
+  return { inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens };
 }
 
 /** Read JSONL file from byte offset, return new entries + new offset. */


### PR DESCRIPTION
## Summary

Track input/output/cache tokens per session from CC JSONL events and display estimated API cost in the dashboard.

### Backend

- **transcript.ts**: Export \JsonlEntry\, \TokenUsageDelta\ interface, and \xtractTokenDelta(raw)\ helper that sums token usage across a batch of raw JSONL entries
- **jsonl-watcher.ts**: Add \	okenUsageDelta: TokenUsageDelta\ to \JsonlWatcherEvent\; computed in \eadAndEmit\ from the raw entries
- **metrics.ts**: Add \SessionTokenUsage\ interface + \COST_TABLE\ (haiku/sonnet/opus rates) + \ecordTokenUsage(sessionId, delta, model?)\. Cost estimation is model-aware via session's \model\ field
- **api-contracts.ts**: Add optional \	okenUsage?\ to \SessionMetrics\
- **server.ts**: Second \jsonlWatcher.onEntries\ subscriber calls \metrics.recordTokenUsage\ for token-bearing events; guarded for startup window

### Dashboard

- **schemas.ts**: Extend \SessionMetricsSchema\ with optional tokenUsage object
- **SessionMetricsPanel.tsx**: Token Usage row (Input / Output / Cache Write / Cache Read / Est. Cost) when present; cost shown to 3-4 dp with pricing-tier disclaimer

### Pricing table (Anthropic list prices)

| Tier | Input \$/M | Output \$/M | Cache-Write \$/M | Cache-Read \$/M |
|------|-----------|------------|----------------|----------------|
| haiku | 0.80 | 4.00 | 1.00 | 0.08 |
| sonnet (default) | 3.00 | 15.00 | 3.75 | 0.30 |
| opus | 15.00 | 75.00 | 18.75 | 1.50 |

## Quality gate

- \
px tsc --noEmit\ — PASS
- \
pm run build\ — PASS
- \
pm test\ — 2227 pass / 6 fail (pre-existing Windows path-separator failures only)

## Aegis version
**Developed with:** v2.14.0

Closes #488