### PR TITLE
fix: auto-restart JsonlWatcher on fs.watch errors (#1420)

### DIFF
--- a/src/__tests__/jsonl-watcher.test.ts
+++ b/src/__tests__/jsonl-watcher.test.ts
@@ -416,4 +416,117 @@ describe('JsonlWatcher', () => {
 
     watcher.destroy();
   }, TEST_TIMEOUT);
+
+  describe('error recovery (Issue #1420)', () => {
+    it('re-watches the file after an fs.watch error', async () => {
+      const watcher = new JsonlWatcher({
+        debounceMs: 50,
+        maxRestartAttempts: 3,
+        restartBaseDelayMs: 100,
+      });
+      const sessionId = 'test-restart';
+
+      writeJsonl(sessionId, [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+      ]);
+
+      watcher.watch(sessionId, jsonlPath(sessionId), 0);
+      await settle();
+
+      // Simulate an fs.watch error
+      const entry = (watcher as unknown as { entries: Map<string, { fsWatcher: { emit: (event: string, ...args: unknown[]) => boolean } }> }).entries.get(sessionId);
+      expect(entry).toBeDefined();
+      entry!.fsWatcher.emit('error', new Error('watch error'));
+
+      // Wait for the restart backoff (100ms base * 2^0 = 100ms) + settle
+      await settle(300);
+
+      // The watcher should have re-watched the file
+      expect(watcher.isWatching(sessionId)).toBe(true);
+
+      watcher.destroy();
+    }, TEST_TIMEOUT);
+
+    it('stops retrying after max restart attempts', async () => {
+      vi.useFakeTimers();
+
+      const watcher = new JsonlWatcher({
+        debounceMs: 50,
+        maxRestartAttempts: 2,
+        restartBaseDelayMs: 100,
+      });
+      const sessionId = 'test-max-restart';
+
+      writeJsonl(sessionId, [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+      ]);
+
+      watcher.watch(sessionId, jsonlPath(sessionId), 0);
+
+      const entries = (watcher as unknown as { entries: Map<string, { fsWatcher: { emit: (event: string, ...args: unknown[]) => boolean } }> }).entries.get(sessionId);
+      expect(entries).toBeDefined();
+
+      // First error — schedules restart at 100ms
+      entries!.fsWatcher.emit('error', new Error('watch error 1'));
+      vi.advanceTimersByTime(100);
+      // New watcher created — get it
+      const entry2 = (watcher as unknown as { entries: Map<string, { fsWatcher: { emit: (event: string, ...args: unknown[]) => boolean } }> }).entries.get(sessionId);
+      expect(entry2).toBeDefined();
+
+      // Second error — schedules restart at 200ms
+      entry2!.fsWatcher.emit('error', new Error('watch error 2'));
+      vi.advanceTimersByTime(200);
+      const entry3 = (watcher as unknown as { entries: Map<string, { fsWatcher: { emit: (event: string, ...args: unknown[]) => boolean } }> }).entries.get(sessionId);
+      expect(entry3).toBeDefined();
+
+      // Third error — exceeds maxRestartAttempts (2), should give up
+      entry3!.fsWatcher.emit('error', new Error('watch error 3'));
+      vi.advanceTimersByTime(1000);
+
+      expect(watcher.isWatching(sessionId)).toBe(false);
+
+      watcher.destroy();
+      vi.useRealTimers();
+    }, TEST_TIMEOUT);
+
+    it('preserves byte offset across restarts', async () => {
+      const watcher = new JsonlWatcher({
+        debounceMs: 50,
+        maxRestartAttempts: 3,
+        restartBaseDelayMs: 100,
+      });
+      const sessionId = 'test-offset-preserve';
+
+      writeJsonl(sessionId, [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+      ]);
+
+      watcher.watch(sessionId, jsonlPath(sessionId), 0);
+
+      // Register listener BEFORE writing, settle to let fs.watch initialize
+      const eventPromise = waitForEvent(watcher);
+      await settle();
+
+      appendJsonl(sessionId, [
+        JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'response' } }),
+      ]);
+
+      const event = await eventPromise;
+      const savedOffset = event.newOffset;
+      expect(savedOffset).toBeGreaterThan(0);
+
+      // Simulate error to trigger restart
+      const entry = (watcher as unknown as { entries: Map<string, { fsWatcher: { emit: (event: string, ...args: unknown[]) => boolean } }> }).entries.get(sessionId);
+      expect(entry).toBeDefined();
+      entry!.fsWatcher.emit('error', new Error('watch error'));
+
+      // Wait for restart
+      await settle(300);
+
+      // Offset should be preserved after restart
+      expect(watcher.getOffset(sessionId)).toBe(savedOffset);
+
+      watcher.destroy();
+    }, TEST_TIMEOUT);
+  });
 });

--- a/src/jsonl-watcher.ts
+++ b/src/jsonl-watcher.ts
@@ -6,6 +6,7 @@
  * duplicate events from rapid writes.
  *
  * Issue #84: Replace JSONL polling with fs.watch.
