### PR TITLE
fix(session): wait for CC idle before sending messages to prevent stall (#1798)

### DIFF
--- a/src/__tests__/send-message-stall-1798.test.ts
+++ b/src/__tests__/send-message-stall-1798.test.ts
@@ -1,0 +1,207 @@
+/**
+ * send-message-stall-1798.test.ts — Issue #1798: send_message stall fix.
+ *
+ * Tests that sendMessage waits for CC to become idle before sending,
+ * preventing Enter from disrupting active work (extended thinking, etc.)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { detectUIState } from '../terminal-parser.js';
+
+// Real CC pane fixtures (from terminal-parser.test.ts)
+
+const IDLE_PANE = `
+────────────────────────────────────────────────────────────────────────────────
+❯
+`;
+
+const IDLE_WITH_PROMPT = `
+Some previous output here...
+
+────────────────────────────────────────────────────────────────────────────────
+❯ Type your message...
+`;
+
+const WORKING_SPINNER = `
+· Reading files...
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+
+const WORKING_STATUS = `
+✻ Working on your request...
+
+Some content being generated...
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+
+const WORKING_PERAMBULATING = `
+* Perambulating… (2m 27s · ↑ 4.5k tokens)
+
+────────────────────────────────────────────────────────────────────────────────
+`;
+
+const PERMISSION_PROMPT = `
+Do you want to proceed?
+
+  1. Yes
+  2. No
+
+  (a) Always allow for this session
+  (b) Always allow
+
+Choice: _
+`;
+
+const UNKNOWN_PANE = `
+some random terminal output
+without any recognized patterns
+`;
+
+describe('Issue #1798: sendMessage idle-wait', () => {
+  // Verify our test fixtures map to the expected UI states
+  describe('pane fixture state verification', () => {
+    it('IDLE_PANE is detected as idle', () => {
+      expect(detectUIState(IDLE_PANE)).toBe('idle');
+    });
+
+    it('IDLE_WITH_PROMPT is detected as idle', () => {
+      expect(detectUIState(IDLE_WITH_PROMPT)).toBe('idle');
+    });
+
+    it('WORKING_SPINNER is detected as working', () => {
+      expect(detectUIState(WORKING_SPINNER)).toBe('working');
+    });
+
+    it('WORKING_STATUS is detected as working', () => {
+      expect(detectUIState(WORKING_STATUS)).toBe('working');
+    });
+
+    it('WORKING_PERAMBULATING is detected as working', () => {
+      expect(detectUIState(WORKING_PERAMBULATING)).toBe('working');
+    });
+
+    it('PERMISSION_PROMPT is detected as a non-waitable state', () => {
+      const state = detectUIState(PERMISSION_PROMPT);
+      expect(state).not.toBe('working');
+      expect(state).not.toBe('compacting');
+    });
+
+    it('UNKNOWN_PANE is detected as unknown', () => {
+      expect(detectUIState(UNKNOWN_PANE)).toBe('unknown');
+    });
+  });
+
+  /**
+   * Inline sendMessage + waitForIdleState logic for isolated unit testing.
+   * Mirrors session.ts implementation exactly.
+   */
+  async function sendMessageLogic(
+    capturePane: (windowId: string) => Promise<string>,
+    sendKeysVerified: (windowId: string, text: string) => Promise<{ delivered: boolean; attempts: number }>,
+    windowId: string,
+    text: string,
+    timeoutMs = 30_000,
+    pollMs = 2,
+  ): Promise<{ delivered: boolean; attempts: number }> {
+    const start = Date.now();
+    let idle = false;
+    while (Date.now() - start < timeoutMs) {
+      const paneText = await capturePane(windowId);
+      const uiState = detectUIState(paneText);
+      if (uiState === 'idle' || uiState === 'waiting_for_input') {
+        idle = true;
+        break;
+      }
+      if (uiState !== 'working' && uiState !== 'compacting' && uiState !== 'context_warning') {
+        idle = true;
+        break;
+      }
+      await new Promise(r => setTimeout(r, pollMs));
+    }
+
+    if (!idle) {
+      return { delivered: false, attempts: 0 };
+    }
+
+    return await sendKeysVerified(windowId, text);
+  }
+
+  it('sends immediately when CC is already idle', async () => {
+    const capturePane = vi.fn<(windowId: string) => Promise<string>>().mockResolvedValue(IDLE_PANE);
+    const sendKeysVerified = vi.fn<(windowId: string, text: string) => Promise<{ delivered: boolean; attempts: number }>>()
+      .mockResolvedValue({ delivered: true, attempts: 1 });
+
+    const result = await sendMessageLogic(capturePane, sendKeysVerified, '@1', 'Hello CC');
+
+    expect(result.delivered).toBe(true);
+    expect(capturePane).toHaveBeenCalledTimes(1);
+    expect(sendKeysVerified).toHaveBeenCalledWith('@1', 'Hello CC');
+  });
+
+  it('waits for idle when CC is working, then sends', async () => {
+    const capturePane = vi.fn<(windowId: string) => Promise<string>>()
+      .mockResolvedValueOnce(WORKING_SPINNER)
+      .mockResolvedValueOnce(IDLE_PANE);
+    const sendKeysVerified = vi.fn<(windowId: string, text: string) => Promise<{ delivered: boolean; attempts: number }>>()
+      .mockResolvedValue({ delivered: true, attempts: 1 });
+
+    const result = await sendMessageLogic(capturePane, sendKeysVerified, '@1', 'Hello CC', 5_000, 2);
+
+    expect(result.delivered).toBe(true);
+    expect(capturePane).toHaveBeenCalledTimes(2);
+    expect(sendKeysVerified).toHaveBeenCalledWith('@1', 'Hello CC');
+  });
+
+  it('returns failure when CC stays working past timeout', async () => {
+    const capturePane = vi.fn<(windowId: string) => Promise<string>>().mockResolvedValue(WORKING_STATUS);
+    const sendKeysVerified = vi.fn<(windowId: string, text: string) => Promise<{ delivered: boolean; attempts: number }>>()
+      .mockResolvedValue({ delivered: true, attempts: 1 });
+
+    const result = await sendMessageLogic(capturePane, sendKeysVerified, '@1', 'Hello CC', 20, 2);
+
+    expect(result.delivered).toBe(false);
+    expect(result.attempts).toBe(0);
+    expect(sendKeysVerified).not.toHaveBeenCalled();
+  });
+
+  it('sends immediately when CC is in permission_prompt (non-waitable state)', async () => {
+    const capturePane = vi.fn<(windowId: string) => Promise<string>>().mockResolvedValue(PERMISSION_PROMPT);
+    const sendKeysVerified = vi.fn<(windowId: string, text: string) => Promise<{ delivered: boolean; attempts: number }>>()
+      .mockResolvedValue({ delivered: true, attempts: 1 });
+
+    const result = await sendMessageLogic(capturePane, sendKeysVerified, '@1', 'Hello CC');
+
+    expect(result.delivered).toBe(true);
+    expect(capturePane).toHaveBeenCalledTimes(1);
+    expect(sendKeysVerified).toHaveBeenCalledWith('@1', 'Hello CC');
+  });
+
+  it('sends immediately for unknown state (non-waitable)', async () => {
+    const capturePane = vi.fn<(windowId: string) => Promise<string>>().mockResolvedValue(UNKNOWN_PANE);
+    const sendKeysVerified = vi.fn<(windowId: string, text: string) => Promise<{ delivered: boolean; attempts: number }>>()
+      .mockResolvedValue({ delivered: true, attempts: 1 });
+
+    const result = await sendMessageLogic(capturePane, sendKeysVerified, '@1', 'Hello CC');
+
+    expect(result.delivered).toBe(true);
+    expect(capturePane).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls multiple times when CC stays working for several checks', async () => {
+    const capturePane = vi.fn<(windowId: string) => Promise<string>>()
+      .mockResolvedValueOnce(WORKING_SPINNER)
+      .mockResolvedValueOnce(WORKING_STATUS)
+      .mockResolvedValueOnce(WORKING_PERAMBULATING)
+      .mockResolvedValueOnce(IDLE_WITH_PROMPT);
+    const sendKeysVerified = vi.fn<(windowId: string, text: string) => Promise<{ delivered: boolean; attempts: number }>>()
+      .mockResolvedValue({ delivered: true, attempts: 1 });
+
+    const result = await sendMessageLogic(capturePane, sendKeysVerified, '@1', 'Hello CC', 5_000, 2);
+
+    expect(result.delivered).toBe(true);
+    expect(capturePane).toHaveBeenCalledTimes(4);
+    expect(sendKeysVerified).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/session.ts
+++ b/src/session.ts
@@ -33,6 +33,11 @@ let lastCleanupTime = 0;
 let lastCleanupWorkDir = '';
 const CLEANUP_TTL_MS = 30_000;
 
+/** Issue #1798: Maximum time (ms) sendMessage waits for CC to become idle. */
+const SEND_MESSAGE_IDLE_TIMEOUT_MS = 30_000;
+/** Issue #1798: Poll interval (ms) when waiting for CC idle state. */
+const SEND_MESSAGE_IDLE_POLL_MS = 500;
+
 function hydrateSessions(raw: z.infer<typeof persistedStateSchema>): Record<string, SessionInfo> {
   const sessions: Record<string, SessionInfo> = Object.create(null);
   for (const [id, s] of Object.entries(raw)) {
@@ -1170,6 +1175,9 @@ export class SessionManager {
    *  Issue #1: Uses capture-pane to verify the prompt was delivered.
    *  Returns delivery status for API response.
    *  Issue #1325: Optionally includes stall feedback when monitor is provided.
+   *  Issue #1798: Waits for CC to become idle before sending to prevent
+   *  disrupting active work (especially extended thinking), which causes
+   *  jsonl stalls and session death.
    */
   async sendMessage(
     id: string,
@@ -1177,6 +1185,15 @@ export class SessionManager {
   ): Promise<{ delivered: boolean; attempts: number }> {
     const session = this.state.sessions[id];
     if (!session) throw new Error(`Session ${id} not found`);
+
+    // Issue #1798: Wait for CC to become idle before sending text + Enter.
+    // Sending Enter while CC is actively working (especially during extended
+    // thinking) disrupts CC's internal state, causing the session to become
+    // unresponsive while still showing "working" indicators (jsonl stall).
+    const idle = await this.waitForIdleState(session.windowId, SEND_MESSAGE_IDLE_TIMEOUT_MS);
+    if (!idle) {
+      return { delivered: false, attempts: 0 };
+    }
 
     const result = await this.tmux.sendKeysVerified(session.windowId, text);
     if (result.delivered) {
@@ -1188,6 +1205,27 @@ export class SessionManager {
       }
     }
     return result;
+  }
+
+  /** Issue #1798: Poll CC's terminal state until it becomes idle.
+   *  Returns true if idle within timeout, false if CC is still active.
+   *  Active states (working, compacting, context_warning) are waited on;
+   *  other states (permission_prompt, ask_question, idle, etc.) return immediately. */
+  private async waitForIdleState(windowId: string, timeoutMs: number): Promise<boolean> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const paneText = await this.tmux.capturePane(windowId);
+      const state = detectUIState(paneText);
+      if (state === 'idle' || state === 'waiting_for_input') {
+        return true;
+      }
+      // States that CC will naturally exit — don't wait
+      if (state !== 'working' && state !== 'compacting' && state !== 'context_warning') {
+        return true;
+      }
+      await new Promise(r => setTimeout(r, SEND_MESSAGE_IDLE_POLL_MS));
+    }
+    return false;
   }
 
   /** Send message bypassing the tmux serialize queue.


### PR DESCRIPTION
## Summary
- `sendMessage` now polls CC's terminal state before sending text+Enter, preventing Enter from being injected during active work (extended thinking, compacting, etc.)
- Adds `waitForIdleState` helper (mirrors `sendInitialPrompt`'s `waitForReadyAndSend` pattern) that polls for 30s max at 500ms intervals
- Non-waitable states (permission_prompt, ask_question, unknown, etc.) return immediately without blocking

## Root Cause
When `send_message` was called while CC was actively working (especially during extended thinking), the `Enter` key was injected into the terminal, disrupting CC's internal state. This caused CC to become unresponsive while still showing "working" indicators, triggering the `jsonl` stall. Subsequent `interrupt_session` would then kill the stuck CC process entirely.

## Test plan
- [x] 13 new unit tests in `send-message-stall-1798.test.ts` covering: idle immediate send, working→idle wait, timeout failure, non-waitable states, multi-poll sequences
- [x] Full suite: 2934 tests pass, quality gate passes
- [ ] Manual: start session, wait for extended thinking, call send_message → should wait for idle then deliver

Closes #1798

Generated by Hephaestus (Aegis dev agent)