### PR TITLE
fix(session): check dangerous env prefixes before name regex (#1093)

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -597,15 +597,17 @@ export class SessionManager {
     const mergedEnv: Record<string, string> = {};
     const allEnv = { ...this.config.defaultSessionEnv, ...opts.env };
     for (const [key, value] of Object.entries(allEnv)) {
+      // Issue #1093: Check dangerous prefixes FIRST (before name regex), since some
+      // dangerous prefixes like npm_config_ are lowercase and would fail the regex check.
+      if (DANGEROUS_ENV_PREFIXES.some(prefix => key.startsWith(prefix))) {
+        const matchedPrefix = DANGEROUS_ENV_PREFIXES.find(p => key.startsWith(p))!;
+        throw new Error(`Forbidden env var: "${key}" — cannot override dangerous environment variable prefix "${matchedPrefix}"`);
+      }
       if (!ENV_NAME_RE.test(key)) {
         throw new Error(`Invalid env var name: "${key}" — must match /^[A-Z_][A-Z0-9_]*$/`);
       }
       if (DANGEROUS_ENV_VARS.has(key)) {
         throw new Error(`Forbidden env var: "${key}" — cannot override dangerous environment variables`);
-      }
-      // Issue #630: Check dangerous prefixes
-      if (DANGEROUS_ENV_PREFIXES.some(prefix => key.startsWith(prefix))) {
-        throw new Error(`Forbidden env var: "${key}" — cannot override dangerous environment variable prefix "${DANGEROUS_ENV_PREFIXES.find(p => key.startsWith(p))}"`);
       }
       mergedEnv[key] = value;
     }


### PR DESCRIPTION
**Implementation:**\n\nReorder env var validation checks so `DANGEROUS_ENV_PREFIXES` is checked BEFORE the `ENV_NAME_RE` regex. This fixes the dead code issue where lowercase-prefixed dangerous vars like `npm_config_*` would fail the regex before ever reaching the prefix check.\n\n**Before:**\n1. `ENV_NAME_RE.test(key)` — rejects lowercase names\n2. `DANGEROUS_ENV_PREFIXES` check — never reached for lowercase names\n\n**After:**\n1. `DANGEROUS_ENV_PREFIXES` check — runs first, catches `npm_config_` etc.\n2. `ENV_NAME_RE.test(key)` — still rejects invalid names\n3. `DANGEROUS_ENV_VARS` check\n\n**Acceptance criteria:**\n- ✅ Prefix check runs before regex (dead code removed)\n- ✅ `npm_config_*` prefix now actually blocked\n\n**Test:** 135 test files, 2397 tests passed.\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1093