### PR TITLE
docs: add 4 essential ADRs (0006, 0007, 0014, 0016)

### DIFF
--- a/docs/adr/0006-aegis-middleware-not-agent-framework.md
+++ b/docs/adr/0006-aegis-middleware-not-agent-framework.md
@@ -1,0 +1,53 @@
+# ADR-0006: Aegis as Middleware, Not Agent Framework
+
+Status: Accepted
+Date: 2026-04-10
+Issue: #1756 (related)
+
+## Context
+
+Aegis was initially designed as an orchestration platform. As it evolved, platform risk emerged: **Anthropic will likely release an official Claude Code API**. If that happens, any orchestration layer that is tightly coupled to the tmux runner becomes obsolete.
+
+The question arose: what is Aegis's unique value if intelligence can be provided externally?
+
+## Decision
+
+**Aegis = Enterprise Orchestration Middleware, NOT an agent framework.**
+
+Intelligence stays OUTSIDE. Aegis is "stupid-but-powerful": it provides flows, security, audit, and orchestration — but does not prescribe how AI reasoning should work.
+
+### Core Thesis
+
+Aegis's value is its **Control Plane**, not the tmux runner hack. The tmux runner is a temporary implementation detail. The real product is the infrastructure around session management, permissions, and audit.
+
+### Three Deployment Tiers
+
+1. **Local Orchestration** — single dev, implicit trust, dashboard + Telegram
+2. **CI/CD & Team Automation** — policy-based permissions, Blueprints, Slack
+3. **Zero-Trust Enterprise** — Docker isolation, immutable audit, no network egress
+
+### Kill Your Darlings
+
+Features that don't fit the middleware vision are removed or disabled:
+
+- **Consensus Review** — agent framework territory, not middleware
+- **Model Router** — unless justified by immediate use case
+
+Rule: if it smells like an agent framework feature → remove or disable.
+
+## Consequences
+
+Pros:
+- Aegis survives Anthropic API releases by abstracting the Runner (TmuxRunner → AnthropicApiRunner)
+- Clear product positioning differentiates from Cursor, Copilot, and other AI coding tools
+- Enterprise customers get governance, audit, and compliance — not just automation
+
+Cons:
+- Removes features some users may have expected (consensus, model routing)
+- Requires ongoing discipline to reject features that blur the middleware boundary
+
+## Enforcement
+
+- New features must be evaluated against this thesis
+- If it requires AI reasoning → it's not an Aegis feature
+- Architecture decisions should reference this ADR

