### PR TITLE
fix(1786): prevent 'shell: true' usage and add security check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:fault-harness": "vitest run src/__tests__/fault-injection-harness-901.test.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "format": "prettier --write src scripts"
+    "format": "prettier --write src scripts",
+    "security-check": "node scripts/check-no-shell-true.js"
   },
   "keywords": [
     "claude",

--- a/scripts/check-no-shell-true.js
+++ b/scripts/check-no-shell-true.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const path = require('path');
+try {
+  const out = execSync("git grep -n --line-number --no-color -E 'shell\s*:\s*true' -- src || true", { encoding: 'utf8' }).trim();
+  if (out) {
+    console.error('Security check failed: found occurrences of "shell: true" in source files:\n');
+    console.error(out);
+    process.exit(2);
+  }
+  console.log('Security check passed: no "shell: true" occurrences in src/.');
+  process.exit(0);
+} catch (e) {
+  console.error('Error running security check:', e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Finds occurrences of 'shell: true' in src/ and fails early. No existing occurrences were found; this change adds a security-check script and an npm script 'security-check' to fail PRs that introduce 'shell: true'. This helps enforce the P1 requirement to avoid shell-based executions. If you prefer active replacements, none were found in src; we can follow up to harden any specific exec/child_process call sites if identified.