### PR TITLE
fix(dashboard): correct fork navigation route /session/ → /sessions/

### DIFF
--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -110,7 +110,7 @@ export default function SessionDetailPage() {
     try {
       const forked = await forkSession(s.id, { name: undefined });
       addToast('success', 'Session forked', `New session ${forked.id.slice(0, 8)} created`);
-      navigate(`/session/${forked.id}`);
+      navigate(`/sessions/${forked.id}`);
     } catch (e: unknown) {
       addToast('error', 'Fork failed', e instanceof Error ? e.message : undefined);
     }


### PR DESCRIPTION
Fixes #1082

Fork navigation used singular `/session/${id}` but the route in App.tsx is plural `/sessions/:id`. This caused fork to always land on the 404 page.