### PR TITLE
fix: return stall feedback in send_message response (#1325)

### DIFF
--- a/src/__tests__/stall-detection.test.ts
+++ b/src/__tests__/stall-detection.test.ts
@@ -1043,4 +1043,42 @@ describe('SessionMonitor stall detection (integration)', () => {
       expect(stallHas(monitor, `${session.id}:stall:jsonl`)).toBe(true);
     });
   });
+
+  describe('getStallInfo (Issue #1325)', () => {
+    it('should return stalled: false when no stall is tracked', () => {
+      expect(monitor.getStallInfo('nonexistent')).toEqual({ stalled: false });
+    });
+
+    it('should return stalled: true with types when stalls exist', () => {
+      const session = addSession();
+      stallAdd(monitor, `${session.id}:stall:jsonl`);
+      stallAdd(monitor, `${session.id}:stall:thinking`);
+
+      const info = monitor.getStallInfo(session.id);
+      expect(info.stalled).toBe(true);
+      if (info.stalled) {
+        expect(info.types).toContain('jsonl');
+        expect(info.types).toContain('thinking');
+      }
+    });
+
+    it('should return stalled: false after all stall types are cleared', () => {
+      const session = addSession();
+      stallAdd(monitor, `${session.id}:stall:jsonl`);
+
+      expect(monitor.getStallInfo(session.id).stalled).toBe(true);
+
+      (monitor as any).stallDelete(session.id, 'jsonl');
+      expect(monitor.getStallInfo(session.id)).toEqual({ stalled: false });
+    });
+
+    it('should return stalled: false after removeSession', () => {
+      const session = addSession();
+      stallAdd(monitor, `${session.id}:stall:jsonl`);
+      stallAdd(monitor, `${session.id}:stall:permission`);
+
+      monitor.removeSession(session.id);
+      expect(monitor.getStallInfo(session.id)).toEqual({ stalled: false });
+    });
+  });
 });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -72,6 +72,7 @@ interface SendMessageResponse {
   ok: boolean;
   delivered: boolean;
   attempts: number;
+  stall?: { stalled: true; types: string[] } | { stalled: false };
 }
 
 interface OkResponse {
@@ -605,7 +606,7 @@ export function createMcpServer(aegisPort: number, authToken?: string): McpServe
   // ── send_message ──
   server.tool(
     'send_message',
-    'Send a message to another Aegis session. The message is delivered via tmux send-keys with delivery verification.',
+    'Send a message to another Aegis session. The message is delivered via tmux send-keys with delivery verification. Returns stall information if the session is currently stalled.',
     {
       sessionId: z.string().describe('The target session ID'),
       text: z.string().describe('The message text to send'),

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -975,6 +975,14 @@ export class SessionMonitor {
     // Note: processedStopSignals uses claudeSessionId:timestamp keys, not bridge sessionId.
     // We don't clean them here — they're small and prevent re-processing.
   }
+
+  /** Return active stall types for a session, or null if not stalled.
+   *  Used by send_message to surface stall feedback to callers. */
+  getStallInfo(sessionId: string): { stalled: true; types: string[] } | { stalled: false } {
+    const types = this.stallNotified.get(sessionId);
+    if (!types || types.size === 0) return { stalled: false };
+    return { stalled: true, types: [...types] };
+  }
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1209,14 +1209,17 @@ async function sendMessageHandler(req: IdRequest, reply: FastifyReply): Promise<
   if (!requireOwnership(req.params.id, reply, req.authKeyId)) return;
   const { text } = parsed.data;
   try {
-    const result = await sessions.sendMessage(req.params.id, text);
+    const stallInfo = monitor.getStallInfo(req.params.id);
+    const result = await sessions.sendMessage(req.params.id, text, stallInfo);
     await channels.message({
       event: 'message.user',
       timestamp: new Date().toISOString(),
       session: { id: req.params.id, name: '', workDir: '' },
       detail: text,
     });
-    return { ok: true, delivered: result.delivered, attempts: result.attempts };
+    const response: Record<string, unknown> = { ok: true, delivered: result.delivered, attempts: result.attempts };
+    if (result.stall) response.stall = result.stall;
+    return response;
   } catch (e: unknown) {
     return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -1085,8 +1085,13 @@ export class SessionManager {
   /** Send a message to a session with delivery verification.
    *  Issue #1: Uses capture-pane to verify the prompt was delivered.
    *  Returns delivery status for API response.
+   *  Issue #1325: Optionally includes stall feedback when monitor is provided.
    */
-  async sendMessage(id: string, text: string): Promise<{ delivered: boolean; attempts: number }> {
+  async sendMessage(
+    id: string,
+    text: string,
+    stallInfo?: { stalled: true; types: string[] } | { stalled: false },
+  ): Promise<{ delivered: boolean; attempts: number; stall?: { stalled: true; types: string[] } | { stalled: false } }> {
     const session = this.state.sessions[id];
     if (!session) throw new Error(`Session ${id} not found`);
 
@@ -1099,7 +1104,7 @@ export class SessionManager {
         // Message was delivered — don't let a save failure mask the success
       }
     }
-    return result;
+    return stallInfo ? { ...result, stall: stallInfo } : result;
   }
 
   /** Send message bypassing the tmux serialize queue.


### PR DESCRIPTION
## Summary
- **Issue:** #1325 — `send_message` returns no feedback when session is stalled
- **Root cause:** `sendMessage()` only returned `{delivered, attempts}` with no awareness of stall state
- **Fix:** Query `SessionMonitor.getStallInfo()` before sending and include stall info in the response

## Changes
- **monitor.ts:** Add public `getStallInfo(sessionId)` method — returns `{stalled: true, types: [...]}` or `{stalled: false}`
- **session.ts:** `sendMessage()` accepts optional `stallInfo` param, includes it in return when provided
- **server.ts:** HTTP handler queries monitor for stall info before sending, includes `stall` field in response
- **mcp-server.ts:** Updated `SendMessageResponse` interface and tool description to surface stall info
- **stall-detection.test.ts:** 4 new tests for `getStallInfo` (empty, active, cleared, removed)

## Response examples

**Not stalled:**
```json
{ "ok": true, "delivered": true, "attempts": 1 }
```

**Stalled (extended thinking):**
```json
{ "ok": true, "delivered": true, "attempts": 1, "stall": { "stalled": true, "types": ["thinking"] } }
```

**Stalled (permission prompt):**
```json
{ "ok": true, "delivered": true, "attempts": 1, "stall": { "stalled": true, "types": ["permission"] } }
```

## Test plan
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npm test` — 5521 tests pass (4 new)
- [ ] Manual: send message to a session in extended thinking, verify `stall` field in response

## Aegis version
**Developed with:** v2.9.0

Closes #1325

Generated by Hephaestus (Aegis dev agent)