### PR TITLE
fix(permission): handle ? as single-char wildcard in globToRegExp (#1124)

### DIFF
--- a/src/__tests__/permission-evaluator-742.test.ts
+++ b/src/__tests__/permission-evaluator-742.test.ts
@@ -47,3 +47,19 @@ describe('Issue #742: permission profile evaluator', () => {
     expect(result.behavior).toBe('deny');
   });
 });
+  it('matches ? as single character wildcard', () => {
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{ tool: 'Bash', behavior: 'allow', pattern: 'git st?tus' }],
+    }, { toolName: 'Bash', toolInput: { command: 'git status' } });
+    expect(result.behavior).toBe('allow');
+  });
+
+  it('? does not match multiple characters', () => {
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{ tool: 'Bash', behavior: 'allow', pattern: 'git st?t' }],
+    }, { toolName: 'Bash', toolInput: { command: 'git start' } });
+    expect(result.behavior).toBe('deny');
+  });
+

--- a/src/permission-evaluator.ts
+++ b/src/permission-evaluator.ts
@@ -11,7 +11,7 @@ export interface PermissionEvaluationResult {
 }
 
 function globToRegExp(pattern: string): RegExp {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\?/g, '.').replace(/\*/g, '.*');
   return new RegExp(`^${escaped}$`, 'i');
 }
 


### PR DESCRIPTION
**Bug:** `globToRegExp` in `src/permission-evaluator.ts` escaped most regex special chars but did NOT handle `?`. In glob, `?` means "any single character" but in regex it was passed through unescaped, causing incorrect matches.

**Fix:** Add `.replace(/\\?/g, '.')` so `?` becomes `.\` in regex.

**Tests added:**
- `?` matches single character (`git st?tus` matches `git status`)
- `?` does not match multiple characters (`git st?t` does NOT match `git start`)

Developed with Aegis v0.1.0-alpha

Refs: #1124