### PR TITLE
docs: update README dashboard section with new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ Works with [OpenClaw](https://openclaw.ai), custom orchestrators, or any agent t
 
 Aegis ships with a built-in dashboard at `http://localhost:9100/dashboard/` — real-time session monitoring, activity streams, and health overview.
 
+**Dashboard features:**
+- Dark/light theme with system preference detection
+- Keyboard shortcuts for fast navigation (`?`, `Ctrl+K`, `G+O/S/P/A/U`)
+- Session search, filter by date range, CSV export
+- Metric cards with sparkline mini-charts
+- Consistent empty states across all pages
+- Toast notifications for user feedback
+
 ```bash
 npx @onestepat4time/aegis          # visit http://localhost:9100/dashboard/
 ```


### PR DESCRIPTION
## Summary

Updates README.md Web Dashboard section to mention all new dashboard features.

### Changes
- Added 6 dashboard feature bullets to README Web Dashboard section:
  - Dark/light theme toggle
  - Keyboard shortcuts
  - Session search/filter with CSV export
  - Metric cards with sparklines
  - Consistent empty states
  - Toast notifications

### Note on remaining gaps
- **ADR gaps (0006-0016)**: These are architectural decisions that need team input — not pure doc tasks. Recommend creating a dedicated ADR for each decision if needed.
- **Internal March 2026 docs**: Need review for obsolescence — recommend Athena/Manudis assess.

Closes Athena's remaining audit gap (README update)

Aegis version: 0.5.3-alpha
Milestone: Documentation
Assignee: Scribe