### PR TITLE
fix(security): harden hook/audit paths against symlink and TOCTOU risks

### DIFF
--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { AuditLogger } from '../audit.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { rm, readdir, readFile } from 'node:fs/promises';
+import { rm, readdir, readFile, writeFile, mkdir, symlink } from 'node:fs/promises';
 
 describe('AuditLogger (Issue #1419)', () => {
   let audit: AuditLogger;
@@ -142,6 +142,42 @@ describe('AuditLogger (Issue #1419)', () => {
 
       const newRecord = await restarted.log('system', 'key.revoke', 'After restart');
       expect(newRecord.prevHash).toBe(firstHash);
+    });
+  });
+
+  describe('Issue #1618: symlink hardening', () => {
+    it('rejects a symlinked audit directory when symlinks are supported', async () => {
+      const realDir = join(tmpDir, 'real-audit');
+      await mkdir(realDir, { recursive: true });
+      const linkedDir = join(tmpDir, 'linked-audit');
+
+      try {
+        await symlink(realDir, linkedDir, process.platform === 'win32' ? 'junction' : 'dir');
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === 'EPERM' || err.code === 'EACCES') return;
+        throw error;
+      }
+
+      const linkedAudit = new AuditLogger(linkedDir);
+      await expect(linkedAudit.init()).rejects.toThrow(/symlink path/);
+    });
+
+    it('rejects writes when the target audit log file is a symlink', async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logPath = join(tmpDir, `audit-${date}.log`);
+      const targetPath = join(tmpDir, 'outside.log');
+      await writeFile(targetPath, '');
+
+      try {
+        await symlink(targetPath, logPath, process.platform === 'win32' ? 'file' : undefined);
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === 'EPERM' || err.code === 'EACCES') return;
+        throw error;
+      }
+
+      await expect(audit.log('system', 'key.create', 'Symlink write should fail')).rejects.toThrow(/symlink path/);
     });
   });
 });

--- a/src/__tests__/hook-paths-909.test.ts
+++ b/src/__tests__/hook-paths-909.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { buildHookCommand } from '../hook.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildHookCommand, assertPathNotSymlink, withLockFile } from '../hook.js';
 import { buildProjectSettingsPath } from '../hook-settings.js';
