### PR TITLE
fix: Wave A authz hardening for metrics, keys, permissions, and session health

### DIFF
--- a/src/__tests__/auth-bypass-349.test.ts
+++ b/src/__tests__/auth-bypass-349.test.ts
@@ -22,6 +22,13 @@ const HOOK_ROUTE_RE = /^\/v1\/hooks\/[A-Za-z]+$/;
 /** Matches exactly /v1/sessions/{id}/terminal. */
 const TERMINAL_ROUTE_RE = /^\/v1\/sessions\/[^/]+\/terminal$/;
 
+function isPublicAuthBypassPath(urlPath: string): boolean {
+  return urlPath === '/health'
+    || urlPath === '/v1/health'
+    || urlPath === '/dashboard'
+    || urlPath.startsWith('/dashboard/');
+}
+
 // ── Helpers ──
 
 function createMockSessionManager(session: SessionInfo | null): SessionManager {
@@ -63,6 +70,20 @@ function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 
 describe('Issue #349: Auth bypass via broad path matching', () => {
   describe('Fix 1: Exact path matching for auth skips', () => {
+    it('keeps /health and /v1/health as auth bypass paths', () => {
+      expect(isPublicAuthBypassPath('/health')).toBe(true);
+      expect(isPublicAuthBypassPath('/v1/health')).toBe(true);
+    });
+
+    it('keeps /dashboard routes as auth bypass paths', () => {
+      expect(isPublicAuthBypassPath('/dashboard')).toBe(true);
+      expect(isPublicAuthBypassPath('/dashboard/index.html')).toBe(true);
+    });
+
+    it('does not bypass auth for /metrics', () => {
+      expect(isPublicAuthBypassPath('/metrics')).toBe(false);
+    });
+
     it('should match /v1/hooks/Stop', () => {
       expect(HOOK_ROUTE_RE.test('/v1/hooks/Stop')).toBe(true);
     });

--- a/src/__tests__/auth-rbac.test.ts
+++ b/src/__tests__/auth-rbac.test.ts
@@ -69,4 +69,19 @@ describe('API Key RBAC (Issue #1432)', () => {
       expect(auth.getRole(id)).toBe('operator');
     });
   });
+
+  describe('auth key route guard policy', () => {
+    function canListAuthKeys(role: ApiKeyRole): boolean {
+      return role === 'admin';
+    }
+
+    it('allows admin role to list keys', () => {
+      expect(canListAuthKeys('admin')).toBe(true);
+    });
+
+    it('rejects operator/viewer roles from listing keys', () => {
+      expect(canListAuthKeys('operator')).toBe(false);
+      expect(canListAuthKeys('viewer')).toBe(false);
+    });
+  });
 });

--- a/src/__tests__/session-ownership-1429.test.ts
+++ b/src/__tests__/session-ownership-1429.test.ts
@@ -246,3 +246,129 @@ describe('Session ownership (#1429) — batch delete scoping', () => {
     expect(deletable.map(s => s.id)).toEqual(['s-1', 's-3']);
   });
 });
