### PR TITLE
fix(windows): normalize Claude project hash across unix/windows paths

### DIFF
--- a/src/__tests__/bare-flag.test.ts
+++ b/src/__tests__/bare-flag.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { computeProjectHash } from '../path-utils.js';
 
 describe('--bare flag detection', () => {
   describe('flag detection in claudeCommand', () => {
@@ -30,7 +31,7 @@ describe('--bare flag detection', () => {
   describe('filesystem discovery logic', () => {
     it('should compute project hash correctly', () => {
       const workDir = '/home/user/projects/foo';
-      const hash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
+      const hash = computeProjectHash(workDir);
       expect(hash).toBe('-home-user-projects-foo');
     });
 

--- a/src/__tests__/path-utils-909.test.ts
+++ b/src/__tests__/path-utils-909.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { computeProjectHash } from '../path-utils.js';
+
+describe('Issue #909: computeProjectHash cross-platform normalization', () => {
+  it('normalizes unix absolute paths', () => {
+    expect(computeProjectHash('/home/user/project')).toBe('-home-user-project');
+  });
+
+  it('normalizes windows drive paths', () => {
+    expect(computeProjectHash('D:\\Users\\user\\project')).toBe('-d-Users-user-project');
+  });
+
+  it('normalizes windows paths with spaces', () => {
+    expect(computeProjectHash('D:\\Program Files\\my project')).toBe('-d-Program-Files-my-project');
+  });
+
+  it('handles already slash-normalized windows path', () => {
+    expect(computeProjectHash('C:/Users/test/repo')).toBe('-c-Users-test-repo');
+  });
+
+  it('returns fallback for empty input', () => {
+    expect(computeProjectHash('')).toBe('-');
+  });
+});

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * path-utils.ts — path helpers shared across session/tmux logic.
+ */
+
+/**
+ * Compute the Claude project hash folder from a workDir path.
+ *
+ * Examples:
+ * - /home/user/project -> -home-user-project
+ * - D:\\Users\\me\\project -> -d-Users-me-project
+ */
+export function computeProjectHash(workDir: string): string {
+  const normalized = workDir.replace(/\\/g, '/').trim();
+  const withLowerDrive = normalized.replace(/^[A-Za-z]:/, (m) => `${m[0].toLowerCase()}`);
+  const segments = withLowerDrive
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => segment.replace(/:/g, '').replace(/\s+/g, '-'));
+
+  if (segments.length === 0) return '-';
+  return `-${segments.join('-')}`;
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -25,6 +25,7 @@ import { PermissionRequestManager, type PermissionDecision } from './permission-
 import { QuestionManager } from './question-manager.js';
 import { Mutex } from 'async-mutex';
 import { maybeInjectFault } from './fault-injection.js';
+import { computeProjectHash } from './path-utils.js';
 
 /** Convert parsed JSON arrays to Sets for activeSubagents (#668). */
 function hydrateSessions(raw: z.infer<typeof persistedStateSchema>): Record<string, SessionInfo> {
@@ -1625,7 +1626,7 @@ export class SessionManager {
 
   /** Attempt filesystem-based discovery for a single session poll tick. */
   private async maybeDiscoverFromFilesystem(session: SessionInfo, workDir: string): Promise<boolean> {
-    const projectHash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
+    const projectHash = computeProjectHash(workDir);
     const projectDir = join(this.config.claudeProjectsDir, projectHash);
     if (!existsSync(projectDir)) return false;
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -12,6 +12,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
+import { computeProjectHash } from './path-utils.js';
 
 /** Shell-escape a string by wrapping in single quotes and escaping embedded single quotes. */
 function shellEscape(s: string): string {
@@ -437,7 +438,7 @@ export class TmuxManager {
    */
   private async archiveStaleSessionFiles(workDir: string): Promise<void> {
     // Compute the project hash the same way Claude CLI does
-    const projectHash = '-' + workDir.replace(/^\//, '').replace(/\//g, '-');
+    const projectHash = computeProjectHash(workDir);
     const projectDir = join(homedir(), '.claude', 'projects', projectHash);
 
     if (!existsSync(projectDir)) return;


### PR DESCRIPTION
## Summary\n\nImplements a safe first Windows support slice for issue #909: extract and normalize Claude project hash generation into a shared helper used consistently by discovery/archive code paths.\n\n### Changes\n- Add src/path-utils.ts with computeProjectHash(workDir)\n- Replace duplicated inline hash logic in:\n  - src/tmux.ts (rchiveStaleSessionFiles)\n  - src/session.ts (filesystem discovery path)\n- Add tests:\n  - src/__tests__/path-utils-909.test.ts (cross-platform normalization)\n  - src/__tests__/bare-flag.test.ts updated to use shared helper\n\n### Quality gate\n- 
px tsc --noEmit: PASS\n- 
pm run build: PASS\n- Focused tests: PASS (path-utils-909, are-flag)\n- Full 
pm test: baseline 6 known Windows failures (pre-existing)\n\nRefs #909\n\n## Aegis version\n**Developed with:** v2.15.0