### PR TITLE
docs: fix broken dashboard image reference

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,7 +63,7 @@ curl -H "Authorization: Bearer your-secret-token" http://localhost:9100/v1/sessi
 
 Visit **http://localhost:9100/dashboard/** in your browser. The dashboard shows all sessions, their status, and activity in real time.
 
-![Dashboard](docs/assets/aegis-dashboard-hero.jpg)
+![Dashboard](docs/assets/aegis-hero.jpg)
 
 No extra setup needed — the dashboard is built into Aegis.
 


### PR DESCRIPTION
Fixes wrong image filename in getting-started.md: `aegis-dashboard-hero.jpg` → `aegis-hero.jpg`