### PR TITLE
docs: add dark/light theme toggle to dashboard guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,26 @@ All branches are created from `origin/develop`. Branch names use the format:
 - `main` = release-ready only; Ema promotes `develop → main`
 - `origin/develop` must exist before branching — run `git fetch origin develop:develop` first
 
+### Development Workflow: Git Worktrees
+
+**Use git worktrees for ALL feature development.** Never develop directly in the main repo folder.
+
+```bash
+# Clone once
+git clone https://github.com/OneStepAt4time/aegis.git
+
+# Create a worktree per feature
+git worktree add ~/projects/aegis-feat-name origin/develop
+
+# Inside worktree — create feature branch
+git checkout -b feat/my-feature
+
+# After PR merge — remove worktree
+git worktree remove ~/projects/aegis-feat-name
+```
+
+See the [Worktree Guide](./docs/worktree-guide.md) for detailed setup and cleanup instructions.
+
 ## Commit Conventions
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,162 @@
+# Deployment Guide
+
+This guide covers deploying Aegis in development, CI/CD, and production environments.
+
+## Prerequisites
+
+- Node.js 20+ (LTS recommended)
+- npm 10+
+- Linux/macOS (Windows via WSL2)
+- Tailscale (optional, for remote access)
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AEGIS_AUTH_TOKEN` | Yes | — | Bearer token for API authentication |
+| `AEGIS_PORT` | No | `9100` | HTTP server port |
+| `AEGIS_HOST` | No | `0.0.0.0` | Bind address |
+| `AEGIS_DATA_DIR` | No | `~/.aegis` | Session data storage |
+| `AEGIS_DASHBOARD_URL` | No | `http://localhost:9100/dashboard` | Dashboard URL |
+| `CLAUDE_DATA_DIR` | No | `~/.claude` | Claude Code data directory |
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+node dist/server.js
+```
+
+Visit `http://localhost:9100/dashboard/` to access the dashboard.
+
+## Production Deployment
+
+### Systemd Service
+
+Create `/etc/systemd/system/aegis.service`:
+
+```ini
+[Unit]
+Description=Aegis Server
+After=network.target
+
+[Service]
+Type=simple
+User=aegis
+WorkingDirectory=/opt/aegis
+ExecStart=/usr/bin/node dist/server.js
+Restart=on-failure
+RestartSec=5
+Environment=AEGIS_AUTH_TOKEN=your-secure-token
+Environment=AEGIS_PORT=9100
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable aegis
+sudo systemctl start aegis
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/onestepat4time/aegis:latest
+
+docker run -d \
+  --name aegis \
+  -p 9100:9100 \
+  -e AEGIS_AUTH_TOKEN=your-secure-token \
+  -v aegis-data:/root/.aegis \
+  -v claude-data:/root/.claude \
+  ghcr.io/onestepat4time/aegis:latest
+```
+
+### Docker Compose
+
+```yaml
+version: '3.8'
+services:
+  aegis:
+    image: ghcr.io/onestepat4time/aegis:latest
+    ports:
+      - "9100:9100"
+    environment:
+      AEGIS_AUTH_TOKEN: ${AEGIS_AUTH_TOKEN}
+      AEGIS_PORT: 9100
+    volumes:
+      - aegis-data:/root/.aegis
+      - claude-data:/root/.claude
+    restart: unless-stopped
+
+volumes:
+  aegis-data:
+  claude-data:
+```
+
+## Reverse Proxy
+
+### Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name aegis.example.com;
+
+    ssl_certificate /etc/ssl/aegis.crt;
+    ssl_certificate_key /etc/ssl/aegis.key;
+
+    location / {
+        proxy_pass http://localhost:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+## Health Checks
+
+```bash
+curl http://localhost:9100/v1/health
+```
+
+Response:
+```json
+{
+  "status": "ok",
+  "version": "0.5.3-alpha",
+  "uptime": 3600
+}
+```
+
+## Updating
+
+```bash
+# Docker
+docker pull ghcr.io/onestepat4time/aegis:latest
+docker restart aegis
+
+# Systemd
+cd /opt/aegis
+git pull origin main
+npm install
+npm run build
+sudo systemctl restart aegis
+```
+
+## Monitoring
+
+- Health endpoint: `GET /v1/health`
+- Metrics: `GET /v1/sessions/:id/metrics`
+- Audit log: `GET /v1/audit`
+
+## Troubleshooting
+
+See [Troubleshooting Guide](./docs/troubleshooting.md) for common deployment issues.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -4,6 +4,15 @@ The Aegis dashboard (`/dashboard/`) provides a web UI for managing sessions, pip
 
 ## Features
 
+### Theme Toggle (Dark/Light)
+
+Switch between dark and light theme. The dashboard defaults to your system preference (`prefers-color-scheme`) and persists your choice in localStorage.
+
+- **Toggle button** in the header — Sun (light) / Moon (dark) icons
+- **System detection** — follows OS/browser dark mode setting by default
+- **Manual override** — click to switch, choice saved across sessions
+- **40+ CSS variables** adapt for each theme
+
 ### Keyboard Shortcuts
 
 Navigate faster using keyboard shortcuts:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -66,6 +66,27 @@ All dashboard pages now show consistent empty states when no data is available:
 - Pipelines page: "No pipelines yet" with setup instructions
 - Consistent styling across all pages
 
+### Toast Notifications
+
+Feedback for user actions appears as non-blocking toast notifications:
+
+- **Type icons** — success (checkmark), error (X), warning, info — instantly recognizable
+- **Auto-dismiss progress bar** — visual countdown shows when toast will disappear
+- **Clear all button** — dismiss all toasts at once
+- **Variants** — color-coded by severity (green/red/yellow/blue)
+- **Accessible** — uses `role="alert"` for screen readers
+
+Toasts auto-dismiss after 4 seconds. Click the X to dismiss manually.
+
+### Session Detail Page
+
+The session detail page (`/dashboard/sessions/:id`) includes:
+
+- **Copy session ID** button — one-click copy to clipboard
+- **Back to sessions** link — quick navigation back to the list
+- **Status badges** — visual status indicators
+- **Action buttons** — interrupt, terminate, fork, save as template
+
 ## Pages
 
 ### Overview (`/dashboard/overview`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -241,6 +241,22 @@ For the full configuration reference, see [Enterprise Deployment](./enterprise.m
 - **[TypeDoc API](https://onestepat4time.github.io/aegis/)** — Auto-generated TypeScript reference
 - **[ROADMAP](./ROADMAP.md)** — What's coming next
 
+## Contributing to Aegis
+
+See the [Contributing Guide](../CONTRIBUTING.md) for development workflow, branch conventions, and PR process.
+
+For Aegis development, use **git worktrees** — never develop directly in the main repo folder:
+
+```bash
+# Create a worktree per feature
+git worktree add ~/projects/aegis-my-feature origin/develop
+
+# Inside worktree
+git checkout -b feat/my-feature
+```
+
+See the [Worktree Guide](./worktree-guide.md) for detailed setup instructions.
+
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
## Summary

Major documentation update addressing #1820.

### New files
- **DEPLOYMENT.md** — Production deployment guide covering systemd, Docker, Docker Compose, Nginx reverse proxy, health checks, and updating

### Updated files
- **CONTRIBUTING.md** — Added "Development Workflow: Git Worktrees" section with setup instructions and link to worktree-guide.md
- **docs/getting-started.md** — Added "Contributing to Aegis" section with worktree reference and link to worktree-guide.md
- **docs/dashboard.md** — Added:
  - Toast Notifications section (type icons, progress bar, clear all, variants)
  - Session Detail Page section (copy ID, back link, status badges, action buttons)
  - Theme Toggle section (already added previously)

### Coverage after this PR
| File | Status |
|------|--------|
| CONTRIBUTING.md | ✅ Updated with worktree rules |
| DEPLOYMENT.md | ✅ Created |
| SECURITY.md | ✅ Already exists |
| CHANGELOG.md | ✅ Auto-managed by release-please |
| dashboard.md | ✅ All 8 features covered |
| getting-started.md | ✅ Worktree section added |

Closes #1820

Aegis version: 0.5.3-alpha
Milestone: Documentation
Assignee: Scribe