### PR TITLE
fix: add request/correlation IDs for log correlation (#1416)

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -12,6 +12,7 @@ export interface DiagnosticsEvent {
   component: string;
   operation: string;
   sessionId?: string;
+  requestId?: string;
   errorCode?: string;
   timestamp: string;
   attributes: Record<string, unknown>;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,6 +13,7 @@ export interface LogContext {
   component: string;
   operation: string;
   sessionId?: string;
+  requestId?: string;
   errorCode?: string;
   attributes?: Record<string, unknown>;
 }
@@ -23,6 +24,7 @@ export interface StructuredLogRecord {
   component: string;
   operation: string;
   sessionId?: string;
+  requestId?: string;
   errorCode?: string;
   attributes: Record<string, unknown>;
 }
@@ -73,6 +75,7 @@ export class StructuredLogger {
       component: ctx.component,
       operation: ctx.operation,
       sessionId: ctx.sessionId,
+      requestId: ctx.requestId,
       errorCode: ctx.errorCode,
       attributes,
     };
@@ -91,6 +94,7 @@ export class StructuredLogger {
       component: ctx.component,
       operation: ctx.operation,
       sessionId: ctx.sessionId,
+      requestId: ctx.requestId,
       errorCode: ctx.errorCode,
       timestamp,
       attributes,

--- a/src/server.ts
+++ b/src/server.ts
@@ -239,6 +239,9 @@ async function handleInbound(cmd: InboundCommand): Promise<void> {
 const app = Fastify({
   bodyLimit: 1048576, // 1MB — Issue #349: explicit body size limit
   trustProxy: process.env.TRUST_PROXY === 'true', // #633: Only trust X-Forwarded-For when explicitly enabled
+  // Issue #1416: UUID-v4 request IDs for log correlation across components
+  requestIdHeader: 'x-request-id',
+  genReqId: () => crypto.randomUUID(),
   logger: {
     // #230: Redact auth tokens from request logs
     serializers: {
@@ -277,6 +280,8 @@ app.addHook('onSend', (req, reply, payload, done) => {
   if (req.url?.startsWith('/v1/')) {
     reply.header('X-Aegis-API-Version', '1');
   }
+  // Issue #1416: Return request ID in response header for client-side correlation
+  reply.header('X-Request-Id', req.id);
   reply.header('Referrer-Policy', 'strict-origin-when-cross-origin');
   reply.header('Permissions-Policy', 'camera=(), microphone=()');
   const normalizedPayload = normalizeApiErrorPayload({


### PR DESCRIPTION
## Summary
- Enable Fastify `requestIdHeader: 'x-request-id'` with `genReqId` generating UUID-v4 per request (replaces default incrementing integers)
- Add `requestId` field to `LogContext`, `StructuredLogRecord`, and `DiagnosticsEvent` interfaces
- Return `X-Request-Id` response header on all API responses for client-side correlation
- Error envelopes (`ApiErrorEnvelope.requestId`) now carry UUID-v4 instead of integer IDs

## How it works
1. Incoming requests with `X-Request-Id` header are propagated (Fastify `requestIdHeader`)
2. Requests without it get a fresh `crypto.randomUUID()` (Fastify `genReqId`)
3. The UUID flows through `req.id` → `X-Request-Id` response header + error envelope
4. Route handlers can pass `req.id` as `requestId` in `LogContext` to correlate structured logs
5. Background components (monitor) remain session-scoped — `requestId` is optional

Closes #1416

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 2625 tests pass

Generated by Hephaestus (Aegis dev agent)