### PR TITLE
fix(ci): add dashboard to Dependabot coverage (#1110)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
 
+  - package-ecosystem: npm
+    directory: /dashboard
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
**Implementation:**\n\nAdd `/dashboard` directory entry to `.github/dependabot.yml` npm ecosystem.\nDashboard `package.json` dependencies now covered by Dependabot auto-updates.\n\n**Acceptance criteria:**\n- ✅ Dashboard covered by Dependabot\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1110