### PR TITLE
fix(security): normalize paths before prefix check (#1081)

### DIFF
--- a/src/permission-evaluator.ts
+++ b/src/permission-evaluator.ts
@@ -1,4 +1,5 @@
 import type { PermissionProfile } from './validation.js';
+import { normalize, sep } from 'node:path';
 
 export interface PermissionEvaluationInput {
   toolName: string;
@@ -30,6 +31,15 @@ function isLikelyWriteTool(toolName: string): boolean {
   return /write|edit|delete|rename|move|create/i.test(toolName);
 }
 
+function isPathAllowed(candidate: string, allowedPrefixes: string[]): boolean {
+  const normalizedCandidate = normalize(candidate);
+  return allowedPrefixes.some((prefix) => {
+    const normalizedPrefix = normalize(prefix);
+    return normalizedCandidate === normalizedPrefix ||
+      normalizedCandidate.startsWith(normalizedPrefix + sep);
+  });
+}
+
 export function evaluatePermissionProfile(
   profile: PermissionProfile,
   input: PermissionEvaluationInput,
@@ -50,7 +60,7 @@ export function evaluatePermissionProfile(
 
     if (rule.constraints?.paths && rule.constraints.paths.length > 0) {
       const paths = extractCandidatePaths(input.toolInput);
-      const allowed = paths.every((candidate) => rule.constraints!.paths!.some((prefix) => candidate.startsWith(prefix)));
+      const allowed = paths.every((p) => isPathAllowed(p, rule.constraints!.paths!));
       if (!allowed) {
         return { behavior: 'deny', reason: `Denied by path constraint for ${input.toolName}` };
       }


### PR DESCRIPTION
## Summary

Fixes a path boundary bypass vulnerability in `src/permission-evaluator.ts`.

**Issue:** https://github.com/OneStepAt4time/aegis/issues/1081

### Vulnerability

The path allowlisting used `candidate.startsWith(prefix)` without normalizing paths first. This allowed bypassing the check with paths like `/home/user/project-evil` when the allowed prefix was `/home/user/project` — a string prefix match without respecting path boundaries.

### Fix

1. Added `import { normalize, sep } from 'node:path'` to normalize both the candidate and prefix paths.
2. Replaced the raw `startsWith` check with a new helper `isPathAllowed()` that:
   - Normalizes both the candidate path and each allowed prefix
   - Returns `true` only if the normalized candidate **equals** the prefix OR **starts with** `prefix + path.sep`

This ensures path boundary integrity: `/home/user/project-evil` is no longer incorrectly allowed under prefix `/home/user/project`.

### Acceptance Criteria

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (2397 tests)
- [x] `/home/user/project-evil` is denied when allowed prefix is `/home/user/project`
- [x] `/home/user/project/file.txt` is allowed when allowed prefix is `/home/user/project`
