### PR TITLE
fix(pipeline): fail stage when sendInitialPrompt reports undelivered prompt

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -71,6 +71,8 @@ describe('PipelineManager', () => {
     sessions = makeMockSessions();
     eventBus = makeMockEventBus();
     manager = new PipelineManager(sessions.mock, eventBus.mock);
+    // #1805: Default mock — prompt delivery succeeds
+    sessions.sendInitialPrompt.mockResolvedValue({ delivered: true, attempts: 1 });
   });
 
   afterEach(() => {
@@ -538,6 +540,26 @@ describe('PipelineManager', () => {
       // createSession succeeded but sendInitialPrompt threw
       expect(pipeline.stages[0].status).toBe('failed');
       expect(pipeline.stages[0].error).toBe('send failed');
+      expect(pipeline.status).toBe('failed');
+    });
+
+    // #1805: sendInitialPrompt returns { delivered: false } instead of throwing
+    it('marks stage failed when sendInitialPrompt returns delivered=false', async () => {
+      const config: PipelineConfig = {
+        name: 'prompt-not-delivered',
+        workDir: '/app',
+        stages: [
+          { name: 'A', prompt: 'do stuff', dependsOn: [] },
+        ],
+      };
+
+      sessions.createSession.mockResolvedValue(makeMockSession('s-a'));
+      sessions.sendInitialPrompt.mockResolvedValue({ delivered: false, attempts: 3 });
+
+      const pipeline = await manager.createPipeline(config);
+
+      expect(pipeline.stages[0].status).toBe('failed');
+      expect(pipeline.stages[0].error).toMatch(/Failed to deliver initial prompt/);
       expect(pipeline.status).toBe('failed');
     });
   });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -260,17 +260,21 @@ export class PipelineManager {
           },
         );
 
+        stage.sessionId = session.id;
+
         if (stageConfig.prompt) {
-          await retryWithJitter(
-            async () => this.sessions.sendInitialPrompt(session.id, stageConfig.prompt),
-            {
-              maxAttempts: PipelineManager.PIPELINE_RETRY_MAX_ATTEMPTS,
-              shouldRetry: (error) => shouldRetry(error),
-            },
-          );
+          // #1805: sendInitialPrompt returns { delivered, attempts } but never throws,
+          // so retryWithJitter cannot help (it only retries on exceptions).
+          // sendInitialPrompt has its own internal retry logic — check the result
+          // and fail the stage when delivery was not confirmed.
+          const delivered = await this.sessions.sendInitialPrompt(session.id, stageConfig.prompt);
+          if (!delivered.delivered) {
+            throw new Error(
+              `Failed to deliver initial prompt to session ${session.id} after ${delivered.attempts} attempt(s)`,
+            );
+          }
         }
 
-        stage.sessionId = session.id;
         stage.status = 'running';
         stage.startedAt = Date.now();
         this.transitionPipelineStage(pipeline, 'execute', { stage: stage.name, sessionId: session.id });


### PR DESCRIPTION
## Summary
- `advancePipeline` silently ignored `sendInitialPrompt` returning `{ delivered: false }` because it never throws — the useless `retryWithJitter` wrapper only retries on exceptions
- The pipeline set the stage to `'running'` even though CC never received the prompt, causing sessions to sit at "I'm ready to help" forever
- Fix: check the `delivered` result and throw on failure so the stage is properly marked `'failed'`; also set `stage.sessionId` before prompt delivery for cleanup tracking

## Test plan
- [x] New test: `marks stage failed when sendInitialPrompt returns delivered=false`
- [x] Existing test: `marks stage failed when sendInitialPrompt throws` still passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (72/72 pipeline tests; only pre-existing Playwright failure)

Closes #1805

🤖 Generated with [Claude Code](https://claude.com/claude-code)