### PR TITLE
fix: persist pipeline state to disk and restore on server restart

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -10,6 +10,9 @@ import { PipelineManager } from '../pipeline.js';
 import type { BatchSessionSpec, PipelineConfig } from '../pipeline.js';
 import type { SessionManager, SessionInfo } from '../session.js';
 import type { SessionEventBus } from '../events.js';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import os from 'node:os';
 
 // ---------------------------------------------------------------------------
 // Helpers: mock factories
@@ -1453,6 +1456,220 @@ describe('PipelineManager', () => {
       expect(pipeline.status).toBe('failed');
       // C never started
       expect(pipeline.stages.find(s => s.name === 'C')?.status).toBe('pending');
+    });
+  });
+
+  // =========================================================================
+  // 12. Pipeline Persistence (#1424)
+  // =========================================================================
+
+  describe('pipeline persistence (#1424)', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = join(os.tmpdir(), `aegis-test-pipeline-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      await mkdir(tmpDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+      await import('node:fs/promises').then(fs => fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {}));
+    });
+
+    it('persists running pipeline to disk on creation', async () => {
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const config: PipelineConfig = {
+        name: 'persist-test',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'run a', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-a'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config);
+
+      const file = join(tmpDir, 'pipelines.json');
+      const raw = await readFile(file, 'utf-8');
+      const entries = JSON.parse(raw);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('persist-test');
+      expect(entries[0].status).toBe('running');
+      expect(entries[0]._config).toBeDefined();
+      expect(entries[0]._config.stages[0].prompt).toBe('run a');
+
+      await manager.destroy();
+    });
+
+    it('deletes state file when all pipelines complete', async () => {
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const config: PipelineConfig = {
+        name: 'complete-test',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'run a', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-a'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+      sessions.getSession.mockReturnValue(makeMockSession('s-a', { status: 'idle' }));
+
+      await manager.createPipeline(config);
+      const file = join(tmpDir, 'pipelines.json');
+
+      // File exists after creation
+      await expect(readFile(file, 'utf-8')).resolves.toBeDefined();
+
+      // Poll to detect completion
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // Pipeline completed — persistPipelines should have deleted the file
+      await expect(readFile(file, 'utf-8')).rejects.toThrow();
+
+      await manager.destroy();
+    });
+
+    it('hydrates running pipelines from disk on startup', async () => {
+      // First: create a pipeline and let it persist
+      const config: PipelineConfig = {
+        name: 'hydrate-test',
+        workDir: '/app',
+        stages: [
+          { name: 'build', prompt: 'build it', dependsOn: [] },
+          { name: 'test', prompt: 'test it', dependsOn: ['build'] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-build'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const manager1 = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const original = await manager1.createPipeline(config);
+      await manager1.destroy();
+
+      // Second: simulate server restart — new manager hydrates from disk
+      sessions.getSession.mockReturnValue(makeMockSession('s-build', { status: 'working' }));
+      const manager2 = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const recovered = await manager2.hydrate(tmpDir);
+
+      expect(recovered).toBe(1);
+      const restored = manager2.getPipeline(original.id);
+      expect(restored).not.toBeNull();
+      expect(restored!.name).toBe('hydrate-test');
+      expect(restored!.status).toBe('running');
+      expect(restored!.stages[0].status).toBe('running');
+      expect(restored!.stages[1].status).toBe('pending');
+
+      // Config should also be restored
+      const configs = (manager2 as unknown as { pipelineConfigs: Map<string, PipelineConfig> }).pipelineConfigs;
+      expect(configs.get(original.id)).toBeDefined();
+      expect(configs.get(original.id)!.stages[1].prompt).toBe('test it');
+
+      await manager2.destroy();
+    });
+
+    it('marks orphaned stages as failed during hydration', async () => {
+      // Persist a pipeline with a running stage
+      const config: PipelineConfig = {
+        name: 'orphan-test',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'run a', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-gone'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const manager1 = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      await manager1.createPipeline(config);
+      await manager1.destroy();
+
+      // Restart: session no longer exists
+      sessions.getSession.mockReturnValue(null);
+
+      const manager2 = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const recovered = await manager2.hydrate(tmpDir);
+
+      expect(recovered).toBe(1);
+      const restored = manager2.getPipeline(
+        (manager2.listPipelines()[0]).id,
+      );
+      expect(restored!.status).toBe('failed');
+      expect(restored!.stages[0].status).toBe('failed');
+      expect(restored!.stages[0].error).toBe('Session disappeared during server restart');
+
+      await manager2.destroy();
+    });
+
+    it('returns 0 when no state file exists', async () => {
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const recovered = await manager.hydrate(tmpDir);
+      expect(recovered).toBe(0);
+      await manager.destroy();
+    });
+
+    it('returns 0 when state file is corrupt JSON', async () => {
+      await writeFile(join(tmpDir, 'pipelines.json'), 'not json{{', 'utf-8');
+
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const recovered = await manager.hydrate(tmpDir);
+      expect(recovered).toBe(0);
+      await manager.destroy();
+    });
+
+    it('returns 0 when state file contains non-array', async () => {
+      await writeFile(join(tmpDir, 'pipelines.json'), '{"not": "an array"}', 'utf-8');
+
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const recovered = await manager.hydrate(tmpDir);
+      expect(recovered).toBe(0);
+      await manager.destroy();
+    });
+
+    it('skips malformed entries during hydration', async () => {
+      await writeFile(join(tmpDir, 'pipelines.json'), JSON.stringify([
+        { id: 'good', name: 'good', status: 'running', stages: [{ name: 'A', status: 'pending', dependsOn: [] }], stageHistory: [], createdAt: Date.now(), currentStage: 'plan', retryCount: 0, maxRetries: 3 },
+        { id: 'bad', name: 'bad' },  // missing stages array
+        'not-an-object',
+        null,
+      ]), 'utf-8');
+
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, tmpDir);
+      const recovered = await manager.hydrate(tmpDir);
+      expect(recovered).toBe(1);
+      expect(manager.listPipelines()).toHaveLength(1);
+      expect(manager.listPipelines()[0].name).toBe('good');
+      await manager.destroy();
+    });
+
+    it('does not persist when stateDir is null', async () => {
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, null);
+      const config: PipelineConfig = {
+        name: 'no-dir',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'run', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      await manager.createPipeline(config);
+      // No crash, no file written
+      await manager.destroy();
+    });
+
+    it('persist is non-fatal when stateDir does not exist', async () => {
+      const manager = new PipelineManager(sessions.mock, eventBus.mock, '/nonexistent/path/that/does/not/exist');
+      const config: PipelineConfig = {
+        name: 'bad-dir',
+        workDir: '/app',
+        stages: [{ name: 'A', prompt: 'run', dependsOn: [] }],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s1'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      // Should not throw — write failure is non-fatal
+      await expect(manager.createPipeline(config)).resolves.toBeDefined();
+      await manager.destroy();
     });
   });
 });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,7 +10,7 @@ import { type SessionEventBus } from './events.js';
 import { getErrorMessage } from './validation.js';
 import { shouldRetry } from './error-categories.js';
 import { retryWithJitter } from './retry.js';
-import { readFile, rename, writeFile } from 'node:fs/promises';
+import { readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 export interface BatchSessionSpec {
@@ -337,6 +337,11 @@ export class PipelineManager {
         await this.advancePipeline(id, storedConfig);
       }
 
+      // #1424: Persist after advancePipeline may have transitioned pipeline to completed/failed
+      if (pipeline.status !== 'running') {
+        await this.persistPipelines();
+      }
+
       // #221: Clean up completed/failed pipelines after 30s to avoid memory leak
       // Note: advancePipeline may change status from 'running' to 'completed'/'failed'
       // #1092: Track cleanup timer to prevent duplicates and allow destroy() cleanup
@@ -408,13 +413,21 @@ export class PipelineManager {
     }
   }
 
-  /** #1424: Persist running pipelines to disk using atomic-rename. */
+  /** #1424: Persist running pipelines to disk using atomic-rename.
+   *  When no running pipelines remain, delete the state file so hydrate()
+   *  does not restore stale completed/failed entries on restart. */
   private async persistPipelines(): Promise<void> {
     if (!this.stateDir) return;
 
     // Only persist running pipelines — completed/failed are cleaned up by timers
     const running = Array.from(this.pipelines.values()).filter(p => p.status === 'running');
-    if (running.length === 0) return;
+    const file = join(this.stateDir, 'pipelines.json');
+
+    if (running.length === 0) {
+      // No running pipelines — remove stale state file
+      try { await unlink(file); } catch { /* already gone or never created */ }
+      return;
+    }
 
     // Include config alongside pipeline state so we can restore full stage details on hydration
     type PersistedEntry = PipelineState & { _config?: PipelineConfig };
@@ -425,7 +438,6 @@ export class PipelineManager {
       return entry;
     });
 
-    const file = join(this.stateDir, 'pipelines.json');
     const tmpFile = `${file}.tmp`;
     try {
       await writeFile(tmpFile, JSON.stringify(entries, null, 2));
@@ -437,7 +449,7 @@ export class PipelineManager {
       await rename(tmpFile, file);
     } catch {
       // Rename failed — remove tmp file
-      try { await import('node:fs/promises').then(m => m.unlink(tmpFile)); } catch { /* ignore */ }
+      try { await unlink(tmpFile); } catch { /* ignore */ }
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2246,7 +2246,7 @@ async function main(): Promise<void> {
   registerModelRouterRoutes(app);
 
   // Initialize pipeline manager (Issue #36, #1424)
-  pipelines = new PipelineManager(sessions, eventBus);
+  pipelines = new PipelineManager(sessions, eventBus, config.stateDir);
   await pipelines.hydrate(config.stateDir);
 
   // Initialize batch rate limiter (Issue #583)


### PR DESCRIPTION
## Summary

- **Fixes #1424** — Pipeline state was persisted to `pipelines.json` but the implementation had three bugs that made it ineffective on server restart
- **Stale file leak**: `persistPipelines()` returned early when no running pipelines remained, leaving a stale file that `hydrate()` would restore as completed/failed entries on next startup
- **Missing persist after pipeline completion**: `advancePipeline()` could transition a pipeline to `completed`/`failed` without calling `persistPipelines()`, so the file still showed `running` status
- **Fragile constructor**: `stateDir` was set via `hydrate()` instead of the constructor, creating an ordering dependency with startup

## Changes

| File | Change |
|------|--------|
| `src/pipeline.ts` | Delete state file when no running pipelines; persist after `advancePipeline` transitions; use static `unlink` import |
| `src/server.ts` | Pass `config.stateDir` to `PipelineManager` constructor |
| `src/__tests__/pipeline.test.ts` | Add 10 persistence tests (persist, hydrate, orphan detection, corrupt/missing file, null dir, non-existent dir) |

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 2635 passed, 0 failed
- [x] Manual: create pipeline → verify `pipelines.json` written → simulate restart → verify hydration restores state

## Aegis version
**Developed with:** v0.3.2-alpha

Generated by Hephaestus (Aegis dev agent)