### PR TITLE
docs: fix tool counts, stale version refs, and inconsistencies

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2,7 +2,7 @@
 
 Aegis provides orchestration primitives beyond basic session management. This guide covers the Memory Bridge, Model Router, Session Templates, Verification Protocol, and Diagnostics.
 
-> **Note:** These features are available in v0.1.0-alpha. APIs may change between releases.
+> **Note:** These features are available in v0.2.0-alpha. APIs may change between releases.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ src/
 ├── transcript.ts             # JSONL transcript parsing — entries, token usage
 ├── jsonl-watcher.ts          # File watcher for Claude Code JSONL output
 │
-├── mcp-server.ts             # MCP server (stdio) — 25 tools, 4 resources, 3 prompts
+├── mcp-server.ts             # MCP server (stdio) — 24 tools, 4 resources, 3 prompts
 ├── tool-registry.ts          # MCP tool registration and dispatch
 ├── handshake.ts              # Client capability negotiation
 │
@@ -100,7 +100,7 @@ src/
 
 | Module | Purpose |
 |---|---|
-| `mcp-server.ts` | MCP stdio server — exposes 25 tools, 4 resources, 3 prompts to Claude Code and other MCP hosts |
+| `mcp-server.ts` | MCP stdio server — exposes 24 tools, 4 resources, 3 prompts to Claude Code and other MCP hosts |
 | `tool-registry.ts` | Registers and dispatches MCP tool calls |
 | `handshake.ts` | Client capability negotiation on connection |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ curl http://localhost:9100/v1/health
 Expected response:
 
 ```json
-{"status": "ok", "version": "0.1.0-alpha", "uptime": 12, "sessions": {"active": 0, "total": 0}}
+{"status": "ok", "version": "0.2.0-alpha", "uptime": 12, "sessions": {"active": 0, "total": 0}}
 ```
 
 <details>

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Aegis exposes 25 tools and 3 prompts via the MCP (Model Context Protocol) server. These tools allow Claude Code and other MCP hosts to manage sessions, read transcripts, orchestrate pipelines, and share state.
+Aegis exposes 24 tools and 3 prompts via the MCP (Model Context Protocol) server. These tools allow Claude Code and other MCP hosts to manage sessions, read transcripts, orchestrate pipelines, and share state.
 
 ## Setup
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -160,7 +160,7 @@ HASH2=$(curl -s http://127.0.0.1:9100/v1/sessions/$SID/read | jq -r '.messages |
 
 ## MCP Tool Reference
 
-When MCP is configured, 25 tools are available natively:
+When MCP is configured, 24 tools are available natively:
 
 ### Session Lifecycle
 | Tool | Description |


### PR DESCRIPTION
## Summary
- architecture.md: 25 tools → 24 tools (matches actual mcp-server.ts count)
- skill/SKILL.md: 25 tools → 24 tools
- mcp-tools.md: 25 tools → 24 tools
- advanced.md: v0.1.0-alpha → v0.2.0-alpha
- getting-started.md: fix stale version in example response (0.1.0-alpha → 0.2.0-alpha)

Closes #1323 (bloomed to 81 files via merge commit — this is the narrowed replacement).