### PR TITLE
fix(tmux): add -J flag to capture-pane to preserve spaces on wrapped lines

### DIFF
--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -892,7 +892,7 @@ export class TmuxManager {
    */
   async capturePane(windowId: string): Promise<string> {
     const target = `${this.sessionName}:${windowId}`;
-    const raw = await this.tmux('capture-pane', '-t', target, '-p');
+    const raw = await this.tmux('capture-pane', '-t', target, '-p', '-J');
     return raw.replace(/\x1bP[\s\S]*?\x1b\\/g, '');
   }
 
@@ -908,7 +908,7 @@ export class TmuxManager {
   private async capturePaneDirectInternal(windowId: string): Promise<string> {
     const target = `${this.sessionName}:${windowId}`;
     try {
-      const { stdout } = await execFileAsync('tmux', ['-L', this.socketName, 'capture-pane', '-t', target, '-p'], {
+      const { stdout } = await execFileAsync('tmux', ['-L', this.socketName, 'capture-pane', '-t', target, '-p', '-J'], {
         timeout: TMUX_DEFAULT_TIMEOUT_MS,
       });
       // Issue #89 L23: Strip DCS passthrough sequences


### PR DESCRIPTION
## Summary
- Adds `-J` flag to both `capturePane` and `capturePaneDirectInternal` tmux command calls
- Without `-J`, tmux `capture-pane` joins wrapped lines without a separator, causing spaces between words to be stripped
- With `-J`, tmux preserves the join by inserting a space at wrap points

## Aegis version
**Developed with:** v0.5.2-alpha

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (2823/2823 — 1 pre-existing Playwright failure unrelated to this change)
- [ ] Manual: start a session, produce wrapped text output, verify `capture_pane` preserves spaces

Closes #1800

🤖 Generated with [Claude Code](https://claude.com/claude-code)