### PR TITLE
refactor: extract route middleware helpers (ARC-5)

### DIFF
--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -1,12 +1,18 @@
 /**
- * routes/context.ts — Shared route context, guards, and helpers.
+ * routes/context.ts — Shared route context, guards, middleware helpers.
  *
  * Every route module receives a RouteContext containing the shared
  * service instances needed to handle requests. Guards implement
  * ownership and RBAC checks used across multiple route modules.
+ *
+ * Middleware helpers (ARC-5):
+ *   - registerWithLegacy() — register both /v1/ and legacy paths in one call
+ *   - withValidation()     — wrap Zod body parsing into a handler decorator
+ *   - withOwnership()      — wrap ownership check, passes session to handler
  */
 
-import type { FastifyRequest, FastifyReply } from 'fastify';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { z } from 'zod';
 import type { SessionManager, SessionInfo } from '../session.js';
 import type { TmuxManager } from '../tmux.js';
 import type { AuthManager, ApiKeyRole } from '../services/auth/index.js';
@@ -159,5 +165,68 @@ export function makePayload(
     },
     detail,
     ...(meta && { meta }),
+  };
+}
+
+// ── ARC-5 Middleware Helpers ──────────────────────────────────────
+
+type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
+
+/**
+ * Register a route at both `/v1/...` and its legacy alias (without prefix)
+ * in a single call. Reduces duplicate route registrations.
+ *
+ * Accepts the same argument forms as Fastify's shorthand methods:
+ *   registerWithLegacy(app, 'get', '/v1/path', handler)
+ *   registerWithLegacy(app, 'post', '/v1/path', { config: {...}, handler })
+ */
+export function registerWithLegacy(
+  app: FastifyInstance,
+  method: HttpMethod,
+  v1Path: string,
+  // Fastify's RouteShorthandMethod uses generics that prevent type-safe
+  // dynamic dispatch across route schemas; accept unknown and delegate.
+  handlerOrOpts: unknown,
+): void {
+  const legacyPath = v1Path.replace(/^\/v1/, '');
+  const register = app[method].bind(app) as (path: string, opts: unknown) => void;
+  register(v1Path, handlerOrOpts);
+  register(legacyPath, handlerOrOpts);
+}
+
+type RouteHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<unknown> | unknown;
+
+/**
+ * Wrap a Zod schema parse around a route handler. On validation failure,
+ * returns 400 with structured error details. On success, passes the
+ * parsed data as a third argument to the inner handler.
+ */
+export function withValidation<T>(
+  schema: z.ZodType<T>,
+  handler: (req: FastifyRequest, reply: FastifyReply, data: T) => Promise<unknown> | unknown,
+): RouteHandler {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+    }
+    return handler(req, reply, parsed.data);
+  };
+}
+
+/**
+ * Wrap an ownership check around a session route handler. Validates that
+ * the caller owns the session identified by `req.params.id`, then passes
+ * the resolved SessionInfo to the inner handler.
+ */
+export function withOwnership(
+  sessions: SessionManager,
+  handler: (req: FastifyRequest, reply: FastifyReply, session: SessionInfo) => Promise<unknown> | unknown,
+): RouteHandler {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    const id = (req.params as { id: string }).id;
+    const session = requireOwnership(sessions, id, reply, req.authKeyId);
+    if (!session) return;
+    return handler(req, reply, session);
   };
 }

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { negotiate, type HandshakeRequest } from '../handshake.js';
 import { promRegistry, METRICS_CONTENT_TYPE } from '../prometheus.js';
 import { handshakeRequestSchema } from '../validation.js';
-import { type RouteContext, requireRole } from './context.js';
+import { type RouteContext, requireRole, registerWithLegacy } from './context.js';
 
 export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): void {
   const { sessions, tmux, metrics, channels, alertManager, swarmMonitor, auth } = ctx;
@@ -35,8 +35,7 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
     };
   }
 