--- a/docs/adr/0007-server-decomposition-fastify-plugins.md
+++ b/docs/adr/0007-server-decomposition-fastify-plugins.md
@@ -1,0 +1,66 @@
+# ADR-0007: Server Decomposition into Fastify Plugins
+
+Status: Accepted
+Date: 2026-04-13
+Issue: #1756
+
+## Context
+
+`server.ts` has grown to ~2500 lines, making it difficult to:
+- Navigate and understand the codebase
+- Test individual route handlers in isolation
+- Review PRs that touch multiple unrelated routes
+- Onboard new contributors
+
+The server handles authentication, session management, pipeline orchestration, alerting, memory bridge, MCP integration, and more — all in one file.
+
+## Decision
+
+Decompose `server.ts` into Fastify plugins using the [8-plugin architecture plan](./docs/architecture.md#server-decomposition):
+
+```
+src/server.ts          → ~50 lines (plugin registration only)
+src/routes/sessions.ts → session CRUD + send/answer
+src/routes/pipelines.ts → pipeline management
+src/routes/memory.ts   → memory bridge endpoints
+src/routes/alerting.ts → alert management
+src/routes/auth.ts     → authentication + API keys
+src/plugins/audit.ts   → audit logging plugin
+src/plugins/sse.ts     → SSE connection management
+```
+
+### Constraints
+
+- **Zero API/behavior changes** — all endpoint signatures must remain identical
+- **Each plugin <200 lines** — enforce single responsibility
+- **PRs <500 lines** — decompose incrementally
+- **server.ts target <200 lines** — after decomposition
+- **Backward compatible** — existing clients continue to work without changes
+
+### Migration Strategy
+
+1. Create new plugin files alongside `server.ts`
+2. Move route handlers one plugin at a time
+3. Register plugins in `server.ts` — no logic changes
+4. Remove inline route handlers after migration
+5. Delete `server.ts` when empty
+
+## Consequences
+
+Pros:
+- Smaller, focused files are easier to understand and test
+- Parallel development — different plugins can be owned by different agents
+- Faster CI — plugins can be tested in isolation
+- Better onboarding — new contributors read one plugin at a time
+
+Cons:
+- Risk of breaking API contracts during migration
+- Requires discipline to keep plugins small
+- Cross-plugin dependencies must be managed carefully
+
+## Enforcement
+
+- New routes go into appropriate plugin files — not `server.ts`
+- Plugin files must stay under 200 lines
+- PRs exceeding 500 lines should be split
+- API signatures require review sign-off from Argus

--- a/docs/adr/0014-multi-line-message-sending-via-tmux.md
+++ b/docs/adr/0014-multi-line-message-sending-via-tmux.md
@@ -1,0 +1,50 @@
+# ADR-0014: Multi-line Message Sending via tmux Line-by-Line
+
+Status: Accepted
+Date: 2026-04-14
+Issue: #1770, #1815
+
+## Context
+
+When sending multi-line messages to Claude Code sessions via `POST /v1/sessions/:id/send`, content was truncated at the first newline character. This broke prompts containing code blocks, markdown formatting, or any content with line breaks.
+
+Root cause: the `send` endpoint passed message content directly to tmux without handling newline characters. tmux treats newlines as command terminators, so anything after the first newline was ignored.
+
+## Decision
+
+Send multi-line content **line-by-line via tmux** with proper escaping:
+
+1. Split content on newlines
+2. Send each line as a separate tmux command
+3. Use a continuation marker for lines that are continuations (indented or joined)
+4. Reassemble the complete message on the Claude Code side
+
+### Implementation
+
+The `sendMessage()` function in `src/tmux.ts` now:
+- Detects multi-line content
+- Sends the first line with the full command
+- Sends subsequent lines as `send-keys` with proper tmux escaping
+- Handles special characters (quotes, backslashes) via proper escaping
+
+### API Behavior
+
+- `POST /v1/sessions/:id/send` — accepts multi-line `content` field
+- Content is preserved exactly — no normalization or truncation
+- Works with tmux, psmux (Windows), and direct TCP modes
+
+## Consequences
+
+Pros:
+- Fixes P1 bug affecting all multi-line prompts
+- Enables code block delivery, markdown content, and formatted prompts
+- Consistent behavior across all platforms (Linux, macOS, Windows)
+
+Cons:
+- Slight latency increase for very long messages (multiple tmux round-trips)
+- Requires tmux compatibility on all platforms
+
+## References
+
+- Issue #1770 — original bug report
+- PR #1815 — fix implementation

--- a/docs/adr/0016-release-please-github-app-token.md
+++ b/docs/adr/0016-release-please-github-app-token.md
@@ -1,0 +1,62 @@
+# ADR-0016: Release-please with GitHub App Token
+
+Status: Accepted
+Date: 2026-04-10
+
+## Context
+
+Aegis uses [release-please](https://github.com/googleapis/release-please) for automated changelog generation and semantic versioning. However, release-please requires authentication to create releases and tags on GitHub.
+
+Two authentication options exist:
+1. **Personal Access Token (PAT)** — tied to a individual user, expires, has user permissions
+2. **GitHub App token** — tied to an application, has installation permissions, longer-lived
+
+## Decision
+
+Use **GitHub App token** for release-please automation.
+
+### Why Not PAT?
+
+- PATs expire and require manual renewal
+- PATs carry user permissions that may be too broad
+- If the user leaves, the PAT must be regenerated
+- PATs cannot be scoped to a specific repository in a way that's visible to reviewers
+
+### Why GitHub App?
+
+- Token is associated with the Aegis app, not a user
+- Permissions are installation-scoped (read/write on specific repos)
+- Token auto-refreshes before expiry
+- Audit trail shows "Aegis" as the actor, not an individual
+
+### Configuration
+
+```bash
+# Set in CI environment
+GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n..."
+GITHUB_TOKEN=$(gh auth token --app github-app)
+```
+
+release-please uses the token to:
+- Create tags on release branches
+- Create GitHub releases with changelog
+- Update CHANGELOG.md via PR
+
+## Consequences
+
+Pros:
+- Reliable automation without manual token management
+- Better audit trail — releases attributed to app, not user
+- No token expiration during long-running release processes
+
+Cons:
+- GitHub App setup requires admin access to the GitHub organization
+- App must be installed on the repository
+- App private key must be kept secure (use secrets management)
+
+## Enforcement
+
+- Never commit GitHub App private keys to repository
+- Store app credentials in CI secrets, not environment files
+- Rotate app keys annually or immediately if compromised

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,10 @@ ADRs document significant architectural decisions made during Aegis development.
 | [ADR-0003](0003-windows-minimum-supported-version.md) | Windows Minimum Supported Version | Accepted | 2026-04-07 | — |
 | [ADR-0004](0004-psmux-version-pinning.md) | psmux Version Pinning | Accepted | 2026-04-07 | — |
 | [ADR-0005](0005-module-level-ai-context.md) | Module-Level AI Context Files | Accepted | 2026-04-07 | #1304 |
+| [ADR-0006](0006-aegis-middleware-not-agent-framework.md) | Aegis as Middleware, Not Agent Framework | Accepted | 2026-04-10 | — |
+| [ADR-0007](0007-server-decomposition-fastify-plugins.md) | Server Decomposition into Fastify Plugins | Accepted | 2026-04-13 | #1756 |
+| [ADR-0014](0014-multi-line-message-sending-via-tmux.md) | Multi-line Message Sending via tmux Line-by-Line | Accepted | 2026-04-14 | #1770, #1815 |
+| [ADR-0016](0016-release-please-github-app-token.md) | Release-please with GitHub App Token | Accepted | 2026-04-10 | — |
 | [ADR-0017](0017-opentelemetry-tracing.md) | OpenTelemetry Distributed Tracing | Accepted | 2026-04-08 | — |
 
 ## Creating a New ADR


### PR DESCRIPTION
## Summary

Creates 4 essential Architecture Decision Records as prioritized by Athena's ADR assessment.

### ADRs Created

| Number | Title | Priority |
|--------|-------|----------|
| ADR-0006 | Aegis as Middleware, Not Agent Framework | High |
| ADR-0007 | Server Decomposition into Fastify Plugins | High |
| ADR-0014 | Multi-line Message Sending via tmux Line-by-Line | High |
| ADR-0016 | Release-please with GitHub App Token | High |

### ADR-0006: Aegis as Middleware, Not Agent Framework
Documents the core product thesis: Aegis = Enterprise Orchestration Middleware. Intelligence stays outside. Three deployment tiers. Kill your darlings (Consensus Review, Model Router).

### ADR-0007: Server Decomposition into Fastify Plugins
Documents the server.ts decomposition plan: ~8 plugins, each <200 lines, PRs <500 lines, zero API changes, target server.ts <200 lines.

### ADR-0014: Multi-line Message Sending via tmux Line-by-Line
Documents the fix for #1770: send multi-line content line-by-line via tmux instead of truncating at first newline. Fixes P1 truncation bug.

### ADR-0016: Release-please with GitHub App Token
Documents why GitHub App tokens are used over PATs for release automation. Covers configuration and security considerations.

### Changes
- 4 new ADR files in 
- 1 updated index in 

Closes Athena's ADR assessment priority items

Aegis version: 0.5.3-alpha
Milestone: Documentation
Assignee: Scribe