### PR TITLE
fix(dashboard): add permission_denied to SSE event schema

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -267,6 +267,7 @@ const SSEEventTypes = z.enum([
   'subagent_start',
   'subagent_stop',
   'verification',
+  'permission_denied',
 ]);
 
 export const SessionSSEEventDataSchema: z.ZodType<SessionSSEEvent> = z.object({


### PR DESCRIPTION
Fixes #1084

The Zod SSEEventTypes enum was missing 'permission_denied'. The backend emits this event but the dashboard silently dropped it at parse time. Users never saw permission denial notifications in real-time.