### PR TITLE
fix(security): correct auth bypass negation for localhost binding (#1080)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -367,7 +367,7 @@ function setupAuth(authManager: AuthManager): void {
     // #1080: Only bypass auth if no credentials are configured AND server is bound to localhost.
     // When binding to a non-localhost interface (0.0.0.0, public IP) with no auth configured,
     // do NOT bypass — let validate() reject the request (it returns valid:false in this case).
-    if (!authManager.authEnabled && !authManager.isLocalhostBinding) return;
+    if (!authManager.authEnabled && authManager.isLocalhostBinding) return;
 
     // #124/#125: Accept token from Authorization header; ?token= query param
     // only on SSE routes where EventSource cannot set headers.


### PR DESCRIPTION
## Problem
After #1289 merged, the smoke test and all unauthenticated localhost requests return 401.

## Root Cause
Negation bug in `src/server.ts:370`:
```typescript
// WRONG (current):
if (!authManager.authEnabled && !authManager.isLocalhostBinding) return;
// CORRECT:
if (!authManager.authEnabled && authManager.isLocalhostBinding) return;
```
The logic was inverted — it skipped auth only for **non-localhost** bindings with no auth, instead of **localhost** bindings with no auth.

## Fix
One-line negation fix. Verified locally: smoke test passes, `/v1/sessions` returns 200.

## Verification
- `npm run test:smoke` — exits 0 ✅
- `npm run build` — compiles clean ✅

Refs: #1080, #1289, #1299 (closed — wrong fix)