### PR TITLE
fix: harden runtime safety for session save, hook timeout, and verification checks (#1660 #1662 #1664)

### DIFF
--- a/src/__tests__/answer-timeout-nan.test.ts
+++ b/src/__tests__/answer-timeout-nan.test.ts
@@ -181,4 +181,94 @@ describe('Issue #637: ANSWER_TIMEOUT_MS NaN guard', () => {
 
     expect(capturedTimeout).toBe(5000);
   });
+
+  it('clamps timeout to lower bound when env var is too small', async () => {
+    process.env.ANSWER_TIMEOUT_MS = '1';
+
+    let capturedTimeout: number | undefined;
+    const session = makeSession();
+    const mockSessions: SessionManager = {
+      getSession: vi.fn().mockReturnValue(session),
+      updateStatusFromHook: vi.fn((): UIState | null => 'working'),
+      updateSessionModel: vi.fn(),
+      addSubagent: vi.fn(),
+      removeSubagent: vi.fn(),
+      waitForPermissionDecision: vi.fn(() => Promise.resolve('allow' as const)),
+      hasPendingPermission: vi.fn().mockReturnValue(false),
+      getPendingPermissionInfo: vi.fn().mockReturnValue(null),
+      cleanupPendingPermission: vi.fn(),
+      waitForAnswer: vi.fn((_sid: string, _toolUseId: string, _q: string, timeoutMs?: number) => {
+        capturedTimeout = timeoutMs;
+        return Promise.resolve(null);
+      }),
+      submitAnswer: vi.fn(),
+      hasPendingQuestion: vi.fn().mockReturnValue(false),
+      getPendingQuestionInfo: vi.fn().mockReturnValue(null),
+      cleanupPendingQuestion: vi.fn(),
+      approve: vi.fn(),
+      reject: vi.fn(),
+    } as unknown as SessionManager;
+
+    const { registerHookRoutes } = await import('../hooks.js');
+    const app = Fastify({ logger: false });
+    const eventBus = new SessionEventBus();
+    registerHookRoutes(app, { sessions: mockSessions, eventBus });
+
+    await app.inject({
+      method: 'POST',
+      url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
+      payload: {
+        tool_name: 'AskUserQuestion',
+        tool_use_id: 'toolu_low_bound_test',
+        tool_input: { questions: [{ question: 'Test?' }] },
+      },
+    });
+
+    expect(capturedTimeout).toBe(1_000);
+  });
+
+  it('clamps timeout to upper bound when env var is too large', async () => {
+    process.env.ANSWER_TIMEOUT_MS = '700000';
+
+    let capturedTimeout: number | undefined;
+    const session = makeSession();
+    const mockSessions: SessionManager = {
+      getSession: vi.fn().mockReturnValue(session),
+      updateStatusFromHook: vi.fn((): UIState | null => 'working'),
+      updateSessionModel: vi.fn(),
+      addSubagent: vi.fn(),
+      removeSubagent: vi.fn(),
+      waitForPermissionDecision: vi.fn(() => Promise.resolve('allow' as const)),
+      hasPendingPermission: vi.fn().mockReturnValue(false),
+      getPendingPermissionInfo: vi.fn().mockReturnValue(null),
+      cleanupPendingPermission: vi.fn(),
+      waitForAnswer: vi.fn((_sid: string, _toolUseId: string, _q: string, timeoutMs?: number) => {
+        capturedTimeout = timeoutMs;
+        return Promise.resolve(null);
+      }),
+      submitAnswer: vi.fn(),
+      hasPendingQuestion: vi.fn().mockReturnValue(false),
+      getPendingQuestionInfo: vi.fn().mockReturnValue(null),
+      cleanupPendingQuestion: vi.fn(),
+      approve: vi.fn(),
+      reject: vi.fn(),
+    } as unknown as SessionManager;
+
+    const { registerHookRoutes } = await import('../hooks.js');
+    const app = Fastify({ logger: false });
+    const eventBus = new SessionEventBus();
+    registerHookRoutes(app, { sessions: mockSessions, eventBus });
+
+    await app.inject({
+      method: 'POST',
+      url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
+      payload: {
+        tool_name: 'AskUserQuestion',
+        tool_use_id: 'toolu_high_bound_test',
+        tool_input: { questions: [{ question: 'Test?' }] },
+      },
+    });
+
+    expect(capturedTimeout).toBe(600_000);
+  });
 });

--- a/src/__tests__/tmux-spawn.test.ts
+++ b/src/__tests__/tmux-spawn.test.ts
@@ -675,5 +675,28 @@ describe('Tmux window creation retry logic', () => {
         console.error = originalError;
       }
     });
