### PR TITLE
fix: add global default pipeline stage timeout (#1423)

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -1319,6 +1319,104 @@ describe('PipelineManager', () => {
       expect(pipeline.stages[0].status).toBe('completed');
       expect(pipeline.status).toBe('completed');
     });
+
+    it('uses global defaultStageTimeoutMs when per-stage timeout is not set', async () => {
+      vi.useFakeTimers();
+
+      // Create manager with a global default of 90s
+      const defaultManager = new PipelineManager(sessions.mock, eventBus.mock, null, 90_000);
+
+      const config: PipelineConfig = {
+        name: 'default-timeout',
+        workDir: '/app',
+        stages: [
+          { name: 'slow', prompt: 'run slow', dependsOn: [] },
+          // No stageTimeoutMs — should use global default of 90s
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-slow'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await defaultManager.createPipeline(config);
+
+      sessions.getSession.mockReturnValue(makeMockSession('s-slow', { status: 'working' }));
+
+      // Advance past the 90s global default
+      vi.advanceTimersByTime(91_000);
+      await (defaultManager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('stage_timeout');
+
+      await defaultManager.destroy();
+    });
+
+    it('per-stage timeout overrides global defaultStageTimeoutMs', async () => {
+      vi.useFakeTimers();
+
+      // Global default is 30s, but per-stage is 120s
+      const defaultManager = new PipelineManager(sessions.mock, eventBus.mock, null, 30_000);
+
+      const config: PipelineConfig = {
+        name: 'override-timeout',
+        workDir: '/app',
+        stages: [
+          { name: 'slow', prompt: 'run slow', dependsOn: [], stageTimeoutMs: 120_000 },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-slow'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await defaultManager.createPipeline(config);
+
+      sessions.getSession.mockReturnValue(makeMockSession('s-slow', { status: 'working' }));
+
+      // Advance past global default (30s) but not per-stage (120s)
+      vi.advanceTimersByTime(31_000);
+      await (defaultManager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // Should still be running — per-stage timeout takes precedence
+      expect(pipeline.stages[0].status).toBe('running');
+
+      // Now advance past per-stage timeout
+      vi.advanceTimersByTime(90_000);
+      await (defaultManager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('stage_timeout');
+
+      await defaultManager.destroy();
+    });
+
+    it('timeout wins over idle when both are true at the same poll check', async () => {
+      vi.useFakeTimers();
+
+      // Use a very short timeout so timeout fires on the first poll
+      const config: PipelineConfig = {
+        name: 'timeout-over-idle',
+        workDir: '/app',
+        stages: [
+          { name: 'slow', prompt: 'run slow', dependsOn: [], stageTimeoutMs: 3_000 },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-slow'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Session is idle AND timed out — timeout should win at the same poll
+      sessions.getSession.mockReturnValue(makeMockSession('s-slow', { status: 'idle' }));
+
+      // Advance past the 3s timeout to the first poll at ~5s
+      vi.advanceTimersByTime(6_000);
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('stage_timeout');
+    });
   });
 
   // =========================================================================

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,9 @@ export interface Config {
     /** Run only critical checks: tsc + build (skip slow tests). Default: false = full. */
     criticalOnly: boolean;
   };
+  /** Issue #1423: Default timeout for pipeline stages (ms). 0 = no timeout (infinite).
+   *  Per-stage stageTimeoutMs overrides this. Env: AEGIS_PIPELINE_STAGE_TIMEOUT_MS */
+  pipelineStageTimeoutMs: number;
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -122,6 +125,7 @@ const defaults: Config = {
   memoryBridge: { enabled: false },
   worktreeSiblingDirs: [],
   verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
+  pipelineStageTimeoutMs: 0, // no timeout by default
 };
 
 /** Parse CLI args for --config flag */
@@ -209,6 +213,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_WEBHOOKS', manus: 'MANUS_WEBHOOKS', key: 'webhooks' },
     { aegis: 'AEGIS_SSE_MAX_CONNECTIONS', manus: 'MANUS_SSE_MAX_CONNECTIONS', key: 'sseMaxConnections' },
     { aegis: 'AEGIS_SSE_MAX_PER_IP', manus: 'MANUS_SSE_MAX_PER_IP', key: 'sseMaxPerIp' },
+    { aegis: 'AEGIS_PIPELINE_STAGE_TIMEOUT_MS', manus: 'MANUS_PIPELINE_STAGE_TIMEOUT_MS', key: 'pipelineStageTimeoutMs' },
   ];
 
   for (const { aegis, manus, key } of envMappings) {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -88,12 +88,17 @@ export class PipelineManager {
   private pipelineConfigs = new Map<string, PipelineConfig>(); // #219: preserve original stage config
   private pollInterval: NodeJS.Timeout | null = null;
   private cleanupTimers = new Map<string, NodeJS.Timeout>(); // #1092: track cleanup timers per pipeline
+  /** #1423: Global default stage timeout (ms). 0 = no timeout. */
+  private defaultStageTimeoutMs: number;
 
   constructor(
     private sessions: SessionManager,
     private eventBus?: SessionEventBus,
     private stateDir: string | null = null,
-  ) {}
+    defaultStageTimeoutMs: number = 0,
+  ) {
+    this.defaultStageTimeoutMs = defaultStageTimeoutMs;
+  }
 
   /** Create multiple sessions in parallel. */
   async batchCreate(specs: BatchSessionSpec[]): Promise<BatchResult> {
@@ -311,23 +316,26 @@ export class PipelineManager {
           continue;
         }
 
+        // #1423: Check for stage timeout BEFORE idle check — a timed-out
+        // stage should fail even if the session happens to be idle.
+        const stageConfig = this.pipelineConfigs.get(id)?.stages.find(s => s.name === stage.name);
+        const effectiveTimeout = stageConfig?.stageTimeoutMs ?? this.defaultStageTimeoutMs;
+        if (effectiveTimeout > 0 && stage.startedAt) {
+          const elapsed = Date.now() - stage.startedAt;
+          if (elapsed > effectiveTimeout) {
+            stage.status = 'failed';
+            stage.error = 'stage_timeout';
+            this.transitionPipelineStage(pipeline, 'fix', { stage: stage.name, reason: 'stage_timeout' });
+            await this.persistPipelines(); // #1424: persist after stage times out
+            continue;
+          }
+        }
+
         if (session.status === 'idle') {
           stage.status = 'completed';
           stage.completedAt = Date.now();
           this.transitionPipelineStage(pipeline, 'verify', { stageCompleted: stage.name });
           await this.persistPipelines(); // #1424: persist after stage completes
-        }
-
-        // #1423: Check for stage timeout
-        const stageConfig = this.pipelineConfigs.get(id)?.stages.find(s => s.name === stage.name);
-        if (stageConfig?.stageTimeoutMs && stage.startedAt) {
-          const elapsed = Date.now() - stage.startedAt;
-          if (elapsed > stageConfig.stageTimeoutMs) {
-            stage.status = 'failed';
-            stage.error = 'stage_timeout';
-            this.transitionPipelineStage(pipeline, 'fix', { stage: stage.name, reason: 'stage_timeout' });
-            await this.persistPipelines(); // #1424: persist after stage times out
-          }
         }
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2246,7 +2246,7 @@ async function main(): Promise<void> {
   registerModelRouterRoutes(app);
 
   // Initialize pipeline manager (Issue #36, #1424)
-  pipelines = new PipelineManager(sessions, eventBus);
+  pipelines = new PipelineManager(sessions, eventBus, undefined, config.pipelineStageTimeoutMs);
   await pipelines.hydrate(config.stateDir);
 
   // Initialize batch rate limiter (Issue #583)

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -124,6 +124,7 @@ const pipelineStageSchema = z.object({
   dependsOn: z.array(z.string()).optional(),
   permissionMode: z.enum(['default', 'bypassPermissions', 'plan', 'acceptEdits', 'dontAsk', 'auto']).optional(),
   autoApprove: z.boolean().optional(),
+  stageTimeoutMs: z.number().int().positive().optional(),
 });
 
 /** POST /v1/pipelines */


### PR DESCRIPTION
## Summary

- Fix timeout check ordering: timeout is now evaluated **before** idle status, so a timed-out stage fails even if the session happens to be idle at poll time
- Add configurable global default timeout (`AEGIS_PIPELINE_STAGE_TIMEOUT_MS` / `pipelineStageTimeoutMs` in config) so pipelines without per-stage `stageTimeoutMs` no longer hang forever
- Per-stage `stageTimeoutMs` overrides the global default when set
- Add `stageTimeoutMs` to the pipeline stage validation schema

## Changes

| File | Change |
|------|--------|
| `src/pipeline.ts` | Reorder timeout before idle check; add `defaultStageTimeoutMs` constructor param; use `effectiveTimeout = per-stage ?? global` |
| `src/config.ts` | Add `pipelineStageTimeoutMs` config field + `AEGIS_PIPELINE_STAGE_TIMEOUT_MS` env var |
| `src/validation.ts` | Add `stageTimeoutMs` to `pipelineStageSchema` |
| `src/server.ts` | Pass `config.pipelineStageTimeoutMs` to `PipelineManager` constructor |
| `src/__tests__/pipeline.test.ts` | 3 new tests: global default, per-stage override, timeout-wins-over-idle |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 2628 passed, 0 failed
- [x] New timeout tests cover: global default, per-stage override, timeout-before-idle ordering

Closes #1423

Generated by Hephaestus (Aegis dev agent)