### PR TITLE
fix: Wave C consensus status, OpenAPI alignment, SDK/package cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,14 +398,14 @@ src/
 
 ## TypeScript Client SDK
 
-Official `@aegis/client` package for TypeScript/JavaScript applications.
+Official `@onestepat4time/aegis-client` package for TypeScript/JavaScript applications.
 
 ```bash
-npm install @aegis/client
+npm install @onestepat4time/aegis-client
 ```
 
 ```typescript
-import { AegisClient } from '@aegis/client';
+import { AegisClient } from '@onestepat4time/aegis-client';
 
 const client = new AegisClient('http://localhost:18792', process.env.AEGIS_AUTH_TOKEN);
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1929,10 +1929,20 @@ components:
       properties:
         id:
           type: string
+        windowId:
+          type: string
         windowName:
           type: string
         workDir:
           type: string
+        claudeSessionId:
+          type: string
+        jsonlPath:
+          type: string
+        byteOffset:
+          type: integer
+        monitorOffset:
+          type: integer
         status:
           type: string
           enum: [idle, working, compacting, context_warning, waiting_for_input, permission_prompt, plan_mode, ask_question, bash_approval, settings, error, unknown]
@@ -1940,17 +1950,54 @@ components:
           type: integer
         lastActivity:
           type: integer
+        stallThresholdMs:
+          type: integer
+        permissionStallMs:
+          type: integer
         permissionMode:
           type: string
-        autoApprove:
+        settingsPatched:
           type: boolean
-        promptDelivery:
+        hookSettingsFile:
+          type: string
+        hookSecret:
+          type: string
+        lastHookAt:
+          type: integer
+        activeSubagents:
+          type: array
+          items:
+            type: string
+        permissionPromptAt:
+          type: integer
+        permissionRespondedAt:
+          type: integer
+        lastHookReceivedAt:
+          type: integer
+        lastHookEventAt:
+          type: integer
+        model:
+          type: string
+        lastDeadAt:
+          type: integer
+        ccPid:
+          type: integer
+        parentId:
+          type: string
+        children:
+          type: array
+          items:
+            type: string
+        permissionPolicy:
+          type: array
+          items:
+            type: object
+        permissionProfile:
           type: object
-          properties:
-            delivered:
-              type: boolean
-            attempts:
-              type: integer
+        prd:
+          type: string
+        ownerKeyId:
+          type: string
 
     SessionHealth:
       type: object

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@aegis/client",
+  "name": "@onestepat4time/aegis-client",
   "version": "0.3.2-alpha",
   "type": "module",
-  "description": "Official TypeScript client for Aegis Bridge. Orchestrate Claude Code sessions via HTTP API.",
+  "description": "Official TypeScript client for Aegis. Orchestrate Claude Code sessions via HTTP API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/OneStepAt4time/aegis.git",
     "directory": "packages/client"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": ["aegis", "claude-code", "orchestration", "mcp", "api-client"],
   "license": "MIT",

--- a/packages/client/src/AegisClient.ts
+++ b/packages/client/src/AegisClient.ts
@@ -5,7 +5,7 @@
  * Works in Node.js and browser environments.
  *
  * @example
- * import { AegisClient } from '@aegis/client';
+ * import { AegisClient } from '@onestepat4time/aegis-client';
  *
  * const client = new AegisClient('http://localhost:18792', process.env.AEGIS_AUTH_TOKEN);
  *

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,8 +1,8 @@
 /**
- * @aegis/client — Official TypeScript client for Aegis Bridge.
+ * @onestepat4time/aegis-client — Official TypeScript client for Aegis.
  *
  * @example
- * import { AegisClient, type SessionInfo } from '@aegis/client';
+ * import { AegisClient, type SessionInfo } from '@onestepat4time/aegis-client';
  *
  * const client = new AegisClient('http://localhost:18792', 'your-token');
  * const sessions = await client.listSessions();

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -5,7 +5,7 @@
  * Import this in your application to get full type safety.
  *
  * @example
- * import { AegisClient, type SessionInfo, type UIState } from '@aegis/client';
+ * import { AegisClient, type SessionInfo, type UIState } from '@onestepat4time/aegis-client';
  *
  * const client = new AegisClient('http://localhost:18792', 'your-token');
  * const sessions = await client.listSessions();

--- a/src/__tests__/consensus-1422.test.ts
+++ b/src/__tests__/consensus-1422.test.ts
@@ -1,7 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { parseReviewOutput, mergeConsensusFindings, type ConsensusReview } from '../consensus.js';
+import {
+  parseReviewOutput,
+  mergeConsensusFindings,
+  resolveConsensusRequestStatus,
+  type ConsensusReview,
+} from '../consensus.js';
 
 describe('Issue #1422: consensus status completion', () => {
+  describe('resolveConsensusRequestStatus', () => {
+    it('returns completed when all reviewers are idle and none failed', () => {
+      expect(resolveConsensusRequestStatus(true, false)).toBe('completed');
+    });
+
+    it('returns failed when at least one reviewer failed', () => {
+      expect(resolveConsensusRequestStatus(false, true)).toBe('failed');
+    });
+
+    it('returns failed when all reviewers failed', () => {
+      expect(resolveConsensusRequestStatus(true, true)).toBe('failed');
+    });
+
+    it('returns running when reviewers are still in progress and no failures occurred', () => {
+      expect(resolveConsensusRequestStatus(false, false)).toBe('running');
+    });
+  });
+
   describe('parseReviewOutput', () => {
     it('extracts findings from assistant text entries', () => {
       const entries = [

--- a/src/consensus.ts
+++ b/src/consensus.ts
@@ -16,6 +16,15 @@ export interface ConsensusReview {
   findings: string[];
 }
 
+export function resolveConsensusRequestStatus(
+  allIdle: boolean,
+  anyFailed: boolean,
+): 'running' | 'completed' | 'failed' {
+  if (anyFailed) return 'failed';
+  if (allIdle) return 'completed';
+  return 'running';
+}
+
 export function buildConsensusPrompt(targetSessionId: string, focusArea: ConsensusFocusArea): string {
   return [
     `Review Aegis session ${targetSessionId}.`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,15 @@ import { registerHookRoutes } from './hooks.js';
 import { registerWsTerminalRoute } from './ws-terminal.js';
 import { registerMemoryRoutes } from './memory-routes.js';
 import { registerModelRouterRoutes } from './model-router.js';
-import { buildConsensusPrompt, parseReviewOutput, mergeConsensusFindings, type ConsensusFocusArea, type ConsensusRequest, type ConsensusReview } from './consensus.js';
+import {
+  buildConsensusPrompt,
+  parseReviewOutput,
+  mergeConsensusFindings,
+  resolveConsensusRequestStatus,
+  type ConsensusFocusArea,
+  type ConsensusRequest,
+  type ConsensusReview,
+} from './consensus.js';
 import { readNewEntries } from './transcript.js';
 import * as templateStore from './template-store.js';
 import { SwarmMonitor } from './swarm-monitor.js';
@@ -694,7 +702,6 @@ app.get<IdParams>('/v1/sessions/:id/tools', async (req, reply) => {
   const session = sessions.getSession(sessionId);
   if (!session) return reply.status(404).send({ error: 'Session not found' });
   // Parse JSONL on-demand for tool usage
-  const { readNewEntries } = await import('./transcript.js');
   if (session.jsonlPath) {
     try {
       const result = await readNewEntries(session.jsonlPath, 0);
@@ -1289,7 +1296,7 @@ async function getConsensusHandler(
     }
 
     if (allIdle || anyFailed) {
-      item.status = anyFailed && !allIdle ? 'failed' : 'completed';
+      item.status = resolveConsensusRequestStatus(allIdle, anyFailed);
       item.findings = mergeConsensusFindings(reviews);
     }
   }


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.3.2-alpha

## Summary
- Fix consensus status when all reviewers fail
- Align OpenAPI SessionInfo schema with runtime fields
- Apply safe SDK naming/publish-readiness updates
- Remove duplicate dynamic import of readNewEntries in server
- Add/adjust consensus tests

## Validation
- npx tsc --noEmit
- npm run build
- npm test

Closes #1562
Closes #1563
Closes #1565
Closes #1566