### PR TITLE
refactor: introduce IAegisBackend service layer for MCP (#1697)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7,4 +7,6 @@
  */
 
 export { AegisClient } from './mcp/client.js';
-export { createMcpServer, startMcpServer } from './mcp/server.js';
+export { EmbeddedBackend } from './mcp/embedded.js';
+export { createMcpServer, createMcpServerFromBackend, startMcpServer } from './mcp/server.js';
+export type { IAegisBackend } from './services/interfaces.js';

--- a/src/mcp/auth.ts
+++ b/src/mcp/auth.ts
@@ -5,7 +5,7 @@
  * role mapping, and structured MCP error envelopes.
  */
 
-import type { AegisClient } from './client.js';
+import type { IAegisBackend } from '../services/interfaces.js';
 
 // ── Error handling ──────────────────────────────────────────────────
 
@@ -87,7 +87,7 @@ function formatAuthError(toolName: string, role: string, required: string): { co
 export function withAuth<TArgs>(
   toolName: string,
   handler: (args: TArgs) => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }>,
-  client: AegisClient,
+  client: IAegisBackend,
 ): (args: TArgs) => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
   return async (args) => {
     const role = await client.resolveRole();

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,64 +1,33 @@
-/** mcp/client.ts — AegisClient REST client for MCP remote mode. */
+/** mcp/client.ts — AegisClient REST client (remote-mode IAegisBackend adapter). */
 
 import { resolve } from 'node:path';
 import { isValidUUID } from '../validation.js';
 import type { SessionInfo } from '../session.js';
-import type { SessionMetrics, SessionLatency, SessionLatencySummary } from '../metrics.js';
+import type { SessionMetrics } from '../metrics.js';
 import type { PipelineState, BatchResult } from '../pipeline.js';
+import type {
+  IAegisBackend,
+  ServerHealthResponse,
+  CreateSessionResponse,
+  SendMessageResponse,
+  OkResponse,
+  CapturePaneResponse,
+  SessionLatencyResponse,
+  MemoryEntryResponse,
+} from '../services/interfaces.js';
 
-export interface ServerHealthResponse {
-  status: string;
-  version: string;
-  platform: NodeJS.Platform;
-  uptime: number;
-  sessions: { active: number; total: number };
-  tmux: { healthy: boolean; [key: string]: unknown };
-  timestamp: string;
-}
+// Re-export response types for backward compatibility
+export type {
+  ServerHealthResponse,
+  CreateSessionResponse,
+  SendMessageResponse,
+  OkResponse,
+  CapturePaneResponse,
+  SessionLatencyResponse,
+  MemoryEntryResponse,
+} from '../services/interfaces.js';
 
-export interface CreateSessionResponse {
-  id: string;
-  windowName: string;
-  workDir: string;
-  status: string;
-  promptDelivery?: { delivered: boolean; attempts: number };
-  reused?: boolean;
-  [key: string]: unknown;
-}
-
-export interface SendMessageResponse {
-  ok: boolean;
-  delivered: boolean;
-  attempts: number;
-  stall?: { stalled: true; types: string[] } | { stalled: false };
-}
-
-export interface OkResponse {
-  ok: boolean;
-}
-
-export interface CapturePaneResponse {
-  pane: string;
-}
-
-export interface SessionLatencyResponse {
-  sessionId: string;
-  realtime: SessionLatency | null;
-  aggregated: SessionLatencySummary | null;
-}
-
-export interface MemoryEntryResponse {
-  entry: {
-    key: string;
-    value: string;
-    namespace: string;
-    created_at: number;
-    updated_at: number;
-    expires_at?: number;
-  };
-}
-
-function normalizeWorkDirForCompare(workDir: string): string {
+export function normalizeWorkDirForCompare(workDir: string): string {
   const isWindowsLikePath = /^[a-zA-Z]:[\\/]/.test(workDir) || workDir.startsWith('\\\\');
   const normalizedPath = (isWindowsLikePath ? workDir : resolve(workDir))
     .replace(/\\/g, '/')
@@ -68,13 +37,13 @@ function normalizeWorkDirForCompare(workDir: string): string {
     : normalizedPath;
 }
 
-function isSameOrChildWorkDir(candidate: string, parent: string): boolean {
+export function isSameOrChildWorkDir(candidate: string, parent: string): boolean {
   const normalizedCandidate = normalizeWorkDirForCompare(candidate);
   const normalizedParent = normalizeWorkDirForCompare(parent);
   return normalizedCandidate === normalizedParent || normalizedCandidate.startsWith(`${normalizedParent}/`);
 }
 
-export class AegisClient {
+export class AegisClient implements IAegisBackend {
   /** Cached role resolved from /v1/auth/verify. undefined = not yet resolved. */
   private resolvedRole: string | undefined;
 
@@ -269,7 +238,7 @@ export class AegisClient {
   async createPipeline(config: { name: string; workDir: string; steps: Array<{ name?: string; prompt: string }> }): Promise<PipelineState> {
     return this.request('/v1/pipelines', {
       method: 'POST',
-      body: JSON.stringify(config),
+      body: JSON.stringify({ name: config.name, workDir: config.workDir, stages: config.steps }),
     });
   }
 

--- a/src/mcp/embedded.ts
+++ b/src/mcp/embedded.ts
@@ -1,0 +1,271 @@
+/**
+ * mcp/embedded.ts — In-process IAegisBackend adapter (direct class delegation).
+ *
+ * Used when the MCP server runs inside the same process as the Aegis HTTP server,
+ * avoiding HTTP round-trips. AegisClient remains the remote-mode adapter.
+ */
+
+import { isValidUUID } from '../validation.js';
+import type { SessionManager, SessionInfo } from '../session.js';
+import type { TmuxManager } from '../tmux.js';
+import type { MetricsCollector, SessionMetrics } from '../metrics.js';
+import type { PipelineManager, PipelineState, BatchResult } from '../pipeline.js';
+import type { MemoryBridge } from '../memory-bridge.js';
+import type { SwarmMonitor } from '../swarm-monitor.js';
+import { isSameOrChildWorkDir } from './client.js';
+import type {
+  IAegisBackend,
+  ServerHealthResponse,
+  CreateSessionResponse,
+  SendMessageResponse,
+  OkResponse,
+  CapturePaneResponse,
+  SessionLatencyResponse,
+  MemoryEntryResponse,
+} from '../services/interfaces.js';
+
+export interface EmbeddedBackendDeps {
+  sessions: SessionManager;
+  tmux: TmuxManager;
+  pipelines: PipelineManager;
+  metrics: MetricsCollector;
+  memory: MemoryBridge | null;
+  swarm: SwarmMonitor | null;
+  version: string;
+}
+
+export class EmbeddedBackend implements IAegisBackend {
+  private readonly sessions: SessionManager;
+  private readonly tmux: TmuxManager;
+  private readonly pipelines: PipelineManager;
+  private readonly metrics: MetricsCollector;
+  private readonly memory: MemoryBridge | null;
+  private readonly swarm: SwarmMonitor | null;
+  private readonly version: string;
+  private readonly role: string;
+
+  constructor(deps: EmbeddedBackendDeps, role = 'admin') {
+    this.sessions = deps.sessions;
+    this.tmux = deps.tmux;
+    this.pipelines = deps.pipelines;
+    this.metrics = deps.metrics;
+    this.memory = deps.memory;
+    this.swarm = deps.swarm;
+    this.version = deps.version;
+    this.role = role;
+  }
+
+  private requireSession(id: string): SessionInfo {
+    if (!isValidUUID(id)) throw new Error(`Invalid session ID: ${id}`);
+    const session = this.sessions.getSession(id);
+    if (!session) throw new Error('Session not found');
+    return session;
+  }
+
+  // ── IAuthService ──────────────────────────────────────────────────
+
+  async resolveRole(): Promise<string> {
+    return this.role;
+  }
+
+  // ── ISessionService ───────────────────────────────────────────────
+
+  async listSessions(filter?: { status?: string; workDir?: string }): Promise<SessionInfo[]> {
+    let result = this.sessions.listSessions();
+    if (filter?.status) result = result.filter(s => s.status === filter.status);
+    if (filter?.workDir) result = result.filter(s => isSameOrChildWorkDir(s.workDir, filter.workDir!));
+    return result;
+  }
+
+  async getSession(id: string): Promise<Record<string, unknown>> {
+    return this.requireSession(id) as unknown as Record<string, unknown>;
+  }
+
+  async getHealth(id: string): Promise<Record<string, unknown>> {
+    this.requireSession(id);
+    const health = await this.sessions.getHealth(id);
+    return health as unknown as Record<string, unknown>;
+  }
+
+  async getTranscript(id: string): Promise<Record<string, unknown>> {
+    this.requireSession(id);
+    const messages = await this.sessions.readMessages(id);
+    return messages as unknown as Record<string, unknown>;
+  }
+
+  async createSession(opts: { workDir: string; name?: string; prompt?: string }): Promise<CreateSessionResponse> {
+    // Try idle session reuse (matches HTTP route behavior)
+    const idle = await this.sessions.findIdleSessionByWorkDir(opts.workDir);
+    if (idle) {
+      let promptDelivery: { delivered: boolean; attempts: number } | undefined;
+      if (opts.prompt) {
+        promptDelivery = await this.sessions.sendInitialPrompt(idle.id, opts.prompt);
+      }
+      return {
+        id: idle.id,
+        windowName: idle.windowName,
+        workDir: idle.workDir,
+        status: idle.status,
+        reused: true,
+        promptDelivery,
+      };
+    }
+
+    const session = await this.sessions.createSession({
+      workDir: opts.workDir,
+      name: opts.name,
+    });
+    let promptDelivery: { delivered: boolean; attempts: number } | undefined;
+    if (opts.prompt) {
+      promptDelivery = await this.sessions.sendInitialPrompt(session.id, opts.prompt);
+    }
+    return {
+      id: session.id,
+      windowName: session.windowName,
+      workDir: session.workDir,
+      status: session.status,
+      promptDelivery,
+    };
+  }
+
+  async killSession(id: string): Promise<OkResponse> {
+    this.requireSession(id);
+    await this.sessions.killSession(id);
+    return { ok: true };
+  }
+
+  async sendMessage(id: string, text: string): Promise<SendMessageResponse> {
+    this.requireSession(id);
+    const result = await this.sessions.sendMessage(id, text);
+    return { ok: true, ...result };
+  }
+
+  async approvePermission(id: string): Promise<OkResponse> {
+    this.requireSession(id);
+    await this.sessions.approve(id);
+    return { ok: true };
+  }
+
+  async rejectPermission(id: string): Promise<OkResponse> {
+    this.requireSession(id);
+    await this.sessions.reject(id);
+    return { ok: true };
+  }
+
+  async escapeSession(id: string): Promise<OkResponse> {
+    this.requireSession(id);
+    await this.sessions.escape(id);
+    return { ok: true };
+  }
+
+  async interruptSession(id: string): Promise<OkResponse> {
+    this.requireSession(id);
+    await this.sessions.interrupt(id);
+    return { ok: true };
+  }
+
+  async capturePane(id: string): Promise<CapturePaneResponse> {
+    const session = this.requireSession(id);
+    const pane = await this.tmux.capturePane(session.windowId);
+    return { pane };
+  }
+
+  async sendBash(id: string, command: string): Promise<OkResponse> {
+    this.requireSession(id);
+    const cmd = command.startsWith('!') ? command : `!${command}`;
+    await this.sessions.sendMessage(id, cmd);
+    return { ok: true };
+  }
+
+  async sendCommand(id: string, command: string): Promise<OkResponse> {
+    this.requireSession(id);
+    const cmd = command.startsWith('/') ? command : `/${command}`;
+    await this.sessions.sendMessage(id, cmd);
+    return { ok: true };
+  }
+
+  async getSessionSummary(id: string): Promise<Record<string, unknown>> {
+    this.requireSession(id);
+    const summary = await this.sessions.getSummary(id);
+    return summary as unknown as Record<string, unknown>;
+  }
+
+  async getSessionMetrics(id: string): Promise<SessionMetrics> {
+    this.requireSession(id);
+    const m = this.metrics.getSessionMetrics(id);
+    if (!m) throw new Error('Metrics not found');
+    return m;
+  }
+
+  async getSessionLatency(id: string): Promise<SessionLatencyResponse> {
+    this.requireSession(id);
+    return {
+      sessionId: id,
+      realtime: this.sessions.getLatencyMetrics(id) ?? null,
+      aggregated: this.metrics.getSessionLatency(id) ?? null,
+    };
+  }
+
+  // ── IServerService ────────────────────────────────────────────────
+
+  async getServerHealth(): Promise<ServerHealthResponse> {
+    const tmuxHealth = await this.tmux.isServerHealthy();
+    return {
+      status: tmuxHealth.healthy ? 'ok' : 'degraded',
+      version: this.version,
+      platform: process.platform,
+      uptime: process.uptime(),
+      sessions: {
+        active: this.sessions.listSessions().length,
+        total: this.metrics.getTotalSessionsCreated(),
+      },
+      tmux: tmuxHealth,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  async getSwarm(): Promise<Record<string, unknown>> {
+    if (!this.swarm) return {};
+    const result = this.swarm.getLastResult();
+    return (result ?? {}) as Record<string, unknown>;
+  }
+
+  // ── IPipelineService ──────────────────────────────────────────────
+
+  async batchCreateSessions(sessions: Array<{ workDir: string; name?: string; prompt?: string }>): Promise<BatchResult> {
+    return this.pipelines.batchCreate(sessions);
+  }
+
+  async listPipelines(): Promise<PipelineState[]> {
+    return this.pipelines.listPipelines();
+  }
+
+  async createPipeline(config: { name: string; workDir: string; steps: Array<{ name?: string; prompt: string }> }): Promise<PipelineState> {
+    return this.pipelines.createPipeline({
+      name: config.name,
+      workDir: config.workDir,
+      stages: config.steps.map((s, i) => ({ name: s.name ?? `step-${i + 1}`, prompt: s.prompt })),
+    });
+  }
+
+  // ── IMemoryService ────────────────────────────────────────────────
+
+  async setMemory(key: string, value: string, ttlSeconds?: number): Promise<MemoryEntryResponse> {
+    if (!this.memory) throw new Error('Memory bridge not available');
+    const entry = this.memory.set(key, value, ttlSeconds);
+    return { entry };
+  }
+
+  async getMemory(key: string): Promise<MemoryEntryResponse> {
+    if (!this.memory) throw new Error('Memory bridge not available');
+    const entry = this.memory.get(key);
+    if (!entry) throw new Error(`Memory key not found: ${key}`);
+    return { entry };
+  }
+
+  async deleteMemory(key: string): Promise<OkResponse> {
+    if (!this.memory) throw new Error('Memory bridge not available');
+    this.memory.delete(key);
+    return { ok: true };
+  }
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -9,9 +9,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { isValidUUID } from '../validation.js';
-import type { AegisClient } from './client.js';
+import type { IAegisBackend } from '../services/interfaces.js';
 
-export function registerResources(server: McpServer, client: AegisClient): void {
+export function registerResources(server: McpServer, client: IAegisBackend): void {
   // aegis://sessions — compact session list
   server.resource(
     'sessions',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -12,6 +12,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { AegisClient } from './client.js';
+import type { IAegisBackend } from '../services/interfaces.js';
 import { registerResources } from './resources.js';
 import { registerSessionTools } from './tools/session-tools.js';
 import { registerMonitoringTools } from './tools/monitoring-tools.js';
@@ -24,22 +25,27 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8')) as { version: string };
 const VERSION: string = pkg.version;
 
-export function createMcpServer(aegisPort: number, authToken?: string): McpServer {
-  const client = new AegisClient(`http://127.0.0.1:${aegisPort}`, authToken);
-
+/** Create an MCP server wired to any IAegisBackend implementation. */
+export function createMcpServerFromBackend(backend: IAegisBackend): McpServer {
   const server = new McpServer(
     { name: 'aegis', version: VERSION },
     { capabilities: { tools: {}, resources: {} } },
   );
 
-  registerResources(server, client);
-  registerSessionTools(server, client);
-  registerMonitoringTools(server, client);
-  registerPipelineTools(server, client);
-  registerManagementTools(server, client);
+  registerResources(server, backend);
+  registerSessionTools(server, backend);
+  registerMonitoringTools(server, backend);
+  registerPipelineTools(server, backend);
+  registerManagementTools(server, backend);
   registerPrompts(server);
 
   return server;
+}
+
+/** Create an MCP server using the remote HTTP client (backward-compatible). */
+export function createMcpServer(aegisPort: number, authToken?: string): McpServer {
+  const client = new AegisClient(`http://127.0.0.1:${aegisPort}`, authToken);
+  return createMcpServerFromBackend(client);
 }
 
 export async function startMcpServer(port: number, authToken?: string): Promise<void> {

--- a/src/mcp/tools/management-tools.ts
+++ b/src/mcp/tools/management-tools.ts
@@ -7,10 +7,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import type { AegisClient } from '../client.js';
+import type { IAegisBackend } from '../../services/interfaces.js';
 import { withAuth, formatToolError } from '../auth.js';
 
-export function registerManagementTools(server: McpServer, client: AegisClient): void {
+export function registerManagementTools(server: McpServer, client: IAegisBackend): void {
   // ── state_set ──
   server.tool(
     'state_set',

--- a/src/mcp/tools/monitoring-tools.ts
+++ b/src/mcp/tools/monitoring-tools.ts
@@ -8,10 +8,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import type { AegisClient } from '../client.js';
+import type { IAegisBackend } from '../../services/interfaces.js';
 import { withAuth, formatToolError } from '../auth.js';
 
-export function registerMonitoringTools(server: McpServer, client: AegisClient): void {
+export function registerMonitoringTools(server: McpServer, client: IAegisBackend): void {
   // ── server_health ──
   server.tool(
     'server_health',

--- a/src/mcp/tools/pipeline-tools.ts
+++ b/src/mcp/tools/pipeline-tools.ts
@@ -7,10 +7,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import type { AegisClient } from '../client.js';
+import type { IAegisBackend } from '../../services/interfaces.js';
 import { withAuth, formatToolError } from '../auth.js';
 
-export function registerPipelineTools(server: McpServer, client: AegisClient): void {
+export function registerPipelineTools(server: McpServer, client: IAegisBackend): void {
   // ── batch_create_sessions ──
   server.tool(
     'batch_create_sessions',

--- a/src/mcp/tools/session-tools.ts
+++ b/src/mcp/tools/session-tools.ts
@@ -3,10 +3,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import type { AegisClient } from '../client.js';
+import type { IAegisBackend } from '../../services/interfaces.js';
 import { withAuth, formatToolError } from '../auth.js';
 
-export function registerSessionTools(server: McpServer, client: AegisClient): void {
+export function registerSessionTools(server: McpServer, client: IAegisBackend): void {
   // ── list_sessions ──
   server.tool(
     'list_sessions',

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -1,0 +1,114 @@
+/**
+ * services/interfaces.ts — Shared service interfaces for MCP and HTTP layers.
+ *
+ * These interfaces abstract the Aegis backend so MCP tools can operate
+ * in both remote mode (via HTTP/AegisClient) and embedded mode (direct calls).
+ */
+
+import type { SessionInfo } from '../session.js';
+import type { SessionMetrics, SessionLatencySummary } from '../metrics.js';
+import type { PipelineState, BatchResult } from '../pipeline.js';
+
+// ── Response types ──────────────────────────────────────────────────
+
+export interface ServerHealthResponse {
+  status: string;
+  version: string;
+  platform: NodeJS.Platform;
+  uptime: number;
+  sessions: { active: number; total: number };
+  tmux: { healthy: boolean; [key: string]: unknown };
+  timestamp: string;
+}
+
+export interface CreateSessionResponse {
+  id: string;
+  windowName: string;
+  workDir: string;
+  status: string;
+  promptDelivery?: { delivered: boolean; attempts: number };
+  reused?: boolean;
+  [key: string]: unknown;
+}
+
+export interface SendMessageResponse {
+  ok: boolean;
+  delivered: boolean;
+  attempts: number;
+  stall?: { stalled: true; types: string[] } | { stalled: false };
+}
+
+export interface OkResponse {
+  ok: boolean;
+}
+
+export interface CapturePaneResponse {
+  pane: string;
+}
+
+export interface SessionLatencyResponse {
+  sessionId: string;
+  realtime: {
+    hook_latency_ms: number | null;
+    state_change_detection_ms: number | null;
+    permission_response_ms: number | null;
+  } | null;
+  aggregated: SessionLatencySummary | null;
+}
+
+export interface MemoryEntryResponse {
+  entry: {
+    key: string;
+    value: string;
+    namespace: string;
+    created_at: number;
+    updated_at: number;
+    expires_at?: number;
+  };
+}
+
+// ── Domain interfaces ───────────────────────────────────────────────
+
+export interface ISessionService {
+  listSessions(filter?: { status?: string; workDir?: string }): Promise<SessionInfo[]>;
+  getSession(id: string): Promise<Record<string, unknown>>;
+  getHealth(id: string): Promise<Record<string, unknown>>;
+  getTranscript(id: string): Promise<Record<string, unknown>>;
+  createSession(opts: { workDir: string; name?: string; prompt?: string }): Promise<CreateSessionResponse>;
+  killSession(id: string): Promise<OkResponse>;
+  sendMessage(id: string, text: string): Promise<SendMessageResponse>;
+  approvePermission(id: string): Promise<OkResponse>;
+  rejectPermission(id: string): Promise<OkResponse>;
+  escapeSession(id: string): Promise<OkResponse>;
+  interruptSession(id: string): Promise<OkResponse>;
+  capturePane(id: string): Promise<CapturePaneResponse>;
+  sendBash(id: string, command: string): Promise<OkResponse>;
+  sendCommand(id: string, command: string): Promise<OkResponse>;
+  getSessionSummary(id: string): Promise<Record<string, unknown>>;
+  getSessionMetrics(id: string): Promise<SessionMetrics>;
+  getSessionLatency(id: string): Promise<SessionLatencyResponse>;
+}
+
+export interface IServerService {
+  getServerHealth(): Promise<ServerHealthResponse>;
+  getSwarm(): Promise<Record<string, unknown>>;
+}
+
+export interface IPipelineService {
+  batchCreateSessions(sessions: Array<{ workDir: string; name?: string; prompt?: string }>): Promise<BatchResult>;
+  listPipelines(): Promise<PipelineState[]>;
+  createPipeline(config: { name: string; workDir: string; steps: Array<{ name?: string; prompt: string }> }): Promise<PipelineState>;
+}
+
+export interface IMemoryService {
+  setMemory(key: string, value: string, ttlSeconds?: number): Promise<MemoryEntryResponse>;
+  getMemory(key: string): Promise<MemoryEntryResponse>;
+  deleteMemory(key: string): Promise<OkResponse>;
+}
+
+export interface IAuthService {
+  resolveRole(): Promise<string>;
+}
+
+/** Composite backend interface — everything the MCP layer needs. */
+export interface IAegisBackend extends ISessionService, IServerService, IPipelineService, IMemoryService, IAuthService {}


### PR DESCRIPTION
## Summary

Introduces a shared service interface layer (IAegisBackend) between the MCP tools and the Aegis backend, enabling both remote (HTTP) and in-process (embedded) operation modes.

### Changes

- **src/services/interfaces.ts** — New file defining 5 domain interfaces (ISessionService, IServerService, IPipelineService, IMemoryService, IAuthService) and their composite IAegisBackend, plus shared response types
- **src/mcp/client.ts** — AegisClient now implements IAegisBackend; response types moved to shared interfaces; fix \createPipeline\ body to send \stages\ (matching API schema)
- **src/mcp/embedded.ts** — New \EmbeddedBackend\ implementing \IAegisBackend\ via direct class calls (no HTTP round-trip)
- **src/mcp/server.ts** — New \createMcpServerFromBackend(backend)\ factory accepting any \IAegisBackend\; existing \createMcpServer(port)\ delegates to it
- **src/mcp/auth.ts**, **resources.ts**, **tools/*.ts** — All accept \IAegisBackend\ instead of concrete \AegisClient\
- **src/mcp-server.ts** — Re-exports \EmbeddedBackend\, \createMcpServerFromBackend\, and \IAegisBackend\

### Acceptance Criteria

- [x] Service interfaces shared between HTTP routes and MCP
- [x] MCP can operate without HTTP round-trip (in-process mode via EmbeddedBackend)
- [x] AegisClient retained as remote-mode adapter
- [x] All 24 MCP tools functional in both modes (interface-compatible)
- [x] Quality gate: tsc, build, 159 test files / 2814 tests pass

## Aegis version
**Developed with:** v0.3.2-alpha

Closes #1697