### PR TITLE
fix(config): add Zod schema validation for config file (#1109)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ import { existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { parseIntSafe, getErrorMessage } from './validation.js';
+import { configFileSchema } from './validation.js';
 
 export interface Config {
   /** HTTP server port */
@@ -150,23 +151,25 @@ async function loadConfigFile(): Promise<Partial<Config>> {
     if (existsSync(path)) {
       try {
         const data = await readFile(path, 'utf-8');
-        const parsed = JSON.parse(data);
-        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        const raw = JSON.parse(data);
+        if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
           console.warn(`Config file ${path} is not a JSON object, ignoring`);
           continue;
         }
-        // Expand ~ in paths
-        if (typeof parsed.stateDir === 'string') {
-          parsed.stateDir = expandTilde(parsed.stateDir);
-        }
-        if (typeof parsed.claudeProjectsDir === 'string') {
-          parsed.claudeProjectsDir = expandTilde(parsed.claudeProjectsDir);
+        // Expand ~ in paths before validation
+        if (typeof raw.stateDir === 'string') raw.stateDir = expandTilde(raw.stateDir);
+        if (typeof raw.claudeProjectsDir === 'string') raw.claudeProjectsDir = expandTilde(raw.claudeProjectsDir);
+
+        const parsed = configFileSchema.safeParse(raw);
+        if (!parsed.success) {
+          console.warn(`Config file ${path} has invalid fields, ignoring:`, parsed.error.format());
+          continue;
         }
         // Log if using legacy path
         if (path.includes('manus')) {
           console.log(`Config: loaded from legacy path ${path} — consider migrating to aegis paths`);
         }
-        return parsed;
+        return parsed.data as Partial<Config>;
       } catch (e) {
         console.warn(`Failed to parse config file ${path}:`, e);
       }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -472,3 +472,39 @@ export async function validateWorkDir(
 
   return realPath;
 }
+
+/** Schema for aegis config file (Issue #1109). */
+export const configFileSchema = z.object({
+  port: z.number().int().positive().optional(),
+  host: z.string().optional(),
+  authToken: z.string().optional(),
+  tmuxSession: z.string().optional(),
+  stateDir: z.string().optional(),
+  claudeProjectsDir: z.string().optional(),
+  maxSessionAgeMs: z.number().int().positive().optional(),
+  reaperIntervalMs: z.number().int().positive().optional(),
+  continuationPointerTtlMs: z.number().int().positive().optional(),
+  tgBotToken: z.string().optional(),
+  tgGroupId: z.string().optional(),
+  tgAllowedUsers: z.array(z.number()).optional(),
+  tgTopicTtlMs: z.number().int().positive().optional(),
+  webhooks: z.array(z.string()).optional(),
+  defaultSessionEnv: z.record(z.string(), z.string()).optional(),
+  defaultPermissionMode: z.enum(["default", "plan", "acceptEdits", "bypassPermissions", "dontAsk", "auto"]).optional(),
+  stallThresholdMs: z.number().int().positive().optional(),
+  sseMaxConnections: z.number().int().positive().optional(),
+  sseMaxPerIp: z.number().int().positive().optional(),
+  allowedWorkDirs: z.array(z.string()).optional(),
+  worktreeAwareContinuation: z.boolean().optional(),
+  memoryBridge: z.object({
+    enabled: z.boolean(),
+    persistPath: z.string().optional(),
+    reaperIntervalMs: z.number().int().positive().optional(),
+  }).optional(),
+  worktreeSiblingDirs: z.array(z.string()).optional(),
+  verificationProtocol: z.object({
+    autoVerifyOnStop: z.boolean(),
+    criticalOnly: z.boolean(),
+  }).partial().optional(),
+});
+


### PR DESCRIPTION
**Implementation:**\n\n1. **configFileSchema** — Zod schema in  covering all config file fields (port, host, authToken, stateDir, etc.)\n2. **loadConfigFile updated** — uses  instead of basic  check\n3. Invalid fields are logged with  and the config file is skipped\n4. Type cast on success path () — Zod validates at runtime, TypeScript needs the cast for schema shape mismatch with optionals\n\n**Acceptance criteria:**\n- ✅ Config file parsed with Zod schema validation\n- ✅ Invalid fields logged and rejected\n- ✅ Type errors caught at load time (e.g.  is rejected, not accepted as )\n\n**Test:** 135 test files, 2397 tests passed.\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1109