### PR TITLE
fix: address auth and permission correctness issues (#1645 #1646 #1647 #1648)

### DIFF
--- a/src/__tests__/auth-rate-limiter.test.ts
+++ b/src/__tests__/auth-rate-limiter.test.ts
@@ -6,18 +6,34 @@ describe('RateLimiter', () => {
     vi.useRealTimers();
   });
 
-  it('enforces and resets auth-failure limits per IP', () => {
+  it('enforces auth-failure lockout at configured threshold and resets after window', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const limiter = new RateLimiter();
+
+    for (let i = 0; i < 4; i++) {
+      limiter.recordAuthFailure('10.0.0.1');
+      expect(limiter.checkAuthFailRateLimit('10.0.0.1')).toBe(false);
+    }
+
+    limiter.recordAuthFailure('10.0.0.1');
+    expect(limiter.checkAuthFailRateLimit('10.0.0.1')).toBe(true);
+
+    vi.setSystemTime(61_000);
+    expect(limiter.checkAuthFailRateLimit('10.0.0.1')).toBe(false);
+  });
+
+  it('does not double-count auth failures when checked before record', () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const limiter = new RateLimiter();
 
     for (let i = 0; i < 5; i++) {
-      expect(limiter.checkAuthFailRateLimit('10.0.0.1')).toBe(false);
+      expect(limiter.checkAuthFailRateLimit('10.0.0.9')).toBe(false);
+      limiter.recordAuthFailure('10.0.0.9');
     }
-    expect(limiter.checkAuthFailRateLimit('10.0.0.1')).toBe(true);
 
-    vi.setSystemTime(61_000);
-    expect(limiter.checkAuthFailRateLimit('10.0.0.1')).toBe(false);
+    expect(limiter.checkAuthFailRateLimit('10.0.0.9')).toBe(true);
   });
 
   it('enforces per-IP request limits with higher allowance for master token', () => {
@@ -57,5 +73,23 @@ describe('RateLimiter', () => {
 
     expect(limiter.checkIpRateLimit('10.0.0.4', false)).toBe(false);
     expect(limiter.checkAuthFailRateLimit('10.0.0.5')).toBe(false);
+  });
+
+  it('bounds per-IP in-memory bucket growth for sustained traffic', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const limiter = new RateLimiter();
+
+    for (let i = 0; i < 2_000; i++) {
+      limiter.checkIpRateLimit('10.0.0.8', true);
+      limiter.recordAuthFailure('10.0.0.8');
+    }
+
+    const ipBucket = (limiter as any).ipRateLimits.get('10.0.0.8');
+    const authBucket = (limiter as any).authFailLimits.get('10.0.0.8');
+    const ipActiveCount = ipBucket.entries.length - ipBucket.start;
+
+    expect(ipActiveCount).toBeLessThanOrEqual(301);
+    expect(authBucket.timestamps.length).toBeLessThanOrEqual(5);
   });
 });

--- a/src/__tests__/hooks-coverage-1305.test.ts
+++ b/src/__tests__/hooks-coverage-1305.test.ts
@@ -328,7 +328,7 @@ describe('Issue #1305: hooks.ts additional coverage', () => {
           rules: [{
             tool: 'Bash',
             behavior: 'deny',
-            pattern: 'rm *',
+            pattern: 'rm **',
           }],
         },
       });

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1213,6 +1213,23 @@ describe('AegisClient edge cases', () => {
     expect(result).toEqual([]);
   });
 
