### PR TITLE
feat(dashboard): add loading skeleton to session detail page

### DIFF
--- a/dashboard/src/components/shared/Skeleton.tsx
+++ b/dashboard/src/components/shared/Skeleton.tsx
@@ -1,0 +1,46 @@
+/**
+ * components/shared/Skeleton.tsx — Loading skeleton components.
+ */
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function SkeletonLine({ className = '' }: SkeletonProps) {
+  return (
+    <div
+      className={`animate-pulse rounded bg-[var(--color-void-lighter)] ${className}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+export function SkeletonCard({ className = '' }: SkeletonProps) {
+  return (
+    <div className={`rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-4 ${className}`}>
+      <div className="space-y-3">
+        <SkeletonLine className="h-4 w-1/3" />
+        <SkeletonLine className="h-3 w-2/3" />
+        <SkeletonLine className="h-3 w-1/2" />
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonTable({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-2">
+      {/* Header */}
+      <SkeletonLine className="h-8 w-full" />
+      {/* Rows */}
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex gap-4 py-2">
+          <SkeletonLine className="h-4 w-1/4" />
+          <SkeletonLine className="h-4 w-1/6" />
+          <SkeletonLine className="h-4 w-1/6" />
+          <SkeletonLine className="h-4 w-1/6" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -106,8 +106,26 @@ export default function SessionDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-[var(--color-void)] flex items-center justify-center text-[#555] text-sm">
-        <div className="animate-pulse">Loading session…</div>
+      <div className="flex flex-col gap-6 p-4 sm:p-6 animate-pulse">
+        {/* Header skeleton */}
+        <div className="bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg p-4">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="h-5 w-48 rounded bg-[var(--color-void-lighter)]" />
+            <div className="h-5 w-20 rounded-full bg-[var(--color-void-lighter)]" />
+          </div>
+          <div className="flex gap-2">
+            <div className="h-4 w-32 rounded bg-[var(--color-void-lighter)]" />
+            <div className="h-4 w-24 rounded bg-[var(--color-void-lighter)]" />
+          </div>
+        </div>
+        {/* Tabs skeleton */}
+        <div className="flex gap-2 border-b border-[var(--color-void-lighter)] pb-2">
+          <div className="h-8 w-20 rounded bg-[var(--color-void-lighter)]" />
+          <div className="h-8 w-20 rounded bg-[var(--color-void-lighter)]" />
+          <div className="h-8 w-20 rounded bg-[var(--color-void-lighter)]" />
+        </div>
+        {/* Content skeleton */}
+        <div className="h-64 rounded-lg bg-[var(--color-surface)] border border-[var(--color-void-lighter)]" />
       </div>
     );
   }


### PR DESCRIPTION
## What
Replaces the plain "Loading session..." text with a visual skeleton layout that shows the page structure while loading.

Changes:
- Skeleton.tsx component (SkeletonLine, SkeletonCard, SkeletonTable)
- Session detail page now shows header + tabs + content placeholders during load
- Better UX — users see the page layout while data loads

Note: SessionHistoryPage already has SkeletonRows for loading states. Build and 284 tests pass.