### PR TITLE
fix: add per-tool authorization to MCP server (#1407)

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1535,4 +1535,177 @@ describe('MCP Resources', () => {
     expect(text).toContain('capture_pane');
   });
 });
+
+// ── MCP Tool Authorization tests (Issue #1407) ─────────────────────
+
+describe('MCP Tool Authorization (Issue #1407)', () => {
+  const UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockVerifyRole(role: string): void {
+    (fetch as any).mockImplementation(async (url: string, opts?: RequestInit) => {
+      // /v1/auth/verify — role resolution
+      if (url.includes('/v1/auth/verify')) {
+        return { ok: true, json: () => Promise.resolve({ valid: true, role }) };
+      }
+      // All other requests — success
+      return { ok: true, json: () => Promise.resolve({ ok: true }) };
+    });
+  }
+
+  function getToolHandlerWithAuth(toolName: string, role: string): (args: any) => Promise<any> {
+    mockVerifyRole(role);
+    const server = createMcpServer(9100, 'test-token');
+    return (server as any)._registeredTools[toolName].handler;
+  }
+
+  // ── Admin tools (kill_session, send_bash) ──
+
+  it('operator cannot call kill_session', async () => {
+    const handler = getToolHandlerWithAuth('kill_session', 'operator');
+    const result = await handler({ sessionId: UUID });
+    expect(result.isError).toBe(true);
+    const envelope = JSON.parse(result.content[0].text);
+    expect(envelope.code).toBe('FORBIDDEN');
+    expect(envelope.message).toContain('kill_session');
+    expect(envelope.message).toContain('admin');
+    expect(envelope.message).toContain('operator');
+  });
+
+  it('viewer cannot call kill_session', async () => {
+    const handler = getToolHandlerWithAuth('kill_session', 'viewer');
+    const result = await handler({ sessionId: UUID });
+    expect(result.isError).toBe(true);
+    const envelope = JSON.parse(result.content[0].text);
+    expect(envelope.code).toBe('FORBIDDEN');
+  });
+
+  it('admin can call kill_session', async () => {
+    mockVerifyRole('admin');
+    const server = createMcpServer(9100, 'test-token');
+    const handler = (server as any)._registeredTools.kill_session.handler;
+    const result = await handler({ sessionId: UUID });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('operator cannot call send_bash', async () => {
+    const handler = getToolHandlerWithAuth('send_bash', 'operator');
+    const result = await handler({ sessionId: UUID, command: 'ls' });
+    expect(result.isError).toBe(true);
+    const envelope = JSON.parse(result.content[0].text);
+    expect(envelope.code).toBe('FORBIDDEN');
+    expect(envelope.message).toContain('send_bash');
+  });
+
+  it('viewer cannot call send_bash', async () => {
+    const handler = getToolHandlerWithAuth('send_bash', 'viewer');
+    const result = await handler({ sessionId: UUID, command: 'ls' });
+    expect(result.isError).toBe(true);
+    const envelope = JSON.parse(result.content[0].text);
+    expect(envelope.code).toBe('FORBIDDEN');
+  });
+
+  it('admin can call send_bash', async () => {
+    mockVerifyRole('admin');
+    const server = createMcpServer(9100, 'test-token');
+    const handler = (server as any)._registeredTools.send_bash.handler;
+    const result = await handler({ sessionId: UUID, command: 'ls' });
+    expect(result.isError).toBeFalsy();
+  });
+
+  // ── Operator tools ──
+
+  it('viewer cannot call send_message (operator tool)', async () => {
+    const handler = getToolHandlerWithAuth('send_message', 'viewer');
+    const result = await handler({ sessionId: UUID, text: 'hello' });
+    expect(result.isError).toBe(true);
+    const envelope = JSON.parse(result.content[0].text);
+    expect(envelope.code).toBe('FORBIDDEN');
+    expect(envelope.message).toContain('operator');
+  });
+
+  it('viewer cannot call create_session (operator tool)', async () => {
+    const handler = getToolHandlerWithAuth('create_session', 'viewer');
+    const result = await handler({ workDir: '/tmp', name: undefined, prompt: undefined });
+    expect(result.isError).toBe(true);
+    const envelope = JSON.parse(result.content[0].text);
+    expect(envelope.code).toBe('FORBIDDEN');
+  });
+
+  it('operator can call send_message', async () => {
+    mockVerifyRole('operator');
+    const server = createMcpServer(9100, 'test-token');
+    const handler = (server as any)._registeredTools.send_message.handler;
+    const result = await handler({ sessionId: UUID, text: 'hello' });
+    expect(result.isError).toBeFalsy();
+  });
+
+  // ── Viewer tools (all roles can access) ──
+
+  it('viewer can call list_sessions', async () => {
+    mockVerifyRole('viewer');
+    const server = createMcpServer(9100, 'test-token');
+    (fetch as any).mockImplementation(async (url: string) => {
+      if (url.includes('/v1/auth/verify')) {
+        return { ok: true, json: () => Promise.resolve({ valid: true, role: 'viewer' }) };
+      }
+      return { ok: true, json: () => Promise.resolve({ sessions: [], total: 0 }) };
+    });
+    const handler = (server as any)._registeredTools.list_sessions.handler;
+    const result = await handler({ status: undefined, workDir: undefined });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('viewer can call server_health', async () => {
+    mockVerifyRole('viewer');
+    const server = createMcpServer(9100, 'test-token');
+    (fetch as any).mockImplementation(async (url: string) => {
+      if (url.includes('/v1/auth/verify')) {
+        return { ok: true, json: () => Promise.resolve({ valid: true, role: 'viewer' }) };
+      }
+      return { ok: true, json: () => Promise.resolve({ status: 'ok' }) };
+    });
+    const handler = (server as any)._registeredTools.server_health.handler;
+    const result = await handler({});
+    expect(result.isError).toBeFalsy();
+  });
+
+  // ── No auth token = admin (backward compat) ──
+
+  it('no auth token defaults to admin and can call any tool', async () => {
+    (fetch as any).mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    const server = createMcpServer(9100);
+    const handler = (server as any)._registeredTools.kill_session.handler;
+    const result = await handler({ sessionId: UUID });
+    expect(result.isError).toBeFalsy();
+  });
+
+  // ── Role caching ──
+
+  it('role is resolved once and cached', async () => {
+    let verifyCallCount = 0;
+    (fetch as any).mockImplementation(async (url: string) => {
+      if (url.includes('/v1/auth/verify')) {
+        verifyCallCount++;
+        return { ok: true, json: () => Promise.resolve({ valid: true, role: 'operator' }) };
+      }
+      return { ok: true, json: () => Promise.resolve({ ok: true }) };
+    });
+    const server = createMcpServer(9100, 'test-token');
+    const killHandler = (server as any)._registeredTools.kill_session.handler;
+    const sendBashHandler = (server as any)._registeredTools.send_bash.handler;
+
+    // Both calls should trigger only one verify request (cached after first)
+    await killHandler({ sessionId: UUID });
+    await sendBashHandler({ sessionId: UUID, command: 'ls' });
+    expect(verifyCallCount).toBe(1);
+  });
+});
 });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -102,12 +102,43 @@ interface MemoryEntryResponse {
 // ── Aegis REST client ───────────────────────────────────────────────
 
 export class AegisClient {
+  /** Cached role resolved from /v1/auth/verify. undefined = not yet resolved. */
+  private resolvedRole: string | undefined;
+
   constructor(private baseUrl: string, private authToken?: string) {}
 
   private validateSessionId(id: string): void {
     if (!isValidUUID(id)) {
       throw new Error(`Invalid session ID: ${id}`);
     }
+  }
+
+  /**
+   * Resolve the RBAC role for the configured auth token.
+   * Calls POST /v1/auth/verify once and caches the result.
+   * Returns 'admin' when no auth token is configured (matching server.ts behavior).
+   */
+  async resolveRole(): Promise<string> {
+    if (this.resolvedRole !== undefined) return this.resolvedRole;
+
+    if (!this.authToken) {
+      this.resolvedRole = 'admin';
+      return this.resolvedRole;
+    }
+
+    try {
+      const result = await this.request<{ valid: boolean; role?: string }>('/v1/auth/verify', {
+        method: 'POST',
+        body: JSON.stringify({ token: this.authToken }),
+      });
+      this.resolvedRole = result.role ?? 'admin';
+    } catch {
+      // If server is unreachable or verify fails, default to admin (no enforcement)
+      // to avoid breaking existing setups during upgrade.
+      this.resolvedRole = 'admin';
+    }
+
+    return this.resolvedRole;
   }
 
   private async request<T = unknown>(path: string, opts?: RequestInit): Promise<T> {
@@ -319,6 +350,69 @@ function formatToolError(e: unknown): { content: Array<{ type: 'text'; text: str
   };
 }
 
+// ── MCP Tool Authorization (Issue #1407) ──────────────────────────────
+
+/** Minimum RBAC role required to call each MCP tool. */
+const TOOL_REQUIRED_ROLE: Record<string, string> = {
+  // viewer — read-only, no side effects
+  list_sessions: 'viewer',
+  get_status: 'viewer',
+  get_transcript: 'viewer',
+  server_health: 'viewer',
+  capture_pane: 'viewer',
+  get_session_metrics: 'viewer',
+  get_session_summary: 'viewer',
+  get_session_latency: 'viewer',
+  list_pipelines: 'viewer',
+  get_swarm: 'viewer',
+  state_get: 'viewer',
+  // operator — interactive but non-destructive
+  send_message: 'operator',
+  create_session: 'operator',
+  approve_permission: 'operator',
+  reject_permission: 'operator',
+  escape_session: 'operator',
+  interrupt_session: 'operator',
+  send_command: 'operator',
+  batch_create_sessions: 'operator',
+  create_pipeline: 'operator',
+  state_set: 'operator',
+  state_delete: 'operator',
+  // admin — destructive, requires elevated access
+  kill_session: 'admin',
+  send_bash: 'admin',
+};
+
+/** Numeric role levels for comparison. */
+const ROLE_LEVEL: Record<string, number> = {
+  admin: 3,
+  operator: 2,
+  viewer: 1,
+};
+
+function formatAuthError(toolName: string, role: string, required: string): { content: Array<{ type: 'text'; text: string }>; isError: true } {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ code: 'FORBIDDEN', message: `Tool '${toolName}' requires '${required}' role, but token has '${role}' role` } satisfies McpErrorEnvelope) }],
+    isError: true,
+  };
+}
+
+/** Wrap a tool handler with per-tool role authorization. */
+function withAuth<TArgs>(
+  toolName: string,
+  handler: (args: TArgs) => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }>,
+  client: AegisClient,
+): (args: TArgs) => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
+  return async (args) => {
+    const role = await client.resolveRole();
+    const required = TOOL_REQUIRED_ROLE[toolName];
+    if (required && (ROLE_LEVEL[role] ?? 0) < (ROLE_LEVEL[required] ?? 0)) {
+      return formatAuthError(toolName, role, required);
+    }
+    return handler(args);
+  };
+}
+
 // ── MCP Server ──────────────────────────────────────────────────────
 
 export function createMcpServer(aegisPort: number, authToken?: string): McpServer {
@@ -438,7 +532,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       status: z.string().optional().describe('Filter by status (e.g., idle, working, permission_prompt)'),
       workDir: z.string().optional().describe('Filter by workDir substring (e.g., "my-project")'),
     },
