### PR TITLE
docs: add deployment tiers section to README (Tier 1-3 positioning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,41 @@ npx @onestepat4time/aegis          # visit http://localhost:9100/dashboard/
 
 ---
 
+## Use Cases & Deployment Tiers
+
+Aegis serves three deployment scenarios:
+
+### Tier 1 — Local Orchestration
+**Single developer.** Run Claude Code tasks in the background, monitor via dashboard, approve via Telegram.
+
+```bash
+aegis
+# Dashboard: http://localhost:9100/dashboard/
+# Telegram approvals while AFK
+```
+
+### Tier 2 — CI/CD & Team Automation
+**Development teams.** Policy-based permission control, batch operations, Slack notifications.
+
+```bash
+# Blueprint: PR Reviewer
+curl -X POST http://localhost:9100/v1/pipelines \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"name":"pr-reviewer","stages":[...],"permissionMode":"plan"}'
+```
+
+### Tier 3 — Zero-Trust Enterprise
+**Banks, SaaS, regulated industries.** Docker-isolated containers, no network egress, audit-first.
+
+- Each task runs in an ephemeral Docker container
+- No cross-container networking
+- Immutable audit log for compliance
+- See [Enterprise Deployment](docs/enterprise.md) for production hardening guide
+
+**Golden rule:** Intelligence stays outside Aegis. Aegis is a stupid-but-powerful middleware — flows, security, audit. OpenClaw (or any external orchestrator) provides the brains.
+
+---
+
 ## Security
 
 Aegis includes built-in security defaults:


### PR DESCRIPTION
## Summary

Adds a **Use Cases & Deployment Tiers** section to README.md — Tier 1 through Tier 3 positioning per the product vision.

### Changes

- **Tier 1 — Local Orchestration:** Single developer, dashboard + Telegram
- **Tier 2 — CI/CD & Team Automation:** Policy-based permissions, batch ops, Slack
- **Tier 3 — Zero-Trust Enterprise:** Docker isolation, immutable audit, zero egress
- **Golden rule:** "Intelligence stays outside Aegis" — Aegis is middleware, not an agent framework

### Before/After

Before: README jumped straight from Quick Start to Ecosystem Integrations with no use-case framing.

After: Clear 3-tier story before Security section, positioning Aegis as middleware.

## Checklist

- [x] All 3 tiers documented with brief examples
- [x] Links to Enterprise Deployment guide for Tier 3
- [x] Golden rule included (intelligence stays outside)
- [x] Version: 0.3.2-alpha

---

Aegis version: 0.3.2-alpha
Milestone: Documentation
Assignee: Scribe