### PR TITLE
feat(dashboard): CSV export for session history

### DIFF
--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -10,6 +10,7 @@ import {
   History,
   RefreshCw,
   SearchX,
+  Download,
 } from 'lucide-react';
 import {
   fetchSessionHistory,
@@ -18,6 +19,7 @@ import {
 } from '../api/client';
 import { formatTimeAgo } from '../utils/format';
 import EmptyState from '../components/shared/EmptyState';
+import { generateSessionHistoryCSV, downloadCSV } from '../utils/csv-export';
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All statuses' },
@@ -158,6 +160,12 @@ export default function SessionHistoryPage() {
     setFilterSort('newest');
   };
 
+  const handleExport = () => {
+    const csv = generateSessionHistoryCSV(records);
+    const date = new Date().toISOString().slice(0, 10);
+    downloadCSV(csv, `aegis-sessions-${date}.csv`);
+  };
+
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   return (
@@ -175,6 +183,16 @@ export default function SessionHistoryPage() {
           <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
           Refresh
         </button>
+        {records.length > 0 && (
+          <button
+            onClick={handleExport}
+            className="flex items-center gap-1.5 rounded border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700"
+            aria-label="Export session history as CSV"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Export CSV
+          </button>
+        )}
       </div>
 
       <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">

--- a/dashboard/src/utils/csv-export.ts
+++ b/dashboard/src/utils/csv-export.ts
@@ -1,0 +1,36 @@
+/**
+ * utils/csv-export.ts — Generate CSV from session history records.
+ */
+
+import type { SessionHistoryRecord } from '../api/client';
+
+function escapeCSV(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function generateSessionHistoryCSV(records: SessionHistoryRecord[]): string {
+  const headers = ['Session ID', 'Owner Key ID', 'Status', 'Source', 'Created At', 'Last Seen At'];
+  const rows = records.map((r) => [
+    escapeCSV(r.id),
+    escapeCSV(r.ownerKeyId ?? ''),
+    escapeCSV(r.finalStatus),
+    escapeCSV(r.source),
+    r.createdAt !== undefined ? new Date(r.createdAt).toISOString() : '',
+    new Date(r.lastSeenAt).toISOString(),
+  ]);
+
+  return [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
+}
+
+export function downloadCSV(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## What
One-click CSV export of filtered session history records.

Changes:
- csv-export utility (generateSessionHistoryCSV + downloadCSV)
- Export button on SessionHistoryPage (appears when records exist)
- Downloads as aegis-sessions-{date}.csv
- Respects current filters (status, owner, date range)
- Zero external dependencies

Build and 284 tests pass. Closes #1790