### PR TITLE
docs: fix tool count mismatch and add missing API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Or via `.mcp.json`:
 }
 ```
 
-**21 tools** — `create_session`, `send_message`, `get_transcript`, `approve_permission`, `batch_create_sessions`, `create_pipeline`, and more.
+**25 tools** — `create_session`, `send_message`, `get_transcript`, `approve_permission`, `batch_create_sessions`, `create_pipeline`, `state_set`, and more.
 
 **4 resources** — `aegis://sessions`, `aegis://sessions/{id}/transcript`, `aegis://sessions/{id}/pane`, `aegis://health`
 
@@ -141,6 +141,18 @@ All endpoints under `/v1/`.
 | `POST` | `/v1/sessions/batch` | Batch create |
 | `POST` | `/v1/handshake` | Capability negotiation |
 | `POST` | `/v1/pipelines` | Create pipeline |
+| `POST` | `/v1/memory` | Set memory entry |
+| `GET` | `/v1/memory` | List memory entries |
+| `GET` | `/v1/memory/:key` | Get memory entry |
+| `DELETE` | `/v1/memory/:key` | Delete memory entry |
+| `POST` | `/v1/templates` | Create session template |
+| `GET` | `/v1/templates` | List templates |
+| `GET` | `/v1/templates/:id` | Get template |
+| `PUT` | `/v1/templates/:id` | Update template |
+| `DELETE` | `/v1/templates/:id` | Delete template |
+| `POST` | `/v1/dev/route-task` | Route task to model tier |
+| `GET` | `/v1/dev/model-tiers` | List model tiers |
+| `GET` | `/v1/diagnostics` | Server diagnostics |
 
 <details>
 <summary>Full API Reference</summary>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ src/
 ├── transcript.ts             # JSONL transcript parsing — entries, token usage
 ├── jsonl-watcher.ts          # File watcher for Claude Code JSONL output
 │
-├── mcp-server.ts             # MCP server (stdio) — 21 tools, 4 resources, 3 prompts
+├── mcp-server.ts             # MCP server (stdio) — 25 tools, 4 resources, 3 prompts
 ├── tool-registry.ts          # MCP tool registration and dispatch
 ├── handshake.ts              # Client capability negotiation
 │
@@ -100,7 +100,7 @@ src/
 
 | Module | Purpose |
 |---|---|
-| `mcp-server.ts` | MCP stdio server — exposes 21 tools, 4 resources, 3 prompts to Claude Code and other MCP hosts |
+| `mcp-server.ts` | MCP stdio server — exposes 25 tools, 4 resources, 3 prompts to Claude Code and other MCP hosts |
 | `tool-registry.ts` | Registers and dispatches MCP tool calls |
 | `handshake.ts` | Client capability negotiation on connection |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ curl http://localhost:9100/v1/health
 Expected response:
 
 ```json
-{"status": "ok", "version": "2.17.4-alpha", "uptime": 12, "sessions": {"active": 0, "total": 0}}
+{"status": "ok", "version": "0.1.0-alpha", "uptime": 12, "sessions": {"active": 0, "total": 0}}
 ```
 
 <details>

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -160,7 +160,7 @@ HASH2=$(curl -s http://127.0.0.1:9100/v1/sessions/$SID/read | jq -r '.messages |
 
 ## MCP Tool Reference
 
-When MCP is configured, 21 tools are available natively:
+When MCP is configured, 25 tools are available natively:
 
 ### Session Lifecycle
 | Tool | Description |
@@ -195,6 +195,13 @@ When MCP is configured, 21 tools are available natively:
 | `server_health` | Server version, uptime, session counts |
 | `get_session_metrics` | Per-session performance metrics |
 | `get_session_latency` | Latency measurements |
+
+### State (Memory Bridge)
+| Tool | Description |
+|------|-------------|
+| `state_set` | Set a shared state key/value entry |
+| `state_get` | Get a shared state key/value entry |
+| `state_delete` | Delete a shared state key/value entry |
 
 ### Advanced
 | Tool | Description |

--- a/skill/references/api-quick-ref.md
+++ b/skill/references/api-quick-ref.md
@@ -43,6 +43,39 @@ Base URL: `http://127.0.0.1:9100`
 | POST | `/v1/pipelines` | Create pipeline |
 | GET | `/v1/swarm` | Swarm status |
 
+## Memory
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/v1/memory` | Set key/value. Body: `{key, value, ttlSeconds?}` |
+| GET | `/v1/memory/{key}` | Get value |
+| GET | `/v1/memory` | List entries. Query: `?prefix=` |
+| DELETE | `/v1/memory/{key}` | Delete entry |
+| POST | `/v1/sessions/:id/memories` | Attach memory to session. Body: `{key, value}` |
+
+## Templates
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/v1/templates` | Create template. Body: `{name, workDir?, prompt?, ...}` |
+| GET | `/v1/templates` | List all templates |
+| GET | `/v1/templates/:id` | Get specific template |
+| PUT | `/v1/templates/:id` | Update template |
+| DELETE | `/v1/templates/:id` | Delete template |
+
+## Model Router
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/v1/dev/route-task` | Route task to model tier. Body: `{title, labels, description}` |
+| GET | `/v1/dev/model-tiers` | List configured tiers |
+
+## Diagnostics
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/v1/diagnostics` | Internal events log. Query: `?limit=50` |
+
 ## Server
 
 | Method | Endpoint | Description |
@@ -96,7 +129,7 @@ See [workflow-examples.md](./workflow-examples.md) for complete scripts for:
 - PR review loop
 - Batch pipeline loop
 
-## MCP Tool Mapping (21 tools)
+## MCP Tool Mapping (25 tools)
 
 | MCP Tool | REST Equivalent |
 |----------|----------------|
@@ -121,3 +154,6 @@ See [workflow-examples.md](./workflow-examples.md) for complete scripts for:
 | `create_pipeline` | `POST /v1/pipelines` |
 | `get_swarm` | `GET /v1/swarm` |
 | `server_health` | `GET /v1/health` |
+| `state_set` | `POST /v1/memory` |
+| `state_get` | `GET /v1/memory/{key}` |
+| `state_delete` | `DELETE /v1/memory/{key}` |


### PR DESCRIPTION
## Summary

Documentation audit found 20 issues. This PR fixes the P0 and P1 issues.

### Fixes
- **Tool count 21→25** in README.md, architecture.md, SKILL.md, api-quick-ref.md
- **Added Memory Bridge endpoints** (\`/v1/memory/*\`) to README and api-quick-ref.md
- **Added Template endpoints** (\`/v1/templates/*\`) to README and api-quick-ref.md
- **Added Model Router endpoints** (\`/v1/dev/*\`) to README and api-quick-ref.md
- **Added Diagnostics endpoint** to README and api-quick-ref.md
- **Added missing tools** (state_set, state_get, state_delete) to SKILL.md MCP tool table
- **Fixed stale version** in getting-started.md example (2.17.4-alpha → 0.1.0-alpha)

### Remaining (future PRs)
- P2: Document MCP Resources in mcp-tools.md, document consensus/continuation-pointer/question-manager/hooks
- P3: Dashboard guide, update ROADMAP.md, move internal report to ADRs