### PR TITLE
docs(integrations): add Cursor and Windsurf MCP setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <img src="https://img.shields.io/github/actions/workflow/status/OneStepAt4time/aegis/ci.yml?branch=main" alt="CI" />
   <img src="https://img.shields.io/npm/l/aegis-bridge.svg" alt="license" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.0.0-blue.svg" alt="node" />
+  <img src="https://img.shields.io/badge/MCP-ready-green.svg" alt="MCP ready" />
 </p>
 
 <p align="center">
@@ -95,6 +96,14 @@ Or via `.mcp.json`:
 **4 resources** — `aegis://sessions`, `aegis://sessions/{id}/transcript`, `aegis://sessions/{id}/pane`, `aegis://health`
 
 **3 prompts** — `implement_issue`, `review_pr`, `debug_session`
+
+## Ecosystem Integrations
+
+Aegis works beyond Claude Code anywhere an MCP host can launch a local stdio server.
+
+- [Cursor integration](docs/integrations/cursor.md)
+- [Windsurf integration](docs/integrations/windsurf.md)
+- [MCP Registry preparation](docs/integrations/mcp-registry.md)
 
 ---
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,47 @@
+# Cursor Integration
+
+Use Aegis as an MCP server inside Cursor.
+
+## Prerequisites
+
+- `aegis-bridge` installed or runnable via `npx`
+- Cursor with MCP support enabled
+- Local Aegis server reachable on `127.0.0.1:9100`
+
+## Configuration
+
+Add an MCP server entry that launches Aegis in stdio mode:
+
+```json
+{
+  "mcpServers": {
+    "aegis": {
+      "command": "npx",
+      "args": ["aegis-bridge", "mcp"]
+    }
+  }
+}
+```
+
+## Verification
+
+1. Start Aegis: `aegis-bridge start`
+2. Restart Cursor
+3. Check that Aegis tools appear
+4. Call `server_health` and `list_sessions`
+
+## Expected Working Tools
+
+- `create_session`
+- `list_sessions`
+- `get_status`
+- `get_transcript`
+- `send_message`
+- `approve_permission`
+- `state_get` / `state_set` / `state_delete`
+
+## Troubleshooting
+
+- If the host cannot start the server, run `npx aegis-bridge mcp` manually.
+- If HTTP calls fail, verify `http://127.0.0.1:9100/v1/health`.
+- If tools are stale, restart the host after config changes.

--- a/docs/integrations/mcp-registry.md
+++ b/docs/integrations/mcp-registry.md
@@ -1,0 +1,26 @@
+# MCP Registry Preparation
+
+This document tracks the metadata needed to publish Aegis to an MCP registry.
+
+## Package Identity
+
+- Name: `Aegis Bridge`
+- Slug: `aegis-bridge`
+- Summary: `HTTP + MCP orchestration for Claude Code sessions`
+- Homepage: `https://github.com/OneStepAt4time/aegis`
+- License: `MIT`
+
+## Suggested Metadata
+
+- Tags: `mcp`, `claude-code`, `orchestration`, `automation`, `sessions`
+- Transport: `stdio`
+- Launch command: `npx aegis-bridge mcp`
+- Health endpoint: `GET /v1/health`
+
+## Registry Checklist
+
+- Confirm npm package is public
+- Confirm README contains MCP install instructions
+- Confirm example config for at least 2 MCP hosts
+- Confirm versioned release pipeline is active
+- Add registry badge/link to README after listing is live

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -1,0 +1,37 @@
+# Windsurf Integration
+
+Use Aegis from Windsurf as a local MCP server.
+
+## Prerequisites
+
+- Windsurf build with MCP host support
+- Local access to `npx`
+- Aegis server running locally
+
+## Configuration
+
+Register Aegis as a stdio MCP server:
+
+```json
+{
+  "mcpServers": {
+    "aegis": {
+      "command": "npx",
+      "args": ["aegis-bridge", "mcp", "--port", "9100"]
+    }
+  }
+}
+```
+
+## Smoke Test
+
+1. Start Aegis.
+2. Reload Windsurf.
+3. Run `server_health`.
+4. Create a scratch session with `create_session`.
+5. Confirm `get_status` and `send_message` work.
+
+## Notes
+
+- If Windsurf supports environment variables for MCP servers, point it at the same local Node runtime used for Aegis.
+- If your host keeps stale tool schemas, remove and re-add the `aegis` server entry.


### PR DESCRIPTION
## Summary\n\nImplements a documentation-first slice for issue #451 by preparing ecosystem integration guidance for non-Claude-Code MCP hosts.\n\n### Changes\n- docs/integrations/cursor.md\n- docs/integrations/windsurf.md\n- docs/integrations/mcp-registry.md\n- README.md\n  - add Ecosystem Integrations section\n  - add MCP-ready badge\n\n### Validation\n- 
px tsc --noEmit: PASS\n- 
pm run build: PASS\n\nRefs #451\n\n## Aegis version\n**Developed with:** v2.15.0