### PR TITLE
chore: rename npm package to @onestepat4time/aegis

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
       label: Steps to reproduce
       description: How can we reproduce this?
       placeholder: |
-        1. Start Aegis with `npx aegis-bridge`
+        1. Start Aegis with `npx @onestepat4time/aegis`
         2. Create a session via `POST /v1/sessions`
         3. ...
     validations:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: package
-          path: /tmp/aegis-bridge-*.tgz
+          path: /tmp/onestepat4time-aegis-*.tgz
           retention-days: 1
 
   generate-sbom:
@@ -151,4 +151,4 @@ jobs:
         if: secrets.CLAWHUB_TOKEN != ''
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest publish skill/ --slug aegis-bridge --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"
+          npx clawhub@latest publish skill/ --slug @onestepat4time/aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,7 +318,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * use correct aegis-bridge slug in release and skill metadata ([#806](https://github.com/OneStepAt4time/aegis/issues/806)) ([12d6640](https://github.com/OneStepAt4time/aegis/commit/12d6640f3bc1d8b2092ee98f468ac2996288f709))
 * use module-scoped nextKey counter in CreateSessionModal ([#639](https://github.com/OneStepAt4time/aegis/issues/639)) ([#928](https://github.com/OneStepAt4time/aegis/issues/928)) ([838cd03](https://github.com/OneStepAt4time/aegis/commit/838cd035972262b703b1cfea2745173b571ca3ba))
 * use npm pack to eliminate TOCTOU race in release workflow ([#649](https://github.com/OneStepAt4time/aegis/issues/649)) ([#944](https://github.com/OneStepAt4time/aegis/issues/944)) ([831fa01](https://github.com/OneStepAt4time/aegis/commit/831fa01e2f396a8730a9c38c52f2a9271fd8bbe7))
-* use plain v{version} tags instead of aegis-bridge-v{version} ([90a5e07](https://github.com/OneStepAt4time/aegis/commit/90a5e0722183af62981b8dc6bf5f97f35f4e6bce))
+* use plain v{version} tags instead of aegis-v{version} ([90a5e07](https://github.com/OneStepAt4time/aegis/commit/90a5e0722183af62981b8dc6bf5f97f35f4e6bce))
 * use short-lived SSE tokens ([5e32554](https://github.com/OneStepAt4time/aegis/commit/5e325540d7fbf0a490581eb6f030c56219db84ef)), closes [#297](https://github.com/OneStepAt4time/aegis/issues/297)
 * use single-fd pattern in transcript reader to eliminate TOCTOU race ([#623](https://github.com/OneStepAt4time/aegis/issues/623)) ([895d248](https://github.com/OneStepAt4time/aegis/commit/895d248515e9cdba58f6c8df8667ce6736324625))
 * use timingSafeEqual for token comparison — Issue [#402](https://github.com/OneStepAt4time/aegis/issues/402) ([d401183](https://github.com/OneStepAt4time/aegis/commit/d4011837bbd24a4160d1fa5de3e81c4b05bb4d7a))
@@ -921,7 +921,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * use correct aegis-bridge slug in release and skill metadata ([#806](https://github.com/OneStepAt4time/aegis/issues/806)) ([12d6640](https://github.com/OneStepAt4time/aegis/commit/12d6640f3bc1d8b2092ee98f468ac2996288f709))
 * use module-scoped nextKey counter in CreateSessionModal ([#639](https://github.com/OneStepAt4time/aegis/issues/639)) ([#928](https://github.com/OneStepAt4time/aegis/issues/928)) ([838cd03](https://github.com/OneStepAt4time/aegis/commit/838cd035972262b703b1cfea2745173b571ca3ba))
 * use npm pack to eliminate TOCTOU race in release workflow ([#649](https://github.com/OneStepAt4time/aegis/issues/649)) ([#944](https://github.com/OneStepAt4time/aegis/issues/944)) ([831fa01](https://github.com/OneStepAt4time/aegis/commit/831fa01e2f396a8730a9c38c52f2a9271fd8bbe7))
-* use plain v{version} tags instead of aegis-bridge-v{version} ([90a5e07](https://github.com/OneStepAt4time/aegis/commit/90a5e0722183af62981b8dc6bf5f97f35f4e6bce))
+* use plain v{version} tags instead of aegis-v{version} ([90a5e07](https://github.com/OneStepAt4time/aegis/commit/90a5e0722183af62981b8dc6bf5f97f35f4e6bce))
 * use short-lived SSE tokens ([5e32554](https://github.com/OneStepAt4time/aegis/commit/5e325540d7fbf0a490581eb6f030c56219db84ef)), closes [#297](https://github.com/OneStepAt4time/aegis/issues/297)
 * use single-fd pattern in transcript reader to eliminate TOCTOU race ([#623](https://github.com/OneStepAt4time/aegis/issues/623)) ([895d248](https://github.com/OneStepAt4time/aegis/commit/895d248515e9cdba58f6c8df8667ce6736324625))
 * use timingSafeEqual for token comparison — Issue [#402](https://github.com/OneStepAt4time/aegis/issues/402) ([d401183](https://github.com/OneStepAt4time/aegis/commit/d4011837bbd24a4160d1fa5de3e81c4b05bb4d7a))
@@ -1471,9 +1471,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * dashboard dedup bounded set + stable debounce refs ([#504](https://github.com/OneStepAt4time/aegis/issues/504), [#512](https://github.com/OneStepAt4time/aegis/issues/512), [#514](https://github.com/OneStepAt4time/aegis/issues/514)) ([#535](https://github.com/OneStepAt4time/aegis/issues/535)) ([f035c50](https://github.com/OneStepAt4time/aegis/commit/f035c5040f624dd546e8fa13fd909052bad615c4))
-* use plain v{version} tags instead of aegis-bridge-v{version} ([90a5e07](https://github.com/OneStepAt4time/aegis/commit/90a5e0722183af62981b8dc6bf5f97f35f4e6bce))
+* use plain v{version} tags instead of aegis-v{version} ([90a5e07](https://github.com/OneStepAt4time/aegis/commit/90a5e0722183af62981b8dc6bf5f97f35f4e6bce))
 
-## [2.1.2](https://github.com/OneStepAt4time/aegis/compare/aegis-bridge-v2.1.1...aegis-bridge-v2.1.2) (2026-03-29)
+## [2.1.2](https://github.com/OneStepAt4time/aegis/compare/aegis-v2.1.1...aegis-v2.1.2) (2026-03-29)
 
 
 ### Bug Fixes
@@ -1482,7 +1482,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * read version dynamically from package.json in MCP server test ([#534](https://github.com/OneStepAt4time/aegis/issues/534)) ([c4b648c](https://github.com/OneStepAt4time/aegis/commit/c4b648c09ab18577dda1185b65d61b87cf61bdb7))
 * wrap SSE mutex await in try/finally to prevent deadlock ([#509](https://github.com/OneStepAt4time/aegis/issues/509)) ([#531](https://github.com/OneStepAt4time/aegis/issues/531)) ([1d624a0](https://github.com/OneStepAt4time/aegis/commit/1d624a0a32b72a53e58ed8bcc0aef83e2e5d22d9))
 
-## [2.1.1](https://github.com/OneStepAt4time/aegis/compare/aegis-bridge-v2.1.0...aegis-bridge-v2.1.1) (2026-03-29)
+## [2.1.1](https://github.com/OneStepAt4time/aegis/compare/aegis-v2.1.0...aegis-v2.1.1) (2026-03-29)
 
 
 ### Bug Fixes
@@ -1491,7 +1491,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * systematic input validation at external boundaries (Cluster 2) ([#528](https://github.com/OneStepAt4time/aegis/issues/528)) ([d6192e7](https://github.com/OneStepAt4time/aegis/commit/d6192e781328a6819e3a17546f2939f5bf197fba))
 * WebSocket handshake auth + SSE subscription error handling ([#529](https://github.com/OneStepAt4time/aegis/issues/529)) ([f7088d2](https://github.com/OneStepAt4time/aegis/commit/f7088d20a711c4b3e24eabb320eb3354aff367f3))
 
-## [2.1.0](https://github.com/OneStepAt4time/aegis/compare/aegis-bridge-v2.0.0...aegis-bridge-v2.1.0) (2026-03-29)
+## [2.1.0](https://github.com/OneStepAt4time/aegis/compare/aegis-v2.0.0...aegis-v2.1.0) (2026-03-29)
 
 
 ### Features
@@ -1520,7 +1520,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * automated release pipeline (npm publish + GitHub Releases) — Issue [#365](https://github.com/OneStepAt4time/aegis/issues/365) ([7fd11fe](https://github.com/OneStepAt4time/aegis/commit/7fd11fe6352253e6349b6acbdf810cbf506122f9))
 * batch create + pipeline orchestration ([#36](https://github.com/OneStepAt4time/aegis/issues/36)) ([#38](https://github.com/OneStepAt4time/aegis/issues/38)) ([c1f702d](https://github.com/OneStepAt4time/aegis/commit/c1f702dc6c7b5366e7a0c234a5339305ecf73306))
 * capture all CC SessionStart fields in hook + use transcript_path ([#77](https://github.com/OneStepAt4time/aegis/issues/77)) ([#97](https://github.com/OneStepAt4time/aegis/issues/97)) ([b38abef](https://github.com/OneStepAt4time/aegis/commit/b38abefe4cc1483f14535afcfcbd0ce33f922638))
-* CLI entry point for npx aegis-bridge (issue [#5](https://github.com/OneStepAt4time/aegis/issues/5)) ([#14](https://github.com/OneStepAt4time/aegis/issues/14)) ([26efc49](https://github.com/OneStepAt4time/aegis/commit/26efc49d02b96cfb6e11d85d6705aa7b78f5ef8c))
+* CLI entry point for npx @onestepat4time/aegis (issue [#5](https://github.com/OneStepAt4time/aegis/issues/5)) ([#14](https://github.com/OneStepAt4time/aegis/issues/14)) ([26efc49](https://github.com/OneStepAt4time/aegis/commit/26efc49d02b96cfb6e11d85d6705aa7b78f5ef8c))
 * configurable per-session stall detection (issue [#4](https://github.com/OneStepAt4time/aegis/issues/4)) ([#13](https://github.com/OneStepAt4time/aegis/issues/13)) ([a38630d](https://github.com/OneStepAt4time/aegis/commit/a38630dac35bcf02b4d81d99e249808baf6fc897))
 * Dashboard v2 Sprint 1 — Activity Stream, Create Session, Interact, Responsive ([#107](https://github.com/OneStepAt4time/aegis/issues/107)) ([a870adb](https://github.com/OneStepAt4time/aegis/commit/a870adb0a83a9fe6e68de52eb106e85799619d77))
 * **dashboard:** Activity Stream, Create Session Modal, Message Input ([#107](https://github.com/OneStepAt4time/aegis/issues/107)) ([04dfd0f](https://github.com/OneStepAt4time/aegis/commit/04dfd0f2d708cb3538cc0800073f83b899f2cc3b))

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -57,7 +57,7 @@ describe('Layout SSE error handling (#587)', () => {
       currentVersion: '2.13.1',
       latestVersion: '2.13.1',
       updateAvailable: false,
-      releaseUrl: 'https://www.npmjs.com/package/aegis-bridge',
+      releaseUrl: 'https://www.npmjs.com/package/@onestepat4time/aegis',
     });
     localStorage.removeItem(UPDATE_CHECK_CACHE_KEY);
   });
@@ -91,7 +91,7 @@ describe('Layout SSE error handling (#587)', () => {
       currentVersion: '2.13.1',
       latestVersion: '2.14.0',
       updateAvailable: true,
-      releaseUrl: 'https://www.npmjs.com/package/aegis-bridge',
+      releaseUrl: 'https://www.npmjs.com/package/@onestepat4time/aegis',
     });
 
     renderLayout();
@@ -123,7 +123,7 @@ describe('Layout SSE error handling (#587)', () => {
       currentVersion: '2.13.1',
       latestVersion: '2.14.0',
       updateAvailable: true,
-      releaseUrl: 'https://www.npmjs.com/package/aegis-bridge',
+      releaseUrl: 'https://www.npmjs.com/package/@onestepat4time/aegis',
       checkedAt: Date.now(),
       sourceVersion: '2.13.1',
     }));

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -112,14 +112,14 @@ describe('checkForUpdates', () => {
 
     const result = await checkForUpdates('2.15.5');
 
-    expect(fetchMock).toHaveBeenCalledWith('https://registry.npmjs.org/aegis-bridge/latest', {
+    expect(fetchMock).toHaveBeenCalledWith('https://registry.npmjs.org/@onestepat4time/aegis/latest', {
       headers: { Accept: 'application/json' },
     });
     expect(result).toEqual({
       currentVersion: '2.15.5',
       latestVersion: '2.15.5',
       updateAvailable: false,
-      releaseUrl: 'https://www.npmjs.com/package/aegis-bridge',
+      releaseUrl: 'https://www.npmjs.com/package/@onestepat4time/aegis',
     });
   });
 

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -167,7 +167,7 @@ interface NpmPackageResponse {
   version?: string;
 }
 
-const NPM_PACKAGE_NAME = 'aegis-bridge';
+const NPM_PACKAGE_NAME = '@onestepat4time/aegis';
 const NPM_REGISTRY_URL = `https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`;
 const NPM_PACKAGE_URL = `https://www.npmjs.com/package/${NPM_PACKAGE_NAME}`;
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -180,7 +180,7 @@ Override defaults with environment variables:
 MODEL_FAST=claude-haiku-4-5 \
 MODEL_STANDARD=claude-sonnet-4-6 \
 MODEL_POWER=claude-opus-4-6 \
-aegis-bridge start
+aegis start
 ```
 
 ### API

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ Get from zero to orchestrating Claude Code sessions in under 5 minutes.
 No install required — run directly with npx:
 
 ```bash
-npx aegis-bridge
+npx @onestepat4time/aegis
 ```
 
 Aegis starts on **http://localhost:9100**. Verify it's running:
@@ -36,8 +36,8 @@ Expected response:
 <summary>Install globally (optional)</summary>
 
 ```bash
-npm install -g aegis-bridge
-aegis-bridge
+npm install -g @onestepat4time/aegis
+aegis
 ```
 
 </details>
@@ -48,7 +48,7 @@ aegis-bridge
 Set a bearer token to protect all endpoints (except `/v1/health`):
 
 ```bash
-AEGIS_AUTH_TOKEN=your-secret-token npx aegis-bridge
+AEGIS_AUTH_TOKEN=your-secret-token npx @onestepat4time/aegis
 ```
 
 Then include the token in every request:
@@ -190,8 +190,8 @@ curl http://localhost:9100/v1/sessions
 | `Claude Code CLI not found` | Install Claude Code: `npm install -g @anthropic-ai/claude-code` and run `claude` to authenticate |
 | `401 Unauthorized` | Set `AEGIS_AUTH_TOKEN` or include `Authorization: Bearer <token>` header |
 | Session stuck on `stalled` | Send an interrupt: `curl -X POST http://localhost:9100/v1/sessions/:id/interrupt` |
-| MCP tools not showing in Claude Code | Re-run `claude mcp add aegis -- npx aegis-bridge mcp` and restart Claude Code |
+| MCP tools not showing in Claude Code | Re-run `claude mcp add aegis -- npx @onestepat4time/aegis mcp` and restart Claude Code |
 | Dashboard won't load | Verify Aegis is running on port 9100: `curl http://localhost:9100/v1/health` |
-| `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 npx aegis-bridge` |
+| `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 npx @onestepat4time/aegis` |
 | Screenshot returns 501 | Install Playwright: `npx playwright install chromium` |
 | No output from `/read` | Wait for transcript entries, or check raw terminal: `curl /v1/sessions/:id/pane` |

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -4,7 +4,7 @@ Use Aegis as an MCP server inside Cursor.
 
 ## Prerequisites
 
-- `aegis-bridge` installed or runnable via `npx`
+- `aegis` installed or runnable via `npx`
 - Cursor with MCP support enabled
 - Local Aegis server reachable on `127.0.0.1:9100`
 
@@ -17,7 +17,7 @@ Add an MCP server entry that launches Aegis in stdio mode:
   "mcpServers": {
     "aegis": {
       "command": "npx",
-      "args": ["aegis-bridge", "mcp"]
+      "args": ["aegis", "mcp"]
     }
   }
 }
@@ -25,7 +25,7 @@ Add an MCP server entry that launches Aegis in stdio mode:
 
 ## Verification
 
-1. Start Aegis: `aegis-bridge start`
+1. Start Aegis: `aegis start`
 2. Restart Cursor
 3. Check that Aegis tools appear
 4. Call `server_health` and `list_sessions`
@@ -42,6 +42,6 @@ Add an MCP server entry that launches Aegis in stdio mode:
 
 ## Troubleshooting
 
-- If the host cannot start the server, run `npx aegis-bridge mcp` manually.
+- If the host cannot start the server, run `npx @onestepat4time/aegis mcp` manually.
 - If HTTP calls fail, verify `http://127.0.0.1:9100/v1/health`.
 - If tools are stale, restart the host after config changes.

--- a/docs/integrations/mcp-registry.md
+++ b/docs/integrations/mcp-registry.md
@@ -5,7 +5,7 @@ This document tracks the metadata needed to publish Aegis to an MCP registry.
 ## Package Identity
 
 - Name: `Aegis Bridge`
-- Slug: `aegis-bridge`
+- Slug: `aegis`
 - Summary: `HTTP + MCP orchestration for Claude Code sessions`
 - Homepage: `https://github.com/OneStepAt4time/aegis`
 - License: `MIT`
@@ -14,7 +14,7 @@ This document tracks the metadata needed to publish Aegis to an MCP registry.
 
 - Tags: `mcp`, `claude-code`, `orchestration`, `automation`, `sessions`
 - Transport: `stdio`
-- Launch command: `npx aegis-bridge mcp`
+- Launch command: `npx @onestepat4time/aegis mcp`
 - Health endpoint: `GET /v1/health`
 
 ## Registry Checklist

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -17,7 +17,7 @@ Register Aegis as a stdio MCP server:
   "mcpServers": {
     "aegis": {
       "command": "npx",
-      "args": ["aegis-bridge", "mcp", "--port", "9100"]
+      "args": ["aegis", "mcp", "--port", "9100"]
     }
   }
 }

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -5,7 +5,7 @@ Aegis exposes 24 tools and 3 prompts via the MCP (Model Context Protocol) server
 ## Setup
 
 ```bash
-claude mcp add aegis -- npx aegis-bridge mcp
+claude mcp add aegis -- npx @onestepat4time/aegis mcp
 ```
 
 This connects Claude Code to the Aegis MCP server running on `localhost:9100`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "aegis-bridge",
+  "name": "@onestepat4time/aegis",
   "version": "0.2.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aegis-bridge",
+      "name": "@onestepat4time/aegis",
       "version": "0.2.0-alpha",
       "license": "MIT",
       "dependencies": {
@@ -19,7 +19,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "aegis-bridge": "dist/cli.js"
+        "aegis": "dist/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     }
   },
   "bin": {
-    "@onestepat4time/aegis": "dist/cli.js"
+    "aegis": "dist/cli.js"
   },
   "files": [
     "dist",

--- a/skill/README.md
+++ b/skill/README.md
@@ -6,12 +6,12 @@ Install and run Aegis orchestration workflows from Claude Code via MCP.
 
 - Node.js 20+
 - Claude Code CLI available in PATH
-- Aegis server running locally (`aegis-bridge start`)
+- Aegis server running locally (`aegis start`)
 
 ## Quick Install
 
 ```bash
-skill install aegis-bridge
+skill install aegis
 ```
 
 Then configure MCP:
@@ -36,7 +36,7 @@ Expected output includes `OK` and exit code `0`.
 
 ## Troubleshooting
 
-- If connection fails, start server with `aegis-bridge start`.
+- If connection fails, start server with `aegis start`.
 - If MCP server is missing, run setup script again and restart Claude Code.
 - If `jq` is missing, install it and rerun scripts.
 

--- a/src/__tests__/cli-create.test.ts
+++ b/src/__tests__/cli-create.test.ts
@@ -1,10 +1,10 @@
 /**
- * cli-create.test.ts — Tests for Issue #5 stretch: aegis-bridge create subcommand.
+ * cli-create.test.ts — Tests for Issue #5 stretch: aegis create subcommand.
  */
 
 import { describe, it, expect } from 'vitest';
 
-describe('aegis-bridge create subcommand', () => {
+describe('aegis create subcommand', () => {
   describe('argument parsing', () => {
     it('should extract brief from first non-flag argument', () => {
       const args = ['Build a login page'];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 /**
  * cli.ts — CLI entry point for Aegis.
  *
- * `npx aegis-bridge` or `aegis-bridge` starts the server with sensible defaults.
+ * `npx @onestepat4time/aegis` or `aegis` starts the server with sensible defaults.
  * Auto-detects tmux and claude CLI, prints helpful startup message.
  */
 
@@ -15,7 +15,7 @@ import { parseIntSafe, getErrorMessage } from './validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
-/** Current aegis-bridge version read from package.json at startup. */
+/** Current aegis version read from package.json at startup. */
 const VERSION: string = pkg.version;
 
 /** Check whether a required external dependency can be executed. */
@@ -71,7 +71,7 @@ async function handleCreate(args: string[]): Promise<void> {
   }
 
   if (!brief) {
-    console.error('  ❌ Missing brief. Usage: aegis-bridge create "Build a login page"');
+    console.error('  ❌ Missing brief. Usage: aegis create "Build a login page"');
     process.exit(1);
   }
 
@@ -101,7 +101,7 @@ async function handleCreate(args: string[]): Promise<void> {
     const cause = (e as { cause?: { code?: string } }).cause;
     if (cause?.code === 'ECONNREFUSED') {
       console.error(`  ❌ Cannot connect to Aegis on port ${port}.`);
-      console.error(`     Start the server first: aegis-bridge`);
+      console.error(`     Start the server first: aegis`);
     } else {
       console.error(`  ❌ ${getErrorMessage(e)}`);
     }
@@ -141,23 +141,23 @@ async function main(): Promise<void> {
   // Help
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`
-  aegis-bridge — Claude Code session bridge
+  aegis — Claude Code session bridge
 
   Usage:
-    aegis-bridge                  Start the server (port 9100)
-    aegis-bridge --port 3000      Custom port
-    aegis-bridge create "brief"   Create a session and send brief
-    aegis-bridge mcp              Start MCP server (stdio transport)
-    aegis-bridge --help           Show this help
+    aegis                  Start the server (port 9100)
+    aegis --port 3000      Custom port
+    aegis create "brief"   Create a session and send brief
+    aegis mcp              Start MCP server (stdio transport)
+    aegis --help           Show this help
 
   Create:
-    aegis-bridge create "Build a login page" --cwd /path/to/project
-    aegis-bridge create "Fix the tests"      (uses current directory)
+    aegis create "Build a login page" --cwd /path/to/project
+    aegis create "Fix the tests"      (uses current directory)
 
   MCP server:
-    aegis-bridge mcp              Start MCP stdio server
-    aegis-bridge mcp --port 3000  Custom Aegis API port
-    claude mcp add aegis -- npx aegis-bridge mcp
+    aegis mcp              Start MCP stdio server
+    aegis mcp --port 3000  Custom Aegis API port
+    claude mcp add aegis -- npx @onestepat4time/aegis mcp
 
   Environment variables:
     AEGIS_PORT                    Server port (default: 9100)
@@ -187,7 +187,7 @@ async function main(): Promise<void> {
 
   // Version
   if (args.includes('--version') || args.includes('-v')) {
-    console.log(`aegis-bridge v${VERSION}`);
+    console.log(`aegis v${VERSION}`);
     process.exit(0);
   }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -5,9 +5,9 @@
  * CC sessions can natively discover and communicate with sibling sessions.
  *
  * Usage:
- *   aegis-bridge mcp                    # default port 9100
- *   aegis-bridge mcp --port 3000        # custom port
- *   claude mcp add --scope user aegis -- npx aegis-bridge mcp
+ *   aegis mcp                    # default port 9100
+ *   aegis mcp --port 3000        # custom port
+ *   claude mcp add --scope user aegis -- npx @onestepat4time/aegis mcp
  *
  * Issue #48: https://github.com/OneStepAt4time/aegis/issues/48
  */


### PR DESCRIPTION
Clean re-do of #1333 (which had merge conflicts).

## Changes
- **package.json**: `name` → `@onestepat4time/aegis`, `bin` → `aegis` (shorter CLI name)
- **CLI**: All help text and commands reference `aegis` instead of `aegis-bridge`
- **MCP**: `npx @onestepat4time/aegis mcp` for MCP server setup
- **Docs**: All installation/usage references updated across getting-started, integrations, advanced guides
- **Dashboard**: npm registry URLs updated, tests updated for unencoded scoped package URLs
- **CI**: release workflow artifact path updated for new package name
- **CHANGELOG**: Historical references updated where appropriate

Closes #1328