### PR TITLE
docs: fix API key docs to use role instead of scopes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -276,7 +276,7 @@ curl -X POST http://127.0.0.1:9100/v1/sessions/abc123/reject \
 ```bash
 curl -X POST http://localhost:9100/v1/auth/keys \
   -H "Content-Type: application/json" \
-  -d '{"name": "ci-bot", "scopes": ["sessions:read", "sessions:write"]}'
+  -d '{"name": "ci-bot", "role": "operator"}'
 ```
 
 ### List API Keys

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -25,18 +25,29 @@ curl -H "Authorization: Bearer your-secret-token" http://localhost:9100/v1/sessi
 
 ### Multi-Key API Keys
 
-Aegis supports multiple API keys with different scopes:
+Aegis supports multiple API keys with role-based access control:
+
+| Role | Permissions |
+|------|-------------|
+| `viewer` | Read-only access to sessions and metrics |
+| `operator` | Read + write sessions, approve permissions |
+| `admin` | Full access including key management |
 
 ```bash
-# Create a read-only key
+# Create a viewer key (read-only)
 curl -X POST http://localhost:9100/v1/auth/keys \
   -H "Content-Type: application/json" \
-  -d '{"name": "monitoring-bot", "scopes": ["sessions:read"]}'
+  -d '{"name": "monitoring-bot", "role": "viewer"}'
 
-# Create a full-access key
+# Create an operator key
 curl -X POST http://localhost:9100/v1/auth/keys \
   -H "Content-Type: application/json" \
-  -d '{"name": "ci-bot", "scopes": ["sessions:read", "sessions:write"]}'
+  -d '{"name": "ci-bot", "role": "operator"}'
+
+# Create an admin key (full access)
+curl -X POST http://localhost:9100/v1/auth/keys \
+  -H "Content-Type: application/json" \
+  -d '{"name": "admin-bot", "role": "admin"}'
 ```
 
 ### SSE Tokens
@@ -93,7 +104,7 @@ Sessions created before this feature was introduced may not have an `ownerKeyId`
 
 ### Scope Requirements
 
-Session ownership works alongside API key scopes. Even with `sessions:write` scope, a key can only send/approve/kill sessions it owns. Scope grants permission; ownership grants access.
+Session ownership works alongside API key roles. Even with `operator` role, a key can only send/approve/kill sessions it owns. Role grants permission; ownership grants access.
 
 ### Verifying Ownership
 


### PR DESCRIPTION
## Summary

P1 fix: Docs used  but the API expects . This broke new users trying to create API keys.

### Changes

**docs/enterprise.md:**
- Replaced  with  in API key examples
- Added role permissions table (viewer/operator/admin)
- Fixed session ownership section to reference 'operator role' instead of 'sessions:write scope'

**docs/api-reference.md:**
- Fixed POST /v1/auth/keys example to use  instead of 

### Files
- 2 files changed, +18/-7 lines

### Verification
Code confirms  is the correct field:
```typescript
// src/validation.ts:17
export const authKeySchema = z.object({
  name: z.string().min(1),
  rateLimit: z.number().int().positive().optional(),
  ttlDays: z.number().int().positive().optional(),
  role: z.enum(['admin', 'operator', 'viewer']).optional(),
}).strict();
```

Aegis version: 0.5.1-alpha
Milestone: Documentation
Assignee: Scribe