### PR TITLE
fix: add global defaultStageTimeoutMs for pipeline stages (#1423)

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -1322,6 +1322,105 @@ describe('PipelineManager', () => {
       expect(pipeline.stages[0].status).toBe('completed');
       expect(pipeline.status).toBe('completed');
     });
+
+    it('uses global defaultStageTimeoutMs when per-stage timeout is not set', async () => {
+      vi.useFakeTimers();
+
+      // Create manager with a global default of 90s
+      const defaultManager = new PipelineManager(sessions.mock, eventBus.mock, null, 90_000);
+
+      const config: PipelineConfig = {
+        name: 'default-timeout',
+        workDir: '/app',
+        stages: [
+          { name: 'slow', prompt: 'run slow', dependsOn: [] },
+          // No stageTimeoutMs — should use global default of 90s
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-slow'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await defaultManager.createPipeline(config);
+
+      sessions.getSession.mockReturnValue(makeMockSession('s-slow', { status: 'working' }));
+
+      // Advance past the 90s global default
+      vi.advanceTimersByTime(91_000);
+      await (defaultManager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('stage_timeout');
+
+      await defaultManager.destroy();
+    });
+
+    it('per-stage timeout overrides global defaultStageTimeoutMs', async () => {
+      vi.useFakeTimers();
+
+      // Global default is 30s, but per-stage is 120s
+      const defaultManager = new PipelineManager(sessions.mock, eventBus.mock, null, 30_000);
+
+      const config: PipelineConfig = {
+        name: 'override-timeout',
+        workDir: '/app',
+        stages: [
+          { name: 'slow', prompt: 'run slow', dependsOn: [], stageTimeoutMs: 120_000 },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-slow'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await defaultManager.createPipeline(config);
+
+      sessions.getSession.mockReturnValue(makeMockSession('s-slow', { status: 'working' }));
+
+      // Advance past global default (30s) but not per-stage (120s)
+      vi.advanceTimersByTime(31_000);
+      await (defaultManager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // Should still be running — per-stage timeout takes precedence
+      expect(pipeline.stages[0].status).toBe('running');
+
+      // Now advance past per-stage timeout
+      vi.advanceTimersByTime(90_000);
+      await (defaultManager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('stage_timeout');
+
+      await defaultManager.destroy();
+    });
+
+    it('timeout wins over idle when both are true at the same poll check', async () => {
+      vi.useFakeTimers();
+
+      // Use a very short timeout so timeout fires on the first poll
+      const config: PipelineConfig = {
+        name: 'timeout-over-idle',
+        workDir: '/app',
+        stages: [
+          { name: 'slow', prompt: 'run slow', dependsOn: [], stageTimeoutMs: 3_000 },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-slow'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      // Session is idle AND timed out — timeout should win at the same poll
+      sessions.getSession.mockReturnValue(makeMockSession('s-slow', { status: 'idle' }));
+
+      // Advance past the 3s timeout to the first poll at ~5s
+      vi.advanceTimersByTime(5_000);
+      await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();
+
+      // Should be failed (timeout wins over idle)
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toBe('stage_timeout');
+    });
   });
 
   // =========================================================================

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,8 @@ export interface Config {
    *  When set, /metrics requires this token (or the primary authToken).
    *  When empty, /metrics falls through to normal auth (same as any other endpoint). */
   metricsToken: string;
+  /** Issue #1423: Default pipeline stage timeout in milliseconds. 0 = no timeout. Env: AEGIS_PIPELINE_STAGE_TIMEOUT_MS */
+  pipelineStageTimeoutMs: number;
   /** Production alerting (Issue #1418). */
   alerting: {
     /** Webhook URLs for alert notifications (separate from general webhooks). */
@@ -136,6 +138,7 @@ const defaults: Config = {
   worktreeSiblingDirs: [],
   verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
   metricsToken: '',
+  pipelineStageTimeoutMs: 0,
   alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 10 * 60 * 1000 },
 };
 
@@ -225,6 +228,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_WEBHOOKS', manus: 'MANUS_WEBHOOKS', key: 'webhooks' },
     { aegis: 'AEGIS_SSE_MAX_CONNECTIONS', manus: 'MANUS_SSE_MAX_CONNECTIONS', key: 'sseMaxConnections' },
     { aegis: 'AEGIS_SSE_MAX_PER_IP', manus: 'MANUS_SSE_MAX_PER_IP', key: 'sseMaxPerIp' },
+    { aegis: 'AEGIS_PIPELINE_STAGE_TIMEOUT_MS', manus: 'MANUS_PIPELINE_STAGE_TIMEOUT_MS', key: 'pipelineStageTimeoutMs' },
   ];
 
   for (const { aegis, manus, key } of envMappings) {
@@ -240,6 +244,7 @@ function applyEnvOverrides(config: Config): Config {
       case 'tgTopicTtlMs':
       case 'sseMaxConnections':
       case 'sseMaxPerIp':
+      case 'pipelineStageTimeoutMs':
         config[key] = parseIntSafe(value, config[key]);
         break;
       case 'webhooks':

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -93,6 +93,8 @@ export class PipelineManager {
     private sessions: SessionManager,
     private eventBus?: SessionEventBus,
     private stateDir: string | null = null,
+    /** Issue #1423: Global default stage timeout in milliseconds. 0 = no timeout. */
+    private defaultStageTimeoutMs: number = 0,
   ) {}
 
   /** Create multiple sessions in parallel. */
@@ -311,23 +313,25 @@ export class PipelineManager {
           continue;
         }
 
+        // #1423: Check for stage timeout BEFORE idle (timeout wins over idle)
+        const stageConfig = this.pipelineConfigs.get(id)?.stages.find(s => s.name === stage.name);
+        const effectiveTimeout = stageConfig?.stageTimeoutMs ?? this.defaultStageTimeoutMs;
+        if (effectiveTimeout > 0 && stage.startedAt) {
+          const elapsed = Date.now() - stage.startedAt;
+          if (elapsed > effectiveTimeout) {
+            stage.status = 'failed';
+            stage.error = 'stage_timeout';
+            this.transitionPipelineStage(pipeline, 'fix', { stage: stage.name, reason: 'stage_timeout' });
+            await this.persistPipelines(); // #1424: persist after stage times out
+            continue;
+          }
+        }
+
         if (session.status === 'idle') {
           stage.status = 'completed';
           stage.completedAt = Date.now();
           this.transitionPipelineStage(pipeline, 'verify', { stageCompleted: stage.name });
           await this.persistPipelines(); // #1424: persist after stage completes
-        }
-
-        // #1423: Check for stage timeout
-        const stageConfig = this.pipelineConfigs.get(id)?.stages.find(s => s.name === stage.name);
-        if (stageConfig?.stageTimeoutMs && stage.startedAt) {
-          const elapsed = Date.now() - stage.startedAt;
-          if (elapsed > stageConfig.stageTimeoutMs) {
-            stage.status = 'failed';
-            stage.error = 'stage_timeout';
-            this.transitionPipelineStage(pipeline, 'fix', { stage: stage.name, reason: 'stage_timeout' });
-            await this.persistPipelines(); // #1424: persist after stage times out
-          }
         }
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2235,7 +2235,7 @@ async function main(): Promise<void> {
   registerHookRoutes(app, { sessions, eventBus, metrics });
 
   // Initialize pipeline manager (Issue #36, #1424)
-  pipelines = new PipelineManager(sessions, eventBus, config.stateDir);
+  pipelines = new PipelineManager(sessions, eventBus, config.stateDir, config.pipelineStageTimeoutMs);
   await pipelines.hydrate(config.stateDir);
 
   // Initialize batch rate limiter (Issue #583)


### PR DESCRIPTION
## Summary

Add global default stage timeout for pipeline stages.

## Changes

- **src/pipeline.ts**: Add  parameter to PipelineManager constructor
- **src/config.ts**: Add  config with  env var
- **src/server.ts**: Pass  to PipelineManager

## Behavior

-  means no timeout (backward compatible)
- Per-stage  overrides the global default
- Timeout is checked BEFORE idle in the poll loop (timeout wins over idle)

## Tests

3 new tests added:
1. Uses global defaultStageTimeoutMs when per-stage timeout is not set
2. Per-stage timeout overrides global default
3. Timeout wins over idle when both are true at the same poll check

## PR Stats

- 4 files changed, 119 insertions(+), 11 deletions(-)
- Well within 500 line diff limit ✅