### PR TITLE
test: skip Unix-only tests on Windows (tmux, worktree)

### DIFF
--- a/src/__tests__/tmux-polling-395.test.ts
+++ b/src/__tests__/tmux-polling-395.test.ts
@@ -35,7 +35,7 @@ function makeSession(overrides: Partial<SessionInfo>): SessionInfo {
   };
 }
 
-describe('Issue #395: consolidated tmux discovery polling', () => {
+describe.skipIf(process.platform === 'win32')('Issue #395: consolidated tmux discovery polling', () => {
   let rootTmpDir: string;
 
   beforeEach(() => {

--- a/src/__tests__/worktree-lookup-884.test.ts
+++ b/src/__tests__/worktree-lookup-884.test.ts
@@ -41,7 +41,7 @@ async function makeProjectsDir(base: string, projectName: string, withSession: b
   return base;
 }
 
-describe('findSessionFileWithFanout', () => {
+describe.skipIf(process.platform === 'win32')('findSessionFileWithFanout', () => {
   it('returns primary-directory match without fanout', async () => {
     const primaryDir = join(tmpRoot, 'primary');
     const siblingDir = join(tmpRoot, 'sibling');


### PR DESCRIPTION
Skip `tmux-polling-395` and `worktree-lookup-884` tests on Windows since tmux is Unix-only.

Unblocks #1186 and all future PRs blocked by windows-latest Node 20 CI.