### PR TITLE
fix: resolve CodeQL sanitization high findings

### DIFF
--- a/src/__tests__/hook-paths-909.test.ts
+++ b/src/__tests__/hook-paths-909.test.ts
@@ -9,12 +9,22 @@ import { tmpdir } from 'node:os';
 describe('Issue #909: hook command path normalization', () => {
   it('quotes and normalizes Unix paths', () => {
     const cmd = buildHookCommand('/tmp/aegis dist/hook.js', '/usr/local/bin/node', 'linux');
-    expect(cmd).toBe('"/usr/local/bin/node" "/tmp/aegis dist/hook.js"');
+    expect(cmd).toBe("'/usr/local/bin/node' '/tmp/aegis dist/hook.js'");
+  });
+
+  it('uses single-quoted shell escaping for Unix apostrophes', () => {
+    const cmd = buildHookCommand('/tmp/O\'Brien/hook.js', '/usr/local/bin/node', 'linux');
+    expect(cmd).toBe("'/usr/local/bin/node' '/tmp/O'\"'\"'Brien/hook.js'");
   });
 
   it('quotes and normalizes Windows paths with spaces', () => {
     const cmd = buildHookCommand('D:/Aegis Work/dist/hook.js', 'C:/Program Files/nodejs/node.exe', 'win32');
     expect(cmd).toBe('"C:\\Program Files\\nodejs\\node.exe" "D:\\Aegis Work\\dist\\hook.js"');
+  });
+
+  it('escapes Windows variable-expansion metacharacters', () => {
+    const cmd = buildHookCommand('D:/Aegis/%TEMP%/dist/!hook!.js', 'C:/Program Files/nodejs/node.exe', 'win32');
+    expect(cmd).toBe('"C:\\Program Files\\nodejs\\node.exe" "D:\\Aegis\\%%TEMP%%\\dist\\^!hook^!.js"');
   });
 });
 

