### PR TITLE
fix(tmux): prevent DCS regex from stripping visible text across lines

### DIFF
--- a/src/__tests__/capture-pane-dcs.test.ts
+++ b/src/__tests__/capture-pane-dcs.test.ts
@@ -1,14 +1,14 @@
 /**
- * capture-pane-dcs.test.ts — Tests for Issue #89 L23: DCS passthrough leak.
+ * capture-pane-dcs.test.ts — Tests for Issue #89 L23 and Issue #1800.
  *
  * Tests that DCS sequences (Device Control String, ESC P ... ESC \)
- * are stripped from capture-pane output.
+ * are stripped from capture-pane output WITHOUT eating visible text.
  */
 
 import { describe, it, expect } from 'vitest';
 
-/** DCS stripping regex used in TmuxManager.capturePane. */
-const DCS_PATTERN = /\x1bP[^\x1b]*\x1b\\/g;
+/** DCS stripping regex used in TmuxManager.capturePane (must match src/tmux.ts). */
+const DCS_PATTERN = /\x1bP[^\x1b\n]*\x1b\\/g;
 
 describe('DCS sequence stripping (Issue #89 L23)', () => {
   it('should strip a single DCS sequence from pane output', () => {
@@ -46,5 +46,73 @@ describe('DCS sequence stripping (Issue #89 L23)', () => {
     expect(result).not.toContain('\x1b');
     expect(result).toContain('✻ Reading src/server.ts');
     expect(result).toContain('❯');
+  });
+
+  it('should strip tmux passthrough DCS sequences', () => {
+    const input = '\x1bPtmux;DA1\x1b\\Visible pane text';
+    const result = input.replace(DCS_PATTERN, '');
+    expect(result).toBe('Visible pane text');
+  });
+});
+
+describe('DCS stripping preserves visible text (Issue #1800)', () => {
+  it('should NOT strip visible text when DCS start and terminator are on different lines', () => {
+    const input = '\x1bPtmux;DA1\nNow I\'ll make the changes\n\x1b\\';
+    const result = input.replace(DCS_PATTERN, '');
+    // The old regex /[\s\S]*?/ would match across lines and strip everything.
+    // The new regex /[^\x1b\n]*/ must NOT match across lines.
+    // The DCS markers remain (they weren't matched), but visible text is preserved.
+    expect(result).toContain('Now I\'ll make the changes');
+  });
+
+  it('should preserve spaces between words when DCS sequences appear in output', () => {
+    const input = 'Now \x1bPtmux;DA1\x1b\\ I\'ll make the changes';
+    const result = input.replace(DCS_PATTERN, '');
+    expect(result).toContain('Now');
+    expect(result).toContain('I\'ll');
+    expect(result).toContain('make');
+    expect(result).toContain('changes');
+  });
+
+  it('should handle DCS sequences that contain only a space (passthrough padding)', () => {
+    // Spaces between words should not be eaten by DCS stripping
+    const input = 'Now\x1bP \x1b\\I\'ll\x1bP \x1b\\make\x1bP \x1b\\the\x1bP \x1b\\changes';
+    const result = input.replace(DCS_PATTERN, '');
+    // After stripping DCS markers, words may be concatenated (DCS data is stripped),
+    // but the pattern should not match across lines.
+    expect(result).not.toContain('\x1b');
+  });
+
+  it('should not match DCS start on one line and terminator on another', () => {
+    // Simulates a pane where DCS opens on line 1 and closes on line 3
+    const input = [
+      'Header \x1bPdata',
+      'Now I\'ll make the changes. First, update the combo counter',
+      'initialization to start at 1.\x1b\\',
+      'Footer',
+    ].join('\n');
+    const result = input.replace(DCS_PATTERN, '');
+    // Visible text must survive — the regex must not match across newlines
+    expect(result).toContain('Now I\'ll make the changes');
+    expect(result).toContain('Header');
+    expect(result).toContain('Footer');
+  });
+
+  it('should correctly handle multiple single-line DCS sequences in multi-line output', () => {
+    const input = [
+      '\x1bPseq1\x1b\\Line 1 content',
+      '\x1bPseq2\x1b\\Line 2 content',
+      '\x1bPseq3\x1b\\Line 3 content',
+    ].join('\n');
+    const result = input.replace(DCS_PATTERN, '');
+    expect(result).toBe('Line 1 content\nLine 2 content\nLine 3 content');
+  });
+
+  it('should handle commit messages with spaces preserved', () => {
+    const commitMessage = 'Add combo counter with milestone flash effects';
+    const input = `\x1bPtmux;DA1\x1b\\${commitMessage}`;
+    const result = input.replace(DCS_PATTERN, '');
+    expect(result).toBe(commitMessage);
+    expect(result).toContain(' ');
   });
 });

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -889,11 +889,13 @@ export class TmuxManager {
   /** Capture the visible pane content.
    *  Issue #89 L23: Strips DCS passthrough sequences (ESC P ... ESC \\)
    *  that can leak through tmux's capture-pane into the output.
+   *  Issue #1800: Use [^\x1b\n] instead of [\s\S] to prevent the regex from
+   *  matching across lines and stripping visible text (including spaces).
    */
   async capturePane(windowId: string): Promise<string> {
     const target = `${this.sessionName}:${windowId}`;
     const raw = await this.tmux('capture-pane', '-t', target, '-p', '-J');
-    return raw.replace(/\x1bP[\s\S]*?\x1b\\/g, '');
+    return raw.replace(/\x1bP[^\x1b\n]*\x1b\\/g, '');
   }
 
   /** Capture pane content through the serialize queue.
@@ -912,7 +914,8 @@ export class TmuxManager {
         timeout: TMUX_DEFAULT_TIMEOUT_MS,
       });
       // Issue #89 L23: Strip DCS passthrough sequences
-      return stdout.trim().replace(/\x1bP[\s\S]*?\x1b\\/g, '');
+      // Issue #1800: Use [^\x1b\n] to prevent cross-line over-matching
+      return stdout.trim().replace(/\x1bP[^\x1b\n]*\x1b\\/g, '');
     } catch (e: unknown) {
       if (e && typeof e === 'object' && 'killed' in e && (e as { killed: boolean }).killed) {
         throw new TmuxTimeoutError(['capture-pane', '-t', target, '-p'], TMUX_DEFAULT_TIMEOUT_MS);


### PR DESCRIPTION
## Summary
- The DCS passthrough regex `/\x1bP[\s\S]*?\x1b\\/g` used `[\s\S]*?` which matches any character **including newlines**. When a DCS start (`ESC P`) appeared on one line and the terminator (`ESC \`) on a different line, the regex matched across lines and stripped all visible text between them — including spaces between words.
- Changed to `/\x1bP[^\x1b\n]*\x1b\\/g` which only matches within a single line and cannot jump across ESC characters. This still correctly strips single-line DCS passthrough sequences (Issue #89) while preserving visible pane content.
- Updated the test file to match the actual implementation regex and added 7 new test cases covering cross-line over-matching, space preservation, and commit message integrity.

Closes #1800

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 2527/2528 pass (1 pre-existing screenshot test failure on develop)
- [x] New DCS test cases (12 total) all pass
- [ ] Manual: start an Aegis session, produce text output, call `capture_pane` — verify spaces are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)