### PR TITLE
fix: lock release-please to 0.1.x-alpha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,10 +5,12 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": true, "prereleaseType": "alpha",
+      "prerelease": true,
+      "prereleaseType": "alpha",
+      "release-as": "0.1.0",
+      "include-sha-in-tag": false,
+      "tag-separator": "-",
       "extra-files": []
     }
   }


### PR DESCRIPTION
Lock release-please to 0.1.x-alpha series.

**Changes:**
- release-as: 0.1.0 — all releases start from 0.1.0
- prerelease: true, prereleaseType: alpha
- include-sha-in-tag: false
- tag-separator: -

This prevents release-please from bumping to 2.x. Future releases will be 0.1.0-alpha, 0.1.1-alpha, etc.

Refs: #1210