### PR TITLE
feat: mark v2.17.4 as alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aegis-bridge",
-  "version": "2.17.4",
+  "version": "2.17.4-alpha",
   "type": "module",
   "description": "Orchestrate Claude Code sessions via API. Create, brief, monitor, refine, ship.",
   "main": "dist/server.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false,
+      "prerelease": true, "prereleaseType": "alpha",
       "extra-files": []
     }
   }


### PR DESCRIPTION
Mark v2.17.4 as alpha and configure release-please for alpha prereleases.

**Changes:**
- package.json: version → 2.17.4-alpha
- release-please-config.json: prerelease: true, prereleaseType: alpha

Part of alpha branding initiative (#1210). 👁️