### PR TITLE
feat(webhook): keep session.id and name in redactPayload (#1123)

### DIFF
--- a/src/__tests__/webhook-retry.test.ts
+++ b/src/__tests__/webhook-retry.test.ts
@@ -131,13 +131,10 @@ describe('Webhook delivery with retry', () => {
     await channel.onStatusChange!(makePayload('status.working'));
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.api).toBeDefined();
-    // Issue #827: session IDs are redacted from webhook payloads
-    expect(body.api.read).toBe('GET /sessions/[REDACTED]/read');
-    expect(body.api.send).toBe('POST /sessions/[REDACTED]/send');
-    expect(body.api.kill).toBe('DELETE /sessions/[REDACTED]');
-    expect(body.session.id).toBe('[REDACTED]');
-    expect(body.session.name).toBe('[REDACTED]');
+    // Issue #1123: session.id and name are NOT secrets — keep them.
+    // Only workDir is redacted (contains filesystem paths).
+    expect(body.session.id).toBe('test-123');
+    expect(body.session.name).toBe('test-session');
     expect(body.session.workDir).toBe('[REDACTED]');
   });
 
@@ -187,9 +184,9 @@ describe('Webhook delivery with retry', () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.event).toBe('status.permission');
-    // Issue #827: session metadata is redacted
-    expect(body.session.id).toBe('[REDACTED]');
-    expect(body.session.name).toBe('[REDACTED]');
+    // Issue #1123: session.id and name are NOT secrets — keep them.
+    expect(body.session.id).toBe('test-123');
+    expect(body.session.name).toBe('test-session');
     expect(body.session.workDir).toBe('[REDACTED]');
   });
 

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -125,14 +125,9 @@ export class WebhookChannel implements Channel {
     return {
       ...rest,
       session: {
-        id: '[REDACTED]',
-        name: '[REDACTED]',
-        workDir: '[REDACTED]',
-      },
-      api: {
-        read: 'GET /sessions/[REDACTED]/read',
-        send: 'POST /sessions/[REDACTED]/send',
-        kill: 'DELETE /sessions/[REDACTED]',
+        id: session.id,  // Not a secret — safe to expose
+        name: session.name,  // Not a secret — safe to expose
+        workDir: '[REDACTED]',  // Contains filesystem paths — redact
       },
     };
   }


### PR DESCRIPTION
**Enhancement:** Previously `redactPayload` replaced `session.id` and `session.name` (which are NOT secrets) with `'[REDACTED]'`, making webhooks useless for automation consumers.

**Fix:**
- `session.id`: kept (UUID — not a secret, visible in CI logs anyway)
- `session.name`: kept (window name — not a secret)
- `session.workDir`: still redacted (contains filesystem paths)
- Removed fake API URLs from redaction (misleading, added no value)

**Tests updated:** 2 tests in `webhook-retry.test.ts` to reflect new behavior.

Developed with Aegis v0.1.0-alpha

Refs: #1123