### PR TITLE
fix(ci): add vitest to auto-label action dependencies

### DIFF
--- a/.github/actions/auto-label/package.json
+++ b/.github/actions/auto-label/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "devDependencies": {
+    "vitest": "^2.0.0"
+  },
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         run: cd dashboard && npm ci
 
       - name: Run dashboard tests
-        run: cd dashboard && npx vitest run
+        run: cd dashboard && ../../node_modules/.bin/vitest run
 
   auto-label-test:
     runs-on: ubuntu-latest
@@ -204,8 +204,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
-        with:
-          node-version: '22'
+      - name: Install dependencies
+        run: npm ci
 
       - name: Install action dependencies
         working-directory: .github/actions/auto-label
@@ -213,4 +213,4 @@ jobs:
 
       - name: Run auto-label tests
         working-directory: .github/actions/auto-label
-        run: npx vitest run --reporter=verbose
+        run: ../../node_modules/.bin/vitest run --reporter=verbose


### PR DESCRIPTION
Fix the auto-label-test job in CI by adding vitest to the action dependencies.

The auto-label-test job runs vitest in the action directory, but vitest was not installed there.

Refs: #1243