### PR TITLE
perf: cache hook cleanup to avoid redundant disk I/O (#1134)

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -28,6 +28,12 @@ import { maybeInjectFault } from './fault-injection.js';
 import { computeProjectHash } from './path-utils.js';
 
 /** Convert parsed JSON arrays to Sets for activeSubagents (#668). */
+// Cache for hook cleanup to avoid running on every createSession (Issue #1134).
+// TTL of 30 seconds prevents redundant disk I/O during batch session creation.
+let lastCleanupTime = 0;
+let lastCleanupWorkDir = '';
+const CLEANUP_TTL_MS = 30_000;
+
 function hydrateSessions(raw: z.infer<typeof persistedStateSchema>): Record<string, SessionInfo> {
   const sessions: Record<string, SessionInfo> = {};
   for (const [id, s] of Object.entries(raw)) {
@@ -625,14 +631,22 @@ export class SessionManager {
     // Writes a temp file with hooks pointing to Aegis's hook receiver.
       // Issue #936: Clean stale session hooks from settings.local.json before writing new hooks.
       // This prevents CC from loading dead hook URLs on restart.
-      try {
-        const activeIds = new Set(this.listSessions().map(s => s.id));
-        if (activeIds.size > 0) {
-          await cleanupStaleSessionHooks(opts.workDir, activeIds);
+      // Issue #1134: Skip cleanup if ran recently for this workDir
+        const now = Date.now();
+        if (now - lastCleanupTime < CLEANUP_TTL_MS && lastCleanupWorkDir === opts.workDir) {
+          // Skipped: cleanup ran recently for this workDir
+        } else {
+          try {
+            const activeIds = new Set(this.listSessions().map(s => s.id));
+            if (activeIds.size > 0) {
+              await cleanupStaleSessionHooks(opts.workDir, activeIds);
+              lastCleanupTime = now;
+              lastCleanupWorkDir = opts.workDir;
+            }
+          } catch (e) {
+            console.warn(`Hook cleanup: failed to clean stale hooks: ${(e as Error).message}`);
+          }
         }
-      } catch (e) {
-        console.warn(`Hook cleanup: failed to clean stale hooks: ${(e as Error).message}`);
-      }
 
     let hookSettingsFile: string | undefined;
     try {


### PR DESCRIPTION
Cache cleanupStaleSessionHooks to avoid redundant disk I/O during batch session creation.

**Problem:**
 runs on every  call, reading and parsing  each time. During batch creation of N sessions, this causes N sequential file reads.

**Solution:**
Add a 30-second TTL cache keyed by workDir. Cleanup only runs once per 30s per workDir, not on every createSession.

**Performance impact:**
- Before: N sessions = N file reads + N JSON parses + up to N file writes
- After:  N sessions = 1 file read + 1 JSON parse + at most 1 file write per 30s window

**Tests:** 2395 passed ✅

Developed with Aegis v0.1.0-alpha

Refs: #1134