### PR TITLE
ci: add permissions block and concurrency group to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 # ⚠️ Branch protection requires these exact check names.
 # If you rename jobs or change the matrix, update required status checks in repo settings.
 jobs:


### PR DESCRIPTION
Closes #1135

- permissions: contents read (least privilege)
- concurrency: cancel overlapping runs on same branch