### PR TITLE
feat(dashboard): add session owner/createdBy display (E6-3)

### DIFF
--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -62,6 +62,7 @@ const sessions: SessionInfo[] = [
     permissionMode: 'default',
     byteOffset: 0,
     monitorOffset: 0,
+    ownerKeyId: 'ak_test_alpha_key',
   },
   {
     id: 's2',
@@ -348,5 +349,38 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     await waitFor(() => {
       expect(screen.getByText('Polling fallback')).toBeTruthy();
     });
+  });
+
+  it('renders "Created by" column header in desktop table', async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+    });
+
+    expect(screen.getByRole('columnheader', { name: /Created by/i })).toBeTruthy();
+  });
+
+  it('shows truncated ownerKeyId for sessions that have one', async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+    });
+
+    // alpha has ownerKeyId: 'ak_test_alpha_key' → truncated to 'ak_test_…'
+    expect(screen.getByText('ak_test_…')).toBeTruthy();
+  });
+
+  it('shows em dash for sessions without ownerKeyId', async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('bravo').length).toBeGreaterThan(0);
+    });
+
+    // bravo has no ownerKeyId → should show '—'
+    const emDashes = screen.getAllByText('\u2014');
+    expect(emDashes.length).toBeGreaterThan(0);
   });
 });

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -256,6 +256,10 @@ const SessionDesktopRow = memo(function SessionDesktopRow({
         </div>
       </td>
 
+      <td className="hidden md:table-cell whitespace-nowrap px-4 py-3 font-mono text-xs text-zinc-400">
+        {session.ownerKeyId ? `${session.ownerKeyId.slice(0, 8)}${session.ownerKeyId.length > 8 ? '…' : ''}` : '\u2014'}
+      </td>
+
       <td className="px-4 py-3">
         <Link
           to={`/sessions/${encodeURIComponent(session.id)}`}
@@ -801,6 +805,7 @@ export default function SessionTable() {
                     />
                   </th>
                   <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="hidden md:table-cell px-4 py-3 font-medium">Created by</th>
                   <th className="px-4 py-3 font-medium">Name</th>
                   <th className="px-4 py-3 font-medium">WorkDir</th>
                   <th className="px-4 py-3 font-medium">Age</th>

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -93,6 +93,9 @@ export function SessionHeader({ session, health, onApprove, onReject, onInterrup
         <span>Created: {formatDate(session.createdAt)}</span>
         <span className="hidden sm:inline">Last activity: {formatDate(session.lastActivity)}</span>
         <span className="font-mono hidden sm:inline">ID: {truncateMiddle(session.id, 16)}</span>
+        {session.ownerKeyId && (
+          <span className="font-mono hidden sm:inline">Owner: {session.ownerKeyId.slice(0, 8)}{session.ownerKeyId.length > 8 ? '…' : ''}</span>
+        )}
         {health.details && <span className="text-[#888] italic">{health.details}</span>}
       </div>
 


### PR DESCRIPTION
## Summary
Implements E6-3 from enterprise-review — session owner visibility.

### Changes (3 files, +42)
- **SessionTable.tsx** — Created by column showing ownerKeyId (truncated to 8 chars), hidden on mobile
- **SessionHeader.tsx** — Owner key displayed in session detail header
- **SessionTable.test.tsx** — 2 tests: ownerKeyId rendering, fallback for undefined

### Quality Gate
- ✅ TSC clean
- ✅ Build passed
- ✅ 267 tests passed, 0 failed

Refs: enterprise-review E6-3