-  app.get('/v1/health', { config: { rateLimit: healthRateLimitConfig }, handler: healthHandler });
-  app.get('/health', { config: { rateLimit: healthRateLimitConfig }, handler: healthHandler });
+  registerWithLegacy(app, 'get', '/v1/health', { config: { rateLimit: healthRateLimitConfig }, handler: healthHandler });
 
   // Issue #1412: Prometheus metrics scrape endpoint
   app.get('/metrics', async (req, reply) => {

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -9,8 +9,9 @@ import type { PermissionPolicy } from '../validation.js';
 import { registerPermissionRoutes } from '../permission-routes.js';
 import { cleanupTerminatedSessionState } from '../session-cleanup.js';
 import {
-  type RouteContext, type IdParams, type IdRequest,
+  type RouteContext, type IdRequest,
   requireRole, requireOwnership, makePayload,
+  registerWithLegacy, withOwnership,
 } from './context.js';
 
 export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteContext): void {
@@ -42,32 +43,22 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
   }
-  app.post<IdParams>('/v1/sessions/:id/send', sendMessageHandler);
-  app.post<IdParams>('/sessions/:id/send', sendMessageHandler);
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/send', sendMessageHandler);
 
   // Issue #702: GET children sessions
-  async function getChildrenHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return reply as unknown as Record<string, unknown>;
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/children', withOwnership(sessions, async (_req, _reply, session) => {
     const children = (session.children ?? []).map(id => {
       const child = sessions.getSession(id);
       if (!child) return null;
       return { id: child.id, windowName: child.windowName, status: child.status, createdAt: child.createdAt };
     }).filter(Boolean);
     return { children };
-  }
-  app.get<IdParams>('/v1/sessions/:id/children', getChildrenHandler);
-  app.get<IdParams>('/sessions/:id/children', getChildrenHandler);
+  }));
 
   // Issue #702: Spawn child session
   interface SpawnBody { name?: string; prompt?: string; workDir?: string; permissionMode?: string; }
-  type SpawnRequest = FastifyRequest<{ Params: { id: string }; Body: SpawnBody | undefined }>;
-  async function spawnChildHandler(req: SpawnRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const parentId = req.params.id;
-    const parent = requireOwnership(sessions, parentId, reply, req.authKeyId);
-    if (!parent) return reply as unknown as Record<string, unknown>;
-    const { name, prompt, workDir, permissionMode } = req.body ?? {};
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/spawn', withOwnership(sessions, async (req, reply, parent) => {
+    const { name, prompt, workDir, permissionMode } = (req.body as SpawnBody | undefined) ?? {};
     const childName = name ?? `${parent.windowName ?? 'session'}-child`;
     const requestedWorkDir = workDir ?? parent.workDir;
     const safeChildWorkDir = await validateWorkDir(requestedWorkDir);
@@ -75,22 +66,16 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       return reply.status(400).send({ error: `Invalid workDir: ${safeChildWorkDir.error}`, code: safeChildWorkDir.code });
     }
     const childPermMode = permissionMode ?? parent.permissionMode ?? 'default';
-    const childSession = await sessions.createSession({ workDir: safeChildWorkDir, name: childName, parentId, permissionMode: childPermMode, ownerKeyId: req.authKeyId });
+    const childSession = await sessions.createSession({ workDir: safeChildWorkDir, name: childName, parentId: parent.id, permissionMode: childPermMode, ownerKeyId: req.authKeyId });
     let promptDelivery: { delivered: boolean; attempts: number } | undefined;
     if (prompt) { promptDelivery = await sessions.sendInitialPrompt(childSession.id, prompt); }
     return reply.status(201).send({ ...childSession, promptDelivery });
-  }
-  app.post('/v1/sessions/:id/spawn', spawnChildHandler);
-  app.post('/sessions/:id/spawn', spawnChildHandler);
+  }));
 
   // Issue #468: Fork session
   interface ForkBody { name?: string; prompt?: string; clearPanes?: boolean; }
