### PR TITLE
fix(security): change default permissionMode to require approval

### DIFF
--- a/src/__tests__/auto-approve.test.ts
+++ b/src/__tests__/auto-approve.test.ts
@@ -9,15 +9,15 @@ const AUTO_APPROVE_MODES = new Set(['bypassPermissions', 'dontAsk', 'acceptEdits
 
 describe('Permission mode', () => {
   describe('SessionInfo.permissionMode', () => {
-    it('should default to "bypassPermissions" when not specified', () => {
+    it('should default to "default" when not specified', () => {
       const val: string | undefined = undefined;
-      const permissionMode = val ?? 'bypassPermissions';
-      expect(permissionMode).toBe('bypassPermissions');
+      const permissionMode = val ?? 'default';
+      expect(permissionMode).toBe('default');
     });
 
     it('should accept a permission mode string from session creation opts', () => {
       const opts = { permissionMode: 'acceptEdits' };
-      const permissionMode = opts.permissionMode ?? 'bypassPermissions';
+      const permissionMode = opts.permissionMode ?? 'default';
       expect(permissionMode).toBe('acceptEdits');
     });
 
@@ -145,9 +145,9 @@ describe('Permission mode', () => {
   });
 
   describe('Config.defaultPermissionMode', () => {
-    it('should default to "bypassPermissions"', () => {
-      const defaultPermissionMode = 'bypassPermissions';
-      expect(defaultPermissionMode).toBe('bypassPermissions');
+    it('should default to "default" (safest mode)', () => {
+      const defaultPermissionMode = 'default';
+      expect(defaultPermissionMode).toBe('default');
     });
 
     it('should be overridable to other modes', () => {

--- a/src/__tests__/session-persistence.test.ts
+++ b/src/__tests__/session-persistence.test.ts
@@ -55,9 +55,9 @@ describe('Session persistence and resume (Issue #35)', () => {
       expect(workDir).toBe(homedir());
     });
 
-    it('should set permissionMode to "bypassPermissions" for adopted sessions', () => {
-      const permissionMode = 'bypassPermissions';
-      expect(permissionMode).toBe('bypassPermissions');
+    it('should set permissionMode to "default" for adopted sessions', () => {
+      const permissionMode = 'default';
+      expect(permissionMode).toBe('default');
     });
 
     it('should set status to unknown for adopted sessions', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,7 +112,7 @@ const defaults: Config = {
   tgTopicTtlMs: 24 * 60 * 60 * 1000,
   webhooks: [],
   defaultSessionEnv: {},
-  defaultPermissionMode: 'bypassPermissions',
+  defaultPermissionMode: 'default',
   stallThresholdMs: computeStallThreshold(),
   sseMaxConnections: 100,
   sseMaxPerIp: 10,

--- a/src/server.ts
+++ b/src/server.ts
@@ -976,7 +976,7 @@ async function spawnChildHandler(req: SpawnRequest, reply: FastifyReply): Promis
   if (typeof safeChildWorkDir === 'object') {
     return reply.status(400).send({ error: `Invalid workDir: ${safeChildWorkDir.error}`, code: safeChildWorkDir.code });
   }
-  const childPermMode = permissionMode ?? parent.permissionMode ?? 'bypassPermissions';
+  const childPermMode = permissionMode ?? parent.permissionMode ?? 'default';
   const childSession = await sessions.createSession({ workDir: safeChildWorkDir, name: childName, parentId, permissionMode: childPermMode });
   let promptDelivery: { delivered: boolean; attempts: number } | undefined;
   if (prompt) { promptDelivery = await sessions.sendInitialPrompt(childSession.id, prompt); }

--- a/src/session.ts
+++ b/src/session.ts
@@ -612,7 +612,7 @@ export class SessionManager {
     const effectivePermissionMode = opts.permissionMode
       ?? (opts.autoApprove === true ? 'bypassPermissions' : opts.autoApprove === false ? 'default' : undefined)
       ?? this.config.defaultPermissionMode
-      ?? 'bypassPermissions';
+      ?? 'default';
     let settingsPatched = false;
     if (effectivePermissionMode !== 'bypassPermissions') {
       settingsPatched = await neutralizeBypassPermissions(opts.workDir, effectivePermissionMode);


### PR DESCRIPTION
## Summary

- Changes `defaultPermissionMode` from `'bypassPermissions'` to `'default'` across all fallback paths
- Sessions without an explicit `permissionMode` now require user approval instead of auto-approving all tool calls
- Safer default for non-localhost deployments where auth may not be enabled

## Changes

| File | Change |
|------|--------|
| `src/config.ts:115` | Default config value: `bypassPermissions` → `default` |
| `src/session.ts:615` | Ultimate fallback: `bypassPermissions` → `default` |
| `src/server.ts:979` | Child session fallback: `bypassPermissions` → `default` |
| `src/__tests__/auto-approve.test.ts` | Updated 3 test assertions to match new default |
| `src/__tests__/session-persistence.test.ts` | Updated 1 test assertion to match new default |

## Aegis version
**Developed with:** v2.15.7

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm test` (130 project test files) — all pass
- [ ] Manual: create session without `permissionMode` → verify it defaults to `"default"` and requires approval

Fixes #1086

Generated by Hephaestus (Aegis dev agent)