### PR TITLE
fix: calculate actual avg_duration_sec instead of hardcoding 0

### DIFF
--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -2,7 +2,7 @@
  * metrics.test.ts — Tests for Issue #40: metrics + usage data.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MetricsCollector } from '../metrics.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -46,6 +46,41 @@ describe('Metrics and usage data (Issue #40)', () => {
       const m = metrics.getGlobalMetrics(0);
       expect((m.sessions as any).completed).toBe(1);
       expect((m.sessions as any).failed).toBe(1);
+    });
+
+    it('should calculate avg_duration_sec for completed sessions (#1414)', () => {
+      vi.useFakeTimers();
+      metrics.sessionCreated('s1');
+      vi.advanceTimersByTime(5000); // 5 seconds
+      metrics.sessionCreated('s2');
+      vi.advanceTimersByTime(3000); // s2 ran 3s, s1 ran 8s total
+      metrics.sessionCompleted('s1');
+      vi.advanceTimersByTime(4000); // s2 ran 7s total
+      metrics.sessionFailed('s2');
+
+      const m = metrics.getGlobalMetrics(0);
+      // s1: 8s, s2: 7s → avg = 7.5 → rounds to 8
+      expect(m.sessions.avg_duration_sec).toBe(8);
+      vi.useRealTimers();
+    });
+
+    it('should include active session duration in avg_duration_sec', () => {
+      vi.useFakeTimers();
+      metrics.sessionCreated('s1');
+      vi.advanceTimersByTime(10000); // 10 seconds
+      metrics.sessionCompleted('s1');
+      metrics.sessionCreated('s2');
+      vi.advanceTimersByTime(4000); // s2 active for 4s
+
+      const m = metrics.getGlobalMetrics(1);
+      // s1: 10s (completed), s2: 4s (active) → avg = 7
+      expect(m.sessions.avg_duration_sec).toBe(7);
+      vi.useRealTimers();
+    });
+
+    it('should return 0 avg_duration_sec when no sessions exist', () => {
+      const m = metrics.getGlobalMetrics(0);
+      expect(m.sessions.avg_duration_sec).toBe(0);
     });
 
     it('should count auto-approvals', () => {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -103,6 +103,7 @@ export class MetricsCollector {
 
   private perSession = new Map<string, SessionMetrics>();
   private latency = new Map<string, SessionLatency>();
+  private sessionStartTimes = new Map<string, number>();
   private startTime = Date.now();
 
   /** Maximum samples per latency type per session (rolling window). */
@@ -159,20 +160,32 @@ export class MetricsCollector {
   sessionCreated(sessionId: string): void {
     this.global.sessionsCreated++;
     sessionsCreatedTotal.inc();
+    this.sessionStartTimes.set(sessionId, Date.now());
     this.perSession.set(sessionId, {
       durationSec: 0, messages: 0, toolCalls: 0,
       approvals: 0, autoApprovals: 0, statusChanges: [],
     });
   }
 
-  sessionCompleted(_sessionId: string): void {
+  sessionCompleted(sessionId: string): void {
     this.global.sessionsCompleted++;
     sessionsCompletedTotal.inc();
+    this.finalizeSessionDuration(sessionId);
   }
 
-  sessionFailed(_sessionId: string): void {
+  sessionFailed(sessionId: string): void {
     this.global.sessionsFailed++;
     sessionsFailedTotal.inc();
+    this.finalizeSessionDuration(sessionId);
+  }
+
+  /** Record the final duration for a completed or failed session. */
+  private finalizeSessionDuration(sessionId: string): void {
+    const startedAt = this.sessionStartTimes.get(sessionId);
+    const m = this.perSession.get(sessionId);
+    if (startedAt !== undefined && m) {
+      m.durationSec = Math.round((Date.now() - startedAt) / 1000);
+    }
   }
 
   messageReceived(sessionId: string): void {
@@ -335,11 +348,29 @@ export class MetricsCollector {
   cleanupSession(sessionId: string): void {
     this.perSession.delete(sessionId);
     this.latency.delete(sessionId);
+    this.sessionStartTimes.delete(sessionId);
   }
 
   getGlobalMetrics(activeSessionCount: number): GlobalMetricsResponse {
     const avgMessages = this.global.sessionsCreated > 0
       ? Math.round(this.global.totalMessages / this.global.sessionsCreated) : 0;
+
+    // Issue #1414: Calculate avg_duration_sec from per-session durations.
+    // Completed/failed sessions have finalized durationSec; active sessions use elapsed time.
+    let totalDuration = 0;
+    const now = Date.now();
+    for (const [id, m] of this.perSession) {
+      if (m.durationSec > 0) {
+        totalDuration += m.durationSec;
+      } else {
+        const startedAt = this.sessionStartTimes.get(id);
+        if (startedAt !== undefined) {
+          totalDuration += Math.round((now - startedAt) / 1000);
+        }
+      }
+    }
+    const avgDuration = this.perSession.size > 0
+      ? Math.round(totalDuration / this.perSession.size) : 0;
 
     // Update Prometheus sessions_active gauge
     sessionsActive.set(activeSessionCount);
@@ -357,7 +388,7 @@ export class MetricsCollector {
         currently_active: activeSessionCount,
         completed: this.global.sessionsCompleted,
         failed: this.global.sessionsFailed,
-        avg_duration_sec: 0,
+        avg_duration_sec: avgDuration,
         avg_messages_per_session: avgMessages,
       },
       auto_approvals: this.global.autoApprovals,


### PR DESCRIPTION
## Summary
- Fixes #1414: `avg_duration_sec` was hardcoded to `0` in `getGlobalMetrics()`
- Now tracks session start times and computes the real average duration across all sessions (completed, failed, and still active)

## Changes
- **`src/metrics.ts`**: Added `sessionStartTimes` map; `sessionCreated` records start time, `sessionCompleted`/`sessionFailed` finalize `durationSec` on per-session metrics; `getGlobalMetrics` computes `avg_duration_sec` from per-session durations (using elapsed time for active sessions)
- **`src/__tests__/metrics.test.ts`**: Added 3 tests covering completed-only, mixed active+completed, and zero-session scenarios

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (32/32, +3 new)
- [ ] Verify `/v1/health` returns non-zero `avg_duration_sec` after completing sessions

Generated by Hephaestus (Aegis dev agent)