+ * Issue #1420: Auto-restart watcher on fs.watch errors with exponential backoff.
  */
 
 import { watch, type FSWatcher } from 'node:fs';
@@ -25,10 +26,16 @@ export interface JsonlWatcherEvent {
 export interface JsonlWatcherConfig {
   /** Debounce interval in ms to coalesce rapid writes (default: 100). */
   debounceMs: number;
+  /** Maximum number of restart attempts before giving up (default: 5). */
+  maxRestartAttempts: number;
+  /** Base delay in ms for exponential backoff on restart (default: 1000). */
+  restartBaseDelayMs: number;
 }
 
 const DEFAULT_CONFIG: JsonlWatcherConfig = {
   debounceMs: 100,
+  maxRestartAttempts: 5,
+  restartBaseDelayMs: 1000,
 };
 
 /** Watch state for a single JSONL file. */
@@ -39,6 +46,10 @@ interface WatchEntry {
   debounceTimer: ReturnType<typeof setTimeout> | null;
   /** Current byte offset — updated after each read. */
   offset: number;
+  /** Issue #1420: Consecutive restart attempt count for exponential backoff. */
+  restartAttempts: number;
+  /** Issue #1420: Pending restart timer handle. */
+  restartTimer: ReturnType<typeof setTimeout> | null;
 }
 
 /**
@@ -106,8 +117,8 @@ export class JsonlWatcher {
 
     fsWatcher.on('error', (err) => {
       console.error(`JsonlWatcher: error watching ${jsonlPath}:`, err.message);
-      // Stop watching on persistent errors
-      this.unwatch(sessionId);
+      // Issue #1420: Attempt restart with exponential backoff instead of giving up.
+      this.scheduleRestart(sessionId);
     });
 
     this.entries.set(sessionId, {
@@ -116,6 +127,8 @@ export class JsonlWatcher {
       fsWatcher,
       debounceTimer: null,
       offset: initialOffset,
+      restartAttempts: 0,
+      restartTimer: null,
     });
   }
 
@@ -127,6 +140,9 @@ export class JsonlWatcher {
     if (entry.debounceTimer) {
       clearTimeout(entry.debounceTimer);
     }
+    if (entry.restartTimer) {
+      clearTimeout(entry.restartTimer);
+    }
     entry.fsWatcher.close();
     this.entries.delete(sessionId);
   }
@@ -136,6 +152,9 @@ export class JsonlWatcher {
     for (const [sessionId, entry] of this.entries) {
       if (entry.debounceTimer) {
         clearTimeout(entry.debounceTimer);
+      }
+      if (entry.restartTimer) {
+        clearTimeout(entry.restartTimer);
       }
       entry.fsWatcher.close();
     }
@@ -167,6 +186,41 @@ export class JsonlWatcher {
       this.unwatch(sessionId);
     }
     this.listeners.length = 0;
+  }
+
+  /** Issue #1420: Schedule a restart with exponential backoff after an fs.watch error. */
+  private scheduleRestart(sessionId: string): void {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return;
+
+    if (entry.restartAttempts >= this.config.maxRestartAttempts) {
+      console.error(
+        `JsonlWatcher: max restart attempts (${this.config.maxRestartAttempts}) reached for ${entry.jsonlPath}, giving up`,
+      );
+      this.unwatch(sessionId);
+      return;
+    }
+
+    const delay = this.config.restartBaseDelayMs * Math.pow(2, entry.restartAttempts);
+    entry.restartAttempts++;
+
+    console.error(
+      `JsonlWatcher: scheduling restart attempt ${entry.restartAttempts}/${this.config.maxRestartAttempts} for ${entry.jsonlPath} in ${delay}ms`,
+    );
+
+    entry.restartTimer = setTimeout(() => {
+      entry.restartTimer = null;
+      const currentOffset = entry.offset;
+      // Close the broken watcher first, then re-watch from saved offset
+      entry.fsWatcher.close();
+      this.entries.delete(sessionId);
+      this.watch(sessionId, entry.jsonlPath, currentOffset);
+      // Preserve restart counter across the re-watch
+      const newEntry = this.entries.get(sessionId);
+      if (newEntry) {
+        newEntry.restartAttempts = entry.restartAttempts;
+      }
+    }, delay);
   }
 
   /** Schedule a debounced read for a session. */


### PR DESCRIPTION
## Summary
- Replaced permanent `unwatch()` on fs.watch errors with automatic restart using exponential backoff (1s → 2s → 4s → 8s → 16s, max 5 attempts)
- Byte offset is preserved across restarts so no entries are lost
- After exhausting max attempts, the watcher gives up and logs an error (prevents infinite retry loops)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — all 2628 tests pass (3 new tests for error recovery)
- [x] Test: re-watches file after fs.watch error
- [x] Test: stops retrying after max restart attempts
- [x] Test: preserves byte offset across restarts

Closes #1420

Generated by Hephaestus (Aegis dev agent)