+  it('resolveRole fails closed to viewer when verify request errors', async () => {
+    const client = new AegisClient('http://127.0.0.1:9100', 'test-token');
+    (fetch as any).mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(client.resolveRole()).resolves.toBe('viewer');
+  });
+
+  it('resolveRole fails closed to viewer when verify response is invalid', async () => {
+    const client = new AegisClient('http://127.0.0.1:9100', 'test-token');
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ valid: false, role: 'admin' }),
+    });
+
+    await expect(client.resolveRole()).resolves.toBe('viewer');
+  });
+
   it('sendMessage with special characters in text', async () => {
     const client = new AegisClient('http://127.0.0.1:9100');
     const UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';

--- a/src/__tests__/permission-evaluator-742.test.ts
+++ b/src/__tests__/permission-evaluator-742.test.ts
@@ -63,3 +63,25 @@ describe('Issue #742: permission profile evaluator', () => {
     expect(result.behavior).toBe('deny');
   });
 
+  it('single-star does not cross path separators', () => {
+    const matched = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{ tool: 'Bash', behavior: 'allow', pattern: 'src/*/index.ts' }],
+    }, { toolName: 'Bash', toolInput: { command: 'src/lib/index.ts' } });
+    expect(matched.behavior).toBe('allow');
+
+    const notMatched = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{ tool: 'Bash', behavior: 'allow', pattern: 'src/*/index.ts' }],
+    }, { toolName: 'Bash', toolInput: { command: 'src/lib/utils/index.ts' } });
+    expect(notMatched.behavior).toBe('deny');
+  });
+
+  it('double-star can cross path separators', () => {
+    const result = evaluatePermissionProfile({
+      defaultBehavior: 'deny',
+      rules: [{ tool: 'Bash', behavior: 'allow', pattern: 'src/**/index.ts' }],
+    }, { toolName: 'Bash', toolInput: { command: 'src/lib/utils/index.ts' } });
+    expect(result.behavior).toBe('allow');
+  });
+

--- a/src/__tests__/permission-evaluator-coverage-1305.test.ts
+++ b/src/__tests__/permission-evaluator-coverage-1305.test.ts
@@ -27,14 +27,14 @@ describe('Issue #1305: permission evaluator additional coverage', () => {
         rules: [{
           tool: 'Read',
           behavior: 'allow',
-          pattern: '*',
+          pattern: '**',
         }],
       }, {
         toolName: 'Read',
         toolInput: { file_path: '/tmp/test.ts' },
       });
 
-      // * matches anything — should match the JSON.stringify output
+      // ** matches full JSON.stringify output including path separators
       expect(result.behavior).toBe('allow');
     });
 

