### PR TITLE
feat(dashboard): sparkline mini-charts on overview MetricCards

### DIFF
--- a/dashboard/src/components/overview/MetricCard.tsx
+++ b/dashboard/src/components/overview/MetricCard.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { ReactNode } from 'react';
+import { SparkLine } from './SparkLine';
 
 interface MetricCardProps {
   label: string;
@@ -15,6 +16,8 @@ interface MetricCardProps {
   color?: 'blue' | 'green' | 'amber' | 'red' | 'purple';
   /** Optional progress bar (0–100) */
   bar?: number;
+  /** Sparkline trend data */
+  sparkData?: number[];
 }
 
 const colorMap: Record<string, string> = {
@@ -33,7 +36,7 @@ const barColorMap: Record<string, string> = {
   purple: 'bg-[var(--color-info)]',
 };
 
-export default function MetricCard({ label, value, icon, suffix, subLabel, color = 'blue', bar }: MetricCardProps) {
+export default function MetricCard({ label, value, icon, suffix, subLabel, color = 'blue', bar, sparkData }: MetricCardProps) {
   return (
     <div
       role="article"
@@ -58,6 +61,11 @@ export default function MetricCard({ label, value, icon, suffix, subLabel, color
       )}
       {subLabel && (
         <div className="mt-1.5 text-xs text-[#666]">{subLabel}</div>
+      )}
+      {sparkData && sparkData.length >= 2 && (
+        <div className="mt-2">
+          <SparkLine data={sparkData} color={color === "blue" ? "var(--color-accent-cyan)" : color === "green" ? "var(--color-success)" : color === "amber" ? "var(--color-warning)" : color === "red" ? "var(--color-error)" : "var(--color-accent)"} />
+        </div>
       )}
     </div>
   );

--- a/dashboard/src/components/overview/SparkLine.tsx
+++ b/dashboard/src/components/overview/SparkLine.tsx
@@ -1,0 +1,56 @@
+/**
+ * components/overview/SparkLine.tsx — Tiny SVG sparkline for MetricCard trends.
+ */
+
+interface SparkLineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function SparkLine({
+  data,
+  width = 80,
+  height = 24,
+  color = 'var(--color-accent-cyan)',
+  className = '',
+  ariaLabel,
+}: SparkLineProps) {
+  if (data.length < 2) return null;
+
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+
+  const points = data.map((value, i) => {
+    const x = (i / (data.length - 1)) * width;
+    const y = height - ((value - min) / range) * (height - 4) - 2;
+    return `${x},${y}`;
+  });
+
+  const pathD = `M${points.join(' L')}`;
+  const label = ariaLabel ?? `Trend: ${data.length} points, range ${min}–${max}`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      role="img"
+      aria-label={label}
+    >
+      <path
+        d={pathD}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What
Adds tiny SVG sparkline charts to Overview page MetricCards for trend visualization.

Changes:
- SparkLine component (pure SVG, zero deps)
- MetricCard sparkData prop for trend data
- Color-matched to metric variant
- Accessible (aria-label)

Build and 284 tests pass. Closes #1784