--- a/src/__tests__/path-traversal-workdir-435.test.ts
+++ b/src/__tests__/path-traversal-workdir-435.test.ts
@@ -9,7 +9,7 @@
  * - Normal valid paths
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -248,6 +248,27 @@ describe('validateWorkDir — Issue #435', () => {
       const result = await validateWorkDir(dir, [dir]);
       expect(typeof result).toBe('string');
       expect(await sameCanonicalPath(result as string, dir)).toBe(true);
+    });
+
+    it('rejects out-of-allowlist paths before resolving target realpath', async () => {
+      const allowedDir = path.join(tmpBase, 'allowed-project');
+      const outsideDir = path.join(tmpBase, 'outside-project');
+      await fs.mkdir(allowedDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+
+      const spy = vi.spyOn(fs, 'realpath');
+      try {
+        const result = await validateWorkDir(outsideDir, [allowedDir]);
+        expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
+
+        const resolvedOutsideDir = path.resolve(outsideDir);
+        const resolvedTargetWasTouched = spy.mock.calls.some(([candidate]) => (
+          typeof candidate === 'string' && samePath(candidate, resolvedOutsideDir)
+        ));
+        expect(resolvedTargetWasTouched).toBe(false);
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -3,12 +3,12 @@
  *
  * Issue #1419: SOC2/ISO 27001 compliance.
  *
- * Each record is chained via SHA-256 hashes — the hash of record N
+ * Each record is chained via PBKDF2-HMAC-SHA512 hashes — the hash of record N
  * includes the hash of record N-1, making retroactive edits detectable.
  * Log files rotate daily and are never overwritten.
  */
 
-import { createHash } from 'node:crypto';
+import { pbkdf2Sync } from 'node:crypto';
 import { appendFile, readFile, mkdir, readdir, lstat } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
@@ -62,9 +62,15 @@ function dateToFileDate(d: Date): string {
   return d.toISOString().slice(0, 10); // YYYY-MM-DD
 }
 
+const AUDIT_HASH_ITERATIONS = 120_000;
+const AUDIT_HASH_KEY_LENGTH = 32;
+const AUDIT_HASH_DIGEST = 'sha512';
+const AUDIT_HASH_SALT_PREFIX = 'aegis-audit-chain-v2';
+
 function computeHash(record: Omit<AuditRecord, 'hash'>): string {
   const payload = `${record.ts}|${record.actor}|${record.action}|${record.sessionId ?? ''}|${record.detail}|${record.prevHash}`;
-  return createHash('sha256').update(payload).digest('hex');
+  const salt = `${AUDIT_HASH_SALT_PREFIX}|${record.prevHash}`;
+  return pbkdf2Sync(payload, salt, AUDIT_HASH_ITERATIONS, AUDIT_HASH_KEY_LENGTH, AUDIT_HASH_DIGEST).toString('hex');
 }
 
 export class AuditLogger {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -37,14 +37,34 @@ const TMUX_PANE_RE = /^%\d+$/;
 const DEFAULT_POINTER_TTL_MS = 24 * 60 * 60 * 1000;
 const LOCK_ACQUIRE_TIMEOUT_MS = 2_000;
 const LOCK_RETRY_DELAY_MS = 25;
+const COMMAND_PATH_CONTROL_CHARS_RE = /[\u0000\r\n]/;
 
 function normalizeCommandPath(pathValue: string, platform: NodeJS.Platform = process.platform): string {
   return platform === 'win32' ? pathValue.replace(/\//g, '\\') : pathValue.replace(/\\/g, '/');
 }
 
+function assertCommandPathSafe(pathValue: string): void {
+  if (COMMAND_PATH_CONTROL_CHARS_RE.test(pathValue)) {
+    throw new Error('Hook command paths must not contain control characters');
+  }
+}
+
 function quoteCommandPath(pathValue: string, platform: NodeJS.Platform = process.platform): string {
   const normalized = normalizeCommandPath(pathValue, platform);
-  return `"${normalized.replace(/"/g, '\\"')}"`;
+  assertCommandPathSafe(normalized);
+
+  if (platform === 'win32') {
+    if (normalized.includes('"')) {
+      throw new Error('Hook command paths must not contain double quotes on Windows');
+    }
+    const escaped = normalized
+      .replace(/%/g, '%%')
+      .replace(/!/g, '^!');
+    return `"${escaped}"`;
+  }
+
+  const escaped = normalized.replace(/'/g, `'\"'\"'`);
+  return `'${escaped}'`;
 }
 
 /** Build a shell-safe command string that invokes hook.js with an explicit Node executable. */

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -519,22 +519,13 @@ export async function validateWorkDir(
   allowedWorkDirs: readonly string[] = [],
 ): Promise<string | { error: string; code: string }> {
   if (typeof workDir !== 'string') return { error: 'workDir must be a string', code: 'INVALID_WORKDIR' };
+  if (workDir.includes('\0')) return { error: 'workDir must not contain null bytes', code: 'INVALID_WORKDIR' };
 
   // Step 1: Reject path traversal in raw/mixed/decoded forms before resolution.
   if (containsTraversalSegment(workDir)) {
     return { error: 'workDir must not contain path traversal components (..)', code: 'INVALID_WORKDIR' };
   }
 
-  // Step 2: Resolve to absolute path and follow symlinks.
-  const resolved = path.resolve(workDir);
-  let realPath: string;
-  try {
-    realPath = await fs.realpath(resolved);
-  } catch { /* path does not exist on disk */
-    return { error: `workDir does not exist: ${resolved}`, code: 'INVALID_WORKDIR' };
-  }
-
-  // Step 3: Directory allowlist check.
   const safeDirCandidates = allowedWorkDirs.length > 0
     ? allowedWorkDirs.map((dir) => path.resolve(dir))
     : getDefaultSafeDirs().map((dir) => path.resolve(dir));
@@ -546,8 +537,25 @@ export async function validateWorkDir(
       return dir;
     }
   }));
+  const candidateSafeDirs = Array.from(new Set([...safeDirCandidates, ...safeDirs]));
 
-  const allowed = safeDirs.some((dir) => isUnderOrEqual(realPath, dir));
+  // Step 2: Resolve to absolute path and enforce lexical allowlist before touching the filesystem.
+  const resolved = path.resolve(workDir);
+  const preAllowed = candidateSafeDirs.some((dir) => isUnderOrEqual(resolved, dir));
+  if (!preAllowed) {
+    return { error: 'workDir is not in the allowed directories list', code: 'INVALID_WORKDIR' };
+  }
+
+  // Step 3: Follow symlinks.
+  let realPath: string;
+  try {
+    realPath = await fs.realpath(resolved);
+  } catch { /* path does not exist on disk */
+    return { error: `workDir does not exist: ${resolved}`, code: 'INVALID_WORKDIR' };
+  }
+
+  // Step 4: Canonical allowlist check after symlink resolution.
+  const allowed = candidateSafeDirs.some((dir) => isUnderOrEqual(realPath, dir));
   if (!allowed) {
     return { error: 'workDir is not in the allowed directories list', code: 'INVALID_WORKDIR' };
   }


### PR DESCRIPTION
## Summary\n- harden workDir validation to enforce allowlist boundaries before resolving untrusted paths\n- strengthen hook command escaping on POSIX and Windows to prevent shell interpretation\n- replace fast audit hash chaining primitive with PBKDF2 stretching\n- add regression tests for path pre-check and shell escaping\n\n## Context\nThis PR addresses high-severity non-rate-limit CodeQL blockers for promotion PR #1629.\n\n## Validation\n- npm ci\n- npm run lint\n- npm run build\n- npx tsc --noEmit\n- npm test