### PR TITLE
fix: skip release-please on all promote commits to prevent duplicate tag errors

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   release-please:
-    # Skip runs triggered by release-please's own commits or promote merges
+    # Skip runs triggered by release-please's own commits or promotion merges
     if: |
       !startsWith(github.event.head_commit.message, 'chore(main): release') &&
-      !startsWith(github.event.head_commit.message, 'chore: promote develop to main')
+      !startsWith(github.event.head_commit.message, 'chore: promote')
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
Fixes Release Please workflow to skip on any 'chore: promote' commit, not just 'chore: promote develop to main'.

This prevents duplicate tag errors when promotion PRs are merged to main and trigger Release Please again on release PRs that have already been processed.