### PR TITLE
fix(dashboard): prevent stale overview data with SSE-connected refresh

### DIFF
--- a/dashboard/src/__tests__/MetricCards.test.tsx
+++ b/dashboard/src/__tests__/MetricCards.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, act } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import MetricCards from '../components/overview/MetricCards';
 import { useStore } from '../store/useStore';
+import type { GlobalSSEEvent } from '../types';
 
 const mockGetMetrics = vi.fn();
 const mockGetHealth = vi.fn();
@@ -17,6 +18,7 @@ describe('MetricCards polling strategy', () => {
 
     useStore.setState({
       metrics: null,
+      activities: [],
       sseConnected: false,
     });
 
@@ -63,53 +65,92 @@ describe('MetricCards polling strategy', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   it('uses fallback polling when SSE is disconnected', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
 
     render(<MetricCards />);
 
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(1);
-      expect(mockGetHealth).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.runAllTicks();
     });
 
-    const pollingCall = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    const pollingCall = setTimeoutSpy.mock.calls.find((call) => call[1] === 10_000);
     expect(pollingCall).toBeDefined();
-    const intervalCallback = pollingCall?.[0] as () => void | Promise<void>;
 
     await act(async () => {
-      await intervalCallback?.();
-      await intervalCallback?.();
-      await intervalCallback?.();
+      await vi.advanceTimersByTimeAsync(30_000);
     });
 
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(4);
-      expect(mockGetHealth).toHaveBeenCalledTimes(4);
-    });
+    expect(mockGetMetrics).toHaveBeenCalledTimes(4);
+    expect(mockGetHealth).toHaveBeenCalledTimes(4);
   });
 
-  it('does not run interval polling when SSE is connected', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+  it('backs off polling when SSE is connected', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     useStore.setState({ sseConnected: true });
 
     render(<MetricCards />);
 
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(1);
-      expect(mockGetHealth).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.runAllTicks();
     });
 
-    const pollingCall = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
-    expect(pollingCall).toBeUndefined();
     expect(mockGetMetrics).toHaveBeenCalledTimes(1);
     expect(mockGetHealth).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 30_000)).toBe(true);
