### PR TITLE
fix: use gh release upload for asset attachment to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,7 @@ jobs:
       - name: Attach checksums to GitHub Release
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          gh release edit "$TAG" --add-asset checksums.txt --clobber || \
-            gh release create "$TAG" --title "Release $TAG" --notes "See checksums.txt for artifact integrity." checksums.txt
+          gh release upload "$TAG" checksums.txt --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -119,8 +118,7 @@ jobs:
       - name: Attach SBOM to GitHub Release
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          gh release edit "$TAG" --add-asset sbom.json --clobber || \
-            gh release create "$TAG" --title "Release $TAG" --notes "SBOM available." sbom.json
+          gh release upload "$TAG" sbom.json --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes release workflow asset attachment failure.

The release workflow was using unsupported \gh release edit --add-asset\ flag. This changes it to use \gh release upload --clobber\ instead, which is supported in the GitHub CLI version available in Actions runners.

This fix enables checksums.txt and sbom.json to be properly attached to GitHub releases.

Related to: v0.5.0-alpha release