### PR TITLE
ci: fix invalid secrets expression in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,11 +134,10 @@ jobs:
         with:
           node-version: '22'
       - name: ClawHub Login
-        if: ${{ secrets.CLAWHUB_TOKEN != '' }}
         continue-on-error: true
         run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
       - name: Publish to ClawHub
-        if: ${{ secrets.CLAWHUB_TOKEN != '' }}
+        continue-on-error: true
         run: |
           VERSION=$(node -p "require('./package.json').version")
           npx clawhub@latest publish skill/ --slug aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"


### PR DESCRIPTION
## Summary

Fixes the release.yml workflow that has been failing with a parse error.

GitHub Actions does not allow the secrets context in step-level if: expressions.
The fix removes the invalid if: guards on the ClawHub steps and uses continue-on-error: true instead.
If CLAWHUB_TOKEN is not set, both steps fail gracefully without blocking the release.

## Changes
- .github/workflows/release.yml: removed invalid if conditions, added continue-on-error: true on Publish step

## Aegis version
**Developed with:** v0.3.2-alpha