### PR TITLE
perf(dashboard): reduce overview polling N+1 API calls

### DIFF
--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -5,6 +5,66 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { checkForUpdates, isRetryableError } from '../api/client';
 
+describe('getSessionStatusCounts', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('uses the aggregated session stats endpoint in a single request', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      active: 3,
+      byStatus: {
+        idle: 1,
+        working: 1,
+        permission_prompt: 1,
+      },
+      totalCreated: 3,
+      totalCompleted: 1,
+      totalFailed: 0,
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { getSessionStatusCounts } = await import('../api/client');
+
+    await expect(getSessionStatusCounts()).resolves.toEqual({
+      all: 3,
+      idle: 1,
+      working: 1,
+      compacting: 0,
+      context_warning: 0,
+      waiting_for_input: 0,
+      permission_prompt: 1,
+      plan_mode: 0,
+      ask_question: 0,
+      bash_approval: 0,
+      settings: 0,
+      error: 0,
+      unknown: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/v1/sessions/stats', expect.objectContaining({
+      headers: expect.objectContaining({
+        'Content-Type': 'application/json',
+      }),
+    }));
+  });
+});
+
 describe('isRetryableError', () => {
   it('returns false for AbortError (should not retry)', () => {
     const error = new DOMException('The operation was aborted', 'AbortError');

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -21,6 +21,7 @@ import type {
   SendResponse,
   CreateSessionRequest,
   GlobalSSEEvent,
+  SessionStats,
   SessionsListResponse,
   SessionStatusCounts,
   UIState,
@@ -33,6 +34,7 @@ import {
   SessionInfoSchema,
   SendResponseSchema,
   OkResponseSchema,
+  SessionStatsSchema,
   SessionsListResponseSchema,
   SessionHealthSchema,
   SessionMetricsSchema,
@@ -236,19 +238,32 @@ export function getSessions(options: GetSessionsOptions = {}): Promise<SessionsL
 }
 
 export async function getSessionStatusCounts(): Promise<SessionStatusCounts> {
-  const counts: Partial<SessionStatusCounts> = { all: 0 };
-
-  const [allSessions, ...statusResults] = await Promise.all([
-    getSessions({ page: 1, limit: 1 }),
-    ...SESSION_STATUS_VALUES.map((status) => getSessions({ page: 1, limit: 1, status })),
-  ]);
-
-  counts.all = allSessions.pagination.total;
-  SESSION_STATUS_VALUES.forEach((status, index) => {
-    counts[status] = statusResults[index]?.pagination.total ?? 0;
+  const stats = await request<SessionStats>('/v1/sessions/stats', {
+    schema: SessionStatsSchema,
+    schemaContext: 'getSessionStatusCounts',
   });
 
-  return counts as SessionStatusCounts;
+  const counts: SessionStatusCounts = {
+    all: stats.active,
+    idle: 0,
+    working: 0,
+    compacting: 0,
+    context_warning: 0,
+    waiting_for_input: 0,
+    permission_prompt: 0,
+    plan_mode: 0,
+    ask_question: 0,
+    bash_approval: 0,
+    settings: 0,
+    error: 0,
+    unknown: 0,
+  };
+
+  SESSION_STATUS_VALUES.forEach((status) => {
+    counts[status] = stats.byStatus[status] ?? 0;
+  });
+
+  return counts;
 }
 
 export function getSession(id: string): Promise<SessionInfo> {

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type {
   HealthResponse,
   SessionInfo,
+  SessionStats,
   SessionsListResponse,
   SessionHealth,
   SessionMetrics,
@@ -127,6 +128,16 @@ export const SessionsListResponseSchema: z.ZodType<SessionsListResponse> = z.obj
     total: z.number(),
     totalPages: z.number(),
   }),
+});
+
+// ── SessionStats ───────────────────────────────────────────────
+
+export const SessionStatsSchema: z.ZodType<SessionStats> = z.object({
+  active: z.number(),
+  byStatus: z.partialRecord(UIState, z.number()),
+  totalCreated: z.number(),
+  totalCompleted: z.number(),
+  totalFailed: z.number(),
 });
 
 // ── SessionHealth ──────────────────────────────────────────────

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -10,6 +10,7 @@ export type {
   SessionStatusFilter,
   SessionInfo,
   SessionHealth,
+  SessionStats,
   HealthResponse,
   ParsedEntry,
   MessagesResponse,


### PR DESCRIPTION
## Summary
- Replace status-count N+1 dashboard calls with one aggregated stats request.
- Keep existing client-facing shape while reducing polling load.
- Add regression test to ensure single aggregated request path.

## Validation
- npx vitest run src/__tests__/client.test.ts

## Aegis version
**Developed with:** v2.13.1

Closes #1099