### PR TITLE
fix(monitor): auto-inject /compact on context_warning to prevent API 400 crash

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -36,6 +36,7 @@ export type SessionEvent =
   | 'status.rate_limited'
   | 'status.permission_timeout'
   | 'status.recovered'
+  | 'status.context_warning'
   | 'swarm.teammate_spawned'
   | 'swarm.teammate_finished';
 

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -105,6 +105,8 @@ export class SessionMonitor {
   private lastStallCheck = 0;
   private lastDeadCheck = 0;
   private idleNotified = new Set<string>();       // prevent idle spam
+  // Issue #1808: Track sessions that have already received auto-compact for context_warning
+  private contextWarningCompacted = new Set<string>();
   private idleSince = new Map<string, number>();  // debounce: when idle started
   private processedStopSignals = new Set<string>(); // Issue #15: don't re-process signals
   private static readonly MAX_PROCESSED_STOP_SIGNALS = 1000; // #220: prevent unbounded growth
@@ -470,6 +472,8 @@ export class SessionMonitor {
         this.stateSince.delete(session.id);
         // Clean stall notifications (session recovered) — O(1) with Map
         this.stallDeleteAll(session.id);
+        // Issue #1808: Reset auto-compact tracking so next context_warning triggers fresh
+        this.contextWarningCompacted.delete(session.id);
       }
 
       // Update prevStatusForStall for next cycle
@@ -774,6 +778,35 @@ export class SessionMonitor {
           this.makePayload('status.idle', session, result.statusText || 'Session finished working, awaiting input'),
         );
       }
+    } else if (status === 'context_warning' && prevStatus !== 'context_warning') {
+      // Issue #1808: Auto-inject /compact to prevent context window overflow.
+      // Only trigger once per context_warning episode to avoid duplicate compactions.
+      if (!this.contextWarningCompacted.has(session.id)) {
+        this.contextWarningCompacted.add(session.id);
+        logger.info({
+          component: 'monitor',
+          operation: 'auto_compact_context_warning',
+          sessionId: session.id,
+          attributes: { windowName: session.windowName },
+        });
+        try {
+          if (this.tmux) {
+            await this.tmux.sendKeys(session.windowId, '/compact');
+          }
+          await this.channels.statusChange(
+            this.makePayload('status.context_warning', session,
+              'Context window nearing limit — auto-injected /compact to prevent overflow'),
+          );
+        } catch (e: unknown) {
+          logger.error({
+            component: 'monitor',
+            operation: 'auto_compact_context_warning',
+            sessionId: session.id,
+            errorCode: 'AUTO_COMPACT_FAILED',
+            attributes: { error: e instanceof Error ? e.message : String(e) },
+          });
+        }
+      }
     } else if (status === 'ask_question' && prevStatus !== 'ask_question') {
       this.eventBus?.emitStatus(session.id, 'ask_question', result.interactiveContent || 'Session is asking a question');
       await this.channels.statusChange(
@@ -974,6 +1007,7 @@ export class SessionMonitor {
     // Clean all stall notifications for this session — O(1) with Map
     this.stallDeleteAll(sessionId);
     this.idleNotified.delete(sessionId);
+    this.contextWarningCompacted.delete(sessionId);
     this.idleSince.delete(sessionId);
     this.stateSince.delete(sessionId);
     this.prevStatusForStall.delete(sessionId);


### PR DESCRIPTION
## Summary

- When CC's context window fills up (80%/95% warning detected by `terminal-parser`), the session would eventually hit a 400 API error and enter a "Crunched" state, losing all conversation context
- Adds `context_warning` handling in `broadcastStatusChange()` that auto-injects `/compact` via `tmux.sendKeys()` on first transition TO `context_warning` state
- Uses a `Set<string>` (`contextWarningCompacted`) to ensure the compact command is only injected once per context_warning episode, reset when the session returns to idle or is removed

Closes #1808

## Changes

**`src/monitor.ts`**
- Added `contextWarningCompacted` Set to track sessions that have already received auto-compact (line ~109)
- Added `context_warning` handling block in `broadcastStatusChange()` (line ~781) that sends `/compact` via tmux on first detection
- Resets `contextWarningCompacted` entry when session goes idle (line ~476) so future warnings trigger fresh
- Cleans up `contextWarningCompacted` entry in `removeSession()` (line ~1010)

**`src/channels/types.ts`**
- Added `'status.context_warning'` to the `SessionEvent` union type

## Quality Gate

```
$ npx tsc --noEmit
(no errors)

$ npm run build
> tsc && npm run build:copy-dashboard
(build succeeded)

$ npm test
 Test Files  1 failed | 160 passed | 1 skipped (162)
      Tests  1 failed | 2817 passed | 25 skipped (2843)

The 1 failure (screenshot.test.ts > playwright missing) is pre-existing on develop.
```

## Test plan

- [ ] Verify `context_warning` state is detected by `terminal-parser` (already has unit tests at `terminal-parser.test.ts:725`)
- [ ] Verify `/compact` is sent exactly once per context_warning episode
- [ ] Verify the Set is reset when session returns to idle
- [ ] Verify the Set is cleaned up when session is removed
- [ ] Manual: trigger a long-running CC session that fills context, observe auto-compact injection in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)