### PR TITLE
docs: remove /consensus endpoints from OpenAPI spec (PR #1583)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -697,43 +697,6 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /v1/sessions/{id}/consensus:
-    post:
-      operationId: createConsensus
-      summary: Start a consensus review session
-      tags: [Sessions]
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                reviewerCount:
-                  type: integer
-                  minimum: 1
-                  maximum: 5
-                  default: 3
-                prompt:
-                  type: string
-              required: [prompt]
-      responses:
-        '202':
-          description: Consensus review started
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  consensusId:
-                    type: string
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
   /v1/sessions/{id}/permissions:
     get:
       operationId: getPermissionPolicy
@@ -1226,45 +1189,6 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  # ─── Consensus ─────────────────────────────────────────────────────────────
-
-  /v1/consensus/{id}:
-    get:
-      operationId: getConsensus
-      summary: Get consensus review status and findings
-      tags: [Consensus]
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-          description: Consensus review ID
-      responses:
-        '200':
-          description: Consensus review
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  status:
-                    type: string
-                    enum: [running, complete, failed]
-                  findings:
-                    type: array
-                    items:
-                      type: string
-                  createdAt:
-                    type: integer
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
-  # ─── Events ────────────────────────────────────────────────────────────────
 
   /v1/events:
     get:


### PR DESCRIPTION
## Summary

Remove two stale OpenAPI endpoints that reference the deleted Consensus Review feature (PR #1583).

## Removed

| Endpoint | Method | Reason |
|---------|--------|--------|
|  | POST | Feature removed in PR #1583 |
|  | GET | Feature removed in PR #1583 |

Also removes the now-orphaned `Consensus` tag from the OpenAPI spec.

## Files Changed

- : -76 lines

## Note

Companion PR #1709 (docs cleanup for other docs files) was already merged. This was the only remaining file with stale consensus references.

---
Tagged <@1490089830472880218> for review.