-  type ForkRequest = FastifyRequest<{ Params: { id: string }; Body: ForkBody | undefined }>;
-  async function forkSessionHandler(req: ForkRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const parentId = req.params.id;
-    const parent = requireOwnership(sessions, parentId, reply, req.authKeyId);
-    if (!parent) return reply as unknown as Record<string, unknown>;
-    const { name, prompt } = req.body ?? {};
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/fork', withOwnership(sessions, async (req, reply, parent) => {
+    const { name, prompt } = (req.body as ForkBody | undefined) ?? {};
     const forkName = name ?? `${parent.windowName ?? 'session'}-fork`;
     const forkedSession = await sessions.createSession({
       workDir: parent.workDir,
@@ -104,70 +89,43 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       event: 'session.created',
       timestamp: new Date().toISOString(),
       session: { id: forkedSession.id, name: forkedSession.windowName, workDir: parent.workDir },
-      detail: `Session forked from ${parentId}`,
+      detail: `Session forked from ${parent.id}`,
     });
-    return reply.status(201).send({ ...forkedSession, forkedFrom: parentId, promptDelivery });
-  }
-  app.post('/v1/sessions/:id/fork', forkSessionHandler);
-  app.post('/sessions/:id/fork', forkSessionHandler);
+    return reply.status(201).send({ ...forkedSession, forkedFrom: parent.id, promptDelivery });
+  }));
 
   // Issue #700: Permission policy endpoints
-  type PermissionRequest = FastifyRequest<{ Params: { id: string }; Body: PermissionPolicy | undefined }>;
-  async function getPermissionPolicyHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return reply as unknown as Record<string, unknown>;
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/permissions', withOwnership(sessions, async (_req, _reply, session) => {
     return { permissionPolicy: session.permissionPolicy ?? [] };
-  }
-  async function updatePermissionPolicyHandler(req: PermissionRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return reply as unknown as Record<string, unknown>;
-    const policy = req.body ?? [];
+  }));
+  registerWithLegacy(app, 'put', '/v1/sessions/:id/permissions', withOwnership(sessions, async (req, reply, session) => {
+    const policy = (req.body as PermissionPolicy | undefined) ?? [];
     const result = permissionRuleSchema.array().safeParse(policy);
     if (!result.success) return reply.status(400).send({ error: 'Invalid permission policy', details: result.error.issues });
     session.permissionPolicy = policy;
     await sessions.save();
     return { permissionPolicy: policy };
-  }
-  app.get<IdParams>('/v1/sessions/:id/permissions', getPermissionPolicyHandler);
-  app.put('/v1/sessions/:id/permissions', updatePermissionPolicyHandler);
-  app.get<IdParams>('/sessions/:id/permissions', getPermissionPolicyHandler);
-  app.put('/sessions/:id/permissions', updatePermissionPolicyHandler);
+  }));
 
-  type PermissionProfileRequest = FastifyRequest<{ Params: { id: string }; Body: PermissionProfile | undefined }>;
-  async function getPermissionProfileHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return reply as unknown as Record<string, unknown>;
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/permission-profile', withOwnership(sessions, async (_req, _reply, session) => {
     return { permissionProfile: session.permissionProfile ?? null };
-  }
-  async function updatePermissionProfileHandler(req: PermissionProfileRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return reply as unknown as Record<string, unknown>;
-    const parsed = permissionProfileSchema.safeParse(req.body ?? {});
+  }));
+  registerWithLegacy(app, 'put', '/v1/sessions/:id/permission-profile', withOwnership(sessions, async (req, reply, session) => {
+    const parsed = permissionProfileSchema.safeParse((req.body as PermissionProfile | undefined) ?? {});
     if (!parsed.success) return reply.status(400).send({ error: 'Invalid permission profile', details: parsed.error.issues });
     session.permissionProfile = parsed.data;
     await sessions.save();
     return { permissionProfile: parsed.data };
-  }
-  app.get<IdParams>('/v1/sessions/:id/permission-profile', getPermissionProfileHandler);
-  app.put('/v1/sessions/:id/permission-profile', updatePermissionProfileHandler);
-  app.get<IdParams>('/sessions/:id/permission-profile', getPermissionProfileHandler);
-  app.put('/sessions/:id/permission-profile', updatePermissionProfileHandler);
+  }));
 
   // Read messages
