### PR TITLE
docs: M-E5 API integration — SDK + notification channels (#1440, #1442)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "@fastify/websocket": "^11.2.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@tanstack/react-virtual": "^3.13.23",
+        "@types/nodemailer": "^8.0.0",
         "async-mutex": "^0.5.0",
         "fastify": "^5.8.2",
+        "nodemailer": "^8.0.5",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -1133,10 +1135,18 @@
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -3961,6 +3971,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5182,7 +5201,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
     "@fastify/websocket": "^11.2.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@tanstack/react-virtual": "^3.13.23",
+    "@types/nodemailer": "^8.0.0",
     "async-mutex": "^0.5.0",
     "fastify": "^5.8.2",
+    "nodemailer": "^8.0.5",
     "zod": "^4.3.6"
   },
   "overrides": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@aegis/client",
+  "version": "0.3.2-alpha",
+  "type": "module",
+  "description": "Official TypeScript client for Aegis Bridge. Orchestrate Claude Code sessions via HTTP API.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OneStepAt4time/aegis.git",
+    "directory": "packages/client"
+  },
+  "keywords": ["aegis", "claude-code", "orchestration", "mcp", "api-client"],
+  "license": "MIT",
+  "peerDependencies": {
+    "zod": ">=3.0.0"
+  }
+}

