### PR TITLE
fix(dashboard): skip retries for validation failures in API client

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -92,6 +92,8 @@ export function isRetryableError(error: Error): boolean {
   if (error.name === 'AbortError') return false;
   if (!error.message) return false;
   if (error.message.includes('HTTP ')) return false;
+  // Validation failures are deterministic — retrying won't help
+  if (error.message.includes('validation failed') || error.message.includes('validateResponse')) return false;
   return true;
 }
 


### PR DESCRIPTION
Fixes #1103

Adds a check for validation-related error messages in isRetryableError. Zod validation failures (containing 'validation failed') fail identically on retry and should not be retried.

Change: 1 file, 2 insertions in dashboard/src/api/client.ts