### PR TITLE
fix(auth): add API key expiry support (E2-3) (#1436)

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -94,6 +94,30 @@ describe('Authentication and API key management (Issue #39)', () => {
       const result = withMaster.validate('wrong-token');
       expect(result.valid).toBe(false);
     });
+
+    it('should reject an expired key (#1436)', async () => {
+      const { key } = await auth.createKey('expiring-key', 100, 1);
+      // Manually backdate expiresAt to simulate expiry
+      const stored = (auth as any).store.keys[0];
+      stored.expiresAt = Date.now() - 1000;
+      const result = auth.validate(key);
+      expect(result.valid).toBe(false);
+      expect(result.keyId).toBeNull();
+    });
+
+    it('should accept a non-expired key with ttl (#1436)', async () => {
+      const { key, expiresAt } = await auth.createKey('future-key', 100, 30);
+      expect(expiresAt).not.toBeNull();
+      expect(expiresAt).toBeGreaterThan(Date.now());
+      const result = auth.validate(key);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accept a key without expiry (null expiresAt) (#1436)', async () => {
+      const { key } = await auth.createKey('no-expiry-key');
+      const result = auth.validate(key);
+      expect(result.valid).toBe(true);
+    });
   });
 
   describe('Rate limiting', () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -20,6 +20,7 @@ export interface ApiKey {
   createdAt: number;
   lastUsedAt: number;
   rateLimit: number;     // requests per minute
+  expiresAt: number | null; // Unix timestamp (ms), null = never expires
 }
 
 export interface ApiKeyStore {
@@ -122,10 +123,15 @@ export class AuthManager {
   }
 
   /** Create a new API key. Returns the plaintext key (only shown once). */
-  async createKey(name: string, rateLimit = 100): Promise<{ id: string; key: string; name: string }> {
+  async createKey(
+    name: string,
+    rateLimit = 100,
+    ttlDays?: number,
+  ): Promise<{ id: string; key: string; name: string; expiresAt: number | null }> {
     const id = randomBytes(8).toString('hex');
     const key = `aegis_${randomBytes(32).toString('hex')}`;
     const hash = AuthManager.hashKey(key);
+    const expiresAt = ttlDays ? Date.now() + ttlDays * 86_400_000 : null;
 
     const apiKey: ApiKey = {
       id,
@@ -134,12 +140,13 @@ export class AuthManager {
       createdAt: Date.now(),
       lastUsedAt: 0,
       rateLimit,
+      expiresAt,
     };
 
     this.store.keys.push(apiKey);
     await this.save();
 
-    return { id, key, name };
+    return { id, key, name, expiresAt };
   }
 
   /** List keys (without hashes). */
@@ -181,6 +188,11 @@ export class AuthManager {
     const hash = AuthManager.hashKey(token);
     const key = this.store.keys.find(k => k.hash === hash);
     if (!key) {
+      return { valid: false, keyId: null, rateLimited: false };
+    }
+
+    // #1436: Reject expired keys
+    if (key.expiresAt !== null && Date.now() > key.expiresAt) {
       return { valid: false, keyId: null, rateLimited: false };
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -535,8 +535,8 @@ app.post('/v1/auth/keys', async (req, reply) => {
   if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
   const parsed = authKeySchema.safeParse(req.body);
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
-  const { name, rateLimit } = parsed.data;
-  const result = await auth.createKey(name, rateLimit);
+  const { name, rateLimit, ttlDays } = parsed.data;
+  const result = await auth.createKey(name, rateLimit, ttlDays);
   return reply.status(201).send(result);
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -17,6 +17,7 @@ export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9
 export const authKeySchema = z.object({
   name: z.string().min(1),
   rateLimit: z.number().int().positive().optional(),
+  ttlDays: z.number().int().positive().optional(),
 }).strict();
 
 /** Maximum length for user-supplied prompts/commands (Issue #411). */
@@ -279,6 +280,7 @@ export const authStoreSchema = z.object({
     createdAt: z.number(),
     lastUsedAt: z.number(),
     rateLimit: z.number(),
+    expiresAt: z.number().nullable().optional().default(null),
   })),
 });
 


### PR DESCRIPTION
## Summary
- Add `expiresAt: number | null` to `ApiKey` interface (Unix timestamp in ms)
- `createKey()` accepts optional `ttlDays` parameter; computes `expiresAt` when provided
- `validate()` rejects keys where `expiresAt` is in the past
- Existing keys without `expiresAt` (null) remain valid — fully backward compatible
- `authStoreSchema` defaults `expiresAt` to `null` for persisted stores missing the field
- `POST /v1/auth/keys` accepts optional `ttlDays` in request body

Closes #1436

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (2573 tests)
- [x] Expired key is rejected by `validate()`
- [x] Non-expired key with TTL is accepted
- [x] Key without expiry (null) is accepted
- [x] Existing tests unaffected

## Aegis version
**Developed with:** v0.3.2-alpha

Generated by Hephaestus (Aegis dev agent)