### PR TITLE
fix: quote 'on' key in release.yml (YAML 1.1 boolean bug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-on:
+"on":
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
Fixes the release workflow not executing any jobs.

**Root cause:** YAML 1.1 parses bare `on` as boolean `True` instead of string key `'on'`. This caused GitHub Actions to not recognize the `on: push: tags: - 'v*'` trigger.

**Fix:** Quote the `on` key as `"on":`.

**Testing:** After this fix, pushing a `v*` tag should trigger the full test + publish workflow.

**Impact:** All future releases (0.3.0-alpha and beyond) are blocked until this is merged.