### PR TITLE
chore: align package metadata and source maps for alpha release (#1649 #1654 #1656)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "aegis-bridge",
+  "name": "@onestepat4time/aegis",
   "version": "0.3.2-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aegis-bridge",
+      "name": "@onestepat4time/aegis",
       "version": "0.3.2-alpha",
       "license": "MIT",
       "dependencies": {
@@ -20,7 +20,6 @@
         "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
         "@opentelemetry/sdk-node": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
-        "@tanstack/react-virtual": "^3.13.23",
         "@types/nodemailer": "^8.0.0",
         "async-mutex": "^0.5.0",
         "fastify": "^5.8.2",
@@ -29,7 +28,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "aegis-bridge": "dist/cli.js"
+        "aegis": "dist/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2509,33 +2508,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
-      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.13.23"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
-      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
     },
     "node_modules/@ts-morph/common": {
       "version": "0.28.1",
@@ -6327,29 +6299,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -6569,13 +6518,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aegis-bridge",
+  "name": "@onestepat4time/aegis",
   "version": "0.3.2-alpha",
   "type": "module",
   "description": "Orchestrate Claude Code sessions via API. Create, brief, monitor, refine, ship.",
@@ -15,7 +15,7 @@
     }
   },
   "bin": {
-    "aegis-bridge": "dist/cli.js"
+    "aegis": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -61,7 +61,6 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
     "@opentelemetry/sdk-node": "^0.214.0",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
-    "@tanstack/react-virtual": "^3.13.23",
     "@types/nodemailer": "^8.0.0",
     "async-mutex": "^0.5.0",
     "fastify": "^5.8.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "nodenext",
     "target": "es2022",
     "types": ["node"],
-    "sourceMap": false,
+    "sourceMap": true,
     "declaration": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary\n- align package identity and CLI bin naming with canonical Aegis naming\n- enable TypeScript source maps for production-grade diagnostics\n- remove dashboard-only dependency from root server dependency graph\n- synchronize lockfile with package metadata changes\n\n## Linked Issues\n- Closes #1649\n- Closes #1654\n- Closes #1656\n\n## Verification\n- npx tsc --noEmit\n- npm run build\n\n## Aegis version\n**Developed with:** v0.3.2-alpha\n