+  });
+
+  it('debounces SSE-driven refreshes while connected', async () => {
+    vi.useFakeTimers();
+    useStore.setState({ sseConnected: true, activities: [] });
+
+    render(<MetricCards />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    const event: GlobalSSEEvent = {
+      event: 'session_message',
+      sessionId: 'session-1',
+      timestamp: new Date().toISOString(),
+      data: { text: 'hello' },
+    };
+
+    await act(async () => {
+      useStore.getState().addActivity(event);
+      useStore.getState().addActivity({ ...event, timestamp: new Date(Date.now() + 1).toISOString() });
+      useStore.getState().addActivity({ ...event, timestamp: new Date(Date.now() + 2).toISOString() });
+      await vi.advanceTimersByTimeAsync(999);
+    });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(2);
+    expect(mockGetHealth).toHaveBeenCalledTimes(2);
   });
 
   it('shows enhanced metric cards when data has non-zero values', async () => {
+    vi.useFakeTimers();
+
     mockGetMetrics.mockResolvedValue({
       uptime: 3600,
       sessions: {
@@ -142,9 +183,11 @@ describe('MetricCards polling strategy', () => {
 
     const { getByText } = render(<MetricCards />);
 
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.runAllTicks();
     });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
 
     // Core cards always visible
     expect(getByText('Active Sessions')).toBeDefined();
@@ -164,6 +207,8 @@ describe('MetricCards polling strategy', () => {
   });
 
   it('hides zero/null metric cards gracefully', async () => {
+    vi.useFakeTimers();
+
     mockGetMetrics.mockResolvedValue({
       uptime: 1,
       sessions: {
@@ -196,9 +241,11 @@ describe('MetricCards polling strategy', () => {
 
     const { queryByText } = render(<MetricCards />);
 
-    await waitFor(() => {
-      expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.runAllTicks();
     });
+
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
 
     // These should not render when zero/null
     expect(queryByText('Completed')).toBeNull();

--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { useStore } from '../store/useStore';
-import type { SessionInfo, SessionStatusCounts } from '../types';
+import type { GlobalSSEEvent, SessionInfo, SessionStatusCounts } from '../types';
 
 const mockGetSessions = vi.fn();
 const mockGetSessionStatusCounts = vi.fn();
@@ -118,6 +118,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     useStore.setState({
       sessions: [],
       healthMap: {},
+      activities: [],
       sseConnected: true,
       sseError: null,
     });
@@ -136,7 +137,60 @@ describe('SessionTable filtering, search, and bulk actions', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it('backs off polling when SSE is connected', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    renderTable();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetSessions).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 30_000)).toBe(true);
+  });
+
+  it('debounces SSE-driven session refreshes while connected', async () => {
+    vi.useFakeTimers();
+
+    renderTable();
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetSessions).toHaveBeenCalledTimes(1);
+    expect(mockGetSessionStatusCounts).toHaveBeenCalledTimes(1);
+
+    const event: GlobalSSEEvent = {
+      event: 'session_status_change',
+      sessionId: 's1',
+      timestamp: new Date().toISOString(),
+      data: { status: 'working' },
+    };
+
+    await act(async () => {
+      useStore.getState().addActivity(event);
+      useStore.getState().addActivity({ ...event, sessionId: 's2', timestamp: new Date(Date.now() + 1).toISOString() });
+      useStore.getState().addActivity({ ...event, sessionId: 's3', timestamp: new Date(Date.now() + 2).toISOString() });
+      await vi.advanceTimersByTimeAsync(999);
+    });
+
+    expect(mockGetSessions).toHaveBeenCalledTimes(1);
+    expect(mockGetSessionStatusCounts).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetSessions).toHaveBeenCalledTimes(2);
+    expect(mockGetSessionStatusCounts).toHaveBeenCalledTimes(2);
   });
 
   it('renders status counts and refetches when the status filter changes', async () => {

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -2,7 +2,7 @@
  * components/overview/MetricCards.tsx — Grid of metric cards with fallback polling.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   Activity,
   CheckCircle2,
@@ -18,15 +18,20 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 import { getHealth, getMetrics } from '../../api/client';
+import { useSseAwarePolling } from '../../hooks/useSseAwarePolling';
 import { useStore } from '../../store/useStore';
 import { useToastStore } from '../../store/useToastStore';
 import type { HealthResponse } from '../../types';
 import { formatUptime } from '../../utils/format';
 import MetricCard from './MetricCard';
 
+const FALLBACK_POLL_INTERVAL_MS = 10_000;
+const SSE_HEALTHY_POLL_INTERVAL_MS = 30_000;
+
 export default function MetricCards() {
   const metrics = useStore((s) => s.metrics);
   const sseConnected = useStore((s) => s.sseConnected);
+  const latestActivity = useStore((s) => s.activities[0] ?? null);
   const setMetrics = useStore((s) => s.setMetrics);
   const [health, setHealth] = useState<HealthResponse | null>(null);
 
@@ -40,16 +45,13 @@ export default function MetricCards() {
     }
   }, [setMetrics]);
 
-  useEffect(() => {
-    fetchData();
-
-    if (sseConnected) {
-      return;
-    }
-
-    const interval = setInterval(fetchData, 10_000);
-    return () => clearInterval(interval);
-  }, [fetchData, sseConnected]);
+  useSseAwarePolling({
+    refresh: fetchData,
+    sseConnected,
+    eventTrigger: latestActivity,
+    fallbackPollIntervalMs: FALLBACK_POLL_INTERVAL_MS,
+    healthyPollIntervalMs: SSE_HEALTHY_POLL_INTERVAL_MS,
+  });
 
   const m = metrics;
   const activeSessions = m?.sessions.currently_active ?? health?.sessions.active ?? 0;

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -22,13 +22,15 @@ import {
   interrupt,
   killSession,
 } from '../../api/client';
+import { useSseAwarePolling } from '../../hooks/useSseAwarePolling';
 import { useToastStore } from '../../store/useToastStore';
 import { useStore } from '../../store/useStore';
 import type { RowHealth, SessionInfo, SessionStatusCounts, SessionStatusFilter } from '../../types';
 import { formatTimeAgo } from '../../utils/format';
 import StatusDot from './StatusDot';
 
-const POLL_INTERVAL_MS = 5_000;
+const FALLBACK_POLL_INTERVAL_MS = 5_000;
+const SSE_HEALTHY_POLL_INTERVAL_MS = 30_000;
 const PAGE_SIZE = 20;
 const SEARCH_SCAN_LIMIT = 100;
 const EMPTY_COUNTS: SessionStatusCounts = {
@@ -312,6 +314,7 @@ export default function SessionTable() {
   const sessions = useStore((s) => s.sessions);
   const healthMap = useStore((s) => s.healthMap);
   const sseConnected = useStore((s) => s.sseConnected);
+  const latestActivity = useStore((s) => s.activities[0] ?? null);
   const setSessionsAndHealth = useStore((s) => s.setSessionsAndHealth);
   const addToast = useToastStore((t) => t.addToast);
 
@@ -381,16 +384,13 @@ export default function SessionTable() {
     }
   }, [addToast, deferredSearch, page, setSessionsAndHealth, statusFilter]);
 
-  useEffect(() => {
-    fetchSessions();
-
-    if (sseConnected) {
-      return;
-    }
-
-    const interval = setInterval(fetchSessions, POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchSessions, sseConnected]);
+  useSseAwarePolling({
+    refresh: fetchSessions,
+    sseConnected,
+    eventTrigger: latestActivity,
+    fallbackPollIntervalMs: FALLBACK_POLL_INTERVAL_MS,
+    healthyPollIntervalMs: SSE_HEALTHY_POLL_INTERVAL_MS,
+  });
 
   useEffect(() => {
     const visibleIds = new Set(sessions.map((session) => session.id));

--- a/dashboard/src/hooks/useSseAwarePolling.ts
+++ b/dashboard/src/hooks/useSseAwarePolling.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface UseSseAwarePollingOptions {
+  refresh: () => Promise<void>;
+  sseConnected: boolean;
+  eventTrigger?: unknown;
+  fallbackPollIntervalMs: number;
+  healthyPollIntervalMs: number;
+  eventDebounceMs?: number;
+}
+
+export const DEFAULT_SSE_EVENT_DEBOUNCE_MS = 1_000;
+
+export function useSseAwarePolling({
+  refresh,
+  sseConnected,
+  eventTrigger,
+  fallbackPollIntervalMs,
+  healthyPollIntervalMs,
+  eventDebounceMs = DEFAULT_SSE_EVENT_DEBOUNCE_MS,
+}: UseSseAwarePollingOptions): void {
+  const disposedRef = useRef(false);
+  const inFlightRef = useRef(false);
+  const queuedRefreshRef = useRef(false);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const eventTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastEventTriggerRef = useRef(eventTrigger);
+
+  const clearTimers = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+    if (eventTimerRef.current) {
+      clearTimeout(eventTimerRef.current);
+      eventTimerRef.current = null;
+    }
+  }, []);
+
+  const runRefresh = useCallback(async () => {
+    if (disposedRef.current) {
+      return;
+    }
+
+    if (inFlightRef.current) {
+      queuedRefreshRef.current = true;
+      return;
+    }
+
+    inFlightRef.current = true;
+    try {
+      await refresh();
+    } finally {
+      inFlightRef.current = false;
+
+      if (queuedRefreshRef.current && !disposedRef.current) {
+        queuedRefreshRef.current = false;
+        void runRefresh();
+      }
+    }
+  }, [refresh]);
+
+  useEffect(() => {
+    disposedRef.current = false;
+
+    return () => {
+      disposedRef.current = true;
+      clearTimers();
+    };
+  }, [clearTimers]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      await runRefresh();
+
+      if (cancelled || disposedRef.current) {
+        return;
+      }
+
+      pollTimerRef.current = setTimeout(() => {
+        void poll();
+      }, sseConnected ? healthyPollIntervalMs : fallbackPollIntervalMs);
+    };
+
+    void poll();
+
+    return () => {
+      cancelled = true;
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, [fallbackPollIntervalMs, healthyPollIntervalMs, runRefresh, sseConnected]);
+
+  useEffect(() => {
+    if (!sseConnected) {
+      lastEventTriggerRef.current = eventTrigger;
+      if (eventTimerRef.current) {
+        clearTimeout(eventTimerRef.current);
+        eventTimerRef.current = null;
+      }
+      return;
+    }
+
+    if (typeof eventTrigger === 'undefined' || Object.is(eventTrigger, lastEventTriggerRef.current)) {
+      return;
+    }
+
+    lastEventTriggerRef.current = eventTrigger;
+
+    if (eventTimerRef.current) {
+      return;
+    }
+
+    eventTimerRef.current = setTimeout(() => {
+      eventTimerRef.current = null;
+      void runRefresh();
+    }, eventDebounceMs);
+  }, [eventDebounceMs, eventTrigger, runRefresh, sseConnected]);
+}


### PR DESCRIPTION
## Summary
- Keep overview data fresh while SSE is connected.
- Add SSE-aware, debounced refresh strategy with slow safety polling.
- Update MetricCards and SessionTable tests for deterministic behavior.

## Validation
- npm run typecheck
- npx vitest run src/__tests__/MetricCards.test.tsx src/__tests__/SessionTable.test.tsx

## Aegis version
**Developed with:** v2.13.1

Closes #1102