### PR TITLE
fix: bare positional arg creates session instead of starting server (#1765)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,6 +172,7 @@ async function main(): Promise<void> {
 
   Usage:
     aegis                  Start the server (port 9100)
+    aegis "brief"          Create a session and send brief (shorthand)
     aegis --port 3000      Custom port
     aegis create "brief"   Create a session and send brief
     aegis mcp              Start MCP server (stdio transport)
@@ -235,6 +236,13 @@ async function main(): Promise<void> {
   // Subcommand: create
   if (args[0] === 'create') {
     await handleCreate(args.slice(1));
+    process.exit(0);
+  }
+
+  // Bare positional argument → treat as brief for session creation
+  const positionalArg = args.find(a => !a.startsWith('-') && a !== 'create' && a !== 'mcp');
+  if (positionalArg) {
+    await handleCreate([positionalArg, ...args.filter(a => a !== positionalArg)]);
     process.exit(0);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -239,10 +239,9 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Bare positional argument → treat as brief for session creation
-  const positionalArg = args.find(a => !a.startsWith('-') && a !== 'create' && a !== 'mcp');
-  if (positionalArg) {
-    await handleCreate([positionalArg, ...args.filter(a => a !== positionalArg)]);
+  // Shorthand: single non-flag, non-subcommand arg = brief for session creation
+  if (args.length === 1 && !args[0].startsWith('-')) {
+    await handleCreate(args);
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary
Fixes #1765 — CLI bare positional argument now creates a session instead of silently starting the server.

### Bug
Running `aegis "some brief"` (without `create` subcommand) started the server and silently ignored the positional argument.

### Fix
Added bare positional argument detection in `main()` — after `create`/`mcp` subcommand checks, before server startup:
- Detects non-flag, non-subcommand positional arg
- Routes to `handleCreate()` as shorthand
- Updated `--help` text: `aegis "brief"   Create a session (shorthand)`

### Quality Gate
- ✅ `npx tsc --noEmit`
- ✅ `npm run build`
- ✅ `npm test`

**Developed with:** v0.5.3-alpha

Fixes #1765