### PR TITLE
fix(reliability): add LRU eviction to TmuxCaptureCache (#1433)

### DIFF
--- a/src/__tests__/tmux-capture-cache.test.ts
+++ b/src/__tests__/tmux-capture-cache.test.ts
@@ -91,4 +91,73 @@ describe('TmuxCaptureCache', () => {
 
     expect(fn).toHaveBeenCalledTimes(4);
   });
+
+  describe('LRU eviction', () => {
+    it('evicts oldest entries when maxEntries is exceeded', async () => {
+      const smallCache = new TmuxCaptureCache(5000, 3);
+      const fn = vi.fn(async (id: string) => `text-${id}`);
+
+      await smallCache.get('win-1', () => fn('1'));
+      await smallCache.get('win-2', () => fn('2'));
+      await smallCache.get('win-3', () => fn('3'));
+      // Adding 4th entry should evict win-1
+      await smallCache.get('win-4', () => fn('4'));
+
+      expect(smallCache.size).toBe(3);
+
+      // win-1 should have been evicted (oldest)
+      const fnRefresh = vi.fn(async () => 'refreshed');
+      await smallCache.get('win-1', fnRefresh);
+      expect(fnRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults maxEntries to 100', () => {
+      const defaultCache = new TmuxCaptureCache();
+      expect((defaultCache as any).maxEntries).toBe(100);
+    });
+
+    it('accessing an entry moves it to most-recent', async () => {
+      const smallCache = new TmuxCaptureCache(5000, 3);
+      const fn = vi.fn(async (id: string) => `text-${id}`);
+
+      await smallCache.get('win-1', () => fn('1'));
+      await smallCache.get('win-2', () => fn('2'));
+      await smallCache.get('win-3', () => fn('3'));
+      // Re-access win-1 to make it most-recent
+      await smallCache.get('win-1', () => fn('1-refresh'));
+      // Add new entry — should evict win-2 (now oldest), not win-1
+      await smallCache.get('win-4', () => fn('4'));
+
+      // win-1 should still be cached (not evicted)
+      const fnCheck = vi.fn(async () => 'new');
+      await smallCache.get('win-1', fnCheck);
+      expect(fnCheck).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('invalidateSession', () => {
+    it('removes all entries with matching prefix', async () => {
+      const fn = vi.fn(async () => 'text');
+      await cache.get('session-abc/win-1', fn);
+      await cache.get('session-abc/win-2', fn);
+      await cache.get('session-xyz/win-1', fn);
+
+      cache.invalidateSession('session-abc/');
+
+      expect(cache.size).toBe(1);
+      // session-xyz/win-1 should still be cached
+      const fnCheck = vi.fn(async () => 'new');
+      await cache.get('session-xyz/win-1', fnCheck);
+      expect(fnCheck).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it('size returns current cache count', async () => {
+    const fn = vi.fn(async () => 'text');
+    expect(cache.size).toBe(0);
+    await cache.get('win-1', fn);
+    expect(cache.size).toBe(1);
+    await cache.get('win-2', fn);
+    expect(cache.size).toBe(2);
+  });
 });

--- a/src/tmux-capture-cache.ts
+++ b/src/tmux-capture-cache.ts
@@ -1,9 +1,11 @@
 /**
- * tmux-capture-cache.ts — TTL-based cache for capture-pane results.
+ * tmux-capture-cache.ts — TTL + LRU cache for capture-pane results.
  *
  * Avoids redundant tmux capture-pane CLI calls when the same window
  * is polled multiple times within a short window (e.g. monitor poll +
  * status check hitting the same pane).
+ *
+ * LRU eviction prevents unbounded growth from dead session entries.
  */
 
 interface CacheEntry {
@@ -12,13 +14,29 @@ interface CacheEntry {
 }
 
 const DEFAULT_TTL_MS = 500;
+const DEFAULT_MAX_ENTRIES = 100;
 
 export class TmuxCaptureCache {
   private cache = new Map<string, CacheEntry>();
   private readonly ttlMs: number;
+  private readonly maxEntries: number;
 
-  constructor(ttlMs: number = DEFAULT_TTL_MS) {
+  constructor(ttlMs: number = DEFAULT_TTL_MS, maxEntries: number = DEFAULT_MAX_ENTRIES) {
     this.ttlMs = ttlMs;
+    this.maxEntries = maxEntries;
+  }
+
+  /** Evict oldest entries when cache exceeds maxEntries. */
+  private evict(): void {
+    while (this.cache.size > this.maxEntries) {
+      // Map iterates in insertion order; first key is the oldest
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.cache.delete(oldestKey);
+      } else {
+        break;
+      }
+    }
   }
 
   /** Return cached capture-pane text if within TTL, otherwise call `captureFn` and cache. */
@@ -27,11 +45,17 @@ export class TmuxCaptureCache {
     const entry = this.cache.get(windowId);
 
     if (entry && now - entry.at < this.ttlMs) {
+      // Move to end (most-recently-used) by re-inserting
+      this.cache.delete(windowId);
+      this.cache.set(windowId, entry);
       return entry.text;
     }
 
     const text = await captureFn();
+    // Delete then re-insert to move to end (most-recently-used)
+    this.cache.delete(windowId);
     this.cache.set(windowId, { text, at: now });
+    this.evict();
     return text;
   }
 
@@ -40,8 +64,22 @@ export class TmuxCaptureCache {
     this.cache.delete(windowId);
   }
 
+  /** Remove all entries matching a session prefix. */
+  invalidateSession(sessionPrefix: string): void {
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(sessionPrefix)) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
   /** Clear all cached entries. */
   clear(): void {
     this.cache.clear();
+  }
+
+  /** Current number of cached entries (useful for diagnostics). */
+  get size(): number {
+    return this.cache.size;
   }
 }


### PR DESCRIPTION
## Problem
TmuxCaptureCache had no eviction policy — dead session entries accumulated indefinitely, causing unbounded memory growth.

## Changes
- **LRU eviction**: Configurable `maxEntries` (default 100). When exceeded, oldest entries are evicted.
- **Access-order tracking**: Cache hits move entries to most-recent position (via delete+reinsert in Map).
- **Session cleanup**: New `invalidateSession(prefix)` method to bulk-remove entries for ended sessions.
- **Diagnostics**: `size` getter for monitoring cache usage.
- **Backward compatible**: Existing API unchanged; new parameters have sensible defaults.

## Tests
- All 33 existing + new tests pass
- New tests: LRU eviction, access-order promotion, session invalidation, size tracking

Closes #1433