### PR TITLE
fix(hooks): deduplicate Edit tool duplicate lines (#1799)

### DIFF
--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -862,4 +862,106 @@ describe('Hook validation (Issue #89)', () => {
       expect(session.model).toBe('claude-opus-4-6');
     });
   });
+
+  describe('Issue #1799: Edit tool duplicate line deduplication', () => {
+    it('should deduplicate consecutive identical non-blank lines in Edit new_string', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
+        payload: {
+          tool_name: 'Edit',
+          tool_input: {
+            file_path: '/tmp/test.py',
+            old_string: 'self._near_miss_pending = False',
+            new_string: 'self._last_combo_milestone = 0\nself._last_combo_milestone = 0\nself._near_miss_pending = False',
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.hookSpecificOutput.permissionDecision).toBe('allow');
+      expect(body.hookSpecificOutput.updatedInput.new_string).toBe(
+        'self._last_combo_milestone = 0\nself._near_miss_pending = False',
+      );
+    });
+
+    it('should not modify Edit new_string without consecutive duplicates', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
+        payload: {
+          tool_name: 'Edit',
+          tool_input: {
+            file_path: '/tmp/test.py',
+            old_string: 'x = 1',
+            new_string: 'x = 1\ny = 2',
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.hookSpecificOutput.permissionDecision).toBe('allow');
+      expect(body.hookSpecificOutput.updatedInput).toBeUndefined();
+    });
+
+    it('should preserve intentional blank lines', async () => {
+      const newString = 'x = 1\n\n\ny = 2';
+      const res = await app.inject({
+        method: 'POST',
+        url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
+        payload: {
+          tool_name: 'Edit',
+          tool_input: {
+            file_path: '/tmp/test.py',
+            old_string: 'x = 1',
+            new_string: newString,
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.hookSpecificOutput.updatedInput).toBeUndefined();
+    });
+
+    it('should not affect non-Edit tools', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
+        payload: {
+          tool_name: 'Write',
+          tool_input: {
+            file_path: '/tmp/test.py',
+            content: 'dup\n dup\n',
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.hookSpecificOutput.permissionDecision).toBe('allow');
+      expect(body.hookSpecificOutput.updatedInput).toBeUndefined();
+    });
+
+    it('should handle Edit without new_string gracefully', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/v1/hooks/PreToolUse?sessionId=${session.id}`,
+        payload: {
+          tool_name: 'Edit',
+          tool_input: {
+            file_path: '/tmp/test.py',
+            old_string: 'x = 1',
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.hookSpecificOutput.permissionDecision).toBe('allow');
+      expect(body.hookSpecificOutput.updatedInput).toBeUndefined();
+    });
+  });
 });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -104,6 +104,30 @@ const INFORMATIONAL_EVENTS = new Set([
   'PermissionDenied',
 ]);
 
+/**
+ * Deduplicate consecutive identical non-blank lines in a string.
+ * Returns the deduplicated string, or null if no changes were needed.
+ *
+ * Issue #1799: Workaround for anthropics/claude-code#32891 —
+ * the CC model sometimes generates Edit tool calls with consecutive
+ * duplicate lines in new_string.
+ */
+function deduplicateConsecutiveLines(text: string): string | null {
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let changed = false;
+
+  for (const line of lines) {
+    if (line.trim() !== '' && result.length > 0 && result[result.length - 1] === line) {
+      changed = true;
+      continue; // skip consecutive duplicate
+    }
+    result.push(line);
+  }
+
+  return changed ? result.join('\n') : null;
+}
+
 /** Map hook event names to the UIState they imply. */
 function hookToUIState(eventName: string): UIState | null {
   switch (eventName) {
@@ -400,6 +424,26 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
               hookSpecificOutput: {
                 hookEventName: 'PreToolUse',
                 permissionDecision: decision,
+              },
+            });
+          }
+        }
+
+        // Issue #1799: Deduplicate consecutive lines in Edit tool's new_string.
+        // Workaround for anthropics/claude-code#32891 — model generates
+        // consecutive duplicate lines in Edit new_string.
+        if (toolName === 'Edit' && hookBody.tool_input?.new_string) {
+          const deduplicated = deduplicateConsecutiveLines(hookBody.tool_input.new_string as string);
+          if (deduplicated !== null) {
+            console.log(`Hooks: deduplicated Edit new_string for session ${sessionId} (CC bug #32891 workaround)`);
+            return reply.status(200).send({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'allow',
+                updatedInput: {
+                  ...hookBody.tool_input,
+                  new_string: deduplicated,
+                },
               },
             });
           }


### PR DESCRIPTION
## Summary
- **Root cause**: Claude Code model behavior bug ([anthropics/claude-code#32891](https://github.com/anthropics/claude-code/issues/32891)), not an Aegis bug
- The CC model sometimes generates consecutive duplicate lines in Edit tool's `new_string`, compounding across repeated edits
- Aegis does NOT intercept or modify Edit tool output — communication is purely tmux send-keys/capture-pane

## Investigation findings
1. **Aegis code is clean** — no interception, rewriting, or post-processing of Edit tool output. Retry logic has idle-state guards to prevent duplicate delivery.
2. **Known CC bugs** — [anthropics/claude-code#32891](https://github.com/anthropics/claude-code/issues/32891) (model duplicates context lines in `new_string`, unfixed through v2.1.109) and [#37031](https://github.com/anthropics/claude-code/issues/37031) (display-only duplication in diff view).
3. **tmux send-keys ruled out** — source code analysis confirms no duplication path; synchronous pty writes, no re-delivery mechanism.

## Workaround
Adds a PreToolUse hook that intercepts Edit tool calls, checks `new_string` for consecutive duplicate non-blank lines, and deduplicates via `updatedInput` before the edit is applied. Blank lines are preserved.

## Test plan
- [x] 5 new tests covering: duplicate deduplication, no false positives on clean input, blank line preservation, non-Edit tool passthrough, missing new_string handling
- [x] All 55 existing tests pass
- [x] `tsc --noEmit` passes
- [x] `npm run build` succeeds

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)