### PR TITLE
docs: add module-level AI context and ADR documentation

### DIFF
--- a/dashboard/src/CLAUDE.md
+++ b/dashboard/src/CLAUDE.md
@@ -1,0 +1,74 @@
+# dashboard/src/ — Aegis React Dashboard
+
+Single-page React dashboard for monitoring and interacting with Aegis sessions.
+
+## Stack
+
+- **React 19** + **React Router 7** (lazy-loaded routes)
+- **TypeScript** strict mode
+- **Vite** for dev/build
+- **Zustand** for state management (`store/useStore.ts`)
+- **Zod** for API response validation (`api/schemas.ts`)
+- **TanStack React Virtual** for large session lists
+- **Tailwind CSS** for styling (utility classes in `index.css`)
+
+## Architecture
+
+```
+dashboard/src/
+├── App.tsx            # Root component with lazy-loaded routes
+├── main.tsx           # Entry point, renders App into DOM
+├── api/               # API client layer
+│   ├── client.ts      # REST + SSE + WebSocket client
+│   ├── schemas.ts     # Zod schemas for API responses
+│   ├── resilient-eventsource.ts  # SSE with auto-reconnect
+│   └── resilient-websocket.ts    # WebSocket with backoff
+├── components/        # Shared UI components
+│   ├── overview/      # Session list, metric cards, status dots
+│   ├── session/       # Session detail view, live terminal, transcript
+│   ├── pipeline/      # Pipeline status badges
+│   └── metrics/       # Latency panels
+├── hooks/             # Custom React hooks (polling, SSE awareness)
+├── pages/             # Route-level page components
+├── store/             # Zustand stores (useStore, useToastStore)
+├── types/             # TypeScript type definitions
+└── utils/             # Formatting utilities
+```
+
+### Key patterns
+
+- **Lazy loading** — all page components use `React.lazy()` + `Suspense`. Code-split per route.
+- **Optimistic updates** — store updates before API responses arrive, rollback on error.
+- **SSE + polling hybrid** — `useSseAwarePolling.ts` uses SSE when connected, falls back to polling.
+- **Zod validation at API boundary** — all API responses validated through schemas before hitting the store.
+- **Zustand for global state** — no prop drilling. Stores are flat, not nested.
+- **Error boundary** — catches render errors at the route level.
+
+### API communication
+
+All backend calls go through `api/client.ts`. The client handles:
+- Base URL from `import.meta.env.VITE_API_URL` or defaults to `window.location.origin`
+- SSE via `resilient-eventsource.ts` (auto-reconnect with backoff)
+- WebSocket via `resilient-websocket.ts` (for live terminal streaming)
+- Zod schema validation on all responses
+
+## Conventions
+
+- **Functional components only** — no class components.
+- **Named exports** — prefer `export function Component()` over default exports (exception: lazy-loaded pages use default export).
+- **Tailwind utilities** — use Tailwind classes directly. No custom CSS modules.
+- **Types from API schemas** — derive types from Zod schemas using `z.infer<>`, don't duplicate.
+- **No `any`** — use `unknown` + type narrowing.
+
+## Testing
+
+- Tests live in `dashboard/src/__tests__/`.
+- Dashboard build: `npm run build:dashboard` (from repo root).
+- The dashboard is compiled and copied into `dist/dashboard/` for serving by the Aegis server.
+
+## Common pitfalls
+
+- Dashboard is served as static files by the Aegis server — no separate deployment.
+- API client base URL must be configurable for dev vs production (Vite env vars).
+- WebSocket connections for live terminal need the session ID in the URL path.
+- SSE events may arrive out of order — handle idempotently using event IDs.

