### PR TITLE
ci: remove needs gate on dashboard-test for parallel execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
           echo "Audit passed - no blacklisted files found"
 
   dashboard-test:
-    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #1112

Dashboard tests are independent of backend tests. Removing the needs dependency allows both to run concurrently, reducing CI wall-clock time.