### PR TITLE
feat(dashboard): add MetricsPanel for observability (M-E3)

### DIFF
--- a/dashboard/src/__tests__/MetricsPanel.test.tsx
+++ b/dashboard/src/__tests__/MetricsPanel.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import MetricsPanel from '../components/overview/MetricsPanel';
+import { useStore } from '../store/useStore';
+
+const mockGetMetrics = vi.fn();
+const mockGetHealth = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getMetrics: (...args: unknown[]) => mockGetMetrics(...args),
+  getHealth: (...args: unknown[]) => mockGetHealth(...args),
+}));
+
+const MOCK_HEALTH = {
+  status: 'ok',
+  version: '2.5.0',
+  uptime: 3600,
+  sessions: {
+    active: 3,
+    total: 42,
+  },
+  timestamp: new Date().toISOString(),
+};
+
+const MOCK_METRICS = {
+  uptime: 3600,
+  sessions: {
+    total_created: 42,
+    currently_active: 3,
+    completed: 30,
+    failed: 2,
+    avg_duration_sec: 245,
+    avg_messages_per_session: 8,
+  },
+  auto_approvals: 5,
+  webhooks_sent: 10,
+  webhooks_failed: 0,
+  screenshots_taken: 0,
+  pipelines_created: 2,
+  batches_created: 1,
+  prompt_delivery: {
+    sent: 100,
+    delivered: 98,
+    failed: 2,
+    success_rate: 98,
+  },
+  latency: {
+    hook_latency_ms: { min: 2, max: 6, avg: 4, count: 10 },
+    state_change_detection_ms: { min: 2, max: 6, avg: 4, count: 10 },
+    permission_response_ms: { min: 20, max: 40, avg: 30, count: 10 },
+    channel_delivery_ms: { min: 3, max: 7, avg: 5, count: 10 },
+  },
+};
+
+describe('MetricsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    useStore.setState({
+      metrics: null,
+      activities: [],
+      sseConnected: false,
+      sseError: null,
+    });
+
+    mockGetMetrics.mockResolvedValue(MOCK_METRICS);
+    mockGetHealth.mockResolvedValue(MOCK_HEALTH);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders without crashing', async () => {
+    const { container } = render(<MetricsPanel />);
+    expect(container).toBeDefined();
+  });
+
+  it('shows loading skeleton initially', () => {
+    mockGetMetrics.mockReturnValue(new Promise(() => {}));
+    mockGetHealth.mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(<MetricsPanel />);
+    expect(container.querySelector('.animate-pulse')).toBeDefined();
+  });
+
+  it('shows metrics data when available', async () => {
+    const { getByText } = render(<MetricsPanel />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(getByText('Active Sessions')).toBeDefined();
+    expect(getByText('Total Sessions')).toBeDefined();
+    expect(getByText('Avg Duration')).toBeDefined();
+    expect(getByText('Uptime')).toBeDefined();
+    expect(getByText('3')).toBeDefined();
+    expect(getByText('42')).toBeDefined();
+  });
+
+  it('shows placeholder when both endpoints fail', async () => {
+    mockGetMetrics.mockRejectedValue(new Error('404'));
+    mockGetHealth.mockRejectedValue(new Error('Network error'));
+
+    const { getByText } = render(<MetricsPanel />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(getByText('Metrics endpoint unavailable — showing placeholder values.')).toBeDefined();
+    expect(getByText('Active Sessions')).toBeDefined();
+    expect(getByText('Total Sessions')).toBeDefined();
+  });
+
+  it('uses health-only data when metrics endpoint fails', async () => {
+    mockGetMetrics.mockRejectedValue(new Error('404'));
+
+    const { getByText, queryByText } = render(<MetricsPanel />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(getByText('Active Sessions')).toBeDefined();
+    expect(getByText('42')).toBeDefined();
+    expect(queryByText('Metrics endpoint unavailable')).toBeNull();
+  });
+
+  it('formats avg duration correctly', async () => {
+    const { getByText } = render(<MetricsPanel />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    // 245 seconds = 4m 5s
+    expect(getByText('4m 5s')).toBeDefined();
+  });
+
+  it('formats uptime correctly', async () => {
+    const { getByText } = render(<MetricsPanel />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    // 3600 seconds = 1h
+    expect(getByText('1h')).toBeDefined();
+  });
+});

--- a/dashboard/src/components/overview/MetricsPanel.tsx
+++ b/dashboard/src/components/overview/MetricsPanel.tsx
@@ -1,0 +1,167 @@
+/**
+ * components/overview/MetricsPanel.tsx — Compact metrics bar for at-a-glance stats.
+ *
+ * Shows 4 key metrics in a single horizontal strip: active sessions, total sessions,
+ * avg duration, and system uptime. Uses /v1/health as the primary data source with
+ * graceful degradation when the metrics endpoint is unavailable.
+ */
+
+import { useCallback, useState } from 'react';
+import { Activity, Clock, Layers, Timer } from 'lucide-react';
+import { getHealth, getMetrics } from '../../api/client.js';
+import { useSseAwarePolling } from '../../hooks/useSseAwarePolling.js';
+import { useStore } from '../../store/useStore.js';
+import type { GlobalMetrics, HealthResponse } from '../../types';
+import { formatUptime } from '../../utils/format';
+
+interface MetricsData {
+  activeSessions: number;
+  totalSessions: number;
+  avgDurationSec: number;
+  uptime: number;
+}
+
+const FALLBACK: MetricsData = {
+  activeSessions: 0,
+  totalSessions: 0,
+  avgDurationSec: 0,
+  uptime: 0,
+};
+
+const PLACEHOLDER: MetricsData = {
+  activeSessions: 0,
+  totalSessions: 0,
+  avgDurationSec: 0,
+  uptime: 0,
+};
+
+function formatDuration(seconds: number): string {
+  if (seconds <= 0) return '—';
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  if (m < 60) return s > 0 ? `${m}m ${s}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return `${h}h ${rm}m`;
+}
+
+interface StatTileProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  color?: string;
+}
+
+function StatTile({ icon, label, value, color = 'text-[#3b82f6]' }: StatTileProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-void-lighter bg-[#111118] px-4 py-3">
+      <div className="flex h-9 w-9 items-center justify-center rounded-md bg-[#1e1e2a] text-[#888]">
+        {icon}
+      </div>
+      <div>
+        <div className="text-xs text-[#666]">{label}</div>
+        <div className={`font-mono text-lg font-semibold ${color}`}>{value}</div>
+      </div>
+    </div>
+  );
+}
+
+export default function MetricsPanel() {
+  const latestActivity = useStore((s) => s.activities[0] ?? null);
+  const sseConnected = useStore((s) => s.sseConnected);
+  const [data, setData] = useState<MetricsData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUnavailable, setIsUnavailable] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    const [metricsResult, healthResult] = await Promise.allSettled([
+      getMetrics(),
+      getHealth(),
+    ]);
+
+    const health = healthResult.status === 'fulfilled' ? healthResult.value : null;
+    const metrics = metricsResult.status === 'fulfilled' ? metricsResult.value : null;
+
+    if (!health && !metrics) {
+      setIsUnavailable(true);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsUnavailable(false);
+
+    const m = metrics as GlobalMetrics | null;
+    const h = health as HealthResponse | null;
+
+    setData({
+      activeSessions: m?.sessions.currently_active ?? h?.sessions.active ?? 0,
+      totalSessions: m?.sessions.total_created ?? h?.sessions.total ?? 0,
+      avgDurationSec: m?.sessions.avg_duration_sec ?? 0,
+      uptime: h?.uptime ?? m?.uptime ?? 0,
+    });
+
+    setIsLoading(false);
+  }, []);
+
+  useSseAwarePolling({
+    refresh: fetchData,
+    sseConnected,
+    eventTrigger: latestActivity,
+    fallbackPollIntervalMs: 10_000,
+    healthyPollIntervalMs: 30_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="animate-pulse rounded-lg border border-void-lighter bg-[#111118] px-4 py-3"
+          >
+            <div className="mb-2 h-3 w-16 rounded bg-[#1e1e2a]" />
+            <div className="h-5 w-20 rounded bg-[#1e1e2a]" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const d = isUnavailable ? PLACEHOLDER : (data ?? FALLBACK);
+
+  return (
+    <div className="space-y-1.5">
+      {isUnavailable && (
+        <p className="text-xs text-gray-500">
+          Metrics endpoint unavailable — showing placeholder values.
+        </p>
+      )}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatTile
+          icon={<Activity className="h-4 w-4" />}
+          label="Active Sessions"
+          value={d.activeSessions}
+          color="text-[#22c55e]"
+        />
+        <StatTile
+          icon={<Layers className="h-4 w-4" />}
+          label="Total Sessions"
+          value={d.totalSessions}
+          color="text-[#3b82f6]"
+        />
+        <StatTile
+          icon={<Timer className="h-4 w-4" />}
+          label="Avg Duration"
+          value={formatDuration(d.avgDurationSec)}
+          color="text-[#f59e0b]"
+        />
+        <StatTile
+          icon={<Clock className="h-4 w-4" />}
+          label="Uptime"
+          value={formatUptime(d.uptime)}
+          color="text-[#a78bfa]"
+        />
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -1,0 +1,67 @@
+/**
+ * components/overview/SessionMobileCard.tsx — Compact card for mobile session list.
+ */
+
+import { memo } from 'react';
+import { Link } from 'react-router-dom';
+import { Clock, Cpu, User } from 'lucide-react';
+import StatusDot from './StatusDot';
+import type { SessionInfo } from '../../types';
+import { formatTimeAgo } from '../../utils/format';
+
+interface SessionMobileCardProps {
+  session: SessionInfo;
+  onInterrupt: (id: string) => void;
+}
+
+export const SessionMobileCard = memo(function SessionMobileCard({
+  session,
+  onInterrupt,
+}: SessionMobileCardProps) {
+  const status = session.status ?? 'unknown';
+  const truncatedName = session.windowName
+    ? session.windowName.length > 30
+      ? session.windowName.slice(0, 30) + '…'
+      : session.windowName
+    : session.id.slice(0, 8);
+
+  return (
+    <Link
+      to={`/sessions/${session.id}`}
+      className="block rounded-lg border border-zinc-800 bg-zinc-900 p-3 transition-colors hover:border-zinc-700 active:bg-zinc-800"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 min-w-0">
+          <StatusDot status={status} />
+          <span className="truncate text-sm font-medium text-zinc-100">
+            {truncatedName}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            onInterrupt(session.id);
+          }}
+          className="shrink-0 rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+          title="Interrupt"
+        >
+          <Cpu className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="mt-1.5 flex items-center gap-3 text-xs text-zinc-500">
+        <span className="flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          {session.createdAt ? formatTimeAgo(session.createdAt) : '—'}
+        </span>
+        {session.ownerKeyId && (
+          <span className="flex items-center gap-1 truncate">
+            <User className="h-3 w-3" />
+            {session.ownerKeyId.slice(0, 8)}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+});

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -5,6 +5,7 @@
 import { useState } from 'react';
 import { Plus } from 'lucide-react';
 import MetricCards from '../components/overview/MetricCards';
+import MetricsPanel from '../components/overview/MetricsPanel';
 import SessionTable from '../components/overview/SessionTable';
 import ActivityStream from '../components/ActivityStream';
 import CreateSessionModal from '../components/CreateSessionModal';
@@ -29,6 +30,8 @@ export default function OverviewPage() {
           New Session
         </button>
       </div>
+
+      <MetricsPanel />
 
       <MetricCards />
 


### PR DESCRIPTION
## Summary
M-E3 observability dashboard prep — MetricsPanel component ready for Prometheus endpoint.

### Changes (4 files, +391)
- **MetricsPanel.tsx** — Compact metrics bar (active/total sessions, uptime), graceful 404 fallback
- **MetricsPanel.test.tsx** — 4 tests (render, loading, error, placeholder)
- **SessionMobileCard.tsx** — Mobile session card component
- **OverviewPage.tsx** — MetricsPanel integrated above MetricCards

### Quality Gate
- ✅ TSC clean
- ✅ Build passed
- ✅ 274 tests passed, 0 failed

Refs: enterprise-review M-E3 Observability