### PR TITLE
ci(test): add v8 coverage provider with 70% line threshold

### DIFF
--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -8,5 +8,10 @@ export default defineConfig({
     globals: true,
     setupFiles: ['src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      thresholds: { lines: 70 },
+    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     exclude: ['node_modules', 'dist', 'dashboard/**', '.worktrees/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      thresholds: { lines: 70 },
+    },
   },
 });


### PR DESCRIPTION
Closes #1113

Adds test coverage configuration to both backend and dashboard vitest configs:
- Provider: v8
- Reporters: text + lcov
- Threshold: 70% lines