### PR TITLE
fix(security): move hook secrets from query params to headers

### DIFF
--- a/src/__tests__/security-629-630-634.test.ts
+++ b/src/__tests__/security-629-630-634.test.ts
@@ -61,7 +61,17 @@ describe('Issue #629: Hook endpoint secret validation', () => {
     await app.close();
   });
 
-  it('should accept hook with valid session ID and correct secret', async () => {
+  it('should accept hook with valid session ID and correct secret in header', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}`,
+      headers: { 'x-hook-secret': VALID_SECRET },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should accept hook with valid session ID and correct secret in query param (backward compat)', async () => {
     const res = await app.inject({
       method: 'POST',
       url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=${VALID_SECRET}`,
@@ -70,10 +80,11 @@ describe('Issue #629: Hook endpoint secret validation', () => {
     expect(res.statusCode).toBe(200);
   });
 
-  it('should reject hook with valid session ID but wrong secret', async () => {
+  it('should reject hook with valid session ID but wrong secret in header', async () => {
     const res = await app.inject({
       method: 'POST',
-      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=wrong-secret`,
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}`,
+      headers: { 'x-hook-secret': 'wrong-secret' },
       payload: {},
     });
     expect(res.statusCode).toBe(401);
@@ -105,7 +116,8 @@ describe('Issue #629: Hook endpoint secret validation', () => {
     registerHookRoutes(app2, { sessions: noSessionMgr, eventBus: new SessionEventBus() });
     const res = await app2.inject({
       method: 'POST',
-      url: `/v1/hooks/Stop?sessionId=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee&secret=${VALID_SECRET}`,
+      url: `/v1/hooks/Stop?sessionId=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+      headers: { 'x-hook-secret': VALID_SECRET },
       payload: {},
     });
     expect(res.statusCode).toBe(404);
@@ -121,25 +133,28 @@ describe('Issue #629: Hook endpoint secret validation', () => {
     expect(res.statusCode).toBe(400);
   });
 
-  describe('hook URL generation includes secret', () => {
-    it('should include secret in generated hook URLs', () => {
+  describe('hook URL generation uses headers for secret', () => {
+    it('should include secret in X-Hook-Secret header, not in URL', () => {
       const settings = generateHookSettings('http://localhost:9100', VALID_SESSION_ID, VALID_SECRET);
       for (const entries of Object.values(settings.hooks)) {
-        for (const entry of entries as Array<{ hooks: Array<{ type: string; url: string }> }>) {
+        for (const entry of entries as Array<{ hooks: Array<{ type: string; url: string; headers?: Record<string, string> }> }>) {
           for (const hook of entry.hooks) {
-            expect(hook.url).toContain(`secret=${VALID_SECRET}`);
+            expect(hook.url).not.toContain('secret=');
+            expect(hook.headers).toBeDefined();
+            expect(hook.headers!['X-Hook-Secret']).toBe(VALID_SECRET);
           }
         }
       }
     });
 
-    it('should NOT include secret when none provided', () => {
+    it('should NOT include secret header when none provided', () => {
       const settings = generateHookSettings('http://localhost:9100', VALID_SESSION_ID);
       for (const entries of Object.values(settings.hooks)) {
-        for (const entry of entries as Array<{ hooks: Array<{ type: string; url: string }> }>) {
+        for (const entry of entries as Array<{ hooks: Array<{ type: string; url: string; headers?: Record<string, string> }> }>) {
           for (const hook of entry.hooks) {
             expect(hook.url).toContain(VALID_SESSION_ID);
             expect(hook.url).not.toContain('secret=');
+            expect(hook.headers).toBeUndefined();
           }
         }
       }

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -133,6 +133,7 @@ export type HttpHookEvent = typeof HTTP_HOOK_EVENTS[number];
 interface HttpHookConfig {
   type: 'http';
   url: string;
+  headers?: Record<string, string>;
 }
 
 /** Shape of the `hooks` section in CC settings.json. */
@@ -152,15 +153,16 @@ export function generateHookSettings(baseUrl: string, sessionId: string, hookSec
   const callbackBaseUrl = normalizeHookBaseUrl(baseUrl);
 
   for (const event of HTTP_HOOK_EVENTS) {
-    const secretParam = hookSecret ? `&secret=${hookSecret}` : '';
+    const hookConfig: HttpHookConfig = {
+      type: 'http',
+      url: `${callbackBaseUrl}/v1/hooks/${event}?sessionId=${sessionId}`,
+    };
+    if (hookSecret) {
+      hookConfig.headers = { 'X-Hook-Secret': hookSecret };
+    }
     hooks[event] = [
       {
-        hooks: [
-          {
-            type: 'http',
-            url: `${callbackBaseUrl}/v1/hooks/${event}?sessionId=${sessionId}${secretParam}`,
-          },
-        ],
+        hooks: [hookConfig],
       },
     ];
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -154,8 +154,9 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
       return reply.status(404).send({ error: `Session ${sessionId} not found` });
     }
 
-    // Issue #629: Validate per-session hook secret (defense in depth — also checked in auth middleware)
-    const hookSecret = (req.query as Record<string, string>)?.secret;
+    // Issue #629/#1131: Validate hook secret from X-Hook-Secret header (query param fallback)
+    const hookSecret = (req.headers['x-hook-secret'] as string)
+      || (req.query as Record<string, string>)?.secret;
     if (session.hookSecret && hookSecret !== session.hookSecret) {
       return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -311,8 +311,9 @@ function setupAuth(authManager: AuthManager): void {
       if (hookSessionId) {
         const session = sessions.getSession(hookSessionId);
         if (session) {
-          // Issue #629: Validate hook secret from query param
-          const hookSecret = (req.query as Record<string, string>)?.secret;
+          // Issue #629/#1131: Validate hook secret from X-Hook-Secret header (query param fallback)
+          const hookSecret = (req.headers['x-hook-secret'] as string)
+            || (req.query as Record<string, string>)?.secret;
           if (!hookSecret || hookSecret !== session.hookSecret) {
             return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
           }


### PR DESCRIPTION
## Summary

- Move hook secrets from URL query parameters (`?secret=...`) to `X-Hook-Secret` HTTP header to prevent secrets from appearing in server access logs, tmux pane captures, and process argument lists
- Update sender (`generateHookSettings`) to use CC HTTP hook `headers` field
- Update receivers (`server.ts` auth middleware, `hooks.ts` handler) to read from `x-hook-secret` header with query param fallback for backward compat with running sessions
- Update all related tests to verify header-based authentication

## Aegis version
**Developed with:** v2.15.7

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] All 43 security and hook-auth tests pass
- [ ] Manual: verify new sessions generate hook URLs without `secret=` in query string
- [ ] Manual: verify existing sessions with old URL format still work (query param fallback)

Fixes #1131

Generated by Hephaestus (Aegis dev agent)