### PR TITLE
fix(ci): install auto-label action dependencies in correct directory

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+      - name: Install action dependencies
+        working-directory: .github/actions/auto-label
+        run: npm ci
       - name: Run auto-labeler
         uses: ./.github/actions/auto-label
         with:


### PR DESCRIPTION
Fixes the auto-label GitHub Action crashing with 'Cannot find module @actions/core'.

**Problem:** The auto-label action was using `npm ci` in the repo root instead of in the action directory. When GitHub Actions ran the action, it couldn't find `@actions/core`.

**Solution:** Add explicit `working-directory: .github/actions/auto-label` step to install dependencies in the correct location before running the action.

**Changes:**
- .github/workflows/auto-label.yml: Add `npm ci` step with correct working-directory

Developed with Aegis v2.17.5