### PR TITLE
fix: remove blocking persistence paths and plaintext hook secret storage (#1642 #1643 #1644)

### DIFF
--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -143,6 +143,22 @@ describe('AuditLogger (Issue #1419)', () => {
       const newRecord = await restarted.log('system', 'key.revoke', 'After restart');
       expect(newRecord.prevHash).toBe(firstHash);
     });
+
+    it('should preserve a valid hash chain under concurrent log writes', async () => {
+      await Promise.all(
+        Array.from({ length: 8 }, (_, i) => audit.log('system', 'api.authenticated', `Call ${i}`)),
+      );
+
+      const records = await audit.query({ limit: 8 });
+      expect(records).toHaveLength(8);
+      expect(records[0]!.prevHash).toBe('');
+      for (let i = 1; i < records.length; i++) {
+        expect(records[i]!.prevHash).toBe(records[i - 1]!.hash);
+      }
+
+      const verification = await audit.verify();
+      expect(verification.valid).toBe(true);
+    });
   });
 
   describe('Issue #1618: symlink hardening', () => {

--- a/src/__tests__/memory-bridge.test.ts
+++ b/src/__tests__/memory-bridge.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MemoryBridge } from "../memory-bridge.js";
 import { existsSync, unlinkSync, writeFileSync } from "fs";
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 describe("MemoryBridge", () => {
-  const tmpPath = "/tmp/aegis-memory-test.json";
+  const tmpPath = join(tmpdir(), 'aegis-memory-test.json');
   let bridge: MemoryBridge;
 
   beforeEach(() => {
@@ -95,6 +97,18 @@ describe("MemoryBridge", () => {
     const bridge2 = new MemoryBridge(tmpPath);
     await bridge2.load();
     expect(bridge2.get("ns/k")?.value).toBe("v");
+  });
+
+  it('returns without throwing when persisted path is missing', async () => {
+    const missing = new MemoryBridge(join(tmpdir(), `missing-${Date.now()}`, 'memory.json'));
+    await expect(missing.load()).resolves.toBeUndefined();
+  });
+
+  it('surfaces save errors for invalid parent directories', async () => {
+    const badPath = join(tmpdir(), `missing-${Date.now()}`, 'nested', 'memory.json');
+    const badBridge = new MemoryBridge(badPath);
+    badBridge.set('ns/key', 'value');
+    await expect(badBridge.save()).rejects.toThrow();
   });
 
   it("ignores malformed persisted JSON", async () => {

--- a/src/__tests__/session-persistence.test.ts
+++ b/src/__tests__/session-persistence.test.ts
@@ -4,8 +4,141 @@
 
 import { describe, it, expect } from 'vitest';
 import { homedir } from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { writeFile, readFile } from 'node:fs/promises';
+import { SessionManager } from '../session.js';
 
 describe('Session persistence and resume (Issue #35)', () => {
+  describe('Issue #1644: hook secret persistence hardening', () => {
+    function makeConfig(stateDir: string) {
+      return {
+        stateDir,
+        host: '127.0.0.1',
+        port: 9100,
+        tmuxSession: 'aegis',
+        claudeProjectsDir: '/tmp/.claude/projects',
+        maxSessionAgeMs: 7_200_000,
+        reaperIntervalMs: 60_000,
+        defaultPermissionMode: 'default',
+        defaultSessionEnv: {},
+        allowedWorkDirs: [],
+        sseMaxConnections: 50,
+        sseMaxPerIp: 5,
+        worktreeAwareContinuation: false,
+        worktreeSiblingDirs: [],
+      } as const;
+    }
+
+    function makeTmux(windowId: string, windowName: string) {
+      return {
+        listWindows: async () => [{ windowId, windowName, cwd: '/tmp/project' }],
+      };
+    }
+
+    it('does not persist hookSecret in state.json', async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), 'aegis-1644-state-'));
+      try {
+        const sessionId = '550e8400-e29b-41d4-a716-446655440010';
+        const manager = new SessionManager(
+          makeTmux('@10', 'cc-1644-save') as any,
+          makeConfig(stateDir) as any,
+        );
+
+        (manager as any).state.sessions[sessionId] = {
+          id: sessionId,
+          windowId: '@10',
+          windowName: 'cc-1644-save',
+          workDir: '/tmp/project',
+          claudeSessionId: 'claude-session-1',
+          jsonlPath: '/tmp/project/session.jsonl',
+          byteOffset: 0,
+          monitorOffset: 0,
+          status: 'idle',
+          createdAt: Date.now(),
+          lastActivity: Date.now(),
+          stallThresholdMs: 300000,
+          permissionStallMs: 300000,
+          permissionMode: 'default',
+          hookSecret: 'plaintext-secret-must-not-persist',
+        };
+
+        await manager.save();
+
+        const content = await readFile(join(stateDir, 'state.json'), 'utf-8');
+        expect(content).not.toContain('hookSecret');
+        expect(content).not.toContain('plaintext-secret-must-not-persist');
+      } finally {
+        rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
+
+    it('restores hookSecret from hook settings file during load', async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), 'aegis-1644-restore-'));
+      try {
+        const sessionId = '550e8400-e29b-41d4-a716-446655440011';
+        const hookSettingsFile = join(stateDir, 'hooks.json');
+        const restoredSecret = 'restored-hook-secret';
+
+        await writeFile(
+          hookSettingsFile,
+          JSON.stringify({
+            hooks: {
+              Stop: [
+                {
+                  hooks: [
+                    {
+                      type: 'http',
+                      url: `http://127.0.0.1:9100/v1/hooks/Stop?sessionId=${sessionId}`,
+                      headers: { 'X-Hook-Secret': restoredSecret },
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+          'utf-8',
+        );
+
+        await writeFile(
+          join(stateDir, 'state.json'),
+          JSON.stringify({
+            [sessionId]: {
+              id: sessionId,
+              windowId: '@11',
+              windowName: 'cc-1644-restore',
+              workDir: '/tmp/project',
+              claudeSessionId: 'claude-session-2',
+              jsonlPath: '/tmp/project/session.jsonl',
+              byteOffset: 0,
+              monitorOffset: 0,
+              status: 'idle',
+              createdAt: Date.now(),
+              lastActivity: Date.now(),
+              stallThresholdMs: 300000,
+              permissionStallMs: 300000,
+              permissionMode: 'default',
+              hookSettingsFile,
+            },
+          }, null, 2),
+          'utf-8',
+        );
+
+        const manager = new SessionManager(
+          makeTmux('@11', 'cc-1644-restore') as any,
+          makeConfig(stateDir) as any,
+        );
+
+        await manager.load();
+        const session = manager.getSession(sessionId);
+        expect(session?.hookSecret).toBe(restoredSecret);
+      } finally {
+        rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('Orphan detection', () => {
     it('should identify cc-* windows as adoptable', () => {
       const windowName = 'cc-abc12345';

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -8,11 +8,12 @@
  * Log files rotate daily and are never overwritten.
  */
 
-import { pbkdf2Sync } from 'node:crypto';
+import { pbkdf2 } from 'node:crypto';
 import { appendFile, readFile, mkdir, readdir, lstat } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { promisify } from 'node:util';
 import { secureFilePermissions } from './file-utils.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -66,11 +67,13 @@ const AUDIT_HASH_ITERATIONS = 120_000;
 const AUDIT_HASH_KEY_LENGTH = 32;
 const AUDIT_HASH_DIGEST = 'sha512';
 const AUDIT_HASH_SALT_PREFIX = 'aegis-audit-chain-v2';
+const pbkdf2Async = promisify(pbkdf2);
 
-function computeHash(record: Omit<AuditRecord, 'hash'>): string {
+async function computeHash(record: Omit<AuditRecord, 'hash'>): Promise<string> {
   const payload = `${record.ts}|${record.actor}|${record.action}|${record.sessionId ?? ''}|${record.detail}|${record.prevHash}`;
   const salt = `${AUDIT_HASH_SALT_PREFIX}|${record.prevHash}`;
-  return pbkdf2Sync(payload, salt, AUDIT_HASH_ITERATIONS, AUDIT_HASH_KEY_LENGTH, AUDIT_HASH_DIGEST).toString('hex');
+  const derived = await pbkdf2Async(payload, salt, AUDIT_HASH_ITERATIONS, AUDIT_HASH_KEY_LENGTH, AUDIT_HASH_DIGEST);
+  return derived.toString('hex');
 }
 
 export class AuditLogger {
@@ -190,7 +193,7 @@ export class AuditLogger {
         detail,
         prevHash: this.lastHash,
       };
-      const hash = computeHash(partial);
+      const hash = await computeHash(partial);
       const record: AuditRecord = { ...partial, hash };
 
       const line = JSON.stringify(record) + '\n';
@@ -244,7 +247,7 @@ export class AuditLogger {
               return { valid: false, brokenAt: globalLineNum, file };
             }
 
-            const expectedHash = computeHash(record);
+            const expectedHash = await computeHash(record);
             if (record.hash !== expectedHash) {
               return { valid: false, brokenAt: globalLineNum, file };
             }

--- a/src/memory-bridge.ts
+++ b/src/memory-bridge.ts
@@ -1,4 +1,4 @@
-import { existsSync, renameSync, writeFileSync, readFileSync } from "fs";
+import { readFile, writeFile, rename } from 'node:fs/promises';
 import { safeJsonParse } from './safe-json.js';
 
 interface MemoryEntry {
@@ -89,8 +89,18 @@ export class MemoryBridge {
   }
 
   async load(): Promise<void> {
-    if (!this.persistPath || !existsSync(this.persistPath)) return;
-    const parsed = safeJsonParse(readFileSync(this.persistPath, 'utf-8'), 'Memory bridge store');
+    if (!this.persistPath) return;
+    let raw: string;
+    try {
+      raw = await readFile(this.persistPath, 'utf-8');
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') return;
+      console.error(`Memory bridge: failed to read persisted store at ${this.persistPath}: ${err.message}`);
+      return;
+    }
+
+    const parsed = safeJsonParse(raw, 'Memory bridge store');
     if (!parsed.ok) return;
     if (!Array.isArray(parsed.data)) return;
     for (const rawEntry of parsed.data) {
@@ -103,15 +113,25 @@ export class MemoryBridge {
     if (!this.persistPath) return;
     const entries = [...this.store.values()];
     const tmp = this.persistPath + ".tmp";
-    writeFileSync(tmp, JSON.stringify(entries, null, 2));
-    renameSync(tmp, this.persistPath);
+    try {
+      await writeFile(tmp, JSON.stringify(entries, null, 2));
+      await rename(tmp, this.persistPath);
+    } catch (error) {
+      const err = error as Error;
+      console.error(`Memory bridge: failed to persist store at ${this.persistPath}: ${err.message}`);
+      throw error;
+    }
   }
 
   private scheduleSave(): void {
     if (this.saveTimer) return;
     this.saveTimer = setTimeout(async () => {
       this.saveTimer = null;
-      await this.save();
+      try {
+        await this.save();
+      } catch {
+        // save() already emits a structured error; avoid unhandled rejection in timer callback.
+      }
     }, 1000);
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -46,6 +46,10 @@ function hydrateSessions(raw: z.infer<typeof persistedStateSchema>): Record<stri
   return sessions;
 }
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
  * Canonical runtime metadata for an Aegis-managed Claude Code session.
  *
@@ -209,6 +213,7 @@ export class SessionManager {
         const parsed = persistedStateSchema.safeParse(JSON.parse(raw));
         if (parsed.success && this.isValidState({ sessions: parsed.data })) {
           this.state = { sessions: hydrateSessions(parsed.data) };
+          await this.restoreSessionHookSecrets();
         } else {
           console.warn('State file failed validation, attempting backup restore');
           // Try loading from backup before resetting
@@ -219,6 +224,7 @@ export class SessionManager {
               const backupParsed = persistedStateSchema.safeParse(JSON.parse(backupRaw));
               if (backupParsed.success && this.isValidState({ sessions: backupParsed.data })) {
                 this.state = { sessions: hydrateSessions(backupParsed.data) };
+                await this.restoreSessionHookSecrets();
                 console.log('Restored state from backup');
               } else {
                 this.state = { sessions: {} };
@@ -237,7 +243,7 @@ export class SessionManager {
 
     // Create backup of successfully loaded state
     try {
-      await writeFile(`${this.stateFile}.bak`, JSON.stringify(this.state, null, 2));
+      await writeFile(`${this.stateFile}.bak`, this.serializeState());
     } catch { /* non-critical */ }
 
     // Issue #657: Invalidate sessions list cache after loading state
@@ -409,12 +415,50 @@ export class SessionManager {
       await mkdir(dir, { recursive: true });
     }
     const tmpFile = `${this.stateFile}.tmp`;
-    // #357: Use replacer to serialize Set<string> as arrays
-    await writeFile(tmpFile, JSON.stringify(this.state, (_, value) => {
+    await writeFile(tmpFile, this.serializeState());
+    await rename(tmpFile, this.stateFile);
+  }
+
+  private serializeState(): string {
+    // #357: Serialize Set<string> as arrays.
+    // #1644: Never persist per-session hook secrets to disk.
+    return JSON.stringify(this.state, (key, value) => {
+      if (key === 'hookSecret') return undefined;
       if (value instanceof Set) return [...value];
       return value;
-    }, 2));
-    await rename(tmpFile, this.stateFile);
+    }, 2);
+  }
+
+  private async restoreSessionHookSecrets(): Promise<void> {
+    for (const session of Object.values(this.state.sessions)) {
+      if (session.hookSecret || !session.hookSettingsFile) continue;
+      session.hookSecret = await this.readHookSecretFromSettingsFile(session.hookSettingsFile);
+    }
+  }
+
+  private async readHookSecretFromSettingsFile(settingsPath: string): Promise<string | undefined> {
+    try {
+      const raw = await readFile(settingsPath, 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (!isObjectRecord(parsed) || !isObjectRecord(parsed.hooks)) return undefined;
+
+      for (const eventEntries of Object.values(parsed.hooks)) {
+        if (!Array.isArray(eventEntries)) continue;
+        for (const entry of eventEntries) {
+          if (!isObjectRecord(entry) || !Array.isArray(entry.hooks)) continue;
+          for (const hook of entry.hooks) {
+            if (!isObjectRecord(hook) || !isObjectRecord(hook.headers)) continue;
+            const secret = hook.headers['X-Hook-Secret'];
+            if (typeof secret === 'string' && secret.length > 0) {
+              return secret;
+            }
+          }
+        }
+      }
+    } catch {
+      return undefined;
+    }
+    return undefined;
   }
 
   /** Default stall threshold: 2 min (Issue #392: 1.5x CC's 90s default, configurable via CLAUDE_STREAM_IDLE_TIMEOUT_MS). */


### PR DESCRIPTION
## Summary\n- convert audit hashing path to async implementation to avoid blocking hot path operations\n- convert memory bridge persistence to async fs operations with explicit error handling\n- remove plaintext hook secret persistence in session state and preserve restore behavior safely\n- add focused regression tests for audit, memory bridge, and session persistence paths\n\n## Linked Issues\n- Closes #1642\n- Closes #1643\n- Closes #1644\n\n## Verification\n- npx tsc --noEmit\n- npm run build\n- npx vitest run src/__tests__/audit.test.ts src/__tests__/memory-bridge.test.ts src/__tests__/session-persistence.test.ts\n\n## Aegis version\n**Developed with:** v0.3.2-alpha\n