### PR TITLE
fix(ci): repair release workflow secret guard expression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,15 +128,17 @@ jobs:
     needs: publish-npm
     runs-on: ubuntu-latest
     if: success()
+    env:
+      CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: ClawHub Login
-        if: ${{ secrets.CLAWHUB_TOKEN != '' }}
+        if: ${{ env.CLAWHUB_TOKEN != '' }}
         continue-on-error: true
-        run: npx clawhub@latest login --token ${{ secrets.CLAWHUB_TOKEN }}
+        run: npx clawhub@latest login --token ${{ env.CLAWHUB_TOKEN }}
       - name: Publish to ClawHub
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary
- fix invalid GitHub Actions expression in [./.github/workflows/release.yml](.github/workflows/release.yml) that caused workflow compilation failure
- move ClawHub secret to job env and gate login step with [env.CLAWHUB_TOKEN](.github/workflows/release.yml#L140)

## Root cause
The workflow used [secrets.CLAWHUB_TOKEN != '' ](.github/workflows/release.yml#L137) in a step-level if expression. GitHub marked this as an invalid workflow file with:
- Unrecognized named-value: 'secrets'

## Validation
- Release Please rerun succeeded: https://github.com/OneStepAt4time/aegis/actions/runs/24290354649
- New release PR opened by Release Please: https://github.com/OneStepAt4time/aegis/pull/1675