### PR TITLE
fix(tmux): remove unused windowExistsCache duplicate (#1126)

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -76,8 +76,6 @@ export class TmuxManager {
   /** tmux socket name (-L flag). Isolates sessions from other tmux instances. */
   readonly socketName: string;
 
-  /** #357: Cache for window existence checks — avoids repeated tmux CLI calls. */
-  private windowExistsCache = new Map<string, { exists: boolean; timestamp: number }>();
   private static readonly WINDOW_CACHE_TTL_MS = 2_000;
 
   constructor(private sessionName: string = 'aegis', socketName?: string) {


### PR DESCRIPTION
Remove unused `windowExistsCache` from `src/tmux.ts`.

**Analysis:**
- `windowExistsCache` (line 80) — declared but NEVER referenced anywhere. Dead code.
- `windowCache` (line 94) — the actual cache in use, properly:
  - TTL-based (WINDOW_CACHE_TTL_MS = 2s)  
  - Deleted on `killWindow` (proper cache invalidation on window destroy)

**Fix:** Remove the unused `windowExistsCache` declaration. The surviving `windowCache` is already correctly managed.

Developed with Aegis v0.1.0-alpha

Refs: #1126