### PR TITLE
fix(security): add API key roles RBAC (E2-2) (#1432)

### DIFF
--- a/src/__tests__/auth-rbac.test.ts
+++ b/src/__tests__/auth-rbac.test.ts
@@ -1,0 +1,72 @@
+/**
+ * auth-rbac.test.ts — Tests for Issue #1432: API key roles RBAC.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AuthManager, type ApiKeyRole } from '../auth.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rm } from 'node:fs/promises';
+
+describe('API Key RBAC (Issue #1432)', () => {
+  let auth: AuthManager;
+  let tmpFile: string;
+
+  beforeEach(async () => {
+    tmpFile = join(tmpdir(), `aegis-rbac-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+    auth = new AuthManager(tmpFile, '');
+    await auth.load();
+  });
+
+  afterEach(async () => {
+    try { await rm(tmpFile); } catch { /* ignore */ }
+  });
+
+  // ── Role assignment on key creation ────────────────────────────────────────
+
+  describe('Key creation with roles', () => {
+    it('should default to viewer role when no role specified', async () => {
+      const result = await auth.createKey('viewer-key');
+      expect(result.role).toBe('viewer');
+    });
+
+    it('should create a key with admin role', async () => {
+      const result = await auth.createKey('admin-key', 100, undefined, 'admin');
+      expect(result.role).toBe('admin');
+    });
+
+    it('should create a key with operator role', async () => {
+      const result = await auth.createKey('operator-key', 100, undefined, 'operator');
+      expect(result.role).toBe('operator');
+    });
+
+    it('should persist role in the store', async () => {
+      await auth.createKey('admin-key', 100, undefined, 'admin');
+      await auth.createKey('viewer-key', 100, undefined, 'viewer');
+      const keys = auth.listKeys();
+      const admin = keys.find(k => k.name === 'admin-key');
+      const viewer = keys.find(k => k.name === 'viewer-key');
+      expect(admin?.role).toBe('admin');
+      expect(viewer?.role).toBe('viewer');
+    });
+  });
+
+  // ── Role retrieval ──────────────────────────────────────────────────────────
+
+  describe('getRole()', () => {
+    it('should return admin for master token', () => {
+      const masterAuth = new AuthManager(tmpFile, 'master-secret');
+      expect(masterAuth.getRole('master')).toBe('admin');
+    });
+
+    it('should return viewer for null/undefined keyId', () => {
+      expect(auth.getRole(null)).toBe('viewer');
+      expect(auth.getRole(undefined)).toBe('viewer');
+      expect(auth.getRole('unknown-id')).toBe('viewer');
+    });
+
+    it('should return the correct role for a valid key', async () => {
+      const { id } = await auth.createKey('op-key', 100, undefined, 'operator');
+      expect(auth.getRole(id)).toBe('operator');
+    });
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -13,6 +13,8 @@ import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { secureFilePermissions } from './file-utils.js';
 
+export type ApiKeyRole = 'admin' | 'operator' | 'viewer';
+
 export interface ApiKey {
   id: string;
   name: string;
@@ -21,6 +23,7 @@ export interface ApiKey {
   lastUsedAt: number;
   rateLimit: number;     // requests per minute
   expiresAt: number | null; // Unix timestamp (ms), null = never expires
+  role: ApiKeyRole;      // RBAC role (Issue #1432)
 }
 
 export interface ApiKeyStore {
@@ -127,7 +130,8 @@ export class AuthManager {
     name: string,
     rateLimit = 100,
     ttlDays?: number,
-  ): Promise<{ id: string; key: string; name: string; expiresAt: number | null }> {
+    role: ApiKeyRole = 'viewer',
+  ): Promise<{ id: string; key: string; name: string; expiresAt: number | null; role: ApiKeyRole }> {
     const id = randomBytes(8).toString('hex');
     const key = `aegis_${randomBytes(32).toString('hex')}`;
     const hash = AuthManager.hashKey(key);
@@ -141,12 +145,13 @@ export class AuthManager {
       lastUsedAt: 0,
       rateLimit,
       expiresAt,
+      role,
     };
 
     this.store.keys.push(apiKey);
     await this.save();
 
-    return { id, key, name, expiresAt };
+    return { id, key, name, expiresAt, role };
   }
 
   /** List keys (without hashes). */
@@ -219,6 +224,13 @@ export class AuthManager {
     key.lastUsedAt = Date.now();
 
     return { valid: true, keyId: key.id, rateLimited: false };
+  }
+
+  /** Issue #1432: Get the RBAC role for a key ID. Master token = admin. Unknown/null = viewer (default). */
+  getRole(keyId: string | null | undefined): ApiKeyRole {
+    if (keyId === 'master') return 'admin';
+    const key = keyId ? this.store.keys.find(k => k.id === keyId) : undefined;
+    return key?.role ?? 'viewer';
   }
 
   /** Hash a key with SHA-256. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,7 +41,7 @@ import { SSEWriter } from './sse-writer.js';
 import { SSEConnectionLimiter } from './sse-limiter.js';
 import { PipelineManager } from './pipeline.js';
 import { ToolRegistry } from './tool-registry.js';
-import { AuthManager, classifyBearerTokenForRoute } from './auth.js';
+import { AuthManager, classifyBearerTokenForRoute, type ApiKeyRole } from './auth.js';
 import { MetricsCollector } from './metrics.js';
 import { registerPermissionRoutes } from './permission-routes.js';
 import { registerHookRoutes } from './hooks.js';
@@ -112,6 +112,17 @@ declare module 'fastify' {
 }
 
 type IdRequest = FastifyRequest<IdParams>;
+
+// Issue #1432: Role-based access control — checks if the authenticated key has one of the allowed roles.
+// Returns true if allowed (reply already sent on failure), false otherwise.
+function requireRole(req: FastifyRequest, ...allowedRoles: ApiKeyRole[]): boolean {
+  const keyId = req.authKeyId ?? null;
+  const role = auth.getRole(keyId);
+  if (!allowedRoles.includes(role)) {
+    return false; // caller should send 403
+  }
+  return true;
+}
 
 // Issue #1429: Session ownership guard — rejects 403 if caller keyId does not match session owner.
 // Master key and no-auth mode (null/undefined keyId) bypass ownership.
@@ -533,10 +544,12 @@ app.get('/v1/swarm', async () => {
 // Security: reject all auth key operations when auth is not enabled
 app.post('/v1/auth/keys', async (req, reply) => {
   if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
+  // Issue #1432: Only admin keys can create new API keys
+  if (!requireRole(req, 'admin')) return reply.status(403).send({ error: 'Forbidden: admin role required' });
   const parsed = authKeySchema.safeParse(req.body);
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
-  const { name, rateLimit, ttlDays } = parsed.data;
-  const result = await auth.createKey(name, rateLimit, ttlDays);
+  const { name, rateLimit, ttlDays, role = 'viewer' } = parsed.data;
+  const result = await auth.createKey(name, rateLimit, ttlDays, role);
   return reply.status(201).send(result);
 });
 
@@ -547,6 +560,8 @@ app.get('/v1/auth/keys', async (req, reply) => {
 
 app.delete<{ Params: { id: string } }>('/v1/auth/keys/:id', async (req, reply) => {
   if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
+  // Issue #1432: Only admin keys can revoke API keys
+  if (!requireRole(req, 'admin')) return reply.status(403).send({ error: 'Forbidden: admin role required' });
   const revoked = await auth.revokeKey(req.params.id);
   if (!revoked) return reply.status(404).send({ error: 'Key not found' });
   return { ok: true };
@@ -1324,6 +1339,8 @@ app.post<IdParams>('/sessions/:id/interrupt', interruptHandler);
 
 // Kill session
 async function killSessionHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
+  // Issue #1432: Admin or operator can kill sessions
+  if (!requireRole(req, 'admin', 'operator')) return reply.status(403).send({ error: 'Forbidden: admin or operator role required' });
   if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     // #842: killSession first, then notify — avoids race where channels

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -18,6 +18,7 @@ export const authKeySchema = z.object({
   name: z.string().min(1),
   rateLimit: z.number().int().positive().optional(),
   ttlDays: z.number().int().positive().optional(),
+  role: z.enum(['admin', 'operator', 'viewer']).optional(),
 }).strict();
 
 /** Maximum length for user-supplied prompts/commands (Issue #411). */
@@ -281,6 +282,7 @@ export const authStoreSchema = z.object({
     lastUsedAt: z.number(),
     rateLimit: z.number(),
     expiresAt: z.number().nullable().optional().default(null),
+    role: z.enum(['admin', 'operator', 'viewer']).optional().default('viewer'),
   })),
 });
 


### PR DESCRIPTION
## Summary

Implements role-based access control for API keys (Issue #1432).

### Changes

- **ApiKeyRole type**: 
- **role field** added to  interface with default 
- **getRole()** method on  — returns role for any key ID, master token = admin
- **requireRole()** helper in  for endpoint gating

### Gated Endpoints

| Endpoint | Required Role |
|----------|--------------|
|  | admin |
|  | admin |
|  | admin or operator |

### Testing

- 7 new tests for role creation and  behavior
- All auth tests pass

## Checklist

- [x] Tests added/updated
- [x] Build passes
- [x] Scope contained to RBAC implementation only