--- a/docs/adr/0005-module-level-ai-context.md
+++ b/docs/adr/0005-module-level-ai-context.md
@@ -1,0 +1,61 @@
+# ADR-0005: Module-Level AI Context Files
+
+Status: Accepted
+Date: 2026-04-07
+Issue: #1304
+
+## Context
+
+Aegis has grown to include a substantial server core (`src/`, ~60 files) and a React dashboard (`dashboard/src/`, ~30 files). The single root `CLAUDE.md` provides project-wide conventions but lacks module-specific guidance. When AI agents work within a specific module (e.g., the dashboard), they lack context about that module's architecture, key patterns, and conventions without reading many files first.
+
+Existing AI context infrastructure:
+- Root `CLAUDE.md` — project-wide commit/branching/quality rules
+- `.claude/` — settings, hooks, skills (operational config, not architectural guidance)
+- `CONTEXT.md` — architectural overview (high-level, not module-specific)
+- No nested `CLAUDE.md` files exist in subdirectories
+
+## Decision
+
+Add `CLAUDE.md` files at the module level (`src/CLAUDE.md`, `dashboard/src/CLAUDE.md`) to provide targeted AI context. These files serve as the first thing an AI agent reads when entering a module.
+
+### Principles for module-level context files
+
+1. **Scope**: Each file covers only its module — no repetition of project-wide rules already in root `CLAUDE.md`.
+2. **Brevity**: Under 100 lines. Link to source rather than duplicating.
+3. **Audience**: Written for AI coding agents (Claude Code, Cursor, Copilot) and new contributors.
+4. **Living docs**: Updated when module architecture changes significantly, not on every minor refactor.
+
+### What goes in a module CLAUDE.md
+
+- Module purpose and responsibilities
+- Key files and their roles (not exhaustive file listings)
+- Architecture patterns and conventions specific to the module
+- Testing approach for the module
+- Common pitfalls or anti-patterns to avoid
+- Entry points and dependency flow
+
+### What does NOT go in a module CLAUDE.md
+
+- Project-wide conventions (already in root `CLAUDE.md`)
+- Detailed API documentation (use TSDoc/JSDoc)
+- Implementation details that change frequently
+- Build/CI instructions (already in root `CLAUDE.md` and `package.json`)
+
+## Consequences
+
+Pros:
+- AI agents get relevant context immediately without scanning dozens of files.
+- New contributors can orient within a module faster.
+- Module owners can document patterns specific to their domain.
+- Complements existing ADR and CONTEXT.md infrastructure without duplication.
+
+Cons:
+- Another file to maintain — stale context is worse than no context.
+- Risk of conflicting with root `CLAUDE.md` if conventions diverge.
+- Requires discipline to keep module docs updated during refactors.
+
+## Enforcement
+
+- Module `CLAUDE.md` files are reviewed in PRs that touch module architecture.
+- If a module's `CLAUDE.md` becomes stale (contradicts code), it should be updated or removed.
+- New modules over ~10 files should consider adding their own `CLAUDE.md`.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,67 @@
+# src/ — Aegis Server Core
+
+Module containing the HTTP server, session management, tmux integration, and all backend logic.
+
+## Architecture
+
+```
+src/
+├── server.ts          # Fastify HTTP server + all route registration
+├── session.ts         # Session lifecycle (create/send/read/kill/recover)
+├── tmux.ts            # TmuxManager — tmux command wrapper (async, with timeouts)
+├── monitor.ts         # Background polling loop + event detection
+├── mcp-server.ts      # MCP stdio transport (tool discovery for Claude Code)
+├── config.ts          # Config loading from env + defaults
+├── channels/          # Notification channels (Telegram, webhooks)
+├── pipeline.ts        # Pipeline orchestration (batch session workflows)
+├── auth.ts            # API key auth + bearer token classification
+├── events.ts          # SessionEventBus — SSE + WebSocket event routing
+└── ...                # Supporting modules
+```
+
+### Key patterns
+
+- **No database** — all state in memory + JSON files on disk. Aegis is a bridge, not a platform.
+- **Tmux as session container** — one tmux window per Claude Code session. All interaction via `send-keys`/`capture-pane`.
+- **JSONL transcript parsing** — incremental reads using byte offsets. The `transcript.ts` parser reads CC's native output format.
+- **Terminal state machine** — `terminal-parser.ts` detects idle/working/asking/stalled states via regex patterns on captured pane content.
+- **Async with timeouts** — all tmux commands use `execFile` with timeouts. Never block the event loop.
+- **Fastify schema validation** — routes use Zod schemas for request/response validation.
+- **Event-driven monitoring** — `monitor.ts` polls sessions, emits events through `SessionEventBus`.
+
+### Dependency flow
+
+```
+server.ts → SessionManager → TmuxManager → tmux (process)
+         → SessionMonitor → SessionManager
+         → ChannelManager → TelegramChannel / WebhookChannel
+         → PipelineManager → SessionManager
+         → MCP tools → SessionManager (shared instance)
+```
+
+`SessionManager` is the central state holder. Most other modules either receive it as a dependency or access it through `server.ts`.
+
+## Conventions
+
+- **TypeScript strict mode** — no `any`. Use `unknown` + type guards.
+- **Type imports** — `import type { X }` on separate lines.
+- **Error handling** — use `normalizeApiErrorPayload()` for API responses. Never leak stack traces.
+- **Platform branching** — Windows vs Unix differences handled in `tmux.ts` and `session.ts`. Check `process.platform`.
+- **Session IDs** — UUIDs generated with `crypto.randomUUID()`.
+- **Concurrency** — `async-mutex` for critical sections (e.g., session creation, permission handling).
+
+## Testing
+
+- Tests live in `src/__tests__/`.
+- **Always mock tmux** — never hit real tmux in tests. Use `helpers/mock-tmux.ts`.
+- **Always mock time** — use `vi.useFakeTimers()` for timeout/retry tests.
+- Integration tests go in `src/__tests__/integration/`.
+- Run: `npm test` (vitest)
+
+## Common pitfalls
+
+- `tmux send-keys` is fire-and-forget — prompts may not arrive. Always verify via `capture-pane`.
+- `capture-pane` output includes ANSI codes — use `stripAnsi()` before parsing.
+- Session state is persisted to JSON — concurrent writes need the mutex.
+- The JSONL parser tracks byte offsets — don't reset offsets unless the file is recreated.
+- Windows paths need special handling — use `normalizeWorkDirForCompare()` for comparisons.


### PR DESCRIPTION
## Summary

Adds module-level `CLAUDE.md` files for AI agent guidance and ADR-0005 documenting the decision.

- `src/CLAUDE.md` — server core architecture, patterns, testing conventions, common pitfalls
- `dashboard/src/CLAUDE.md` — dashboard stack, lazy-loading, SSE+polling, Zustand patterns
- `docs/adr/0005-module-level-ai-context.md` — ADR for module-level context decision

Closes #1304

## Aegis version
**Developed with:** 0.1.0-alpha

Generated by Hephaestus (Aegis dev agent)