### PR TITLE
fix(security): use timing-safe comparison for hook secrets (#1085)

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -22,8 +22,20 @@ import { isValidUUID, hookBodySchema, parseIntSafe } from './validation.js';
 import type { MetricsCollector } from './metrics.js';
 import type { UIState } from './terminal-parser.js';
 import { evaluatePermissionProfile } from './permission-evaluator.js';
+import crypto from 'node:crypto';
 
 /** CC hook events that require a decision response. */
+
+/** Timing-safe string comparison to prevent timing attacks on secret values. */
+function timingSafeEqual(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}
+
 const DECISION_EVENTS = new Set(['PreToolUse', 'PermissionRequest']);
 
 /** Permission modes that should be auto-approved via hook response. */
@@ -157,7 +169,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
     // Issue #629/#1131: Validate hook secret from X-Hook-Secret header (query param fallback)
     const hookSecret = (req.headers['x-hook-secret'] as string)
       || (req.query as Record<string, string>)?.secret;
-    if (session.hookSecret && hookSecret !== session.hookSecret) {
+    if (session.hookSecret && !timingSafeEqual(hookSecret, session.hookSecret)) {
       return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import fastifyStatic from '@fastify/static';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyCors from '@fastify/cors';
 import { z } from 'zod';
+import crypto from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { TmuxManager } from './tmux.js';
@@ -67,6 +68,17 @@ import {
   permissionProfileSchema, type PermissionProfile,
 } from './validation.js';
 
+
+
+/** Timing-safe string comparison to prevent timing attacks on secret values. */
+function timingSafeEqual(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -339,7 +351,7 @@ function setupAuth(authManager: AuthManager): void {
           // Issue #629/#1131: Validate hook secret from X-Hook-Secret header (query param fallback)
           const hookSecret = (req.headers['x-hook-secret'] as string)
             || (req.query as Record<string, string>)?.secret;
-          if (!hookSecret || hookSecret !== session.hookSecret) {
+          if (!hookSecret || !timingSafeEqual(hookSecret, session.hookSecret)) {
             return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
           }
           return; // valid session + secret — allow


### PR DESCRIPTION
## Summary

Fixes timing attack vulnerability in hook secret validation by replacing the non-constant-time `!==` comparison with `crypto.timingSafeEqual`.

## Changes

- **src/server.ts**: Added `import crypto from 'node:crypto'` and replaced `hookSecret !== session.hookSecret` with `!timingSafeEqual(hookSecret, session.hookSecret)`
- **src/hooks.ts**: Added `import crypto from 'node:crypto'` and replaced `hookSecret !== session.hookSecret` with `!timingSafeEqual(hookSecret, session.hookSecret)`

A helper function `timingSafeEqual(a, b)` is used to wrap `crypto.timingSafeEqual` and handle edge cases (null/undefined inputs, length mismatch errors).

## Security Impact

Previously, an attacker could measure response timing differences to deduce the session hook secret byte-by-byte. The new implementation uses constant-time comparison, preventing timing attacks.

Refs: https://github.com/OneStepAt4time/aegis/issues/1085