### PR TITLE
fix(reliability): complete graceful shutdown for watchers, pipelines, and reaper (#1427)

### DIFF
--- a/src/__tests__/swarm-monitor.test.ts
+++ b/src/__tests__/swarm-monitor.test.ts
@@ -86,16 +86,16 @@ describe('SwarmMonitor', () => {
   });
 
   describe('start/stop lifecycle', () => {
-    it('should start and stop without errors', () => {
+    it('should start and stop without errors', async () => {
       monitor.start();
-      monitor.stop();
+      await monitor.stop();
       expect(true).toBe(true);
     });
 
-    it('should be idempotent on start', () => {
+    it('should be idempotent on start', async () => {
       monitor.start();
       monitor.start(); // second call should be no-op
-      monitor.stop();
+      await monitor.stop();
       expect(true).toBe(true);
     });
 
@@ -109,7 +109,7 @@ describe('SwarmMonitor', () => {
       expect(infoSpy).toHaveBeenCalled();
       expect(result.swarms).toEqual([]);
       expect(result.totalSockets).toBe(0);
-      monitor.stop();
+      await monitor.stop();
     });
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2202,7 +2202,7 @@ async function main(): Promise<void> {
 
       // 2. Stop background monitors and intervals
       monitor.stop();
-      swarmMonitor.stop();
+      await swarmMonitor.stop();
       clearInterval(reaperInterval);
       clearInterval(zombieReaperInterval);
       clearInterval(metricsSaveInterval);
@@ -2211,19 +2211,24 @@ async function main(): Promise<void> {
       clearInterval(authSweepInterval);
       clearInterval(consensusPruneInterval);
 
+      // 3. Close file watchers, pipelines, and reaper
+      jsonlWatcher.destroy();
+      pipelines.destroy();
+      if (memoryBridge) memoryBridge.stopReaper();
+
       // Issue #569: Kill all CC sessions and tmux windows before exit
       try { await killAllSessions(sessions, tmux, { monitor, metrics, toolRegistry }); } catch (e) { console.error('Error killing sessions:', e); }
 
-      // 3. Destroy channels (awaits Telegram poll loop)
+      // 4. Destroy channels (awaits Telegram poll loop)
       try { await channels.destroy(); } catch (e) { console.error('Error destroying channels:', e); }
 
-      // 4. Save session state
+      // 5. Save session state
       try { await sessions.save(); } catch (e) { console.error('Error saving sessions:', e); }
 
-      // 5. Save metrics
+      // 6. Save metrics
       try { await metrics.save(); } catch (e) { console.error('Error saving metrics:', e); }
 
-      // 6. Cleanup PID file
+      // 7. Cleanup PID file
       removePidFile(pidFilePath);
 
       console.log('Graceful shutdown complete');

--- a/src/swarm-monitor.ts
+++ b/src/swarm-monitor.ts
@@ -88,6 +88,7 @@ export class SwarmMonitor {
   private timer: ReturnType<typeof setInterval> | null = null;
   private eventHandlers: SwarmEventHandler[] = [];
   private windowsDisabledLogged = false;
+  private activeScan: Promise<SwarmScanResult> | null = null;
 
   constructor(
     private sessions: SessionManager,
@@ -127,18 +128,36 @@ export class SwarmMonitor {
     }
     if (this.running) return;
     this.running = true;
-    void this.scan();
+    void this.trackScan();
     this.timer = setInterval(() => {
-      void this.scan();
+      void this.trackScan();
     }, this.config.scanIntervalMs);
   }
 
-  /** Stop the periodic scan loop. */
-  stop(): void {
+  /** Stop the periodic scan loop and await in-flight scans. */
+  async stop(): Promise<void> {
     this.running = false;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    if (this.activeScan) {
+      const timeout = new Promise<void>(resolve => setTimeout(resolve, 2_000));
+      await Promise.race([this.activeScan.then(() => {}), timeout]);
+      this.activeScan = null;
+    }
+  }
+
+  /** Wrap scan() to track the in-flight promise. */
+  private async trackScan(): Promise<void> {
+    const promise = this.scan();
+    this.activeScan = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.activeScan === promise) {
+        this.activeScan = null;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- `gracefulShutdown()` now calls `jsonlWatcher.destroy()` to close all `fs.watch` file handles
- `gracefulShutdown()` now calls `pipelines.destroy()` to clear poll intervals and cleanup timers
- `gracefulShutdown()` now calls `memoryBridge.stopReaper()` to clear reaper and save timers
- `SwarmMonitor.stop()` is now `async`: tracks in-flight scans and awaits them with a 2-second timeout before force-stopping, preventing open handle leaks on SIGTERM

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 2591 passed, 0 failed
- [x] Existing swarm-monitor start/stop lifecycle tests updated for async stop()

## Aegis version
**Developed with:** v0.3.2-alpha

Closes #1427

Generated by Hephaestus (Aegis dev agent)