### PR TITLE
fix(security): reject all Telegram users when allowlist is empty (#1087)

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1546,7 +1546,7 @@ export class TelegramChannel implements Channel {
 
     if (!msg?.text || !msg.message_thread_id || msg.from?.is_bot) return;
 
-    // Issue #348: Check user against allowlist
+    // Issue #348/#1087: Check user against allowlist
     if (this.config.allowedUserIds.length > 0) {
       const userId = msg.from?.id;
       if (!userId || !this.config.allowedUserIds.includes(userId)) {
@@ -1561,6 +1561,19 @@ export class TelegramChannel implements Channel {
         }
         return;
       }
+    } else {
+      // Issue #1087: tgAllowedUsers is empty — reject ALL users when bot is configured
+      // Empty allowlist without explicit opt-in is a security risk
+      const name = msg.from?.first_name ?? 'Unknown';
+      const userId = msg.from?.id ?? 'no id';
+      console.error(`[CRITICAL] Telegram: tgAllowedUsers is empty — ALL users blocked from session control. User "${name}" (${userId}) rejected. Set tgAllowedUsers to explicitly allow specific Telegram user IDs.`);
+      for (const [, topic] of this.topics) {
+        if (topic.topicId === msg.message_thread_id) {
+          await this.sendImmediate(topic.sessionId, `⛔ Telegram access disabled: tgAllowedUsers is empty. Contact the Aegis administrator to add your Telegram user ID to tgAllowedUsers.`);
+          break;
+        }
+      }
+      return;
     }
 
     for (const [sessionId, topic] of this.topics) {


### PR DESCRIPTION
**Implementation:**\n\nWhen `tgAllowedUsers` is empty (the default), ALL Telegram users in a group can control Aegis sessions. Added an `else` branch to the allowlist check that:\n1. Logs a `[CRITICAL]` warning\n2. Sends an error message in the Telegram topic: "Telegram access disabled: tgAllowedUsers is empty"\n3. Returns early — rejecting the message\n\n**Before:** empty allowlist → all users allowed\n**After:** empty allowlist → all users rejected with error\n\n**Acceptance criteria:**\n- ✅ Empty tgAllowedUsers → all users rejected with error message\n- ✅ Critical log warning issued\n- ✅ User gets feedback in Telegram topic\n\n**Test:** 130 test files, 2369 tests passed.\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1087