### PR TITLE
fix(session-actions): re-fetch stall info AFTER send delivery (closes #1809)

### DIFF
--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -28,8 +28,11 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     const { text } = parsed.data;
     const sessionId = session.id;
     try {
-      const stallInfo = monitor.getStallInfo(sessionId);
-      const result = await sessions.sendMessage(sessionId, text, stallInfo);
+      const result = await sessions.sendMessage(sessionId, text);
+      // Issue #1809: Re-fetch stall info AFTER delivery to avoid false-positive.
+      // Previously we called getStallInfo BEFORE send, capturing a stale state
+      // (session was temporarily quiet but became active after message delivery).
+      const currentStallInfo = monitor.getStallInfo(sessionId);
       await channels.message({
         event: 'message.user',
         timestamp: new Date().toISOString(),
@@ -37,7 +40,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
         detail: text,
       });
       const response: Record<string, unknown> = { ok: true, delivered: result.delivered, attempts: result.attempts };
-      if (result.stall) response.stall = result.stall;
+      if (currentStallInfo.stalled) response.stall = currentStallInfo;
       return response;
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });

--- a/src/session.ts
+++ b/src/session.ts
@@ -1170,8 +1170,7 @@ export class SessionManager {
   async sendMessage(
     id: string,
     text: string,
-    stallInfo?: { stalled: true; types: string[] } | { stalled: false },
-  ): Promise<{ delivered: boolean; attempts: number; stall?: { stalled: true; types: string[] } | { stalled: false } }> {
+  ): Promise<{ delivered: boolean; attempts: number }> {
     const session = this.state.sessions[id];
     if (!session) throw new Error(`Session ${id} not found`);
 
@@ -1184,7 +1183,7 @@ export class SessionManager {
         // Message was delivered — don't let a save failure mask the success
       }
     }
-    return stallInfo ? { ...result, stall: stallInfo } : result;
+    return result;
   }
 
   /** Send message bypassing the tmux serialize queue.


### PR DESCRIPTION
## Summary

Fix for **#1809** — send_message returns false-positive `stall: true` when session is actually working.

### Root Cause

In `POST /v1/sessions/:id/send`, `getStallInfo()` was called **BEFORE** `sendMessage()` — capturing the stall state at that moment. If the session was temporarily quiet (CC processing), it would be marked as stalled. After the message was delivered and CC started producing output, the monitor would clear the stall — but the **stale value from before delivery** was returned.

### Fix

Move `getStallInfo()` call to **after** successful message delivery. If the session became active after receiving the message, the fresh call reflects the current (non-stalled) state.

**Before:**


**After:**


### Files Changed

| File | Change |
|------|--------|
| `src/routes/session-actions.ts` | Moved `getStallInfo` to after `sendMessage`; use `currentStallInfo` in response |
| `src/session.ts` | Removed unused `stallInfo` parameter from `sendMessage` |

### Verification

```
tsc --noEmit    ✓ PASS
npm run build   ✓ PASS
npm test        ✓ 2818 tests PASS
```

**Branch:** `feature/1809-send-message-stall-fix`  
**Commit:** `2788af4`  
**Base:** `develop`  
**Issue:** #1809