-    async ({ status, workDir }) => {
+    withAuth('list_sessions', async ({ status, workDir }) => {
       try {
         const sessions = await client.listSessions({ status, workDir });
         const summary = sessions.map((s) => ({
@@ -458,7 +552,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── get_status ──
@@ -468,7 +562,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to check'),
     },
-    async ({ sessionId }) => {
+    withAuth('get_status', async ({ sessionId }) => {
       try {
         const [session, health] = await Promise.all([
           client.getSession(sessionId),
@@ -483,7 +577,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── get_transcript ──
@@ -493,7 +587,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to read from'),
     },
-    async ({ sessionId }) => {
+    withAuth('get_transcript', async ({ sessionId }) => {
       try {
         const transcript = await client.getTranscript(sessionId);
         return {
@@ -505,7 +599,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── send_message ──
@@ -516,7 +610,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       sessionId: z.string().describe('The target session ID'),
       text: z.string().describe('The message text to send'),
     },
-    async ({ sessionId, text }) => {
+    withAuth('send_message', async ({ sessionId, text }) => {
       try {
         const result = await client.sendMessage(sessionId, text);
         return {
@@ -528,7 +622,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── create_session ──
@@ -540,7 +634,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       name: z.string().optional().describe('Optional human-readable name for the session'),
       prompt: z.string().optional().describe('Optional initial prompt to send after creation'),
     },
-    async ({ workDir, name, prompt }) => {
+    withAuth('create_session', async ({ workDir, name, prompt }) => {
       try {
         const session = await client.createSession({ workDir, name, prompt });
         return {
@@ -558,7 +652,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── kill_session ──
@@ -568,7 +662,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to kill'),
     },
-    async ({ sessionId }) => {
+    withAuth('kill_session', async ({ sessionId }) => {
       try {
         const result = await client.killSession(sessionId);
         return {
@@ -580,7 +674,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── approve_permission ──
@@ -590,7 +684,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID with a pending permission prompt'),
     },
-    async ({ sessionId }) => {
+    withAuth('approve_permission', async ({ sessionId }) => {
       try {
         const result = await client.approvePermission(sessionId);
         return {
@@ -602,7 +696,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── reject_permission ──
@@ -612,7 +706,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID with a pending permission prompt'),
     },
-    async ({ sessionId }) => {
+    withAuth('reject_permission', async ({ sessionId }) => {
       try {
         const result = await client.rejectPermission(sessionId);
         return {
@@ -624,7 +718,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── server_health ──
@@ -632,7 +726,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     'server_health',
     'Check the health and status of the Aegis server. Returns version, uptime, and session counts.',
     {},
-    async () => {
+    withAuth('server_health', async () => {
       try {
         const result = await client.getServerHealth();
         return {
@@ -644,7 +738,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── escape_session ──
@@ -654,7 +748,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to send escape to'),
     },
-    async ({ sessionId }) => {
+    withAuth('escape_session', async ({ sessionId }) => {
       try {
         const result = await client.escapeSession(sessionId);
         return {
@@ -666,7 +760,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── interrupt_session ──
@@ -676,7 +770,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to interrupt'),
     },
-    async ({ sessionId }) => {
+    withAuth('interrupt_session', async ({ sessionId }) => {
       try {
         const result = await client.interruptSession(sessionId);
         return {
@@ -688,7 +782,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── capture_pane ──
@@ -698,7 +792,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to capture'),
     },
-    async ({ sessionId }) => {
+    withAuth('capture_pane', async ({ sessionId }) => {
       try {
         const result = await client.capturePane(sessionId);
         return {
@@ -710,7 +804,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── get_session_metrics ──
@@ -720,7 +814,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to get metrics for'),
     },
-    async ({ sessionId }) => {
+    withAuth('get_session_metrics', async ({ sessionId }) => {
       try {
         const result = await client.getSessionMetrics(sessionId);
         return {
@@ -732,7 +826,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── get_session_summary ──
@@ -742,7 +836,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to summarize'),
     },
-    async ({ sessionId }) => {
+    withAuth('get_session_summary', async ({ sessionId }) => {
       try {
         const result = await client.getSessionSummary(sessionId);
         return {
@@ -754,7 +848,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── send_bash ──
@@ -765,7 +859,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       sessionId: z.string().describe('The session ID to send the bash command to'),
       command: z.string().describe('The bash command to execute'),
     },
-    async ({ sessionId, command }) => {
+    withAuth('send_bash', async ({ sessionId, command }) => {
       try {
         const result = await client.sendBash(sessionId, command);
         return {
@@ -777,7 +871,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── send_command ──
@@ -788,7 +882,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       sessionId: z.string().describe('The session ID to send the command to'),
       command: z.string().describe('The slash command to send (e.g., "help", "compact")'),
     },
-    async ({ sessionId, command }) => {
+    withAuth('send_command', async ({ sessionId, command }) => {
       try {
         const result = await client.sendCommand(sessionId, command);
         return {
@@ -800,7 +894,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── get_session_latency ──
@@ -810,7 +904,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       sessionId: z.string().describe('The session ID to get latency for'),
     },
-    async ({ sessionId }) => {
+    withAuth('get_session_latency', async ({ sessionId }) => {
       try {
         const result = await client.getSessionLatency(sessionId);
         return {
@@ -822,7 +916,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── batch_create_sessions ──
@@ -836,7 +930,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
         prompt: z.string().optional().describe('Optional initial prompt'),
       })).describe('Array of session specifications to create'),
     },
-    async ({ sessions: sessionSpecs }) => {
+    withAuth('batch_create_sessions', async ({ sessions: sessionSpecs }) => {
       try {
         const result = await client.batchCreateSessions(sessionSpecs);
         return {
@@ -848,7 +942,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── list_pipelines ──
@@ -856,7 +950,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     'list_pipelines',
     'List all configured pipelines in the Aegis server.',
     {},
-    async () => {
+    withAuth('list_pipelines', async () => {
       try {
         const result = await client.listPipelines();
         return {
@@ -868,7 +962,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── create_pipeline ──
@@ -883,7 +977,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
         prompt: z.string().describe('Prompt for this step'),
       })).describe('Array of pipeline steps'),
     },
-    async ({ name, workDir, steps }) => {
+    withAuth('create_pipeline', async ({ name, workDir, steps }) => {
       try {
         const result = await client.createPipeline({ name, workDir, steps });
         return {
@@ -895,7 +989,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── get_swarm ──
@@ -903,7 +997,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     'get_swarm',
     'Get a snapshot of all Claude Code processes detected on the system (the "swarm").',
     {},
-    async () => {
+    withAuth('get_swarm', async () => {
       try {
         const result = await client.getSwarm();
         return {
@@ -915,7 +1009,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── state_set ──
@@ -927,7 +1021,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       value: z.string().describe('State payload as string'),
       ttlSeconds: z.number().int().positive().max(86400 * 30).optional().describe('Optional TTL in seconds (max 30 days)'),
     },
-    async ({ key, value, ttlSeconds }) => {
+    withAuth('state_set', async ({ key, value, ttlSeconds }) => {
       try {
         const result = await client.setMemory(key, value, ttlSeconds);
         return {
@@ -939,7 +1033,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── state_get ──
@@ -949,7 +1043,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       key: z.string().describe('State key in namespace/key format (e.g., pipeline/run-123)'),
     },
-    async ({ key }) => {
+    withAuth('state_get', async ({ key }) => {
       try {
         const result = await client.getMemory(key);
         return {
@@ -961,7 +1055,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── state_delete ──
@@ -971,7 +1065,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
     {
       key: z.string().describe('State key in namespace/key format (e.g., pipeline/run-123)'),
     },
-    async ({ key }) => {
+    withAuth('state_delete', async ({ key }) => {
       try {
         const result = await client.deleteMemory(key);
         return {
@@ -983,7 +1077,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       } catch (e: unknown) {
         return formatToolError(e);
       }
-    },
+    }, client),
   );
 
   // ── MCP Prompts (Issue #443) ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- MCP tools now enforce RBAC role checks before execution using the existing `ApiKeyRole` system (`admin`/`operator`/`viewer`)
- Destructive tools (`kill_session`, `send_bash`) require `admin` role
- Interactive tools (`send_message`, `create_session`, `approve_permission`, etc.) require `operator` role
- Read-only tools (`list_sessions`, `get_status`, `server_health`, etc.) are accessible to all roles including `viewer`
- Role is resolved lazily via `POST /v1/auth/verify` on first tool call and cached for the process lifetime
- When no auth token is configured, defaults to `admin` (backward compatible — no behavior change for existing setups)

## Acceptance Criteria (from #1407)
- [x] An `operator` MCP key cannot call `kill_session`; receives a `FORBIDDEN` tool error
- [x] An `operator` MCP key cannot call `send_bash`; receives a `FORBIDDEN` tool error
- [x] `admin` role can call all tools
- [x] `viewer` role can only call read-only tools

## Files changed
- `src/mcp-server.ts` — Added `resolveRole()` to `AegisClient`, `TOOL_REQUIRED_ROLE` map, `withAuth()` wrapper, applied to all 24 tool handlers
- `src/__tests__/mcp-server.test.ts` — 13 new tests covering role enforcement for all tiers, caching, and backward compatibility

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (2638 tests, 13 new)

Closes #1407

Generated by Hephaestus (Aegis dev agent)