-  async function readMessagesHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
-    if (!requireOwnership(sessions, req.params.id, reply, req.authKeyId)) return;
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/read', withOwnership(sessions, async (_req, reply, session) => {
     try {
-      return await sessions.readMessages(req.params.id);
+      return await sessions.readMessages(session.id);
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
-  }
-  app.get<IdParams>('/v1/sessions/:id/read', readMessagesHandler);
-  app.get<IdParams>('/sessions/:id/read', readMessagesHandler);
+  }));
 
   // Register approve/reject permission routes
   registerPermissionRoutes(
@@ -189,23 +147,17 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   );
 
   // Issue #336: Answer pending AskUserQuestion
-  app.post<{
-    Params: { id: string };
-    Body: { questionId?: string; answer?: string };
-  }>('/v1/sessions/:id/answer', async (req, reply) => {
-    const { questionId, answer } = req.body || {};
+  app.post('/v1/sessions/:id/answer', withOwnership(sessions, async (req, reply, session) => {
+    const { questionId, answer } = (req.body as { questionId?: string; answer?: string } | undefined) || {};
     if (!questionId || answer === undefined || answer === null) {
       return reply.status(400).send({ error: 'questionId and answer are required' });
     }
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return;
-    const resolved = sessions.submitAnswer(req.params.id, questionId, answer);
+    const resolved = sessions.submitAnswer(session.id, questionId, answer);
     if (!resolved) {
       return reply.status(409).send({ error: 'No pending question matching this questionId' });
     }
     return { ok: true };
-  });
+  }));
 
   // Escape
   async function escapeHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
@@ -218,8 +170,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
   }
-  app.post<IdParams>('/v1/sessions/:id/escape', escapeHandler);
-  app.post<IdParams>('/sessions/:id/escape', escapeHandler);
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/escape', escapeHandler);
 
   // Interrupt (Ctrl+C)
   async function interruptHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
@@ -232,8 +183,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
   }
-  app.post<IdParams>('/v1/sessions/:id/interrupt', interruptHandler);
-  app.post<IdParams>('/sessions/:id/interrupt', interruptHandler);
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/interrupt', interruptHandler);
 
   // Kill session
   async function killSessionHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
@@ -251,19 +201,13 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
   }
-  app.delete<IdParams>('/v1/sessions/:id', killSessionHandler);
-  app.delete<IdParams>('/sessions/:id', killSessionHandler);
+  registerWithLegacy(app, 'delete', '/v1/sessions/:id', killSessionHandler);
 
   // Capture raw pane
-  async function capturePaneHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return;
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/pane', withOwnership(sessions, async (_req, _reply, session) => {
     const pane = await tmux.capturePane(session.windowId);
     return { pane };
-  }
-  app.get<IdParams>('/v1/sessions/:id/pane', capturePaneHandler);
-  app.get<IdParams>('/sessions/:id/pane', capturePaneHandler);
+  }));
 
   // Slash command
   async function commandHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
@@ -280,8 +224,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
   }
-  app.post<IdParams>('/v1/sessions/:id/command', commandHandler);
-  app.post<IdParams>('/sessions/:id/command', commandHandler);
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/command', commandHandler);
 
   // Bash mode
   async function bashHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
@@ -298,6 +241,5 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
   }
-  app.post<IdParams>('/v1/sessions/:id/bash', bashHandler);
-  app.post<IdParams>('/sessions/:id/bash', bashHandler);
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/bash', bashHandler);
 }

