### PR TITLE
docs: add ROADMAP.md and alpha banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
   <img src="https://img.shields.io/npm/l/aegis-bridge.svg" alt="license" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.0.0-blue.svg" alt="node" />
   <img src="https://img.shields.io/badge/MCP-ready-green.svg" alt="MCP ready" />
+  <a href="https://github.com/OneStepAt4time/aegis/blob/main/ROADMAP.md"><img src="https://img.shields.io/badge/roadmap-alpha-orange" alt="Roadmap" /></a>
 </p>
+
+> ⚠️ **Aegis is in Alpha.** APIs may change. See [ROADMAP.md](./ROADMAP.md) for the path to stable.
 
 <p align="center">
   <strong>Orchestrate Claude Code sessions via REST API, MCP, CLI, webhooks, or Telegram.</strong>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,56 @@
+# Aegis Roadmap
+
+> **Aegis is currently in Alpha.** APIs and features may change. See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to help.
+
+---
+
+## Vision
+
+Aegis aims to be the reference orchestration bridge for Claude Code — production-ready, documented, tested, and secure.
+
+---
+
+## Milestone 1: Foundation
+
+**Goal:** Zero regressions, CI always green, coverage ≥ 65%
+
+- [ ] Integration tests: session lifecycle (create → poll → kill)
+- [ ] Integration tests: dashboard SSE events
+- [ ] Fix dashboard-test flakiness → deterministic
+- [ ] Coverage gate: 65% minimum enforced in CI
+
+## Milestone 2: Security Hardening
+
+**Goal:** Security documented and tested
+
+- [ ] Permission modes documented for end users
+- [ ] Rate limiting documented
+- [ ] Audit log system
+- [ ] Security integration tests
+
+## Milestone 3: Enterprise Ready
+
+**Goal:** Production-grade stability
+
+- [ ] Structured health check endpoint
+- [ ] Error recovery tested
+- [ ] Graceful degradation
+- [ ] Integration tests: auth + rate limiting
+
+## Milestone 4: Documentation & Growth
+
+**Goal:** 5-minute onboarding, community-ready
+
+- [ ] Getting Started guide (zero to running in 5 minutes)
+- [ ] Onboarding documentation
+- [ ] Case study template
+- [ ] Contributing guide complete
+
+---
+
+## Principles
+
+1. **Quality over velocity** — every PR must make the product better, not just different
+2. **Coverage gate enforced** — no merge if coverage drops
+3. **Zero regressions** — integration tests as gates
+4. **Documentation required** — no release without updated docs


### PR DESCRIPTION
Creates ROADMAP.md with 4 milestones from #1210 (Enterprise Roadmap):

- **M1: Foundation** — integration tests, coverage 65%, fix flaky tests
- **M2: Security Hardening** — permission docs, audit log, security tests
- **M3: Enterprise Ready** — health checks, error recovery, graceful degradation
- **M4: Documentation & Growth** — 5-min Getting Started, case studies

Also adds:
- Alpha warning banner to README
- Roadmap badge in README badge row