### PR TITLE
refactor(dashboard): enterprise UI quick wins — ConfirmDialog, a11y, keyboard shortcuts

### DIFF
--- a/dashboard/src/__tests__/AuthKeysPage.test.tsx
+++ b/dashboard/src/__tests__/AuthKeysPage.test.tsx
@@ -108,7 +108,6 @@ describe('AuthKeysPage', () => {
       },
     ]);
     mockRevokeAuthKey.mockResolvedValueOnce({ ok: true });
-    vi.stubGlobal('confirm', vi.fn(() => true));
 
     renderPage();
 
@@ -117,6 +116,15 @@ describe('AuthKeysPage', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+
+    // Confirm in the dialog — scope query to the dialog to avoid ambiguity
+    await waitFor(() => {
+      expect(screen.getByRole('alertdialog')).toBeDefined();
+    });
+    const dialog = screen.getByRole('alertdialog');
+    // The confirm button is the second button inside the dialog
+    const buttons = dialog.querySelectorAll('button');
+    fireEvent.click(buttons[1]);
 
     await waitFor(() => {
       expect(mockRevokeAuthKey).toHaveBeenCalledWith('key-1');

--- a/dashboard/src/__tests__/ConfirmDialog.test.tsx
+++ b/dashboard/src/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('renders nothing when open is false', () => {
+    render(
+      <ConfirmDialog
+        open={false}
+        title="Test"
+        message="Test message"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+  });
+
+  it('renders the dialog when open is true', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Delete Item"
+        message="Are you sure?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('alertdialog')).toBeDefined();
+    expect(screen.getByText('Delete Item')).toBeDefined();
+    expect(screen.getByText('Are you sure?')).toBeDefined();
+  });
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Confirm'));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when backdrop is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    // The backdrop is the first div child with absolute inset-0
+    const backdrop = screen.getByRole('alertdialog').parentElement?.querySelector('.absolute');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel on Escape key', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('uses custom labels', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        confirmLabel="Delete"
+        cancelLabel="Keep"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Delete')).toBeDefined();
+    expect(screen.getByText('Keep')).toBeDefined();
+  });
+
+  it('has aria-labelledby pointing to the title', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="My Title"
+        message="Body text"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const dialog = screen.getByRole('alertdialog');
+    const titleId = dialog.getAttribute('aria-labelledby');
+    expect(titleId).not.toBeNull();
+    const titleEl = document.getElementById(titleId!);
+    expect(titleEl?.textContent).toBe('My Title');
+  });
+
+  it('applies danger variant styles to confirm button', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        variant="danger"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const confirmBtn = screen.getByText('Confirm');
+    expect(confirmBtn.className).toContain('text-red-300');
+  });
+
+  it('applies warning variant styles to confirm button', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        variant="warning"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const confirmBtn = screen.getByText('Confirm');
+    expect(confirmBtn.className).toContain('text-amber-300');
+  });
+
+  it('applies default variant styles to confirm button', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Test"
+        message="Test"
+        variant="default"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const confirmBtn = screen.getByText('Confirm');
+    expect(confirmBtn.className).toContain('text-[#3b82f6]');
+  });
+});

