### PR TITLE
fix(ci): use proper secrets syntax in release.yml if conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,10 +145,10 @@ jobs:
         with:
           node-version: '22'
       - name: ClawHub Login
-        if: secrets.CLAWHUB_TOKEN != ''
+        if: ${{ secrets.CLAWHUB_TOKEN != '' }}
         run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
       - name: Publish to ClawHub
-        if: secrets.CLAWHUB_TOKEN != ''
+        if: ${{ secrets.CLAWHUB_TOKEN != '' }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           npx clawhub@latest publish skill/ --slug aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"


### PR DESCRIPTION
Fix GitHub Actions workflow file error: secrets must use \`\${{ }}\` wrapper in if conditions.