### PR TITLE
fix(#1134): include new session ID in activeIds before cleanup

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -632,12 +632,16 @@ export class SessionManager {
       // Issue #936: Clean stale session hooks from settings.local.json before writing new hooks.
       // This prevents CC from loading dead hook URLs on restart.
       // Issue #1134: Skip cleanup if ran recently for this workDir
+        // Note: cleanup runs BEFORE the new session is added to this.state.sessions.
+        // We must include the new session's ID in activeIds to prevent cleanup from
+        // removing hooks for a session that was just created.
         const now = Date.now();
         if (now - lastCleanupTime < CLEANUP_TTL_MS && lastCleanupWorkDir === opts.workDir) {
           // Skipped: cleanup ran recently for this workDir
         } else {
           try {
             const activeIds = new Set(this.listSessions().map(s => s.id));
+            activeIds.add(id); // Include the new session so cleanup preserves its hooks
             if (activeIds.size > 0) {
               await cleanupStaleSessionHooks(opts.workDir, activeIds);
               lastCleanupTime = now;


### PR DESCRIPTION
Fix the root cause of the flaky session-lifecycle test.

**Bug:** cleanupStaleSessionHooks runs BEFORE the new session is added to this.state.sessions (line 692). So cleanup doesn't see the new session and may remove its hooks from settings.local.json.

**Fix:** Add the new session's ID to activeIds before cleanup runs, so the new session's hooks are preserved.

This is the root cause fix — the test workaround (>= 2) should no longer be needed.

Developed with Aegis v0.1.0-alpha

Refs: #1134