### PR TITLE
fix(ci): make release gh commands repository-explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,15 +99,15 @@ jobs:
       - name: Ensure GitHub Release exists for tag
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG already exists"
             exit 0
           fi
 
           if [[ "$TAG" == *-alpha* || "$TAG" == *-beta* || "$TAG" == *-rc* ]]; then
-            gh release create "$TAG" --prerelease --generate-notes
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease --generate-notes
           else
-            gh release create "$TAG" --generate-notes
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --generate-notes
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,7 +123,7 @@ jobs:
       - name: Attach checksums to GitHub Release
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          gh release upload "$TAG" checksums.txt --clobber
+          gh release upload "$TAG" checksums.txt --repo "$GITHUB_REPOSITORY" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -138,7 +138,7 @@ jobs:
       - name: Attach SBOM to GitHub Release
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          gh release upload "$TAG" sbom.json --clobber
+          gh release upload "$TAG" sbom.json --repo "$GITHUB_REPOSITORY" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- fix nsure-github-release and release asset upload commands to always target ${GITHUB_REPOSITORY}
- avoid gh inferring repository from local .git context in jobs without checkout
- prevent false-red release runs after successful npm publish

## Validation
- reviewed workflow diff for all gh release invocations in .github/workflows/release.yml

## Aegis version
**Developed with:** N/A (local health endpoint not running in this environment)
