### PR TITLE
fix(monitor): default jsonl watcher initial offset to 0 to avoid undefined start (fix #1767) - clean

### DIFF
--- a/src/__tests__/monitor-initial-offset.test.ts
+++ b/src/__tests__/monitor-initial-offset.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest';
+import { SessionMonitor, DEFAULT_MONITOR_CONFIG } from '../monitor.js';
+
+test('monitor passes numeric initial offset to JsonlWatcher.watch when session.monitorOffset is undefined', async () => {
+  // sessions stub: returns one session with undefined monitorOffset
+  const sessionObj = { id: 'sess-1', jsonlPath: '/tmp/fake-session.jsonl', monitorOffset: undefined } as any;
+  const sessionsStub = {
+    listSessions: () => [sessionObj],
+    readMessagesForMonitor: async (id: string) => ({ messages: [], status: 'idle', statusText: null, interactiveContent: null }),
+  } as any;
+
+  const channelsStub = { statusChange: async (_: any) => {} } as any;
+
+  let capturedOffset: any = undefined;
+  const watcherStub = {
+    entries: {} as Record<string, boolean>,
+    watch(sessionId: string, jsonlPath: string, initialOffset: any) {
+      this.entries[sessionId] = true;
+      capturedOffset = initialOffset;
+    },
+    unwatch(sessionId: string) { delete this.entries[sessionId]; },
+    isWatching(sessionId: string) { return !!this.entries[sessionId]; },
+    onEntries(_listener: any) { return () => {}; },
+  } as any;
+
+  const monitor = new SessionMonitor(sessionsStub, channelsStub, DEFAULT_MONITOR_CONFIG);
+  monitor.setJsonlWatcher(watcherStub);
+
+  // Prevent health/stall/dead checks from running in this unit test run
+  (monitor as any).lastTmuxHealthCheck = Date.now();
+  (monitor as any).lastStallCheck = Date.now();
+  (monitor as any).lastDeadCheck = Date.now();
+
+  // Call the internal poll once
+  await (monitor as any).poll();
+
+  // After poll, watcher.watch should have been invoked with numeric offset 0
+  expect(capturedOffset).toBe(0);
+});

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -233,7 +233,8 @@ export class SessionMonitor {
       try {
         // Issue #84: Start watching when jsonlPath is discovered
         if (this.jsonlWatcher && session.jsonlPath && !this.jsonlWatcher.isWatching(session.id)) {
-          this.jsonlWatcher.watch(session.id, session.jsonlPath, session.monitorOffset);
+          const initialOffset = typeof session.monitorOffset === 'number' ? session.monitorOffset : 0;
+        this.jsonlWatcher.watch(session.id, session.jsonlPath, initialOffset);
         }
         await this.checkSession(session);
       } catch (e) {


### PR DESCRIPTION
Fix: ensure the SessionMonitor passes a numeric initial offset to JsonlWatcher.watch to avoid a race where the watcher may start with `undefined` and skip existing JSONL entries.

Changes:
- src/monitor.ts: default the initial offset passed to `jsonlWatcher.watch` to `0` when `session.monitorOffset` is not a number.
- src/__tests__/monitor-initial-offset.test.ts: unit test asserting the monitor passes numeric offset (0) when `session.monitorOffset` is undefined.

Why:
- Triage of #1767 showed a race where monitor can call `watch` with undefined during discovery. This minimal fix prevents that race and is conservative.

Tests:
- Ran `npx tsc --noEmit` and the added unit test locally during triage.

Notes:
- This PR is intentionally minimal (only the two files). The previous PR #1833 has been closed because it was contaminated with unrelated changes; that branch remains for investigation. The tmux/mock work is tracked in issue #1810 and a separate branch.
