### PR TITLE
feat(dashboard): breadcrumb navigation component

### DIFF
--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -76,7 +76,7 @@ describe('Layout SSE error handling (#587)', () => {
   it('renders without crashing when subscribeGlobalSSE succeeds', () => {
     mockSubscribeGlobalSSE.mockReturnValue(() => {});
     renderLayout();
-    expect(screen.getByText('Aegis Dashboard')).toBeDefined();
+    expect(screen.getByRole('main')).toBeDefined();
     expect(mockSubscribeGlobalSSE).toHaveBeenCalled();
   });
 
@@ -147,7 +147,7 @@ describe('Layout SSE error handling (#587)', () => {
 
     // Should NOT throw — the component catches the error
     expect(() => renderLayout()).not.toThrow();
-    expect(screen.getByText('Aegis Dashboard')).toBeDefined();
+    expect(screen.getByRole('main')).toBeDefined();
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Failed to subscribe to global SSE"),
       expect.any(Number),

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -4,6 +4,7 @@
 
 import { NavLink, Outlet } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import Breadcrumb from './shared/Breadcrumb';
 import {
   Activity,
   AlertTriangle,
@@ -337,9 +338,7 @@ export default function Layout() {
             >
               <Menu className="h-5 w-5" />
             </button>
-            <h1 className="text-sm font-medium text-gray-300">
-              Aegis Dashboard
-            </h1>
+            <Breadcrumb />
           </div>
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2 text-xs text-gray-400">

--- a/dashboard/src/components/shared/Breadcrumb.tsx
+++ b/dashboard/src/components/shared/Breadcrumb.tsx
@@ -1,0 +1,79 @@
+/**
+ * components/shared/Breadcrumb.tsx — Navigation breadcrumb trail.
+ */
+
+import { Link, useLocation } from 'react-router-dom';
+import { ChevronRight, Home } from 'lucide-react';
+
+interface Crumb {
+  label: string;
+  path?: string;
+}
+
+const ROUTE_LABELS: Record<string, string> = {
+  '': 'Overview',
+  sessions: 'Sessions',
+  history: 'History',
+  pipelines: 'Pipelines',
+  audit: 'Audit',
+  users: 'Users',
+  auth: 'Auth',
+  keys: 'Keys',
+};
+
+function buildCrumbs(pathname: string): Crumb[] {
+  const segments = pathname.split('/').filter(Boolean);
+  const crumbs: Crumb[] = [{ label: 'Home', path: '/' }];
+
+  let currentPath = '';
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    currentPath += `/${seg}`;
+
+    const isParam = seg.length > 8 && /^[a-f0-9-]+$/.test(seg);
+
+    if (isParam) {
+      crumbs.push({
+        label: seg.slice(0, 8) + '…',
+        path: i < segments.length - 1 ? currentPath : undefined,
+      });
+    } else {
+      const label = ROUTE_LABELS[seg] ?? seg.charAt(0).toUpperCase() + seg.slice(1);
+      crumbs.push({
+        label,
+        path: i < segments.length - 1 ? currentPath : undefined,
+      });
+    }
+  }
+
+  return crumbs;
+}
+
+export default function Breadcrumb() {
+  const location = useLocation();
+
+  if (location.pathname === '/' || location.pathname === '') return null;
+
+  const crumbs = buildCrumbs(location.pathname);
+
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-zinc-500">
+      {crumbs.map((crumb, i) => (
+        <span key={i} className="flex items-center gap-1">
+          {i > 0 && <ChevronRight className="h-3 w-3 text-zinc-600" />}
+          {i === 0 && <Home className="h-3.5 w-3.5 text-zinc-500" />}
+          {crumb.path ? (
+            <Link
+              to={crumb.path}
+              className="text-zinc-400 hover:text-zinc-200 transition-colors"
+            >
+              {crumb.label}
+            </Link>
+          ) : (
+            <span className="text-zinc-300 font-medium">{crumb.label}</span>
+          )}
+        </span>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## What
Replaces static 'Aegis Dashboard' header with dynamic breadcrumb navigation.

Changes:
- Breadcrumb component (route-aware labels, UUID truncation)
- Integrated into Layout header
- Shows Home > Sessions > {id} pattern
- Hidden on home page
- Accessible (nav + aria-label)
- Updated Layout tests

Build and 284 tests pass. Closes #1792