### PR TITLE
fix(ci): disable auth explicitly in smoke test to prevent CI env conflicts

### DIFF
--- a/scripts/uat-smoke.mjs
+++ b/scripts/uat-smoke.mjs
@@ -176,6 +176,9 @@ try {
       AEGIS_STATE_DIR: stateDir,
       AEGIS_TMUX_SESSION: tmuxSession,
       FORCE_COLOR: '0',
+      // Issue #1099: explicitly disable auth for smoke test to prevent
+      // environment-auth-token from causing 401 in local smoke test
+      AEGIS_AUTH_TOKEN: '',
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });


### PR DESCRIPTION
**Implementation:**\n\nSmoke test runs Aegis with `AEGIS_HOST=127.0.0.1` and calls `GET /v1/sessions`. If `AEGIS_AUTH_TOKEN` is set in the CI environment, auth is enabled and the endpoint returns 401.\n\nFix: set `AEGIS_AUTH_TOKEN=''` in the smoke test env to explicitly disable auth regardless of CI environment.\n\n**Acceptance criteria:**\n- ✅ Smoke test passes regardless of CI environment\n- ✅ Explicit auth disable in smoke test\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1099 (regression from #1089 auth guard)