### PR TITLE
fix(session): use stored byteOffset in detectWaitingForInput (#1095)

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -809,7 +809,7 @@ export class SessionManager {
     if (!session?.jsonlPath) return false;
 
     try {
-      const { raw } = await readNewEntries(session.jsonlPath, 0);
+      const { raw } = await readNewEntries(session.jsonlPath, session.byteOffset);
       // Walk backwards to find the last assistant JSONL entry
       for (let i = raw.length - 1; i >= 0; i--) {
         const entry = raw[i];


### PR DESCRIPTION
**Implementation:**\n\n`detectWaitingForInput()` now uses `session.byteOffset` instead of hardcoded `0` to read only new JSONL entries since the last poll cycle.\n\n**Before:** `readNewEntries(session.jsonlPath, 0)` — reads entire file every call\n**After:** `readNewEntries(session.jsonlPath, session.byteOffset)` — reads only new entries\n\n**Partial fix:** The tool endpoint (`GET /v1/sessions/:id/tools`) still reads from offset 0. Fixing it requires a new `toolOffset` field in SessionInfo to avoid double-counting tools (processEntries does count++). Filed as follow-up.\n\n**Acceptance criteria:**\n- ✅ detectWaitingForInput uses stored byteOffset\n- ⚠️ Tool endpoint still reads from 0 (needs toolOffset field)\n\n**Test:** 135 test files, 2397 tests passed.\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1095