### PR TITLE
feat: deliver wave 1/2 hardening for hooks, tmux, config, and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ curl -X POST http://localhost:9100/v1/pipelines \
 Aegis includes built-in security defaults:
 
 - **Permission mode** — `default` requires approval for dangerous operations (shell commands, file writes). Change with `permissionMode` when creating a session.
-- **Hook secrets** — webhook and hook secrets are passed via headers (not query params) to prevent log leakage.
+- **Hook secrets** — use `X-Hook-Secret` header (preferred). Query-param `secret` remains backward compatible by default but is deprecated.
 - **Auth tokens** — protect the API with `AEGIS_AUTH_TOKEN` (Bearer auth on all endpoints except `/v1/health`).
 - **WebSocket auth** — session existence is not revealed before authentication.
 
@@ -387,6 +387,7 @@ Aegis includes built-in security defaults:
 | `AEGIS_TG_TOKEN` | — | Telegram bot token |
 | `AEGIS_TG_GROUP` | — | Telegram group chat ID |
 | `AEGIS_WEBHOOKS` | — | Webhook URLs (comma-separated) |
+| `AEGIS_HOOK_SECRET_HEADER_ONLY` | false | Enforce `X-Hook-Secret` header and reject deprecated `?secret=` transport |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,6 +16,22 @@ curl http://localhost:9100/v1/sessions
 
 For multi-key auth, see [Enterprise Deployment](./enterprise.md#authentication).
 
+## Claude Code Hook Receiver Authentication
+
+`POST /v1/hooks/{eventName}` is the inbound callback endpoint used by Claude Code hooks.
+
+- Send the session ID via `X-Session-Id` header (or `sessionId` query fallback).
+- Send the hook secret via `X-Hook-Secret` header.
+- Query-param `secret` is deprecated in compatibility mode and logs a warning.
+- Set `AEGIS_HOOK_SECRET_HEADER_ONLY=true` to enforce header-only secret transport and reject query-param secrets.
+
+```bash
+curl -X POST "http://localhost:9100/v1/hooks/Stop?sessionId=<session-uuid>" \
+  -H "X-Hook-Secret: <hook-secret>" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
 ---
 
 ## Core Endpoints

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,11 @@ src/
 ├── ws-terminal.ts            # WebSocket terminal relay
 │
 ├── permission-guard.ts       # Permission request interception and routing
-├── permission-evaluator.ts   # Permission profile evaluation logic
+├── services/
+│   └── permission/
+│       ├── evaluator.ts      # Permission profile evaluation logic
+│       ├── types.ts          # Permission evaluator input/output types
+│       └── index.ts          # Permission evaluator exports
 ├── permission-request-manager.ts  # Permission request queue and lifecycle
 ├── permission-routes.ts      # REST endpoints for approve/reject/list permissions
 │
@@ -162,7 +166,7 @@ dashboard/                     # React dashboard (served by Fastify static)
 | Module | Purpose |
 |---|---|
 | `permission-guard.ts` | Intercepts permission requests and routes to evaluator |
-| `permission-evaluator.ts` | Evaluates permission requests against profiles |
+| `services/permission/evaluator.ts` | Evaluates permission requests against profiles |
 | `permission-request-manager.ts` | Queues and tracks pending permission requests |
 | `permission-routes.ts` | REST endpoints: approve, reject, list pending permissions |
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -250,6 +250,78 @@ paths:
                   message:
                     type: string
 
+  /v1/hooks/{eventName}:
+    post:
+      operationId: receiveHookEvent
+      summary: Receive Claude Code hook event
+      tags: [Hooks]
+      security: []
+      description: |
+        Inbound callback endpoint for Claude Code HTTP hooks.
+
+        Preferred transport is `X-Hook-Secret` header authentication.
+        Query-param `secret` is deprecated and only accepted in compatibility mode
+        (`AEGIS_HOOK_SECRET_HEADER_ONLY=false`, default). When
+        `AEGIS_HOOK_SECRET_HEADER_ONLY=true`, any request using query-param
+        hook secrets is rejected.
+      parameters:
+        - name: eventName
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Hook event name (for example Stop, PreToolUse, PermissionRequest)
+        - name: X-Session-Id
+          in: header
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Session ID (preferred transport).
+        - name: sessionId
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Session ID fallback when header transport is unavailable.
+        - name: X-Hook-Secret
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Hook secret header. Required when the session has a configured hook secret.
+        - name: secret
+          in: query
+          required: false
+          deprecated: true
+          schema:
+            type: string
+          description: |
+            Deprecated query-param hook secret.
+            Accepted only in compatibility mode and rejected in header-only mode.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Hook event accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   # ─── Sessions ─────────────────────────────────────────────────────────────
 
   /v1/sessions:

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getConfig } from '../config.js';
 import { testPath } from './helpers/platform.js';
 
@@ -17,6 +17,7 @@ describe('config', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     // Restore env
     for (const key of Object.keys(process.env)) {
       if (key.startsWith('AEGIS_') || key.startsWith('MANUS_')) {
@@ -48,6 +49,7 @@ describe('config', () => {
       expect(config.tgBotToken).toBe('');
       expect(config.tgGroupId).toBe('');
       expect(config.tgTopicTtlMs).toBe(24 * 60 * 60 * 1000);
+      expect(config.hookSecretHeaderOnly).toBe(false);
     });
   });
 
@@ -104,6 +106,12 @@ describe('config', () => {
       process.env.AEGIS_TG_TOPIC_TTL_MS = '60000';
       const config = getConfig();
       expect(config.tgTopicTtlMs).toBe(60000);
+    });
+
+    it('overrides hook secret transport mode via AEGIS_HOOK_SECRET_HEADER_ONLY', () => {
+      process.env.AEGIS_HOOK_SECRET_HEADER_ONLY = 'true';
+      const config = getConfig();
+      expect(config.hookSecretHeaderOnly).toBe(true);
     });
   });
 
@@ -173,6 +181,12 @@ describe('config', () => {
       const config = getConfig();
       expect(config.webhooks).toEqual(['https://example.com/hook']);
     });
+
+    it('overrides hook secret transport mode via MANUS_HOOK_SECRET_HEADER_ONLY (legacy)', () => {
+      process.env.MANUS_HOOK_SECRET_HEADER_ONLY = 'true';
+      const config = getConfig();
+      expect(config.hookSecretHeaderOnly).toBe(true);
+    });
   });
 
   describe('AEGIS_* takes priority over MANUS_*', () => {
@@ -196,6 +210,13 @@ describe('config', () => {
       const config = getConfig();
       expect(config.tmuxSession).toBe('aegis');
     });
+
+    it('AEGIS_HOOK_SECRET_HEADER_ONLY wins over MANUS_HOOK_SECRET_HEADER_ONLY', () => {
+      process.env.MANUS_HOOK_SECRET_HEADER_ONLY = 'false';
+      process.env.AEGIS_HOOK_SECRET_HEADER_ONLY = 'true';
+      const config = getConfig();
+      expect(config.hookSecretHeaderOnly).toBe(true);
+    });
   });
 
   describe('numeric parsing', () => {
@@ -212,6 +233,71 @@ describe('config', () => {
       expect(config.port).toBe(8080);
       expect(config.maxSessionAgeMs).toBe(7200000);
       expect(config.reaperIntervalMs).toBe(120000);
+    });
+
+    it('falls back and warns when AEGIS_PORT is out of range', () => {
+      process.env.AEGIS_PORT = '70000';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const config = getConfig();
+      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+
+      expect(config.port).toBe(9100);
+      expect(warnings).toContain("AEGIS_PORT='70000'");
+      expect(warnings).toContain('<= 65535');
+    });
+
+    it('falls back and warns when numeric env value is not a strict integer', () => {
+      process.env.AEGIS_MAX_SESSION_AGE_MS = '3600000ms';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const config = getConfig();
+      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+
+      expect(config.maxSessionAgeMs).toBe(2 * 60 * 60 * 1000);
+      expect(warnings).toContain("AEGIS_MAX_SESSION_AGE_MS='3600000ms'");
+      expect(warnings).toContain('expected an integer');
+    });
+
+    it('accepts 0 for AEGIS_PIPELINE_STAGE_TIMEOUT_MS and rejects negative values', () => {
+      process.env.AEGIS_PIPELINE_STAGE_TIMEOUT_MS = '0';
+      const zeroConfig = getConfig();
+      expect(zeroConfig.pipelineStageTimeoutMs).toBe(0);
+
+      process.env.AEGIS_PIPELINE_STAGE_TIMEOUT_MS = '-1';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const negativeConfig = getConfig();
+      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+
+      expect(negativeConfig.pipelineStageTimeoutMs).toBe(0);
+      expect(warnings).toContain("AEGIS_PIPELINE_STAGE_TIMEOUT_MS='-1'");
+      expect(warnings).toContain('>= 0');
+    });
+  });
+
+  describe('invalid env warnings', () => {
+    it('warns and keeps default when AEGIS_HOOK_SECRET_HEADER_ONLY is invalid', () => {
+      process.env.AEGIS_HOOK_SECRET_HEADER_ONLY = 'yes';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const config = getConfig();
+      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+
+      expect(config.hookSecretHeaderOnly).toBe(false);
+      expect(warnings).toContain("AEGIS_HOOK_SECRET_HEADER_ONLY='yes'");
+      expect(warnings).toContain('expected "true" or "false"');
+    });
+
+    it('warns for invalid Telegram allowlist entries while keeping valid IDs', () => {
+      process.env.AEGIS_TG_ALLOWED_USERS = '111,abc,-5,222';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const config = getConfig();
+      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+
+      expect(config.tgAllowedUsers).toEqual([111, 222]);
+      expect(warnings).toContain('AEGIS_TG_ALLOWED_USERS');
+      expect(warnings).toContain('abc, -5');
     });
   });
 

--- a/src/__tests__/input-validation.test.ts
+++ b/src/__tests__/input-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   authKeySchema,
   sendMessageSchema,
@@ -230,6 +230,20 @@ describe('parseIntSafe', () => {
   });
   it('returns fallback for Infinity string', () => {
     expect(parseIntSafe('Infinity', 99)).toBe(99);
+  });
+  it('supports strict integer parsing', () => {
+    expect(parseIntSafe('42x', 7, { strict: true })).toBe(7);
+    expect(parseIntSafe('42', 7, { strict: true })).toBe(42);
+  });
+  it('supports inclusive min/max bounds', () => {
+    expect(parseIntSafe('70000', 9100, { strict: true, min: 1, max: 65535 })).toBe(9100);
+    expect(parseIntSafe('8080', 9100, { strict: true, min: 1, max: 65535 })).toBe(8080);
+  });
+  it('reports parse failures through onError callback', () => {
+    const onError = vi.fn();
+    expect(parseIntSafe('abc', 123, { strict: true, context: 'AEGIS_PORT', onError })).toBe(123);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toContain("AEGIS_PORT='abc'");
   });
 });
 

--- a/src/__tests__/permission-evaluator-742.test.ts
+++ b/src/__tests__/permission-evaluator-742.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { evaluatePermissionProfile } from '../permission-evaluator.js';
+import { evaluatePermissionProfile } from '../services/permission/index.js';
 
 describe('Issue #742: permission profile evaluator', () => {
   it('falls back to defaultBehavior when no rule matches', () => {

--- a/src/__tests__/permission-evaluator-coverage-1305.test.ts
+++ b/src/__tests__/permission-evaluator-coverage-1305.test.ts
@@ -1,7 +1,7 @@
 /**
  * permission-evaluator-coverage-1305.test.ts — Additional coverage tests for Issue #1305.
  *
- * Targets uncovered branches in src/permission-evaluator.ts:
+ * Targets uncovered branches in src/services/permission/evaluator.ts:
  * - Pattern matching with JSON.stringify fallback (no command field in toolInput)
  * - readOnly constraint with non-write tool (should allow)
  * - Path constraint with empty paths array (no constraint applied)
@@ -14,10 +14,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { evaluatePermissionProfile } from '../permission-evaluator.js';
-import type { PermissionProfile } from '../validation.js';
+import { join } from 'node:path';
+import { evaluatePermissionProfile, type PermissionProfile } from '../services/permission/index.js';
 
-describe('Issue #1305: permission-evaluator.ts additional coverage', () => {
+describe('Issue #1305: permission evaluator additional coverage', () => {
   // ── Pattern matching ────────────────────────────────────────────────
 
   describe('Pattern matching with JSON.stringify fallback', () => {
@@ -521,32 +521,34 @@ describe('Issue #1305: permission-evaluator.ts additional coverage', () => {
     });
 
     it('should extract path from target field in toolInput', () => {
+      const allowedPrefix = join(process.cwd(), 'allowed-root');
       const result = evaluatePermissionProfile({
         defaultBehavior: 'deny',
         rules: [{
           tool: 'Delete',
           behavior: 'allow',
-          constraints: { paths: ['/tmp'] },
+          constraints: { paths: [allowedPrefix] },
         }],
       }, {
         toolName: 'Delete',
-        toolInput: { target: '/tmp/file.txt' },
+        toolInput: { target: join(allowedPrefix, 'file.txt') },
       });
 
       expect(result.behavior).toBe('allow');
     });
 
     it('should deny when target field path is outside allowed prefixes', () => {
+      const allowedPrefix = join(process.cwd(), 'allowed-root');
       const result = evaluatePermissionProfile({
         defaultBehavior: 'allow',
         rules: [{
           tool: 'Delete',
           behavior: 'allow',
-          constraints: { paths: ['/tmp'] },
+          constraints: { paths: [allowedPrefix] },
         }],
       }, {
         toolName: 'Delete',
-        toolInput: { target: '/etc/important' },
+        toolInput: { target: join(process.cwd(), 'outside.txt') },
       });
 
       expect(result.behavior).toBe('deny');

--- a/src/__tests__/permission-evaluator-symlink-1402.test.ts
+++ b/src/__tests__/permission-evaluator-symlink-1402.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, symlinkSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { evaluatePermissionProfile } from '../permission-evaluator.js';
+import { evaluatePermissionProfile } from '../services/permission/index.js';
 
 describe('Issue #1402: permission evaluator symlink bypass', () => {
   let allowedDir: string;
@@ -47,9 +47,11 @@ describe('Issue #1402: permission evaluator symlink bypass', () => {
     expect(result.reason).toContain('path constraint');
   });
 
-  it('rejects symlink to /etc/passwd from allowed dir', () => {
+  it('rejects symlink to outside file from allowed dir', () => {
     const linkPath = join(allowedDir, 'passwd');
-    symlinkSync('/etc/passwd', linkPath);
+    const outsideFile = join(outsideDir, 'passwd');
+    writeFileSync(outsideFile, 'root:x:0:0:root:/root:/bin/bash');
+    symlinkSync(outsideFile, linkPath);
 
     const result = evaluatePermissionProfile({
       defaultBehavior: 'deny',

--- a/src/__tests__/security-629-630-634.test.ts
+++ b/src/__tests__/security-629-630-634.test.ts
@@ -58,6 +58,7 @@ describe('Issue #629: Hook endpoint secret validation', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await app.close();
   });
 
@@ -72,12 +73,72 @@ describe('Issue #629: Hook endpoint secret validation', () => {
   });
 
   it('should accept hook with valid session ID and correct secret in query param (backward compat)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await app.inject({
       method: 'POST',
       url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=${VALID_SECRET}`,
       payload: {},
     });
     expect(res.statusCode).toBe(200);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('query-string hook secret is deprecated'));
