### PR TITLE
feat(ci): publish SHA256 checksums as GitHub release asset (#1171)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,29 @@ jobs:
           path: /tmp/aegis-bridge-*.tgz
           retention-days: 1
 
+  generate-checksums:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: package
+          path: /tmp
+      - name: Generate SHA256 checksums
+        run: |
+          cd /tmp
+          for f in *.tgz; do
+            echo "$(sha256sum "$f" | cut -d' ' -f1)  $(basename "$f")" >> checksums.txt
+          done
+          cat checksums.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: checksums
+          path: /tmp/checksums.txt
+          retention-days: 30
+
   publish-npm:
     needs: test
     environment: production
@@ -51,6 +74,24 @@ jobs:
       - run: npm publish --provenance --access public *.tgz
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  attach-checksums:
+    needs: [publish-npm, generate-checksums]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: checksums
+          path: .
+      - name: Attach checksums to GitHub Release
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          gh release edit "$TAG" --add-asset checksums.txt --clobber || \
+            gh release create "$TAG" --title "Release $TAG" --notes "See checksums.txt for artifact integrity." --prerelease checksums.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-clawhub:
     needs: publish-npm


### PR DESCRIPTION
**Implementation:**\n\n1. **generate-checksums job** — downloads the npm artifact, computes SHA256 for each .tgz, writes to checksums.txt, uploads as artifact (30-day retention)\n\n2. **attach-checksums job** — downloads checksums artifact, attaches to GitHub Release via `gh release edit --add-asset`\n\n**Acceptance criteria:**\n- ✅ Checksums generated for each artifact\n- ✅ Checksum manifest attached to release (via gh CLI)\n- ℹ️ Provenance attestation via `npm publish --provenance` already exists\n\n**Scope (Option A per Manudis):** SHA256 checksums only, no GPG signing. Simple, pragmatic.\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1171