### PR TITLE
build: enable source maps for backend and dashboard

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   base: '/dashboard/',
+  build: { sourcemap: 'hidden' },
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {


### PR DESCRIPTION
Closes #1114

- Backend: sourceMap true in tsconfig.json (maps excluded from npm package via files field)
- Dashboard: sourcemap 'hidden' in vite config (generates maps without exposing them)