### PR TITLE
fix(ws-terminal): stop poll timer immediately on session death (#1122)

### DIFF
--- a/src/ws-terminal.ts
+++ b/src/ws-terminal.ts
@@ -346,7 +346,9 @@ async function tickPoll(
 ): Promise<void> {
   const session = sessions.getSession(sessionId);
   if (!session) {
-    // Session gone — evict all subscribers
+    // Session gone — evict all subscribers and stop the poll
+    if (poll.timer) clearInterval(poll.timer);
+    poll.timer = null;
     for (const [socket, sub] of [...poll.subscribers]) {
       if (!sub.closed) {
         sendError(socket, 'Session no longer exists');
@@ -359,7 +361,9 @@ async function tickPoll(
   let content: string;
   try {
     content = await tmux.capturePane(session.windowId);
-  } catch { /* pane gone — evict all subscribers */
+  } catch { /* pane gone — evict all subscribers and stop the poll */
+    if (poll.timer) clearInterval(poll.timer);
+    poll.timer = null;
     for (const [socket, sub] of [...poll.subscribers]) {
       if (!sub.closed) {
         sendError(socket, 'Failed to capture pane — session may have ended');


### PR DESCRIPTION
**Bug:** `tickPoll` detected dead sessions (no session entry or `capturePane` failure) and evicted subscribers, but did NOT stop the interval timer. The timer kept firing and the poll entry remained in `sessionPolls`.

**Fix:** Explicitly `clearInterval(poll.timer)` and `poll.timer = null` in both error cases:
- `!session` — session entry gone from `sessions`
- `capturePane` failure — tmux window dead

This ensures immediate cleanup of orphaned poll timers.

Developed with Aegis v0.1.0-alpha

Refs: #1122