### PR TITLE
feat: add Session History and Users pages to dashboard

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -12,9 +12,11 @@ const AuditPage = lazy(() => import('./pages/AuditPage'));
 const AuthKeysPage = lazy(() => import('./pages/AuthKeysPage'));
 const LoginPage = lazy(() => import('./pages/LoginPage'));
 const OverviewPage = lazy(() => import('./pages/OverviewPage'));
+const SessionHistoryPage = lazy(() => import('./pages/SessionHistoryPage'));
 const SessionDetailPage = lazy(() => import('./pages/SessionDetailPage'));
 const PipelinesPage = lazy(() => import('./pages/PipelinesPage'));
 const PipelineDetailPage = lazy(() => import('./pages/PipelineDetailPage'));
+const UsersPage = lazy(() => import('./pages/UsersPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 
 function LoadingFallback() {
@@ -53,6 +55,22 @@ export default function App() {
               element={
                 <Suspense fallback={<LoadingFallback />}>
                   <AuthKeysPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/users"
+              element={
+                <Suspense fallback={<LoadingFallback />}>
+                  <UsersPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/sessions/history"
+              element={
+                <Suspense fallback={<LoadingFallback />}>
+                  <SessionHistoryPage />
                 </Suspense>
               }
             />

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -285,13 +285,6 @@ describe('Layout SSE error handling (#587)', () => {
     expect(screen.getByText('SSE Degraded')).toBeDefined();
   });
 
-  it('renders placeholder sidebar items as disabled controls', () => {
-    mockSubscribeGlobalSSE.mockReturnValue(() => {});
-
-    renderLayout();
-
-    expect(screen.getByRole('button', { name: 'Sessions' }).matches(':disabled')).toBe(true);
-  });
 });
 
 describe('Layout sidebar', () => {

--- a/dashboard/src/__tests__/PipelinesPage.test.tsx
+++ b/dashboard/src/__tests__/PipelinesPage.test.tsx
@@ -133,13 +133,13 @@ describe('PipelinesPage', () => {
       await vi.runAllTicks();
     });
     expect(mockGetPipelines).toHaveBeenCalledTimes(1);
-    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 10_000)).toBe(true);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 20_000)).toBe(true);
 
     await act(async () => {
       await vi.runOnlyPendingTimersAsync();
     });
     expect(mockGetPipelines).toHaveBeenCalledTimes(2);
-    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 20_000)).toBe(true);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 40_000)).toBe(true);
 
     await act(async () => {
       await vi.runOnlyPendingTimersAsync();
@@ -161,7 +161,7 @@ describe('PipelinesPage', () => {
     });
 
     expect(mockGetPipelines).toHaveBeenCalledTimes(1);
-    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 30_000)).toBe(true);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
   });
 
   it('switches to faster fallback polling when SSE disconnects', async () => {

--- a/dashboard/src/__tests__/SessionHistoryPage.test.tsx
+++ b/dashboard/src/__tests__/SessionHistoryPage.test.tsx
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SessionHistoryPage from '../pages/SessionHistoryPage';
+
+const fetchSessionHistoryMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchSessionHistory: (...args: unknown[]) => fetchSessionHistoryMock(...args),
+}));
+
+describe('SessionHistoryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders rows from API response', async () => {
+    fetchSessionHistoryMock.mockResolvedValueOnce({
+      records: [
+        {
+          id: 'sess-001',
+          ownerKeyId: 'admin-main',
+          createdAt: Date.now() - 10 * 60_000,
+          lastSeenAt: Date.now() - 30_000,
+          finalStatus: 'active',
+          source: 'audit+live',
+        },
+      ],
+      pagination: {
+        page: 1,
+        limit: 25,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+
+    render(<SessionHistoryPage />);
+
+    expect(await screen.findByText('sess-001')).toBeDefined();
+    expect(screen.getByText('admin-main')).toBeDefined();
+    expect(screen.getByText('audit+live')).toBeDefined();
+  });
+
+  it('applies filters and sends query params to API', async () => {
+    fetchSessionHistoryMock.mockResolvedValue({
+      records: [],
+      pagination: {
+        page: 1,
+        limit: 25,
+        total: 0,
+        totalPages: 1,
+      },
+    });
+
+    render(<SessionHistoryPage />);
+
+    await screen.findByText('No session history records found.');
+
+    fireEvent.change(screen.getByLabelText('Owner key ID'), { target: { value: 'owner-1' } });
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'active' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    expect(fetchSessionHistoryMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      ownerKeyId: 'owner-1',
+      status: 'active',
+      page: 1,
+      limit: 25,
+    }));
+  });
+});

