### PR TITLE
feat: add OpenAPI 3.1 spec at openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,2081 @@
+openapi: 3.1.0
+info:
+  title: Aegis API
+  version: 1.0.0
+  description: |
+    Orchestrate Claude Code sessions via REST API. Aegis wraps Claude Code in tmux sessions
+    and exposes everything through a unified API.
+
+    **Base URL:** `http://localhost:9100`
+
+    **Authentication:** All endpoints except `/v1/health` and `/health` require a bearer token.
+    Pass `Authorization: Bearer <your-token>` header, or set `AEGIS_AUTH_TOKEN` env var.
+
+    **Session lifecycle:** `working` → `idle` → `permission_prompt` → `asking` → `stalled`
+servers:
+  - url: http://localhost:9100
+    description: Local Aegis server
+
+security:
+  - BearerAuth: []
+
+paths:
+  # ─── Health & Info ─────────────────────────────────────────────────────────
+
+  /v1/health:
+    get:
+      operationId: getHealth
+      summary: Server health check
+      security: []
+      tags: [Health]
+      responses:
+        '200':
+          description: Server is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /health:
+    get:
+      operationId: getHealthAlias
+      summary: Server health check (alias)
+      security: []
+      tags: [Health]
+      responses:
+        '200':
+          description: Server is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/swarm:
+    get:
+      operationId: getSwarmStatus
+      summary: Get tmux swarm status
+      tags: [System]
+      responses:
+        '200':
+          description: Swarm status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  monitors:
+                    type: integer
+                    description: Number of active swarm monitors
+                  activeWindows:
+                    type: integer
+                    description: Number of active Claude Code windows across all monitors
+
+  # ─── Authentication ────────────────────────────────────────────────────────
+
+  /v1/auth/keys:
+    get:
+      operationId: listApiKeys
+      summary: List all API keys
+      tags: [Auth]
+      responses:
+        '200':
+          description: List of API keys (plaintext shown only at creation)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  keys:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ApiKey'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      operationId: createApiKey
+      summary: Create a new API key
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Human-readable name for this key
+                  example: production-operator
+                expiresAt:
+                  type: string
+                  format: date-time
+                  description: Optional expiration timestamp (ISO 8601)
+                  example: '2025-12-31T23:59:59Z'
+              required: [name]
+      responses:
+        '201':
+          description: API key created (plaintext shown only now)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyCreated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/auth/keys/{id}:
+    delete:
+      operationId: revokeApiKey
+      summary: Revoke an API key
+      tags: [Auth]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: API key ID
+      responses:
+        '204':
+          description: API key revoked
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/auth/sse-token:
+    post:
+      operationId: createSseToken
+      summary: Generate a short-lived SSE token for browser clients
+      tags: [Auth]
+      description: |
+        SSE tokens are short-lived (60s), single-use, and allow EventSource clients
+        (which cannot set custom headers) to authenticate SSE subscriptions.
+      responses:
+        '200':
+          description: SSE token generated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: Short-lived SSE token
+                  expiresAt:
+                    type: integer
+                    description: Unix timestamp of expiration
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/handshake:
+    post:
+      operationId: negotiateHandshake
+      summary: Capability negotiation
+      tags: [System]
+      security: []
+      description: |
+        Before using advanced integration paths, clients can negotiate capabilities
+        with Aegis. This prevents version-drift breakage.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                protocolVersion:
+                  type: string
+                  example: '1'
+                clientCapabilities:
+                  type: array
+                  items:
+                    type: string
+                  example: ['session.create', 'session.transcript.cursor']
+      responses:
+        '200':
+          description: Negotiation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandshakeResponse'
+        '409':
+          description: Protocol version conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  compatible:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+
+  # ─── Sessions ─────────────────────────────────────────────────────────────
+
+  /v1/sessions:
+    get:
+      operationId: listSessions
+      summary: List all sessions
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/SessionStatusFilter'
+          description: Filter by session UI state
+      responses:
+        '200':
+          description: List of sessions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SessionInfo'
+                  total:
+                    type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      operationId: createSession
+      summary: Create or reuse a session
+      tags: [Sessions]
+      description: |
+        Creates a new Claude Code session or reuses an existing idle session for the same `workDir`.
+        Returns `201` for new sessions, `200` for reused ones.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSessionRequest'
+      responses:
+        '201':
+          description: New session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionCreated'
+        '200':
+          description: Existing idle session reused
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionReused'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Session creation conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  sessionId:
+                    type: string
+
+  /v1/sessions/stats:
+    get:
+      operationId: getSessionStats
+      summary: Get session statistics
+      tags: [Sessions]
+      responses:
+        '200':
+          description: Session statistics
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /v1/sessions/batch:
+    post:
+      operationId: batchCreateSessions
+      summary: Batch create multiple sessions
+      tags: [Sessions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sessions:
+                  type: array
+                  maxItems: 50
+                  items:
+                    $ref: '#/components/schemas/CreateSessionRequest'
+              required: [sessions]
+      responses:
+        '201':
+          description: Sessions created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SessionCreated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    delete:
+      operationId: batchDeleteSessions
+      summary: Kill multiple sessions
+      tags: [Sessions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: string
+                  description: Session IDs to kill
+              required: [ids]
+      responses:
+        '200':
+          description: Sessions killed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  killed:
+                    type: array
+                    items:
+                      type: string
+                  notFound:
+                    type: array
+                    items:
+                      type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/sessions/{id}:
+    get:
+      operationId: getSession
+      summary: Get session details
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Session details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionInfo'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      operationId: killSession
+      summary: Kill a session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '204':
+          description: Session killed
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/send:
+    post:
+      operationId: sendMessage
+      summary: Send a message to a session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                  description: Message text to send to Claude Code
+                  maxLength: 100000
+              required: [text]
+      responses:
+        '202':
+          description: Message delivered
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  delivered:
+                    type: boolean
+                  attempts:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Session not in a state that accepts messages
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  status:
+                    type: string
+
+  /v1/sessions/{id}/read:
+    get:
+      operationId: readMessages
+      summary: Read session transcript
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: Byte offset to start reading from
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Parsed transcript entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TranscriptEntry'
+                  hasMore:
+                    type: boolean
+                  nextOffset:
+                    type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/events:
+    get:
+      operationId: subscribeSessionEvents
+      summary: SSE event stream for a single session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: SSE stream of session events
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              example: |
+                event: status_change
+                data: {"id":"abc123","status":"working"}
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/children:
+    get:
+      operationId: getChildren
+      summary: List child sessions spawned from this session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Child sessions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  children:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SessionInfo'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/spawn:
+    post:
+      operationId: spawnChild
+      summary: Spawn a child session from a running session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                workDir:
+                  type: string
+                prompt:
+                  type: string
+                permissionMode:
+                  type: string
+                  enum: [default, bypassPermissions, plan, acceptEdits, dontAsk, auto]
+      responses:
+        '201':
+          description: Child session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/fork:
+    post:
+      operationId: forkSession
+      summary: Fork a session — clone context into a new session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '201':
+          description: Forked session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/consensus:
+    post:
+      operationId: createConsensus
+      summary: Start a consensus review session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reviewerCount:
+                  type: integer
+                  minimum: 1
+                  maximum: 5
+                  default: 3
+                prompt:
+                  type: string
+              required: [prompt]
+      responses:
+        '202':
+          description: Consensus review started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  consensusId:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/permissions:
+    get:
+      operationId: getPermissionPolicy
+      summary: Get session's permission policy
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Permission policy
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: updatePermissionPolicy
+      summary: Update session's permission policy
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Policy updated
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/permission-profile:
+    get:
+      operationId: getPermissionProfile
+      summary: Get session's permission profile
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Permission profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  profile:
+                    type: string
+                    enum: [allow, deny, ask]
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: updatePermissionProfile
+      summary: Update session's permission profile
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile:
+                  type: string
+                  enum: [allow, deny, ask]
+              required: [profile]
+      responses:
+        '200':
+          description: Profile updated
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/approve:
+    post:
+      operationId: approvePermission
+      summary: Approve a pending permission prompt
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '202':
+          description: Permission approved
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: No pending permission prompt
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+
+  /v1/sessions/{id}/reject:
+    post:
+      operationId: rejectPermission
+      summary: Reject a pending permission prompt
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '202':
+          description: Permission rejected
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: No pending permission prompt
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /v1/sessions/{id}/interrupt:
+    post:
+      operationId: interruptSession
+      summary: Send Ctrl+C to interrupt Claude Code
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '202':
+          description: Interrupt sent
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/escape:
+    post:
+      operationId: sendEscape
+      summary: Send Escape key
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '202':
+          description: Escape sent
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/verify:
+    post:
+      operationId: verifySession
+      summary: Run build + test verification in the session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+                  default: npm run build && npm test
+      responses:
+        '200':
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerificationResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/pane:
+    get:
+      operationId: capturePane
+      summary: Raw terminal capture
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Terminal pane content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pane:
+                    type: string
+                  uiState:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/command:
+    post:
+      operationId: sendCommand
+      summary: Send a shell command directly
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+                  description: Shell command to execute
+                workingDirectory:
+                  type: string
+              required: [command]
+      responses:
+        '202':
+          description: Command sent
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/bash:
+    post:
+      operationId: sendBash
+      summary: Send a bash command (raw, no prompt wrapping)
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+              required: [command]
+      responses:
+        '202':
+          description: Command sent
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/summary:
+    get:
+      operationId: getSessionSummary
+      summary: Condensed transcript summary
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Session summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: string
+                  messages:
+                    type: integer
+                  toolCalls:
+                    type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/screenshot:
+    post:
+      operationId: takeScreenshot
+      summary: Screenshot a URL (Playwright)
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  format: uri
+                  description: URL to screenshot
+      responses:
+        '200':
+          description: Screenshot taken
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  screenshot:
+                    type: string
+                    format: byte
+                    description: PNG image data (base64)
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          description: Playwright not installed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+
+  /v1/sessions/{id}/metrics:
+    get:
+      operationId: getSessionMetrics
+      summary: Per-session metrics (token usage, latency, etc.)
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Session metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionMetrics'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/health:
+    get:
+      operationId: getSessionHealth
+      summary: Session health check with actionable hints
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Session health
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionHealth'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/latency:
+    get:
+      operationId: getSessionLatency
+      summary: Session latency metrics
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Latency metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  realtime:
+                    type: number
+                  aggregated:
+                    type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/transcript/cursor:
+    get:
+      operationId: getTranscriptCursor
+      summary: Cursor-based transcript replay (stable pagination)
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+        - name: before_id
+          in: query
+          schema:
+            type: integer
+          description: Cursor ID to page before. Omit for newest entries.
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: role
+          in: query
+          schema:
+            type: string
+            enum: [user, assistant, system]
+      responses:
+        '200':
+          description: Paginated transcript
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TranscriptEntry'
+                  has_more:
+                    type: boolean
+                  oldest_id:
+                    type: integer
+                  newest_id:
+                    type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/sessions/{id}/memories:
+    get:
+      operationId: getSessionMemories
+      summary: Get memory entries for a session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      responses:
+        '200':
+          description: Memory entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  memories:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      operationId: setSessionMemory
+      summary: Set a memory entry for a session
+      tags: [Sessions]
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+              required: [key, value]
+      responses:
+        '201':
+          description: Memory set
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ─── Consensus ─────────────────────────────────────────────────────────────
+
+  /v1/consensus/{id}:
+    get:
+      operationId: getConsensus
+      summary: Get consensus review status and findings
+      tags: [Consensus]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Consensus review ID
+      responses:
+        '200':
+          description: Consensus review
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  status:
+                    type: string
+                    enum: [running, complete, failed]
+                  findings:
+                    type: array
+                    items:
+                      type: string
+                  createdAt:
+                    type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ─── Events ────────────────────────────────────────────────────────────────
+
+  /v1/events:
+    get:
+      operationId: subscribeGlobalEvents
+      summary: Global SSE event stream (all sessions)
+      tags: [Events]
+      description: |
+        Subscribe to events from all sessions. Uses `text/event-stream`.
+        Pass `Last-Event-ID` header for resumption after reconnection.
+      parameters:
+        - name: Last-Event-ID
+          in: header
+          schema:
+            type: string
+          description: Last event ID for resumption
+      responses:
+        '200':
+          description: Global SSE stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ─── Pipelines ─────────────────────────────────────────────────────────────
+
+  /v1/pipelines:
+    get:
+      operationId: listPipelines
+      summary: List all pipelines
+      tags: [Pipelines]
+      responses:
+        '200':
+          description: List of pipelines
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      operationId: createPipeline
+      summary: Create a pipeline (DAG of sessions)
+      tags: [Pipelines]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePipelineRequest'
+      responses:
+        '201':
+          description: Pipeline created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  status:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/pipelines/{id}:
+    get:
+      operationId: getPipeline
+      summary: Get pipeline status
+      tags: [Pipelines]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pipeline status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  status:
+                    type: string
+                  stages:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ─── Templates ──────────────────────────────────────────────────────────────
+
+  /v1/templates:
+    get:
+      operationId: listTemplates
+      summary: List session templates
+      tags: [Templates]
+      responses:
+        '200':
+          description: List of templates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SessionTemplate'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      operationId: createTemplate
+      summary: Create a session template
+      tags: [Templates]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTemplateRequest'
+      responses:
+        '201':
+          description: Template created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionTemplate'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/templates/{id}:
+    get:
+      operationId: getTemplate
+      summary: Get a template
+      tags: [Templates]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionTemplate'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: updateTemplate
+      summary: Update a template
+      tags: [Templates]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTemplateRequest'
+      responses:
+        '200':
+          description: Template updated
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      operationId: deleteTemplate
+      summary: Delete a template
+      tags: [Templates]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Template deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ─── Memory ────────────────────────────────────────────────────────────────
+
+  /v1/memory:
+    get:
+      operationId: listMemoryEntries
+      summary: List memory entries
+      tags: [Memory]
+      parameters:
+        - name: prefix
+          in: query
+          schema:
+            type: string
+          description: Filter entries by key prefix
+      responses:
+        '200':
+          description: Memory entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                    createdAt:
+                      type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      operationId: setMemoryEntry
+      summary: Set a memory entry
+      tags: [Memory]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+              required: [key, value]
+      responses:
+        '201':
+          description: Memory entry set
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/memory/{key}:
+    get:
+      operationId: getMemoryEntry
+      summary: Get a memory entry
+      tags: [Memory]
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Memory entry
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                  createdAt:
+                    type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      operationId: deleteMemoryEntry
+      summary: Delete a memory entry
+      tags: [Memory]
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Memory entry deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /v1/memories:
+    get:
+      operationId: listMemories
+      summary: List memory entries (scope-filtered)
+      tags: [Memory]
+      parameters:
+        - name: scope
+          in: query
+          schema:
+            type: string
+          description: Filter by scope
+      responses:
+        '200':
+          description: Memory entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ─── System ────────────────────────────────────────────────────────────────
+
+  /v1/metrics:
+    get:
+      operationId: getGlobalMetrics
+      summary: Global metrics (counters, token usage, latency)
+      tags: [System]
+      responses:
+        '200':
+          description: Global metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalMetrics'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/diagnostics:
+    get:
+      operationId: getDiagnostics
+      summary: Recent diagnostic events
+      tags: [System]
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+      responses:
+        '200':
+          description: Diagnostic events
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/tools:
+    get:
+      operationId: listTools
+      summary: List all available tools (global tool registry)
+      tags: [System]
+      responses:
+        '200':
+          description: Tool definitions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/webhooks/dead-letter:
+    get:
+      operationId: getDeadLetterQueue
+      summary: Get webhook delivery failures
+      tags: [System]
+      responses:
+        '200':
+          description: Dead letter queue entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/channels/health:
+    get:
+      operationId: getChannelHealth
+      summary: Health status of all notification channels
+      tags: [System]
+      responses:
+        '200':
+          description: Channel health
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    healthy:
+                      type: boolean
+                    message:
+                      type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ─── Development ───────────────────────────────────────────────────────────
+
+  /v1/dev/route-task:
+    post:
+      operationId: routeTask
+      summary: Route a task to the appropriate model tier
+      tags: [Dev]
+      description: Model router — determines which model tier should handle a task based on complexity keywords.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                task:
+                  type: string
+                context:
+                  type: string
+      responses:
+        '200':
+          description: Routing decision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  recommendedTier:
+                    type: string
+                  reason:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/dev/model-tiers:
+    get:
+      operationId: listModelTiers
+      summary: List available model tiers and their keywords
+      tags: [Dev]
+      responses:
+        '200':
+          description: Model tiers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tiers:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ─── Legacy aliases (no /v1 prefix) ──────────────────────────────────────
+
+  /sessions:
+    get:
+      operationId: listSessionsAlias
+      summary: List all sessions (alias, no /v1 prefix)
+      tags: [Sessions]
+      responses:
+        '200':
+          description: List of sessions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SessionInfo'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+# ─── Components ────────────────────────────────────────────────────────────────
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API key
+
+  parameters:
+    sessionId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Session ID
+    limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        default: 50
+        minimum: 1
+        maximum: 200
+    offset:
+      name: offset
+      in: query
+      schema:
+        type: integer
+        default: 0
+
+  responses:
+    BadRequest:
+      description: Invalid request body or parameters
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+    Unauthorized:
+      description: Missing or invalid authentication token
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: Unauthorized
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: Not found
+
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        version:
+          type: string
+          example: 0.3.2-alpha
+        uptime:
+          type: integer
+          description: Seconds since server start
+        sessions:
+          type: object
+          properties:
+            active:
+              type: integer
+            total:
+              type: integer
+
+    ApiKey:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        keyId:
+          type: string
+          description: First 8 characters of the key hash
+        createdAt:
+          type: integer
+        expiresAt:
+          type: integer
+          nullable: true
+        lastUsedAt:
+          type: integer
+          nullable: true
+
+    ApiKeyCreated:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        key:
+          type: string
+          description: Full plaintext key — shown ONLY here, never again
+        keyId:
+          type: string
+        createdAt:
+          type: integer
+
+    HandshakeResponse:
+      type: object
+      properties:
+        protocolVersion:
+          type: string
+        serverCapabilities:
+          type: array
+          items:
+            type: string
+        negotiatedCapabilities:
+          type: array
+          items:
+            type: string
+        warnings:
+          type: array
+          items:
+            type: string
+        compatible:
+          type: boolean
+
+    CreateSessionRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Human-readable session name
+          example: feature-auth
+        workDir:
+          type: string
+          description: Working directory for Claude Code
+          example: /home/user/my-project
+        prompt:
+          type: string
+          description: Initial prompt to send to Claude Code
+        permissionMode:
+          type: string
+          enum: [default, bypassPermissions, plan, acceptEdits, dontAsk, auto]
+          default: default
+        autoApprove:
+          type: boolean
+          default: false
+        env:
+          type: object
+          additionalProperties:
+            type: string
+          description: Environment variables to inject into the session
+        claudeCommand:
+          type: string
+          maxLength: 10000
+          description: Custom Claude Code command/flags
+        maxSessionAgeMs:
+          type: integer
+          description: Maximum session lifetime in milliseconds
+        stallThresholdMs:
+          type: integer
+          description: Stall detection threshold override
+      required: [workDir]
+
+    SessionCreated:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+          example: working
+        workDir:
+          type: string
+        reused:
+          type: boolean
+          example: false
+        promptDelivery:
+          type: object
+          properties:
+            delivered:
+              type: boolean
+            attempts:
+              type: integer
+
+    SessionReused:
+      allOf:
+        - $ref: '#/components/schemas/SessionCreated'
+        - type: object
+          properties:
+            reused:
+              type: boolean
+              example: true
+
+    SessionInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        windowName:
+          type: string
+        workDir:
+          type: string
+        status:
+          type: string
+          enum: [idle, working, compacting, context_warning, waiting_for_input, permission_prompt, plan_mode, ask_question, bash_approval, settings, error, unknown]
+        createdAt:
+          type: integer
+        lastActivity:
+          type: integer
+        permissionMode:
+          type: string
+        autoApprove:
+          type: boolean
+        promptDelivery:
+          type: object
+          properties:
+            delivered:
+              type: boolean
+            attempts:
+              type: integer
+
+    SessionHealth:
+      type: object
+      properties:
+        alive:
+          type: boolean
+        windowExists:
+          type: boolean
+        paneState:
+          type: string
+        lastSeen:
+          type: integer
+        suggestion:
+          type: string
+          nullable: true
+
+    SessionMetrics:
+      type: object
+      properties:
+        messages:
+          type: integer
+        toolCalls:
+          type: integer
+        approvals:
+          type: integer
+        autoApprovals:
+          type: integer
+        statusChanges:
+          type: array
+          items:
+            type: object
+        tokenUsage:
+          type: object
+          properties:
+            inputTokens:
+              type: integer
+            outputTokens:
+              type: integer
+            cacheCreation:
+              type: integer
+            cacheRead:
+              type: integer
+            estimatedCostUsd:
+              type: number
+              format: float
+
+    TranscriptEntry:
+      type: object
+      properties:
+        id:
+          type: integer
+        role:
+          type: string
+          enum: [user, assistant, system]
+        content:
+          type: string
+        timestamp:
+          type: integer
+        toolCalls:
+          type: array
+          items:
+            type: object
+
+    VerificationResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        output:
+          type: string
+        durationMs:
+          type: integer
+        exitCode:
+          type: integer
+
+    SessionTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        prompt:
+          type: string
+        workDir:
+          type: string
+        permissionMode:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: integer
+
+    CreateTemplateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        prompt:
+          type: string
+        workDir:
+          type: string
+        permissionMode:
+          type: string
+          enum: [default, bypassPermissions, plan, acceptEdits, dontAsk, auto]
+        tags:
+          type: array
+          items:
+            type: string
+      required: [name, prompt]
+
+    CreatePipelineRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        stages:
+          type: array
+          maxItems: 50
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              prompt:
+                type: string
+              workDir:
+                type: string
+              permissionMode:
+                type: string
+              dependencies:
+                type: array
+                items:
+                  type: string
+              maxSessionAgeMs:
+                type: integer
+          required: [id, prompt, workDir]
+      required: [stages]
+
+    GlobalMetrics:
+      type: object
+      properties:
+        sessionsCreated:
+          type: integer
+        sessionsCompleted:
+          type: integer
+        sessionsFailed:
+          type: integer
+        totalMessages:
+          type: integer
+        totalToolCalls:
+          type: integer
+        autoApprovals:
+          type: integer
+        webhooksSent:
+          type: integer
+        webhooksFailed:
+          type: integer
+        screenshotsTaken:
+          type: integer
+        pipelinesCreated:
+          type: integer
+        batchesCreated:
+          type: integer
+        promptsSent:
+          type: integer
+        promptsDelivered:
+          type: integer
+        promptsFailed:
+          type: integer
+        avgDurationSec:
+          type: number
+          format: float
+
+    SessionStatusFilter:
+      type: string
+      enum: [all, idle, working, compacting, context_warning, waiting_for_input, permission_prompt, plan_mode, ask_question, bash_approval, settings, error, unknown]

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -5,6 +5,7 @@
  * Configure via AEGIS_WEBHOOKS (or legacy MANUS_WEBHOOKS) env var or config file.
  */
 
+import crypto from 'node:crypto';
 import type {
   Channel,
   SessionEvent,
@@ -24,6 +25,8 @@ export interface WebhookEndpoint {
   headers?: Record<string, string>;
   /** Timeout in ms (default: 5000). */
   timeoutMs?: number;
+  /** HMAC-SHA256 signing secret. If set, outbound requests include X-Aegis-Signature header. */
+  secret?: string;
 }
 
 export interface WebhookChannelConfig {
@@ -175,6 +178,11 @@ export class WebhookChannel implements Channel {
           'Content-Type': 'application/json',
           ...(ep.headers || {}),
         };
+        // E5-4: HMAC-SHA256 signing — compute signature before DNS check (body must match)
+        if (ep.secret) {
+          const sig = crypto.createHmac('sha256', ep.secret).update(body, 'utf8').digest('hex');
+          headers['X-Aegis-Signature'] = `sha256=${sig}`;
+        }
         if (bareHost !== '127.0.0.1' && bareHost !== '::1' && bareHost !== 'localhost') {
           const dnsResult = await resolveAndCheckIp(bareHost);
           if (dnsResult.error) {

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -27,6 +27,8 @@ export interface WebhookEndpoint {
   timeoutMs?: number;
   /** HMAC-SHA256 signing secret. If set, outbound requests include X-Aegis-Signature header. */
   secret?: string;
+  /** E5-6: Redact message content from webhook payloads. When true, detail field is replaced with [REDACTED]. */
+  redactContent?: boolean;
 }
 
 export interface WebhookChannelConfig {
@@ -121,7 +123,7 @@ export class WebhookChannel implements Channel {
   }
 
   /** Redact sensitive session metadata from webhook payloads. */
-  private static redactPayload(
+  private static redactSessionMeta(
     payload: SessionEventPayload,
   ): Record<string, unknown> {
     const { session, ...rest } = payload;
@@ -135,12 +137,31 @@ export class WebhookChannel implements Channel {
     };
   }
 
-  private async fire(payload: SessionEventPayload): Promise<void> {
-    const body = JSON.stringify(WebhookChannel.redactPayload(payload));
+  /** Build webhook payload, applying per-endpoint redaction rules. */
+  private buildPayload(
+    payload: SessionEventPayload,
+    ep: WebhookEndpoint,
+  ): Record<string, unknown> {
+    const base = WebhookChannel.redactSessionMeta(payload);
+    // E5-6: When redactContent is enabled, replace message detail with [REDACTED]
+    // This prevents LLM-generated content with secrets/PII from reaching webhook receivers
+    if (ep.redactContent) {
+      base['detail'] = '[REDACTED]';
+      // Also redact meta content if it contains message data
+      if (base['meta']) {
+        base['meta'] = '[REDACTED]';
+      }
+    }
+    return base;
+  }
 
+  private async fire(payload: SessionEventPayload): Promise<void> {
     const promises = this.endpoints.map(async ep => {
       // Skip if endpoint filters and this event isn't in the list
       if (ep.events && ep.events.length > 0 && !ep.events.includes(payload.event)) return;
+
+      // E5-6: Build per-endpoint body with its redaction settings
+      const body = JSON.stringify(this.buildPayload(payload, ep));
 
       await this.deliverWithRetry(ep, body, payload.event);
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -202,6 +202,10 @@ app.addHook('onSend', (req, reply, payload, done) => {
   }
   reply.header('X-Content-Type-Options', 'nosniff');
   reply.header('X-Frame-Options', 'DENY');
+  // E5-2: API versioning — all /v1/ responses include version header
+  if (req.url?.startsWith('/v1/')) {
+    reply.header('X-Aegis-API-Version', '1');
+  }
   reply.header('Referrer-Policy', 'strict-origin-when-cross-origin');
   reply.header('Permissions-Policy', 'camera=(), microphone=()');
   const normalizedPayload = normalizeApiErrorPayload({

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -53,6 +53,8 @@ export const webhookEndpointSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
   // E5-4: HMAC-SHA256 signing secret for webhook payload authentication
   secret: z.string().optional(),
+  // E5-6: Redact message content from webhook payloads
+  redactContent: z.boolean().optional(),
 }).strict();
 
 /** POST /v1/hooks/:eventName — CC hook event payload (Issue #665). */

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -51,6 +51,8 @@ export const webhookEndpointSchema = z.object({
   events: z.array(z.string()).optional(),
   headers: z.record(z.string(), z.string()).optional(),
   timeoutMs: z.number().int().positive().optional(),
+  // E5-4: HMAC-SHA256 signing secret for webhook payload authentication
+  secret: z.string().optional(),
 }).strict();
 
 /** POST /v1/hooks/:eventName — CC hook event payload (Issue #665). */


### PR DESCRIPTION
## Summary

Four M-E5 issues delivered:

**#1438 — OpenAPI 3.1 spec:** 50+ endpoints, 2,081 lines. swagger-cli validated (0 errors).

**#1439 — API versioning headers:** All `/v1/` responses include `X-Aegis-API-Version: 1`.

**#1441 — Webhook HMAC-SHA256 signing:** `secret` field in endpoint config triggers `X-Aegis-Signature: sha256=<hmac>` header.

**#1443 — PII content redaction:** `redactContent: true` in endpoint config replaces message `detail` and `meta` with `[REDACTED]`.

## Changes

- **openapi.yaml** (new) — comprehensive API spec
- **src/server.ts** — X-Aegis-API-Version header
- **src/channels/webhook.ts** — HMAC signing + content redaction
- **src/validation.ts** — secret + redactContent schema fields

## Quality

- `npx tsc --noEmit` — 0 errors

## Remaining M-E5

- #1440 — TypeScript client SDK (separate PR)
- #1442 — Notification channels: Slack + email (separate PR)

Closes #1438, Closes #1439, Closes #1441, Closes #1443
