### PR TITLE
ci(governance): add mandatory production approval gate for release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
 
   publish-npm:
     needs: test
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Fixes #1173

Adds `environment: production` to the `publish-npm` job in the release workflow. This requires explicit human approval before any npm publish can proceed.

Note: A `production` environment must be configured in GitHub repo Settings > Environments with required reviewers for this to take effect.