### PR TITLE
fix(security): validate template workDir at creation time (#1125)

### DIFF
--- a/src/__tests__/template-workdir-validation-1125.test.ts
+++ b/src/__tests__/template-workdir-validation-1125.test.ts
@@ -1,0 +1,84 @@
+/**
+ * template-workdir-validation-1125.test.ts — Tests for Issue #1125.
+ *
+ * Security test: Template workDir must be validated at creation time
+ * to prevent storing path-traversal payloads.
+ *
+ * The POST /v1/templates endpoint must call validateWorkDirWithConfig
+ * before persisting the template, following the same pattern as:
+ * - POST /v1/sessions (line 803)
+ * - POST /v1/sessions/batch (line 1536)
+ * - POST /v1/pipelines (line 1575)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateWorkDir, containsTraversalSegment } from '../validation.js';
+
+describe('Issue #1125: Template workDir validation', () => {
+  describe('validateWorkDir rejects path traversal payloads', () => {
+    it('rejects /tmp/../etc (would escape to /etc)', async () => {
+      const result = await validateWorkDir('/tmp/../etc');
+      expect(typeof result).toBe('object');
+      if (typeof result === 'object') {
+        expect(result.code).toBe('INVALID_WORKDIR');
+        expect(result.error).toMatch(/\.\./);
+      }
+    });
+
+    it('rejects relative path traversal ../etc', async () => {
+      const result = await validateWorkDir('../etc');
+      expect(typeof result).toBe('object');
+      if (typeof result === 'object') {
+        expect(result.code).toBe('INVALID_WORKDIR');
+      }
+    });
+
+    it('rejects deeply nested traversal /tmp/a/b/../../../../etc/shadow', async () => {
+      const result = await validateWorkDir('/tmp/a/b/../../../../etc/shadow');
+      expect(typeof result).toBe('object');
+      if (typeof result === 'object') {
+        expect(result.code).toBe('INVALID_WORKDIR');
+      }
+    });
+
+    it('rejects encoded traversal /tmp/%2e%2e/etc', async () => {
+      const result = await validateWorkDir('/tmp/%2e%2e/etc');
+      expect(typeof result).toBe('object');
+      if (typeof result === 'object') {
+        expect(result.code).toBe('INVALID_WORKDIR');
+      }
+    });
+
+    it('rejects mixed-separator traversal tmp\\..\\etc', async () => {
+      const result = await validateWorkDir('tmp\\..\\etc');
+      expect(typeof result).toBe('object');
+      if (typeof result === 'object') {
+        expect(result.code).toBe('INVALID_WORKDIR');
+      }
+    });
+  });
+
+  describe('containsTraversalSegment helper catches all forms', () => {
+    it('detects literal ".." in path', () => {
+      expect(containsTraversalSegment('/tmp/../etc')).toBe(true);
+    });
+
+    it('detects URL-encoded ".." (%2e%2e)', () => {
+      expect(containsTraversalSegment('/tmp/%2e%2e/etc')).toBe(true);
+    });
+
+    it('detects mixed-case encoded ".." (%2E%2E)', () => {
+      expect(containsTraversalSegment('/tmp/%2E%2E/etc')).toBe(true);
+    });
+
+    it('detects backslash traversal on Windows-style paths', () => {
+      expect(containsTraversalSegment('tmp\\..\\etc')).toBe(true);
+    });
+
+    it('allows directory names with dots but no traversal', () => {
+      expect(containsTraversalSegment('/tmp/project...name')).toBe(false);
+      expect(containsTraversalSegment('/tmp/.hidden')).toBe(false);
+      expect(containsTraversalSegment('/tmp/v1.2.3')).toBe(false);
+    });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1667,11 +1667,17 @@ app.post<{ Body: CreateTemplateRequest }>('/v1/templates', async (req, reply) =>
     return reply.status(400).send({ error: 'workDir is required (provide sessionId or explicit workDir)' });
   }
 
+  // Issue #1125: Validate workDir for path traversal at template creation time
+  const safeWorkDir = await validateWorkDirWithConfig(finalData.workDir);
+  if (typeof safeWorkDir === 'object') {
+    return reply.status(400).send({ error: `Invalid workDir: ${safeWorkDir.error}`, code: safeWorkDir.code });
+  }
+
   try {
     const template = await templateStore.createTemplate({
       name,
       description,
-      workDir: finalData.workDir,
+      workDir: safeWorkDir,
       prompt: finalData.prompt,
       claudeCommand: finalData.claudeCommand,
       env: finalData.env,


### PR DESCRIPTION
## Summary

- Validates `workDir` at template creation time using `validateWorkDirWithConfig`
- Prevents storing path-traversal payloads in templates that would only be caught at instantiation
- Follows the same pattern as session creation, batch sessions, and pipeline endpoints

## Security Impact

Previously, a malicious `workDir` containing path traversal (e.g., `/tmp/../etc`) could be stored in a template. The vulnerability would only be caught when the template was instantiated, not at creation time.

## Changes

- Added `validateWorkDirWithConfig` call to `POST /v1/templates` endpoint (server.ts:1670-1674)
- Uses the canonicalized `safeWorkDir` path when creating the template
- Added test file documenting the security requirement

## Aegis version
**Developed with:** v2.15.7

Fixes #1125