+  });
+
+  it('should reject query-param hook secret in header-only mode', async () => {
+    const app2 = Fastify({ logger: false });
+    registerHookRoutes(app2, {
+      sessions: createMockSessionManager(),
+      eventBus: new SessionEventBus(),
+      hookSecretHeaderOnly: true,
+    });
+
+    const res = await app2.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=${VALID_SECRET}`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toContain('X-Hook-Secret');
+    await app2.close();
+  });
+
+  it('should reject query-param hook secret even when header secret is present in header-only mode', async () => {
+    const app2 = Fastify({ logger: false });
+    registerHookRoutes(app2, {
+      sessions: createMockSessionManager(),
+      eventBus: new SessionEventBus(),
+      hookSecretHeaderOnly: true,
+    });
+
+    const res = await app2.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=${VALID_SECRET}`,
+      headers: { 'x-hook-secret': VALID_SECRET },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toContain('X-Hook-Secret');
+    await app2.close();
+  });
+
+  it('should accept header hook secret in header-only mode', async () => {
+    const app2 = Fastify({ logger: false });
+    registerHookRoutes(app2, {
+      sessions: createMockSessionManager(),
+      eventBus: new SessionEventBus(),
+      hookSecretHeaderOnly: true,
+    });
+
+    const res = await app2.inject({
+      method: 'POST',
+      url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}`,
+      headers: { 'x-hook-secret': VALID_SECRET },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    await app2.close();
   });
 
   it('should reject hook with valid session ID but wrong secret in header', async () => {

--- a/src/__tests__/startup.test.ts
+++ b/src/__tests__/startup.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { testTmpDir } from './helpers/platform.js';
+
+vi.mock('../file-utils.js', () => ({
+  secureFilePermissions: vi.fn(),
+}));
+
+import { writePidFile } from '../startup.js';
+
+const mockSecureFilePermissions = vi.mocked((await import('../file-utils.js')).secureFilePermissions);
+
+describe('writePidFile', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSecureFilePermissions.mockResolvedValue(undefined);
+    stateDir = mkdtempSync(join(testTmpDir(), 'aegis-startup-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('writes PID file and applies permission hardening', async () => {
+    const pidFilePath = await writePidFile(stateDir);
+    expect(pidFilePath).toBe(join(stateDir, 'aegis.pid'));
+    expect(readFileSync(pidFilePath, 'utf-8')).toBe(String(process.pid));
+    expect(mockSecureFilePermissions).toHaveBeenCalledWith(pidFilePath);
+
+    const perms = statSync(pidFilePath).mode & 0o777;
+    if (process.platform === 'win32') {
+      expect(perms).toBeGreaterThan(0);
+    } else {
+      expect(perms).toBe(0o600);
+    }
+  });
+
+  it('returns empty string if permission hardening fails', async () => {
+    mockSecureFilePermissions.mockRejectedValueOnce(new Error('chmod failed'));
+    await expect(writePidFile(stateDir)).resolves.toBe('');
+  });
+});

--- a/src/__tests__/tmux-queue-recovery-1615.test.ts
+++ b/src/__tests__/tmux-queue-recovery-1615.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { TmuxManager } from '../tmux.js';
+
+interface QueueHarness {
+  queue: Promise<void>;
+  serialize<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+function createQueueHarness(): QueueHarness {
+  return new TmuxManager('queue-recovery-session', 'queue-recovery-socket') as unknown as QueueHarness;
+}
+
+function poisonQueue(harness: QueueHarness, marker: string): void {
+  const poisonedQueue = Promise.reject(new Error(`poisoned-queue:${marker}`));
+  void poisonedQueue.catch(() => undefined);
+  harness.queue = poisonedQueue;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number = 1_000): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function expectRejectedMessage(result: PromiseSettledResult<string>, expected: string): void {
+  expect(result.status).toBe('rejected');
+  if (result.status !== 'rejected') return;
+  const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+  expect(message).toContain(expected);
+}
+
+describe('TmuxManager serialize queue rejection recovery (Issue #1615)', () => {
+  it('single rejection recovery: subsequent operation still runs', async () => {
+    const harness = createQueueHarness();
+    const executed: string[] = [];
+    poisonQueue(harness, 'single');
+
+    await expect(withTimeout(harness.serialize(async () => {
+      executed.push('first');
+      throw new Error('first failure');
+    }))).rejects.toThrow('first failure');
+
+    await expect(withTimeout(harness.serialize(async () => {
+      executed.push('second');
+      return 'ok';
+    }))).resolves.toBe('ok');
+
+    expect(executed).toEqual(['first', 'second']);
+  });
+
+  it('repeated rejection recovery: queue continues after multiple failures', async () => {
+    const harness = createQueueHarness();
+    const executed: string[] = [];
+    poisonQueue(harness, 'repeated');
+
+    await expect(withTimeout(harness.serialize(async () => {
+      executed.push('first');
+      throw new Error('fail-1');
+    }))).rejects.toThrow('fail-1');
+
+    await expect(withTimeout(harness.serialize(async () => {
+      executed.push('second');
+      throw new Error('fail-2');
+    }))).rejects.toThrow('fail-2');
+
+    await expect(withTimeout(harness.serialize(async () => {
+      executed.push('third');
+      return 'recovered';
+    }))).resolves.toBe('recovered');
+
+    expect(executed).toEqual(['first', 'second', 'third']);
+  });
+
+  it('mixed success/failure sequence runs in order without queue poisoning', async () => {
+    const harness = createQueueHarness();
+    const executed: string[] = [];
+    poisonQueue(harness, 'mixed');
+
+    const operations = [
+      withTimeout(harness.serialize(async () => {
+        executed.push('success-1');
+        return 'success-1';
+      })),
+      withTimeout(harness.serialize(async () => {
+        executed.push('failure-1');
+        throw new Error('failure-1');
+      })),
+      withTimeout(harness.serialize(async () => {
+        executed.push('success-2');
+        return 'success-2';
+      })),
+      withTimeout(harness.serialize(async () => {
+        executed.push('failure-2');
+        throw new Error('failure-2');
+      })),
+      withTimeout(harness.serialize(async () => {
+        executed.push('success-3');
+        return 'success-3';
+      })),
+    ];
+
+    const results = await Promise.allSettled(operations);
+
+    expect(results[0]).toMatchObject({ status: 'fulfilled', value: 'success-1' });
+    expectRejectedMessage(results[1], 'failure-1');
+    expect(results[2]).toMatchObject({ status: 'fulfilled', value: 'success-2' });
+    expectRejectedMessage(results[3], 'failure-2');
+    expect(results[4]).toMatchObject({ status: 'fulfilled', value: 'success-3' });
+    expect(executed).toEqual(['success-1', 'failure-1', 'success-2', 'failure-2', 'success-3']);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,8 @@ export interface Config {
    *  Empty array = all directories allowed (backward compatible).
    *  Paths are resolved and symlink-resolved before checking. */
   allowedWorkDirs: string[];
+  /** Issue #1619: Require X-Hook-Secret header and reject query param secrets. */
+  hookSecretHeaderOnly: boolean;
   /** Memory bridge: key/value store for cross-session context (default: disabled). */
   memoryBridge: { enabled: boolean; persistPath?: string; reaperIntervalMs?: number };
   /** Issue #884: Enable worktree-aware continuation metadata lookup (default: false).
@@ -133,6 +135,7 @@ const defaults: Config = {
   sseMaxConnections: 100,
   sseMaxPerIp: 10,
   allowedWorkDirs: [],
+  hookSecretHeaderOnly: false,
   worktreeAwareContinuation: false,
   memoryBridge: { enabled: false },
   worktreeSiblingDirs: [],
@@ -205,6 +208,63 @@ function expandTilde(path: string): string {
   return path;
 }
 
+type NumericConfigEnvKey =
+  | 'port'
+  | 'maxSessionAgeMs'
+  | 'reaperIntervalMs'
+  | 'continuationPointerTtlMs'
+  | 'tgTopicTtlMs'
+  | 'sseMaxConnections'
+  | 'sseMaxPerIp'
+  | 'pipelineStageTimeoutMs';
+
+const MAX_ENV_INT = Number.MAX_SAFE_INTEGER;
+
+const numericEnvBounds: Record<NumericConfigEnvKey, { min: number; max: number }> = {
+  port: { min: 1, max: 65535 },
+  maxSessionAgeMs: { min: 1, max: MAX_ENV_INT },
+  reaperIntervalMs: { min: 1, max: MAX_ENV_INT },
+  continuationPointerTtlMs: { min: 1, max: MAX_ENV_INT },
+  tgTopicTtlMs: { min: 1, max: MAX_ENV_INT },
+  sseMaxConnections: { min: 1, max: MAX_ENV_INT },
+  sseMaxPerIp: { min: 1, max: MAX_ENV_INT },
+  pipelineStageTimeoutMs: { min: 0, max: MAX_ENV_INT },
+};
+
+function parseNumericEnvOverride(
+  envName: string,
+  rawValue: string,
+  fallback: number,
+  bounds: { min: number; max: number },
+): number {
+  return parseIntSafe(rawValue, fallback, {
+    context: envName,
+    strict: true,
+    min: bounds.min,
+    max: bounds.max,
+    onError: (message) => console.warn(`Config: ${message}`),
+  });
+}
+
+function parseTgAllowedUsers(envName: string, value: string): number[] {
+  const parsedUsers: number[] = [];
+  const invalidEntries: string[] = [];
+  for (const token of value.split(',')) {
+    const trimmed = token.trim();
+    if (!trimmed) continue;
+    const parsed = Number(trimmed);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+      invalidEntries.push(trimmed);
+      continue;
+    }
+    parsedUsers.push(parsed);
+  }
+  if (invalidEntries.length > 0) {
+    console.warn(`Config: invalid ${envName} entries ignored: ${invalidEntries.join(', ')}`);
+  }
+  return parsedUsers;
+}
+
 /** Apply environment variable overrides.
  *  AEGIS_* vars take priority over MANUS_* (backward compat).
  */
@@ -229,12 +289,14 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_SSE_MAX_CONNECTIONS', manus: 'MANUS_SSE_MAX_CONNECTIONS', key: 'sseMaxConnections' },
     { aegis: 'AEGIS_SSE_MAX_PER_IP', manus: 'MANUS_SSE_MAX_PER_IP', key: 'sseMaxPerIp' },
     { aegis: 'AEGIS_PIPELINE_STAGE_TIMEOUT_MS', manus: 'MANUS_PIPELINE_STAGE_TIMEOUT_MS', key: 'pipelineStageTimeoutMs' },
+    { aegis: 'AEGIS_HOOK_SECRET_HEADER_ONLY', manus: 'MANUS_HOOK_SECRET_HEADER_ONLY', key: 'hookSecretHeaderOnly' },
   ];
 
   for (const { aegis, manus, key } of envMappings) {
     // AEGIS_* takes priority over MANUS_*
     const value = process.env[aegis] ?? process.env[manus];
     if (value === undefined) continue;
+    const envName = process.env[aegis] !== undefined ? aegis : manus;
 
     switch (key) {
       case 'port':
@@ -245,7 +307,16 @@ function applyEnvOverrides(config: Config): Config {
       case 'sseMaxConnections':
       case 'sseMaxPerIp':
       case 'pipelineStageTimeoutMs':
-        config[key] = parseIntSafe(value, config[key]);
+        config[key] = parseNumericEnvOverride(envName, value, config[key], numericEnvBounds[key]);
+        break;
+      case 'hookSecretHeaderOnly':
+        if (value === 'true' || value === 'false') {
+          config[key] = value === 'true';
+        } else {
+          console.warn(
+            `Config: Invalid ${envName}='${value}' (expected "true" or "false"); using ${config[key]}`,
+          );
+        }
         break;
       case 'webhooks':
         // Support comma-separated webhooks
@@ -254,7 +325,7 @@ function applyEnvOverrides(config: Config): Config {
           : [value];
         break;
       case 'tgAllowedUsers':
-        config[key] = value.split(',').map(s => Number(s.trim())).filter(n => !isNaN(n) && n > 0);
+        config[key] = parseTgAllowedUsers(envName, value);
         break;
       // All remaining env-mapped keys are string-typed — assign directly.
       case 'host':
@@ -285,12 +356,22 @@ function applyAlertingEnvOverrides(config: Config): Config {
       : [alertWebhooksRaw];
   }
   const alertThreshold = process.env.AEGIS_ALERT_FAILURE_THRESHOLD;
-  if (alertThreshold) {
-    config.alerting.failureThreshold = parseIntSafe(alertThreshold, config.alerting.failureThreshold);
+  if (alertThreshold !== undefined) {
+    config.alerting.failureThreshold = parseNumericEnvOverride(
+      'AEGIS_ALERT_FAILURE_THRESHOLD',
+      alertThreshold,
+      config.alerting.failureThreshold,
+      { min: 1, max: MAX_ENV_INT },
+    );
   }
   const alertCooldown = process.env.AEGIS_ALERT_COOLDOWN_MS;
-  if (alertCooldown) {
-    config.alerting.cooldownMs = parseIntSafe(alertCooldown, config.alerting.cooldownMs);
+  if (alertCooldown !== undefined) {
+    config.alerting.cooldownMs = parseNumericEnvOverride(
+      'AEGIS_ALERT_COOLDOWN_MS',
+      alertCooldown,
+      config.alerting.cooldownMs,
+      { min: 1, max: MAX_ENV_INT },
+    );
   }
   return config;
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -21,7 +21,7 @@ import type { SessionEventBus } from './events.js';
 import { isValidUUID, hookBodySchema, parseIntSafe } from './validation.js';
 import type { MetricsCollector } from './metrics.js';
 import type { UIState } from './terminal-parser.js';
-import { evaluatePermissionProfile } from './permission-evaluator.js';
+import { evaluatePermissionProfile } from './services/permission/index.js';
 import crypto from 'node:crypto';
 
 /** CC hook events that require a decision response. */
@@ -133,6 +133,7 @@ export interface HookRouteDeps {
   sessions: SessionManager;
   eventBus: SessionEventBus;
   metrics?: MetricsCollector;
+  hookSecretHeaderOnly?: boolean;
 }
 
 /**
@@ -144,7 +145,7 @@ export interface HookRouteDeps {
 export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): void {
   app.post<{
     Params: { eventName: string };
-    Querystring: { sessionId?: string };
+    Querystring: { sessionId?: string; secret?: string };
   }>('/v1/hooks/:eventName', async (req, reply) => {
     const { eventName } = req.params;
     // Issue #349: Validate event name against known list to prevent injection
@@ -166,9 +167,16 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
       return reply.status(404).send({ error: `Session ${sessionId} not found` });
     }
 
-    // Issue #629/#1131: Validate hook secret from X-Hook-Secret header (query param fallback)
-    const hookSecret = (req.headers['x-hook-secret'] as string)
-      || (req.query as Record<string, string>)?.secret;
+    const headerHookSecret = req.headers['x-hook-secret'] as string | undefined;
+    const queryHookSecret = req.query.secret;
+    const hasQueryHookSecret = queryHookSecret !== undefined;
+    if (deps.hookSecretHeaderOnly && hasQueryHookSecret) {
+      return reply.status(401).send({ error: 'Unauthorized — hook secret must be sent via X-Hook-Secret header' });
+    }
+    if (!deps.hookSecretHeaderOnly && hasQueryHookSecret) {
+      console.warn(`Hooks: query-string hook secret is deprecated (session ${sessionId}, event ${eventName}); use X-Hook-Secret header`);
+    }
+    const hookSecret = headerHookSecret || queryHookSecret;
     if (session.hookSecret && !timingSafeEqual(hookSecret, session.hookSecret)) {
       return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -410,9 +410,11 @@ function setupAuth(authManager: AuthManager): void {
       if (hookSessionId) {
         const session = sessions.getSession(hookSessionId);
         if (session) {
-          // Issue #629/#1131: Validate hook secret from X-Hook-Secret header (query param fallback)
-          const hookSecret = (req.headers['x-hook-secret'] as string)
-            || (req.query as Record<string, string>)?.secret;
+          const queryHookSecret = (req.query as Record<string, string>)?.secret;
+          if (config.hookSecretHeaderOnly && queryHookSecret !== undefined) {
+            return reply.status(401).send({ error: 'Unauthorized — hook secret must be sent via X-Hook-Secret header' });
+          }
+          const hookSecret = (req.headers['x-hook-secret'] as string) || queryHookSecret;
           if (!hookSecret || !timingSafeEqual(hookSecret, session.hookSecret)) {
             return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
           }
@@ -2241,7 +2243,7 @@ async function main(): Promise<void> {
   }
 
   // Register HTTP hook receiver (Issue #169, Issue #87: pass metrics for latency tracking)
-  registerHookRoutes(app, { sessions, eventBus, metrics });
+  registerHookRoutes(app, { sessions, eventBus, metrics, hookSecretHeaderOnly: config.hookSecretHeaderOnly });
 
   // Initialize pipeline manager (Issue #36, #1424)
   pipelines = new PipelineManager(sessions, eventBus, config.stateDir, config.pipelineStageTimeoutMs);
@@ -2440,7 +2442,7 @@ toolRegistry = new ToolRegistry();
     return reply.status(404).send({ error: "Not found" });
   });
   await listenWithRetry(app, config.port, config.host, config.stateDir);
-  pidFilePath = writePidFile(config.stateDir);
+  pidFilePath = await writePidFile(config.stateDir);
   console.log(`Aegis running on http://${config.host}:${config.port}`);
   console.log(`Channels: ${channels.count} registered`);
   console.log(`State dir: ${config.stateDir}`);

--- a/src/services/permission/evaluator.ts
+++ b/src/services/permission/evaluator.ts
@@ -1,16 +1,10 @@
-import type { PermissionProfile } from './validation.js';
 import { existsSync, realpathSync } from 'node:fs';
 import { normalize, sep } from 'node:path';
-
-export interface PermissionEvaluationInput {
-  toolName: string;
-  toolInput?: Record<string, unknown>;
-}
-
-export interface PermissionEvaluationResult {
-  behavior: 'allow' | 'deny' | 'ask';
-  reason: string;
-}
+import type {
+  PermissionEvaluationInput,
+  PermissionEvaluationResult,
+  PermissionProfile,
+} from './types.js';
 
 function globToRegExp(pattern: string): RegExp {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\?/g, '.').replace(/\*/g, '.*');

--- a/src/services/permission/index.ts
+++ b/src/services/permission/index.ts
@@ -1,0 +1,6 @@
+export { evaluatePermissionProfile } from './evaluator.js';
+export type {
+  PermissionEvaluationInput,
+  PermissionEvaluationResult,
+  PermissionProfile,
+} from './types.js';

--- a/src/services/permission/types.ts
+++ b/src/services/permission/types.ts
@@ -1,0 +1,11 @@
+export type { PermissionProfile } from '../../validation.js';
+
+export interface PermissionEvaluationInput {
+  toolName: string;
+  toolInput?: Record<string, unknown>;
+}
+
+export interface PermissionEvaluationResult {
+  behavior: 'allow' | 'deny' | 'ask';
+  reason: string;
+}

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -2,12 +2,14 @@ import Fastify from 'fastify';
 import fs from 'node:fs/promises';
 import { writeFileSync, unlinkSync } from 'node:fs';
 import path from 'node:path';
+import { secureFilePermissions } from './file-utils.js';
 import { findPidOnPort, readParentPid } from './process-utils.js';
 
-export function writePidFile(stateDir: string): string {
+export async function writePidFile(stateDir: string): Promise<string> {
   try {
     const pidFilePath = path.join(stateDir, 'aegis.pid');
-    writeFileSync(pidFilePath, String(process.pid));
+    writeFileSync(pidFilePath, String(process.pid), { mode: 0o600 });
+    await secureFilePermissions(pidFilePath);
     return pidFilePath;
   } catch {
     return '';

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -93,14 +93,15 @@ export class TmuxManager {
 
   /** Run `fn` sequentially after all previously-queued operations complete. */
   private serialize<T>(fn: () => Promise<T>): Promise<T> {
-    let resolve!: () => void;
-    const next = new Promise<void>(r => { resolve = r; });
-    const prev = this.queue;
-    this.queue = next;
-    return prev.then(async () => {
-      try { return await fn(); }
-      finally { resolve(); }
-    });
+    const run = this.queue.then(
+      () => fn(),
+      () => fn(),
+    );
+    this.queue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   /** Run a tmux command and return stdout (serialized through the queue).

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -146,11 +146,74 @@ export function clamp(value: number, min: number, max: number, fallback: number)
   return Math.max(min, Math.min(max, value));
 }
 
-/** Parse an env string to integer with NaN/isFinite guard. Returns fallback on failure. */
-export function parseIntSafe(value: string | undefined, fallback: number): number {
+export interface ParseIntSafeOptions {
+  /** Optional label for warning output (for example, env var name). */
+  context?: string;
+  /** Minimum accepted integer value (inclusive). */
+  min?: number;
+  /** Maximum accepted integer value (inclusive). */
+  max?: number;
+  /** Require a strict integer string (no trailing text). */
+  strict?: boolean;
+  /** Optional warning callback when parsing or bounds validation fails. */
+  onError?: (message: string) => void;
+}
+
+function reportParseIntSafeError(
+  options: ParseIntSafeOptions | undefined,
+  rawValue: string,
+  fallback: number,
+  reason: string,
+): void {
+  if (!options?.onError) return;
+  const context = options.context ?? 'value';
+  options.onError(`Invalid ${context}='${rawValue}' (${reason}); using ${fallback}`);
+}
+
+/** Parse an env string to integer with optional strict parsing and bounds checks. */
+export function parseIntSafe(
+  value: string | undefined,
+  fallback: number,
+  options?: ParseIntSafeOptions,
+): number {
   if (value === undefined) return fallback;
+
+  if (options?.strict) {
+    const trimmed = value.trim();
+    if (!/^[+-]?\d+$/.test(trimmed)) {
+      reportParseIntSafeError(options, value, fallback, 'expected an integer');
+      return fallback;
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isSafeInteger(parsed)) {
+      reportParseIntSafeError(options, value, fallback, 'value is outside the safe integer range');
+      return fallback;
+    }
+    if (options.min !== undefined && parsed < options.min) {
+      reportParseIntSafeError(options, value, fallback, `must be >= ${options.min}`);
+      return fallback;
+    }
+    if (options.max !== undefined && parsed > options.max) {
+      reportParseIntSafeError(options, value, fallback, `must be <= ${options.max}`);
+      return fallback;
+    }
+    return parsed;
+  }
+
   const parsed = parseInt(value, 10);
-  if (!Number.isFinite(parsed)) return fallback;
+  if (!Number.isFinite(parsed)) {
+    reportParseIntSafeError(options, value, fallback, 'expected an integer');
+    return fallback;
+  }
+  if (options?.min !== undefined && parsed < options.min) {
+    reportParseIntSafeError(options, value, fallback, `must be >= ${options.min}`);
+    return fallback;
+  }
+  if (options?.max !== undefined && parsed > options.max) {
+    reportParseIntSafeError(options, value, fallback, `must be <= ${options.max}`);
+    return fallback;
+  }
   return parsed;
 }
 
@@ -514,6 +577,7 @@ export const configFileSchema = z.object({
   sseMaxConnections: z.number().int().positive().optional(),
   sseMaxPerIp: z.number().int().positive().optional(),
   allowedWorkDirs: z.array(z.string()).optional(),
+  hookSecretHeaderOnly: z.boolean().optional(),
   worktreeAwareContinuation: z.boolean().optional(),
   memoryBridge: z.object({
     enabled: z.boolean(),


### PR DESCRIPTION
## Summary

This PR packages the completed wave 1/2 implementation work for:
- #1619 hook secret header-only migration (with compatibility mode)
- #1620 PID file permission hardening
- #1615 tmux queue deadlock hardening
- #1617 stricter config/env validation and bounds checks
- #1613 permission evaluator extraction to service module

## What changed

### Security and reliability
- Added hookSecretHeaderOnly config/env flag (AEGIS_HOOK_SECRET_HEADER_ONLY / backward-compatible MANUS alias).
- Enforced header-only hook secret path when enabled; compatibility mode keeps query fallback with deprecation warning.
- Preserved timing-safe secret validation.
- Switched PID file write to restrictive permissions and secure post-write permission handling.
- Made tmux serialization queue resilient to promise rejection chains to prevent queue poisoning/deadlocks.

### Config validation
- Extended numeric env parsing with strict integer parsing, optional bounds, and warning callbacks.
- Added explicit bounds for key numeric config values (including port range validation).
- Improved invalid AEGIS_TG_ALLOWED_USERS parsing with warnings for dropped entries.

### Architecture refactor
- Moved permission evaluator from src/permission-evaluator.ts to src/services/permission/evaluator.ts.
- Added src/services/permission/{types.ts,index.ts} and updated imports/tests/docs accordingly.

### Tests and docs
- Added src/__tests__/startup.test.ts.
- Added src/__tests__/tmux-queue-recovery-1615.test.ts.
- Updated affected config/security/permission tests.
- Updated openapi.yaml, docs/api-reference.md, docs/architecture.md, and README sections tied to these changes.

## Validation
- 
pm run build
- 
px tsc --noEmit
- Targeted vitest suite for modified areas (startup/tmux queue/config/security/permission) passing.
