### PR TITLE
perf: cache hook cleanup to avoid redundant disk I/O (#1134)

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -28,6 +28,7 @@ import { maybeInjectFault } from './fault-injection.js';
 import { computeProjectHash } from './path-utils.js';
 
 /** Convert parsed JSON arrays to Sets for activeSubagents (#668). */
+
 function hydrateSessions(raw: z.infer<typeof persistedStateSchema>): Record<string, SessionInfo> {
   const sessions: Record<string, SessionInfo> = {};
   for (const [id, s] of Object.entries(raw)) {
@@ -113,6 +114,11 @@ export type { PermissionDecision };
  * interactive approval/question flows for all managed Claude Code sessions.
  */
 export class SessionManager {
+  // Issue #1134: Cache for hook cleanup (per-instance, not module-level)
+  private lastCleanupTime = 0;
+  private lastCleanupWorkDir = '';
+  private readonly CLEANUP_TTL_MS = 30_000;
+
   private state: SessionState = { sessions: {} };
   private stateFile: string;
   private sessionMapFile: string;
@@ -625,14 +631,22 @@ export class SessionManager {
     // Writes a temp file with hooks pointing to Aegis's hook receiver.
       // Issue #936: Clean stale session hooks from settings.local.json before writing new hooks.
       // This prevents CC from loading dead hook URLs on restart.
-      try {
-        const activeIds = new Set(this.listSessions().map(s => s.id));
-        if (activeIds.size > 0) {
-          await cleanupStaleSessionHooks(opts.workDir, activeIds);
+      // Issue #1134: Skip cleanup if ran recently for this workDir
+        const now = Date.now();
+        if (now - this.lastCleanupTime < this.CLEANUP_TTL_MS && this.lastCleanupWorkDir === opts.workDir) {
+          // Skipped: cleanup ran recently for this workDir
+        } else {
+          try {
+            const activeIds = new Set(this.listSessions().map(s => s.id));
+            if (activeIds.size > 0) {
+              await cleanupStaleSessionHooks(opts.workDir, activeIds);
+              this.lastCleanupTime = now;
+              this.lastCleanupWorkDir = opts.workDir;
+            }
+          } catch (e) {
+            console.warn(`Hook cleanup: failed to clean stale hooks: ${(e as Error).message}`);
+          }
         }
-      } catch (e) {
-        console.warn(`Hook cleanup: failed to clean stale hooks: ${(e as Error).message}`);
-      }
 
     let hookSettingsFile: string | undefined;
     try {


### PR DESCRIPTION
Add TTL cache (30s) for cleanupStaleSessionHooks to avoid running on every createSession during batch session creation. Cache is per-instance (SessionManager), not module-level, to avoid test pollution.

Refs: #1134