### PR TITLE
fix: resolve symlinks in permission evaluator to prevent path bypass

### DIFF
--- a/src/__tests__/permission-evaluator-symlink-1402.test.ts
+++ b/src/__tests__/permission-evaluator-symlink-1402.test.ts
@@ -1,0 +1,127 @@
+/**
+ * permission-evaluator-symlink-1402.test.ts — Symlink bypass fix for Issue #1402.
+ *
+ * Validates that isPathAllowed resolves symlinks via realpath before
+ * checking path prefixes, preventing symlink-based escapes outside
+ * the allowed directory.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, symlinkSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { evaluatePermissionProfile } from '../permission-evaluator.js';
+
+describe('Issue #1402: permission evaluator symlink bypass', () => {
+  let allowedDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    allowedDir = mkdtempSync(join(tmpdir(), 'aegis-allowed-'));
+    outsideDir = mkdtempSync(join(tmpdir(), 'aegis-outside-'));
+  });
+
+  afterEach(() => {
+    rmSync(allowedDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it('rejects symlink pointing outside allowed prefix', () => {
+    // Create a symlink inside allowedDir that points outside
+    const linkPath = join(allowedDir, 'escape');
+    symlinkSync(outsideDir, linkPath);
+
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{
+        tool: 'Read',
+        behavior: 'allow',
+        constraints: { paths: [allowedDir] },
+      }],
+    }, {
+      toolName: 'Read',
+      toolInput: { file_path: linkPath },
+    });
+
+    expect(result.behavior).toBe('deny');
+    expect(result.reason).toContain('path constraint');
+  });
+
+  it('rejects symlink to /etc/passwd from allowed dir', () => {
+    const linkPath = join(allowedDir, 'passwd');
+    symlinkSync('/etc/passwd', linkPath);
+
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{
+        tool: 'Read',
+        behavior: 'allow',
+        constraints: { paths: [allowedDir] },
+      }],
+    }, {
+      toolName: 'Read',
+      toolInput: { path: linkPath },
+    });
+
+    expect(result.behavior).toBe('deny');
+  });
+
+  it('allows real file inside allowed prefix', () => {
+    const realFile = join(allowedDir, 'safe.ts');
+    writeFileSync(realFile, '// safe');
+
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{
+        tool: 'Read',
+        behavior: 'allow',
+        constraints: { paths: [allowedDir] },
+      }],
+    }, {
+      toolName: 'Read',
+      toolInput: { file_path: realFile },
+    });
+
+    expect(result.behavior).toBe('allow');
+  });
+
+  it('allows symlink that resolves inside allowed prefix', () => {
+    const subDir = join(allowedDir, 'sub');
+    mkdirSync(subDir);
+    const realFile = join(subDir, 'target.ts');
+    writeFileSync(realFile, '// target');
+
+    const linkPath = join(allowedDir, 'link');
+    symlinkSync(realFile, linkPath);
+
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{
+        tool: 'Read',
+        behavior: 'allow',
+        constraints: { paths: [allowedDir] },
+      }],
+    }, {
+      toolName: 'Read',
+      toolInput: { file_path: linkPath },
+    });
+
+    expect(result.behavior).toBe('allow');
+  });
+
+  it('falls back to normalize for non-existent paths', () => {
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{
+        tool: 'Write',
+        behavior: 'allow',
+        constraints: { paths: [allowedDir] },
+      }],
+    }, {
+      toolName: 'Write',
+      toolInput: { file_path: join(allowedDir, 'new-file.ts'), content: 'x' },
+    });
+
+    expect(result.behavior).toBe('allow');
+  });
+});

--- a/src/permission-evaluator.ts
+++ b/src/permission-evaluator.ts
@@ -1,4 +1,5 @@
 import type { PermissionProfile } from './validation.js';
+import { existsSync, realpathSync } from 'node:fs';
 import { normalize, sep } from 'node:path';
 
 export interface PermissionEvaluationInput {
@@ -31,12 +32,27 @@ function isLikelyWriteTool(toolName: string): boolean {
   return /write|edit|delete|rename|move|create/i.test(toolName);
 }
 
+/**
+ * Resolve a path to its real (canonical) form, stripping any symlinks.
+ * Falls back to `normalize()` when the path does not exist on disk.
+ */
+function resolveRealPath(filePath: string): string {
+  try {
+    if (existsSync(filePath)) {
+      return normalize(realpathSync(filePath));
+    }
+  } catch {
+    // realpathSync can throw for broken symlinks or permission issues
+  }
+  return normalize(filePath);
+}
+
 function isPathAllowed(candidate: string, allowedPrefixes: string[]): boolean {
-  const normalizedCandidate = normalize(candidate);
+  const resolvedCandidate = resolveRealPath(candidate);
   return allowedPrefixes.some((prefix) => {
-    const normalizedPrefix = normalize(prefix);
-    return normalizedCandidate === normalizedPrefix ||
-      normalizedCandidate.startsWith(normalizedPrefix + sep);
+    const resolvedPrefix = resolveRealPath(prefix);
+    return resolvedCandidate === resolvedPrefix ||
+      resolvedCandidate.startsWith(resolvedPrefix + sep);
   });
 }
 


### PR DESCRIPTION
## Summary
- `isPathAllowed` now resolves symlinks via `fs.realpathSync` for both the candidate path and allowed prefixes before prefix matching
- Prevents symlink-based escapes outside the allowed directory (e.g. `allowed_dir/link -> /etc/passwd` is now rejected)
- Falls back to `path.normalize` for non-existent paths (can't be a symlink bypass)

## Aegis version
**Developed with:** v0.4.0-alpha

## Test plan
- [x] 5 new tests covering symlink escape, symlink to `/etc/passwd`, internal symlinks, real files, and non-existent paths
- [x] All 44 permission evaluator tests pass
- [x] `tsc --noEmit` passes
- [x] `npm run build` passes

Closes #1402

Generated by Hephaestus (Aegis dev agent)