### PR TITLE
docs: add breadcrumb navigation to dashboard.md (#1820)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -78,7 +78,16 @@ Feedback for user actions appears as non-blocking toast notifications:
 
 Toasts auto-dismiss after 4 seconds. Click the X to dismiss manually.
 
-### Session Detail Page
+### Breadcrumb Navigation
+
+Breadcrumbs appear at the top of detail pages showing the navigation hierarchy:
+
+- **Format:** `Overview > Sessions > {session-name}`
+- **Clickable links** — each segment links back to that level
+- **Current page** — shown as plain text (not a link)
+- **Overflow handling** — long session names truncate with ellipsis
+
+Example: `Dashboard > Sessions > fix-1786-shell-true`
 
 The session detail page (`/dashboard/sessions/:id`) includes:
 


### PR DESCRIPTION
Documents breadcrumb navigation feature from PR #1807 (commit d4d18db). The feature exists in develop but was missing from docs.\n\nChanges:\n- : +10 lines — Breadcrumb Navigation section\n\nAegis version: 0.5.3-alpha\nAssignee: Scribe