--- a/src/__tests__/webhook-dlq.test.ts
+++ b/src/__tests__/webhook-dlq.test.ts
@@ -29,9 +29,13 @@ describe('Webhook dead letter queue (L14)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockFetch.mockReset();
+    vi.spyOn(WebhookChannel, 'backoff').mockReturnValue(0);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -164,7 +168,7 @@ describe('Webhook dead letter queue (L14)', () => {
 
   it('should log when adding to DLQ', async () => {
     mockFetch.mockRejectedValue(new Error('fail'));
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn');
 
     const channel = new WebhookChannel({
       endpoints: [{ url: 'https://example.com/hook' }],
@@ -179,6 +183,5 @@ describe('Webhook dead letter queue (L14)', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Webhook DLQ'),
     );
-    warnSpy.mockRestore();
   });
 });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -117,7 +117,8 @@ export class AegisClient {
   /**
    * Resolve the RBAC role for the configured auth token.
    * Calls POST /v1/auth/verify once and caches the result.
-   * Returns 'admin' when no auth token is configured (matching server.ts behavior).
+    * Returns 'admin' when no auth token is configured (matching server.ts behavior).
+    * Returns 'viewer' if role resolution fails or returns invalid data.
    */
   async resolveRole(): Promise<string> {
     if (this.resolvedRole !== undefined) return this.resolvedRole;
@@ -132,11 +133,13 @@ export class AegisClient {
         method: 'POST',
         body: JSON.stringify({ token: this.authToken }),
       });
-      this.resolvedRole = result.role ?? 'admin';
+      if (result.valid && (result.role === 'admin' || result.role === 'operator' || result.role === 'viewer')) {
+        this.resolvedRole = result.role;
+      } else {
+        this.resolvedRole = 'viewer';
+      }
     } catch {
-      // If server is unreachable or verify fails, default to admin (no enforcement)
-      // to avoid breaking existing setups during upgrade.
-      this.resolvedRole = 'admin';
+      this.resolvedRole = 'viewer';
     }
 
     return this.resolvedRole;

--- a/src/services/auth/RateLimiter.ts
+++ b/src/services/auth/RateLimiter.ts
@@ -11,6 +11,7 @@ const IP_WINDOW_MS = 60_000;
 const IP_LIMIT_NORMAL = 120;
 const IP_LIMIT_MASTER = 300;
 const MAX_IP_ENTRIES = 10_000;
+const MAX_IP_EVENTS_PER_BUCKET = IP_LIMIT_MASTER + 1;
 
 const AUTH_FAIL_WINDOW_MS = 60_000;
 const AUTH_FAIL_MAX = 5;
@@ -39,6 +40,9 @@ export class RateLimiter {
     }
 
     bucket.entries.push(now);
+    while (bucket.entries.length - bucket.start > MAX_IP_EVENTS_PER_BUCKET) {
+      bucket.start++;
+    }
     this.ipRateLimits.set(ip, bucket);
 
     if (this.ipRateLimits.size > MAX_IP_ENTRIES) {
@@ -60,12 +64,29 @@ export class RateLimiter {
   }
 
   checkAuthFailRateLimit(ip: string): boolean {
+    const cutoff = Date.now() - AUTH_FAIL_WINDOW_MS;
+    const bucket = this.authFailLimits.get(ip);
+    if (!bucket) return false;
+
+    bucket.timestamps = bucket.timestamps.filter((t) => t >= cutoff);
+    if (bucket.timestamps.length === 0) {
+      this.authFailLimits.delete(ip);
+      return false;
+    }
+
+    return bucket.timestamps.length >= AUTH_FAIL_MAX;
+  }
+
+  recordAuthFailure(ip: string): void {
     const now = Date.now();
     const cutoff = now - AUTH_FAIL_WINDOW_MS;
     const bucket = this.authFailLimits.get(ip) || { timestamps: [] };
 
     bucket.timestamps = bucket.timestamps.filter((t) => t >= cutoff);
     bucket.timestamps.push(now);
+    if (bucket.timestamps.length > AUTH_FAIL_MAX) {
+      bucket.timestamps = bucket.timestamps.slice(bucket.timestamps.length - AUTH_FAIL_MAX);
+    }
     this.authFailLimits.set(ip, bucket);
 
     if (this.authFailLimits.size > MAX_AUTH_FAIL_IP_ENTRIES) {
@@ -80,12 +101,6 @@ export class RateLimiter {
       }
       if (oldestIp) this.authFailLimits.delete(oldestIp);
     }
-
-    return bucket.timestamps.length > AUTH_FAIL_MAX;
-  }
-
-  recordAuthFailure(ip: string): void {
-    this.checkAuthFailRateLimit(ip);
   }
 
   pruneAuthFailLimits(): void {

--- a/src/services/permission/evaluator.ts
+++ b/src/services/permission/evaluator.ts
@@ -7,8 +7,26 @@ import type {
 } from './types.js';
 
 function globToRegExp(pattern: string): RegExp {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\?/g, '.').replace(/\*/g, '.*');
-  return new RegExp(`^${escaped}$`, 'i');
+  let regex = '';
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]!;
+    if (char === '*') {
+      const isDoubleStar = pattern[i + 1] === '*';
+      if (isDoubleStar) {
+        regex += '.*';
+        i++;
+      } else {
+        regex += '[^/\\\\]*';
+      }
+      continue;
+    }
+    if (char === '?') {
+      regex += '[^/\\\\]';
+      continue;
+    }
+    regex += /[.+^${}()|[\]\\]/.test(char) ? `\\${char}` : char;
+  }
+  return new RegExp(`^${regex}$`, 'i');
 }
 
 function extractCandidatePaths(toolInput?: Record<string, unknown>): string[] {


### PR DESCRIPTION
## Summary\n- fix RateLimiter failure accounting so lockout threshold matches configured value\n- bound per-IP failure bucket growth in RateLimiter\n- harden permission evaluator wildcard semantics to prevent single-star crossing path separators\n- change MCP role resolution error path to fail closed\n- add focused regression tests for each corrected behavior\n\n## Linked Issues\n- Closes #1645\n- Closes #1646\n- Closes #1647\n- Closes #1648\n\n## Verification\n- npx tsc --noEmit\n- npx vitest run src/__tests__/auth-rate-limiter.test.ts src/__tests__/permission-evaluator-742.test.ts src/__tests__/mcp-server.test.ts\n\n## Aegis version\n**Developed with:** v0.3.2-alpha\n