### PR TITLE
ci(governance): enforce feat minor-bump approval gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,35 @@ jobs:
             revert
           requireScope: false
 
+  feat-minor-bump-gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce approved minor bump label for feat PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.info('Not a pull request event; skipping gate.');
+              return;
+            }
+
+            const title = pr.title || '';
+            const isFeat = /^feat(\(.+\))?!?:\s/i.test(title);
+            if (!isFeat) {
+              core.info(`PR title is not feat:* (${title}); gate passed.`);
+              return;
+            }
+
+            const labels = (pr.labels || []).map(label => label.name);
+            if (labels.includes('approved-minor-bump')) {
+              core.info('approved-minor-bump label present; feat gate passed.');
+              return;
+            }
+
+            core.setFailed('feat: PRs require the approved-minor-bump label before CI can pass.');
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,13 @@ Every PR must include:
 
 ## Branching Strategy — GitHub Flow + develop
 
-**Golden rule: All new agent PRs target `develop`, never `main` (except maintainer-directed bootstrap or hotfix work).**
+**Golden rule: while Aegis remains in alpha, all standard agent PRs target `develop` and `main` stays frozen.**
 
-> Transition note: during the Week 1 rollout, maintainers may temporarily relax or move branch protection checks while `develop` is being bootstrapped. As soon as the rollout PR lands, re-enable protection and send all new agent PRs to `develop`.
+Use `main` only for:
+- maintainer-directed hotfixes
+- an explicit beta/release promotion window announced by the maintainer
+
+> Until that promotion window exists, do not open sync or release PRs from `develop` to `main`.
 
 ```
 feature/fix branches ──PR──> develop ──PR──> main ──> Release Please ──> npm
@@ -124,10 +128,25 @@ hotfix/<issue-number>-<short-description>
 
 ---
 
+## feat: Gate — IMPORTANT
+
+`feat:` commits are allowed only for genuine user-facing features.
+CI now enforces this rule mechanically:
+
+1. Open the PR with a `feat:` title only if the change is truly user-visible
+2. Ask for the `approved-minor-bump` label
+3. That label may be added only by the maintainer or a designated governance/release reviewer acting on maintainer authority
+4. Without the label, the PR stays blocked
+
+**When in doubt → `fix:` or `refactor:`.** Most internal work is **not** `feat:`.
+
+---
+
 ## What NOT to do
 
 - ❌ Never push directly to `main` — always use a PR
-- ❌ Never open a PR targeting `main` — target `develop` (exceptions: hotfixes or maintainer-directed bootstrap PRs)
+- ❌ Never open a PR targeting `main` during alpha — target `develop` (exceptions: maintainer-directed hotfixes or explicit promotion windows)
+- ❌ Never open a `develop` → `main` sync/release PR unless the maintainer has announced a promotion window
 - ❌ Never merge your own PR — Argus reviews and merges
 - ❌ Never use `feat:` for internal improvements, type safety, or refactors
 - ❌ Never open a PR with failing CI


### PR DESCRIPTION
## Summary\n- add a CI gate that blocks `feat:` PRs unless they carry the `approved-minor-bump` label\n- document the alpha-on-`develop` policy in `CLAUDE.md`\n- clarify that only the maintainer or a designated governance reviewer may approve the minor-bump label\n\n## Testing\n- npx tsc --noEmit\n- npm run build\n- npm test\n\n## Policy impact\n- `main` stays frozen during alpha unless the maintainer opens an explicit promotion window\n- standard agent work continues on `develop`\n\n## Aegis version\n**Developed with:** v0.1.0-alpha