### PR TITLE
fix(security): correct isLocalhostBinding negation in auth guard (#1080 regression)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -367,7 +367,7 @@ function setupAuth(authManager: AuthManager): void {
     // #1080: Only bypass auth if no credentials are configured AND server is bound to localhost.
     // When binding to a non-localhost interface (0.0.0.0, public IP) with no auth configured,
     // do NOT bypass — let validate() reject the request (it returns valid:false in this case).
-    if (!authManager.authEnabled && !authManager.isLocalhostBinding) return;
+    if (!authManager.authEnabled && authManager.isLocalhostBinding) return;
 
     // #124/#125: Accept token from Authorization header; ?token= query param
     // only on SSE routes where EventSource cannot set headers.


### PR DESCRIPTION
**Bug:** The security fix #1089 introduced an inverted negation:\n\n\n\n**Logic:**\n| Auth | Binding | Result |\n|------|---------|--------|\n| Disabled | localhost | ✅ Allow (dev mode) |\n| Disabled | 0.0.0.0 | ❌ Reject (security risk) |\n| Enabled | any | Normal auth check |\n\n**Acceptance criteria:**\n- ✅ No-auth localhost → allowed\n- ✅ No-auth non-localhost → rejected with 401\n\n**Test:** 2397 tests passed.\n\nDeveloped with Aegis v0.1.0-alpha\n\nRefs: #1080 (regression from #1289)