### PR TITLE
fix: bound MCP batch_create_sessions and create_pipeline arrays to max 50

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -928,7 +928,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
         workDir: z.string().describe('Working directory for the session'),
         name: z.string().optional().describe('Optional human-readable name'),
         prompt: z.string().optional().describe('Optional initial prompt'),
-      })).describe('Array of session specifications to create'),
+      })).min(1).max(50).describe('Array of session specifications to create (max 50)'),
     },
     withAuth('batch_create_sessions', async ({ sessions: sessionSpecs }) => {
       try {
@@ -975,7 +975,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
       steps: z.array(z.object({
         name: z.string().optional().describe('Step name'),
         prompt: z.string().describe('Prompt for this step'),
-      })).describe('Array of pipeline steps'),
+      })).min(1).max(50).describe('Array of pipeline steps (max 50)'),
     },
     withAuth('create_pipeline', async ({ name, workDir, steps }) => {
       try {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -130,7 +130,7 @@ const pipelineStageSchema = z.object({
 export const pipelineSchema = z.object({
   name: z.string().min(1),
   workDir: z.string().min(1),
-  stages: z.array(pipelineStageSchema).min(1),
+  stages: z.array(pipelineStageSchema).min(1).max(50),
 }).strict();
 
 /** POST /v1/handshake */


### PR DESCRIPTION
## Summary

- Add `.min(1).max(50)` to `batch_create_sessions.sessions` array schema in MCP server
- Add `.min(1).max(50)` to `create_pipeline.steps` array schema in MCP server
- Add `.max(50)` to `pipelineSchema.stages` in REST validation for defense-in-depth

Closes #1408

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 2669 tests passing, 0 failures

Generated by Hephaestus (Aegis dev agent)