### PR TITLE
fix: correct dashboard packaging for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "files": [
     "dist",
-    "dashboard/dist",
     "!dist/__tests__",
     "!dist/**/*.map"
   ],

--- a/scripts/copy-dashboard.mjs
+++ b/scripts/copy-dashboard.mjs
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+/**
+ * copy-dashboard.mjs — Copy dashboard build output into dist/dashboard/
+ *
+ * Called by `npm run build:copy-dashboard` (part of the main build).
+ * Validates that the copy succeeds and index.html is present.
+ *
+ * Issue #1699 / ARC-6: Added post-copy validation and proper error handling.
+ */
 import { cpSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -7,10 +15,19 @@ const dst = join("dist", "dashboard");
 
 if (existsSync(src)) {
   cpSync(src, dst, { recursive: true });
-  console.log("Dashboard copied to dist/dashboard/");
-} else if (process.env.npm_config_publish) {
-  console.error("Error: dashboard/dist/ not found in publish/CI context. Build the dashboard first.");
+
+  // Post-copy validation: ensure index.html was copied
+  const indexPath = join(dst, "index.html");
+  if (!existsSync(indexPath)) {
+    console.error(`Error: dashboard copy succeeded but ${indexPath} not found. Dashboard build may be incomplete.`);
+    process.exit(1);
+  }
+
+  console.log("Dashboard copied to dist/dashboard/ ✓");
+} else if (process.env.npm_lifecycle_event === 'prepublishOnly') {
+  // During npm publish, missing dashboard is a hard error
+  console.error("Error: dashboard/dist/ not found. Run 'npm run build:dashboard' first.");
   process.exit(1);
 } else {
-  console.log("No dashboard/dist/ found — skipping dashboard copy");
+  console.log("No dashboard/dist/ found — skipping dashboard copy (dev mode)");
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2621,10 +2621,11 @@ toolRegistry = new ToolRegistry();
 
   // #127: Serve dashboard static files (Issue #105) — graceful if missing
   // Issue #539: Dashboard is copied into dist/dashboard/ during build
+  // Issue #1699: Validates index.html presence for clearer diagnostics
   const dashboardRoot = path.join(__dirname, "dashboard");
   let dashboardAvailable = false;
   try {
-    await fs.access(dashboardRoot);
+    await fs.access(path.join(dashboardRoot, 'index.html'));
     dashboardAvailable = true;
   } catch {
     logger.warn({
@@ -2633,6 +2634,7 @@ toolRegistry = new ToolRegistry();
       errorCode: 'DASHBOARD_DIR_MISSING',
       attributes: {
         dashboardRoot,
+        hint: 'Run "npm run build:dashboard && npm run build:copy-dashboard" to populate dist/dashboard/',
       },
     });
   }


### PR DESCRIPTION
## Summary

Fix the dashboard 404 error in the published npm package (#1691). The root cause was \dashboard/dist\ in \package.json#files\ creating a wrong-path duplicate in the tarball, plus insufficient validation in the copy script.

## Changes

- **\package.json\** — Remove \dashboard/dist\ from \iles\ array. The dashboard is already copied to \dist/dashboard/\ by the build script; including \dashboard/dist\ caused a duplicate at the wrong path.
- **\scripts/copy-dashboard.mjs\** — Add post-copy validation (checks \dist/dashboard/index.html\ exists) and CI-aware error handling (hard fail if dashboard missing during publish).
- **\src/server.ts\** — Improve dashboard availability check: validate \index.html\ presence instead of just the directory, with actionable hint in the warning log.

## Testing

- \
px tsc --noEmit\ — clean
- \
pm run build\ — passes
- \
pm test\ — 158 passed, 0 failed (2801 tests total)

## Aegis version
**Developed with:** v0.3.2-alpha

Closes #1699
Fixes #1691