### PR TITLE
fix(dashboard): add connected/heartbeat to GlobalSSEEventType enum

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -17,7 +17,6 @@ import type {
   MessagesResponse,
   GlobalMetrics,
   SessionSSEEvent,
-  GlobalSSEEvent,
 } from '../types';
 
 // ── Primitives ──────────────────────────────────────────────────
@@ -286,6 +285,8 @@ export const SessionSSEEventDataSchema: z.ZodType<SessionSSEEvent> = z.object({
 // ── Global SSE Event (Issue #410) ──────────────────────────────
 
 const GlobalSSEEventType = z.enum([
+  'connected',
+  'heartbeat',
   'session_status_change',
   'session_message',
   'session_approval',
@@ -298,7 +299,7 @@ const GlobalSSEEventType = z.enum([
   'session_verification',
 ]);
 
-export const GlobalSSEEventSchema: z.ZodType<GlobalSSEEvent> = z.object({
+export const GlobalSSEEventSchema = z.object({
   event: GlobalSSEEventType,
   sessionId: z.string(),
   timestamp: z.string(),


### PR DESCRIPTION
## Bug (found during UAT)

Server sends `connected` and `heartbeat` events in the global SSE stream. Dashboard schema only accepted session-scoped events. Every global event failed Zod validation and was silently dropped.

## Fix
- Added `connected` and `heartbeat` to `GlobalSSEEventType` Zod enum
- Removed stale explicit type annotation (Zod infers correctly)

## Impact
Non-crashing — polling fallback still worked. But real-time global SSE updates on the Overview page were lost.

## Testing
- tsc --noEmit: clean (excluding pre-existing useToastStore issue)
- vite build: passes