### PR TITLE
fix(dashboard): harden E2E test assertions

### DIFF
--- a/dashboard/e2e/critical-paths.spec.ts
+++ b/dashboard/e2e/critical-paths.spec.ts
@@ -3,80 +3,60 @@ import { test, expect } from '@playwright/test';
 test.describe('Critical Path E2E Tests', () => {
 
   // 1. Dashboard loads and renders overview
-  test('overview page loads and renders', async ({ page }) => {
+  test('overview page loads and renders heading and sessions text', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /overview/i })).toBeVisible({ timeout: 10_000 });
-    // MetricCards should render
     await expect(page.getByText(/sessions/i)).toBeVisible();
   });
 
-  // 2. Login flow
-  test('login page rejects empty token', async ({ page }) => {
+  // 2. Login page renders and stays on login without token
+  test('login page stays on /login without valid token', async ({ page }) => {
     await page.goto('/login');
-    const input = page.getByPlaceholder(/token/i);
-    if (await input.isVisible()) {
-      await input.fill('');
-      await page.getByRole('button', { name: /login|submit|enter/i }).click();
-      // Should show error or stay on login
-      await expect(page).toHaveURL(/login/);
-    }
+    const submitButton = page.getByRole('button', { name: /login|submit|enter|sign/i });
+    await expect(submitButton).toBeVisible({ timeout: 10_000 });
+    // Click without filling token
+    await submitButton.click();
+    // Should remain on login page
+    await expect(page).toHaveURL(/login/);
   });
 
-  // 3. Session list page with search
-  test('session history page loads with search', async ({ page }) => {
+  // 3. Session history page renders with search input
+  test('session history page renders search input', async ({ page }) => {
     await page.goto('/sessions/history');
-    await expect(page.getByRole('heading', { name: /session/i }).or(page.getByText(/session/i))).toBeVisible({ timeout: 10_000 });
-    // Search input should exist
-    const searchInput = page.getByPlaceholder(/search|filter/i);
-    if (await searchInput.isVisible()) {
-      await searchInput.fill('test-query');
-      await page.waitForTimeout(500);
-    }
+    await expect(page.getByPlaceholder(/search|filter/i)).toBeVisible({ timeout: 10_000 });
   });
 
-  // 4. Session detail page loads
-  test('session detail page shows not found for invalid ID', async ({ page }) => {
-    await page.goto('/sessions/nonexistent-session-id');
-    // Should render something (error state or empty)
-    await expect(page.locator('body')).toBeVisible();
+  // 4. Session detail page renders error state for invalid ID
+  test('session detail shows error for invalid session ID', async ({ page }) => {
+    await page.goto('/sessions/nonexistent-session-id-12345');
+    // Page should render content (either error message or not found)
+    // Assert that the page didn't crash (no blank screen)
+    await expect(page.locator('main')).toBeVisible({ timeout: 10_000 });
   });
 
-  // 5. Theme toggle persists
-  test('theme toggle changes and persists', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForTimeout(1000);
+  // 5. Theme toggle changes data-theme attribute on settings page
+  test('theme toggle changes data-theme on settings page', async ({ page }) => {
+    await page.goto('/settings');
+    const themeButton = page.getByRole('button', { name: /dark|light/i });
+    await expect(themeButton).toBeVisible({ timeout: 10_000 });
 
-    // Navigate to settings if theme toggle in sidebar
-    const settingsLink = page.getByRole('link', { name: /settings/i });
-    if (await settingsLink.isVisible()) {
-      await settingsLink.click();
-      const themeButton = page.getByRole('button', { name: /dark|light/i });
-      if (await themeButton.isVisible()) {
-        const htmlBefore = await page.locator('html').getAttribute('data-theme');
-        await themeButton.click();
-        const htmlAfter = await page.locator('html').getAttribute('data-theme');
-        expect(htmlAfter).not.toBe(htmlBefore);
-      }
-    }
+    const themeBefore = await page.locator('html').getAttribute('data-theme');
+    await themeButton.click();
+    const themeAfter = await page.locator('html').getAttribute('data-theme');
+    expect(themeAfter).not.toBe(themeBefore);
   });
 
-  // 6. CSV export — check button exists
-  test('CSV export button exists on session history', async ({ page }) => {
+  // 6. CSV export button is visible on session history page
+  test('CSV export button is present on session history page', async ({ page }) => {
     await page.goto('/sessions/history');
-    await page.waitForTimeout(1000);
     const exportBtn = page.getByRole('button', { name: /export|csv/i });
-    // Button should exist (may or may not be visible depending on data)
-    const count = await exportBtn.count();
-    expect(count).toBeGreaterThanOrEqual(0);
+    await expect(exportBtn).toBeVisible({ timeout: 10_000 });
   });
 
-  // 7. SSE connection indicator visible
-  test('SSE status indicator renders on overview', async ({ page }) => {
+  // 7. SSE connection indicator visible on overview
+  test('SSE status indicator shows Live or Polling', async ({ page }) => {
     await page.goto('/');
-    await page.waitForTimeout(2000);
-    // Should show either Live or Polling badge
-    const liveIndicator = page.getByText(/live|polling/i);
-    await expect(liveIndicator).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/^(Live|Polling)$/i)).toBeVisible({ timeout: 15_000 });
   });
 
 });


### PR DESCRIPTION
## What
Fixes weak assertions flagged by Argus on #1830.

Changes:
- Remove all if-guards — tests assert directly or fail
- Replace `waitForTimeout` with proper `waitFor` assertions
- CSV export: assert button IS visible (not `count >= 0`)
- Theme toggle: assert directly on /settings page
- Session detail: assert `main` element is visible (not `body`)
- Login: assert submit button visible before clicking
- SSE: anchored regex `^(Live|Polling)$`

Build and 284 tests pass.