### PR TITLE
fix(security): use exact path match for SSE route detection (#1089)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -358,7 +358,8 @@ function setupAuth(authManager: AuthManager): void {
     // #124/#125: Accept token from Authorization header; ?token= query param
     // only on SSE routes where EventSource cannot set headers.
     // #297: SSE routes also accept short-lived SSE tokens via ?token=.
-    const isSSERoute = req.url?.includes('/events');
+    // SSE routes: /v1/events and /v1/sessions/:id/events
+    const isSSERoute = /^\/v1\/events$|^\/v1\/sessions\/[^/]+\/events$/.test(urlPath);
     let token: string | undefined;
     const header = req.headers.authorization;
     if (header?.startsWith('Bearer ')) {


### PR DESCRIPTION
## Summary

Fixes the `isSSERoute` check in `src/server.ts:361` which incorrectly used `req.url?.includes('/events')` — a substring match that would misclassify any URL containing `/events` as an SSE route (e.g., `/v1/sessions/abc/prevent-events-loss`).

## Fix

Replaced the `.includes()` check with a proper regex that matches only the two actual SSE routes:
- `/v1/events` (exact match)
- `/v1/sessions/:id/events` (pattern match)

```typescript
// Before (vulnerable):
const isSSERoute = req.url?.includes('/events');

// After (secure):
const isSSERoute = /^\/v1\/events$|^\/v1\/sessions\/[^/]+\/events$/.test(urlPath);
```

## Testing

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npm test` ✅ (2397 passed)

Refs: #1089