### PR TITLE
fix(dashboard): session UI overhaul - clean TTY terminal, readable transcript, metrics duration fallback

### DIFF
--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -1,18 +1,18 @@
-﻿import { useState } from 'react';
+import { useState } from 'react';
 import type { ParsedEntry } from '../../types';
 import { RenderWithCodeBlocks } from '../shared/CodeBlock';
 
 const TOOL_ICONS: Record<string, string> = {
-  Read: 'ðŸ“–',
-  Edit: 'âœï¸',
-  Write: 'ðŸ“',
-  Bash: 'ðŸ’»',
-  Search: 'ðŸ”',
+  Read: 'R',
+  Edit: 'E',
+  Write: 'W',
+  Bash: 'B',
+  Search: 'S',
 };
 
 function getToolIcon(toolName?: string): string {
-  if (!toolName) return 'â“';
-  return TOOL_ICONS[toolName] ?? 'â“';
+  if (!toolName) return '?';
+  return TOOL_ICONS[toolName] ?? toolName.charAt(0).toUpperCase();
 }
 
 function formatTimestamp(ts?: string): string {
@@ -25,22 +25,21 @@ function formatTimestamp(ts?: string): string {
   }
 }
 
-// â”€â”€â”€ Text Message â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 function TextMessage({ entry }: { entry: ParsedEntry }) {
   const isUser = entry.role === 'user';
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div
-        className={`max-w-[80%] rounded-lg px-4 py-2.5 text-sm leading-relaxed ${
+        className={`max-w-[92%] sm:max-w-[86%] rounded-xl px-4 py-3 text-sm leading-6 shadow-sm ${
           isUser
-            ? 'bg-[var(--color-accent-purple)] text-[var(--color-text-primary)] rounded-br-sm'
+            ? 'bg-[var(--color-accent-purple)] text-[var(--color-text-primary)] rounded-br-sm border border-[var(--color-accent-cyan)]/15'
             : 'bg-[var(--color-surface)] text-[var(--color-text-primary)] rounded-bl-sm border border-[var(--color-void-lighter)]'
         }`}
       >
         <RenderWithCodeBlocks text={entry.text} />
         {entry.timestamp && (
-          <div className={`text-[10px] mt-1 ${isUser ? 'text-[#555]' : 'text-[#444]'}`}>
+          <div className={`text-[10px] mt-2 uppercase tracking-wide ${isUser ? 'text-[#73738a]' : 'text-[#66667a]'}`}>
             {formatTimestamp(entry.timestamp)}
           </div>
         )}
@@ -49,27 +48,26 @@ function TextMessage({ entry }: { entry: ParsedEntry }) {
   );
 }
 
-// â”€â”€â”€ Thinking Block â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="flex justify-start mb-3">
-      <div className="max-w-[80%] w-full">
+    <div className="flex justify-start">
+      <div className="max-w-[92%] sm:max-w-[86%] w-full rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)]/70 overflow-hidden">
         <button
-          onClick={() => setOpen(o => !o)}
-          className="flex items-center gap-2 text-xs text-[#555] hover:text-[#777] transition-colors py-1 group"
+          onClick={() => setOpen((o) => !o)}
+          className="w-full flex items-center gap-2 text-xs text-[#777] hover:text-[#9a9ab1] transition-colors px-3 py-2"
         >
           <span
             className="inline-block transition-transform duration-200"
             style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}
           >
-            â–¶
+            {'>'}
           </span>
-          <span className="italic">Thinkingâ€¦</span>
+          <span className="font-mono uppercase tracking-wide">Thinking</span>
         </button>
         {open && (
-          <div className="bg-[var(--color-void-deepest)] border border-[var(--color-void-lighter)] rounded-lg px-4 py-3 mt-1 text-sm text-[#555] italic leading-relaxed whitespace-pre-wrap break-words max-h-64 overflow-y-auto">
+          <div className="px-4 pb-3 text-sm text-[#8f90a6] leading-6 whitespace-pre-wrap break-words max-h-72 overflow-y-auto">
             {entry.text}
           </div>
         )}
@@ -78,22 +76,21 @@ function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
   );
 }
 
-// â”€â”€â”€ Tool Use Card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 function ToolUseCard({ entry }: { entry: ParsedEntry }) {
   const rawPreview = entry.text;
-  const preview = rawPreview.length > 100 ? rawPreview.slice(0, 100) + 'â€¦' : rawPreview;
+  const preview = rawPreview.length > 300 ? `${rawPreview.slice(0, 300)}...` : rawPreview;
 
   return (
-    <div className="flex justify-start mb-3">
-      <div className="max-w-[80%] w-full bg-[var(--color-void-deepest)] border border-[var(--color-void-lighter)] rounded-lg overflow-hidden">
+    <div className="flex justify-start">
+      <div className="max-w-[92%] sm:max-w-[86%] w-full rounded-xl overflow-hidden border border-[var(--color-accent-cyan)]/25 bg-[var(--color-void-deepest)]">
         <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--color-void-lighter)]">
-          <span className="text-base">{getToolIcon(entry.toolName)}</span>
-          <span className="text-xs font-semibold text-[var(--color-accent)] font-mono">
-            {entry.toolName ?? 'Tool'}
+          <span className="w-5 h-5 rounded-full bg-[var(--color-accent-cyan)]/15 text-[var(--color-accent-cyan)] flex items-center justify-center text-[11px] font-mono">
+            {getToolIcon(entry.toolName)}
           </span>
-          <span className="text-[10px] text-[#555] ml-auto">tool_use</span>
+          <span className="text-xs font-semibold text-[var(--color-accent-cyan)] font-mono">{entry.toolName ?? 'Tool'}</span>
+          <span className="text-[10px] text-[#666] ml-auto uppercase">tool use</span>
         </div>
-        <div className="px-3 py-2 text-xs text-[#888] font-mono whitespace-pre-wrap break-all max-h-32 overflow-y-auto">
+        <div className="px-3 py-2.5 text-xs text-[#a1a1bb] font-mono whitespace-pre-wrap break-all max-h-48 overflow-y-auto leading-5">
           {preview}
         </div>
       </div>
@@ -101,28 +98,25 @@ function ToolUseCard({ entry }: { entry: ParsedEntry }) {
   );
 }
 
-// â”€â”€â”€ Tool Result Card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 function ToolResultCard({ entry }: { entry: ParsedEntry }) {
   const isError =
     /^\s*error(?:\s*[:\-]|\s*$)/i.test(entry.text)
     || /^\s*(?:failed|exception)(?:\s*[:\-]|\s*$)/i.test(entry.text);
 
   return (
-    <div className="flex justify-start mb-3">
+    <div className="flex justify-start">
       <div
-        className={`max-w-[80%] w-full bg-[var(--color-void-deepest)] rounded-lg overflow-hidden ${
-          isError ? 'border border-[var(--color-error)]/40' : 'border border-[var(--color-success)]/30'
+        className={`max-w-[92%] sm:max-w-[86%] w-full rounded-xl overflow-hidden bg-[var(--color-void-deepest)] ${
+          isError ? 'border border-[var(--color-error)]/45' : 'border border-[var(--color-success)]/35'
         }`}
       >
         <div className="flex items-center gap-2 px-3 py-1.5 border-b border-[var(--color-void-lighter)]">
-          <span className="text-xs font-semibold text-[#888]">
-            {isError ? 'X Result' : 'OK Result'}
+          <span className={`text-[11px] font-semibold uppercase tracking-wide ${isError ? 'text-[var(--color-error)]' : 'text-[var(--color-success)]'}`}>
+            {isError ? 'Error Result' : 'Result'}
           </span>
-          {entry.toolName && (
-            <span className="text-[10px] text-[#555] font-mono">{entry.toolName}</span>
-          )}
+          {entry.toolName && <span className="text-[10px] text-[#666] font-mono">{entry.toolName}</span>}
         </div>
-        <div className="px-3 py-2 text-xs text-[#666] font-mono whitespace-pre-wrap break-all max-h-32 overflow-y-auto">
+        <div className="px-3 py-2.5 text-xs text-[#b0b0c4] font-mono whitespace-pre-wrap break-all max-h-56 overflow-y-auto leading-5">
           {entry.text || '(empty)'}
         </div>
       </div>
@@ -132,16 +126,15 @@ function ToolResultCard({ entry }: { entry: ParsedEntry }) {
 
 function PermissionRequestMessage({ entry }: { entry: ParsedEntry }) {
   return (
-    <div className="flex justify-start mb-3">
-      <div className="max-w-[85%] w-full bg-[var(--color-error-border)] border border-[var(--color-error-bg)] text-[var(--color-error-light)] rounded-lg px-3 py-2">
+    <div className="flex justify-start">
+      <div className="max-w-[92%] sm:max-w-[86%] w-full bg-[var(--color-error-border)] border border-[var(--color-error-bg)] text-[var(--color-error-light)] rounded-xl px-3 py-2.5">
         <div className="text-[11px] uppercase tracking-wide font-semibold text-[var(--color-error-mid)]">Permission Request</div>
-        <div className="mt-1 text-sm font-mono whitespace-pre-wrap break-words">{entry.text}</div>
+        <div className="mt-1.5 text-sm font-mono whitespace-pre-wrap break-words leading-6">{entry.text}</div>
       </div>
     </div>
   );
 }
 
-// â”€â”€â”€ MessageBubble (main export) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 export function MessageBubble({ entry }: { entry: ParsedEntry }) {
   if (entry.contentType === 'permission_request') {
     return <PermissionRequestMessage entry={entry} />;
@@ -164,4 +157,3 @@ export function MessageBubble({ entry }: { entry: ParsedEntry }) {
       return <TextMessage entry={entry} />;
   }
 }
-

--- a/dashboard/src/components/session/SessionMetricsPanel.tsx
+++ b/dashboard/src/components/session/SessionMetricsPanel.tsx
@@ -5,6 +5,7 @@ import { TokenBreakdown } from './TokenBreakdown';
 interface SessionMetricsPanelProps {
   metrics: SessionMetrics | null;
   loading: boolean;
+  fallbackDurationSec?: number;
 }
 
 interface MetricCardData {
@@ -14,7 +15,7 @@ interface MetricCardData {
   color: string;
 }
 
-export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelProps) {
+export function SessionMetricsPanel({ metrics, loading, fallbackDurationSec }: SessionMetricsPanelProps) {
   if (loading || !metrics) {
     return (
       <div className="flex items-center justify-center h-48 text-[#555] text-sm animate-pulse">
@@ -23,8 +24,12 @@ export function SessionMetricsPanel({ metrics, loading }: SessionMetricsPanelPro
     );
   }
 
+  const durationSec = Number.isFinite(metrics.durationSec) && metrics.durationSec > 0
+    ? metrics.durationSec
+    : Math.max(0, fallbackDurationSec ?? 0);
+
   const cards: MetricCardData[] = [
-    { label: 'Duration', value: formatDuration(metrics.durationSec * 1000), icon: '\u23f1', color: 'var(--color-accent)' },
+    { label: 'Duration', value: formatDuration(durationSec * 1000), icon: '\u23f1', color: 'var(--color-accent)' },
     { label: 'Messages', value: metrics.messages.toString(), icon: '\ud83d\udcac', color: 'var(--color-accent)' },
     { label: 'Tool Calls', value: metrics.toolCalls.toString(), icon: '\ud83d\udd27', color: 'var(--color-accent)' },
     { label: 'Approvals', value: metrics.approvals.toString(), icon: '\u2705', color: 'var(--color-success)' },

--- a/dashboard/src/components/session/TerminalPassthrough.tsx
+++ b/dashboard/src/components/session/TerminalPassthrough.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
@@ -6,169 +6,44 @@ import '@xterm/xterm/css/xterm.css';
 import { ResilientWebSocket } from '../../api/resilient-websocket';
 import { useStore } from '../../store/useStore';
 import type { AppState } from '../../store/useStore';
-import { useToastStore } from '../../store/useToastStore';
-import { getSessionMessages, subscribeSSE } from '../../api/client';
-import type { ParsedEntry, UIState } from '../../types';
-import { SessionSSEEventDataSchema, WsInboundMessageSchema } from '../../api/schemas';
+import type { UIState } from '../../types';
+import { WsInboundMessageSchema } from '../../api/schemas';
 
 interface TerminalPassthroughProps {
   sessionId: string;
   status: UIState;
 }
 
-interface FilterState {
-  thinking: boolean;
-  tool_use: boolean;
-  tool_result: boolean;
-}
-
-const MAX_SESSION_MESSAGES = 1000;
-
-/** Composite dedup key for messages (fixes #512) */
-function dedupKey(m: ParsedEntry): string {
-  return `${m.timestamp ?? ''}:${m.role}:${m.contentType}:${m.text.length}:${m.text.slice(0, 80)}`;
-}
-
-/** Format a transcript entry as readable text for xterm output */
-function formatTranscriptEntry(entry: ParsedEntry): string {
-  const role = entry.role === 'assistant' ? 'Agent' : entry.role === 'user' ? 'You' : entry.role;
-  const contentTypeLabel = entry.contentType === 'tool_use' ? '[Tool]' : entry.contentType === 'tool_result' ? '[Result]' : entry.contentType === 'thinking' ? '[Thinking]' : '';
-  
-  const header = contentTypeLabel ? `${role} ${contentTypeLabel}` : role;
-  const headerLine = `\u001b[36m${header}\u001b[0m:`;
-  const textLine = entry.text.split('\n')[0].slice(0, 200) + (entry.text.length > 200 ? '…' : '');
-  
-  return `${headerLine} ${textLine}`;
-}
-
 export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughProps) {
   const token = useStore((s: AppState) => s.token);
-  const addToast = useToastStore((s) => s.addToast);
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<ResilientWebSocket | null>(null);
-  const statusRef = useRef<UIState>(status);
   const prevPaneContentRef = useRef<string>('');
 
-  // Message state
-  const [messages, setMessages] = useState<ParsedEntry[]>([]);
-  const [loadingMessages, setLoadingMessages] = useState(true);
-  const [fetchError, setFetchError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<FilterState>({
-    thinking: false,
-    tool_use: true,
-    tool_result: true,
-  });
-  const seenKeys = useRef<Set<string>>(new Set());
-  const filteredMessagesRef = useRef<ParsedEntry[]>([]);
-  const prevRenderedCountRef = useRef<number>(0);
-
-  // Connection state
   const [connectionState, setConnectionState] = useState<'connecting' | 'connected' | 'reconnecting' | 'disconnected'>('connecting');
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  // Keep status ref in sync
-  useEffect(() => {
-    statusRef.current = status;
-  }, [status]);
-
-  // Apply filters
-  const filteredMessages = useMemo(() => messages.filter(entry => {
-    if (entry.role === 'user') return true;
-    if (entry.contentType === 'thinking' && !filters.thinking) return false;
-    if (entry.contentType === 'tool_use' && !filters.tool_use) return false;
-    if (entry.contentType === 'tool_result' && !filters.tool_result) return false;
-    return true;
-  }), [messages, filters]);
-
-  // Keep filteredMessages ref in sync
-  useEffect(() => {
-    filteredMessagesRef.current = filteredMessages;
-  }, [filteredMessages]);
-
-  // Fetch initial transcript messages
-  useEffect(() => {
-    let cancelled = false;
-
-    getSessionMessages(sessionId)
-      .then(data => {
-        if (!cancelled) {
-          const msgs = data.messages ?? [];
-          const capped = msgs.length > MAX_SESSION_MESSAGES
-            ? msgs.slice(msgs.length - MAX_SESSION_MESSAGES)
-            : msgs;
-          setMessages(capped);
-          seenKeys.current = new Set(capped.map(dedupKey));
-          setFetchError(null);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          const message = err instanceof Error ? err.message : String(err);
-          setFetchError(message);
-          addToast('error', 'Failed to load session messages', message);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingMessages(false);
-      });
-
-    return () => { cancelled = true; };
-  }, [sessionId, addToast]);
-
-  // Subscribe to SSE for real-time message updates
-  useEffect(() => {
-    const unsubscribe = subscribeSSE(sessionId, (e) => {
-      try {
-        const result = SessionSSEEventDataSchema.safeParse(JSON.parse(e.data as string));
-        if (!result.success) {
-          console.warn('SSE event failed validation', result.error.message);
-          return;
-        }
-        const parsed = result.data;
-        if (parsed.event !== 'message') return;
-        const data = parsed.data as unknown as ParsedEntry;
-        setMessages(prev => {
-          const key = dedupKey(data);
-          if (seenKeys.current.has(key)) return prev;
-          seenKeys.current.add(key);
-          const next = [...prev, data];
-          if (next.length > MAX_SESSION_MESSAGES) {
-            const evictedCount = next.length - MAX_SESSION_MESSAGES;
-            const capped = next.slice(evictedCount);
-            for (let i = 0; i < evictedCount; i++) {
-              seenKeys.current.delete(dedupKey(next[i]));
-            }
-            return capped;
-          }
-          return next;
-        });
-      } catch {
-        // Ignore malformed events
-      }
-    }, token);
-
-    return () => unsubscribe();
-  }, [sessionId, token]);
-
-  // Initialize xterm.js
   useEffect(() => {
     if (!terminalRef.current) return;
 
     const term = new Terminal({
       cursorBlink: true,
-      fontSize: 13,
+      fontSize: 14,
+      lineHeight: 1.28,
+      letterSpacing: 0.15,
       fontFamily: '"JetBrains Mono", "Fira Code", "Cascadia Code", Consolas, monospace',
       theme: {
         background: 'var(--color-void-deep)',
         foreground: 'var(--color-cyan-bright)',
         cursor: 'var(--color-cyan-bright)',
         cursorAccent: 'var(--color-void-deep)',
-        selectionBackground: 'rgba(0, 229, 255, 0.25)',
+        selectionBackground: 'rgba(0, 229, 255, 0.22)',
       },
       convertEol: true,
-      scrollback: 2000,
+      scrollback: 5000,
+      allowProposedApi: false,
     });
 
     const fitAddon = new FitAddon();
@@ -179,15 +54,13 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
     xtermRef.current = term;
     fitAddonRef.current = fitAddon;
 
-    // Handle resize
     const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
       const { cols, rows } = term;
       wsRef.current?.send({ type: 'resize', cols, rows });
     });
-    if (terminalRef.current) {
-      resizeObserver.observe(terminalRef.current);
-    }
+
+    resizeObserver.observe(terminalRef.current);
 
     return () => {
       resizeObserver.disconnect();
@@ -197,124 +70,37 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
     };
   }, []);
 
-  // Render filtered transcript + terminal content when filters or messages change
   useEffect(() => {
-    const term = xtermRef.current;
-    if (!term || loadingMessages) return;
-
-    const prevCount = prevRenderedCountRef.current;
-    const newCount = filteredMessages.length;
-
-    // Full reset needed if: first render, filter change (count decreased), or no messages
-    if (prevCount === 0 || newCount < prevCount) {
-      term.reset();
-
-      // Write transcript section header
-      if (newCount > 0) {
-        term.writeln('\u001b[33m╔═══════════════════════════════════════════════════════════╗\u001b[0m');
-        term.writeln('\u001b[33m║                       SESSION TRANSCRIPT                      ║\u001b[0m');
-        term.writeln('\u001b[33m╚═══════════════════════════════════════════════════════════╝\u001b[0m');
-        term.writeln('');
-
-        // Write all filtered messages
-        for (const entry of filteredMessages) {
-          term.writeln(formatTranscriptEntry(entry));
-        }
-
-        term.writeln('');
-        term.writeln('\u001b[33m╔═══════════════════════════════════════════════════════════╗\u001b[0m');
-        term.writeln('\u001b[33m║                      LIVE TERMINAL OUTPUT                    ║\u001b[0m');
-        term.writeln('\u001b[33m╚═══════════════════════════════════════════════════════════╝\u001b[0m');
-        term.writeln('');
-      }
-
-      // Write the current pane content
-      const paneContent = prevPaneContentRef.current;
-      if (paneContent) {
-        term.write(paneContent);
-      }
-    } else if (newCount > prevCount) {
-      // Incremental: only append new messages
-      const newMessages = filteredMessages.slice(prevCount);
-      for (const entry of newMessages) {
-        term.writeln(formatTranscriptEntry(entry));
-      }
-    }
-    // If newCount === prevCount, nothing to do (no new messages)
-
-    prevRenderedCountRef.current = newCount;
-    fitAddonRef.current?.fit();
-  }, [filteredMessages, loadingMessages]);
-
-  // WebSocket connection for live pane content
-  useEffect(() => {
-    const getWsUrl = (): string => {
-      const base = window.location.origin;
-      const path = `/v1/sessions/${encodeURIComponent(sessionId)}/terminal`;
-      const wsBase = base.replace(/^http/, 'ws');
-      return `${wsBase}${path}`;
-    };
-
-    const url = getWsUrl();
-    const ws = new ResilientWebSocket(url, {
+    const wsBase = window.location.origin.replace(/^http/, 'ws');
+    const path = `/v1/sessions/${encodeURIComponent(sessionId)}/terminal`;
+    const ws = new ResilientWebSocket(`${wsBase}${path}`, {
       onMessage: (data: unknown) => {
         const result = WsInboundMessageSchema.safeParse(data);
         if (!result.success) {
           console.warn('WebSocket message failed validation', result.error.message);
           return;
         }
+
         const msg = result.data;
         const term = xtermRef.current;
         if (!term) return;
 
         switch (msg.type) {
           case 'pane': {
-            // Write delta pane content to xterm
             const prev = prevPaneContentRef.current;
             const next = msg.content;
             if (prev && next.startsWith(prev)) {
               term.write(next.slice(prev.length));
             } else {
-              // Content diverged — need to re-render everything
-              // Save current pane content and re-render the full view
-              prevPaneContentRef.current = next;
-              // Trigger re-render with current filter state
-              const term = xtermRef.current;
-              if (term) {
-                term.reset();
-
-                // Re-write transcript section
-                if (filteredMessagesRef.current.length > 0) {
-                  term.writeln('\u001b[33m╔═══════════════════════════════════════════════════════════╗\u001b[0m');
-                  term.writeln('\u001b[33m║                       SESSION TRANSCRIPT                      ║\u001b[0m');
-                  term.writeln('\u001b[33m╚═══════════════════════════════════════════════════════════╝\u001b[0m');
-                  term.writeln('');
-
-                  for (const entry of filteredMessagesRef.current) {
-                    term.writeln(formatTranscriptEntry(entry));
-                  }
-
-                  term.writeln('');
-                  term.writeln('\u001b[33m╔═══════════════════════════════════════════════════════════╗\u001b[0m');
-                  term.writeln('\u001b[33m║                      LIVE TERMINAL OUTPUT                    ║\u001b[0m');
-                  term.writeln('\u001b[33m╚═══════════════════════════════════════════════════════════╝\u001b[0m');
-                  term.writeln('');
-                }
-
-                term.write(next);
-                // Update rendered count after full re-render
-                prevRenderedCountRef.current = filteredMessagesRef.current.length;
-              }
+              term.reset();
+              term.write(next);
             }
             prevPaneContentRef.current = next;
             setErrorMsg(null);
             break;
           }
-
           case 'status':
-            // Auth handshake
             break;
-
           case 'error':
             setErrorMsg(msg.message);
             break;
@@ -328,15 +114,9 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
           wsRef.current?.send({ type: 'resize', cols: term.cols, rows: term.rows });
         }
       },
-      onReconnecting: () => {
-        setConnectionState('reconnecting');
-      },
-      onGiveUp: () => {
-        setConnectionState('disconnected');
-      },
-      onClose: () => {
-        setConnectionState('disconnected');
-      },
+      onReconnecting: () => setConnectionState('reconnecting'),
+      onGiveUp: () => setConnectionState('disconnected'),
+      onClose: () => setConnectionState('disconnected'),
     }, token ?? undefined);
 
     wsRef.current = ws;
@@ -347,7 +127,6 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
     };
   }, [sessionId, token]);
 
-  // Forward user input to WebSocket
   useEffect(() => {
     const term = xtermRef.current;
     if (!term) return;
@@ -361,40 +140,15 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
     };
   }, []);
 
-  const toggleFilter = useCallback((key: keyof FilterState) => {
-    setFilters(prev => ({ ...prev, [key]: !prev[key] }));
-  }, []);
-
   const isLive = status === 'working';
   const isConnected = connectionState === 'connected';
 
   return (
     <div className="flex flex-col h-full bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg overflow-hidden">
-      {/* Header with filters and connection status */}
       <div className="flex items-center justify-between px-4 py-2 text-xs border-b border-[var(--color-void-lighter)] bg-[var(--color-void)] shrink-0 flex-wrap gap-2">
-        <div className="flex items-center gap-3">
-          <span className="text-[10px] text-[#555] uppercase tracking-wider">Filter:</span>
-          {(['thinking', 'tool_use', 'tool_result'] as const).map(key => (
-            <button
-              key={key}
-              onClick={() => toggleFilter(key)}
-              aria-pressed={filters[key]}
-              className={`text-xs px-2 py-0.5 rounded border transition-colors ${
-                filters[key]
-                  ? 'border-[var(--color-accent-cyan)]/40 text-[var(--color-accent-cyan)] bg-[var(--color-accent-cyan)]/10'
-                  : 'border-[var(--color-void-lighter)] text-[#555] hover:text-[#888]'
-              }`}
-            >
-              {key === 'tool_use' ? 'Tools' : key === 'tool_result' ? 'Results' : key}
-            </button>
-          ))}
-          <span className="text-[10px] text-[#444]">
-            {filteredMessages.length} / {messages.length} messages
-          </span>
-        </div>
+        <span className="font-mono uppercase tracking-wider text-[10px] text-[#888]">Claude Session TTY</span>
 
         <div className="flex items-center gap-3 ml-auto">
-          {/* Connection indicator */}
           <div className="flex items-center gap-1.5">
             <span
               className="w-1.5 h-1.5 rounded-full"
@@ -405,14 +159,13 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
               }}
             />
             <span className="text-[10px] text-[#555] uppercase">
-              {connectionState === 'connecting' ? 'connecting…'
-                : connectionState === 'reconnecting' ? 'reconnecting…'
+              {connectionState === 'connecting' ? 'connecting...'
+                : connectionState === 'reconnecting' ? 'reconnecting...'
                 : connectionState === 'connected' ? 'ws live'
                 : 'disconnected'}
             </span>
           </div>
 
-          {/* Status indicator */}
           <div className="flex items-center gap-1.5">
             <span
               className="w-1.5 h-1.5 rounded-full"
@@ -428,25 +181,13 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
         </div>
       </div>
 
-      {/* Error banner */}
       {errorMsg && (
         <div className="px-4 py-2 text-xs text-[var(--color-danger)] bg-[var(--color-danger)]/10 border-b border-[var(--color-danger)]/20">
           {errorMsg}
         </div>
       )}
 
-      {/* Message fetch error banner */}
-      {fetchError && (
-        <div className="px-4 py-2 text-xs text-[var(--color-danger)] bg-[var(--color-danger)]/10 border-b border-[var(--color-danger)]/20">
-          Failed to load session messages: {fetchError}
-        </div>
-      )}
-
-      {/* Terminal */}
-      <div
-        ref={terminalRef}
-        className="flex-1 overflow-hidden"
-      />
+      <div ref={terminalRef} className="session-terminal flex-1 min-h-0" />
     </div>
   );
 }

--- a/dashboard/src/components/session/TranscriptViewer.tsx
+++ b/dashboard/src/components/session/TranscriptViewer.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import type { ParsedEntry } from '../../types';
 import { getSessionMessages, subscribeSSE } from '../../api/client';
 import { useStore } from '../../store/useStore';
@@ -8,7 +7,6 @@ import { SessionSSEEventDataSchema } from '../../api/schemas';
 
 const MAX_SESSION_MESSAGES = 1000;
 
-/** Composite dedup key: timestamp + content fingerprint (fixes #512) */
 function dedupKey(m: ParsedEntry): string {
   return `${m.timestamp ?? ''}:${m.role}:${m.contentType}:${m.text.length}:${m.text.slice(0, 80)}`;
 }
@@ -33,75 +31,72 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
     tool_use: true,
     tool_result: true,
   });
-  const [showScrollBtn, setShowScrollBtn] = useState(false);
+
   const containerRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
   const seenKeys = useRef<Set<string>>(new Set());
+  const [showScrollBtn, setShowScrollBtn] = useState(false);
 
-  // Fetch initial messages via API client
   useEffect(() => {
     let cancelled = false;
 
     getSessionMessages(sessionId)
-      .then(data => {
-        if (!cancelled) {
-          const msgs = data.messages ?? [];
-          const capped = msgs.length > MAX_SESSION_MESSAGES
-            ? msgs.slice(msgs.length - MAX_SESSION_MESSAGES)
-            : msgs;
-          setMessages(capped);
-          seenKeys.current = new Set(capped.map(dedupKey));
-        }
+      .then((data) => {
+        if (cancelled) return;
+        const msgs = data.messages ?? [];
+        const capped = msgs.length > MAX_SESSION_MESSAGES
+          ? msgs.slice(msgs.length - MAX_SESSION_MESSAGES)
+          : msgs;
+        setMessages(capped);
+        seenKeys.current = new Set(capped.map(dedupKey));
       })
-      .catch(e => {
+      .catch((e) => {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load');
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [sessionId]);
 
-  // #124: SSE for real-time messages — uses client subscribeSSE which handles auth
   useEffect(() => {
     const unsubscribe = subscribeSSE(sessionId, (e) => {
       try {
         const result = SessionSSEEventDataSchema.safeParse(JSON.parse(e.data as string));
-        if (!result.success) {
-          console.warn('SSE event failed validation', result.error.message);
-          return;
-        }
+        if (!result.success) return;
+
         const parsed = result.data;
-        // Issue #261: Only process message events; skip status, heartbeat,
-        // approval, stall, dead, ended, hook, and subagent events.
         if (parsed.event !== 'message') return;
+
         const data = parsed.data as unknown as ParsedEntry;
-        setMessages(prev => {
+        setMessages((prev) => {
           const key = dedupKey(data);
           if (seenKeys.current.has(key)) return prev;
+
           seenKeys.current.add(key);
           const next = [...prev, data];
           if (next.length > MAX_SESSION_MESSAGES) {
             const evictedCount = next.length - MAX_SESSION_MESSAGES;
-            const capped = next.slice(evictedCount);
-            // Incrementally remove keys for evicted messages only
             for (let i = 0; i < evictedCount; i++) {
               seenKeys.current.delete(dedupKey(next[i]));
             }
-            return capped;
+            return next.slice(evictedCount);
           }
           return next;
         });
       } catch {
-        // ignore malformed events
+        // Ignore malformed events
       }
     }, token);
 
     return () => unsubscribe();
   }, [sessionId, token]);
 
-  const filteredMessages = useMemo(() => messages.filter(entry => {
+  const filteredMessages = useMemo(() => messages.filter((entry) => {
     if (entry.role === 'user') return true;
     if (entry.contentType === 'thinking' && !filters.thinking) return false;
     if (entry.contentType === 'tool_use' && !filters.tool_use) return false;
@@ -109,64 +104,33 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
     return true;
   }), [messages, filters]);
 
-  const getItemKey = useCallback((index: number) => {
-    const entry = filteredMessages[index];
-    return entry.toolUseId ?? `${entry.role}-${entry.timestamp ?? `${index}`}`;
-  }, [filteredMessages]);
-
-  const estimateSize = useCallback((index: number): number => {
-    const entry = filteredMessages[index];
-    if (!entry) return 80;
-    switch (entry.contentType) {
-      case 'thinking': return 36;
-      case 'tool_use': return 100;
-      case 'tool_result': return 110;
-      case 'tool_error': return 110;
-      case 'permission_request': return 80;
-      case 'progress': return 40;
-      default: return 80;
-    }
-  }, [filteredMessages]);
-
-  const virtualizer = useVirtualizer({
-    count: filteredMessages.length,
-    getScrollElement: () => containerRef.current,
-    estimateSize,
-    overscan: 10,
-    getItemKey,
-    scrollMargin: 16,
-  });
-
-  // Auto-scroll when new messages arrive (unless user scrolled up)
-  useEffect(() => {
-    if (!userScrolledRef.current && filteredMessages.length > 0) {
-      virtualizer.scrollToIndex(filteredMessages.length - 1, { align: 'end' });
-    }
-  }, [filteredMessages.length, virtualizer]);
-
   const handleScroll = useCallback(() => {
     const el = containerRef.current;
     if (!el) return;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
     userScrolledRef.current = !atBottom;
     setShowScrollBtn(!atBottom);
   }, []);
 
   const scrollToBottom = useCallback(() => {
     userScrolledRef.current = false;
-    if (filteredMessages.length > 0) {
-      virtualizer.scrollToIndex(filteredMessages.length - 1, { align: 'end' });
+    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, []);
+
+  useEffect(() => {
+    if (!userScrolledRef.current) {
+      endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' });
     }
-  }, [filteredMessages.length, virtualizer]);
+  }, [filteredMessages.length]);
 
   const toggleFilter = useCallback((key: keyof FilterState) => {
-    setFilters(prev => ({ ...prev, [key]: !prev[key] }));
+    setFilters((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full text-[#555] text-sm">
-        <div className="animate-pulse">Loading transcript…</div>
+        <div className="animate-pulse">Loading transcript...</div>
       </div>
     );
   }
@@ -174,72 +138,56 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
   if (error) {
     return (
       <div className="flex items-center justify-center h-full text-[var(--color-error)] text-sm">
-        ⚠ {error}
+        {error}
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col h-full relative">
-      {/* Filter bar */}
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-[var(--color-void-lighter)] bg-[var(--color-void)] shrink-0">
-        <span className="text-[10px] text-[#555] uppercase tracking-wider">Filter:</span>
-        {(['thinking', 'tool_use', 'tool_result'] as const).map(key => (
+    <div className="flex flex-col h-full relative bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg overflow-hidden">
+      <div className="sticky top-0 z-10 flex items-center gap-2 px-3 sm:px-4 py-2.5 border-b border-[var(--color-void-lighter)] bg-[var(--color-void)] shrink-0 flex-wrap">
+        <span className="text-[10px] text-[#555] uppercase tracking-wider">Filter</span>
+        {(['thinking', 'tool_use', 'tool_result'] as const).map((key) => (
           <button
             key={key}
             onClick={() => toggleFilter(key)}
             aria-pressed={filters[key]}
-            className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+            className={`text-xs px-2.5 py-1 rounded border transition-colors ${
               filters[key]
-                ? 'border-[var(--color-accent)]/40 text-[var(--color-accent)] bg-[var(--color-accent)]/10'
+                ? 'border-[var(--color-accent-cyan)]/50 text-[var(--color-accent-cyan)] bg-[var(--color-accent-cyan)]/10'
                 : 'border-[var(--color-void-lighter)] text-[#555] hover:text-[#888]'
             }`}
           >
-            {key === 'tool_use' ? 'Tools' : key === 'tool_result' ? 'Results' : key}
+            {key === 'tool_use' ? 'Tools' : key === 'tool_result' ? 'Results' : 'Thinking'}
           </button>
         ))}
-        <span className="text-[10px] text-[#444] ml-auto">
+        <span className="text-[11px] text-[#666] ml-auto font-mono">
           {filteredMessages.length} / {messages.length}
         </span>
       </div>
 
-      {/* Messages */}
-      <div
-        ref={containerRef}
-        onScroll={handleScroll}
-        className="flex-1 overflow-y-auto px-4 py-3"
-      >
+      <div ref={containerRef} onScroll={handleScroll} className="flex-1 min-h-0 overflow-y-auto px-3 sm:px-4 py-3 sm:py-4 bg-[var(--color-void)]/45">
         {filteredMessages.length === 0 && (
           <div className="flex items-center justify-center h-full text-[#555] text-sm">
-            No messages yet
+            No transcript messages yet.
           </div>
         )}
+
         {filteredMessages.length > 0 && (
-          <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
-            {virtualizer.getVirtualItems().map((virtualItem) => (
-              <div
-                key={virtualItem.key}
-                style={{
-                  position: 'absolute',
-                  top: virtualItem.start,
-                  left: 0,
-                  right: 0,
-                }}
-                data-index={virtualItem.index}
-                ref={virtualizer.measureElement}
-              >
-                <MessageBubble entry={filteredMessages[virtualItem.index]} />
-              </div>
-            ))}
+          <div className="max-w-4xl mx-auto space-y-2 sm:space-y-3">
+            {filteredMessages.map((entry, index) => {
+              const key = entry.toolUseId ?? `${entry.role}-${entry.timestamp ?? index}`;
+              return <MessageBubble key={key} entry={entry} />;
+            })}
+            <div ref={endRef} />
           </div>
         )}
       </div>
 
-      {/* Scroll to bottom button */}
       {showScrollBtn && (
         <button
           onClick={scrollToBottom}
-          className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-accent)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
+          className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-accent-cyan)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-20"
           title="Scroll to bottom"
         >
           ↓

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -192,3 +192,13 @@ body {
 .animate-slide-in {
   animation: slide-in 0.2s ease-out;
 }
+
+/* Session terminal rendering tweaks for crisper lines and bottom breathing room. */
+.session-terminal .xterm-viewport {
+  overflow-y: auto !important;
+  padding-bottom: 8px;
+}
+
+.session-terminal .xterm-screen canvas {
+  image-rendering: auto;
+}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -351,20 +351,24 @@ export default function SessionDetailPage() {
           )}
 
           {activeTab === 'session' && (
-            <div id="panel-session" role="tabpanel" aria-labelledby="tab-session" tabIndex={0} className="h-[calc(100vh-300px)] sm:h-[calc(100vh-420px)] min-h-[200px] sm:min-h-[300px] overflow-auto">
+            <div id="panel-session" role="tabpanel" aria-labelledby="tab-session" tabIndex={0} className="h-[calc(100vh-300px)] sm:h-[calc(100vh-420px)] min-h-[260px] sm:min-h-[340px] overflow-hidden">
               <TerminalPassthrough sessionId={s.id} status={h.status} />
             </div>
           )}
 
           {activeTab === 'transcript' && (
-            <div id="panel-transcript" role="tabpanel" aria-labelledby="tab-transcript" tabIndex={0} className="h-[calc(100vh-300px)] sm:h-[calc(100vh-420px)] min-h-[200px] sm:min-h-[300px] overflow-auto">
+            <div id="panel-transcript" role="tabpanel" aria-labelledby="tab-transcript" tabIndex={0} className="h-[calc(100vh-300px)] sm:h-[calc(100vh-420px)] min-h-[260px] sm:min-h-[340px] overflow-hidden">
               <TranscriptViewer sessionId={s.id} />
             </div>
           )}
 
           {activeTab === 'metrics' && (
             <div id="panel-metrics" role="tabpanel" aria-labelledby="tab-metrics" tabIndex={0} className="p-3 sm:p-4 overflow-auto">
-              <SessionMetricsPanel metrics={metrics} loading={metricsLoading} />
+              <SessionMetricsPanel
+                metrics={metrics}
+                loading={metricsLoading}
+                fallbackDurationSec={Math.max(0, Math.floor(h.sessionAge / 1000))}
+              />
               <div className="mt-4">
                 <LatencyPanel latency={latency} loading={latencyLoading} />
               </div>


### PR DESCRIPTION
## Summary

Addresses three session detail UI issues:

1. **Terminal tab** — rewrote TerminalPassthrough as a pure live-TTY xterm component. Removed transcript injection from the terminal. Added 'CLAUDE SESSION TTY' header with WS LIVE/ACTIVE status pills. Consistent font size (14), line height (1.28), and 5000-line scrollback.

2. **Transcript tab** — replaced @tanstack/react-virtual virtualizer with flat stacked DOM rendering. Added sticky filter bar (Thinking / Tools / Results). Auto-scrolls to newest message via \ndRef\. Fixed mojibake emoji in tool cards (replaced with ASCII-safe R/E/W/B/S icons).

3. **Metrics tab** — added \allbackDurationSec\ prop to \SessionMetricsPanel\. Passes \Math.floor(h.sessionAge / 1000)\ (converted from ms) as fallback when \metrics.durationSec\ is 0. This fixes the broken/zero duration display.

## Changes
- \dashboard/src/pages/SessionDetailPage.tsx\ — overflow-hidden panels, fallbackDurationSec with /1000 conversion
- \dashboard/src/components/session/TerminalPassthrough.tsx\ — full rewrite as pure TTY
- \dashboard/src/components/session/TranscriptViewer.tsx\ — remove virtualizer, sticky filter bar, endRef scroll
- \dashboard/src/components/session/MessageBubble.tsx\ — ASCII-safe tool icons, improved bubble contrast
- \dashboard/src/components/session/SessionMetricsPanel.tsx\ — fallbackDurationSec prop
- \dashboard/src/index.css\ — xterm viewport and canvas CSS rules

## Quality Gate
- \
px tsc --noEmit\ — clean
- \
pm run build\ — clean
- \
pm test\ — 160 test files, 2820 tests passed

## Aegis version
**Developed with:** v0.5.3-alpha