### PR TITLE
fix(skill): improve install flow and ClawHub release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,4 +64,4 @@ jobs:
         run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
       - run: |
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest publish skill/ --slug aegis-bridge --name "Aegis" --version "$VERSION" --changelog "Release v$VERSION"
+          npx clawhub@latest publish skill/ --slug aegis-bridge --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"

--- a/skill/README.md
+++ b/skill/README.md
@@ -1,0 +1,46 @@
+# Aegis Skill (OpenClaw)
+
+Install and run Aegis orchestration workflows from Claude Code via MCP.
+
+## Prerequisites
+
+- Node.js 20+
+- Claude Code CLI available in PATH
+- Aegis server running locally (`aegis-bridge start`)
+
+## Quick Install
+
+```bash
+skill install aegis-bridge
+```
+
+Then configure MCP:
+
+```bash
+bash skill/scripts/setup-mcp.sh user
+```
+
+Or project-scoped:
+
+```bash
+bash skill/scripts/setup-mcp.sh project
+```
+
+## Verification
+
+```bash
+bash skill/scripts/health-check.sh
+```
+
+Expected output includes `OK` and exit code `0`.
+
+## Troubleshooting
+
+- If connection fails, start server with `aegis-bridge start`.
+- If MCP server is missing, run setup script again and restart Claude Code.
+- If `jq` is missing, install it and rerun scripts.
+
+## Environment Variables
+
+- `AEGIS_HOST` (default `127.0.0.1`)
+- `AEGIS_PORT` (default `9100`)

--- a/skill/scripts/health-check.sh
+++ b/skill/scripts/health-check.sh
@@ -19,14 +19,34 @@ fi
 STATUS_VAL=$(echo "$RESPONSE" | jq -r '.status // . // empty' 2>/dev/null)
 if [ "$STATUS_VAL" = "ok" ] || [ "$STATUS_VAL" = "healthy" ]; then
   echo "OK"
-  exit 0
+else
+  # If response is valid JSON, assume healthy
+  if echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
+    echo "OK (response received)"
+  else
+    echo "FAIL (unexpected response: $RESPONSE)"
+    exit 1
+  fi
 fi
 
-# If response is valid JSON, assume healthy
-if echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
-  echo "OK (response received)"
-  exit 0
+# Best-effort MCP config check
+USER_CFG="$HOME/.claude/settings.json"
+PROJECT_CFG=".mcp.json"
+HAS_MCP=0
+
+if [ -f "$USER_CFG" ] && jq -e '.mcpServers.aegis' "$USER_CFG" >/dev/null 2>&1; then
+  HAS_MCP=1
 fi
 
-echo "FAIL (unexpected response: $RESPONSE)"
-exit 1
+if [ -f "$PROJECT_CFG" ] && jq -e '.mcpServers.aegis' "$PROJECT_CFG" >/dev/null 2>&1; then
+  HAS_MCP=1
+fi
+
+if [ "$HAS_MCP" -eq 1 ]; then
+  echo "MCP config: OK (aegis server found)"
+else
+  echo "MCP config: MISSING"
+  echo "Run: bash skill/scripts/setup-mcp.sh user"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary\n\nDelivers an install/distribution slice for issue #448 (OpenClaw Skill install flow + listing polish).\n\n### Changes\n- skill/README.md (new)\n  - install-focused guide, verification, troubleshooting, env vars\n- skill/scripts/health-check.sh\n  - keep HTTP health validation\n  - add best-effort MCP config verification and guidance\n- .github/workflows/release.yml\n  - update ClawHub publish metadata (Aegis Bridge name + clearer changelog text)\n\n### Validation\n- 
px tsc --noEmit: PASS\n- 
pm run build: PASS\n\nRefs #448\n\n## Aegis version\n**Developed with:** v2.15.0