### PR TITLE
fix: close session ownership gaps on metrics, tools, latency, screenshot, events, stats (#1399)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -768,6 +768,8 @@ app.get('/v1/diagnostics', async (req, reply) => {
 
 // Per-session metrics (Issue #40)
 app.get<{ Params: { id: string } }>('/v1/sessions/:id/metrics', async (req, reply) => {
+  const session = requireOwnership(req.params.id, reply, req.authKeyId);
+  if (!session) return;
   const m = metrics.getSessionMetrics(req.params.id);
   if (!m) return reply.status(404).send({ error: 'No metrics for this session' });
   return m;
@@ -777,8 +779,8 @@ app.get<{ Params: { id: string } }>('/v1/sessions/:id/metrics', async (req, repl
 // Issue #704: Tool usage endpoints
 app.get<IdParams>('/v1/sessions/:id/tools', async (req, reply) => {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return;
   // Parse JSONL on-demand for tool usage
   if (session.jsonlPath) {
     try {
@@ -819,8 +821,8 @@ app.get('/v1/channels/health', async () => {
 // Issue #87: Per-session latency metrics
 app.get<{ Params: { id: string } }>('/v1/sessions/:id/latency', async (req, reply) => {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return;
 
   const realtimeLatency = sessions.getLatencyMetrics(req.params.id);
   const aggregatedLatency = metrics.getSessionLatency(req.params.id);
@@ -953,8 +955,12 @@ app.get<{
 });
 
 // Issue #754: Session statistics endpoint
-app.get('/v1/sessions/stats', async () => {
-  const all = sessions.listSessions();
+app.get('/v1/sessions/stats', async (req) => {
+  let all = sessions.listSessions();
+  const callerKeyId = req.authKeyId;
+  if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined) {
+    all = all.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
+  }
   const byStatus: Partial<Record<string, number>> = {};
   for (const s of all) {
     byStatus[s.status] = (byStatus[s.status] ?? 0) + 1;
@@ -1549,10 +1555,10 @@ async function screenshotHandler(req: IdRequest, reply: FastifyReply): Promise<u
   const dnsResult = await resolveAndCheckIp(hostname);
   if (dnsResult.error) return reply.status(400).send({ error: dnsResult.error });
 
-  // Validate session exists
+  // Validate session exists and caller owns it
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return;
 
   if (!isPlaywrightAvailable()) {
     return reply.status(501).send({
@@ -1578,8 +1584,8 @@ app.post<IdParams>('/sessions/:id/screenshot', screenshotHandler);
 // SSE event stream (Issue #32)
 app.get<{ Params: { id: string } }>('/v1/sessions/:id/events', async (req, reply) => {
   const sessionId = (req.params as { id: string }).id;
-  const session = sessions.getSession(sessionId);
-  if (!session) return reply.status(404).send({ error: 'Session not found' });
+  const session = requireOwnership(sessionId, reply, req.authKeyId);
+  if (!session) return;
 
   const clientIp = req.ip;
   const acquireResult = sseLimiter.acquire(clientIp);


### PR DESCRIPTION
## Summary

Add ownership checks to 6 per-session routes that were missing them:

- GET /v1/sessions/:id/metrics
- GET /v1/sessions/:id/tools
- GET /v1/sessions/:id/latency
- POST /v1/sessions/:id/screenshot
- GET /v1/sessions/:id/events
- GET /v1/sessions/stats (scoped by ownerKeyId for non-master callers)

## Changes

- src/server.ts: +17/-11 lines

## Security

Without these checks, any API key could read metrics, tool usage, latency, screenshots, and event streams for sessions they don't own.

## PR Stats

- 1 file changed, 17 insertions(+), 11 deletions(-)
- Well within 500 line diff limit ✅