### PR TITLE
fix(mcp): add state_get/state_set/state_delete tools

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -475,6 +475,41 @@ describe('AegisClient', () => {
     await expect(client.sendCommand('bad', 'cmd')).rejects.toThrow('Invalid session ID: bad');
     await expect(client.getSessionLatency('bad')).rejects.toThrow('Invalid session ID: bad');
   });
+
+  it('setMemory sends POST /v1/memory', async () => {
+    const mockEntry = { entry: { key: 'pipeline/run-1', value: 'ok', namespace: 'pipeline', created_at: 1, updated_at: 1 } };
+    (fetch as any).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockEntry) });
+
+    const result = await client.setMemory('pipeline/run-1', 'ok', 60);
+    expect(result.entry.key).toBe('pipeline/run-1');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:9100/v1/memory',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ key: 'pipeline/run-1', value: 'ok', ttlSeconds: 60 }) }),
+    );
+  });
+
+  it('getMemory sends GET /v1/memory/:key', async () => {
+    const mockEntry = { entry: { key: 'pipeline/run-2', value: 'x', namespace: 'pipeline', created_at: 1, updated_at: 1 } };
+    (fetch as any).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockEntry) });
+
+    const result = await client.getMemory('pipeline/run-2');
+    expect(result.entry.value).toBe('x');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:9100/v1/memory/pipeline%2Frun-2',
+      expect.anything(),
+    );
+  });
+
+  it('deleteMemory sends DELETE /v1/memory/:key', async () => {
+    (fetch as any).mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) });
+
+    const result = await client.deleteMemory('pipeline/run-3');
+    expect(result.ok).toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:9100/v1/memory/pipeline%2Frun-3',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
 });
 
 // ── MCP server creation tests ───────────────────────────────────────
@@ -494,7 +529,7 @@ describe('createMcpServer', () => {
     expect(info.name).toBe('aegis');
   });
 
-  it('registers all 21 tools', () => {
+  it('registers all 24 tools', () => {
     const server = createMcpServer(9100);
     // The internal _registeredTools is private, but we can check via the server
     // We verify by checking that the tool handler setup doesn't throw
@@ -522,7 +557,10 @@ describe('createMcpServer', () => {
     expect(Object.keys(tools)).toContain('list_pipelines');
     expect(Object.keys(tools)).toContain('create_pipeline');
     expect(Object.keys(tools)).toContain('get_swarm');
-    expect(Object.keys(tools)).toHaveLength(21);
+    expect(Object.keys(tools)).toContain('state_set');
+    expect(Object.keys(tools)).toContain('state_get');
+    expect(Object.keys(tools)).toContain('state_delete');
+    expect(Object.keys(tools)).toHaveLength(24);
   });
 
   it('accepts custom auth token', () => {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -71,6 +71,17 @@ interface SessionLatencyResponse {
   aggregated: SessionLatencySummary | null;
 }
 
+interface MemoryEntryResponse {
+  entry: {
+    key: string;
+    value: string;
+    namespace: string;
+    created_at: number;
+    updated_at: number;
+    expires_at?: number;
+  };
+}
+
 // ── Aegis REST client ───────────────────────────────────────────────
 
 export class AegisClient {
@@ -242,6 +253,23 @@ export class AegisClient {
 
   async getSwarm(): Promise<Record<string, unknown>> {
     return this.request('/v1/swarm');
+  }
+
+  async setMemory(key: string, value: string, ttlSeconds?: number): Promise<MemoryEntryResponse> {
+    return this.request('/v1/memory', {
+      method: 'POST',
+      body: JSON.stringify({ key, value, ttlSeconds }),
+    });
+  }
+
+  async getMemory(key: string): Promise<MemoryEntryResponse> {
+    return this.request(`/v1/memory/${encodeURIComponent(key)}`);
+  }
+
+  async deleteMemory(key: string): Promise<OkResponse> {
+    return this.request(`/v1/memory/${encodeURIComponent(key)}`, {
+      method: 'DELETE',
+    });
   }
 }
 
@@ -861,6 +889,74 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     async () => {
       try {
         const result = await client.getSwarm();
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (e: unknown) {
+        return formatToolError(e);
+      }
+    },
+  );
+
+  // ── state_set ──
+  server.tool(
+    'state_set',
+    'Set a shared state key/value entry via Aegis memory bridge.',
+    {
+      key: z.string().describe('State key in namespace/key format (e.g., pipeline/run-123)'),
+      value: z.string().describe('State payload as string'),
+      ttlSeconds: z.number().int().positive().max(86400 * 30).optional().describe('Optional TTL in seconds (max 30 days)'),
+    },
+    async ({ key, value, ttlSeconds }) => {
+      try {
+        const result = await client.setMemory(key, value, ttlSeconds);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (e: unknown) {
+        return formatToolError(e);
+      }
+    },
+  );
+
+  // ── state_get ──
+  server.tool(
+    'state_get',
+    'Get a shared state key/value entry via Aegis memory bridge.',
+    {
+      key: z.string().describe('State key in namespace/key format (e.g., pipeline/run-123)'),
+    },
+    async ({ key }) => {
+      try {
+        const result = await client.getMemory(key);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (e: unknown) {
+        return formatToolError(e);
+      }
+    },
+  );
+
+  // ── state_delete ──
+  server.tool(
+    'state_delete',
+    'Delete a shared state key/value entry via Aegis memory bridge.',
+    {
+      key: z.string().describe('State key in namespace/key format (e.g., pipeline/run-123)'),
+    },
+    async ({ key }) => {
+      try {
+        const result = await client.deleteMemory(key);
         return {
           content: [{
             type: 'text' as const,


### PR DESCRIPTION
## Summary\n\nImplements the minimum-value slice of issue #752 by adding shared state tools to the MCP server backed by the existing memory bridge routes.\n\n### Changes\n- src/mcp-server.ts\n  - Add AegisClient methods:\n    - setMemory(key, value, ttlSeconds?)\n    - getMemory(key)\n    - deleteMemory(key)\n  - Register new MCP tools:\n    - state_set\n    - state_get\n    - state_delete\n- src/__tests__/mcp-server.test.ts\n  - Add client tests for the 3 new memory endpoints\n  - Extend tool registry assertions from 21 -> 24 tools\n\n### Quality gate\n- 
px tsc --noEmit: PASS\n- 
pm run build: PASS\n- Focused tests: PASS (mcp-server.test.ts, 119 tests)\n- Full 
pm test: baseline 6 known Windows failures (pre-existing)\n\nRefs #752\n\n## Aegis version\n**Developed with:** v2.15.0