+
+describe('Session ownership (#1568) — permission policy/profile endpoints', () => {
+  type PermissionEndpoint =
+    | '/v1/sessions/:id/permissions [GET]'
+    | '/v1/sessions/:id/permissions [PUT]'
+    | '/v1/sessions/:id/permission-profile [GET]'
+    | '/v1/sessions/:id/permission-profile [PUT]';
+
+  interface SimulatedResponse {
+    statusCode: number;
+    body: Record<string, unknown>;
+  }
+
+  function simulatePermissionEndpoint(
+    endpoint: PermissionEndpoint,
+    session: SessionInfo | null,
+    keyId: string | null | undefined,
+    payload?: unknown,
+  ): SimulatedResponse {
+    if (!session) return { statusCode: 404, body: { error: 'Session not found' } };
+    if (keyId !== 'master' && keyId !== null && keyId !== undefined && session.ownerKeyId && session.ownerKeyId !== keyId) {
+      return { statusCode: 403, body: { error: 'Forbidden: session owned by another API key' } };
+    }
+
+    if (endpoint === '/v1/sessions/:id/permissions [GET]') {
+      return { statusCode: 200, body: { permissionPolicy: session.permissionPolicy ?? [] } };
+    }
+
+    if (endpoint === '/v1/sessions/:id/permissions [PUT]') {
+      return { statusCode: 200, body: { permissionPolicy: Array.isArray(payload) ? payload : [] } };
+    }
+
+    if (endpoint === '/v1/sessions/:id/permission-profile [GET]') {
+      return { statusCode: 200, body: { permissionProfile: session.permissionProfile ?? null } };
+    }
+
+    return { statusCode: 200, body: { permissionProfile: typeof payload === 'object' && payload !== null ? payload as Record<string, unknown> : null } };
+  }
+
+  const endpoints: PermissionEndpoint[] = [
+    '/v1/sessions/:id/permissions [GET]',
+    '/v1/sessions/:id/permissions [PUT]',
+    '/v1/sessions/:id/permission-profile [GET]',
+    '/v1/sessions/:id/permission-profile [PUT]',
+  ];
+
+  it('returns 403 for all four endpoints when caller does not own the session', () => {
+    const s = makeSession({ ownerKeyId: 'key-owner' });
+    for (const endpoint of endpoints) {
+      const result = simulatePermissionEndpoint(endpoint, s, 'key-other', []);
+      expect(result.statusCode).toBe(403);
+    }
+  });
+
+  it('returns data/accepts updates for owner across all four endpoints', () => {
+    const s = makeSession({
+      ownerKeyId: 'key-owner',
+      permissionPolicy: [{ source: 'aegisApi', ruleBehavior: 'allow', toolName: 'Bash' }],
+      permissionProfile: { defaultBehavior: 'ask', rules: [{ tool: 'Read', behavior: 'allow' }] },
+    });
+
+    const getPolicy = simulatePermissionEndpoint('/v1/sessions/:id/permissions [GET]', s, 'key-owner');
+    expect(getPolicy.statusCode).toBe(200);
+    expect(getPolicy.body).toEqual({ permissionPolicy: [{ source: 'aegisApi', ruleBehavior: 'allow', toolName: 'Bash' }] });
+
+    const putPolicyPayload = [{ matcher: 'Edit(*)', mode: 'ask' }];
+    const putPolicy = simulatePermissionEndpoint('/v1/sessions/:id/permissions [PUT]', s, 'key-owner', putPolicyPayload);
+    expect(putPolicy.statusCode).toBe(200);
+    expect(putPolicy.body).toEqual({ permissionPolicy: putPolicyPayload });
+
+    const getProfile = simulatePermissionEndpoint('/v1/sessions/:id/permission-profile [GET]', s, 'key-owner');
+    expect(getProfile.statusCode).toBe(200);
+    expect(getProfile.body).toEqual({ permissionProfile: { defaultBehavior: 'ask', rules: [{ tool: 'Read', behavior: 'allow' }] } });
+
+    const putProfilePayload = { defaultBehavior: 'deny', rules: [{ tool: 'Write', behavior: 'ask' }] };
+    const putProfile = simulatePermissionEndpoint('/v1/sessions/:id/permission-profile [PUT]', s, 'key-owner', putProfilePayload);
+    expect(putProfile.statusCode).toBe(200);
+    expect(putProfile.body).toEqual({ permissionProfile: putProfilePayload });
+  });
+});
+
+describe('Session health ownership/scope (#1569)', () => {
+  function canReadSessionHealth(session: SessionInfo | null, keyId: string | null | undefined): boolean {
+    if (!session) return false;
+    if (keyId === 'master' || keyId === null || keyId === undefined) return true;
+    if (!session.ownerKeyId) return true;
+    return session.ownerKeyId === keyId;
+  }
+
+  function filterBulkHealthSessions(
+    allSessions: SessionInfo[],
+    callerKeyId: string | null | undefined,
+    callerRole: 'admin' | 'operator' | 'viewer',
+  ): string[] {
+    if (callerRole === 'admin' || callerKeyId === null || callerKeyId === undefined) {
+      return allSessions.map(s => s.id);
+    }
+    return allSessions.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId).map(s => s.id);
+  }
+
+  it('per-session health rejects non-owner and allows owner', () => {
+    const owned = makeSession({ id: 's-owned', ownerKeyId: 'key-owner' });
+    expect(canReadSessionHealth(owned, 'key-other')).toBe(false);
+    expect(canReadSessionHealth(owned, 'key-owner')).toBe(true);
+  });
+
+  it('bulk health returns all sessions for admin', () => {
+    const sessions = [
+      makeSession({ id: 's-1', ownerKeyId: 'key-a' }),
+      makeSession({ id: 's-2', ownerKeyId: 'key-b' }),
+      makeSession({ id: 's-3', ownerKeyId: undefined }),
+    ];
+
+    expect(filterBulkHealthSessions(sessions, 'key-any', 'admin')).toEqual(['s-1', 's-2', 's-3']);
+  });
+
+  it('bulk health is scoped to owner+legacy for non-admin callers', () => {
+    const sessions = [
+      makeSession({ id: 's-1', ownerKeyId: 'key-a' }),
+      makeSession({ id: 's-2', ownerKeyId: 'key-b' }),
+      makeSession({ id: 's-3', ownerKeyId: undefined }),
+    ];
+
+    expect(filterBulkHealthSessions(sessions, 'key-a', 'viewer')).toEqual(['s-1', 's-3']);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -398,7 +398,7 @@ function setupAuth(authManager: AuthManager): void {
     // Skip auth for health endpoint and dashboard (Issue #349: exact path matching)
     // #126: Dashboard is served as public static files; API endpoints are protected
     const urlPath = req.url?.split('?')[0] ?? '';
-    if (urlPath === '/health' || urlPath === '/v1/health' || urlPath === '/metrics') return;
+    if (urlPath === '/health' || urlPath === '/v1/health') return;
     if (urlPath === '/dashboard' || urlPath.startsWith('/dashboard/')) return;
     // Hook routes — exact match: /v1/hooks/{eventName} (alpha only, no path traversal)
     // Issue #394: Require valid X-Session-Id for known sessions instead of blanket bypass.
@@ -593,6 +593,7 @@ app.post('/v1/auth/keys', async (req, reply) => {
 
 app.get('/v1/auth/keys', async (req, reply) => {
   if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
+  if (!requireRole(req, reply, 'admin')) return;
   return auth.listKeys();
 });
 
@@ -1027,8 +1028,13 @@ app.get<IdParams>('/v1/sessions/:id', getSessionHandler);
 app.get<IdParams>('/sessions/:id', getSessionHandler);
 
 // #128: Bulk health check — returns health for all sessions in one request
-app.get('/v1/sessions/health', async () => {
+app.get('/v1/sessions/health', async (req) => {
+  const callerKeyId = req.authKeyId;
+  const callerRole = auth.getRole(callerKeyId ?? null);
   const allSessions = sessions.listSessions();
+  const visibleSessions = callerRole === 'admin' || callerKeyId === null || callerKeyId === undefined
+    ? allSessions
+    : allSessions.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
   const results: Record<string, {
     alive: boolean;
     windowExists: boolean;
@@ -1041,7 +1047,7 @@ app.get('/v1/sessions/health', async () => {
     sessionAge: number;
     details: string;
   }> = {};
-  await Promise.all(allSessions.map(async (s) => {
+  await Promise.all(visibleSessions.map(async (s) => {
     try {
       results[s.id] = await sessions.getHealth(s.id);
     } catch { /* health check failed — report error state */
@@ -1058,6 +1064,7 @@ app.get('/v1/sessions/health', async () => {
 
 // Session health check (Issue #2)
 async function sessionHealthHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
+  if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   try {
     return await sessions.getHealth(req.params.id);
   } catch (e: unknown) {
@@ -1263,14 +1270,14 @@ app.get('/v1/consensus/:id', getConsensusHandler);
 type PermissionRequest = FastifyRequest<{ Params: { id: string }; Body: PermissionPolicy | undefined }>;
 async function getPermissionPolicyHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return reply as unknown as Record<string, unknown>;
   return { permissionPolicy: session.permissionPolicy ?? [] };
 }
 async function updatePermissionPolicyHandler(req: PermissionRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return reply as unknown as Record<string, unknown>;
   const policy = req.body ?? [];
   const result = permissionRuleSchema.array().safeParse(policy);
   if (!result.success) return reply.status(400).send({ error: 'Invalid permission policy', details: result.error.issues });
@@ -1286,14 +1293,14 @@ app.put('/sessions/:id/permissions', updatePermissionPolicyHandler);
 type PermissionProfileRequest = FastifyRequest<{ Params: { id: string }; Body: PermissionProfile | undefined }>;
 async function getPermissionProfileHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return reply as unknown as Record<string, unknown>;
   return { permissionProfile: session.permissionProfile ?? null };
 }
 async function updatePermissionProfileHandler(req: PermissionProfileRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return reply as unknown as Record<string, unknown>;
   const parsed = permissionProfileSchema.safeParse(req.body ?? {});
   if (!parsed.success) return reply.status(400).send({ error: 'Invalid permission profile', details: parsed.error.issues });
   session.permissionProfile = parsed.data;


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.3.2-alpha

## Summary
- Require auth for /metrics
- Enforce admin role for GET /v1/auth/keys
- Enforce ownership on permission policy/profile endpoints
- Scope session health endpoints by ownership (admin sees all)
- Consistency cleanup for requireRole guard behavior

## Validation
- npx tsc --noEmit
- npm run build
- npm test

Closes #1559
Closes #1560
Closes #1568
Closes #1569
Closes #1570