--- a/src/routes/session-data.ts
+++ b/src/routes/session-data.ts
@@ -13,36 +13,32 @@ import { readNewEntries } from '../transcript.js';
 import { SSEWriter } from '../sse-writer.js';
 import type { SessionSSEEvent } from '../events.js';
 import {
-  type RouteContext, type IdParams, type IdRequest,
-  requireOwnership, makePayload,
+  type RouteContext, type IdRequest,
+  requireOwnership,
+  registerWithLegacy, withOwnership,
 } from './context.js';
 
 export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContext): void {
   const { sessions, auth, config, metrics, monitor, eventBus, channels, toolRegistry, sseLimiter } = ctx;
 
   // Per-session metrics (Issue #40)
-  app.get<{ Params: { id: string } }>('/v1/sessions/:id/metrics', async (req, reply) => {
-    const session = requireOwnership(sessions, req.params.id, reply, req.authKeyId);
-    if (!session) return;
-    const m = metrics.getSessionMetrics(req.params.id);
+  app.get('/v1/sessions/:id/metrics', withOwnership(sessions, async (req, reply, session) => {
+    const m = metrics.getSessionMetrics(session.id);
     if (!m) return reply.status(404).send({ error: 'No metrics for this session' });
     return m;
-  });
+  }));
 
   // Issue #704: Tool usage per session
-  app.get<IdParams>('/v1/sessions/:id/tools', async (req, reply) => {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return;
+  app.get('/v1/sessions/:id/tools', withOwnership(sessions, async (_req, _reply, session) => {
     if (session.jsonlPath) {
       try {
         const result = await readNewEntries(session.jsonlPath, 0);
-        toolRegistry.processEntries(req.params.id, result.entries);
+        toolRegistry.processEntries(session.id, result.entries);
       } catch { /* JSONL not available */ }
     }
-    const tools = toolRegistry.getSessionTools(req.params.id);
-    return { sessionId: req.params.id, tools, totalCalls: tools.reduce((sum, t) => sum + t.count, 0) };
-  });
+    const tools = toolRegistry.getSessionTools(session.id);
+    return { sessionId: session.id, tools, totalCalls: tools.reduce((sum, t) => sum + t.count, 0) };
+  }));
 
   // Global tool definitions
   app.get('/v1/tools', async () => {
@@ -52,24 +48,18 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
   });
 
   // Issue #87: Per-session latency metrics
-  app.get<{ Params: { id: string } }>('/v1/sessions/:id/latency', async (req, reply) => {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return;
-    const realtimeLatency = sessions.getLatencyMetrics(req.params.id);
-    const aggregatedLatency = metrics.getSessionLatency(req.params.id);
-    return { sessionId: req.params.id, realtime: realtimeLatency, aggregated: aggregatedLatency };
-  });
+  app.get('/v1/sessions/:id/latency', withOwnership(sessions, async (_req, _reply, session) => {
+    const realtimeLatency = sessions.getLatencyMetrics(session.id);
+    const aggregatedLatency = metrics.getSessionLatency(session.id);
+    return { sessionId: session.id, realtime: realtimeLatency, aggregated: aggregatedLatency };
+  }));
 
   // Session summary (Issue #35)
-  async function summaryHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
-    if (!requireOwnership(sessions, req.params.id, reply, req.authKeyId)) return;
-    try { return await sessions.getSummary(req.params.id); } catch (e: unknown) {
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/summary', withOwnership(sessions, async (_req, reply, session) => {
+    try { return await sessions.getSummary(session.id); } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
-  }
-  app.get<IdParams>('/v1/sessions/:id/summary', summaryHandler);
-  app.get<IdParams>('/sessions/:id/summary', summaryHandler);
+  }));
 
   // Paginated transcript read
   app.get<{
@@ -154,31 +144,26 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
       return reply.status(500).send({ error: `Screenshot failed: ${e instanceof Error ? e.message : String(e)}` });
     }
   }
