### PR TITLE
fix(security): implement session ownership model (RBAC)

### DIFF
--- a/src/__tests__/permission-routes.test.ts
+++ b/src/__tests__/permission-routes.test.ts
@@ -29,6 +29,7 @@ describe('permission-routes', () => {
     approve: ReturnType<typeof vi.fn>;
     reject: ReturnType<typeof vi.fn>;
     getLatencyMetrics: ReturnType<typeof vi.fn>;
+    getSession: ReturnType<typeof vi.fn>;
   };
   let metrics: {
     recordPermissionResponse: ReturnType<typeof vi.fn>;

--- a/src/__tests__/permission-routes.test.ts
+++ b/src/__tests__/permission-routes.test.ts
@@ -40,6 +40,7 @@ describe('permission-routes', () => {
       approve: vi.fn(async () => {}),
       reject: vi.fn(async () => {}),
       getLatencyMetrics: vi.fn(() => ({ permission_response_ms: null })),
+      getSession: vi.fn(() => ({ id: 's-1', ownerKeyId: undefined })),
     };
     metrics = {
       recordPermissionResponse: vi.fn(),

--- a/src/__tests__/session-ownership-1429.test.ts
+++ b/src/__tests__/session-ownership-1429.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerPermissionRoutes } from '../permission-routes.js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { SessionInfo } from '../session.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+type RouteHandler = (req: { params: { id: string }; authKeyId?: string | null }, reply: any) => Promise<unknown>;
+
+function makeMockApp(): FastifyInstance {
+  return { post: vi.fn() } as unknown as FastifyInstance;
+}
+
+function makeReply() {
+  const send = vi.fn((payload: unknown) => payload);
+  const status = vi.fn(() => ({ send }));
+  return { send, status };
+}
+
+function getHandler(app: FastifyInstance, path: string): RouteHandler {
+  const post = app.post as ReturnType<typeof vi.fn>;
+  const call = post.mock.calls.find((args: unknown[]) => args[0] === path);
+  if (!call) throw new Error(`Missing route registration for ${path}`);
+  return call[1] as RouteHandler;
+}
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 's-1',
+    windowId: '@1',
+    windowName: 'cc-test',
+    workDir: '/tmp/test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ...overrides,
+  } as SessionInfo;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('Session ownership (#1429) — permission routes', () => {
+  let app: FastifyInstance;
+  let sessions: {
+    approve: ReturnType<typeof vi.fn>;
+    reject: ReturnType<typeof vi.fn>;
+    getLatencyMetrics: ReturnType<typeof vi.fn>;
+    getSession: ReturnType<typeof vi.fn>;
+  };
+  let metrics: { recordPermissionResponse: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    app = makeMockApp();
+    sessions = {
+      approve: vi.fn(async () => {}),
+      reject: vi.fn(async () => {}),
+      getLatencyMetrics: vi.fn(() => ({ permission_response_ms: null })),
+      getSession: vi.fn(() => makeSession({ ownerKeyId: 'key-alice' })),
+    };
+    metrics = { recordPermissionResponse: vi.fn() };
+  });
+
+  it('owner can approve own session', async () => {
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    const result = await handler({ params: { id: 's-1' }, authKeyId: 'key-alice' }, reply);
+
+    expect(result).toEqual({ ok: true });
+    expect(sessions.approve).toHaveBeenCalledWith('s-1');
+    expect(reply.status).not.toHaveBeenCalledWith(403);
+  });
+
+  it('non-owner gets 403 on approve', async () => {
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    await handler({ params: { id: 's-1' }, authKeyId: 'key-bob' }, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(403);
+    expect(sessions.approve).not.toHaveBeenCalled();
+  });
+
+  it('non-owner gets 403 on reject', async () => {
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+    const handler = getHandler(app, '/v1/sessions/:id/reject');
+    const reply = makeReply();
+    await handler({ params: { id: 's-1' }, authKeyId: 'key-bob' }, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(403);
+    expect(sessions.reject).not.toHaveBeenCalled();
+  });
+
+  it('master key bypasses ownership on approve', async () => {
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    const result = await handler({ params: { id: 's-1' }, authKeyId: 'master' }, reply);
+
+    expect(result).toEqual({ ok: true });
+    expect(sessions.approve).toHaveBeenCalledWith('s-1');
+  });
+
+  it('null keyId (no auth) bypasses ownership', async () => {
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    const result = await handler({ params: { id: 's-1' }, authKeyId: null }, reply);
+
+    expect(result).toEqual({ ok: true });
+    expect(sessions.approve).toHaveBeenCalledWith('s-1');
+  });
+
+  it('session without ownerKeyId (legacy) allows all access', async () => {
+    sessions.getSession.mockReturnValue(makeSession({ ownerKeyId: undefined }));
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    const result = await handler({ params: { id: 's-1' }, authKeyId: 'key-bob' }, reply);
+
+    expect(result).toEqual({ ok: true });
+    expect(sessions.approve).toHaveBeenCalledWith('s-1');
+  });
+
+  it('returns 404 when session not found', async () => {
+    sessions.getSession.mockReturnValue(null);
+    registerPermissionRoutes(app, sessions as any, metrics as any);
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    await handler({ params: { id: 'missing' }, authKeyId: 'key-alice' }, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(404);
+  });
+});
+
+describe('Session ownership (#1429) — requireOwnership logic', () => {
+  // Test the ownership logic patterns directly
+  function checkOwnership(session: SessionInfo | null, keyId: string | null | undefined): { allowed: boolean; code?: number } {
+    if (!session) return { allowed: false, code: 404 };
+    if (keyId === 'master' || keyId === null || keyId === undefined) return { allowed: true };
+    if (!session.ownerKeyId) return { allowed: true };
+    if (session.ownerKeyId !== keyId) return { allowed: false, code: 403 };
+    return { allowed: true };
+  }
+
+  it('allows owner key', () => {
+    const s = makeSession({ ownerKeyId: 'key-a' });
+    expect(checkOwnership(s, 'key-a').allowed).toBe(true);
+  });
+
+  it('rejects non-owner key', () => {
+    const s = makeSession({ ownerKeyId: 'key-a' });
+    expect(checkOwnership(s, 'key-b')).toEqual({ allowed: false, code: 403 });
+  });
+
+  it('allows master key', () => {
+    const s = makeSession({ ownerKeyId: 'key-a' });
+    expect(checkOwnership(s, 'master').allowed).toBe(true);
+  });
+
+  it('allows when keyId is null (no auth)', () => {
+    const s = makeSession({ ownerKeyId: 'key-a' });
+    expect(checkOwnership(s, null).allowed).toBe(true);
+  });
+
+  it('allows when keyId is undefined', () => {
+    const s = makeSession({ ownerKeyId: 'key-a' });
+    expect(checkOwnership(s, undefined).allowed).toBe(true);
+  });
+
+  it('allows any key when session has no ownerKeyId (legacy)', () => {
+    const s = makeSession({ ownerKeyId: undefined });
+    expect(checkOwnership(s, 'key-random').allowed).toBe(true);
+  });
+
+  it('returns 404 when session is null', () => {
+    expect(checkOwnership(null, 'key-a')).toEqual({ allowed: false, code: 404 });
+  });
+});
+
+describe('Session ownership (#1429) — listSessions scoping', () => {
+  it('scopes sessions to owner for non-master keys', () => {
+    const sessions = [
+      makeSession({ id: 's-1', ownerKeyId: 'key-alice' }),
+      makeSession({ id: 's-2', ownerKeyId: 'key-bob' }),
+      makeSession({ id: 's-3', ownerKeyId: 'key-alice' }),
+      makeSession({ id: 's-4', ownerKeyId: undefined }), // legacy
+    ];
+
+    // Simulate the filter logic from the list sessions route
+    const callerKeyId = 'key-alice';
+    const filtered = sessions.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
+
+    expect(filtered.map(s => s.id)).toEqual(['s-1', 's-3', 's-4']);
+  });
+
+  it('returns all sessions for master key', () => {
+    const sessions = [
+      makeSession({ id: 's-1', ownerKeyId: 'key-alice' }),
+      makeSession({ id: 's-2', ownerKeyId: 'key-bob' }),
+    ];
+
+    // Master key: no filter applied
+    const callerKeyId: string | null = 'master';
+    const filtered = callerKeyId === 'master' ? sessions : sessions.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
+
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('returns all sessions when auth is disabled', () => {
+    const sessions = [
+      makeSession({ id: 's-1', ownerKeyId: 'key-alice' }),
+      makeSession({ id: 's-2', ownerKeyId: 'key-bob' }),
+    ];
+
+    const callerKeyId = null;
+    const filtered = (callerKeyId === 'master' || callerKeyId === null || callerKeyId === undefined)
+      ? sessions
+      : sessions.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
+
+    expect(filtered).toHaveLength(2);
+  });
+});
+
+describe('Session ownership (#1429) — batch delete scoping', () => {
+  it('skips sessions owned by another key', () => {
+    const allSessions = [
+      makeSession({ id: 's-1', ownerKeyId: 'key-alice' }),
+      makeSession({ id: 's-2', ownerKeyId: 'key-bob' }),
+      makeSession({ id: 's-3', ownerKeyId: undefined }), // legacy
+    ];
+
+    const callerKeyId: string | null = 'key-alice';
+    const deletable = allSessions.filter(s => {
+      if (s.ownerKeyId && callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined && s.ownerKeyId !== callerKeyId) {
+        return false;
+      }
+      return true;
+    });
+
+    expect(deletable.map(s => s.id)).toEqual(['s-1', 's-3']);
+  });
+});

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -43,6 +43,7 @@ export interface SessionInfo {
     url: string;
     description: string;
   }>;
+  ownerKeyId?: string;
 }
 
 export interface SessionHealth {

--- a/src/permission-routes.ts
+++ b/src/permission-routes.ts
@@ -6,7 +6,7 @@ type PermissionAction = 'approve' | 'reject';
 type IdParams = { Params: { id: string } };
 type IdRequest = FastifyRequest<IdParams>;
 
-type PermissionSessions = Pick<SessionManager, 'approve' | 'reject' | 'getLatencyMetrics'>;
+type PermissionSessions = Pick<SessionManager, 'approve' | 'reject' | 'getLatencyMetrics' | 'getSession'>;
 type PermissionMetrics = Pick<MetricsCollector, 'recordPermissionResponse'>;
 
 function createPermissionHandler(
@@ -15,6 +15,14 @@ function createPermissionHandler(
   metrics: PermissionMetrics,
 ): (req: IdRequest, reply: FastifyReply) => Promise<unknown> {
   return async (req: IdRequest, reply: FastifyReply): Promise<unknown> => {
+    // Issue #1429: Enforce session ownership
+    const session = sessions.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: 'Session not found' });
+    const keyId = req.authKeyId;
+    if (keyId !== 'master' && keyId !== null && keyId !== undefined && session.ownerKeyId && session.ownerKeyId !== keyId) {
+      return reply.status(403).send({ error: 'Forbidden: session owned by another API key' });
+    }
+
     try {
       if (action === 'approve') {
         await sessions.approve(req.params.id);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -19,6 +19,8 @@ export interface BatchSessionSpec {
   /** @deprecated Use permissionMode instead. */
   autoApprove?: boolean;
   stallThresholdMs?: number;
+  /** Issue #1429: API key ID that owns the created session */
+  ownerKeyId?: string;
 }
 
 export interface BatchResult {
@@ -99,6 +101,7 @@ export class PipelineManager {
           permissionMode: spec.permissionMode,
           autoApprove: spec.autoApprove,
           stallThresholdMs: spec.stallThresholdMs,
+          ownerKeyId: spec.ownerKeyId,
         });
 
         let promptDelivery: { delivered: boolean; attempts: number } | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import crypto from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { TmuxManager } from './tmux.js';
-import { SessionManager } from './session.js';
+import { SessionManager, type SessionInfo } from './session.js';
 import { SessionMonitor, DEFAULT_MONITOR_CONFIG } from './monitor.js';
 import { JsonlWatcher } from './jsonl-watcher.js';
 import {
@@ -109,6 +109,31 @@ declare module 'fastify' {
 }
 
 type IdRequest = FastifyRequest<IdParams>;
+
+// Issue #1429: Session ownership guard — rejects 403 if caller keyId does not match session owner.
+// Master key and no-auth mode (null/undefined keyId) bypass ownership.
+// Legacy sessions without ownerKeyId allow all access (backward compat).
+// Returns the session if allowed, or null if rejected (reply already sent).
+function requireOwnership(
+  sessionId: string,
+  reply: FastifyReply,
+  keyId: string | null | undefined,
+): SessionInfo | null {
+  const session = sessions.getSession(sessionId);
+  if (!session) {
+    reply.status(404).send({ error: 'Session not found' });
+    return null;
+  }
+  // Master key and no-auth mode bypass ownership checks
+  if (keyId === 'master' || keyId === null || keyId === undefined) return session;
+  // Legacy sessions without ownerKeyId allow all access
+  if (!session.ownerKeyId) return session;
+  if (session.ownerKeyId !== keyId) {
+    reply.status(403).send({ error: 'Forbidden: session owned by another API key' });
+    return null;
+  }
+  return session;
+}
 
 // ── Configuration ────────────────────────────────────────────────────
 
@@ -722,6 +747,11 @@ app.get<{
   const projectFilter = req.query.project;
 
   let all = sessions.listSessions();
+  // Issue #1429: Scope sessions to owner for non-master keys
+  const callerKeyId = req.authKeyId;
+  if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined) {
+    all = all.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
+  }
   if (statusFilter) {
     all = all.filter(s => s.status === statusFilter);
   }
@@ -795,8 +825,15 @@ app.delete('/v1/sessions/batch', async (req, reply) => {
   const errors: string[] = [];
 
   for (const id of targets) {
-    if (!sessions.getSession(id)) {
+    const session = sessions.getSession(id);
+    // Issue #1429: Enforce ownership in batch delete
+    if (!session) {
       notFound.push(id);
+      continue;
+    }
+    // Skip sessions owned by another key (unless master/no-auth)
+    const callerKeyId = req.authKeyId;
+    if (session.ownerKeyId && callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined && session.ownerKeyId !== callerKeyId) {
       continue;
     }
     try {
@@ -877,7 +914,7 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
   }
 
   console.time("POST_CREATE_SESSION");
-  const session = await sessions.createSession({ workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId });
+  const session = await sessions.createSession({ workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId });
   console.timeEnd("POST_CREATE_SESSION"); console.time("POST_CHANNEL_CREATED");
 
   // Issue #625: Track session in metrics so sessionsCreated counter is accurate
@@ -926,8 +963,8 @@ app.post('/sessions', createSessionHandler);
 // Get session (Issue #20: includes actionHints for interactive states)
 async function getSessionHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return reply as unknown as Record<string, unknown>;
   return addActionHints(session, sessions);
 }
 app.get<IdParams>('/v1/sessions/:id', getSessionHandler);
@@ -978,6 +1015,7 @@ app.get<IdParams>('/sessions/:id/health', sessionHealthHandler);
 async function sendMessageHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
   const parsed = sendMessageSchema.safeParse(req.body);
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   const { text } = parsed.data;
   try {
     const result = await sessions.sendMessage(req.params.id, text);
@@ -998,8 +1036,8 @@ app.post<IdParams>('/sessions/:id/send', sendMessageHandler);
 // Issue #702: GET children sessions
 async function getChildrenHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return reply as unknown as Record<string, unknown>;
   const children = (session.children ?? []).map(id => {
     const child = sessions.getSession(id);
     if (!child) return null;
@@ -1015,8 +1053,8 @@ interface SpawnBody { name?: string; prompt?: string; workDir?: string; permissi
 type SpawnRequest = FastifyRequest<{ Params: { id: string }; Body: SpawnBody | undefined }>;
 async function spawnChildHandler(req: SpawnRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const parentId = req.params.id;
-  const parent = sessions.getSession(parentId);
-  if (!parent) return reply.status(404).send({ error: 'Parent session not found' });
+  const parent = requireOwnership(parentId, reply, req.authKeyId);
+  if (!parent) return reply as unknown as Record<string, unknown>;
   const { name, prompt, workDir, permissionMode } = req.body ?? {};
   const childName = name ?? `${parent.windowName ?? 'session'}-child`;
   const requestedWorkDir = workDir ?? parent.workDir;
@@ -1025,7 +1063,7 @@ async function spawnChildHandler(req: SpawnRequest, reply: FastifyReply): Promis
     return reply.status(400).send({ error: `Invalid workDir: ${safeChildWorkDir.error}`, code: safeChildWorkDir.code });
   }
   const childPermMode = permissionMode ?? parent.permissionMode ?? 'default';
-  const childSession = await sessions.createSession({ workDir: safeChildWorkDir, name: childName, parentId, permissionMode: childPermMode });
+  const childSession = await sessions.createSession({ workDir: safeChildWorkDir, name: childName, parentId, permissionMode: childPermMode, ownerKeyId: req.authKeyId });
   let promptDelivery: { delivered: boolean; attempts: number } | undefined;
   if (prompt) { promptDelivery = await sessions.sendInitialPrompt(childSession.id, prompt); }
   return reply.status(201).send({ ...childSession, promptDelivery });
@@ -1038,8 +1076,8 @@ interface ForkBody { name?: string; prompt?: string; clearPanes?: boolean; }
 type ForkRequest = FastifyRequest<{ Params: { id: string }; Body: ForkBody | undefined }>;
 async function forkSessionHandler(req: ForkRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const parentId = req.params.id;
-  const parent = sessions.getSession(parentId);
-  if (!parent) return reply.status(404).send({ error: 'Parent session not found' });
+  const parent = requireOwnership(parentId, reply, req.authKeyId);
+  if (!parent) return reply as unknown as Record<string, unknown>;
   const { name, prompt } = req.body ?? {};
   const forkName = name ?? `${parent.windowName ?? 'session'}-fork`;
   // Inherit: workDir, permissionMode, env (collect from parent's env vars if stored)
@@ -1049,6 +1087,7 @@ async function forkSessionHandler(req: ForkRequest, reply: FastifyReply): Promis
     workDir: parent.workDir,
     name: forkName,
     permissionMode: parent.permissionMode,
+    ownerKeyId: req.authKeyId,
   });
   let promptDelivery: { delivered: boolean; attempts: number } | undefined;
   if (prompt) { promptDelivery = await sessions.sendInitialPrompt(forkedSession.id, prompt); }
@@ -1169,6 +1208,7 @@ app.put('/sessions/:id/permission-profile', updatePermissionProfileHandler);
 
 // Read messages
 async function readMessagesHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     return await sessions.readMessages(req.params.id);
   } catch (e: unknown) {
@@ -1184,6 +1224,7 @@ registerPermissionRoutes(
     approve: async (id: string) => sessions.approve(id),
     reject: async (id: string) => sessions.reject(id),
     getLatencyMetrics: (id: string) => sessions.getLatencyMetrics(id),
+    getSession: (id: string) => sessions.getSession(id),
   },
   {
     recordPermissionResponse: (id: string, latencyMs: number) => metrics.recordPermissionResponse(id, latencyMs),
@@ -1200,8 +1241,8 @@ app.post<{
     return reply.status(400).send({ error: 'questionId and answer are required' });
   }
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return;
   const resolved = sessions.submitAnswer(req.params.id, questionId, answer);
   if (!resolved) {
     return reply.status(409).send({ error: 'No pending question matching this questionId' });
@@ -1211,6 +1252,7 @@ app.post<{
 
 // Escape
 async function escapeHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     await sessions.escape(req.params.id);
     return { ok: true };
@@ -1223,6 +1265,7 @@ app.post<IdParams>('/sessions/:id/escape', escapeHandler);
 
 // Interrupt (Ctrl+C)
 async function interruptHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     await sessions.interrupt(req.params.id);
     return { ok: true };
@@ -1235,9 +1278,7 @@ app.post<IdParams>('/sessions/:id/interrupt', interruptHandler);
 
 // Kill session
 async function killSessionHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
-  if (!sessions.getSession(req.params.id)) {
-    return reply.status(404).send({ error: 'Session not found' });
-  }
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     // #842: killSession first, then notify — avoids race where channels
     // reference a session that is still being destroyed.
@@ -1256,8 +1297,8 @@ app.delete<IdParams>('/sessions/:id', killSessionHandler);
 // Capture raw pane
 async function capturePaneHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return;
   const pane = await tmux.capturePane(session.windowId);
   return { pane };
 }
@@ -1268,6 +1309,7 @@ app.get<IdParams>('/sessions/:id/pane', capturePaneHandler);
 async function commandHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
   const parsed = commandSchema.safeParse(req.body);
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   const { command } = parsed.data;
   try {
     const cmd = command.startsWith('/') ? command : `/${command}`;
@@ -1284,6 +1326,7 @@ app.post<IdParams>('/sessions/:id/command', commandHandler);
 async function bashHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
   const parsed = bashSchema.safeParse(req.body);
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   const { command } = parsed.data;
   try {
     const cmd = command.startsWith('!') ? command : `!${command}`;
@@ -1298,6 +1341,7 @@ app.post<IdParams>('/sessions/:id/bash', bashHandler);
 
 // Session summary (Issue #35)
 async function summaryHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     return await sessions.getSummary(req.params.id);
   } catch (e: unknown) {
@@ -1312,6 +1356,7 @@ app.get<{
   Params: { id: string };
   Querystring: { page?: string; limit?: string; role?: string };
 }>('/v1/sessions/:id/transcript', async (req, reply) => {
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     const page = Math.max(1, parseInt(req.query.page || '1', 10) || 1);
     const limit = Math.min(200, Math.max(1, parseInt(req.query.limit || '50', 10) || 50));
@@ -1332,6 +1377,7 @@ app.get<{
   Params: { id: string };
   Querystring: { before_id?: string; limit?: string; role?: string };
 }>('/v1/sessions/:id/transcript/cursor', async (req, reply) => {
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     const rawBeforeId = req.query.before_id;
     const beforeId = rawBeforeId !== undefined ? parseInt(rawBeforeId, 10) : undefined;
@@ -1585,6 +1631,8 @@ app.post('/v1/sessions/batch', async (req, reply) => {
       return reply.status(400).send({ error: `Invalid workDir "${spec.workDir}": ${safeWorkDir.error}`, code: safeWorkDir.code });
     }
     spec.workDir = safeWorkDir;
+    // Issue #1429: Stamp owner on batch-created sessions
+    if (req.authKeyId) (spec as Record<string, unknown>).ownerKeyId = req.authKeyId;
   }
   const result = await pipelines.batchCreate(specs);
   return reply.status(201).send(result);
@@ -1593,8 +1641,8 @@ app.post('/v1/sessions/batch', async (req, reply) => {
 // Issue #740: Verification Protocol — run quality gate (tsc + build + test) on a session's workDir
 app.post('/v1/sessions/:id/verify', async (req, reply) => {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return;
 
   const { workDir } = session;
   if (!workDir) return reply.status(400).send({ error: 'Session has no workDir' });

--- a/src/session.ts
+++ b/src/session.ts
@@ -85,6 +85,7 @@ export interface SessionInfo {
   permissionPolicy?: PermissionPolicy;  // Issue #700: Dynamic permission rules
   permissionProfile?: PermissionProfile; // Issue #742: Per-session tool permission profile
   prd?: string;                // Issue #735: Optional PRD contract text attached to the session
+  ownerKeyId?: string;         // Issue #1429: API key ID that created this session (ownership)
 }
 
 /** Persisted session store keyed by Aegis session ID. */
@@ -557,6 +558,8 @@ export class SessionManager {
     autoApprove?: boolean;
     /** Issue #702: Parent session ID for sub-agent hierarchy */
     parentId?: string;
+    /** Issue #1429: API key ID that owns this session */
+    ownerKeyId?: string | null;
   }): Promise<SessionInfo> {
     const id = crypto.randomUUID();
     const windowName = opts.name || `cc-${id.slice(0, 8)}`;
@@ -693,6 +696,7 @@ export class SessionManager {
       hookSettingsFile,
       hookSecret,
       prd: opts.prd,
+      ownerKeyId: opts.ownerKeyId ?? undefined,
     };
 
     this.state.sessions[id] = session;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -223,6 +223,7 @@ export const persistedStateSchema = z.record(
       commandPattern: z.string().optional(),
     })).optional(),
     permissionProfile: permissionProfileSchema.optional(),
+    ownerKeyId: z.string().optional(),
   }),
 );
 


### PR DESCRIPTION
## Summary

- Adds `ownerKeyId` field to `SessionInfo`, persisted state schema, and API contracts to track which API key created each session
- Enforces ownership via `requireOwnership()` guard on all protected session operations: send, approve, reject, kill, interrupt, escape, capture pane, transcript, read messages, summary, command, bash, verify, batch delete, and list sessions
- Master key (`keyId === 'master'`) and no-auth mode (`keyId === null/undefined`) bypass ownership checks
- Legacy sessions without `ownerKeyId` remain accessible to all keys for backward compatibility
- Child/spawned/forked sessions inherit the caller's `ownerKeyId`
- Batch create stamps owner on all created sessions
- Permission routes (approve/reject) enforce ownership before acting

Closes #1429 (SD-AUTHZ-01 — HIGH)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 136 files, 2417 tests pass (including new `session-ownership-1429.test.ts`)
- [ ] Manual: create two API keys, Key A creates session, Key B gets 403 on all operations
- [ ] Manual: master token can operate on Key A's session → 200
- [ ] Manual: legacy sessions (no `ownerKeyId`) remain accessible

## Aegis version
**Developed with:** v0.2.0-alpha

Generated by Hephaestus (Aegis dev agent)