### PR TITLE
fix(agent): add consensus review request flow

### DIFF
--- a/src/__tests__/consensus-734.test.ts
+++ b/src/__tests__/consensus-734.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { buildConsensusPrompt, mergeConsensusFindings } from '../consensus.js';
+
+describe('Issue #734: consensus helpers', () => {
+  it('builds focus-specific reviewer prompt', () => {
+    const prompt = buildConsensusPrompt('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 'security');
+    expect(prompt).toContain('security');
+    expect(prompt).toContain('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('deduplicates findings across reviewers', () => {
+    const findings = mergeConsensusFindings([
+      { reviewerId: 'r1', focusArea: 'correctness', findings: ['Bug A', 'Bug B'] },
+      { reviewerId: 'r2', focusArea: 'security', findings: ['Bug B', 'Risk C'] },
+    ]);
+    expect(findings).toEqual(['Bug A', 'Bug B', 'Risk C']);
+  });
+
+  it('ignores empty findings', () => {
+    const findings = mergeConsensusFindings([
+      { reviewerId: 'r1', focusArea: 'performance', findings: ['  ', 'Slow path'] },
+    ]);
+    expect(findings).toEqual(['Slow path']);
+  });
+});

--- a/src/consensus.ts
+++ b/src/consensus.ts
@@ -1,0 +1,36 @@
+export type ConsensusFocusArea = 'correctness' | 'security' | 'performance';
+
+export interface ConsensusRequest {
+  id: string;
+  targetSessionId: string;
+  reviewerIds: string[];
+  focusAreas: ConsensusFocusArea[];
+  status: 'running' | 'completed' | 'failed';
+  createdAt: number;
+}
+
+export interface ConsensusReview {
+  reviewerId: string;
+  focusArea: ConsensusFocusArea;
+  findings: string[];
+}
+
+export function buildConsensusPrompt(targetSessionId: string, focusArea: ConsensusFocusArea): string {
+  return [
+    `Review Aegis session ${targetSessionId}.`,
+    `Focus area: ${focusArea}.`,
+    'Return concise findings ordered by severity.',
+    'Prefer concrete regressions, risks, and missing verification.',
+  ].join(' ');
+}
+
+export function mergeConsensusFindings(reviews: ConsensusReview[]): string[] {
+  const merged = new Set<string>();
+  for (const review of reviews) {
+    for (const finding of review.findings) {
+      const normalized = finding.trim();
+      if (normalized) merged.add(normalized);
+    }
+  }
+  return Array.from(merged.values());
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ import { registerHookRoutes } from './hooks.js';
 import { registerWsTerminalRoute } from './ws-terminal.js';
 import { registerMemoryRoutes } from './memory-routes.js';
 import { registerModelRouterRoutes } from './model-router.js';
+import { buildConsensusPrompt, type ConsensusFocusArea, type ConsensusRequest } from './consensus.js';
 import * as templateStore from './template-store.js';
 import { SwarmMonitor } from './swarm-monitor.js';
 import { killAllSessions } from './signal-cleanup-helper.js';
@@ -66,6 +67,8 @@ import {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const consensusRequests = new Map<string, ConsensusRequest>();
 
 // ── Shared route handler types ────────────────────────────────────────
 type IdParams = { Params: { id: string } };
@@ -1008,6 +1011,64 @@ async function forkSessionHandler(req: ForkRequest, reply: FastifyReply): Promis
 }
 app.post('/v1/sessions/:id/fork', forkSessionHandler);
 app.post('/sessions/:id/fork', forkSessionHandler);
+
+type ConsensusBody = {
+  focusAreas?: ConsensusFocusArea[];
+  reviewerCount?: number;
+};
+
+async function createConsensusHandler(
+  req: FastifyRequest<{ Params: { id: string }; Body: ConsensusBody | undefined }>,
+  reply: FastifyReply,
+): Promise<Record<string, unknown>> {
+  const targetSessionId = req.params.id;
+  const target = sessions.getSession(targetSessionId);
+  if (!target) return reply.status(404).send({ error: 'Target session not found' });
+
+  const focusAreas: ConsensusFocusArea[] = (req.body?.focusAreas && req.body.focusAreas.length > 0)
+    ? req.body.focusAreas
+    : ['correctness', 'security', 'performance'];
+
+  const reviewerCount = Math.min(5, Math.max(1, req.body?.reviewerCount ?? focusAreas.length));
+  const selectedFocus: ConsensusFocusArea[] = focusAreas.slice(0, reviewerCount);
+  const reviewerIds: string[] = [];
+
+  for (let i = 0; i < selectedFocus.length; i += 1) {
+    const focus = selectedFocus[i];
+    const child = await sessions.createSession({
+      workDir: target.workDir,
+      name: `consensus-${focus}-${targetSessionId.slice(0, 6)}`,
+      parentId: targetSessionId,
+      permissionMode: target.permissionMode,
+    });
+    reviewerIds.push(child.id);
+    await sessions.sendInitialPrompt(child.id, buildConsensusPrompt(targetSessionId, focus));
+  }
+
+  const consensusId = crypto.randomUUID();
+  const record: ConsensusRequest = {
+    id: consensusId,
+    targetSessionId,
+    reviewerIds,
+    focusAreas: selectedFocus,
+    status: 'running',
+    createdAt: Date.now(),
+  };
+  consensusRequests.set(consensusId, record);
+  return reply.status(202).send(record);
+}
+
+function getConsensusHandler(
+  req: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply,
+): unknown {
+  const item = consensusRequests.get(req.params.id);
+  if (!item) return reply.status(404).send({ error: 'Consensus request not found' });
+  return item;
+}
+
+app.post('/v1/sessions/:id/consensus', createConsensusHandler);
+app.get('/v1/consensus/:id', getConsensusHandler);
 
 // Issue #700: Permission policy endpoints
 type PermissionRequest = FastifyRequest<{ Params: { id: string }; Body: PermissionPolicy | undefined }>;


### PR DESCRIPTION
## Summary\n\nImplements a first functional slice of issue #734 by allowing callers to create a consensus review request that spawns multiple reviewer sessions with different focus areas.\n\n### Changes\n- src/consensus.ts\n  - add consensus types\n  - add focus-specific prompt builder\n  - add finding merge helper\n- src/server.ts\n  - add POST /v1/sessions/:id/consensus\n  - add GET /v1/consensus/:id\n  - spawn reviewer sessions with correctness / security / performance focus prompts\n- src/__tests__/consensus-734.test.ts\n  - add focused helper tests\n\n### Quality gate\n- 
px tsc --noEmit: PASS\n- 
pm run build: PASS\n- Focused tests: PASS\n- Full 
pm test: baseline 6 known Windows failures (pre-existing)\n\nRefs #734\n\n## Aegis version\n**Developed with:** v2.15.0