### PR TITLE
fix(security): add TLS/key/credential patterns to .gitignore (#1106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,13 @@ dist/
 node_modules/
 # OS files
 # Secrets and local config
+# TLS/credential files (Issue #1106)
+*.pem
+*.key
+*.p12
+*.pfx
+credentials*.json
+!credentials.example.json
 session_map.json
 settings.local.json
 # State files


### PR DESCRIPTION
**Implementation:**\n\nAdd missing patterns to `.gitignore`:\n- `*.pem` — PEM certificate files\n- `*.key` — TLS private keys\n- `*.p12`, `*.pfx` — PKCS12 keystore files\n- `credentials*.json` — credential files\n- `!credentials.example.json` — exception for example file\n\n**Acceptance criteria:**\n- ✅ .gitignore covers private keys and credential patterns\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1106