### PR TITLE
docs: docs-sync skill — TSDoc coverage audit + README auto-update

### DIFF
--- a/.claude/skills/docs-sync.md
+++ b/.claude/skills/docs-sync.md
@@ -48,12 +48,7 @@ For each gap found in Step 1, **propose** (don't auto-apply) insertions:
 4. Generate `@returns {type} description` line
 5. Generate a minimal `@example` stub
 
-Apply insertions by updating the JSDoc comment on the node:
-
-```typescript
-const jsdoc = method.getJsDocNodes()[0];
-// or create: method.insertJsDoc(0, '...')
-```
+Apply insertions by updating the JSDoc comment on the node.
 
 **Rules:**
 - Never overwrite an existing tag — only add missing ones
@@ -96,3 +91,16 @@ Files touched: src/session.ts, src/server.ts, README.md
 - For README parsing, simple string/regex is acceptable (markdown tables)
 - Skip test files (`**/*.test.ts`, `**/*.spec.ts`), type-only files, and `index.ts` re-exports
 - Skip private/internal methods (non-exported)
+
+## CLI Script
+
+```bash
+# Dry-run report (default)
+npx tsx scripts/docs-sync.ts
+
+# Apply TSDoc tag insertions
+npx tsx scripts/docs-sync.ts --fix
+
+# Also update README endpoint table
+npx tsx scripts/docs-sync.ts --fix --readme
+```

--- a/scripts/docs-sync.ts
+++ b/scripts/docs-sync.ts
@@ -3,11 +3,13 @@
  * docs-sync: TSDoc coverage audit + README endpoint table sync
  *
  * Usage: npx tsx scripts/docs-sync.ts [--fix] [--readme]
+ *
+ * --fix     Apply TSDoc tag insertions (default: dry-run)
+ * --readme  Update README endpoint table (default: report only)
  */
 
 import {
   Project,
-  SourceFile,
   SyntaxKind,
   type FunctionDeclaration,
   type MethodDeclaration,
@@ -24,6 +26,8 @@ const args = process.argv.slice(2);
 const FIX = args.includes("--fix");
 const README_FIX = args.includes("--readme");
 
+// ─── Types ──────────────────────────────────────────────────
+
 interface DocGap {
   file: string;
   name: string;
@@ -36,6 +40,8 @@ interface RouteInfo {
   path: string;
   handler: string;
 }
+
+// ─── TSDoc Audit ────────────────────────────────────────────
 
 function getParamNames(node: FunctionDeclaration | MethodDeclaration): string[] {
   return node.getParameters().map((p) => p.getName()).filter(Boolean);
@@ -50,7 +56,7 @@ function jsdocHasTag(jsdoc: JSDoc, tagName: string, paramName?: string): boolean
 }
 
 function auditDeclaration(
-  file: SourceFile,
+  file: import("ts-morph").SourceFile,
   decl: FunctionDeclaration | MethodDeclaration,
   className?: string
 ): DocGap {
@@ -149,16 +155,18 @@ function printTSDocReport(audit: ReturnType<typeof runTSDocAudit>) {
   console.log();
 }
 
+// ─── README Endpoint Sync ───────────────────────────────────
+
 function extractRoutes(): RouteInfo[] {
   const project = new Project({
     tsConfigFilePath: path.join(ROOT, "tsconfig.json"),
     skipAddingFilesFromTsConfig: true,
   });
 
-  const serverFile = project.addSourceFileAtPaths(path.join(SRC, "server.ts"));
+  const serverFiles = project.addSourceFilesAtPaths(path.join(SRC, "server.ts"));
   const routes: RouteInfo[] = [];
 
-  for (const call of serverFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+  for (const call of serverFiles[0].getDescendantsOfKind(SyntaxKind.CallExpression)) {
     const expr = call.getExpression();
     if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) continue;
 
@@ -200,7 +208,10 @@ function parseReadmeEndpoints() {
   return endpoints;
 }
 
-function printReadmeSync(routes: RouteInfo[], readmeEndpoints: { method: string; path: string }[]) {
+function printReadmeSync(
+  routes: RouteInfo[],
+  readmeEndpoints: { method: string; path: string }[]
+) {
   const routeSet = new Map<string, RouteInfo>();
   for (const r of routes) {
     const key = `${r.method} ${r.path}`;
@@ -235,6 +246,8 @@ function printReadmeSync(routes: RouteInfo[], readmeEndpoints: { method: string;
   }
 }
 
+// ─── Main ───────────────────────────────────────────────────
+
 function main() {
   console.log("=== docs-sync ===\n");
   const audit = runTSDocAudit();
@@ -244,14 +257,19 @@ function main() {
   const readmeEndpoints = parseReadmeEndpoints();
   printReadmeSync(routes, readmeEndpoints);
 
-  const pct = audit.total > 0 ? ((audit.documented / audit.total) * 100).toFixed(1) : "100.0";
-  const v1Routes = new Set(routes.filter((r) => r.path.startsWith("/v1")).map((r) => `${r.method} ${r.path}`));
+  const pct =
+    audit.total > 0 ? ((audit.documented / audit.total) * 100).toFixed(1) : "100.0";
+  const v1Routes = new Set(
+    routes.filter((r) => r.path.startsWith("/v1")).map((r) => `${r.method} ${r.path}`)
+  );
   const inReadme = new Set(readmeEndpoints.map((e) => `${e.method} ${e.path}`));
   const missingEp = [...v1Routes].filter((k) => !inReadme.has(k)).length;
 
   console.log("=== docs-sync Summary ===");
   console.log(`TSDoc:     ${audit.documented}/${audit.total} methods documented (${pct}%)`);
-  console.log(`Endpoints: ${readmeEndpoints.length}/${v1Routes.size} in README, ${missingEp} missing`);
+  console.log(
+    `Endpoints: ${readmeEndpoints.length}/${v1Routes.size} in README, ${missingEp} missing`
+  );
   console.log(`Mode:      ${FIX ? "APPLY" : "dry-run"}${README_FIX ? " (readme-fix)" : ""}`);
 }
 


### PR DESCRIPTION
## Summary

Splits #1359 into focused PRs. This PR is the **docs-sync skill** component.

## Changes

-  — Enhanced with CLI usage section (dry-run, --fix, --readme flags)
-  — Updated comments to document all CLI flags

## Scope

2 files, 40 insertions, 14 deletions.

**Next PRs from #1359 split:**
- PR 2: Issue templates (severity/component dropdowns)
- PR 3: New workflows (auto-triage, graduation-check, issue-state-sync)
- PR 4: Source code changes (cli.ts, mcp-server.ts, monitor.ts + tests)