### PR TITLE
fix(routing): tiered model routing -- complexity scorer, keyword detector, model registry

### DIFF
--- a/src/__tests__/model-router-743.test.ts
+++ b/src/__tests__/model-router-743.test.ts
@@ -1,0 +1,167 @@
+/**
+ * model-router-743.test.ts — Unit tests for Issue #743: Tiered Model Routing.
+ *
+ * Tests: scoreTaskComplexity, scoreToTier, routeTask, MODEL_TIERS.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  scoreTaskComplexity,
+  scoreToTier,
+  routeTask,
+  MODEL_TIERS,
+  type ModelTier,
+} from '../model-router.js';
+
+// ── scoreToTier() ────────────────────────────────────────────────────
+
+describe('Issue #743: scoreToTier boundaries', () => {
+  it('0 → fast', () => { expect(scoreToTier(0)).toBe('fast'); });
+  it('30 → fast', () => { expect(scoreToTier(30)).toBe('fast'); });
+  it('31 → standard', () => { expect(scoreToTier(31)).toBe('standard'); });
+  it('50 → standard', () => { expect(scoreToTier(50)).toBe('standard'); });
+  it('70 → standard', () => { expect(scoreToTier(70)).toBe('standard'); });
+  it('71 → power', () => { expect(scoreToTier(71)).toBe('power'); });
+  it('100 → power', () => { expect(scoreToTier(100)).toBe('power'); });
+});
+
+// ── scoreTaskComplexity() keyword signals ────────────────────────────
+
+describe('Issue #743: scoreTaskComplexity — keyword signals', () => {
+  it('security keyword raises score to power tier', () => {
+    const { score, reasoning } = scoreTaskComplexity(
+      'fix security vulnerability in auth',
+      [],
+      '',
+    );
+    expect(score).toBeGreaterThan(70);
+    expect(reasoning.some(r => r.includes('security'))).toBe(true);
+  });
+
+  it('typo keyword lowers score to fast tier', () => {
+    const { score, reasoning } = scoreTaskComplexity(
+      'fix typo in README',
+      [],
+      '',
+    );
+    expect(score).toBeLessThanOrEqual(30);
+    expect(reasoning.some(r => r.includes('typo'))).toBe(true);
+  });
+
+  it('docs label lowers score to fast tier', () => {
+    const { score } = scoreTaskComplexity('update changelog', ['docs'], '');
+    expect(score).toBeLessThanOrEqual(20);
+  });
+
+  it('feature keyword produces standard tier', () => {
+    const { score } = scoreTaskComplexity('add new feature for API', [], '');
+    expect(score).toBeGreaterThan(30);
+    expect(score).toBeLessThanOrEqual(70);
+  });
+});
+
+describe('Issue #743: scoreTaskComplexity — label overrides', () => {
+  it('security label overrides to power regardless of title', () => {
+    const { score } = scoreTaskComplexity('update readme', ['security'], '');
+    expect(score).toBeGreaterThanOrEqual(80);
+  });
+
+  it('chore label pushes to fast tier', () => {
+    const { score } = scoreTaskComplexity('do something important', ['chore'], '');
+    expect(score).toBeLessThanOrEqual(20);
+  });
+
+  it('P0 label elevates to power tier', () => {
+    const { score } = scoreTaskComplexity('fix something small', ['P0'], '');
+    expect(score).toBeGreaterThanOrEqual(72);
+  });
+
+  it('P1 label elevates to power tier', () => {
+    const { score } = scoreTaskComplexity('fix something', ['P1'], '');
+    expect(score).toBeGreaterThanOrEqual(72);
+  });
+
+  it('P3 label caps at standard tier', () => {
+    const { score } = scoreTaskComplexity('complex migration task', ['P3'], '');
+    expect(score).toBeLessThanOrEqual(55);
+  });
+
+  it('reasoning array is never empty', () => {
+    const { reasoning } = scoreTaskComplexity('some generic task', [], '');
+    expect(reasoning.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Issue #743: scoreTaskComplexity — score clamped to 0–100', () => {
+  it('score never exceeds 100', () => {
+    const { score } = scoreTaskComplexity(
+      'critical security auth vulnerability migration',
+      ['security', 'P0', 'critical'],
+      'security auth cryptography encryption injection',
+    );
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it('score never goes below 0', () => {
+    const { score } = scoreTaskComplexity(
+      'typo docs documentation chore',
+      ['docs', 'chore'],
+      'typo whitespace comment',
+    );
+    expect(score).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── routeTask() ──────────────────────────────────────────────────────
+
+describe('Issue #743: routeTask() output structure', () => {
+  it('returns tier, model, score, reasoning', () => {
+    const decision = routeTask({ title: 'add new feature', labels: [], description: '' });
+    expect(decision).toHaveProperty('tier');
+    expect(decision).toHaveProperty('model');
+    expect(decision).toHaveProperty('score');
+    expect(decision).toHaveProperty('reasoning');
+    expect(typeof decision.score).toBe('number');
+    expect(Array.isArray(decision.reasoning)).toBe(true);
+  });
+
+  it('model matches MODEL_TIERS for the returned tier', () => {
+    const decision = routeTask({ title: 'fix typo in docs', labels: ['docs'] });
+    expect(decision.model).toBe(MODEL_TIERS[decision.tier as ModelTier]);
+  });
+
+  it('security task routes to power tier', () => {
+    const decision = routeTask({ title: 'fix security injection vulnerability' });
+    expect(decision.tier).toBe('power');
+  });
+
+  it('typo fix routes to fast tier', () => {
+    const decision = routeTask({ title: 'fix typo in README', labels: ['docs'] });
+    expect(decision.tier).toBe('fast');
+  });
+
+  it('labels default to [] when not provided', () => {
+    expect(() => routeTask({ title: 'any task' })).not.toThrow();
+  });
+
+  it('description defaults to empty string when not provided', () => {
+    expect(() => routeTask({ title: 'any task', labels: ['P2'] })).not.toThrow();
+  });
+});
+
+// ── MODEL_TIERS ──────────────────────────────────────────────────────
+
+describe('Issue #743: MODEL_TIERS configuration', () => {
+  it('has fast, standard, and power entries', () => {
+    expect(MODEL_TIERS).toHaveProperty('fast');
+    expect(MODEL_TIERS).toHaveProperty('standard');
+    expect(MODEL_TIERS).toHaveProperty('power');
+  });
+
+  it('all tier values are non-empty strings', () => {
+    for (const [, model] of Object.entries(MODEL_TIERS)) {
+      expect(typeof model).toBe('string');
+      expect(model.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/model-router.ts
+++ b/src/model-router.ts
@@ -1,0 +1,180 @@
+/**
+ * model-router.ts — Issue #743: Tiered Model Routing
+ *
+ * Scores task complexity from metadata (title, labels, description) and routes
+ * to the optimal model tier: fast | standard | power.
+ *
+ * Scoring (0–100):
+ *   0–30  → fast     (cheapest, e.g. Haiku-class)
+ *   31–70 → standard (balanced, e.g. Sonnet-class)
+ *   71–100 → power   (most capable, e.g. Opus-class)
+ *
+ * Concrete model names are configurable via environment variables:
+ *   MODEL_FAST, MODEL_STANDARD, MODEL_POWER
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+export type ModelTier = 'fast' | 'standard' | 'power';
+
+export interface RoutingDecision {
+  tier: ModelTier;
+  model: string;
+  score: number;
+  reasoning: string[];
+}
+
+/** Keyword signals mapped to model tier. First match in each tier wins. */
+const ROUTING_KEYWORDS: Record<ModelTier, readonly string[]> = {
+  power: [
+    'security', 'auth', 'authentication', 'authorization',
+    'architecture', 'redesign', 'migration', 'critical',
+    'vulnerability', 'injection', 'cryptography', 'encryption',
+    'race condition', 'concurrency', 'breaking change',
+    'permission', 'privilege', 'escalation',
+  ],
+  standard: [
+    'feature', 'enhancement', 'refactor', 'type-safety',
+    'integration', 'api', 'endpoint', 'validation',
+    'test', 'coverage', 'hook', 'pipeline', 'routing',
+    'module', 'performance', 'optimization',
+  ],
+  fast: [
+    'typo', 'docs', 'documentation', 'label', 'rename',
+    'bump', 'chore', 'formatting', 'comment', 'readme',
+    'changelog', 'version', 'lint', 'whitespace',
+  ],
+};
+
+/** Default model names per tier (overridable via env vars). */
+export const MODEL_TIERS: Record<ModelTier, string> = {
+  fast: process.env.MODEL_FAST ?? 'claude-haiku-4-5',
+  standard: process.env.MODEL_STANDARD ?? 'claude-sonnet-4-6',
+  power: process.env.MODEL_POWER ?? 'claude-opus-4-6',
+};
+
+/**
+ * Score a task 0–100 based on its metadata.
+ * Returns the score and a human-readable reasoning list.
+ */
+export function scoreTaskComplexity(
+  title: string,
+  labels: string[],
+  description: string,
+): { score: number; reasoning: string[] } {
+  const reasoning: string[] = [];
+  let score = 35; // baseline: low-standard
+
+  const text = `${title} ${description}`.toLowerCase();
+
+  // Power keywords → raise score to at least power tier threshold
+  for (const kw of ROUTING_KEYWORDS.power) {
+    if (text.includes(kw)) {
+      score = Math.max(score, 75);
+      reasoning.push(`power keyword: "${kw}"`);
+      break;
+    }
+  }
+
+  // Fast keywords → lower score to at most fast tier threshold
+  for (const kw of ROUTING_KEYWORDS.fast) {
+    if (text.includes(kw)) {
+      score = Math.min(score, 20);
+      reasoning.push(`fast keyword: "${kw}"`);
+      break;
+    }
+  }
+
+  // Standard keywords → minor boost (avoid staying at baseline)
+  if (reasoning.length === 0) {
+    for (const kw of ROUTING_KEYWORDS.standard) {
+      if (text.includes(kw)) {
+        score += 5;
+        reasoning.push(`standard keyword: "${kw}"`);
+        break;
+      }
+    }
+  }
+
+  // Label overrides — applied after keyword signals
+  for (const label of labels) {
+    const l = label.toLowerCase();
+    if (l === 'security' || l === 'critical' || l === 'breaking-change') {
+      score = Math.max(score, 80);
+      reasoning.push(`label override: "${l}" → power tier`);
+    } else if (l === 'docs' || l === 'documentation' || l === 'chore') {
+      score = Math.min(score, 20);
+      reasoning.push(`label override: "${l}" → fast tier`);
+    }
+  }
+
+  // Priority labels
+  for (const label of labels) {
+    if (label === 'P0' || label === 'P1') {
+      score = Math.max(score, 72);
+      reasoning.push(`priority label: "${label}" → elevate to power`);
+    } else if (label === 'P3') {
+      score = Math.min(score, 55);
+      reasoning.push(`priority label: "P3" → cap at standard`);
+    }
+  }
+
+  if (reasoning.length === 0) reasoning.push('baseline score — no keyword or label signals');
+
+  return { score: Math.max(0, Math.min(100, score)), reasoning };
+}
+
+/** Map a 0–100 score to a model tier. */
+export function scoreToTier(score: number): ModelTier {
+  if (score <= 30) return 'fast';
+  if (score <= 70) return 'standard';
+  return 'power';
+}
+
+/**
+ * Route a task to the optimal model tier and concrete model name.
+ *
+ * @example
+ *   routeTask({ title: 'fix typo in README', labels: ['docs'] })
+ *   // → { tier: 'fast', model: 'claude-haiku-4-5', score: 15, reasoning: [...] }
+ */
+export function routeTask(opts: {
+  title: string;
+  labels?: string[];
+  description?: string;
+}): RoutingDecision {
+  const { title, labels = [], description = '' } = opts;
+  const { score, reasoning } = scoreTaskComplexity(title, labels, description);
+  const tier = scoreToTier(score);
+  const model = MODEL_TIERS[tier];
+  return { tier, model, score, reasoning };
+}
+
+/** Zod schema for POST /v1/dev/route-task request body. */
+const routeTaskSchema = z.object({
+  title: z.string().min(1).max(500),
+  labels: z.array(z.string().max(100)).max(50).optional(),
+  description: z.string().max(10_000).optional(),
+});
+
+/**
+ * Register the model-routing endpoint on the Fastify app.
+ *
+ * POST /v1/dev/route-task — score a task and return model recommendation.
+ * GET  /v1/dev/model-tiers — return current model-tier configuration.
+ */
+export function registerModelRouterRoutes(app: FastifyInstance): void {
+  app.post('/v1/dev/route-task', async (req, reply) => {
+    const parsed = routeTaskSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid body', details: parsed.error.issues });
+    }
+    const { title, labels, description } = parsed.data;
+    return routeTask({ title, labels, description });
+  });
+
+  app.get('/v1/dev/model-tiers', async () => {
+    return { tiers: MODEL_TIERS };
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ import { registerPermissionRoutes } from './permission-routes.js';
 import { registerHookRoutes } from './hooks.js';
 import { registerWsTerminalRoute } from './ws-terminal.js';
 import { registerMemoryRoutes } from './memory-routes.js';
+import { registerModelRouterRoutes } from './model-router.js';
 import * as templateStore from './template-store.js';
 import { SwarmMonitor } from './swarm-monitor.js';
 import { killAllSessions } from './signal-cleanup-helper.js';
@@ -1890,6 +1891,9 @@ async function main(): Promise<void> {
 
   // Register HTTP hook receiver (Issue #169, Issue #87: pass metrics for latency tracking)
   registerHookRoutes(app, { sessions, eventBus, metrics });
+
+  // Issue #743: Register model-routing endpoints
+  registerModelRouterRoutes(app);
 
   // Initialize pipeline manager (Issue #36)
   pipelines = new PipelineManager(sessions, eventBus);


### PR DESCRIPTION
## Summary

Implements Issue #743: a standalone **Tiered Model Routing** module that scores task complexity and routes to the optimal model tier.

### New file: src/model-router.ts

**Scoring (0–100 → fast|standard|power):**

| Range | Tier | Default model |
|---|---|---|
| 0–30 | fast | claude-haiku-4-5 (overridable via MODEL_FAST) |
| 31–70 | standard | claude-sonnet-4-6 (overridable via MODEL_STANDARD) |
| 71–100 | power | claude-opus-4-6 (overridable via MODEL_POWER) |

**Keyword signals:**
- Power: security, uth, rchitecture, migration, ulnerability, cryptography, …
- Standard: eature, efactor, pi, alidation, integration, …
- Fast: 	ypo, docs, chore, ename, changelog, lint, …

**Label overrides:**
- security / critical / reaking-change → floor at 80 (power)
- docs / documentation / chore → ceiling at 20 (fast)
- P0 / P1 → floor at 72 (power)
- P3 → ceiling at 55 (standard)

**New endpoints registered in src/server.ts:**
- POST /v1/dev/route-task — body: {title, labels?, description?} → returns {tier, model, score, reasoning[]}
- GET /v1/dev/model-tiers — returns current tier→model mapping

### Quality gate

| Check | Result |
|---|---|
| 
px tsc --noEmit | PASS |
| 
pm run build | PASS |
| 
pm test | 2254 pass / 6 pre-existing Windows failures (baseline) |

Closes #743

## Aegis version
**Developed with:** v2.14.0