### PR TITLE
fix(ci): fail packaging when dashboard build output is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,10 @@ jobs:
       - run: npm ci
       - run: npm audit --audit-level=high
       - run: npx tsc --noEmit
-      - run: npm run build
       - run: npm run build:dashboard
+      - run: AEGIS_REQUIRE_DASHBOARD_COPY=true npm run build
+      - name: Validate packaged dashboard bundle
+        run: test -f dist/dashboard/index.html
       - run: npm test
       - run: cd dashboard && npx vitest run
       - name: Pack artifact

--- a/scripts/copy-dashboard.mjs
+++ b/scripts/copy-dashboard.mjs
@@ -28,6 +28,10 @@ if (existsSync(src)) {
   // During npm publish, missing dashboard is a hard error
   console.error("Error: dashboard/dist/ not found. Run 'npm run build:dashboard' first.");
   process.exit(1);
+} else if (process.env.CI === 'true') {
+  // In CI we never want a successful build artifact without dashboard assets.
+  console.error("Error: dashboard/dist/ not found in CI. Refusing to produce a package without dashboard assets.");
+  process.exit(1);
 } else {
   console.log("No dashboard/dist/ found — skipping dashboard copy (dev mode)");
 }

--- a/scripts/copy-dashboard.mjs
+++ b/scripts/copy-dashboard.mjs
@@ -28,9 +28,9 @@ if (existsSync(src)) {
   // During npm publish, missing dashboard is a hard error
   console.error("Error: dashboard/dist/ not found. Run 'npm run build:dashboard' first.");
   process.exit(1);
-} else if (process.env.CI === 'true') {
-  // In CI we never want a successful build artifact without dashboard assets.
-  console.error("Error: dashboard/dist/ not found in CI. Refusing to produce a package without dashboard assets.");
+} else if (process.env.AEGIS_REQUIRE_DASHBOARD_COPY === 'true') {
+  // Explicit hard-fail mode for release packaging pipelines.
+  console.error("Error: dashboard/dist/ not found. AEGIS_REQUIRE_DASHBOARD_COPY=true requires dashboard assets.");
   process.exit(1);
 } else {
   console.log("No dashboard/dist/ found — skipping dashboard copy (dev mode)");


### PR DESCRIPTION
## Summary
- make scripts/copy-dashboard.mjs fail in CI when dashboard/dist is missing
- prevents publishing npm artifacts without dashboard static bundle
- complements workflow guard in .github/workflows/release.yml

## Validation
- 
ode scripts/copy-dashboard.mjs (local dev mode)

## Incident context
This patch is part of immediate remediation for the broken dashboard in 0.5.2-alpha.
