### PR TITLE
docs: clarify alpha release channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 </p>
 
 > ⚠️ **Aegis is in Alpha.** APIs may change. See [ROADMAP.md](./ROADMAP.md) for the path to stable.
+> Current release channel remains `alpha` until graduation criteria are explicitly met.
 >
 > 📦 **Package renamed:** `aegis-bridge` → [`@onestepat4time/aegis`](https://www.npmjs.com/package/@onestepat4time/aegis). See [Migration Guide](docs/migration-guide.md) if you're upgrading.
 


### PR DESCRIPTION
## Summary
- add a small README clarification that the project remains on alpha channel
- create a non-no-op change on main to trigger release-please safely

## Validation
- docs-only change

## Aegis version
**Developed with:** N/A (local health endpoint not running in this environment)
