### PR TITLE
docs: document allowedWorkDirs config and restart requirement (#1753)

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -250,6 +250,12 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_IDLE_TIMEOUT_MS` | `600000` | Session idle timeout (10 min default) |
 | `AEGIS_STALL_THRESHOLD_MS` | `120000` | Stall detection threshold (2 min default) |
 
+#### Security
+
+| Variable | Default | Description |
+|---|---|---|
+| `AEGIS_ALLOWED_WORKDIRS` | _(home, /tmp, cwd)_ | JSON array of allowed session working directories |
+
 #### Notification Channels
 
 | Variable | Default | Description |
@@ -282,6 +288,8 @@ Create `aegis.config.json` in the working directory or set `AEGIS_CONFIG`:
   },
 }
 ```
+
+> **Note:** Changes to `config.json` (including `allowedWorkDirs`) require a server restart to take effect. There is no runtime config hot-reload — edit the file then restart the server.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,6 +98,8 @@ The response includes the session ID:
 
 Save the `id` — you'll need it for follow-up commands.
 
+> **Note:** `workDir` must be under an allowed directory. By default, Aegis allows `$HOME`, `/tmp`, and the current working directory. To restrict sessions to specific directories, set `AEGIS_ALLOWED_WORKDIRS` in your environment or `allowedWorkDirs` in `aegis.config.json`. Changes to this setting require a server restart.
+
 ## 4. Monitor Progress
 
 Watch the session in the dashboard, or poll the API:


### PR DESCRIPTION
## Summary

Issue #1753: Documents that  changes in config.json require a server restart.

### Changes

**docs/enterprise.md:**
- Added  to the Security configuration table
- Added note that config file changes require server restart (no hot-reload)

**docs/getting-started.md:**
- Added note near session creation about  validation and 
- Mentions the restart requirement

### Behavior documented
- Default allowed dirs: , , 
- To restrict: set  or  in config
- Changes require restart — no runtime hot-reload

Aegis version: 0.5.3-alpha
Milestone: Documentation
Assignee: Scribe