### PR TITLE
fix: compareSemver fails closed on unparseable versions

### DIFF
--- a/src/__tests__/cc-version-check-564.test.ts
+++ b/src/__tests__/cc-version-check-564.test.ts
@@ -69,9 +69,9 @@ describe('Issue #564: CC version validation — pure functions', () => {
       expect(compareSemver('3.0.0', '2.1.80')).toBe(1);
     });
 
-    it('should return 0 if either version is unparseable (fails open)', () => {
-      expect(compareSemver('invalid', '2.1.80')).toBe(0);
-      expect(compareSemver('2.1.80', 'invalid')).toBe(0);
+    it('should return -1 if either version is unparseable (fails closed)', () => {
+      expect(compareSemver('invalid', '2.1.80')).toBe(-1);
+      expect(compareSemver('2.1.80', 'invalid')).toBe(-1);
     });
   });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -361,12 +361,12 @@ export function parseSemver(v: string): [number, number, number] | null {
 
 /**
  * Compare two semver strings.
- * Returns -1 if a < b, 0 if equal or either is unparseable (fails open), 1 if a > b.
+ * Returns -1 if a < b or either is unparseable (fails closed), 0 if equal, 1 if a > b.
  */
 export function compareSemver(a: string, b: string): number {
   const pa = parseSemver(a);
   const pb = parseSemver(b);
-  if (!pa || !pb) return 0;
+  if (!pa || !pb) return -1;
   for (let i = 0; i < 3; i++) {
     if (pa[i] < pb[i]) return -1;
     if (pa[i] > pb[i]) return 1;


### PR DESCRIPTION
## Summary
- `compareSemver` returned `0` (equal) when either version string was unparseable, causing minimum version enforcement to silently pass for unrecognized Claude Code binaries (security issue SD-VAL-05)
- Changed to return `-1` (older) so unparseable versions are blocked by the existing version check in `server.ts`
- Updated test expectations to match the new fails-closed behavior

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (23/23 tests in cc-version-check-564.test.ts)
- [x] Verified `compareSemver('invalid', '2.1.80')` returns `-1`
- [x] Verified `compareSemver('2.1.80', 'invalid')` returns `-1`

Closes #1395

Generated by Hephaestus (Aegis dev agent)