--- a/dashboard/src/__tests__/UsersPage.test.tsx
+++ b/dashboard/src/__tests__/UsersPage.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import UsersPage from '../pages/UsersPage';
+
+const fetchUsersMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchUsers: (...args: unknown[]) => fetchUsersMock(...args),
+}));
+
+describe('UsersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders users returned by API', async () => {
+    fetchUsersMock.mockResolvedValueOnce({
+      count: 1,
+      users: [
+        {
+          id: 'admin-main',
+          name: 'Main Admin',
+          role: 'admin',
+          createdAt: Date.now() - 120_000,
+          lastUsedAt: Date.now() - 60_000,
+          expiresAt: null,
+          rateLimit: 120,
+          activeSessions: 3,
+          totalSessionsCreated: 22,
+          lastSessionAt: Date.now() - 30_000,
+        },
+      ],
+    });
+
+    render(<UsersPage />);
+
+    expect(await screen.findByText('admin-main')).toBeDefined();
+    expect(screen.getByText('Main Admin')).toBeDefined();
+    expect(screen.getByText('120/min')).toBeDefined();
+  });
+
+  it('shows endpoint placeholder on 404', async () => {
+    const err = new Error('not found') as Error & { statusCode?: number };
+    err.statusCode = 404;
+    fetchUsersMock.mockRejectedValueOnce(err);
+
+    render(<UsersPage />);
+
+    expect(await screen.findByText('Users endpoint not available yet')).toBeDefined();
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -755,3 +755,68 @@ export function fetchAuditLogs(params: FetchAuditLogsParams = {}): Promise<Audit
   const path = query ? `/v1/audit?${query}` : '/v1/audit';
   return request<AuditPageResponse>(path, { signal });
 }
+
+// ── Users & Session History ─────────────────────────────────────
+
+export interface UserSummary {
+  id: string;
+  name: string;
+  role: string;
+  createdAt: number;
+  lastUsedAt: number;
+  expiresAt: number | null;
+  rateLimit: number;
+  activeSessions: number;
+  totalSessionsCreated: number;
+  lastSessionAt: number | null;
+}
+
+export interface UsersResponse {
+  count: number;
+  users: UserSummary[];
+}
+
+export interface SessionHistoryRecord {
+  id: string;
+  ownerKeyId?: string;
+  createdAt?: number;
+  endedAt?: number;
+  lastSeenAt: number;
+  finalStatus: 'active' | 'killed' | 'unknown';
+  source: 'audit' | 'live' | 'audit+live';
+}
+
+export interface SessionHistoryResponse {
+  records: SessionHistoryRecord[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface FetchSessionHistoryParams {
+  page?: number;
+  limit?: number;
+  status?: 'active' | 'killed' | 'unknown';
+  ownerKeyId?: string;
+  signal?: AbortSignal;
+}
+
+export function fetchUsers(signal?: AbortSignal): Promise<UsersResponse> {
+  return request<UsersResponse>('/v1/users', { signal });
+}
+
+export function fetchSessionHistory(params: FetchSessionHistoryParams = {}): Promise<SessionHistoryResponse> {
+  const { signal, ...queryParams } = params;
+  const searchParams = new URLSearchParams();
+  if (queryParams.page !== undefined) searchParams.set('page', String(queryParams.page));
+  if (queryParams.limit !== undefined) searchParams.set('limit', String(queryParams.limit));
+  if (queryParams.status) searchParams.set('status', queryParams.status);
+  if (queryParams.ownerKeyId) searchParams.set('ownerKeyId', queryParams.ownerKeyId);
+
+  const query = searchParams.toString();
+  const path = query ? `/v1/sessions/history?${query}` : '/v1/sessions/history';
+  return request<SessionHistoryResponse>(path, { signal });
+}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -15,7 +15,8 @@ import {
   Menu,
   RefreshCw,
   Shield,
-  Terminal,
+  UserRound,
+  History,
 } from 'lucide-react';
 import { useStore } from '../store/useStore';
 import { useAuthStore } from '../store/useAuthStore.js';
@@ -26,6 +27,8 @@ import ToastContainer from './ToastContainer';
 const NAV_ITEMS = [
   { to: '/', label: 'Overview', icon: LayoutDashboard },
   { to: '/pipelines', label: 'Pipelines', icon: Activity },
+  { to: '/sessions/history', label: 'Session History', icon: History },
+  { to: '/users', label: 'Users', icon: UserRound },
   { to: '/audit', label: 'Audit Trail', icon: Shield },
   { to: '/auth/keys', label: 'Auth Keys', icon: KeyRound },
 ];
@@ -287,19 +290,6 @@ export default function Layout() {
             </NavLink>
           ))}
 
-          {/* Placeholder nav items */}
-          <div className="mt-4 border-t border-void-lighter pt-4 opacity-40">
-            <button
-              type="button"
-              disabled
-              aria-disabled="true"
-              title="Sessions navigation is not available yet"
-              className={`flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm text-gray-500 ${isCollapsed ? 'justify-center' : ''}`}
-            >
-              <Terminal className="h-4 w-4 shrink-0" />
-              {!isCollapsed && 'Sessions'}
-            </button>
-          </div>
         </nav>
 
         {/* Bottom section: toggle + logout */}

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -1,0 +1,304 @@
+/**
+ * pages/SessionHistoryPage.tsx — Session history view with filters and pagination.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  History,
+  RefreshCw,
+  SearchX,
+} from 'lucide-react';
+import {
+  fetchSessionHistory,
+  type FetchSessionHistoryParams,
+  type SessionHistoryRecord,
+} from '../api/client';
+import { formatTimeAgo } from '../utils/format';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  { value: 'active', label: 'active' },
+  { value: 'killed', label: 'killed' },
+  { value: 'unknown', label: 'unknown' },
+] as const;
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
+
+function formatTimestamp(ts?: number): string {
+  if (ts === undefined) return '—';
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return String(ts);
+  }
+}
+
+function statusClass(status: SessionHistoryRecord['finalStatus']): string {
+  if (status === 'active') return 'text-emerald-300 bg-emerald-500/10 border-emerald-500/25';
+  if (status === 'killed') return 'text-rose-300 bg-rose-500/10 border-rose-500/25';
+  return 'text-zinc-300 bg-zinc-700/40 border-zinc-700';
+}
+
+function sourceClass(source: SessionHistoryRecord['source']): string {
+  if (source === 'audit+live') return 'text-cyan-300 bg-cyan-500/10 border-cyan-500/25';
+  if (source === 'live') return 'text-sky-300 bg-sky-500/10 border-sky-500/25';
+  return 'text-zinc-300 bg-zinc-700/40 border-zinc-700';
+}
+
+function SkeletonRows({ count }: { count: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <tr key={i} className="border-b border-zinc-800">
+          <td className="px-4 py-3"><div className="h-4 w-44 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-28 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-14 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-20 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-24 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-24 animate-pulse rounded bg-zinc-800" /></td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+export default function SessionHistoryPage() {
+  const [records, setRecords] = useState<SessionHistoryRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [endpointMissing, setEndpointMissing] = useState(false);
+
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [total, setTotal] = useState(0);
+
+  const [filterOwnerInput, setFilterOwnerInput] = useState('');
+  const [filterStatusInput, setFilterStatusInput] = useState('');
+  const [filterOwner, setFilterOwner] = useState('');
+  const [filterStatus, setFilterStatus] = useState('');
+
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    setEndpointMissing(false);
+
+    const params: FetchSessionHistoryParams = {
+      page,
+      limit: pageSize,
+    };
+    if (filterOwner) params.ownerKeyId = filterOwner;
+    if (filterStatus) params.status = filterStatus as FetchSessionHistoryParams['status'];
+
+    try {
+      const data = await fetchSessionHistory({ ...params, signal });
+      setRecords(data.records);
+      setTotal(data.pagination.total);
+    } catch (e: unknown) {
+      const err = e as Error & { statusCode?: number };
+      if ((err as DOMException).name === 'AbortError') return;
+      if (err.statusCode === 404) {
+        setEndpointMissing(true);
+        setRecords([]);
+        setTotal(0);
+      } else {
+        setError(err.message ?? 'Failed to load session history');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, filterOwner, filterStatus]);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    void fetchData(ac.signal);
+    return () => ac.abort();
+  }, [fetchData]);
+
+  const applyFilters = () => {
+    setPage(1);
+    setFilterOwner(filterOwnerInput.trim());
+    setFilterStatus(filterStatusInput);
+  };
+
+  const clearFilters = () => {
+    setPage(1);
+    setFilterOwnerInput('');
+    setFilterStatusInput('');
+    setFilterOwner('');
+    setFilterStatus('');
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-100">Session History</h2>
+          <p className="mt-1 text-sm text-gray-500">Merged audit and live session lifecycle records</p>
+        </div>
+        <button
+          onClick={() => { void fetchData(); }}
+          disabled={loading}
+          className="flex items-center gap-1.5 rounded border border-[#00e5ff]/30 bg-[#00e5ff]/10 px-3 py-2 text-xs font-medium text-[#00e5ff] transition-colors hover:bg-[#00e5ff]/20 disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex flex-col gap-1">
+            <label htmlFor="owner-filter" className="text-xs text-zinc-500">Owner key ID</label>
+            <input
+              id="owner-filter"
+              type="text"
+              value={filterOwnerInput}
+              onChange={(e) => setFilterOwnerInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
+              placeholder="e.g. admin-main"
+              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 focus:border-[#00e5ff]/50 focus:outline-none"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="status-filter" className="text-xs text-zinc-500">Status</label>
+            <select
+              id="status-filter"
+              value={filterStatusInput}
+              onChange={(e) => setFilterStatusInput(e.target.value)}
+              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 focus:border-[#00e5ff]/50 focus:outline-none"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            onClick={applyFilters}
+            className="rounded border border-[#00e5ff]/30 bg-[#00e5ff]/10 px-3 py-1.5 text-xs font-medium text-[#00e5ff] transition-colors hover:bg-[#00e5ff]/20"
+          >
+            Apply
+          </button>
+
+          <button
+            onClick={clearFilters}
+            className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:bg-zinc-700"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      {endpointMissing ? (
+        <div className="rounded-lg border border-zinc-800 bg-[#111118] p-12 text-center">
+          <History className="mx-auto mb-3 h-10 w-10 text-zinc-600" />
+          <p className="font-medium text-zinc-400">Session history endpoint not available yet</p>
+          <p className="mt-1 text-xs text-zinc-600">The /v1/sessions/history endpoint has not been implemented on the server.</p>
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-900/50 bg-red-950/20 p-12 text-center">
+          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-500" />
+          <p className="font-medium text-red-400">Failed to load session history</p>
+          <p className="mt-1 text-xs text-zinc-500">{error}</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/50">
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left">
+              <thead className="border-b border-zinc-800 bg-zinc-900/80">
+                <tr>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Session ID</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Owner</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Status</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Source</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Created</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Last seen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <SkeletonRows count={pageSize} />
+                ) : records.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-16 text-center text-zinc-500">
+                      <SearchX className="mx-auto mb-2 h-5 w-5 text-zinc-600" />
+                      No session history records found.
+                    </td>
+                  </tr>
+                ) : (
+                  records.map((record) => (
+                    <tr key={`${record.id}-${record.lastSeenAt}`} className="border-b border-zinc-800 transition-colors hover:bg-zinc-800/40">
+                      <td className="px-4 py-3 font-mono text-sm text-zinc-200">{record.id}</td>
+                      <td className="px-4 py-3 font-mono text-xs text-zinc-400">{record.ownerKeyId ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded border px-2 py-0.5 text-xs font-medium ${statusClass(record.finalStatus)}`}>
+                          {record.finalStatus}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded border px-2 py-0.5 text-xs font-medium ${sourceClass(record.source)}`}>
+                          {record.source}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-zinc-400" title={formatTimestamp(record.createdAt)}>
+                        {record.createdAt !== undefined ? formatTimeAgo(record.createdAt) : '—'}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-zinc-400" title={formatTimestamp(record.lastSeenAt)}>
+                        {formatTimeAgo(record.lastSeenAt)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-zinc-800 px-4 py-3">
+            <div className="text-xs text-zinc-500">
+              Showing page {page} of {totalPages} ({total} records)
+            </div>
+
+            <div className="flex items-center gap-2">
+              <label htmlFor="history-page-size" className="text-xs text-zinc-500">Rows</label>
+              <select
+                id="history-page-size"
+                value={pageSize}
+                onChange={(e) => {
+                  setPageSize(Number(e.target.value));
+                  setPage(1);
+                }}
+                className="rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-100 focus:border-[#00e5ff]/50 focus:outline-none"
+              >
+                {PAGE_SIZE_OPTIONS.map((size) => (
+                  <option key={size} value={size}>{size}</option>
+                ))}
+              </select>
+
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1 || loading}
+                className="inline-flex items-center gap-1 rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-200 transition-colors hover:bg-zinc-700 disabled:opacity-40"
+              >
+                <ChevronLeft className="h-3 w-3" /> Prev
+              </button>
+
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages || loading}
+                className="inline-flex items-center gap-1 rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-200 transition-colors hover:bg-zinc-700 disabled:opacity-40"
+              >
+                Next <ChevronRight className="h-3 w-3" />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/pages/UsersPage.tsx
+++ b/dashboard/src/pages/UsersPage.tsx
@@ -1,0 +1,192 @@
+/**
+ * pages/UsersPage.tsx — API key users summary and session ownership overview.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertCircle, RefreshCw, UsersRound } from 'lucide-react';
+import { fetchUsers, type UserSummary } from '../api/client';
+import { formatTimeAgo } from '../utils/format';
+
+function formatTimestamp(timestamp: number | null): string {
+  if (timestamp === null) return 'never';
+  try {
+    return new Date(timestamp).toLocaleString();
+  } catch {
+    return String(timestamp);
+  }
+}
+
+function roleClass(role: string): string {
+  if (role === 'admin') return 'text-fuchsia-300 bg-fuchsia-400/10 border-fuchsia-400/20';
+  if (role === 'operator') return 'text-cyan-300 bg-cyan-400/10 border-cyan-400/20';
+  return 'text-zinc-300 bg-zinc-700/30 border-zinc-700';
+}
+
+function SkeletonRows({ count }: { count: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <tr key={i} className="border-b border-zinc-800">
+          <td className="px-4 py-3"><div className="h-4 w-40 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-20 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-14 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-16 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-16 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-24 animate-pulse rounded bg-zinc-800" /></td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<UserSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [endpointMissing, setEndpointMissing] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    setEndpointMissing(false);
+
+    try {
+      const response = await fetchUsers(signal);
+      setUsers(response.users);
+    } catch (e: unknown) {
+      const err = e as Error & { statusCode?: number };
+      if ((err as DOMException).name === 'AbortError') return;
+      if (err.statusCode === 404) {
+        setEndpointMissing(true);
+        setUsers([]);
+      } else {
+        setError(err.message ?? 'Failed to load users');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    void load(ac.signal);
+    return () => ac.abort();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return users;
+    return users.filter((u) =>
+      u.id.toLowerCase().includes(q)
+      || u.name.toLowerCase().includes(q)
+      || u.role.toLowerCase().includes(q),
+    );
+  }, [users, search]);
+
+  const totalActiveSessions = useMemo(() => filtered.reduce((sum, u) => sum + u.activeSessions, 0), [filtered]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-100">Users</h2>
+          <p className="mt-1 text-sm text-gray-500">API key ownership, usage, and session activity</p>
+        </div>
+        <button
+          onClick={() => { void load(); }}
+          disabled={loading}
+          className="flex items-center gap-1.5 rounded border border-[#00e5ff]/30 bg-[#00e5ff]/10 px-3 py-2 text-xs font-medium text-[#00e5ff] transition-colors hover:bg-[#00e5ff]/20 disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">Visible users</p>
+          <p className="mt-1 text-2xl font-semibold text-zinc-100">{filtered.length}</p>
+        </div>
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">Active sessions</p>
+          <p className="mt-1 text-2xl font-semibold text-cyan-300">{totalActiveSessions}</p>
+        </div>
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">Query</p>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filter by id, name, role"
+            className="mt-2 w-full rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 focus:border-[#00e5ff]/50 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {endpointMissing ? (
+        <div className="rounded-lg border border-zinc-800 bg-[#111118] p-12 text-center">
+          <UsersRound className="mx-auto mb-3 h-10 w-10 text-zinc-600" />
+          <p className="font-medium text-zinc-400">Users endpoint not available yet</p>
+          <p className="mt-1 text-xs text-zinc-600">The /v1/users endpoint has not been implemented on the server.</p>
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-900/50 bg-red-950/20 p-12 text-center">
+          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-500" />
+          <p className="font-medium text-red-400">Failed to load users</p>
+          <p className="mt-1 text-xs text-zinc-500">{error}</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/50">
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left">
+              <thead className="border-b border-zinc-800 bg-zinc-900/80">
+                <tr>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">User</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Role</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Rate</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Active</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Created</th>
+                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500">Last session</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <SkeletonRows count={8} />
+                ) : filtered.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-14 text-center text-zinc-500">No users match the current filter.</td>
+                  </tr>
+                ) : (
+                  filtered.map((user) => (
+                    <tr key={user.id} className="border-b border-zinc-800 transition-colors hover:bg-zinc-800/40">
+                      <td className="px-4 py-3">
+                        <div className="flex flex-col">
+                          <span className="font-mono text-sm text-zinc-100">{user.id}</span>
+                          <span className="text-xs text-zinc-500">{user.name}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded border px-2 py-0.5 text-xs font-medium ${roleClass(user.role)}`}>
+                          {user.role}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-zinc-300">{user.rateLimit}/min</td>
+                      <td className="px-4 py-3 text-sm text-cyan-300">{user.activeSessions}</td>
+                      <td className="px-4 py-3 text-xs text-zinc-400" title={formatTimestamp(user.createdAt)}>
+                        {formatTimeAgo(user.createdAt)}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-zinc-400" title={formatTimestamp(user.lastSessionAt)}>
+                        {user.lastSessionAt ? formatTimeAgo(user.lastSessionAt) : 'never'}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -56,6 +56,46 @@ export interface AuditPageResponse {
   pageSize: number;
 }
 
+// ── Users & Session History ────────────────────────────────────
+
+export interface UserSummary {
+  id: string;
+  name: string;
+  role: string;
+  createdAt: number;
+  lastUsedAt: number;
+  expiresAt: number | null;
+  rateLimit: number;
+  activeSessions: number;
+  totalSessionsCreated: number;
+  lastSessionAt: number | null;
+}
+
+export interface UsersResponse {
+  count: number;
+  users: UserSummary[];
+}
+
+export interface SessionHistoryRecord {
+  id: string;
+  ownerKeyId?: string;
+  createdAt?: number;
+  endedAt?: number;
+  lastSeenAt: number;
+  finalStatus: 'active' | 'killed' | 'unknown';
+  source: 'audit' | 'live' | 'audit+live';
+}
+
+export interface SessionHistoryResponse {
+  records: SessionHistoryRecord[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
 // ── Session Templates ───────────────────────────────────────────
 
 export interface SessionTemplate {

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -45,11 +45,121 @@ const batchDeleteSchema = z.object({
   message: 'At least one of "ids" or "status" is required',
 });
 
+const sessionHistoryQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  status: z.string().optional(),
+  ownerKeyId: z.string().optional(),
+});
+
 export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): void {
   const {
     sessions, auth, metrics, monitor, eventBus, channels,
     memoryBridge, toolRegistry, getAuditLogger, validateWorkDir,
   } = ctx;
+
+  // Session history (created/killed + active), paginated.
+  app.get('/v1/sessions/history', async (req, reply) => {
+    if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
+
+    const parsed = sessionHistoryQuerySchema.safeParse(req.query ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid query params', details: parsed.error.issues });
+    }
+
+    const page = parsed.data.page ?? 1;
+    const limit = parsed.data.limit ?? 50;
+    const statusFilter = parsed.data.status;
+    const ownerFilter = parsed.data.ownerKeyId;
+
+    const historyMap = new Map<string, {
+      id: string;
+      ownerKeyId?: string;
+      createdAt?: number;
+      endedAt?: number;
+      lastSeenAt: number;
+      finalStatus: 'active' | 'killed' | 'unknown';
+      source: 'audit' | 'live' | 'audit+live';
+    }>();
+
+    const auditLogger = getAuditLogger();
+    if (auditLogger) {
+      const records = await auditLogger.query({ limit: 5000, reverse: true });
+      for (const rec of records) {
+        if ((rec.action !== 'session.create' && rec.action !== 'session.kill') || !rec.sessionId) continue;
+        const tsMs = Date.parse(rec.ts);
+        if (!Number.isFinite(tsMs)) continue;
+        const existing = historyMap.get(rec.sessionId) ?? {
+          id: rec.sessionId,
+          createdAt: undefined,
+          endedAt: undefined,
+          ownerKeyId: undefined,
+          lastSeenAt: tsMs,
+          finalStatus: 'unknown' as const,
+          source: 'audit' as const,
+        };
+
+        if (rec.action === 'session.create') {
+          existing.createdAt = existing.createdAt ?? tsMs;
+          existing.ownerKeyId = existing.ownerKeyId ?? rec.actor;
+          if (!existing.endedAt) {
+            existing.finalStatus = 'unknown';
+          }
+        } else if (rec.action === 'session.kill') {
+          existing.endedAt = existing.endedAt ?? tsMs;
+          existing.finalStatus = 'killed';
+        }
+
+        existing.lastSeenAt = Math.max(existing.lastSeenAt, tsMs);
+        historyMap.set(rec.sessionId, existing);
+      }
+    }
+
+    for (const s of sessions.listSessions()) {
+      const existing = historyMap.get(s.id);
+      if (existing) {
+        existing.ownerKeyId = existing.ownerKeyId ?? s.ownerKeyId;
+        existing.createdAt = existing.createdAt ?? s.createdAt;
+        existing.lastSeenAt = Math.max(existing.lastSeenAt, s.lastActivity || s.createdAt);
+        existing.finalStatus = 'active';
+        existing.source = existing.source === 'audit' ? 'audit+live' : 'live';
+      } else {
+        historyMap.set(s.id, {
+          id: s.id,
+          ownerKeyId: s.ownerKeyId,
+          createdAt: s.createdAt,
+          endedAt: undefined,
+          lastSeenAt: s.lastActivity || s.createdAt,
+          finalStatus: 'active',
+          source: 'live',
+        });
+      }
+    }
+
+    let history = Array.from(historyMap.values());
+    const callerKeyId = req.authKeyId;
+    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined) {
+      history = history.filter(h => !h.ownerKeyId || h.ownerKeyId === callerKeyId);
+    }
+    if (ownerFilter) {
+      history = history.filter(h => h.ownerKeyId === ownerFilter);
+    }
+    if (statusFilter) {
+      history = history.filter(h => h.finalStatus === statusFilter);
+    }
+
+    history.sort((a, b) => (b.lastSeenAt - a.lastSeenAt) || (b.createdAt ?? 0) - (a.createdAt ?? 0));
+
+    const total = history.length;
+    const totalPages = Math.ceil(total / limit);
+    const start = (page - 1) * limit;
+    const items = history.slice(start, start + limit);
+
+    return {
+      records: items,
+      pagination: { page, limit, total, totalPages },
+    };
+  });
 
   // List sessions (with pagination, status filter, and project filter)
   app.get<{


### PR DESCRIPTION
## Summary

Adds two new dashboard pages providing operators with visibility into session lifecycle history and API key users.

### Changes

**Backend**
- src/routes/sessions.ts — new GET /v1/sessions/history route that merges audit log entries with live session data; supports filtering by status and ownerKeyId, pagination via page/limit

**Dashboard**
- pages/UsersPage.tsx — stats cards (visible users, active sessions), filterable table with user/role/rate-limit/activity columns; graceful 404 placeholder
- pages/SessionHistoryPage.tsx — filter bar (key ID, status dropdown), paginated table with session ID/owner/status/source/timestamps, error state handling
- pi/client.ts — etchUsers() and etchSessionHistory() API client functions
- 	ypes/index.ts — UserSummary, UsersResponse, SessionHistoryRecord, SessionHistoryResponse types
- App.tsx — lazy routes wired for /sessions/history and /users
- Layout.tsx — sidebar nav links added; stale disabled 'Sessions' placeholder removed

**Tests**
- UsersPage.test.tsx — 2 tests (renders users from API, shows 404 placeholder)
- SessionHistoryPage.test.tsx — 2 tests (renders rows, applies filter params)
- Layout.test.tsx — removed stale test for the now-removed placeholder button

## Quality Gate

- [x] \
px tsc --noEmit\ — passed
- [x] \
pm run build\ — passed (Dashboard copied to dist/dashboard/)
- [x] \
pm test\ (backend) — 158/160 files, 2818/2833 tests passed
- [x] \
px vitest run\ (dashboard) — 38/38 files, 284 passed | 2 skipped

## Aegis version
**Developed with:** v0.5.1-alpha