### PR TITLE
fix: use bare on: in release.yml (GitHub Actions compatibility)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-"on":
+on:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
Minimal fix: change quoted '"on":' to bare 'on:' in release.yml.

This is likely why the release workflow fails to create any jobs — GitHub Actions may not recognize the quoted YAML key.