### PR TITLE
ci: run security-check in lint job (prevent 'shell: true' regressions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,12 @@ jobs:
       with:
         node-version: '22'
         cache: npm
-    - run: npm ci
-    - run: npm run lint
+    - name: Install dependencies
+      run: npm ci
+    - name: Security check - prevent shell: true
+      run: npm run security-check
+    - name: Run linter
+      run: npm run lint
   feat-minor-bump-gate:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:fault-harness": "vitest run src/__tests__/fault-injection-harness-901.test.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "format": "prettier --write src scripts"
+    "format": "prettier --write src scripts",
+    "security-check": "node scripts/check-no-shell-true.js"
   },
   "keywords": [
     "claude",

--- a/scripts/check-no-shell-true.js
+++ b/scripts/check-no-shell-true.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const path = require('path');
+try {
+  const out = execSync("git grep -n --line-number --no-color -E 'shell\s*:\s*true' -- src || true", { encoding: 'utf8' }).trim();
+  if (out) {
+    console.error('Security check failed: found occurrences of "shell: true" in source files:\n');
+    console.error(out);
+    process.exit(2);
+  }
+  console.log('Security check passed: no "shell: true" occurrences in src/.');
+  process.exit(0);
+} catch (e) {
+  console.error('Error running security check:', e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Add npm run security-check to the CI lint job to prevent introduction of 'shell: true' in src/. This enforces the P1 security requirement from #1786 by failing PRs that introduce shell-based execution patterns.\n\nFiles changed: .github/workflows/ci.yml (add step to run the security check).\n\nThis is non-invasive and blocks the risk at CI time. Follow-up: optionally add an ESLint rule to surface the problem earlier in dev.