### PR TITLE
fix(security): resolve CodeQL missing rate limiting blockers for #1629

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^11.2.0",
+        "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.0.0",
         "@fastify/websocket": "^11.2.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
@@ -423,6 +424,27 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@fastify/send": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "license": "MIT",
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.2.0",
     "@modelcontextprotocol/sdk": "^1.28.0",

--- a/src/__tests__/auth-verify-endpoint-1555.test.ts
+++ b/src/__tests__/auth-verify-endpoint-1555.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
+import fastifyRateLimit from '@fastify/rate-limit';
 import { z } from 'zod';
 import { AuthManager } from '../auth.js';
 import { join } from 'node:path';
@@ -16,6 +17,8 @@ const verifyTokenSchema = z.object({
 
 const AUTH_FAIL_WINDOW_MS = 60_000;
 const AUTH_FAIL_MAX = 5;
+const RATE_LIMIT_WINDOW = '1 minute';
+const VERIFY_ROUTE_LIMIT = { max: 60, timeWindow: RATE_LIMIT_WINDOW } as const;
 
 interface AuthFailBucket {
   timestamps: number[];
@@ -23,6 +26,13 @@ interface AuthFailBucket {
 
 async function registerVerifyRoute(app: FastifyInstance, auth: AuthManager): Promise<void> {
   const authFailLimits = new Map<string, AuthFailBucket>();
+
+  await app.register(fastifyRateLimit, {
+    global: true,
+    max: 600,
+    timeWindow: RATE_LIMIT_WINDOW,
+    keyGenerator: (req) => req.ip ?? 'unknown',
+  });
 
   function checkAuthFailRateLimit(ip: string): boolean {
     const now = Date.now();
@@ -46,7 +56,7 @@ async function registerVerifyRoute(app: FastifyInstance, auth: AuthManager): Pro
     }
   });
 
-  app.post('/v1/auth/verify', async (req, reply) => {
+  app.post('/v1/auth/verify', { config: { rateLimit: VERIFY_ROUTE_LIMIT } }, async (req, reply) => {
     const parsed = verifyTokenSchema.safeParse(req.body ?? {});
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });

--- a/src/__tests__/auth-verify-endpoint-1555.test.ts
+++ b/src/__tests__/auth-verify-endpoint-1555.test.ts
@@ -33,6 +33,7 @@ async function registerVerifyRoute(app: FastifyInstance, auth: AuthManager): Pro
     timeWindow: RATE_LIMIT_WINDOW,
     keyGenerator: (req) => req.ip ?? 'unknown',
   });
+  const verifyRouteRateLimit = app.rateLimit(VERIFY_ROUTE_LIMIT);
 
   function checkAuthFailRateLimit(ip: string): boolean {
     const now = Date.now();
@@ -56,7 +57,7 @@ async function registerVerifyRoute(app: FastifyInstance, auth: AuthManager): Pro
     }
   });
 
-  app.post('/v1/auth/verify', { config: { rateLimit: VERIFY_ROUTE_LIMIT } }, async (req, reply) => {
+  app.post('/v1/auth/verify', { preHandler: verifyRouteRateLimit }, async (req, reply) => {
     const parsed = verifyTokenSchema.safeParse(req.body ?? {});
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@
  */
 
 import Fastify, { type FastifyRequest, type FastifyReply } from 'fastify';
+import fastifyRateLimit from '@fastify/rate-limit';
 import fs from 'node:fs/promises';
 import fastifyStatic from '@fastify/static';
 import fastifyWebsocket from '@fastify/websocket';
@@ -238,6 +239,25 @@ const app = Fastify({
       },
     },
   },
+});
+
+const RATE_LIMIT_WINDOW = '1 minute';
+const RATE_LIMITS = {
+  global: { max: 600, timeWindow: RATE_LIMIT_WINDOW },
+  health: { max: 240, timeWindow: RATE_LIMIT_WINDOW },
+  metrics: { max: 240, timeWindow: RATE_LIMIT_WINDOW },
+  adminAction: { max: 60, timeWindow: RATE_LIMIT_WINDOW },
+  authVerify: { max: 60, timeWindow: RATE_LIMIT_WINDOW },
+  authKeyWrite: { max: 60, timeWindow: RATE_LIMIT_WINDOW },
+  audit: { max: 120, timeWindow: RATE_LIMIT_WINDOW },
+  sessionCreate: { max: 120, timeWindow: RATE_LIMIT_WINDOW },
+  expensiveRead: { max: 120, timeWindow: RATE_LIMIT_WINDOW },
+} as const;
+
+app.register(fastifyRateLimit, {
+  global: true,
+  keyGenerator: (req) => req.ip ?? 'unknown',
+  ...RATE_LIMITS.global,
 });
 
 // #1108: Decorate request with authKeyId — type-safe alternative to unsafe cast
@@ -495,11 +515,11 @@ async function healthHandler(): Promise<Record<string, unknown>> {
     timestamp: new Date().toISOString(),
   };
 }
-app.get('/v1/health', healthHandler);
-app.get('/health', healthHandler);
+app.get('/v1/health', { config: { rateLimit: RATE_LIMITS.health } }, healthHandler);
+app.get('/health', { config: { rateLimit: RATE_LIMITS.health } }, healthHandler);
 
 // Issue #1412: Prometheus metrics scrape endpoint — text/plain; version=0.0.4
-app.get('/metrics', async (req, reply) => {
+app.get('/metrics', { config: { rateLimit: RATE_LIMITS.metrics } }, async (req, reply) => {
   try {
     const metrics = await promRegistry.metrics();
     return reply
@@ -512,7 +532,7 @@ app.get('/metrics', async (req, reply) => {
 });
 
 // Issue #1418: Alert webhook validation and stats
-app.post('/v1/alerts/test', async (req, reply) => {
+app.post('/v1/alerts/test', { config: { rateLimit: RATE_LIMITS.adminAction } }, async (req, reply) => {
   if (!requireRole(req, reply, 'admin', 'operator')) return;
   try {
     const result = await alertManager.fireTestAlert();
@@ -539,7 +559,7 @@ app.post<{ Body: HandshakeRequest }>('/v1/handshake', async (req, reply) => {
 // Issue #81: Swarm awareness
 
 // Issue #81: Swarm awareness — list all detected CC swarms and their teammates
-app.get('/v1/swarm', async () => {
+app.get('/v1/swarm', { config: { rateLimit: RATE_LIMITS.expensiveRead } }, async () => {
   const result = await swarmMonitor.scan();
   return result;
 });
@@ -550,7 +570,7 @@ const verifyTokenSchema = z.object({
   token: z.string().min(1),
 }).strict();
 
-app.post('/v1/auth/verify', async (req, reply) => {
+app.post('/v1/auth/verify', { config: { rateLimit: RATE_LIMITS.authVerify } }, async (req, reply) => {
   const parsed = verifyTokenSchema.safeParse(req.body ?? {});
   if (!parsed.success) {
     return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
@@ -578,7 +598,7 @@ app.post('/v1/auth/verify', async (req, reply) => {
   return { valid: true, role: auth.getRole(result.keyId) };
 });
 
-app.post('/v1/auth/keys', async (req, reply) => {
+app.post('/v1/auth/keys', { config: { rateLimit: RATE_LIMITS.authKeyWrite } }, async (req, reply) => {
   if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
   // Issue #1432: Only admin keys can create new API keys
   if (!requireRole(req, reply, 'admin')) return;
@@ -647,7 +667,7 @@ const auditQuerySchema = z.object({
   verify: z.coerce.boolean().optional(),
 });
 
-app.get('/v1/audit', async (req, reply) => {
+app.get('/v1/audit', { config: { rateLimit: RATE_LIMITS.audit } }, async (req, reply) => {
   if (!requireRole(req, reply, 'admin')) return;
 
   const parsed = auditQuerySchema.safeParse(req.query ?? {});
@@ -1065,8 +1085,8 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
 
   return reply.status(201).send({ ...session, promptDelivery });
 }
-app.post('/v1/sessions', createSessionHandler);
-app.post('/sessions', createSessionHandler);
+app.post('/v1/sessions', { config: { rateLimit: RATE_LIMITS.sessionCreate } }, createSessionHandler);
+app.post('/sessions', { config: { rateLimit: RATE_LIMITS.sessionCreate } }, createSessionHandler);
 
 // Get session (Issue #20: includes actionHints for interactive states)
 async function getSessionHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
@@ -1852,7 +1872,7 @@ app.post<{ Body: CreateTemplateRequest }>('/v1/templates', async (req, reply) =>
 });
 
 // GET /v1/templates — List all templates
-app.get('/v1/templates', async () => {
+app.get('/v1/templates', { config: { rateLimit: RATE_LIMITS.expensiveRead } }, async () => {
   try {
     return await templateStore.listTemplates();
   } catch (_e: unknown) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -260,6 +260,22 @@ app.register(fastifyRateLimit, {
   ...RATE_LIMITS.global,
 });
 
+function createRateLimitPreHandler(options: { max: number; timeWindow: string }) {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    const limiter = app.rateLimit(options);
+    await limiter.call(app, req, reply);
+  };
+}
+
+const healthRateLimit = createRateLimitPreHandler(RATE_LIMITS.health);
+const metricsRateLimit = createRateLimitPreHandler(RATE_LIMITS.metrics);
+const adminActionRateLimit = createRateLimitPreHandler(RATE_LIMITS.adminAction);
+const authVerifyRateLimit = createRateLimitPreHandler(RATE_LIMITS.authVerify);
+const authKeyWriteRateLimit = createRateLimitPreHandler(RATE_LIMITS.authKeyWrite);
+const auditRateLimit = createRateLimitPreHandler(RATE_LIMITS.audit);
+const sessionCreateRateLimit = createRateLimitPreHandler(RATE_LIMITS.sessionCreate);
+const expensiveReadRateLimit = createRateLimitPreHandler(RATE_LIMITS.expensiveRead);
+
 // #1108: Decorate request with authKeyId — type-safe alternative to unsafe cast
 app.decorateRequest('authKeyId', null as unknown as string);
 
@@ -515,11 +531,11 @@ async function healthHandler(): Promise<Record<string, unknown>> {
     timestamp: new Date().toISOString(),
   };
 }
-app.get('/v1/health', { config: { rateLimit: RATE_LIMITS.health } }, healthHandler);
-app.get('/health', { config: { rateLimit: RATE_LIMITS.health } }, healthHandler);
+app.get('/v1/health', { preHandler: healthRateLimit }, healthHandler);
+app.get('/health', { preHandler: healthRateLimit }, healthHandler);
 
 // Issue #1412: Prometheus metrics scrape endpoint — text/plain; version=0.0.4
-app.get('/metrics', { config: { rateLimit: RATE_LIMITS.metrics } }, async (req, reply) => {
+app.get('/metrics', { preHandler: metricsRateLimit }, async (req, reply) => {
   try {
     const metrics = await promRegistry.metrics();
     return reply
@@ -532,7 +548,7 @@ app.get('/metrics', { config: { rateLimit: RATE_LIMITS.metrics } }, async (req, 
 });
 
 // Issue #1418: Alert webhook validation and stats
-app.post('/v1/alerts/test', { config: { rateLimit: RATE_LIMITS.adminAction } }, async (req, reply) => {
+app.post('/v1/alerts/test', { preHandler: adminActionRateLimit }, async (req, reply) => {
   if (!requireRole(req, reply, 'admin', 'operator')) return;
   try {
     const result = await alertManager.fireTestAlert();
@@ -559,7 +575,7 @@ app.post<{ Body: HandshakeRequest }>('/v1/handshake', async (req, reply) => {
 // Issue #81: Swarm awareness
 
 // Issue #81: Swarm awareness — list all detected CC swarms and their teammates
-app.get('/v1/swarm', { config: { rateLimit: RATE_LIMITS.expensiveRead } }, async () => {
+app.get('/v1/swarm', { preHandler: expensiveReadRateLimit }, async () => {
   const result = await swarmMonitor.scan();
   return result;
 });
@@ -570,7 +586,7 @@ const verifyTokenSchema = z.object({
   token: z.string().min(1),
 }).strict();
 
-app.post('/v1/auth/verify', { config: { rateLimit: RATE_LIMITS.authVerify } }, async (req, reply) => {
+app.post('/v1/auth/verify', { preHandler: authVerifyRateLimit }, async (req, reply) => {
   const parsed = verifyTokenSchema.safeParse(req.body ?? {});
   if (!parsed.success) {
     return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
@@ -598,7 +614,7 @@ app.post('/v1/auth/verify', { config: { rateLimit: RATE_LIMITS.authVerify } }, a
   return { valid: true, role: auth.getRole(result.keyId) };
 });
 
-app.post('/v1/auth/keys', { config: { rateLimit: RATE_LIMITS.authKeyWrite } }, async (req, reply) => {
+app.post('/v1/auth/keys', { preHandler: authKeyWriteRateLimit }, async (req, reply) => {
   if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
   // Issue #1432: Only admin keys can create new API keys
   if (!requireRole(req, reply, 'admin')) return;
@@ -667,7 +683,7 @@ const auditQuerySchema = z.object({
   verify: z.coerce.boolean().optional(),
 });
 
-app.get('/v1/audit', { config: { rateLimit: RATE_LIMITS.audit } }, async (req, reply) => {
+app.get('/v1/audit', { preHandler: auditRateLimit }, async (req, reply) => {
   if (!requireRole(req, reply, 'admin')) return;
 
   const parsed = auditQuerySchema.safeParse(req.query ?? {});
@@ -1085,8 +1101,8 @@ async function createSessionHandler(req: FastifyRequest, reply: FastifyReply): P
 
   return reply.status(201).send({ ...session, promptDelivery });
 }
-app.post('/v1/sessions', { config: { rateLimit: RATE_LIMITS.sessionCreate } }, createSessionHandler);
-app.post('/sessions', { config: { rateLimit: RATE_LIMITS.sessionCreate } }, createSessionHandler);
+app.post('/v1/sessions', { preHandler: sessionCreateRateLimit }, createSessionHandler);
+app.post('/sessions', { preHandler: sessionCreateRateLimit }, createSessionHandler);
 
 // Get session (Issue #20: includes actionHints for interactive states)
 async function getSessionHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
@@ -1872,7 +1888,7 @@ app.post<{ Body: CreateTemplateRequest }>('/v1/templates', async (req, reply) =>
 });
 
 // GET /v1/templates — List all templates
-app.get('/v1/templates', { config: { rateLimit: RATE_LIMITS.expensiveRead } }, async () => {
+app.get('/v1/templates', { preHandler: expensiveReadRateLimit }, async () => {
   try {
     return await templateStore.listTemplates();
   } catch (_e: unknown) {


### PR DESCRIPTION
## Summary
This PR fixes the high-severity CodeQL Missing rate limiting findings blocking promotion PR #1629.

## Changes
- Added recognized Fastify rate limiting via @fastify/rate-limit.
- Enabled global per-IP throttling and added explicit route-level limits for flagged handlers in src/server.ts.
- Added rate-limit coverage to the test-side mock verify route in src/__tests__/auth-verify-endpoint-1555.test.ts.
- Kept existing auth/authorization behavior and response semantics intact.

## Validation
Executed successfully in the worktree:
- 
pm ci
- 
pm run lint
- 
pm run build
- 
px tsc --noEmit
- 
pm test

## Context
Main-blocker follow-up for promotion PR #1629 (develop -> main).