### PR TITLE
fix(monitor): only fast-poll when hooks are configured (#1097)

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -186,16 +186,21 @@ export class SessionMonitor {
     }
   }
 
-  /** Check if any active session hasn't received a hook recently. */
+  /** Check if any active session hasn't received a hook recently.
+   *  Issue #1097: Only fast-poll if hooks are configured (at least one session
+   *  has received a hook). If no session has ever received a hook, hooks are
+   *  likely not configured — use slow polling. */
   private needsFastPolling(): boolean {
     const now = Date.now();
+    let anySessionHasReceivedHook = false;
     for (const session of this.sessions.listSessions()) {
       const lastHook = session.lastHookAt;
-      // If a session has never received a hook, always fast-poll (hooks may not be configured)
-      if (lastHook === undefined) return true;
-      // If no hook for hookQuietMs, switch to fast polling
+      if (lastHook === undefined) continue; // session with no hook, skip
+      anySessionHasReceivedHook = true;
+      // Session received a hook but is now quiet — need fast polling
       if (now - lastHook > this.config.hookQuietMs) return true;
     }
+    // If no session has ever received a hook, hooks are not configured — slow poll
     return false;
   }
 


### PR DESCRIPTION
**Implementation:**\n\n`needsFastPolling()` now only returns `true` if at least one session has received a hook. If no session has ever received a hook, hooks are likely not configured — use slow polling (30s) instead of fast polling (5s).\n\n**Before:** `lastHook === undefined` → always fast-poll (6x more frequent)\n**After:** `lastHook === undefined` → skip; only fast-poll when hook-quiet\n\n**Impact:** 6x reduction in poll frequency when hooks are not configured (dev environments).\n\n**Acceptance criteria:**\n- ✅ needsFastPolling only true when hooks ARE configured\n- ✅ Slow polling (30s) when hooks not configured\n\n**Test:** 135 test files, 2397 tests passed.\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1097