### PR TITLE
fix(session): check stored ccPid liveness in isWindowAlive (closes #1817)

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -987,7 +987,11 @@ export class SessionManager {
     const session = this.state.sessions[id];
     if (!session) return false;
     try {
-      // Issue #390: Fast crash detection via stored CC PID
+      // Issue #390/#1817: Fast crash detection via stored CC PID
+      // If session.ccPid was recorded and the process is now dead, session is dead
+      if (session.ccPid != null && !this.tmux.isPidAlive(session.ccPid)) {
+        return false;
+      }
 
       const windowHealth = await this.tmux.getWindowHealth(session.windowId);
       if (!windowHealth.windowExists) return false;


### PR DESCRIPTION
## Summary

Fix for **#1817** — Aegis session hangs at Proofing state with MiniMax model.

### Root Cause

`isWindowAlive()` in `src/session.ts` had a comment referencing **Issue #390** ("check stored ccPid first for immediate crash detection") but the actual `ccPid` check was **never implemented**. 

When the CC process exits (normal completion or crash) but the shell pane remains alive, `isWindowAlive()` returns `true` → session stays `'working'` indefinitely → orchestrator hangs waiting for completion.

### Fix

Added `session.ccPid` liveness check as the **first guard** in `isWindowAlive()`:

```typescript
// Issue #390/#1817: Fast crash detection via stored CC PID
// If session.ccPid was recorded and the process is now dead, session is dead
if (session.ccPid != null && !this.tmux.isPidAlive(session.ccPid)) {
  return false;
}
```

No grace period needed — a stored `ccPid` that is dead is definitive evidence the CC process is gone.

### Files Changed

| File | Change |
|------|--------|
| `src/session.ts` | Added ccPid check in `isWindowAlive()`; updated JSDoc comment |

### Verification

```
tsc --noEmit    ✓ PASS
npm run build   ✓ PASS  
npm test        ✓ 2818 tests PASS
```

**Branch:** `feature/1817-session-hang-minimax`  
**Commit:** `05a6f6b`  
**Base:** `develop`  
**Issue:** #1817