--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -265,13 +265,18 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     fireEvent.click(screen.getAllByLabelText('Select session charlie')[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Kill 2 selected sessions' }));
 
+    // Confirm in the dialog
+    await waitFor(() => {
+      expect(screen.getByRole('alertdialog')).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+
     await waitFor(() => {
       expect(mockKillSession).toHaveBeenCalledTimes(2);
     });
 
     expect(mockKillSession).toHaveBeenCalledWith('s1');
     expect(mockKillSession).toHaveBeenCalledWith('s3');
-    expect(globalThis.confirm).toHaveBeenCalled();
   });
 
   it('does not rerender unchanged rows on unrelated table state changes', async () => {

--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -1,0 +1,150 @@
+/**
+ * components/ConfirmDialog.tsx — Reusable confirmation modal dialog.
+ */
+
+import { useEffect, useRef } from 'react';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'danger' | 'warning' | 'default';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const VARIANT_STYLES = {
+  danger: {
+    confirm:
+      'bg-red-500/10 hover:bg-red-500/20 text-red-300 border border-red-500/30',
+  },
+  warning: {
+    confirm:
+      'bg-amber-500/10 hover:bg-amber-500/20 text-amber-300 border border-amber-500/30',
+  },
+  default: {
+    confirm:
+      'bg-[#3b82f6]/10 hover:bg-[#3b82f6]/20 text-[#3b82f6] border border-[#3b82f6]/30',
+  },
+} as const;
+
+const FOCUSABLE_SELECTOR =
+  'input, textarea, select, button, [tabindex]:not([tabindex="-1"])';
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const titleId = 'confirm-dialog-title';
+
+  // Auto-focus the confirm button when opened
+  useEffect(() => {
+    if (!open) return;
+    const timer = setTimeout(() => confirmRef.current?.focus(), 50);
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  // Escape to cancel
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onCancel]);
+
+  // Focus trap
+  useEffect(() => {
+    if (!open) return;
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = Array.from(
+        modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    modal.addEventListener('keydown', handler);
+    return () => modal.removeEventListener('keydown', handler);
+  }, [open]);
+
+  if (!open) return null;
+
+  const styles = VARIANT_STYLES[variant];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+
+      {/* Dialog */}
+      <div
+        ref={modalRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative w-full max-w-sm mx-4 bg-[#111118] border border-[#1a1a2e] rounded-lg shadow-2xl"
+      >
+        <div className="p-4 sm:p-5 space-y-4">
+          <h2
+            id={titleId}
+            className="text-sm font-semibold text-gray-100"
+          >
+            {title}
+          </h2>
+          <p className="text-sm text-gray-400">{message}</p>
+        </div>
+
+        <div className="flex gap-2 px-4 sm:px-5 pb-4 sm:pb-5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[#0a0a0f] border border-[#1a1a2e] text-gray-300 hover:text-gray-100 hover:border-[#333] transition-colors"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            className={`flex-1 min-h-[44px] px-3 py-2 text-xs font-medium rounded transition-colors ${styles.confirm}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -205,6 +205,13 @@ export default function Layout() {
 
   return (
     <div className="flex h-screen overflow-hidden bg-void">
+      {/* Skip-to-content link */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-0 focus:left-0 focus:z-[100] focus:bg-white focus:text-black focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none"
+      >
+        Skip to content
+      </a>
       {/* ── Sidebar ─────────────────────────────────────────── */}
       <aside className="flex w-56 flex-col border-r border-void-lighter bg-void-light shrink-0">
         {/* Logo */}
@@ -318,7 +325,7 @@ export default function Layout() {
         </header>
 
         {/* Content */}
-        <main className="flex-1 overflow-auto p-6">
+        <main id="main-content" className="flex-1 overflow-auto p-6">
           <Outlet />
         </main>
       </div>

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -27,6 +27,7 @@ import { useToastStore } from '../../store/useToastStore';
 import { useStore } from '../../store/useStore';
 import type { RowHealth, SessionInfo, SessionStatusCounts, SessionStatusFilter } from '../../types';
 import { formatTimeAgo } from '../../utils/format';
+import { ConfirmDialog } from '../ConfirmDialog';
 import RealtimeBadge from './RealtimeBadge';
 import StatusDot from './StatusDot';
 
@@ -329,6 +330,7 @@ export default function SessionTable() {
   const [actionLoading, setActionLoading] = useState<Record<string, string | null>>({});
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkAction, setBulkAction] = useState<'interrupt' | 'kill' | null>(null);
+  const [confirmKill, setConfirmKill] = useState<{ type: 'single'; id: string } | { type: 'bulk'; count: number } | null>(null);
   const [statusFilter, setStatusFilter] = useState<SessionStatusFilter>('all');
   const [statusCounts, setStatusCounts] = useState<SessionStatusCounts>(EMPTY_COUNTS);
   const [searchInput, setSearchInput] = useState('');
@@ -444,12 +446,12 @@ export default function SessionTable() {
     });
   }, [addToast, fetchSessions, withLoading]);
 
-  const handleKill = useCallback(async (e: MouseEvent, id: string) => {
+  const handleKill = useCallback((e: MouseEvent, id: string) => {
     e.preventDefault();
-    if (!confirm('Kill this session?')) {
-      return;
-    }
+    setConfirmKill({ type: 'single', id });
+  }, []);
 
+  const executeKill = useCallback(async (id: string) => {
     await withLoading(id, 'kill', async () => {
       try {
         await killSession(id);
@@ -477,13 +479,7 @@ export default function SessionTable() {
     setSelectedIds(sessions.map((session) => session.id));
   }, [sessions]);
 
-  const runBulkAction = useCallback(async (action: 'interrupt' | 'kill') => {
-    if (selectedIds.length === 0) {
-      return;
-    }
-    if (action === 'kill' && !confirm(`Kill ${selectedIds.length} selected session${selectedIds.length === 1 ? '' : 's'}?`)) {
-      return;
-    }
+  const executeBulkAction = useCallback(async (action: 'interrupt' | 'kill') => {
 
     setBulkAction(action);
     setActionLoading((prev) => {
@@ -530,7 +526,34 @@ export default function SessionTable() {
     }
   }, [addToast, fetchSessions, selectedIds]);
 
+  const runBulkAction = useCallback((action: 'interrupt' | 'kill') => {
+    if (selectedIds.length === 0) {
+      return;
+    }
+    if (action === 'kill') {
+      setConfirmKill({ type: 'bulk', count: selectedIds.length });
+      return;
+    }
+    void executeBulkAction(action);
+  }, [selectedIds, executeBulkAction]);
+
   const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const handleConfirmKill = useCallback(() => {
+    if (!confirmKill) return;
+    if (confirmKill.type === 'single') {
+      void executeKill(confirmKill.id);
+    } else {
+      void executeBulkAction('kill');
+    }
+    setConfirmKill(null);
+  }, [confirmKill, executeKill, executeBulkAction]);
+
+  const confirmKillMessage = confirmKill
+    ? confirmKill.type === 'single'
+      ? 'Kill this session? This action cannot be undone.'
+      : `Kill ${confirmKill.count} selected session${confirmKill.count === 1 ? '' : 's'}? This action cannot be undone.`
+    : '';
 
   const rowViewModels = useMemo<SessionRowViewModel[]>(() => {
     return sessions.map((session) => {
@@ -819,6 +842,16 @@ export default function SessionTable() {
           )}
         </>
       )}
+
+      <ConfirmDialog
+        open={confirmKill !== null}
+        title="Kill Sessions"
+        message={confirmKillMessage}
+        confirmLabel="Kill"
+        variant="danger"
+        onConfirm={handleConfirmKill}
+        onCancel={() => setConfirmKill(null)}
+      />
     </div>
   );
 }

--- a/dashboard/src/pages/AuthKeysPage.tsx
+++ b/dashboard/src/pages/AuthKeysPage.tsx
@@ -16,6 +16,7 @@ import {
   type CreatedAuthKey,
 } from '../api/client';
 import { useToastStore } from '../store/useToastStore';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 import { formatTimeAgo } from '../utils/format';
 
 const REFRESH_INTERVAL_MS = 15_000;
@@ -38,6 +39,7 @@ export default function AuthKeysPage() {
   const [creating, setCreating] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [revokeConfirm, setRevokeConfirm] = useState<{ id: string; name: string } | null>(null);
   const [createdKey, setCreatedKey] = useState<CreatedAuthKey | null>(null);
   const [secretVisible, setSecretVisible] = useState(false);
   const addToast = useToastStore((store) => store.addToast);
@@ -128,10 +130,10 @@ export default function AuthKeysPage() {
   }
 
   async function handleRevoke(id: string, keyName: string): Promise<void> {
-    if (!window.confirm(`Revoke auth key "${keyName}"? This cannot be undone.`)) {
-      return;
-    }
+    setRevokeConfirm({ id, name: keyName });
+  }
 
+  async function executeRevoke(id: string): Promise<void> {
     setRevokingId(id);
     try {
       await revokeAuthKey(id);
@@ -329,6 +331,21 @@ export default function AuthKeysPage() {
           )}
         </section>
       </div>
+
+      <ConfirmDialog
+        open={revokeConfirm !== null}
+        title="Revoke Auth Key"
+        message={revokeConfirm ? `Revoke auth key "${revokeConfirm.name}"? This cannot be undone.` : ''}
+        confirmLabel="Revoke"
+        variant="danger"
+        onConfirm={() => {
+          if (revokeConfirm) {
+            void executeRevoke(revokeConfirm.id);
+            setRevokeConfirm(null);
+          }
+        }}
+        onCancel={() => setRevokeConfirm(null)}
+      />
     </div>
   );
 }

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import {
   Camera,
@@ -65,6 +65,8 @@ export default function SessionDetailPage() {
   const [screenshot, setScreenshot] = useState<ScreenshotState | null>(null);
   const msgInputRef = useRef<HTMLInputElement>(null);
   const sendingRef = useRef(false);
+  const handleSendRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const handleInterruptRef = useRef<() => void>(() => {});
   const addToast = useToastStore((t) => t.addToast);
 
   if (loading) {
@@ -225,6 +227,42 @@ export default function SessionDetailPage() {
       handleSend();
     }
   }
+
+  // Global keyboard shortcuts (uses refs to avoid re-registering on every state change)
+  handleSendRef.current = handleSend;
+  handleInterruptRef.current = handleInterrupt;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      const isTyping = tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable;
+
+      // Ctrl/Cmd+Enter: submit message (only when message input is focused)
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        if (document.activeElement === msgInputRef.current) {
+          e.preventDefault();
+          void handleSendRef.current();
+        }
+        return;
+      }
+
+      // Escape: interrupt session (skip if user is typing in input/textarea)
+      if (e.key === 'Escape' && !isTyping) {
+        e.preventDefault();
+        handleInterruptRef.current();
+        return;
+      }
+
+      // / key: focus message input (skip if user is already typing)
+      if (e.key === '/' && !isTyping) {
+        e.preventDefault();
+        msgInputRef.current?.focus();
+        return;
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   return (
     <div className="min-h-screen bg-[#0a0a0f]">


### PR DESCRIPTION
## Summary
Implements enterprise-grade UI improvements for the Aegis dashboard.

### Changes
- **ConfirmDialog component** — Reusable modal dialog replacing `window.confirm()`. Dark theme, focus trap, Escape to cancel, aria-labelledby. Props: open, title, message, variant (danger/warning/default), confirmLabel, cancelLabel.
- **Replace window.confirm()** — SessionTable (kill/bulk-kill) and AuthKeysPage (revoke) now use ConfirmDialog.
- **Skip-to-content link** — Layout.tsx: visually-hidden link that appears on focus, targets `#main-content` for keyboard/screen-reader users.
- **Keyboard shortcuts** — SessionDetailPage: Ctrl/Cmd+Enter to send, Escape to interrupt, `/` to focus message input.

### Quality Gate
- ✅ TSC: clean (no errors)
- ✅ Build: passes
- ✅ Tests: 28 files, 219 passed, 2 skipped (+11 new tests)

### Scope
- All changes inside `dashboard/` only
- Closes #1347 (partially — skeleton loaders and responsive sidebar as follow-up)

### Files Changed
- `dashboard/src/components/ConfirmDialog.tsx` (new)
- `dashboard/src/__tests__/ConfirmDialog.test.tsx` (new)
- `dashboard/src/components/Layout.tsx` (skip link)
- `dashboard/src/components/overview/SessionTable.tsx` (ConfirmDialog)
- `dashboard/src/pages/AuthKeysPage.tsx` (ConfirmDialog)
- `dashboard/src/pages/SessionDetailPage.tsx` (keyboard shortcuts)
- `dashboard/src/__tests__/SessionTable.test.tsx` (updated)
- `dashboard/src/__tests__/AuthKeysPage.test.tsx` (updated)