### PR TITLE
fix: log startup warning when no auth is configured

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2444,7 +2444,11 @@ toolRegistry = new ToolRegistry();
   console.log(`Channels: ${channels.count} registered`);
   console.log(`State dir: ${config.stateDir}`);
   console.log(`Claude projects dir: ${config.claudeProjectsDir}`);
-  if (config.authToken) console.log('Auth: Bearer token required');
+  if (auth.authEnabled) {
+    console.log('Auth: enabled');
+  } else {
+    console.warn('WARNING: No authentication configured — set AEGIS_AUTH_TOKEN to secure the server');
+  }
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- Log a `console.warn` at startup when `auth.authEnabled === false`, alerting operators that the server is running without authentication
- Closes #1405

## Aegis version
**Developed with:** v0.3.2-alpha

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (2625 passed)
- [ ] Manual: run `npm start` without `AEGIS_AUTH_TOKEN` and verify warning is printed

Generated by Hephaestus (Aegis dev agent)