### PR TITLE
fix: add tamper-evident audit log for SOC2/ISO 27001 compliance

### DIFF
--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -1,0 +1,147 @@
+/**
+ * audit.test.ts — Tests for Issue #1419: Tamper-evident audit log.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AuditLogger } from '../audit.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rm, readdir, readFile } from 'node:fs/promises';
+
+describe('AuditLogger (Issue #1419)', () => {
+  let audit: AuditLogger;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `aegis-audit-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    audit = new AuditLogger(tmpDir);
+    await audit.init();
+  });
+
+  afterEach(async () => {
+    try { await rm(tmpDir, { recursive: true }); } catch { /* ignore */ }
+  });
+
+  describe('log()', () => {
+    it('should append a record with correct fields', async () => {
+      const record = await audit.log('master', 'key.create', 'Test key created');
+      expect(record.ts).toBeTruthy();
+      expect(record.actor).toBe('master');
+      expect(record.action).toBe('key.create');
+      expect(record.detail).toBe('Test key created');
+      expect(record.prevHash).toBe('');
+      expect(record.hash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should chain hashes between consecutive records', async () => {
+      const r1 = await audit.log('key-1', 'session.create', 'Session started', 'sess-1');
+      const r2 = await audit.log('key-1', 'session.kill', 'Session killed', 'sess-1');
+      expect(r2.prevHash).toBe(r1.hash);
+      expect(r2.hash).not.toBe(r1.hash);
+    });
+
+    it('should include sessionId when provided', async () => {
+      const record = await audit.log('admin', 'session.create', 'Created', 'abc-123');
+      expect(record.sessionId).toBe('abc-123');
+    });
+
+    it('should omit sessionId when not provided', async () => {
+      const record = await audit.log('system', 'key.create', 'Key made');
+      expect(record.sessionId).toBeUndefined();
+    });
+
+    it('should create a date-stamped log file', async () => {
+      await audit.log('system', 'key.create', 'Test');
+      const files = await readdir(tmpDir);
+      const logFiles = files.filter(f => f.startsWith('audit-') && f.endsWith('.log'));
+      expect(logFiles.length).toBe(1);
+      expect(logFiles[0]).toMatch(/^audit-\d{4}-\d{2}-\d{2}\.log$/);
+    });
+  });
+
+  describe('verify()', () => {
+    it('should return valid=true for an untampered log', async () => {
+      await audit.log('master', 'key.create', 'Key 1');
+      await audit.log('master', 'key.create', 'Key 2');
+      const result = await audit.verify();
+      expect(result.valid).toBe(true);
+    });
+
+    it('should detect a tampered record', async () => {
+      await audit.log('master', 'key.create', 'Original');
+      // Manually tamper with the file
+      const files = await readdir(tmpDir);
+      const logFile = files.find(f => f.startsWith('audit-'));
+      if (!logFile) throw new Error('No log file');
+      const content = await readFile(join(tmpDir, logFile), 'utf-8');
+      const tampered = content.replace(/"detail":"Original"/, '"detail":"Tampered"');
+      const { writeFile } = await import('node:fs/promises');
+      await writeFile(join(tmpDir, logFile), tampered);
+      const result = await audit.verify();
+      expect(result.valid).toBe(false);
+      expect(result.brokenAt).toBeDefined();
+    });
+  });
+
+  describe('query()', () => {
+    it('should return records filtered by actor', async () => {
+      await audit.log('admin', 'key.create', 'Admin key');
+      await audit.log('viewer', 'session.create', 'Viewer session');
+      const results = await audit.query({ actor: 'admin' });
+      expect(results).toHaveLength(1);
+      expect(results[0]!.actor).toBe('admin');
+    });
+
+    it('should return records filtered by action', async () => {
+      await audit.log('master', 'key.create', 'Created');
+      await audit.log('master', 'key.revoke', 'Revoked');
+      const results = await audit.query({ action: 'key.revoke' });
+      expect(results).toHaveLength(1);
+      expect(results[0]!.action).toBe('key.revoke');
+    });
+
+    it('should return records filtered by sessionId', async () => {
+      await audit.log('admin', 'session.create', 'S1', 's1');
+      await audit.log('admin', 'session.create', 'S2', 's2');
+      const results = await audit.query({ sessionId: 's1' });
+      expect(results).toHaveLength(1);
+    });
+
+    it('should respect the limit parameter', async () => {
+      for (let i = 0; i < 10; i++) {
+        await audit.log('system', 'api.authenticated', `Call ${i}`);
+      }
+      const results = await audit.query({ limit: 3 });
+      expect(results).toHaveLength(3);
+    });
+
+    it('should return records in reverse order when requested', async () => {
+      await audit.log('system', 'key.create', 'First');
+      await audit.log('system', 'key.create', 'Second');
+      await audit.log('system', 'key.create', 'Third');
+      const results = await audit.query({ limit: 2, reverse: true });
+      expect(results).toHaveLength(2);
+      expect(results[0]!.detail).toBe('Third');
+      expect(results[1]!.detail).toBe('Second');
+    });
+
+    it('should return empty array for no matching records', async () => {
+      const results = await audit.query({ actor: 'nonexistent' });
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('hash chain integrity', () => {
+    it('should recover last hash across restarts', async () => {
+      await audit.log('system', 'key.create', 'Before restart');
+      const firstHash = (await audit.query({ limit: 1 }))[0]!.hash;
+
+      // Simulate restart — create a new AuditLogger pointing to same dir
+      const restarted = new AuditLogger(tmpDir);
+      await restarted.init();
+
+      const newRecord = await restarted.log('system', 'key.revoke', 'After restart');
+      expect(newRecord.prevHash).toBe(firstHash);
+    });
+  });
+});

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,0 +1,287 @@
+/**
+ * audit.ts — Tamper-evident append-only audit trail.
+ *
+ * Issue #1419: SOC2/ISO 27001 compliance.
+ *
+ * Each record is chained via SHA-256 hashes — the hash of record N
+ * includes the hash of record N-1, making retroactive edits detectable.
+ * Log files rotate daily and are never overwritten.
+ */
+
+import { createHash } from 'node:crypto';
+import { appendFile, readFile, mkdir, stat, readdir, access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { secureFilePermissions } from './file-utils.js';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface AuditRecord {
+  /** ISO 8601 timestamp */
+  ts: string;
+  /** Actor key ID (or 'master' / 'system') */
+  actor: string;
+  /** Action category (e.g. 'key.create', 'session.kill') */
+  action: string;
+  /** Associated session ID, if applicable */
+  sessionId?: string;
+  /** Human-readable detail */
+  detail: string;
+  /** SHA-256 hash of previous record (hex) — empty string for first record */
+  prevHash: string;
+  /** SHA-256 hash of this record (hex) — covers all fields except itself */
+  hash: string;
+}
+
+export type AuditAction =
+  | 'key.create'
+  | 'key.revoke'
+  | 'session.create'
+  | 'session.kill'
+  | 'permission.approve'
+  | 'permission.reject'
+  | 'api.authenticated';
+
+export interface AuditQueryOptions {
+  /** Filter by actor key ID */
+  actor?: string;
+  /** Filter by action */
+  action?: AuditAction;
+  /** Filter by session ID */
+  sessionId?: string;
+  /** Max records to return (default 100) */
+  limit?: number;
+  /** Return records from newest first (default false = chronological) */
+  reverse?: boolean;
+}
+
+// ── Implementation ─────────────────────────────────────────────────────
+
+function dateToFileDate(d: Date): string {
+  return d.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function computeHash(record: Omit<AuditRecord, 'hash'>): string {
+  const payload = `${record.ts}|${record.actor}|${record.action}|${record.sessionId ?? ''}|${record.detail}|${record.prevHash}`;
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+export class AuditLogger {
+  private logDir: string;
+  private lastHash: string;
+  private writeLock: Promise<void>;
+
+  constructor(logDir?: string) {
+    this.logDir = logDir ?? join(homedir(), '.aegis', 'audit');
+    this.lastHash = '';
+    this.writeLock = Promise.resolve();
+  }
+
+  /** Initialize the audit logger — ensure directory exists, read last hash. */
+  async init(): Promise<void> {
+    if (!existsSync(this.logDir)) {
+      await mkdir(this.logDir, { recursive: true });
+    }
+    await this.recoverLastHash();
+  }
+
+  /** Recover the last hash from the most recent audit log file. */
+  private async recoverLastHash(): Promise<void> {
+    try {
+      const files = await readdir(this.logDir);
+      const logFiles = files
+        .filter(f => f.startsWith('audit-') && f.endsWith('.log'))
+        .sort()
+        .reverse();
+
+      if (logFiles.length === 0) {
+        this.lastHash = '';
+        return;
+      }
+
+      const latestFile = join(this.logDir, logFiles[0]!);
+      const content = await readFile(latestFile, 'utf-8');
+      const lines = content.trim().split('\n');
+
+      if (lines.length === 0) {
+        this.lastHash = '';
+        return;
+      }
+
+      const lastLine = lines[lines.length - 1]!;
+      try {
+        const record = JSON.parse(lastLine) as AuditRecord;
+        this.lastHash = record.hash;
+      } catch {
+        // Corrupted last line — scan backwards for valid JSON
+        for (let i = lines.length - 1; i >= 0; i--) {
+          try {
+            const rec = JSON.parse(lines[i]!) as AuditRecord;
+            this.lastHash = rec.hash;
+            return;
+          } catch {
+            continue;
+          }
+        }
+        this.lastHash = '';
+      }
+    } catch {
+      this.lastHash = '';
+    }
+  }
+
+  /** Get the file path for a given date. */
+  private filePath(d: Date): string {
+    return join(this.logDir, `audit-${dateToFileDate(d)}.log`);
+  }
+
+  /**
+   * Append an audit record. Serialized through a write lock to guarantee
+   * ordering and correct hash chaining even under concurrent callers.
+   */
+  async log(
+    actor: string,
+    action: AuditAction,
+    detail: string,
+    sessionId?: string,
+  ): Promise<AuditRecord> {
+    let release: () => void = () => {};
+    const lock = new Promise<void>((resolve) => { release = resolve; });
+    const previous = this.writeLock;
+    this.writeLock = lock;
+
+    try {
+      await previous.catch(() => {});
+
+      const ts = new Date().toISOString();
+      const partial: Omit<AuditRecord, 'hash'> = {
+        ts,
+        actor,
+        action,
+        sessionId,
+        detail,
+        prevHash: this.lastHash,
+      };
+      const hash = computeHash(partial);
+      const record: AuditRecord = { ...partial, hash };
+
+      const line = JSON.stringify(record) + '\n';
+      const file = this.filePath(new Date(ts));
+
+      // Ensure directory exists (in case it was cleaned)
+      if (!existsSync(dirname(file))) {
+        await mkdir(dirname(file), { recursive: true });
+      }
+
+      // Append-only — never overwrite
+      await appendFile(file, line, { mode: 0o600 });
+      await secureFilePermissions(file);
+
+      this.lastHash = hash;
+      return record;
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Verify the integrity of the audit log by checking the hash chain.
+   * Returns { valid: true } if all records chain correctly,
+   * or { valid: false, brokenAt: lineNumber } if a tampered record is found.
+   */
+  async verify(): Promise<{ valid: boolean; brokenAt?: number; file?: string }> {
+    try {
+      const files = await readdir(this.logDir);
+      const logFiles = files
+        .filter(f => f.startsWith('audit-') && f.endsWith('.log'))
+        .sort();
+
+      let prevHash = '';
+      let globalLineNum = 0;
+
+      for (const file of logFiles) {
+        const fullPath = join(this.logDir, file);
+        const content = await readFile(fullPath, 'utf-8');
+        const lines = content.trim().split('\n');
+
+        for (const line of lines) {
+          globalLineNum++;
+          try {
+            const record = JSON.parse(line) as AuditRecord;
+
+            if (record.prevHash !== prevHash) {
+              return { valid: false, brokenAt: globalLineNum, file };
+            }
+
+            const expectedHash = computeHash(record);
+            if (record.hash !== expectedHash) {
+              return { valid: false, brokenAt: globalLineNum, file };
+            }
+
+            prevHash = record.hash;
+          } catch {
+            return { valid: false, brokenAt: globalLineNum, file };
+          }
+        }
+      }
+
+      return { valid: true };
+    } catch {
+      return { valid: true };
+    }
+  }
+
+  /**
+   * Query audit records across all log files.
+   * Reads files in chronological order and applies filters.
+   */
+  async query(options: AuditQueryOptions = {}): Promise<AuditRecord[]> {
+    const {
+      actor,
+      action,
+      sessionId,
+      limit = 100,
+      reverse = false,
+    } = options;
+
+    try {
+      const files = await readdir(this.logDir);
+      const logFiles = files
+        .filter(f => f.startsWith('audit-') && f.endsWith('.log'))
+        .sort();
+
+      const allRecords: AuditRecord[] = [];
+
+      for (const file of logFiles) {
+        const fullPath = join(this.logDir, file);
+        const content = await readFile(fullPath, 'utf-8');
+        const lines = content.trim().split('\n');
+
+        for (const line of lines) {
+          try {
+            const record = JSON.parse(line) as AuditRecord;
+
+            if (actor && record.actor !== actor) continue;
+            if (action && record.action !== action) continue;
+            if (sessionId && record.sessionId !== sessionId) continue;
+
+            allRecords.push(record);
+          } catch {
+            // Skip malformed lines
+            continue;
+          }
+        }
+      }
+
+      // Apply limit after filtering
+      const result = reverse
+        ? allRecords.slice(-limit).reverse()
+        : allRecords.slice(-limit);
+
+      return result;
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,6 +12,7 @@ import { authStoreSchema } from './validation.js';
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { secureFilePermissions } from './file-utils.js';
+import type { AuditLogger } from './audit.js';
 
 export type ApiKeyRole = 'admin' | 'operator' | 'viewer';
 
@@ -76,6 +77,8 @@ export class AuthManager {
   private batchRateLimits = new Map<string, number>();
   /** #1080: HTTP server host binding (set after construction via setHost()). */
   private host: string = '127.0.0.1';
+  /** #1419: Audit logger — optional, injected via setAuditLogger(). */
+  private audit: AuditLogger | null = null;
 
 
   constructor(
@@ -88,6 +91,11 @@ export class AuthManager {
   /** #1080: Set the HTTP server host binding after construction (config.host is not available at construction time). */
   setHost(host: string): void {
     this.host = host;
+  }
+
+  /** #1419: Inject audit logger for key lifecycle events. */
+  setAuditLogger(audit: AuditLogger): void {
+    this.audit = audit;
   }
 
   /** #1080: Expose host binding for server.ts setupAuth() check. */
@@ -151,6 +159,11 @@ export class AuthManager {
     this.store.keys.push(apiKey);
     await this.save();
 
+    // #1419: Audit key creation
+    if (this.audit) {
+      void this.audit.log('system', 'key.create', `Key created: ${name} (${id}) role=${role}`, undefined);
+    }
+
     return { id, key, name, expiresAt, role };
   }
 
@@ -163,9 +176,16 @@ export class AuthManager {
   async revokeKey(id: string): Promise<boolean> {
     const idx = this.store.keys.findIndex(k => k.id === id);
     if (idx === -1) return false;
+    const revoked = this.store.keys[idx]!;
     this.store.keys.splice(idx, 1);
     this.rateLimits.delete(id);
     await this.save();
+
+    // #1419: Audit key revocation
+    if (this.audit) {
+      void this.audit.log('system', 'key.revoke', `Key revoked: ${revoked.name} (${id})`, undefined);
+    }
+
     return true;
   }
 

--- a/src/permission-routes.ts
+++ b/src/permission-routes.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { SessionManager } from './session.js';
 import type { MetricsCollector } from './metrics.js';
+import type { AuditLogger } from './audit.js';
 
 type PermissionAction = 'approve' | 'reject';
 type IdParams = { Params: { id: string } };
@@ -13,6 +14,7 @@ function createPermissionHandler(
   action: PermissionAction,
   sessions: PermissionSessions,
   metrics: PermissionMetrics,
+  audit: AuditLogger | null,
 ): (req: IdRequest, reply: FastifyReply) => Promise<unknown> {
   return async (req: IdRequest, reply: FastifyReply): Promise<unknown> => {
     // Issue #1429: Enforce session ownership
@@ -28,6 +30,11 @@ function createPermissionHandler(
         await sessions.approve(req.params.id);
       } else {
         await sessions.reject(req.params.id);
+      }
+
+      // #1419: Audit permission decision
+      if (audit) {
+        void audit.log(keyId ?? 'system', `permission.${action}` as `permission.${typeof action}`, `Permission ${action} for session ${req.params.id}`, req.params.id);
       }
 
       // Issue #87: Record permission response latency.
@@ -47,9 +54,10 @@ export function registerPermissionRoutes(
   app: FastifyInstance,
   sessions: PermissionSessions,
   metrics: PermissionMetrics,
+  audit: AuditLogger | null = null,
 ): void {
   for (const action of ['approve', 'reject'] as const) {
-    const handler = createPermissionHandler(action, sessions, metrics);
+    const handler = createPermissionHandler(action, sessions, metrics, audit);
     app.post<IdParams>(`/v1/sessions/:id/${action}`, handler);
     app.post<IdParams>(`/sessions/:id/${action}`, handler);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,7 @@ import { SSEConnectionLimiter } from './sse-limiter.js';
 import { PipelineManager } from './pipeline.js';
 import { ToolRegistry } from './tool-registry.js';
 import { AuthManager, classifyBearerTokenForRoute, type ApiKeyRole } from './auth.js';
+import { AuditLogger, type AuditAction } from './audit.js';
 import { MetricsCollector } from './metrics.js';
 import { promRegistry, METRICS_CONTENT_TYPE } from './prometheus.js';
 import { registerPermissionRoutes } from './permission-routes.js';
@@ -201,6 +202,7 @@ let sseLimiter: SSEConnectionLimiter;let pipelines: PipelineManager;
 let toolRegistry: ToolRegistry;
 let auth: AuthManager;
 let metrics: MetricsCollector;
+let auditLogger: AuditLogger | undefined;
 let swarmMonitor: SwarmMonitor;
 
 // ── Inbound command handler ─────────────────────────────────────────
@@ -503,6 +505,11 @@ function setupAuth(authManager: AuthManager): void {
     requestKeyMap.set(req.id, result.keyId ?? 'anonymous');
     req.authKeyId = result.keyId;
 
+    // #1419: Audit authenticated API calls (fire-and-forget, non-blocking)
+    if (typeof auditLogger !== 'undefined') {
+      void auditLogger.log(result.keyId ?? 'anonymous', 'api.authenticated', `${req.method} ${req.url?.split('?')[0] ?? req.url}`);
+    }
+
     // #228: Per-IP rate limiting (applies to all authenticated requests)
     // #633: Only use req.ip — trustProxy controls whether X-Forwarded-For is considered
     const isMaster = result.keyId === 'master';
@@ -664,6 +671,36 @@ app.post('/v1/auth/sse-token', async (req, reply) => {
   } catch (e: unknown) {
     return reply.status(429).send({ error: e instanceof Error ? e.message : 'SSE token limit reached' });
   }
+});
+
+// #1419: Audit log endpoint — admin only
+const auditQuerySchema = z.object({
+  actor: z.string().optional(),
+  action: z.string().optional(),
+  sessionId: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+  reverse: z.coerce.boolean().optional(),
+  verify: z.coerce.boolean().optional(),
+});
+
+app.get('/v1/audit', async (req, reply) => {
+  if (!requireRole(req, reply, 'admin')) return;
+
+  const parsed = auditQuerySchema.safeParse(req.query ?? {});
+  if (!parsed.success) {
+    return reply.status(400).send({ error: 'Invalid query params', details: parsed.error.issues });
+  }
+
+  const { verify: verifyChain, action, ...rest } = parsed.data;
+  const queryOpts = { ...rest, action: action as AuditAction | undefined };
+
+  if (verifyChain) {
+    const result = await auditLogger!.verify();
+    return { integrity: result, records: await auditLogger!.query(queryOpts) };
+  }
+
+  const records = await auditLogger!.query(queryOpts);
+  return { count: records.length, records };
 });
 
 const diagnosticsQuerySchema = z.object({
@@ -1017,6 +1054,9 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
 
   // Issue #625: Track session in metrics so sessionsCreated counter is accurate
   metrics.sessionCreated(session.id);
+
+  // #1419: Audit session creation
+  if (auditLogger) void auditLogger.log(req.authKeyId ?? 'system', 'session.create', `Session created: ${session.windowName} in ${safeWorkDir}`, session.id);
 
   // Issue #46: Create Telegram topic BEFORE sending prompt.
   // The monitor starts polling immediately after createSession().
@@ -1376,6 +1416,7 @@ registerPermissionRoutes(
   {
     recordPermissionResponse: (id: string, latencyMs: number) => metrics.recordPermissionResponse(id, latencyMs),
   },
+  auditLogger ?? null,
 );
 
 // Issue #336: Answer pending AskUserQuestion
@@ -1433,6 +1474,8 @@ async function killSessionHandler(req: IdRequest, reply: FastifyReply): Promise<
     // reference a session that is still being destroyed.
     await sessions.killSession(req.params.id);
     eventBus.emitEnded(req.params.id, 'killed');
+    // #1419: Audit session kill
+    if (auditLogger) void auditLogger.log(req.authKeyId ?? 'system', 'session.kill', `Session killed: ${req.params.id}`, req.params.id);
     await channels.sessionEnded(makePayload('session.ended', req.params.id, 'killed'));
     cleanupTerminatedSessionState(req.params.id, { monitor, metrics, toolRegistry });
     return { ok: true };
@@ -2188,6 +2231,12 @@ async function main(): Promise<void> {
   auth = new AuthManager(path.join(config.stateDir, 'keys.json'), config.authToken);
   auth.setHost(config.host);  // #1080: needed for auth bypass security check
   await auth.load();
+
+  // #1419: Initialize audit logger and wire into auth
+  auditLogger = new AuditLogger(path.join(config.stateDir, 'audit'));
+  await auditLogger.init();
+  auth.setAuditLogger(auditLogger);
+
   setupAuth(auth);
 
   // Register WebSocket plugin for live terminal streaming (Issue #108)


### PR DESCRIPTION
## Summary
- Implements a tamper-evident append-only audit trail (Issue #1419) for SOC2/ISO 27001 compliance
- SHA-256 hash chain links each record to its predecessor, making retroactive edits detectable
- Daily log rotation under `~/.aegis/audit/audit-YYYY-MM-DD.log` — never overwritten

## Changes

### New: `src/audit.ts`
- **`AuditRecord`** type: `{ ts, actor, action, sessionId, detail, prevHash, hash }`
- **`AuditLogger`** class: append-only writes, hash chain verification, filtered queries
- Supports restart recovery (reads last hash from most recent log file)

### Modified: `src/auth.ts`
- Injected `AuditLogger` via `setAuditLogger()` (dependency injection, no tight coupling)
- Audits `key.create` and `key.revoke` events

### Modified: `src/permission-routes.ts`
- Accepts optional `AuditLogger` in `registerPermissionRoutes()`
- Audits `permission.approve` and `permission.reject` decisions

### Modified: `src/server.ts`
- Initializes `AuditLogger` in `main()`, wires into `AuthManager`
- Audits `session.create`, `session.kill`, `api.authenticated` (every validated API call)
- **New endpoint:** `GET /v1/audit` (admin-only) with filters: `?actor=&action=&sessionId=&limit=&reverse=&verify=`

### New: `src/__tests__/audit.test.ts`
- 14 unit tests covering log/write, hash chaining, tamper detection, filtering, limit/reverse, and restart recovery

## Audit events logged
| Action | Trigger |
|--------|---------|
| `key.create` | API key created |
| `key.revoke` | API key revoked |
| `session.create` | Session created |
| `session.kill` | Session killed |
| `permission.approve` | Permission approved |
| `permission.reject` | Permission rejected |
| `api.authenticated` | Any authenticated API call |

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 2639 passed, 0 failed (14 new audit tests)
- [ ] Manual: verify `GET /v1/audit` returns records with correct hash chain
- [ ] Manual: verify `GET /v1/audit?verify=true` detects tampering

## Aegis version
**Developed with:** v0.3.2-alpha

Closes #1419

Generated by Hephaestus (Aegis dev agent)