### PR TITLE
ci: bootstrap develop rollout and tiered CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read
@@ -43,7 +43,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # PRs and pushes on develop run Linux-only for faster, lower-cost agent feedback.
+        # main keeps the full cross-platform matrix as the release gate.
+        os: ${{ fromJSON(((github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name == 'push' && github.ref == 'refs/heads/develop')) && '["ubuntu-latest"]' || '["ubuntu-latest", "windows-latest", "macos-latest"]') }}
         node-version: ['20', '22']
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,47 @@ Every PR must include:
 
 ---
 
+## Branching Strategy — GitHub Flow + develop
+
+**Golden rule: All new agent PRs target `develop`, never `main` (except maintainer-directed bootstrap or hotfix work).**
+
+> Transition note: during the Week 1 rollout, maintainers may temporarily relax or move branch protection checks while `develop` is being bootstrapped. As soon as the rollout PR lands, re-enable protection and send all new agent PRs to `develop`.
+
+```
+feature/fix branches ──PR──> develop ──PR──> main ──> Release Please ──> npm
+                                              ↑
+                              hotfix/* ───PR──┘ (+ cherry-pick to develop)
+```
+
+### Worktree workflow (required for all agents)
+
+```bash
+# 0. Ensure the shared worktree folder exists
+mkdir -p .claude/worktrees
+
+git fetch origin
+
+# 1. Create worktree from develop
+git worktree add .claude/worktrees/fix-123 -b fix/123-bug origin/develop
+
+# 2. Work, commit, push
+git push origin fix/123-bug
+
+# 3. Open PR targeting develop (NEVER main unless maintainer explicitly says so)
+gh pr create --base develop --title "fix: resolve session crash" --body "Closes #123"
+```
+
+### Hotfix workflow (critical production bugs only)
+
+```bash
+# Exception: branch from main, PR to main
+git worktree add .claude/worktrees/hotfix-999 -b hotfix/999-critical origin/main
+# Fix, push, PR to main
+# After merge: cherry-pick to develop
+```
+
+---
+
 ## Branch naming
 
 ```
@@ -78,6 +119,7 @@ feat/<issue-number>-<short-description>
 refactor/<issue-number>-<short-description>
 docs/<topic>
 chore/<topic>
+hotfix/<issue-number>-<short-description>
 ```
 
 ---
@@ -85,6 +127,7 @@ chore/<topic>
 ## What NOT to do
 
 - ❌ Never push directly to `main` — always use a PR
+- ❌ Never open a PR targeting `main` — target `develop` (exceptions: hotfixes or maintainer-directed bootstrap PRs)
 - ❌ Never merge your own PR — Argus reviews and merges
 - ❌ Never use `feat:` for internal improvements, type safety, or refactors
 - ❌ Never open a PR with failing CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,11 @@ Welcome! Aegis is an open-source bridge that orchestrates Claude Code sessions v
 3. **Install**: `npm ci`
 4. **Build**: `npm run build`
 5. **Test**: `npm test`
-6. **Create a branch**: `git checkout -b fix/my-fix main`
+6. **Create a branch from `develop`**: `git fetch origin && git checkout -b fix/my-fix origin/develop`
 7. **Commit**: follow [Conventional Commits](#commit-conventions)
-8. **Push** and open a PR against `main`
+8. **Push** and open a PR against `develop`
+
+> Transition note: maintainer-directed bootstrap or hotfix work may still target `main` temporarily while branch protections are being moved. Unless explicitly told otherwise, contributors should target `develop`.
 
 ## Issue Workflow
 


### PR DESCRIPTION
## Summary
- bootstrap the Week 1 \`develop\` rollout and create the integration-buffer workflow
- run Linux-only CI for \`develop\` while keeping the full cross-platform matrix on \`main\`
- update \`CLAUDE.md\` and \`CONTRIBUTING.md\` to use worktrees and target \`develop\`

## Testing
- npx tsc --noEmit
- npm run build
- npm test

## Rollout notes
- \`develop\` has been bootstrapped from the current \`main\` tip
- if branch protection needs to be moved, relax it only for the final flip and re-enable it immediately after merge

## Aegis version
**Developed with:** v0.1.0-alpha