### PR TITLE
fix: add API key rotation endpoint and expired-key rejection reason

### DIFF
--- a/src/__tests__/auth-key-rotation-1403.test.ts
+++ b/src/__tests__/auth-key-rotation-1403.test.ts
@@ -1,0 +1,145 @@
+/**
+ * auth-key-rotation-1403.test.ts — Tests for Issue #1403: API key expiry + rotation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AuthManager, type AuthRejectReason } from '../auth.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rm } from 'node:fs/promises';
+
+describe('API key expiry and rotation (Issue #1403)', () => {
+  let auth: AuthManager;
+  let tmpFile: string;
+
+  beforeEach(async () => {
+    tmpFile = join(tmpdir(), `aegis-1403-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+    auth = new AuthManager(tmpFile, '');
+  });
+
+  afterEach(async () => {
+    try { await rm(tmpFile); } catch { /* ignore */ }
+  });
+
+  describe('validate() reason field', () => {
+    it('should return reason="expired" for an expired key', async () => {
+      const { key } = await auth.createKey('expiring', 100, 1);
+      const stored = (auth as unknown as { store: { keys: Array<{ expiresAt: number }> } }).store.keys[0];
+      stored.expiresAt = Date.now() - 1000;
+      const result = auth.validate(key);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('expired');
+    });
+
+    it('should return reason="invalid" for a wrong key', async () => {
+      await auth.createKey('my-key');
+      const result = auth.validate('aegis_deadbeef');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('invalid');
+    });
+
+    it('should return reason="no_auth" when no auth configured on non-localhost', () => {
+      const noAuth = new AuthManager(tmpFile, '');
+      noAuth.setHost('0.0.0.0');
+      const result = noAuth.validate('anything');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('no_auth');
+    });
+
+    it('should not set reason when valid', async () => {
+      const { key } = await auth.createKey('valid-key');
+      const result = auth.validate(key);
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should not set reason when no auth on localhost', () => {
+      const noAuth = new AuthManager(tmpFile, '');
+      const result = noAuth.validate('anything');
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+  });
+
+  describe('rotateKey()', () => {
+    it('should rotate an existing key and return the new plaintext', async () => {
+      const { id, key: oldKey } = await auth.createKey('rotate-me');
+      const rotated = await auth.rotateKey(id);
+      expect(rotated).not.toBeNull();
+      expect(rotated!.key).not.toBe(oldKey);
+      expect(rotated!.key).toMatch(/^aegis_[a-f0-9]{64}$/);
+      expect(rotated!.id).toBe(id);
+      expect(rotated!.name).toBe('rotate-me');
+    });
+
+    it('should invalidate the old key after rotation', async () => {
+      const { id, key: oldKey } = await auth.createKey('rotate-me');
+      const rotated = await auth.rotateKey(id);
+      // Old key must no longer validate
+      expect(auth.validate(oldKey).valid).toBe(false);
+      // New key must validate
+      expect(auth.validate(rotated!.key).valid).toBe(true);
+    });
+
+    it('should preserve role from original key', async () => {
+      const { id } = await auth.createKey('admin-key', 100, undefined, 'admin');
+      const rotated = await auth.rotateKey(id);
+      expect(rotated!.role).toBe('admin');
+    });
+
+    it('should preserve rateLimit from original key', async () => {
+      const { id } = await auth.createKey('limited-key', 42);
+      const rotated = await auth.rotateKey(id);
+      // Validate that the new key works and the rate limit is inherited
+      const result = auth.validate(rotated!.key);
+      expect(result.valid).toBe(true);
+      // The stored key should still have rateLimit=42
+      const stored = (auth as unknown as { store: { keys: Array<{ rateLimit: number }> } }).store.keys[0];
+      expect(stored.rateLimit).toBe(42);
+    });
+
+    it('should set new expiresAt when ttlDays is provided', async () => {
+      const { id } = await auth.createKey('old-expiry', 100, 1);
+      const rotated = await auth.rotateKey(id, 30);
+      expect(rotated!.expiresAt).not.toBeNull();
+      expect(rotated!.expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('should preserve existing expiresAt when ttlDays is omitted', async () => {
+      const { id } = await auth.createKey('keep-expiry', 100, 90);
+      const rotated = await auth.rotateKey(id);
+      // The expiresAt should still be set (not null)
+      expect(rotated!.expiresAt).not.toBeNull();
+    });
+
+    it('should return null for non-existent key', async () => {
+      const rotated = await auth.rotateKey('nonexistent-id');
+      expect(rotated).toBeNull();
+    });
+
+    it('should persist rotated key to disk', async () => {
+      const { id } = await auth.createKey('persist-rotate');
+      const rotated = await auth.rotateKey(id);
+
+      // Reload from disk
+      const auth2 = new AuthManager(tmpFile, '');
+      await auth2.load();
+
+      // New key should validate
+      expect(auth2.validate(rotated!.key).valid).toBe(true);
+    });
+
+    it('should reset rate limit counters on rotation', async () => {
+      const { id, key } = await auth.createKey('rate-reset', 2);
+      // Exhaust rate limit
+      auth.validate(key);
+      auth.validate(key);
+      expect(auth.validate(key).rateLimited).toBe(true);
+
+      // Rotate
+      const rotated = await auth.rotateKey(id);
+      // New key should not be rate limited
+      expect(auth.validate(rotated!.key).rateLimited).toBe(false);
+    });
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -62,6 +62,9 @@ export function classifyBearerTokenForRoute(
   return token.startsWith('sse_') ? 'sse' : 'reject';
 }
 
+/** Rejection reason when validate() returns valid=false. Issue #1403. */
+export type AuthRejectReason = 'expired' | 'invalid' | 'no_auth';
+
 export class AuthManager {
   private store: ApiKeyStore = { keys: [] };
   private rateLimits = new Map<string, RateLimitBucket>();
@@ -170,16 +173,44 @@ export class AuthManager {
   }
 
   /**
-   * Validate a bearer token.
-   * Returns { valid, keyId, rateLimited } or null if no auth configured.
+   * Rotate a key by ID (Issue #1403).
+   * Generates a new plaintext key, replaces the old hash, and preserves
+   * name, role, rateLimit, and ttlDays. Returns the new key or null if not found.
    */
-  validate(token: string): { valid: boolean; keyId: string | null; rateLimited: boolean } {
+  async rotateKey(
+    id: string,
+    ttlDays?: number,
+  ): Promise<{ id: string; key: string; name: string; expiresAt: number | null; role: ApiKeyRole } | null> {
+    const existing = this.store.keys.find(k => k.id === id);
+    if (!existing) return null;
+
+    const newKey = `aegis_${randomBytes(32).toString('hex')}`;
+    const newHash = AuthManager.hashKey(newKey);
+    const expiresAt = ttlDays ? Date.now() + ttlDays * 86_400_000 : existing.expiresAt;
+
+    existing.hash = newHash;
+    existing.expiresAt = expiresAt;
+    existing.createdAt = Date.now();
+    existing.lastUsedAt = 0;
+    this.rateLimits.delete(id);
+
+    await this.save();
+
+    return { id: existing.id, key: newKey, name: existing.name, expiresAt, role: existing.role };
+  }
+
+  /**
+   * Validate a bearer token.
+   * Returns { valid, keyId, rateLimited, reason }.
+   * When valid=false, reason indicates why (Issue #1403).
+   */
+  validate(token: string): { valid: boolean; keyId: string | null; rateLimited: boolean; reason?: AuthRejectReason } {
     // No auth configured and no keys → allow all
     if (!this.masterToken && this.store.keys.length === 0) {
       // #1080: SECURITY FIX — when binding to a non-localhost interface without auth,
       // reject all requests. Running Aegis on 0.0.0.0 with no auth is a critical vuln.
       if (!this.isLocalhostBinding) {
-        return { valid: false, keyId: null, rateLimited: false };
+        return { valid: false, keyId: null, rateLimited: false, reason: 'no_auth' };
       }
       return { valid: true, keyId: null, rateLimited: false };
     }
@@ -193,12 +224,12 @@ export class AuthManager {
     const hash = AuthManager.hashKey(token);
     const key = this.store.keys.find(k => k.hash === hash);
     if (!key) {
-      return { valid: false, keyId: null, rateLimited: false };
+      return { valid: false, keyId: null, rateLimited: false, reason: 'invalid' };
     }
 
-    // #1436: Reject expired keys
+    // #1436/#1403: Reject expired keys with specific reason
     if (key.expiresAt !== null && Date.now() > key.expiresAt) {
-      return { valid: false, keyId: null, rateLimited: false };
+      return { valid: false, keyId: null, rateLimited: false, reason: 'expired' };
     }
 
     // Rate limiting

--- a/src/server.ts
+++ b/src/server.ts
@@ -491,6 +491,10 @@ function setupAuth(authManager: AuthManager): void {
 
     if (!result.valid) {
       recordAuthFailure(clientIp);
+      // Issue #1403: Distinguish expired keys from invalid keys
+      if (result.reason === 'expired') {
+        return reply.status(401).send({ error: 'Unauthorized — API key has expired', code: 'KEY_EXPIRED' });
+      }
       return reply.status(401).send({ error: 'Unauthorized — invalid API key' });
     }
 
@@ -646,6 +650,21 @@ app.delete<{ Params: { id: string } }>('/v1/auth/keys/:id', async (req, reply) =
   const revoked = await auth.revokeKey(req.params.id);
   if (!revoked) return reply.status(404).send({ error: 'Key not found' });
   return { ok: true };
+});
+
+// Issue #1403: Rotate an API key — replaces the key hash while preserving metadata
+const rotateKeySchema = z.object({
+  ttlDays: z.number().int().positive().optional(),
+}).strict();
+
+app.post<{ Params: { id: string } }>('/v1/auth/keys/:id/rotate', async (req, reply) => {
+  if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
+  if (!requireRole(req, reply, 'admin')) return;
+  const parsed = rotateKeySchema.safeParse(req.body ?? {});
+  if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+  const rotated = await auth.rotateKey(req.params.id, parsed.data.ttlDays);
+  if (!rotated) return reply.status(404).send({ error: 'Key not found' });
+  return reply.status(200).send(rotated);
 });
 
 // #297: SSE token endpoint — generates short-lived, single-use token


### PR DESCRIPTION
## Summary
- Adds `reason` field to `validate()` return type (`'expired'`, `'invalid'`, `'no_auth'`) so callers can distinguish why a key was rejected
- Adds `rotateKey()` method to `AuthManager` — replaces the key hash while preserving name, role, rateLimit, and expiry
- Adds `POST /v1/auth/keys/:id/rotate` endpoint (admin-only, accepts optional `ttlDays` body param)
- Returns specific `KEY_EXPIRED` error code when expired keys are used (instead of generic "invalid API key")

## Aegis version
**Developed with:** v0.4.0-alpha

Closes #1403

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] 14 new tests pass (expiry reasons + key rotation)
- [x] 127 existing auth tests still pass

Generated by Hephaestus (Aegis dev agent)