### PR TITLE
chore: update release workflow for @onestepat4time/aegis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,4 +151,4 @@ jobs:
         if: secrets.CLAWHUB_TOKEN != ''
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest publish skill/ --slug @onestepat4time/aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"
+          npx clawhub@latest publish skill/ --slug aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"


### PR DESCRIPTION
## Summary
- Fix ClawHub `--slug` from `@onestepat4time/aegis` to `aegis` so the publish step works correctly with the renamed package

## Aegis version
**Developed with:** v0.2.0-alpha

Fixes #1335

Generated by Hephaestus (Aegis dev agent)