### PR TITLE
refactor(architecture): add DI container and lifecycle orchestration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@ Aegis is built around a layered architecture: a CLI entrypoint, a Fastify HTTP s
 src/
 ├── cli.ts                    # CLI entrypoint — parses args, starts server or MCP
 ├── startup.ts                # Server bootstrap — PID file, graceful shutdown
+├── container.ts              # Lightweight DI container + lifecycle orchestration
 ├── server.ts                 # Fastify HTTP server — all REST routes
 ├── config.ts                 # Configuration loading from env + config file
 ├── auth.ts                   # Backward-compatible auth re-export (services/auth)
@@ -244,3 +245,25 @@ server.ts (Fastify, port 9100)
   └─ mcp-server.ts (MCP protocol, stdio)
         └─ tool-registry.ts (tool dispatch)
 ```
+
+## Service lifecycle dependency graph
+
+Issue #1622 introduces explicit service registration and dependency-driven startup/shutdown in `src/container.ts`.
+
+```text
+tmuxManager
+  └─ sessionManager
+      ├─ channelManager
+      └─ sessionMonitor
+authManager
+```
+
+| Service | Depends on | Startup action | Shutdown action |
+|---|---|---|---|
+| `tmuxManager` | — | `tmux.ensureSession()` | no-op |
+| `sessionManager` | `tmuxManager` | `sessions.load()` | `sessions.save()` |
+| `authManager` | — | `auth.load()` | no-op |
+| `channelManager` | `sessionManager` | `channels.init(handleInbound)` | `channels.destroy()` |
+| `sessionMonitor` | `tmuxManager`, `sessionManager`, `channelManager` | `monitor.start()` | `monitor.stop()` |
+
+Startup follows topological order from the dependency graph. Graceful shutdown runs in the reverse order with per-service timeout protection.

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { ServiceContainer, type LifecycleService } from '../container.js';
+
+function makeLifecycle(
+  name: string,
+  events: string[],
+  overrides: Partial<LifecycleService> = {},
+): LifecycleService {
+  return {
+    async start(): Promise<void> {
+      events.push(`start:${name}`);
+    },
+    async stop(): Promise<void> {
+      events.push(`stop:${name}`);
+    },
+    async health(): Promise<{ healthy: boolean }> {
+      return { healthy: true };
+    },
+    ...overrides,
+  };
+}
+
+describe('ServiceContainer', () => {
+  it('starts in dependency order and stops in reverse dependency order', async () => {
+    const events: string[] = [];
+    const container = new ServiceContainer();
+
+    container.register('tmux', {}, makeLifecycle('tmux', events));
+    container.register('sessions', {}, makeLifecycle('sessions', events), ['tmux']);
+    container.register('channels', {}, makeLifecycle('channels', events), ['sessions']);
+
+    await container.start(['channels']);
+    expect(events).toEqual([
+      'start:tmux',
+      'start:sessions',
+      'start:channels',
+    ]);
+
+    await container.stopAll();
+    expect(events).toEqual([
+      'start:tmux',
+      'start:sessions',
+      'start:channels',
+      'stop:channels',
+      'stop:sessions',
+      'stop:tmux',
+    ]);
+  });
+
+  it('fails on missing dependencies', async () => {
+    const container = new ServiceContainer();
+    container.register('sessions', {}, makeLifecycle('sessions', []), ['tmux']);
+
+    await expect(container.startAll()).rejects.toThrow(
+      'Service "sessions" depends on unregistered service "tmux"',
+    );
+  });
+
+  it('fails on circular dependencies', async () => {
+    const container = new ServiceContainer();
+    container.register('a', {}, makeLifecycle('a', []), ['b']);
+    container.register('b', {}, makeLifecycle('b', []), ['a']);
+
+    await expect(container.startAll()).rejects.toThrow('Circular service dependency');
+  });
+
+  it('enforces startup health gate', async () => {
+    const container = new ServiceContainer();
+    container.register('healthy', {}, makeLifecycle('healthy', []));
+    container.register('unhealthy', {}, makeLifecycle('unhealthy', [], {
+      async health() {
+        return { healthy: false, details: 'simulated failure' };
+      },
+    }));
+
+    await container.startAll();
+    await expect(container.assertHealthy()).rejects.toThrow(
+      'Service health gate failed: unhealthy (simulated failure)',
+    );
+  });
+
+  it('continues shutdown when a service times out', async () => {
+    const events: string[] = [];
+    const container = new ServiceContainer();
+
+    container.register('fast', {}, makeLifecycle('fast', events));
+    container.register('slow', {}, makeLifecycle('slow', events, {
+      async stop(): Promise<void> {
+        events.push('stop:slow:pending');
+        await new Promise<void>(() => {});
+      },
+    }), ['fast']);
+
+    await container.startAll();
+    const results = await container.stopAll({ timeoutMs: 20 });
+
+    expect(results).toEqual([
+      { name: 'slow', status: 'timeout' },
+      { name: 'fast', status: 'stopped' },
+    ]);
+    expect(events).toContain('stop:slow:pending');
+    expect(events).toContain('stop:fast');
+  });
+
+  it('rolls back newly started services when startup fails', async () => {
+    const events: string[] = [];
+    const container = new ServiceContainer();
+
+    container.register('tmux', {}, makeLifecycle('tmux', events));
+    container.register('sessions', {}, makeLifecycle('sessions', events, {
+      async start(): Promise<void> {
+        events.push('start:sessions');
+        throw new Error('session startup failed');
+      },
+    }), ['tmux']);
+
+    await expect(container.startAll()).rejects.toThrow('session startup failed');
+    expect(events).toEqual([
+      'start:tmux',
+      'start:sessions',
+      'stop:tmux',
+    ]);
+  });
+});

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,0 +1,216 @@
+export interface ServiceHealth {
+  healthy: boolean;
+  details?: string;
+}
+
+export interface LifecycleService {
+  start(): Promise<void>;
+  stop(signal: AbortSignal): Promise<void>;
+  health?(): Promise<ServiceHealth>;
+}
+
+interface ServiceRegistration<T = unknown> {
+  name: string;
+  instance: T;
+  lifecycle: LifecycleService;
+  dependencies: string[];
+}
+
+export interface ServiceHealthResult extends ServiceHealth {
+  name: string;
+}
+
+export interface ServiceStopResult {
+  name: string;
+  status: 'stopped' | 'timeout' | 'error';
+  error?: Error;
+}
+
+export interface ServiceStopOptions {
+  timeoutMs?: number;
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
+}
+
+export class ServiceContainer {
+  private readonly services = new Map<string, ServiceRegistration>();
+  private readonly registrationOrder: string[] = [];
+  private readonly started = new Set<string>();
+  private readonly startOrder: string[] = [];
+
+  register<T>(
+    name: string,
+    instance: T,
+    lifecycle: LifecycleService,
+    dependencies: readonly string[] = [],
+  ): T {
+    if (this.services.has(name)) {
+      throw new Error(`Service "${name}" is already registered`);
+    }
+    this.services.set(name, {
+      name,
+      instance,
+      lifecycle,
+      dependencies: [...dependencies],
+    });
+    this.registrationOrder.push(name);
+    return instance;
+  }
+
+  resolve<T>(name: string): T {
+    const service = this.services.get(name);
+    if (!service) {
+      throw new Error(`Service "${name}" is not registered`);
+    }
+    return service.instance as T;
+  }
+
+  async start(names: readonly string[]): Promise<string[]> {
+    const startPlan = this.resolveStartOrder(names);
+    const startedNow: string[] = [];
+    try {
+      for (const name of startPlan) {
+        if (this.started.has(name)) continue;
+        const service = this.services.get(name)!;
+        await service.lifecycle.start();
+        this.started.add(name);
+        this.startOrder.push(name);
+        startedNow.push(name);
+      }
+      return startedNow;
+    } catch (error) {
+      await this.stopServices([...startedNow].reverse(), 5_000);
+      throw error;
+    }
+  }
+
+  async startAll(): Promise<string[]> {
+    return this.start(this.registrationOrder);
+  }
+
+  async checkHealth(names?: readonly string[]): Promise<ServiceHealthResult[]> {
+    const healthPlan = names ? this.resolveStartOrder(names) : this.startOrder;
+    const report: ServiceHealthResult[] = [];
+
+    for (const name of healthPlan) {
+      if (!this.started.has(name)) continue;
+      const service = this.services.get(name)!;
+      if (!service.lifecycle.health) {
+        report.push({ name, healthy: true });
+        continue;
+      }
+      try {
+        const result = await service.lifecycle.health();
+        report.push({ name, healthy: result.healthy, details: result.details });
+      } catch (error) {
+        report.push({
+          name,
+          healthy: false,
+          details: `health check failed: ${toError(error).message}`,
+        });
+      }
+    }
+    return report;
+  }
+
+  async assertHealthy(names?: readonly string[]): Promise<ServiceHealthResult[]> {
+    const report = await this.checkHealth(names);
+    const unhealthy = report.filter(service => !service.healthy);
+    if (unhealthy.length > 0) {
+      const reason = unhealthy
+        .map(service => `${service.name}${service.details ? ` (${service.details})` : ''}`)
+        .join(', ');
+      throw new Error(`Service health gate failed: ${reason}`);
+    }
+    return report;
+  }
+
+  async stopAll(options: ServiceStopOptions = {}): Promise<ServiceStopResult[]> {
+    const timeoutMs = Math.max(1, options.timeoutMs ?? 5_000);
+    const names = [...this.startOrder].reverse();
+    const results = await this.stopServices(names, timeoutMs);
+    this.startOrder.length = 0;
+    this.started.clear();
+    return results;
+  }
+
+  private async stopServices(names: readonly string[], timeoutMs: number): Promise<ServiceStopResult[]> {
+    const results: ServiceStopResult[] = [];
+
+    for (const name of names) {
+      if (!this.started.has(name)) continue;
+      const service = this.services.get(name);
+      if (!service) continue;
+
+      const abortController = new AbortController();
+      let timer: NodeJS.Timeout | undefined;
+      const stopPromise = Promise.resolve()
+        .then(() => service.lifecycle.stop(abortController.signal))
+        .then(() => ({ status: 'stopped' as const }))
+        .catch((error: unknown) => ({ status: 'error' as const, error: toError(error) }));
+      const timeoutPromise = new Promise<{ status: 'timeout' }>((resolve) => {
+        timer = setTimeout(() => {
+          abortController.abort();
+          resolve({ status: 'timeout' });
+        }, timeoutMs);
+      });
+
+      const outcome = await Promise.race([stopPromise, timeoutPromise]);
+      if (timer) clearTimeout(timer);
+
+      this.started.delete(name);
+      const startOrderIndex = this.startOrder.indexOf(name);
+      if (startOrderIndex >= 0) this.startOrder.splice(startOrderIndex, 1);
+
+      if (outcome.status === 'timeout') {
+        results.push({ name, status: 'timeout' });
+        continue;
+      }
+
+      if (outcome.status === 'error') {
+        results.push({ name, status: 'error', error: outcome.error });
+        continue;
+      }
+
+      results.push({ name, status: 'stopped' });
+    }
+    return results;
+  }
+
+  private resolveStartOrder(names: readonly string[]): string[] {
+    const order: string[] = [];
+    const state = new Map<string, 'visiting' | 'visited'>();
+
+    const visit = (name: string, stack: string[]): void => {
+      const service = this.services.get(name);
+      if (!service) {
+        throw new Error(`Service "${name}" is not registered`);
+      }
+
+      const currentState = state.get(name);
+      if (currentState === 'visited') return;
+      if (currentState === 'visiting') {
+        throw new Error(`Circular service dependency: ${[...stack, name].join(' -> ')}`);
+      }
+
+      state.set(name, 'visiting');
+      for (const dependency of service.dependencies) {
+        if (!this.services.has(dependency)) {
+          throw new Error(`Service "${name}" depends on unregistered service "${dependency}"`);
+        }
+        visit(dependency, [...stack, name]);
+      }
+      state.set(name, 'visited');
+      order.push(name);
+    };
+
+    for (const name of names) {
+      visit(name, []);
+    }
+
+    return order;
+  }
+}

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -179,6 +179,10 @@ export class SessionMonitor {
     this.running = false;
   }
 
+  get isRunning(): boolean {
+    return this.running;
+  }
+
   private async loop(): Promise<void> {
     while (this.running) {
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,6 +64,7 @@ import { normalizeApiErrorPayload } from './api-error-envelope.js';
 import { listenWithRetry, removePidFile, writePidFile } from './startup.js';
 import { AlertManager, type AlertType } from './alerting.js';
 import { isWindowsShutdownMessage, parseShutdownTimeoutMs } from './shutdown-utils.js';
+import { ServiceContainer } from './container.js';
 import {
   authKeySchema, sendMessageSchema, commandSchema, bashSchema,
   screenshotSchema, permissionHookSchema, stopHookSchema,
@@ -2081,6 +2082,7 @@ async function main(): Promise<void> {
   // Initialize core components with config
   tmux = new TmuxManager(config.tmuxSession);
   sessions = new SessionManager(tmux, config);
+  const container = new ServiceContainer();
 
   // Memory bridge (Issue #783)
   if (config.memoryBridge?.enabled) {
@@ -2101,12 +2103,72 @@ async function main(): Promise<void> {
   // Setup auth (Issue #39: multi-key + backward compat)
   auth = new AuthManager(path.join(config.stateDir, 'keys.json'), config.authToken);
   auth.setHost(config.host);  // #1080: needed for auth bypass security check
-  await auth.load();
 
   // #1419: Initialize audit logger and wire into auth
   auditLogger = new AuditLogger(path.join(config.stateDir, 'audit'));
   await auditLogger.init();
   auth.setAuditLogger(auditLogger);
+
+  // Issue #1418: Initialize production alerting
+  alertManager = new AlertManager(config.alerting);
+  if (config.alerting.webhooks.length > 0) {
+    console.log(`Alerting enabled: ${config.alerting.webhooks.length} webhook(s), threshold=${config.alerting.failureThreshold}`);
+  }
+
+  // Wire monitor dependencies before lifecycle startup.
+  monitor.setEventBus(eventBus);
+  monitor.setTmuxManager(tmux);
+  monitor.setAlertManager(alertManager);
+  jsonlWatcher = new JsonlWatcher();
+  monitor.setJsonlWatcher(jsonlWatcher);
+
+  container.register('tmuxManager', tmux, {
+    start: async () => {
+      await tmux.ensureSession();
+    },
+    stop: async () => {},
+    health: async () => {
+      const tmuxHealth = await tmux.isServerHealthy();
+      return { healthy: tmuxHealth.healthy, details: tmuxHealth.error ?? undefined };
+    },
+  });
+  container.register('sessionManager', sessions, {
+    start: async () => {
+      await sessions.load();
+    },
+    stop: async () => {
+      await sessions.save();
+    },
+    health: async () => ({ healthy: true, details: `sessions=${sessions.listSessions().length}` }),
+  }, ['tmuxManager']);
+  container.register('authManager', auth, {
+    start: async () => {
+      await auth.load();
+    },
+    stop: async () => {},
+    health: async () => ({ healthy: true }),
+  });
+  container.register('channelManager', channels, {
+    start: async () => {
+      await channels.init(handleInbound);
+    },
+    stop: async () => {
+      await channels.destroy();
+    },
+    health: async () => ({ healthy: true, details: `channels=${channels.count}` }),
+  }, ['sessionManager']);
+  container.register('sessionMonitor', monitor, {
+    start: async () => {
+      monitor.start();
+    },
+    stop: async () => {
+      monitor.stop();
+    },
+    health: async () => ({
+      healthy: monitor.isRunning,
+      details: monitor.isRunning ? 'running' : 'not running',
+    }),
+  }, ['sessionManager', 'channelManager', 'tmuxManager']);
 
   setupAuth(auth);
 
@@ -2123,26 +2185,7 @@ async function main(): Promise<void> {
   await app.register(fastifyCors, {
     origin: corsOrigin ? corsOrigin.split(',').map(s => s.trim()) : false,
   });
-
-  // Load persisted sessions
-  await sessions.load();
-  await tmux.ensureSession();
-
-  // Initialize channels
-  await channels.init(handleInbound);
-
-  // Wire SSE event bus (Issue #32)
-  monitor.setEventBus(eventBus);
-
-  // Issue #397: Wire TmuxManager for tmux health monitoring
-  monitor.setTmuxManager(tmux);
-
-  // Issue #1418: Wire AlertManager for production alerting
-  monitor.setAlertManager(alertManager);
-
-  // Issue #84: Wire JSONL watcher for fs.watch-based message detection
-  jsonlWatcher = new JsonlWatcher();
-  monitor.setJsonlWatcher(jsonlWatcher);
+  await container.start(['tmuxManager', 'sessionManager', 'authManager', 'channelManager']);
 
   // Issue #488: Accumulate token usage from JSONL events into per-session metrics.
   jsonlWatcher.onEntries((event) => {
@@ -2174,12 +2217,6 @@ async function main(): Promise<void> {
   // Initialize metrics (Issue #40)
   metrics = new MetricsCollector(path.join(config.stateDir, 'metrics.json'));
   await metrics.load();
-
-  // Issue #1418: Initialize production alerting
-  alertManager = new AlertManager(config.alerting);
-  if (config.alerting.webhooks.length > 0) {
-    console.log(`Alerting enabled: ${config.alerting.webhooks.length} webhook(s), threshold=${config.alerting.failureThreshold}`);
-  }
 
   // Issue #361: Store interval refs so graceful shutdown can clear them
   const reaperInterval = setInterval(() => reapStaleSessions(config.maxSessionAgeMs), config.reaperIntervalMs);
@@ -2229,16 +2266,21 @@ async function main(): Promise<void> {
       // Issue #569: Kill all CC sessions and tmux windows before exit
       try { await killAllSessions(sessions, tmux, { monitor, metrics, toolRegistry }); } catch (e) { console.error('Error killing sessions:', e); }
 
-      // 4. Destroy channels (awaits Telegram poll loop)
-      try { await channels.destroy(); } catch (e) { console.error('Error destroying channels:', e); }
+      // 4. Stop managed services in reverse dependency order with timeout safety
+      const serviceStopTimeoutMs = Math.max(1_000, Math.floor(shutdownTimeoutMs / 5));
+      const serviceStops = await container.stopAll({ timeoutMs: serviceStopTimeoutMs });
+      for (const stopResult of serviceStops) {
+        if (stopResult.status === 'timeout') {
+          console.error(`Service shutdown timed out: ${stopResult.name}`);
+        } else if (stopResult.status === 'error') {
+          console.error(`Service shutdown failed: ${stopResult.name}`, stopResult.error);
+        }
+      }
 
-      // 5. Save session state
-      try { await sessions.save(); } catch (e) { console.error('Error saving sessions:', e); }
-
-      // 6. Save metrics
+      // 5. Save metrics
       try { await metrics.save(); } catch (e) { console.error('Error saving metrics:', e); }
 
-      // 7. Cleanup PID file
+      // 6. Cleanup PID file
       removePidFile(pidFilePath);
 
       console.log('Graceful shutdown complete');
@@ -2262,8 +2304,8 @@ async function main(): Promise<void> {
     console.error('unhandledRejection:', reason);
   });
 
-  // Start monitor
-  monitor.start();
+  // Start monitor via dependency-aware service lifecycle.
+  await container.start(['sessionMonitor']);
 
   // Issue #81: Start swarm monitor for agent swarm awareness
   swarmMonitor = new SwarmMonitor(sessions);
@@ -2361,6 +2403,7 @@ toolRegistry = new ToolRegistry();
     }
     return reply.status(404).send({ error: "Not found" });
   });
+  await container.assertHealthy();
   await listenWithRetry(app, config.port, config.host, config.stateDir);
   pidFilePath = await writePidFile(config.stateDir);
   console.log(`Aegis running on http://${config.host}:${config.port}`);


### PR DESCRIPTION
## Summary
- implement issue #1622 by introducing ServiceContainer with explicit registration and dependency resolution (topological startup)
- refactor core service wiring in server.ts for TmuxManager, SessionManager, AuthManager, ChannelManager, and SessionMonitor via lifecycle adapters
- add startup health gate before listenWithRetry and reverse-order timeout-aware shutdown via container lifecycle management
- document the service dependency graph in architecture docs and add focused container lifecycle tests

## Validation
- npm run lint
- npm run build
- npx tsc --noEmit
- npm test

Closes #1622