### PR TITLE
docs: enterprise-grade documentation overhaul

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ Get from zero to orchestrating Claude Code sessions in under 5 minutes.
 No install required — run directly with npx:
 
 ```bash
-npx aegis-bridge
+npx @onestepat4time/aegis
 ```
 
 Aegis starts on **http://localhost:9100**. Verify it's running:
@@ -36,8 +36,8 @@ Expected response:
 <summary>Install globally (optional)</summary>
 
 ```bash
-npm install -g aegis-bridge
-aegis-bridge
+npm install -g @onestepat4time/aegis
+aegis
 ```
 
 </details>
@@ -48,7 +48,7 @@ aegis-bridge
 Set a bearer token to protect all endpoints (except `/v1/health`):
 
 ```bash
-AEGIS_AUTH_TOKEN=your-secret-token npx aegis-bridge
+AEGIS_AUTH_TOKEN=your-secret-token npx @onestepat4time/aegis
 ```
 
 Then include the token in every request:
@@ -190,8 +190,8 @@ curl http://localhost:9100/v1/sessions
 | `Claude Code CLI not found` | Install Claude Code: `npm install -g @anthropic-ai/claude-code` and run `claude` to authenticate |
 | `401 Unauthorized` | Set `AEGIS_AUTH_TOKEN` or include `Authorization: Bearer <token>` header |
 | Session stuck on `stalled` | Send an interrupt: `curl -X POST http://localhost:9100/v1/sessions/:id/interrupt` |
-| MCP tools not showing in Claude Code | Re-run `claude mcp add aegis -- npx aegis-bridge mcp` and restart Claude Code |
+| MCP tools not showing in Claude Code | Re-run `claude mcp add aegis -- npx @onestepat4time/aegis mcp` and restart Claude Code |
 | Dashboard won't load | Verify Aegis is running on port 9100: `curl http://localhost:9100/v1/health` |
-| `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 npx aegis-bridge` |
+| `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 npx @onestepat4time/aegis` |
 | Screenshot returns 501 | Install Playwright: `npx playwright install chromium` |
 | No output from `/read` | Wait for transcript entries, or check raw terminal: `curl /v1/sessions/:id/pane` |


### PR DESCRIPTION
## Summary

Comprehensive documentation update for the  package rename and enterprise readiness.

## Changes (5 files, +844 / -65)

### New Files
- **docs/api-reference.md** — Full REST API reference covering all 40+ endpoints across Core, Auth, Memory, Orchestration, Consensus, Permission, and Observability categories. Includes curl examples for every endpoint.
- **docs/enterprise.md** — Enterprise deployment guide: authentication (bearer + multi-key), rate limiting, security (CSP, auth middleware, permission modes), production deployment (systemd, nginx, Docker), configuration reference, monitoring, multi-tenant considerations.
- **docs/migration-guide.md** — Step-by-step migration from `aegis-bridge` to `@onestepat4time/aegis`: CLI rename, MCP config, CI/CD updates, Docker, systemd, rollback instructions.

### Updated Files
- **docs/getting-started.md** — Updated 6 stale `aegis-bridge` references to `@onestepat4time/aegis` and `aegis` CLI binary
- **docs/advanced.md** — Version reference updated from v0.2.0-alpha to v0.3.0-alpha

### Removed Files
- **docs/windows-pre-gate-report-908.md** — Internal report, not user-facing documentation

## Quality
- Zero placeholders, zero TODO/FIXME
- All curl examples syntactically correct
- All code blocks have language specified
- Cross-linked between docs
- English only

## Scope
2 commits on `docs/stale-package-name-refs` branch, targets `develop`.