### PR TITLE
docs(windows): add Sprint 0 pre-gate evidence and ADR decisions

### DIFF
--- a/docs/adr/0001-windows-env-injection-strategy.md
+++ b/docs/adr/0001-windows-env-injection-strategy.md
@@ -1,0 +1,32 @@
+# ADR-0001: Windows Environment Injection Strategy
+
+Status: Accepted
+Date: 2026-04-04
+Issue: #908
+
+## Context
+
+Aegis injects sensitive env vars into the running Claude pane. Existing Unix flow relies on shell semantics (`export`, `source`). On Windows/psmux, direct shell parity is unreliable.
+
+## Decision
+
+Adopt a hybrid strategy:
+- Session-level propagation via `tmux set-environment`.
+- Active pane propagation via temporary PowerShell file (`.ps1`) dot-sourcing and immediate cleanup.
+
+## Consequences
+
+Pros:
+- Works for newly created panes and active panes.
+- Avoids exposing secret values directly in terminal command history.
+- Supports explicit escaping behavior in PowerShell.
+
+Cons:
+- Requires platform-specific branching and cleanup logic.
+- ACL hardening must be best-effort on NTFS.
+
+## Alternatives Considered
+
+- A: set-environment only: insufficient for already-running pane process.
+- B: PowerShell temp file only: does not persist session-level environment.
+- C: inline send-keys with `$env:KEY=...`: simplest but leaks values in visible command stream.

--- a/docs/adr/0002-windows-swarm-monitor-strategy.md
+++ b/docs/adr/0002-windows-swarm-monitor-strategy.md
@@ -1,0 +1,26 @@
+# ADR-0002: SwarmMonitor Strategy on Windows
+
+Status: Accepted (MVP)
+Date: 2026-04-04
+Issue: #908
+
+## Context
+
+Current SwarmMonitor discovers tmux sockets using Unix-centric patterns. psmux uses a different control/socket model on Windows.
+
+## Decision
+
+Disable SwarmMonitor behavior on `win32` in MVP, with explicit informational logging and graceful no-op responses.
+
+## Consequences
+
+Pros:
+- Prevents false errors and unstable discovery behavior.
+- Keeps single-session and core orchestration reliable.
+
+Cons:
+- Multi-instance swarm discovery is unavailable on Windows in MVP.
+
+## Future Work
+
+Implement psmux-native discovery from `~/.psmux/*.key` and `.port` metadata, or move to explicit HTTP registration.

--- a/docs/adr/0003-windows-minimum-supported-version.md
+++ b/docs/adr/0003-windows-minimum-supported-version.md
@@ -1,0 +1,19 @@
+# ADR-0003: Minimum Supported Windows Version
+
+Status: Accepted
+Date: 2026-04-04
+Issue: #908
+
+## Decision
+
+Set minimum supported version to Windows 10 (1903+) with Windows 11 recommended.
+
+## Rationale
+
+- ConPTY and terminal behavior are materially more stable on these versions.
+- Tooling support (Node, PowerShell, psmux compatibility) is adequate.
+
+## Consequences
+
+- Older Windows versions are out of support for Aegis Windows mode.
+- Documentation must clearly state this requirement.

--- a/docs/adr/0004-psmux-version-pinning.md
+++ b/docs/adr/0004-psmux-version-pinning.md
@@ -1,0 +1,23 @@
+# ADR-0004: psmux Version Pinning
+
+Status: Accepted
+Date: 2026-04-04
+Issue: #908
+
+## Decision
+
+Require psmux/tmux compatibility at version 3.3+ for Windows support.
+
+## Rationale
+
+- Empirical checks in Sprint 0 performed on tmux 3.3 (psmux) succeeded.
+- Known behavior differences and bugs are documented and manageable at this level.
+
+## Enforcement
+
+- CI installs psmux on Windows runners.
+- Startup diagnostics should surface tmux version when capabilities are missing.
+
+## Consequences
+
+- Users on older psmux versions may experience undefined behavior and should upgrade.

--- a/docs/windows-pre-gate-report-908.md
+++ b/docs/windows-pre-gate-report-908.md
@@ -1,0 +1,64 @@
+# Windows Sprint 0 Pre-Gate Report (#908)
+
+Date: 2026-04-04
+Environment: Windows host, `tmux 3.3` (psmux), `claude 2.1.92`
+
+## Gate 1: Claude Code inside psmux pane
+
+Status: PASS (with caveats)
+
+Evidence:
+- `tmux -V` returned `tmux 3.3`
+- `claude --version` returned `2.1.92 (Claude Code)`
+- Running `claude --version` inside a psmux pane succeeded.
+- Running `claude` interactively in-pane rendered UI and accepted `Ctrl+C` interruption.
+- In-pane env variables were present:
+  - `TMUX=/tmp/psmux-17068/test908,64817,0`
+  - `TMUX_PANE=%1`
+
+Caveats:
+- ANSI rendering in captured pane output includes heavy glyph/noise artifacts.
+- Further manual validation of multi-turn prompt/response latency should be tracked in Sprint 4 E2E.
+
+## Gate 2: Project hash computation on Windows
+
+Status: PARTIAL / NEEDS ALIGNMENT
+
+Evidence:
+- Claude project directories found under `%USERPROFILE%/.claude/projects`, with names like:
+  - `C--Users-manus--claude-double-shot-latte`
+  - `D--LoLProjects-lolstonks`
+- Current Aegis hash utility (`src/path-utils.ts`) normalizes drive letter to lowercase and prefixes with `-`.
+
+Assessment:
+- Folder naming convention in local Claude cache indicates a Windows-specific canonicalization strategy.
+- Existing Aegis logic may diverge for some paths/cases (drive-letter casing and prefix behavior).
+
+Decision:
+- Keep current normalized function for now (already shared and tested) but treat exact parity as a validation item in Sprint 4 E2E fixtures.
+
+## Gate 3: Command hook execution on Windows
+
+Status: PASS (execution path), PARTIAL (full matrix)
+
+Evidence:
+- Hook runtime assumptions validated in code/tests for explicit Node invocation and path quoting.
+- Windows-safe path handling and hook command construction are implemented in Sprint 1 work.
+
+Open checks:
+- Full matrix for shebang fallback and quoting edge cases with spaces/unicode should be captured in Sprint 4 E2E evidence.
+
+## GO / NO-GO
+
+Current decision: GO
+
+Rationale:
+- Gate 1 confirms Claude can run in psmux panes with interrupt support.
+- Gate 3 has a viable, explicit-node execution strategy.
+- Gate 2 is not a hard blocker; remaining mismatch risk is bounded and testable in upcoming E2E.
+
+## Follow-up Actions
+
+- Execute Windows E2E matrix in issue #912 and attach terminal output/screenshots.
+- Add project-hash parity fixture checks against real Claude project folders in Sprint 4 validation notes.
+- Update parent epic #907 with this gate report and links to ADRs.


### PR DESCRIPTION
## Summary\n- add Windows Sprint 0 pre-gate report with gate-by-gate evidence and GO/NO-GO decision\n- add ADRs for environment injection, SwarmMonitor Windows strategy, minimum Windows version, and psmux version pinning\n- commit findings under docs/adr and docs/windows-pre-gate-report-908.md\n\n## Notes\n- this PR documents empirical checks and architecture decisions required before/alongside implementation\n\nCloses #908