### PR TITLE
fix(ci): use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,12 +16,18 @@ jobs:
       !startsWith(github.event.head_commit.message, 'chore: promote develop to main')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.AEGIS_APP_ID }}
+          private-key: ${{ secrets.AEGIS_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # Use PAT so release-please PRs trigger CI workflows.
-          # GITHUB_TOKEN PRs don't trigger workflows (GitHub anti-loop protection).
-          token: ${{ secrets.RELEASE_PAT }}
+          # Use GitHub App token for separate rate limit (15K/h)
+          # and to trigger CI workflows on release PRs.
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
     outputs:


### PR DESCRIPTION
Switch release-please from RELEASE_PAT (personal account, shared rate limit) to aegis-gh-agent GitHub App token (separate 15K req/h quota).

Fixes persistent secondary rate limit on user ID 106186915.

**Changes:**
- Add `actions/create-github-app-token@v2` step
- Use App token instead of RELEASE_PAT
- Add `AEGIS_APP_ID` variable (3235882)
- Add `AEGIS_APP_PRIVATE_KEY` secret