-  app.post<IdParams>('/v1/sessions/:id/screenshot', screenshotHandler);
-  app.post<IdParams>('/sessions/:id/screenshot', screenshotHandler);
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/screenshot', screenshotHandler);
 
   // Issue #740: Verification Protocol
-  app.post('/v1/sessions/:id/verify', async (req, reply) => {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return;
-
+  app.post('/v1/sessions/:id/verify', withOwnership(sessions, async (_req, reply, session) => {
     const { workDir } = session;
     if (!workDir) return reply.status(400).send({ error: 'Session has no workDir' });
 
     const criticalOnly = (config as { verificationProtocol?: { criticalOnly?: boolean } }).verificationProtocol?.criticalOnly ?? false;
-    eventBus.emitStatus(sessionId, 'working', `Running verification (criticalOnly=${criticalOnly})…`);
+    eventBus.emitStatus(session.id, 'working', `Running verification (criticalOnly=${criticalOnly})…`);
 
     try {
       const result = await runVerification(workDir, criticalOnly);
-      eventBus.emitVerification(sessionId, result);
+      eventBus.emitVerification(session.id, result);
       const httpStatus = result.ok ? 200 : 422;
       return reply.status(httpStatus).send(result);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       return reply.status(500).send({ ok: false, summary: `Verification error: ${msg}` });
     }
-  });
+  }));
 
   // Per-session SSE event stream (Issue #32)
   app.get<{ Params: { id: string } }>('/v1/sessions/:id/events', async (req, reply) => {

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -9,8 +9,9 @@ import { promisify } from 'node:util';
 import { compareSemver, extractCCVersion, MIN_CC_VERSION } from '../validation.js';
 import { cleanupTerminatedSessionState } from '../session-cleanup.js';
 import {
-  type RouteContext, type IdParams, type IdRequest,
-  requireRole, requireOwnership, addActionHints, makePayload,
+  type RouteContext,
+  requireRole, addActionHints, makePayload,
+  registerWithLegacy, withOwnership,
 } from './context.js';
 
 const execFileAsync = promisify(execFile);
@@ -237,16 +238,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
 
     return reply.status(201).send({ ...session, promptDelivery });
   }
-  app.post('/v1/sessions', {
-    config: {
-      rateLimit: {
-        max: 120,
-        timeWindow: '1 minute',
-      },
-    },
-    handler: createSessionHandler,
-  });
-  app.post('/sessions', {
+  registerWithLegacy(app, 'post', '/v1/sessions', {
     config: {
       rateLimit: {
         max: 120,
@@ -257,14 +249,9 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
   });
 
   // Get session (Issue #20: includes actionHints)
-  async function getSessionHandler(req: IdRequest, reply: FastifyReply): Promise<Record<string, unknown>> {
-    const sessionId = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, sessionId, reply, req.authKeyId);
-    if (!session) return reply as unknown as Record<string, unknown>;
+  registerWithLegacy(app, 'get', '/v1/sessions/:id', withOwnership(sessions, async (_req, _reply, session) => {
     return addActionHints(session, sessions);
-  }
-  app.get<IdParams>('/v1/sessions/:id', getSessionHandler);
-  app.get<IdParams>('/sessions/:id', getSessionHandler);
+  }));
 
   // #128: Bulk health check
   app.get('/v1/sessions/health', async (req, reply) => {
@@ -303,14 +290,11 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
   });
 
   // Session health check (Issue #2)
-  async function sessionHealthHandler(req: IdRequest, reply: FastifyReply): Promise<unknown> {
-    if (!requireOwnership(sessions, req.params.id, reply, req.authKeyId)) return;
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/health', withOwnership(sessions, async (_req, reply, session) => {
     try {
-      return await sessions.getHealth(req.params.id);
+      return await sessions.getHealth(session.id);
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
-  }
-  app.get<IdParams>('/v1/sessions/:id/health', sessionHealthHandler);
-  app.get<IdParams>('/sessions/:id/health', sessionHealthHandler);
+  }));
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -181,40 +181,12 @@ const app = Fastify({
   },
 });
 
-const RATE_LIMIT_WINDOW = '1 minute';
-const RATE_LIMITS = {
-  global: { max: 600, timeWindow: RATE_LIMIT_WINDOW },
-  health: { max: 240, timeWindow: RATE_LIMIT_WINDOW },
-  metrics: { max: 240, timeWindow: RATE_LIMIT_WINDOW },
-  adminAction: { max: 60, timeWindow: RATE_LIMIT_WINDOW },
-  authVerify: { max: 60, timeWindow: RATE_LIMIT_WINDOW },
-  authKeyWrite: { max: 60, timeWindow: RATE_LIMIT_WINDOW },
-  audit: { max: 120, timeWindow: RATE_LIMIT_WINDOW },
-  sessionCreate: { max: 120, timeWindow: RATE_LIMIT_WINDOW },
-  expensiveRead: { max: 120, timeWindow: RATE_LIMIT_WINDOW },
-} as const;
-
 app.register(fastifyRateLimit, {
   global: true,
   keyGenerator: (req) => req.ip ?? 'unknown',
-  ...RATE_LIMITS.global,
+  max: 600,
+  timeWindow: '1 minute',
 });
-
-function createRateLimitPreHandler(options: { max: number; timeWindow: string }) {
-  return async (req: FastifyRequest, reply: FastifyReply) => {
-    const limiter = app.rateLimit(options);
-    await limiter.call(app, req, reply);
-  };
-}
-
-const healthRateLimit = createRateLimitPreHandler(RATE_LIMITS.health);
-const metricsRateLimit = createRateLimitPreHandler(RATE_LIMITS.metrics);
-const adminActionRateLimit = createRateLimitPreHandler(RATE_LIMITS.adminAction);
-const authVerifyRateLimit = createRateLimitPreHandler(RATE_LIMITS.authVerify);
-const authKeyWriteRateLimit = createRateLimitPreHandler(RATE_LIMITS.authKeyWrite);
-const auditRateLimit = createRateLimitPreHandler(RATE_LIMITS.audit);
-const sessionCreateRateLimit = createRateLimitPreHandler(RATE_LIMITS.sessionCreate);
-const expensiveReadRateLimit = createRateLimitPreHandler(RATE_LIMITS.expensiveRead);
 
 // #1108: Decorate request with authKeyId — type-safe alternative to unsafe cast
 app.decorateRequest('authKeyId', null as unknown as string);


### PR DESCRIPTION
## Summary
Extracts three route middleware helpers into \src/routes/context.ts\ and applies them across route modules, eliminating boilerplate from dual-registration and inline ownership checks.

### Changes
1. **\egisterWithLegacy()\** — registers both \/v1/...\ and legacy \/...\ paths in one call  
2. **\withOwnership()\** — wraps ownership check, passes resolved \SessionInfo\ to handler  
3. **\withValidation<T>()\** — wraps Zod body parsing (available for future use)  
4. **Dead code cleanup** — removes unused \RATE_LIMITS\, \createRateLimitPreHandler()\, and 8 unused preHandler variables from \server.ts\

### Impact
- 20 dual-registration sites consolidated (session-actions, session-data, sessions, health)
- 15 inline \equireOwnership\ checks replaced with \withOwnership\ wrapper
- Net reduction: **49 lines** of boilerplate  
- 6 files changed, 146 insertions, 195 deletions

### Quality Gate
- \
px tsc --noEmit\ ✅
- \
pm run build\ ✅
- \
pm test\ ✅ (159 files, 2814 tests pass)

## Aegis version
**Developed with:** v0.3.2-alpha

Closes #1698