### PR TITLE
fix(ci): fix continue-on-error asymmetry in ClawHub publish workflow (#1128)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,10 @@ jobs:
         with:
           node-version: '22'
       - name: ClawHub Login
-        continue-on-error: true
+        if: secrets.CLAWHUB_TOKEN != ''
         run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
-      - run: |
+      - name: Publish to ClawHub
+        if: secrets.CLAWHUB_TOKEN != ''
+        run: |
           VERSION=$(node -p "require('./package.json').version")
           npx clawhub@latest publish skill/ --slug aegis-bridge --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"


### PR DESCRIPTION
**Bug:** ClawHub login step had `continue-on-error: true` (swallowing auth failures silently), but the publish step did not — causing opaque errors when auth failed.

**Fix:** Removed `continue-on-error: true` from login. Added `if: secrets.CLAWHUB_TOKEN != ''` to both login and publish steps. Now:
- If token not set → steps are skipped (not failed)
- If token is invalid → login fails clearly, not silently

Developed with Aegis v0.1.0-alpha

Refs: #1128