### PR TITLE
fix(monitor): clean per-session Maps on signal shutdown (#1115)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2055,7 +2055,7 @@ async function main(): Promise<void> {
       clearInterval(consensusPruneInterval);
 
       // Issue #569: Kill all CC sessions and tmux windows before exit
-      try { await killAllSessions(sessions, tmux); } catch (e) { console.error('Error killing sessions:', e); }
+      try { await killAllSessions(sessions, tmux, { monitor, metrics, toolRegistry }); } catch (e) { console.error('Error killing sessions:', e); }
 
       // 3. Destroy channels (awaits Telegram poll loop)
       try { await channels.destroy(); } catch (e) { console.error('Error destroying channels:', e); }

--- a/src/signal-cleanup-helper.ts
+++ b/src/signal-cleanup-helper.ts
@@ -7,6 +7,7 @@
 
 import type { SessionManager } from './session.js';
 import type { TmuxManager } from './tmux.js';
+import { cleanupTerminatedSessionState, type SessionCleanupDeps } from './session-cleanup.js';
 
 /** Result of killAllSessions operation. */
 export interface KillAllResult {
@@ -33,6 +34,7 @@ export interface KillAllWithTimeoutResult extends KillAllResult {
 export async function killAllSessions(
   sessions: SessionManager,
   tmux: TmuxManager,
+  cleanupDeps?: SessionCleanupDeps,
 ): Promise<KillAllResult> {
   const allSessions = sessions.listSessions();
   let killed = 0;
@@ -42,6 +44,7 @@ export async function killAllSessions(
   for (const session of allSessions) {
     try {
       await sessions.killSession(session.id);
+      if (cleanupDeps) cleanupTerminatedSessionState(session.id, cleanupDeps);
       killed++;
     } catch (e) {
       errors++;
@@ -75,6 +78,7 @@ export async function killAllSessionsWithTimeout(
   sessions: SessionManager,
   tmux: TmuxManager,
   perSessionTimeoutMs: number = 5_000,
+  cleanupDeps?: SessionCleanupDeps,
 ): Promise<KillAllWithTimeoutResult> {
   const allSessions = sessions.listSessions();
   let killed = 0;
@@ -88,6 +92,7 @@ export async function killAllSessionsWithTimeout(
         perSessionTimeoutMs,
         `Session kill timeout for ${session.windowName}`,
       );
+      if (cleanupDeps) cleanupTerminatedSessionState(session.id, cleanupDeps);
       killed++;
     } catch (e) {
       if (e instanceof TimeoutError) {


### PR DESCRIPTION
**Bug:** signal-cleanup-helper.ts called `sessions.killSession` but did NOT call `cleanupTerminatedSessionState`. When SIGTERM/SIGINT fired, all monitor/metrics/toolRegistry per-session Maps accumulated stale entries — memory leak.

**Fix:**
1. Added optional `SessionCleanupDeps` parameter to `killAllSessions` and `killAllSessionsWithTimeout` in signal-cleanup-helper.ts
2. After each `killSession`, call `cleanupTerminatedSessionState` if deps provided
3. Updated `server.ts` shutdown path to pass `{ monitor, metrics, toolRegistry }`

Note: `removeSession` (monitor cleanup) was already comprehensive — the issue was that it was never called in the signal shutdown path.

Developed with Aegis v0.1.0-alpha

Refs: #1115