### PR TITLE
fix(reliability): add default shouldRetry to retryWithJitter (E2-2) (#1430)

### DIFF
--- a/src/__tests__/retry-1430.test.ts
+++ b/src/__tests__/retry-1430.test.ts
@@ -1,0 +1,101 @@
+/**
+ * retry-1430.test.ts — Tests for Issue #1430 default shouldRetry policy.
+ *
+ * Verifies that retryWithJitter uses error-categories.shouldRetry as the
+ * default when no shouldRetry callback is provided.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { retryWithJitter } from '../retry.js';
+
+describe('Issue #1430: retryWithJitter default shouldRetry', () => {
+  it('stops retrying a 400 validation error with the default policy', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('validation failed: missing required field');
+    });
+
+    await expect(retryWithJitter(fn, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    })).rejects.toThrow('validation failed: missing required field');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying an auth error with the default policy', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('unauthorized: invalid token');
+    });
+
+    await expect(retryWithJitter(fn, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    })).rejects.toThrow('unauthorized: invalid token');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying a permission error with the default policy', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('permission denied');
+    });
+
+    await expect(retryWithJitter(fn, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    })).rejects.toThrow('permission denied');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient network errors with the default policy', async () => {
+    let attempts = 0;
+    const result = await retryWithJitter(async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error('ECONNREFUSED');
+      return 'recovered';
+    }, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    });
+
+    expect(result).toBe('recovered');
+    expect(attempts).toBe(3);
+  });
+
+  it('retries tmux errors with the default policy', async () => {
+    let attempts = 0;
+    const result = await retryWithJitter(async () => {
+      attempts += 1;
+      if (attempts < 2) throw new Error('tmux: no server running');
+      return 'tmux-ok';
+    }, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    });
+
+    expect(result).toBe('tmux-ok');
+    expect(attempts).toBe(2);
+  });
+
+  it('custom shouldRetry still overrides the default', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+
+    // Custom policy that never retries, even for retryable errors
+    await expect(retryWithJitter(fn, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+      shouldRetry: () => false,
+    })).rejects.toThrow('ECONNREFUSED');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,6 +1,13 @@
 /**
  * retry.ts — shared retry helper with bounded exponential backoff + jitter.
+ *
+ * When no `shouldRetry` callback is provided, the default policy uses
+ * `error-categories.shouldRetry(categorize(err))`, which retries only on
+ * transient errors (network, tmux, rate-limit) and rejects immediately on
+ * validation, auth, permission, and not-found errors.
  */
+
+import { shouldRetry as defaultShouldRetry } from './error-categories.js';
 
 export interface RetryOptions {
   maxAttempts?: number;
@@ -33,7 +40,7 @@ export async function retryWithJitter<T>(fn: () => Promise<T>, options: RetryOpt
     } catch (error) {
       lastError = error;
       const isLastAttempt = attempt >= maxAttempts;
-      const canRetry = options.shouldRetry ? options.shouldRetry(error, attempt) : true;
+      const canRetry = options.shouldRetry ? options.shouldRetry(error, attempt) : defaultShouldRetry(error);
       if (isLastAttempt || !canRetry) {
         throw error;
       }


### PR DESCRIPTION
## Summary

- `retryWithJitter` now uses `error-categories.shouldRetry(categorize(err))` as the default policy when no `shouldRetry` callback is provided
- Previously, omitting `shouldRetry` caused **every** error to retry — including auth failures, validation errors, and permission rejections
- Custom `shouldRetry` callbacks still override the default

## Test plan

- [x] Validation error stops after first attempt (no retries)
- [x] Auth error stops after first attempt
- [x] Permission error stops after first attempt
- [x] Transient network errors still retry and recover
- [x] Tmux errors still retry and recover
- [x] Custom `shouldRetry` overrides the default
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 2584 passed, 0 failed

## Aegis version
**Developed with:** v0.3.2-alpha

Closes #1430

Generated by Hephaestus (Aegis dev agent)