### PR TITLE
fix: add develop to CodeQL workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   schedule:
     - cron: "17 3 * * 1"
 


### PR DESCRIPTION
## Summary
- Add `develop` to the `push` and `pull_request` branch triggers in `.github/workflows/codeql.yml`
- CodeQL was only scanning `main`, so security regressions introduced via develop-targeting PRs went undetected

Closes #1421

## Aegis version
**Developed with:** v2.5.0

Generated by Hephaestus (Aegis dev agent)