--- a/packages/client/src/AegisClient.ts
+++ b/packages/client/src/AegisClient.ts
@@ -1,0 +1,406 @@
+/**
+ * AegisClient.ts — Official TypeScript client for Aegis Bridge.
+ *
+ * HTTP API client for orchestrating Claude Code sessions.
+ * Works in Node.js and browser environments.
+ *
+ * @example
+ * import { AegisClient } from '@aegis/client';
+ *
+ * const client = new AegisClient('http://localhost:18792', process.env.AEGIS_AUTH_TOKEN);
+ *
+ * // List all sessions
+ * const sessions = await client.listSessions();
+ *
+ * // Create a new session
+ * const session = await client.createSession({ workDir: '/path/to/project' });
+ *
+ * // Send a message
+ * await client.sendMessage(session.id, 'Hello, Claude!');
+ */
+
+import type {
+  SessionInfo,
+  CreateSessionRequest,
+  OkResponse,
+  SendResponse,
+  SessionHealth,
+  PaneResponse,
+  SessionLatency,
+  SessionMetrics,
+  SessionSummary,
+  MessagesResponse,
+  BatchResult,
+  PipelineState,
+  MemoryEntryResponse,
+  HealthResponse,
+  SessionsListResponse,
+  AuditPageResponse,
+  GlobalMetrics,
+} from './types.js';
+
+// ── UUID validation ─────────────────────────────────────────────────
+
+function isValidUUID(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+}
+
+function isSameOrChildWorkDir(sessionWorkDir: string, filterWorkDir: string): boolean {
+  return sessionWorkDir === filterWorkDir || sessionWorkDir.startsWith(filterWorkDir + '/');
+}
+
+// ── Client ─────────────────────────────────────────────────────────
+
+export interface AegisClientOptions {
+  /** Base URL of the Aegis server. Defaults to localhost:18792. */
+  baseUrl?: string;
+  /** Bearer token for authentication. */
+  authToken?: string;
+  /** Default request timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+export class AegisClient {
+  private readonly baseUrl: string;
+  private readonly authToken?: string;
+  private readonly timeoutMs: number;
+
+  constructor(authToken: string, options?: AegisClientOptions);
+  constructor(baseUrl: string, authToken?: string, options?: AegisClientOptions);
+  constructor(baseUrlOrToken: string, authTokenOrOptions?: string | AegisClientOptions, maybeOptions?: AegisClientOptions) {
+    if (typeof authTokenOrOptions === 'string') {
+      // Overload 2: (baseUrl, authToken, options?)
+      this.baseUrl = baseUrlOrToken;
+      this.authToken = authTokenOrOptions;
+      this.timeoutMs = maybeOptions?.timeoutMs ?? 30000;
+    } else {
+      // Overload 1: (authToken, options?) — defaults baseUrl to localhost
+      this.baseUrl = baseUrlOrToken ?? 'http://localhost:18792';
+      this.authToken = authTokenOrOptions?.authToken;
+      this.timeoutMs = authTokenOrOptions?.timeoutMs ?? 30000;
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────
+
+  private validateSessionId(id: string): void {
+    if (!isValidUUID(id)) {
+      throw new Error(`Invalid session ID: ${id}`);
+    }
+  }
+
+  private async request<T = unknown>(path: string, opts?: RequestInit & { timeoutMs?: number }): Promise<T> {
+    const hasBody = opts?.body !== undefined;
+    const headers: Record<string, string> = {
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
+      'X-Aegis-API-Version': '1',
+    };
+    const timeout = opts?.timeoutMs ?? this.timeoutMs;
+    let res: Response;
+    try {
+      res = await fetch(`${this.baseUrl}${path}`, {
+        ...opts,
+        headers: { ...headers, ...opts?.headers },
+        signal: timeout > 0 ? AbortSignal.timeout(timeout) : undefined,
+      });
+    } catch (e: unknown) {
+      const cause = (e as { cause?: { code?: string } }).cause;
+      if (cause?.code === 'ECONNREFUSED') {
+        throw new Error('Aegis server is not running or not reachable');
+      }
+      if (e instanceof Error && e.name === 'TimeoutError') {
+        throw new Error(`Request timed out after ${timeout}ms: ${path}`);
+      }
+      throw new Error(`Network error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+      throw new Error(body.error || `HTTP ${res.status}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  // ── Sessions ────────────────────────────────────────────────────
+
+  /**
+   * List all sessions, optionally filtered by status or workDir.
+   */
+  async listSessions(filter?: { status?: string; workDir?: string }): Promise<SessionInfo[]> {
+    const response = await this.request<{ sessions: SessionInfo[]; total: number }>('/v1/sessions');
+    let sessions = response.sessions;
+    if (filter?.status) {
+      sessions = sessions.filter((s) => s.status === filter.status);
+    }
+    if (filter?.workDir) {
+      sessions = sessions.filter((s) => isSameOrChildWorkDir(s.workDir, filter.workDir!));
+    }
+    return sessions;
+  }
+
+  /**
+   * Get detailed info for a single session.
+   */
+  async getSession(id: string): Promise<SessionInfo> {
+    this.validateSessionId(id);
+    return this.request<SessionInfo>(`/v1/sessions/${encodeURIComponent(id)}`);
+  }
+
+  /**
+   * Get session health and liveness data.
+   */
+  async getHealth(id: string): Promise<SessionHealth> {
+    this.validateSessionId(id);
+    return this.request<SessionHealth>(`/v1/sessions/${encodeURIComponent(id)}/health`);
+  }
+
+  /**
+   * Read the full message transcript for a session.
+   */
+  async getTranscript(id: string): Promise<MessagesResponse> {
+    this.validateSessionId(id);
+    return this.request<MessagesResponse>(`/v1/sessions/${encodeURIComponent(id)}/read`);
+  }
+
+  /**
+   * Send a text message to a session.
+   */
+  async sendMessage(id: string, text: string): Promise<SendResponse> {
+    this.validateSessionId(id);
+    return this.request<SendResponse>(`/v1/sessions/${encodeURIComponent(id)}/send`, {
+      method: 'POST',
+      body: JSON.stringify({ text }),
+    });
+  }
+
+  /**
+   * Create a new Claude Code session.
+   */
+  async createSession(opts: CreateSessionRequest): Promise<{ id: string; name?: string }> {
+    return this.request<{ id: string; name?: string }>('/v1/sessions', {
+      method: 'POST',
+      body: JSON.stringify(opts),
+    });
+  }
+
+  /**
+   * Kill (terminate) a session.
+   */
+  async killSession(id: string): Promise<OkResponse> {
+    this.validateSessionId(id);
+    return this.request<OkResponse>(`/v1/sessions/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  /**
+   * Approve a pending permission prompt in a session.
+   */
+  async approvePermission(id: string): Promise<OkResponse> {
+    this.validateSessionId(id);
+    return this.request<OkResponse>(`/v1/sessions/${encodeURIComponent(id)}/approve`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Reject a pending permission prompt in a session.
+   */
+  async rejectPermission(id: string): Promise<OkResponse> {
+    this.validateSessionId(id);
+    return this.request<OkResponse>(`/v1/sessions/${encodeURIComponent(id)}/reject`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Escape from ask_question mode (resume control).
+   */
+  async escapeSession(id: string): Promise<OkResponse> {
+    this.validateSessionId(id);
+    return this.request<OkResponse>(`/v1/sessions/${encodeURIComponent(id)}/escape`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Interrupt the running Claude Code session.
+   */
+  async interruptSession(id: string): Promise<OkResponse> {
+    this.validateSessionId(id);
+    return this.request<OkResponse>(`/v1/sessions/${encodeURIComponent(id)}/interrupt`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Capture the current terminal pane content.
+   */
+  async capturePane(id: string): Promise<PaneResponse> {
+    this.validateSessionId(id);
+    return this.request<PaneResponse>(`/v1/sessions/${encodeURIComponent(id)}/pane`);
+  }
+
+  /**
+   * Get session metrics (token usage, duration, tool calls, etc.).
+   */
+  async getSessionMetrics(id: string): Promise<SessionMetrics> {
+    this.validateSessionId(id);
+    return this.request<SessionMetrics>(`/v1/sessions/${encodeURIComponent(id)}/metrics`);
+  }
+
+  /**
+   * Get a summary of the session.
+   */
+  async getSessionSummary(id: string): Promise<SessionSummary> {
+    this.validateSessionId(id);
+    return this.request<SessionSummary>(`/v1/sessions/${encodeURIComponent(id)}/summary`);
+  }
+
+  /**
+   * Execute a bash command in the session (requires auto-approve or approval).
+   */
+  async sendBash(id: string, command: string): Promise<OkResponse> {
+    this.validateSessionId(id);
+    return this.request<OkResponse>(`/v1/sessions/${encodeURIComponent(id)}/bash`, {
+      method: 'POST',
+      body: JSON.stringify({ command }),
+    });
+  }
+
+  /**
+   * Send a Claude Code command (e.g. /exit).
+   */
+  async sendCommand(id: string, command: string): Promise<OkResponse> {
+    this.validateSessionId(id);
+    return this.request<OkResponse>(`/v1/sessions/${encodeURIComponent(id)}/command`, {
+      method: 'POST',
+      body: JSON.stringify({ command }),
+    });
+  }
+
+  /**
+   * Get latency metrics for a session.
+   */
+  async getSessionLatency(id: string): Promise<SessionLatency> {
+    this.validateSessionId(id);
+    return this.request<SessionLatency>(`/v1/sessions/${encodeURIComponent(id)}/latency`);
+  }
+
+  /**
+   * Bulk-create multiple sessions at once.
+   */
+  async batchCreateSessions(sessions: Array<{ workDir: string; name?: string; prompt?: string }>): Promise<BatchResult> {
+    return this.request<BatchResult>('/v1/sessions/batch', {
+      method: 'POST',
+      body: JSON.stringify({ sessions }),
+    });
+  }
+
+  // ── Server ──────────────────────────────────────────────────────
+
+  /**
+   * Get server health and version info.
+   */
+  async getServerHealth(): Promise<HealthResponse> {
+    return this.request<HealthResponse>('/v1/health');
+  }
+
+  /**
+   * Get global metrics across all sessions.
+   */
+  async getGlobalMetrics(): Promise<GlobalMetrics> {
+    return this.request<GlobalMetrics>('/v1/metrics');
+  }
+
+  /**
+   * Get session statistics.
+   */
+  async getSessionStats(): Promise<{ active: number; byStatus: Record<string, number>; totalCreated: number; totalCompleted: number; totalFailed: number }> {
+    return this.request('/v1/stats');
+  }
+
+  // ── Pipelines ───────────────────────────────────────────────────
+
+  /**
+   * List all pipelines.
+   */
+  async listPipelines(): Promise<PipelineState[]> {
+    return this.request<PipelineState[]>('/v1/pipelines');
+  }
+
+  /**
+   * Create a new pipeline.
+   */
+  async createPipeline(config: { name: string; workDir: string; steps: Array<{ name?: string; prompt: string }> }): Promise<PipelineState> {
+    return this.request<PipelineState>('/v1/pipelines', {
+      method: 'POST',
+      body: JSON.stringify(config),
+    });
+  }
+
+  // ── Swarm ───────────────────────────────────────────────────────
+
+  /**
+   * Get swarm status (multi-agent coordination state).
+   */
+  async getSwarm(): Promise<Record<string, unknown>> {
+    return this.request<Record<string, unknown>>('/v1/swarm');
+  }
+
+  // ── Memory ─────────────────────────────────────────────────────
+
+  /**
+   * Store a value in the Aegis memory store.
+   */
+  async setMemory(key: string, value: string, ttlSeconds?: number): Promise<MemoryEntryResponse> {
+    return this.request<MemoryEntryResponse>('/v1/memory', {
+      method: 'POST',
+      body: JSON.stringify({ key, value, ttlSeconds }),
+    });
+  }
+
+  /**
+   * Retrieve a value from the Aegis memory store.
+   */
+  async getMemory(key: string): Promise<MemoryEntryResponse> {
+    return this.request<MemoryEntryResponse>(`/v1/memory/${encodeURIComponent(key)}`);
+  }
+
+  /**
+   * Delete a value from the Aegis memory store.
+   */
+  async deleteMemory(key: string): Promise<OkResponse> {
+    return this.request<OkResponse>(`/v1/memory/${encodeURIComponent(key)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // ── Audit ──────────────────────────────────────────────────────
+
+  /**
+   * List audit records with pagination and filters.
+   */
+  async getAuditLogs(params?: {
+    page?: number;
+    pageSize?: number;
+    actor?: string;
+    action?: string;
+    sessionId?: string;
+  }): Promise<AuditPageResponse> {
+    const qs = new URLSearchParams();
+    if (params?.page) qs.set('page', String(params.page));
+    if (params?.pageSize) qs.set('pageSize', String(params.pageSize));
+    if (params?.actor) qs.set('actor', params.actor);
+    if (params?.action) qs.set('action', params.action);
+    if (params?.sessionId) qs.set('sessionId', params.sessionId);
+    const query = qs.toString();
+    return this.request<AuditPageResponse>(`/v1/audit${query ? `?${query}` : ''}`);
+  }
+}
+
+// ── Re-exported types (convenience) ─────────────────────────────────
+
+export type { SessionHealth } from './types.js';
+
+export default AegisClient;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * @aegis/client — Official TypeScript client for Aegis Bridge.
+ *
+ * @example
+ * import { AegisClient, type SessionInfo } from '@aegis/client';
+ *
+ * const client = new AegisClient('http://localhost:18792', 'your-token');
+ * const sessions = await client.listSessions();
+ */
+
+export { AegisClient, type AegisClientOptions } from './AegisClient.js';
+export type {
+  // Session
+  SessionInfo,
+  SessionHealth,
+  SessionSummary,
+  SessionMetrics,
+  SessionLatency,
+  MessagesResponse,
+  ParsedEntry,
+  CreateSessionRequest,
+  OkResponse,
+  SendResponse,
+  PaneResponse,
+  // Server
+  HealthResponse,
+  GlobalMetrics,
+  // Pagination
+  SessionsListResponse,
+  SessionStatusCounts,
+  SessionStats,
+  // Batch
+  BatchResult,
+  BatchDeleteRequest,
+  BatchDeleteResponse,
+  // Pipeline
+  PipelineState,
+  // Memory
+  MemoryEntryResponse,
+  // SSE
+  SSEEventType,
+  SessionSSEEvent,
+  GlobalSSEEventType,
+  GlobalSSEEvent,
+  // Metrics
+  LatencySummaryStat,
+  // Audit
+  AuditRecord,
+  AuditPageResponse,
+  // Shared
+  UIState,
+  SessionStatusFilter,
+  ApiError,
+} from './types.js';

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,0 +1,356 @@
+/**
+ * types.ts — Aegis API contract types.
+ *
+ * Shared type definitions for the Aegis HTTP API.
+ * Import this in your application to get full type safety.
+ *
+ * @example
+ * import { AegisClient, type SessionInfo, type UIState } from '@aegis/client';
+ *
+ * const client = new AegisClient('http://localhost:18792', 'your-token');
+ * const sessions = await client.listSessions();
+ */
+
+// ── Primitive & shared types ────────────────────────────────────────
+
+export type UIState =
+  | 'idle'
+  | 'working'
+  | 'compacting'
+  | 'context_warning'
+  | 'waiting_for_input'
+  | 'permission_prompt'
+  | 'plan_mode'
+  | 'ask_question'
+  | 'bash_approval'
+  | 'settings'
+  | 'error'
+  | 'unknown';
+
+export type SessionStatusFilter = 'all' | UIState;
+
+// ── Session types ────────────────────────────────────────────────────
+
+export interface SessionInfo {
+  id: string;
+  windowId: string;
+  windowName: string;
+  workDir: string;
+  claudeSessionId?: string;
+  jsonlPath?: string;
+  byteOffset: number;
+  monitorOffset: number;
+  status: UIState;
+  createdAt: number;
+  lastActivity: number;
+  stallThresholdMs: number;
+  permissionMode: string;
+  autoApprove?: boolean;
+  settingsPatched?: boolean;
+  promptDelivery?: { delivered: boolean; attempts: number };
+  actionHints?: Record<string, {
+    method: string;
+    url: string;
+    description: string;
+  }>;
+}
+
+export interface SessionHealth {
+  alive: boolean;
+  windowExists: boolean;
+  claudeRunning: boolean;
+  paneCommand: string | null;
+  status: UIState;
+  hasTranscript: boolean;
+  lastActivity: number;
+  lastActivityAgo: number;
+  sessionAge: number;
+  details: string;
+  actionHints?: Record<string, {
+    method: string;
+    url: string;
+    description: string;
+  }>;
+}
+
+export interface ParsedEntry {
+  role: 'user' | 'assistant' | 'system';
+  contentType: 'text' | 'thinking' | 'tool_use' | 'tool_result' | 'tool_error' | 'permission_request' | 'progress';
+  text: string;
+  toolName?: string;
+  toolUseId?: string;
+  timestamp?: string;
+}
+
+export interface MessagesResponse {
+  messages: ParsedEntry[];
+  status: UIState;
+  statusText: string | null;
+  interactiveContent: string | null;
+}
+
+export interface SessionSummary {
+  sessionId: string;
+  windowName: string;
+  status: UIState;
+  totalMessages: number;
+  messages: Array<{ role: string; contentType: string; text: string }>;
+  createdAt: number;
+  lastActivity: number;
+  permissionMode: string;
+  prd?: string;
+}
+
+export interface PaneResponse {
+  pane: string;
+}
+
+// ── Request/response bodies ─────────────────────────────────────────
+
+export interface CreateSessionRequest {
+  workDir: string;
+  name?: string;
+  prompt?: string;
+  prd?: string;
+  resumeSessionId?: string;
+  claudeCommand?: string;
+  env?: Record<string, string>;
+  stallThresholdMs?: number;
+  permissionMode?: string;
+  autoApprove?: boolean;
+  parentId?: string;
+  memoryKeys?: string[];
+}
+
+export interface OkResponse {
+  ok: boolean;
+}
+
+export interface SendResponse extends OkResponse {
+  delivered: boolean;
+  attempts: number;
+}
+
+export interface ApiError {
+  error: string;
+}
+
+// ── Server health ───────────────────────────────────────────────────
+
+export interface HealthResponse {
+  status: string;
+  version: string;
+  platform: string;
+  uptime: number;
+  sessions: {
+    active: number;
+    total: number;
+  };
+  timestamp: string;
+}
+
+// ── Metrics ─────────────────────────────────────────────────────────
+
+export interface LatencySummaryStat {
+  min: number | null;
+  max: number | null;
+  avg: number | null;
+  count: number;
+}
+
+export interface SessionMetrics {
+  durationSec: number;
+  messages: number;
+  toolCalls: number;
+  approvals: number;
+  autoApprovals: number;
+  statusChanges: string[];
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    estimatedCostUsd: number;
+  };
+}
+
+export interface SessionLatency {
+  sessionId: string;
+  realtime: {
+    hook_latency_ms: number | null;
+    state_change_detection_ms: number | null;
+    permission_response_ms: number | null;
+  } | null;
+  aggregated: {
+    hook_latency_ms: LatencySummaryStat;
+    state_change_detection_ms: LatencySummaryStat;
+    permission_response_ms: LatencySummaryStat;
+    channel_delivery_ms: LatencySummaryStat;
+  } | null;
+}
+
+export interface GlobalMetrics {
+  uptime: number;
+  sessions: {
+    total_created: number;
+    currently_active: number;
+    completed: number;
+    failed: number;
+    avg_duration_sec: number;
+    avg_messages_per_session: number;
+  };
+  auto_approvals: number;
+  webhooks_sent: number;
+  webhooks_failed: number;
+  screenshots_taken: number;
+  pipelines_created: number;
+  batches_created: number;
+  prompt_delivery: {
+    sent: number;
+    delivered: number;
+    failed: number;
+    success_rate: number | null;
+  };
+  latency: {
+    hook_latency_ms: LatencySummaryStat;
+    state_change_detection_ms: LatencySummaryStat;
+    permission_response_ms: LatencySummaryStat;
+    channel_delivery_ms: LatencySummaryStat;
+  };
+}
+
+// ── SSE events ─────────────────────────────────────────────────────
+
+export type SSEEventType =
+  | 'status'
+  | 'message'
+  | 'approval'
+  | 'ended'
+  | 'heartbeat'
+  | 'stall'
+  | 'dead'
+  | 'system'
+  | 'hook'
+  | 'subagent_start'
+  | 'subagent_stop'
+  | 'verification'
+  | 'permission_denied';
+
+export interface SessionSSEEvent {
+  event: SSEEventType;
+  sessionId: string;
+  timestamp: string;
+  emittedAt?: number;
+  id?: number;
+  data: Record<string, unknown>;
+}
+
+export type GlobalSSEEventType =
+  | 'session_status_change'
+  | 'session_message'
+  | 'session_approval'
+  | 'session_ended'
+  | 'session_created'
+  | 'session_stall'
+  | 'session_dead'
+  | 'session_subagent_start'
+  | 'session_subagent_stop'
+  | 'session_verification';
+
+export interface GlobalSSEEvent {
+  event: GlobalSSEEventType;
+  sessionId: string;
+  timestamp: string;
+  id?: number;
+  data: Record<string, unknown>;
+}
+
+// ── Pagination ─────────────────────────────────────────────────────
+
+export interface SessionsListResponse {
+  sessions: SessionInfo[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export type SessionStatusCounts = Record<SessionStatusFilter, number>;
+
+// ── Session stats ─────────────────────────────────────────────────
+
+export interface SessionStats {
+  active: number;
+  byStatus: Partial<Record<UIState, number>>;
+  totalCreated: number;
+  totalCompleted: number;
+  totalFailed: number;
+}
+
+// ── Batch operations ───────────────────────────────────────────────
+
+export interface BatchDeleteRequest {
+  ids?: string[];
+  status?: UIState;
+}
+
+export interface BatchDeleteResponse {
+  deleted: number;
+  notFound: string[];
+  errors: string[];
+}
+
+export interface BatchResult {
+  sessions: Array<{
+    id: string;
+    name: string;
+    promptDelivery?: { delivered: boolean; attempts: number };
+  }>;
+  created: number;
+  failed: number;
+  errors: string[];
+}
+
+// ── Pipeline ───────────────────────────────────────────────────────
+
+export interface PipelineState {
+  id: string;
+  name: string;
+  currentStage: 'plan' | 'execute' | 'verify' | 'fix' | 'submit' | 'done';
+  status: 'running' | 'completed' | 'failed';
+  retryCount: number;
+  maxRetries: number;
+  stageHistory: Array<{
+    stage: string;
+    enteredAt: number;
+    exitedAt?: number;
+  }>;
+}
+
+// ── Memory ────────────────────────────────────────────────────────
+
+export interface MemoryEntryResponse {
+  key: string;
+  value: string;
+  expiresAt?: number;
+}
+
+// ── Audit ─────────────────────────────────────────────────────────
+
+export interface AuditRecord {
+  id: string;
+  timestamp: string;
+  actor: string;
+  action: string;
+  sessionId?: string;
+  detail?: string;
+}
+
+export interface AuditPageResponse {
+  records: AuditRecord[];
+  total: number;
+  page: number;
+  pageSize: number;
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "nodenext",
+    "target": "es2022",
+    "types": [],
+    "sourceMap": false,
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedSideEffectImports": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/channels/email.ts
+++ b/src/channels/email.ts
@@ -1,0 +1,252 @@
+/**
+ * channels/email.ts — Email notification channel.
+ *
+ * Sends session events to ops email on stall/dead events.
+ * Configure via AEGIS_EMAIL_* env vars.
+ *
+ * @example
+ * // env:
+ * //   AEGIS_EMAIL_HOST=smtp.example.com
+ * //   AEGIS_EMAIL_PORT=587
+ * //   AEGIS_EMAIL_USER=alerts@example.com
+ * //   AEGIS_EMAIL_PASS=...
+ * //   AEGIS_EMAIL_TO=ops@example.com
+ * //   AEGIS_EMAIL_FROM=aegis@example.com
+ * const channel = EmailChannel.fromEnv();
+ */
+
+import type { Transporter } from 'nodemailer';
+import type {
+  Channel,
+  SessionEvent,
+  SessionEventPayload,
+} from './types.js';
+
+export interface EmailChannelConfig {
+  /** SMTP host. */
+  host: string;
+  /** SMTP port (default: 587). */
+  port?: number;
+  /** SMTP secure (default: false, true for 465). */
+  secure?: boolean;
+  /** SMTP username. */
+  user: string;
+  /** SMTP password or API key. */
+  pass: string;
+  /** Destination email address. */
+  to: string;
+  /** Sender email address. */
+  from: string;
+  /** Optional: only fire on these events. Omit = stall/dead events only. */
+  events?: SessionEvent[];
+  /** Connection timeout in ms (default: 10000). */
+  timeoutMs?: number;
+}
+
+interface EmailHealthStatus {
+  channel: string;
+  healthy: boolean;
+  lastSuccess: number | null;
+  lastError: string | null;
+  pendingCount: number;
+}
+
+export class EmailChannel implements Channel {
+  readonly name = 'email';
+
+  private transporter: Transporter;
+  private to: string;
+  private from: string;
+  private events?: SessionEvent[];
+  private lastSuccess: number | null = null;
+  private lastError: string | null = null;
+  private deadLetterQueue: Array<{ timestamp: string; endpoint: string; event: SessionEvent; error: string; attempts: number }> = [];
+  static readonly DLQ_MAX_SIZE = 50;
+  static readonly DEFAULT_EVENTS: SessionEvent[] = ['status.stall', 'status.dead', 'status.error', 'status.permission_timeout'];
+
+  constructor(config: EmailChannelConfig, transporter: Transporter) {
+    this.transporter = transporter;
+    this.to = config.to;
+    this.from = config.from;
+    this.events = config.events;
+    this.lastSuccess = null;
+    this.lastError = null;
+  }
+
+  static fromEnv(): EmailChannel | null {
+    const host = process.env.AEGIS_EMAIL_HOST;
+    const user = process.env.AEGIS_EMAIL_USER;
+    const pass = process.env.AEGIS_EMAIL_PASS;
+    const to = process.env.AEGIS_EMAIL_TO;
+    const from = process.env.AEGIS_EMAIL_FROM ?? 'aegis@localhost';
+
+    if (!host || !user || !pass || !to) return null;
+
+    // Lazy-import nodemailer so the rest of the app doesn't need it
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nodemailer = require('nodemailer');
+
+    const port = parseInt(process.env.AEGIS_EMAIL_PORT ?? '587', 10);
+    const secure = process.env.AEGIS_EMAIL_SECURE === 'true' || port === 465;
+
+    const transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure,
+      auth: { user, pass },
+      connectionTimeout: parseInt(process.env.AEGIS_EMAIL_TIMEOUT_MS ?? '10000', 10),
+    });
+
+    let events: SessionEvent[] | undefined;
+    const rawEvents = process.env.AEGIS_EMAIL_EVENTS;
+    if (rawEvents) {
+      try {
+        events = JSON.parse(rawEvents) as SessionEvent[];
+      } catch {
+        events = EmailChannel.DEFAULT_EVENTS;
+      }
+    } else {
+      events = EmailChannel.DEFAULT_EVENTS;
+    }
+
+    return new EmailChannel({ host, port, secure, user, pass, to, from, events }, transporter);
+  }
+
+  filter(event: SessionEvent): boolean {
+    const allowed = this.events ?? EmailChannel.DEFAULT_EVENTS;
+    return allowed.includes(event);
+  }
+
+  async onStatusChange(payload: SessionEventPayload): Promise<void> {
+    if (!this.filter(payload.event)) return;
+    await this.send(payload);
+  }
+
+  private async send(payload: SessionEventPayload): Promise<void> {
+    const subject = this.buildSubject(payload);
+    const html = this.buildHtml(payload);
+    const text = this.buildText(payload);
+
+    try {
+      const result = await this.transporter.sendMail({
+        from: this.from,
+        to: this.to,
+        subject,
+        text,
+        html,
+      });
+      this.lastSuccess = Date.now();
+      this.lastError = null;
+      console.log(`[email] Sent ${payload.event} email to ${this.to}, messageId: ${result.messageId}`);
+    } catch (e: unknown) {
+      const error = e instanceof Error ? e.message : String(e);
+      this.lastError = error;
+      console.error(`[email] Failed to send ${payload.event} email: ${error}`);
+      this.pushDLQ(payload.event, error);
+    }
+  }
+
+  private buildSubject(payload: SessionEventPayload): string {
+    const prefix = this.eventSubjectPrefix(payload.event);
+    return `[Aegis] ${prefix} — ${payload.session.name}`;
+  }
+
+  private buildHtml(payload: SessionEventPayload): string {
+    const color = this.eventColor(payload.event);
+    const eventLabel = payload.event.replace(/[._]/g, ' ');
+    return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto;">
+  <div style="border-left: 4px solid ${color}; padding: 16px 20px; background: #f9f9f9;">
+    <h2 style="margin: 0 0 12px; color: ${color};">Aegis — ${this.formatEvent(payload.event)}</h2>
+    <table style="width: 100%; border-collapse: collapse;">
+      <tr><td style="padding: 4px 0; color: #666;">Session</td><td style="padding: 4px 0; font-weight: bold;">${this.escapeHtml(payload.session.name)}</td></tr>
+      <tr><td style="padding: 4px 0; color: #666;">Session ID</td><td style="padding: 4px 0; font-family: monospace;">${this.escapeHtml(payload.session.id)}</td></tr>
+      <tr><td style="padding: 4px 0; color: #666;">WorkDir</td><td style="padding: 4px 0; font-family: monospace; font-size: 12px;">${this.escapeHtml(payload.session.workDir)}</td></tr>
+      <tr><td style="padding: 4px 0; color: #666;">Event</td><td style="padding: 4px 0;"><code>${eventLabel}</code></td></tr>
+      <tr><td style="padding: 4px 0; color: #666;">Detail</td><td style="padding: 4px 0;">${this.escapeHtml(payload.detail)}</td></tr>
+      <tr><td style="padding: 4px 0; color: #666;">Time</td><td style="padding: 4px 0;">${new Date(payload.timestamp).toISOString()}</td></tr>
+    </table>
+  </div>
+</body>
+</html>`;
+  }
+
+  private buildText(payload: SessionEventPayload): string {
+    return `Aegis — ${this.formatEvent(payload.event)}
+
+Session: ${payload.session.name} (${payload.session.id})
+WorkDir: ${payload.session.workDir}
+Event: ${payload.event}
+Detail: ${payload.detail}
+Time: ${new Date(payload.timestamp).toISOString()}`;
+  }
+
+  private eventSubjectPrefix(event: SessionEvent): string {
+    switch (event) {
+      case 'status.stall': return '[ACTION] Session Stalled';
+      case 'status.dead': return '[CRITICAL] Session Dead';
+      case 'status.error': return '[ERROR] Session Error';
+      case 'status.permission_timeout': return '[WARNING] Permission Timeout';
+      case 'session.created': return 'Session Created';
+      case 'session.ended': return 'Session Ended';
+      default: return `Event: ${event}`;
+    }
+  }
+
+  private eventColor(event: SessionEvent): string {
+    switch (event) {
+      case 'status.stall': return '#ffcc00';
+      case 'status.dead': return '#dc3545';
+      case 'status.error': return '#dc3545';
+      case 'status.permission_timeout': return '#fd7e14';
+      case 'session.created': return '#28a745';
+      case 'session.ended': return '#6c757d';
+      default: return '#007bff';
+    }
+  }
+
+  private formatEvent(event: SessionEvent): string {
+    return event.replace(/[._]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  private pushDLQ(event: SessionEvent, error: string): void {
+    this.deadLetterQueue.unshift({
+      timestamp: new Date().toISOString(),
+      endpoint: this.to,
+      event,
+      error,
+      attempts: 1,
+    });
+    if (this.deadLetterQueue.length > EmailChannel.DLQ_MAX_SIZE) {
+      this.deadLetterQueue.length = EmailChannel.DLQ_MAX_SIZE;
+    }
+  }
+
+  getDeadLetterQueue() {
+    return this.deadLetterQueue;
+  }
+
+  getHealth(): EmailHealthStatus {
+    return {
+      channel: this.name,
+      healthy: this.lastError === null,
+      lastSuccess: this.lastSuccess,
+      lastError: this.lastError,
+      pendingCount: 0,
+    };
+  }
+
+  async destroy(): Promise<void> {
+    this.transporter.close();
+  }
+}

--- a/src/channels/email.ts
+++ b/src/channels/email.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Transporter } from 'nodemailer';
+import nodemailer from 'nodemailer';
 import type {
   Channel,
   SessionEvent,
@@ -82,9 +83,6 @@ export class EmailChannel implements Channel {
 
     if (!host || !user || !pass || !to) return null;
 
-    // Lazy-import nodemailer so the rest of the app doesn't need it
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const nodemailer = require('nodemailer');
 
     const port = parseInt(process.env.AEGIS_EMAIL_PORT ?? '587', 10);
     const secure = process.env.AEGIS_EMAIL_SECURE === 'true' || port === 465;

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -37,3 +37,7 @@ export {
   type DecisionOption,
   type ProgressStep,
 } from './telegram-style.js';
+
+// M-E5: Notification channels
+export { SlackChannel, type SlackChannelConfig } from './slack.js';
+export { EmailChannel, type EmailChannelConfig } from './email.js';

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -1,0 +1,228 @@
+/**
+ * channels/slack.ts — Slack notification channel.
+ *
+ * Sends session events to Slack channels via Incoming Webhooks.
+ * Configure via AEGIS_SLACK_WEBHOOK_URL env var.
+ *
+ * @example
+ * // env: AEGIS_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx
+ * const channel = SlackChannel.fromEnv();
+ */
+
+import type {
+  Channel,
+  SessionEvent,
+  SessionEventPayload,
+} from './types.js';
+
+export interface SlackChannelConfig {
+  /** Incoming webhook URL from Slack Apps. */
+  webhookUrl: string;
+  /** Optional: only fire on these events. Omit = all events. */
+  events?: SessionEvent[];
+  /** Optional: default channel override (for Slack API bots). */
+  channel?: string;
+  /** Timeout in ms (default: 5000). */
+  timeoutMs?: number;
+}
+
+interface SlackBlock {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface SlackPayload {
+  text: string;
+  blocks?: SlackBlock[];
+  attachments?: Array<{ color: string; blocks: SlackBlock[] }>;
+}
+
+export class SlackChannel implements Channel {
+  readonly name = 'slack';
+
+  private webhookUrl: string;
+  private events?: SessionEvent[];
+  private channel?: string;
+  private timeoutMs: number;
+  private deadLetterQueue: Array<{ timestamp: string; endpoint: string; event: SessionEvent; error: string; attempts: number }> = [];
+  static readonly DLQ_MAX_SIZE = 100;
+
+  constructor(config: SlackChannelConfig) {
+    this.webhookUrl = config.webhookUrl;
+    this.events = config.events;
+    this.channel = config.channel;
+    this.timeoutMs = config.timeoutMs ?? 5000;
+  }
+
+  static fromEnv(): SlackChannel | null {
+    const webhookUrl = process.env.AEGIS_SLACK_WEBHOOK_URL;
+    if (!webhookUrl) return null;
+
+    let events: SessionEvent[] | undefined;
+    const rawEvents = process.env.AEGIS_SLACK_EVENTS;
+    if (rawEvents) {
+      try {
+        events = JSON.parse(rawEvents) as SessionEvent[];
+      } catch {
+        console.error('Failed to parse AEGIS_SLACK_EVENTS, ignoring');
+      }
+    }
+
+    const channel = process.env.AEGIS_SLACK_CHANNEL;
+    const timeoutMs = parseInt(process.env.AEGIS_SLACK_TIMEOUT_MS ?? '5000', 10);
+
+    return new SlackChannel({ webhookUrl, events, channel, timeoutMs });
+  }
+
+  filter(event: SessionEvent): boolean {
+    if (!this.events || this.events.length === 0) return true;
+    return this.events.includes(event);
+  }
+
+  async onSessionCreated(payload: SessionEventPayload): Promise<void> {
+    await this.fire(payload, 'session_created');
+  }
+
+  async onSessionEnded(payload: SessionEventPayload): Promise<void> {
+    await this.fire(payload, 'session_ended');
+  }
+
+  async onMessage(payload: SessionEventPayload): Promise<void> {
+    await this.fire(payload, 'message');
+  }
+
+  async onStatusChange(payload: SessionEventPayload): Promise<void> {
+    await this.fire(payload, 'status_change');
+  }
+
+  private async fire(payload: SessionEventPayload, _eventType: string): Promise<void> {
+    const body = this.buildPayload(payload);
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+      const res = await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      if (!res.ok) {
+        throw new Error(`Slack API error: HTTP ${res.status} ${res.statusText}`);
+      }
+    } catch (e: unknown) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.error(`[slack] Delivery failed for event ${payload.event}: ${error}`);
+      this.pushDLQ(payload.event, error);
+    }
+  }
+
+  private buildPayload(payload: SessionEventPayload): SlackPayload {
+    const emoji = this.eventEmoji(payload.event);
+    const statusColor = this.eventColor(payload.event);
+    const text = `${emoji} Aegis: ${payload.detail}`;
+
+    const blocks: SlackBlock[] = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Aegis Event*\n*${this.formatEvent(payload.event)}*`,
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Session:* \`${payload.session.name}\` (\`${payload.session.id}\`)\n*Detail:* ${payload.detail}`,
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `WorkDir: \`${payload.session.workDir}\` • ${new Date(payload.timestamp).toISOString()}`,
+          },
+        ],
+      },
+    ];
+
+    return {
+      text,
+      blocks,
+      attachments: [
+        {
+          color: statusColor,
+          blocks: [],
+        },
+      ],
+    };
+  }
+
+  private eventEmoji(event: SessionEvent): string {
+    switch (event) {
+      case 'session.created': return ':large_green_circle:';
+      case 'session.ended': return ':grey_circle:';
+      case 'status.working': return ':hourglass_flowing_sand:';
+      case 'status.stall': return ':warning:';
+      case 'status.dead': return ':skull:';
+      case 'status.error': return ':x:';
+      case 'status.idle': return ':white_circle:';
+      case 'status.permission': return ':lock:';
+      case 'status.question': return ':question:';
+      case 'status.plan': return ':thought_balloon:';
+      case 'message.user': return ':bust_in_silhouette:';
+      case 'message.assistant': return ':robot_face:';
+      case 'message.tool_use': return ':wrench:';
+      case 'message.tool_result': return ':checkered_flag:';
+      default: return ':bell:';
+    }
+  }
+
+  private eventColor(event: SessionEvent): string {
+    switch (event) {
+      case 'status.stall': return '#ffcc00';
+      case 'status.dead': return '#dc3545';
+      case 'status.error': return '#dc3545';
+      case 'status.working': return '#17a2b8';
+      case 'session.created': return '#28a745';
+      case 'session.ended': return '#6c757d';
+      default: return '#007bff';
+    }
+  }
+
+  private formatEvent(event: SessionEvent): string {
+    return event.replace(/[._]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  private pushDLQ(event: SessionEvent, error: string): void {
+    this.deadLetterQueue.unshift({
+      timestamp: new Date().toISOString(),
+      endpoint: this.webhookUrl,
+      event,
+      error,
+      attempts: 1,
+    });
+    if (this.deadLetterQueue.length > SlackChannel.DLQ_MAX_SIZE) {
+      this.deadLetterQueue.length = SlackChannel.DLQ_MAX_SIZE;
+    }
+  }
+
+  getDeadLetterQueue() {
+    return this.deadLetterQueue;
+  }
+
+  getHealth() {
+    return {
+      channel: this.name,
+      healthy: true,
+      lastSuccess: null,
+      lastError: this.deadLetterQueue[0]?.error ?? null,
+      pendingCount: 0,
+    };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,8 @@ import { JsonlWatcher } from './jsonl-watcher.js';
 import {
   ChannelManager,
   TelegramChannel,
+  SlackChannel,
+  EmailChannel,
   WebhookChannel,
   type InboundCommand,
   type SessionEvent,
@@ -1989,6 +1991,18 @@ function registerChannels(cfg: Config): void {
       endpoints: cfg.webhooks.map(url => ({ url })),
     });
     channels.register(webhookChannel);
+  }
+
+  // Slack (optional)
+  const slackChannel = SlackChannel.fromEnv();
+  if (slackChannel) {
+    channels.register(slackChannel);
+  }
+
+  // Email (optional)
+  const emailChannel = EmailChannel.fromEnv();
+  if (emailChannel) {
+    channels.register(emailChannel);
   }
 }
 


### PR DESCRIPTION
## Summary

Completes M-E5 API & Integration milestone with two deliverables:

### 1. TypeScript Client SDK (#1440)

New  npm package under :

src/types.ts - All 30+ API contract types (SessionInfo, UIState, etc.)
src/AegisClient.ts - HTTP API client with full endpoint coverage
src/index.ts - Public exports

AegisClient features:
- Works in Node.js and browser
- X-Aegis-API-Version: 1 header on all requests
- Configurable timeouts
- All session, health, metrics, pipeline, memory, audit endpoints

Usage:
import { AegisClient } from '@aegis/client';
const client = new AegisClient('http://localhost:18792', token);
const sessions = await client.listSessions();

### 2. Notification Channels (#1442)

New Slack and Email channels:

src/channels/slack.ts - Slack incoming webhooks for session events
src/channels/email.ts - SMTP/Nodemailer for stall/dead/error alerts

Configuration via env vars:
AEGIS_SLACK_WEBHOOK_URL - Slack webhook URL
AEGIS_EMAIL_HOST/PORT/USER/PASS/TO - SMTP config

Both channels implement the Channel interface with DLQ support and health status.

## Checklist

- [x] TypeScript compiles with 0 errors
- [x] Tests pass (2526 passed)
- [x] X-Aegis-API-Version header on all requests
- [x] nodemailer added as dependency
- [x] Version: 0.3.2-alpha

---

Aegis version: 0.3.2-alpha
Milestone: M-E5 API & Integration
Assignee: Scribe