### PR TITLE
fix: restrict claudeCommand field to prevent shell injection (RCE)

### DIFF
--- a/src/__tests__/claude-command-validation.test.ts
+++ b/src/__tests__/claude-command-validation.test.ts
@@ -1,0 +1,126 @@
+/**
+ * claude-command-validation.test.ts — Tests for Issue #1393: claudeCommand RCE prevention.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Mirror the regex from server.ts
+const SAFE_COMMAND_RE = /^[a-zA-Z0-9_./@:= -]+$/;
+
+function isValidCommand(value: string): boolean {
+  return SAFE_COMMAND_RE.test(value);
+}
+
+describe('claudeCommand validation (#1393)', () => {
+  describe('safe commands allowed', () => {
+    it('allows plain claude command', () => {
+      expect(isValidCommand('claude')).toBe(true);
+    });
+
+    it('allows claude with flags', () => {
+      expect(isValidCommand('claude --model opus')).toBe(true);
+    });
+
+    it('allows claude --print', () => {
+      expect(isValidCommand('claude --print')).toBe(true);
+    });
+
+    it('allows claude with permission mode', () => {
+      expect(isValidCommand('claude --permission-mode bypassPermissions')).toBe(true);
+    });
+
+    it('allows path-like commands', () => {
+      expect(isValidCommand('/usr/local/bin/claude')).toBe(true);
+      expect(isValidCommand('./claude')).toBe(true);
+      expect(isValidCommand('../claude')).toBe(true);
+    });
+
+    it('allows commands with equals signs (common in flags)', () => {
+      expect(isValidCommand('claude --model=opus')).toBe(true);
+    });
+
+    it('allows commands with colons (common in model names)', () => {
+      expect(isValidCommand('claude --model claude-opus-4-20250514')).toBe(true);
+    });
+
+    it('allows commands with at-signs', () => {
+      expect(isValidCommand('claude @context-file')).toBe(true);
+    });
+  });
+
+  describe('dangerous commands rejected', () => {
+    it('rejects semicolon injection', () => {
+      expect(isValidCommand('evil; rm -rf /')).toBe(false);
+    });
+
+    it('rejects pipe injection', () => {
+      expect(isValidCommand('claude | cat /etc/passwd')).toBe(false);
+    });
+
+    it('rejects command substitution with backticks', () => {
+      expect(isValidCommand('claude `rm -rf /`')).toBe(false);
+    });
+
+    it('rejects dollar sign variable expansion', () => {
+      expect(isValidCommand('claude $(whoami)')).toBe(false);
+    });
+
+    it('rejects newline injection', () => {
+      expect(isValidCommand('claude\nrm -rf /')).toBe(false);
+    });
+
+    it('rejects carriage return injection', () => {
+      expect(isValidCommand('claude\rrm -rf /')).toBe(false);
+    });
+
+    it('rejects ampersand backgrounding', () => {
+      expect(isValidCommand('claude & malicious')).toBe(false);
+    });
+
+    it('rejects logical OR', () => {
+      expect(isValidCommand('claude || rm -rf /')).toBe(false);
+    });
+
+    it('rejects logical AND', () => {
+      expect(isValidCommand('claude && rm -rf /')).toBe(false);
+    });
+
+    it('rejects subshell execution', () => {
+      expect(isValidCommand('claude $(cat /etc/shadow)')).toBe(false);
+    });
+
+    it('rejects brace expansion', () => {
+      expect(isValidCommand('claude {a,b,c}')).toBe(false);
+    });
+
+    it('rejects redirection', () => {
+      expect(isValidCommand('claude > /tmp/pwned')).toBe(false);
+      expect(isValidCommand('claude < /etc/passwd')).toBe(false);
+    });
+
+    it('rejects double-ampersand (background)', () => {
+      expect(isValidCommand('claude && disown')).toBe(false);
+    });
+
+    it('rejects backslash continuation', () => {
+      expect(isValidCommand('claude \\n rm -rf /')).toBe(false);
+    });
+
+    it('rejects tab injection', () => {
+      expect(isValidCommand('claude\trm')).toBe(false);
+    });
+
+    it('rejects null byte', () => {
+      expect(isValidCommand('claude\x00rm')).toBe(false);
+    });
+
+    it('rejects parentheses (subshell)', () => {
+      expect(isValidCommand('(rm -rf /)')).toBe(false);
+      expect(isValidCommand('claude (whoami)')).toBe(false);
+    });
+
+    it('rejects curly braces', () => {
+      expect(isValidCommand('claude ${PATH}')).toBe(false);
+    });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -516,6 +516,10 @@ app.addHook('onRequest', async (req, reply) => {
   }
 });
 
+// #1393: claudeCommand must not contain shell metacharacters — it is sent to a shell
+// via tmux send-keys, so arbitrary metacharacters enable RCE for any authenticated caller.
+const SAFE_COMMAND_RE = /^[a-zA-Z0-9_./@:= -]+$/;
+
 // #226: Zod schema for session creation
 const createSessionSchema = z.object({
   workDir: z.string().min(1),
@@ -523,7 +527,7 @@ const createSessionSchema = z.object({
   prompt: z.string().max(100_000).optional(),
   prd: z.string().max(100_000).optional(),
   resumeSessionId: z.string().uuid().optional(),
-  claudeCommand: z.string().max(10_000).optional(),
+  claudeCommand: z.string().max(500).regex(SAFE_COMMAND_RE).optional(),
   env: z.record(z.string(), z.string()).optional(),
   stallThresholdMs: z.number().int().positive().max(3_600_000).optional(),
   permissionMode: z.enum(['default', 'bypassPermissions', 'plan', 'acceptEdits', 'dontAsk', 'auto']).optional(),
@@ -1831,7 +1835,7 @@ const createTemplateSchema = z.object({
   sessionId: z.string().uuid().optional(),
   workDir: z.string().min(1).optional(),
   prompt: z.string().max(100_000).optional(),
-  claudeCommand: z.string().max(10_000).optional(),
+  claudeCommand: z.string().max(500).regex(SAFE_COMMAND_RE).optional(),
   env: z.record(z.string(), z.string()).optional(),
   stallThresholdMs: z.number().int().positive().max(3_600_000).optional(),
   permissionMode: z.enum(['default', 'bypassPermissions', 'plan', 'acceptEdits', 'dontAsk', 'auto']).optional(),


### PR DESCRIPTION
## Summary

- **Closes #1393** (SD-VAL-04, SD-INJ-03 | Severity: HIGH)

`claudeCommand` accepted arbitrary strings up to 10,000 chars with no metacharacter restriction. Since the value is sent to a shell via `tmux send-keys`, this is a direct RCE vector for any authenticated API key.

## Changes

- Added `SAFE_COMMAND_RE` whitelist regex (`/^[a-zA-Z0-9_./@:= -]+$/`) to `server.ts`
- Applied regex validation to both `createSessionSchema` and `createTemplateSchema` Zod schemas
- Reduced max length from 10,000 to 500 chars (no legitimate command needs 10k chars)
- Added 26 unit tests covering safe commands and injection vectors

## Blocked characters

`;` `|` `&` `$` `` ` `` `(` `)` `{` `}` `<` `>` `\n` `\r` `\t` `\0` `\` — all shell metacharacters that enable command chaining, substitution, redirection, or subshell execution.

## Acceptance Criteria

`claudeCommand: "evil; rm -rf /"` → **400 rejected**

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` — 2695 passed, 0 failed
- [x] 26 new tests for claudeCommand validation (safe + dangerous inputs)

Generated by Hephaestus (Aegis dev agent)