+import { mkdtemp, rm, writeFile, symlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 describe('Issue #909: hook command path normalization', () => {
   it('quotes and normalizes Unix paths', () => {
@@ -23,5 +27,47 @@ describe('Issue #909: hook settings path construction', () => {
   it('builds Windows settings.local.json path from slash input', () => {
     const settingsPath = buildProjectSettingsPath('D:/Users/dev/My Repo', 'win32');
     expect(settingsPath).toContain('D:\\Users\\dev\\My Repo\\.claude\\settings.local.json');
+  });
+});
+
+describe('Issue #1618: hook symlink and lock hardening', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'aegis-hook-1618-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('acquires and releases lock files around critical sections', () => {
+    const lockPath = join(tmpDir, 'map.lock');
+    const result = withLockFile(lockPath, () => {
+      expect(existsSync(lockPath)).toBe(true);
+      return 'ok';
+    });
+    expect(result).toBe('ok');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('times out if a lock file is already held', async () => {
+    const lockPath = join(tmpDir, 'held.lock');
+    await writeFile(lockPath, 'held');
+    expect(() => withLockFile(lockPath, () => 'never', 1)).toThrow(/Timed out waiting for lock/);
+  });
+
+  it('rejects symlink paths when symlink creation is permitted', async () => {
+    const targetFile = join(tmpDir, 'target.json');
+    const linkFile = join(tmpDir, 'link.json');
+    await writeFile(targetFile, '{}');
+    try {
+      await symlink(targetFile, linkFile);
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'EPERM' || err.code === 'EACCES') return;
+      throw error;
+    }
+    expect(() => assertPathNotSymlink(linkFile)).toThrow(/symlink path/);
   });
 });

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -9,7 +9,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { appendFile, readFile, mkdir, stat, readdir, access } from 'node:fs/promises';
+import { appendFile, readFile, mkdir, readdir, lstat } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -78,8 +78,28 @@ export class AuditLogger {
     this.writeLock = Promise.resolve();
   }
 
+  private async assertNotSymlink(pathValue: string): Promise<void> {
+    try {
+      const stats = await lstat(pathValue);
+      if (stats.isSymbolicLink()) {
+        throw new Error(`Refusing to operate on symlink path: ${pathValue}`);
+      }
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') return;
+      throw error;
+    }
+  }
+
+  private async assertAuditPathSafe(filePath: string): Promise<void> {
+    await this.assertNotSymlink(this.logDir);
+    await this.assertNotSymlink(dirname(filePath));
+    await this.assertNotSymlink(filePath);
+  }
+
   /** Initialize the audit logger — ensure directory exists, read last hash. */
   async init(): Promise<void> {
+    await this.assertNotSymlink(this.logDir);
     if (!existsSync(this.logDir)) {
       await mkdir(this.logDir, { recursive: true });
     }
@@ -101,6 +121,7 @@ export class AuditLogger {
       }
 
       const latestFile = join(this.logDir, logFiles[0]!);
+      await this.assertNotSymlink(latestFile);
       const content = await readFile(latestFile, 'utf-8');
       const lines = content.trim().split('\n');
 
@@ -168,10 +189,12 @@ export class AuditLogger {
 
       const line = JSON.stringify(record) + '\n';
       const file = this.filePath(new Date(ts));
+      await this.assertAuditPathSafe(file);
 
       // Ensure directory exists (in case it was cleaned)
       if (!existsSync(dirname(file))) {
         await mkdir(dirname(file), { recursive: true });
+        await this.assertNotSymlink(dirname(file));
       }
 
       // Append-only — never overwrite
@@ -202,6 +225,7 @@ export class AuditLogger {
 
       for (const file of logFiles) {
         const fullPath = join(this.logDir, file);
+        await this.assertNotSymlink(fullPath);
         const content = await readFile(fullPath, 'utf-8');
         const lines = content.trim().split('\n');
 
@@ -255,6 +279,7 @@ export class AuditLogger {
 
       for (const file of logFiles) {
         const fullPath = join(this.logDir, file);
+        await this.assertNotSymlink(fullPath);
         const content = await readFile(fullPath, 'utf-8');
         const lines = content.trim().split('\n');
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -16,7 +16,7 @@
  * }
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, lstatSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -35,6 +35,8 @@ const MAP_FILE = join(BRIDGE_DIR, 'session_map.json');
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const TMUX_PANE_RE = /^%\d+$/;
 const DEFAULT_POINTER_TTL_MS = 24 * 60 * 60 * 1000;
+const LOCK_ACQUIRE_TIMEOUT_MS = 2_000;
+const LOCK_RETRY_DELAY_MS = 25;
 
 function normalizeCommandPath(pathValue: string, platform: NodeJS.Platform = process.platform): string {
   return platform === 'win32' ? pathValue.replace(/\//g, '\\') : pathValue.replace(/\\/g, '/');
@@ -52,6 +54,58 @@ export function buildHookCommand(
   platform: NodeJS.Platform = process.platform,
 ): string {
   return `${quoteCommandPath(nodeExecutable, platform)} ${quoteCommandPath(scriptPath, platform)}`;
+}
+
+function sleepSync(ms: number): void {
+  const blocker = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(blocker, 0, 0, ms);
+}
+
+export function assertPathNotSymlink(pathValue: string): void {
+  if (!existsSync(pathValue)) return;
+  const stats = lstatSync(pathValue);
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Refusing to operate on symlink path: ${pathValue}`);
+  }
+}
+
+export function withLockFile<T>(lockFile: string, fn: () => T, timeoutMs: number = LOCK_ACQUIRE_TIMEOUT_MS): T {
+  const start = Date.now();
+  while (true) {
+    try {
+      const fd = openSync(lockFile, 'wx');
+      try {
+        return fn();
+      } finally {
+        closeSync(fd);
+        try { unlinkSync(lockFile); } catch { /* ignore lock cleanup errors */ }
+      }
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'EEXIST') throw error;
+      if (Date.now() - start >= timeoutMs) {
+        throw new Error(`Timed out waiting for lock: ${lockFile}`);
+      }
+      sleepSync(LOCK_RETRY_DELAY_MS);
+    }
+  }
+}
+
+function writeTextAtomic(targetPath: string, content: string): void {
+  const parentDir = dirname(targetPath);
+  mkdirSync(parentDir, { recursive: true });
+  assertPathNotSymlink(parentDir);
+  assertPathNotSymlink(targetPath);
+  const tmpPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
+  assertPathNotSymlink(tmpPath);
+  try {
+    writeFileSync(tmpPath, content, { mode: 0o600 });
+    renameSync(tmpPath, targetPath);
+  } finally {
+    if (existsSync(tmpPath)) {
+      try { unlinkSync(tmpPath); } catch { /* ignore tmp cleanup errors */ }
+    }
+  }
 }
 
 function getPointerTtlMs(): number {
@@ -85,34 +139,33 @@ function handleStopEvent(
   payload: Record<string, unknown>,
 ): void {
   const signalFile = join(BRIDGE_DIR, 'stop_signals.json');
-
-  let signals: Record<string, unknown> = {};
-  if (existsSync(signalFile)) {
-    const parsed = safeJsonParseSchema(readFileSync(signalFile, 'utf-8'), stopSignalsSchema, 'stop_signals.json');
-    if (parsed.ok) {
-      signals = parsed.data;
-    } else {
-      console.warn(`${parsed.error}; starting fresh`);
+  assertPathNotSymlink(BRIDGE_DIR);
+  withLockFile(`${signalFile}.lock`, () => {
+    let signals: Record<string, unknown> = {};
+    if (existsSync(signalFile)) {
+      const parsed = safeJsonParseSchema(readFileSync(signalFile, 'utf-8'), stopSignalsSchema, 'stop_signals.json');
+      if (parsed.ok) {
+        signals = parsed.data;
+      } else {
+        console.warn(`${parsed.error}; starting fresh`);
+      }
     }
-  }
 
-  const p = stopPayloadSchema.safeParse(payload);
-  const pd = p.success ? p.data : {};
-  signals[sessionId] = {
-    event,
-    timestamp: Date.now(),
-    // StopFailure may include error info in the payload
-    error: pd.error ?? pd.message ?? null,
-    error_details: pd.error_details ?? null,
-    last_assistant_message: pd.last_assistant_message ?? null,
-    agent_id: pd.agent_id ?? null,
-    stop_reason: pd.stop_reason ?? null,
-  };
+    const p = stopPayloadSchema.safeParse(payload);
+    const pd = p.success ? p.data : {};
+    signals[sessionId] = {
+      event,
+      timestamp: Date.now(),
+      // StopFailure may include error info in the payload
+      error: pd.error ?? pd.message ?? null,
+      error_details: pd.error_details ?? null,
+      last_assistant_message: pd.last_assistant_message ?? null,
+      agent_id: pd.agent_id ?? null,
+      stop_reason: pd.stop_reason ?? null,
+    };
 
-  // Atomic write: write to temp file then rename (prevents partial writes on crash)
-  const tmpSignalFile = signalFile + '.tmp';
-  writeFileSync(tmpSignalFile, JSON.stringify(signals, null, 2));
-  renameSync(tmpSignalFile, signalFile);
+    writeTextAtomic(signalFile, JSON.stringify(signals, null, 2));
+  });
   console.error(`Aegis hook: ${event} for session ${sessionId.slice(0, 8)}...`);
 }
 
@@ -203,37 +256,36 @@ function main(): void {
 
   // Read-modify-write session_map
   mkdirSync(BRIDGE_DIR, { recursive: true });
-
-  let sessionMap: Record<string, SessionMapEntry> = {};
-  if (existsSync(MAP_FILE)) {
-    const parsed = safeJsonParseSchema(readFileSync(MAP_FILE, 'utf-8'), sessionMapSchema, 'session_map.json');
-    if (parsed.ok) {
-      sessionMap = parsed.data as Record<string, SessionMapEntry>;
-    } else {
-      console.warn(`${parsed.error}; starting fresh`);
+  assertPathNotSymlink(BRIDGE_DIR);
+  withLockFile(`${MAP_FILE}.lock`, () => {
+    let sessionMap: Record<string, SessionMapEntry> = {};
+    if (existsSync(MAP_FILE)) {
+      const parsed = safeJsonParseSchema(readFileSync(MAP_FILE, 'utf-8'), sessionMapSchema, 'session_map.json');
+      if (parsed.ok) {
+        sessionMap = parsed.data as Record<string, SessionMapEntry>;
+      } else {
+        console.warn(`${parsed.error}; starting fresh`);
+      }
     }
-  }
 
-  const writtenAt = Date.now();
-  sessionMap[key] = {
-    session_id: sessionId,
-    cwd,
-    window_name: windowName || '',
-    transcript_path: payload.transcript_path || null,
-    permission_mode: payload.permission_mode || null,
-    agent_id: payload.agent_id || null,
-    source: payload.source || null,
-    agent_type: payload.agent_type || null,
-    model: payload.model || null,
-    written_at: writtenAt,
-    schema_version: 1,
-    expires_at: writtenAt + getPointerTtlMs(),
-  };
+    const writtenAt = Date.now();
+    sessionMap[key] = {
+      session_id: sessionId,
+      cwd,
+      window_name: windowName || '',
+      transcript_path: payload.transcript_path || null,
+      permission_mode: payload.permission_mode || null,
+      agent_id: payload.agent_id || null,
+      source: payload.source || null,
+      agent_type: payload.agent_type || null,
+      model: payload.model || null,
+      written_at: writtenAt,
+      schema_version: 1,
+      expires_at: writtenAt + getPointerTtlMs(),
+    };
 
-  // Atomic write: write to temp file then rename (prevents race-condition data loss)
-  const tmpMapFile = MAP_FILE + '.tmp';
-  writeFileSync(tmpMapFile, JSON.stringify(sessionMap, null, 2));
-  renameSync(tmpMapFile, MAP_FILE);
+    writeTextAtomic(MAP_FILE, JSON.stringify(sessionMap, null, 2));
+  });
   console.error(`Aegis hook: mapped ${key} -> ${sessionId}`);
 }
 
@@ -288,8 +340,12 @@ function install(): void {
 
   settings.hooks = hooks;
 
-  mkdirSync(join(homedir(), '.claude'), { recursive: true });
-  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  const claudeDir = join(homedir(), '.claude');
+  mkdirSync(claudeDir, { recursive: true });
+  assertPathNotSymlink(claudeDir);
+  withLockFile(`${settingsPath}.lock`, () => {
+    writeTextAtomic(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  });
   console.log(`Aegis hook installed in ${settingsPath}`);
 }
 


### PR DESCRIPTION
## Summary

Implements issue #1618 by hardening file operations in hook and audit flows against symlink traversal and concurrent write races.

## What changed

### src/hook.ts
- Added symlink guards (ssertPathNotSymlink) for critical paths.
- Added lock-file serialization (withLockFile) for:
  - stop_signals.json
  - session_map.json
  - ~/.claude/settings.json
- Replaced ad-hoc temp writes with shared atomic writer (writeTextAtomic) + cleanup.

### src/audit.ts
- Added symlink checks before using:
  - audit directory
  - parent directories
  - daily audit log file paths
- Enforced safe-path validation before append/read operations.

### Tests
- Extended src/__tests__/hook-paths-909.test.ts with #1618 lock/symlink cases.
- Extended src/__tests__/audit.test.ts with symlink hardening cases.

## Validation

- 
pm run build ✅
- 
px tsc --noEmit ✅
- 
pm test ✅
- 
pm run lint ✅ (existing repository warnings only, no new errors)

Closes #1618