### PR TITLE
ci: add pull_request trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,8 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "17 3 * * 1"
 


### PR DESCRIPTION
Closes #1111

CodeQL now scans PRs against main before merge, catching security findings earlier instead of only post-merge.