+
+    it('should catch fire-and-forget debounced save rejection', async () => {
+      const errors: string[] = [];
+      const originalError = console.error;
+      console.error = (...args: unknown[]) => errors.push(args.map(String).join(' '));
+
+      try {
+        const save = async (): Promise<void> => {
+          throw new Error('permission denied');
+        };
+
+        // Matches debounced save pattern in session.ts.
+        void save().catch(e => console.error('Session: debounced save failed:', e));
+
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain('Session: debounced save failed:');
+        expect(errors[0]).toContain('permission denied');
+      } finally {
+        console.error = originalError;
+      }
+    });
   });
 });

--- a/src/__tests__/verification-enoent-1664.test.ts
+++ b/src/__tests__/verification-enoent-1664.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { runVerification } from '../verification.js';
+
+describe('Issue #1664: verification package.json checks are ENOENT-safe and deterministic', () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of dirs) {
+      await rm(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it('returns deterministic no-package result when package.json is missing', async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'aegis-verify-'));
+    dirs.push(workDir);
+
+    const first = await runVerification(workDir);
+    const second = await runVerification(workDir);
+
+    expect(first.ok).toBe(false);
+    expect(first.steps).toHaveLength(0);
+    expect(first.summary).toBe('No package.json found — cannot verify');
+
+    expect(second.ok).toBe(false);
+    expect(second.steps).toHaveLength(0);
+    expect(second.summary).toBe('No package.json found — cannot verify');
+  });
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -44,8 +44,18 @@ const AUTO_APPROVE_MODES = new Set(['bypassPermissions', 'dontAsk', 'acceptEdits
 /** Default timeout for waiting on client permission decision (ms). */
 const PERMISSION_TIMEOUT_MS = 10_000;
 
+const ANSWER_TIMEOUT_MIN_MS = 1_000;
+const ANSWER_TIMEOUT_MAX_MS = 600_000;
+
+function getAnswerTimeoutMs(): number {
+  const value = parseIntSafe(process.env.ANSWER_TIMEOUT_MS, 30_000);
+  if (value < ANSWER_TIMEOUT_MIN_MS) return ANSWER_TIMEOUT_MIN_MS;
+  if (value > ANSWER_TIMEOUT_MAX_MS) return ANSWER_TIMEOUT_MAX_MS;
+  return value;
+}
+
 /** Default timeout for waiting on external answer to AskUserQuestion (ms). */
-const ANSWER_TIMEOUT_MS = parseIntSafe(process.env.ANSWER_TIMEOUT_MS, 30_000);
+const ANSWER_TIMEOUT_MS = getAnswerTimeoutMs();
 
 /** Valid permission_mode values accepted by Claude Code. */
 const VALID_PERMISSION_MODES = new Set(['default', 'plan', 'bypassPermissions']);

--- a/src/session.ts
+++ b/src/session.ts
@@ -399,7 +399,7 @@ export class SessionManager {
     if (this.saveDebounceTimer !== null) clearTimeout(this.saveDebounceTimer);
     this.saveDebounceTimer = setTimeout(() => {
       this.saveDebounceTimer = null;
-      void this.save();
+      void this.save().catch(e => console.error('Session: debounced save failed:', e));
     }, SessionManager.SAVE_DEBOUNCE_MS);
   }
 

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -24,7 +24,15 @@ async function runCmd(file: string, args: string[], { cwd, timeoutMs }: RunOptio
 export async function runVerification(workDir: string, criticalOnly = false): Promise<VerificationResult> {
   const start = Date.now();
 
-  const hasPackageJson = statSync(join(workDir, 'package.json')).isFile();
+  const packageJsonPath = join(workDir, 'package.json');
+  let hasPackageJson = false;
+  try {
+    hasPackageJson = statSync(packageJsonPath).isFile();
+  } catch (e: unknown) {
+    const err = e as { code?: string };
+    if (err.code !== 'ENOENT') throw e;
+  }
+
   if (!hasPackageJson) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary\n- add explicit error handling for fire-and-forget session save paths\n- clamp ANSWER_TIMEOUT_MS to safe bounds and preserve deterministic behavior\n- make verification package existence checks ENOENT-safe\n- add focused regression tests for all three fixes\n\n## Linked Issues\n- Closes #1660\n- Closes #1662\n- Closes #1664\n\n## Verification\n- npx tsc --noEmit\n- npm run build\n- npx vitest run src/__tests__/answer-timeout-nan.test.ts src/__tests__/tmux-spawn.test.ts src/__tests__/verification-enoent-1664.test.ts\n\n## Aegis version\n**Developed with:** v0.3.2-alpha\n