### PR TITLE
fix(suppress): handle TmuxTimeoutError for non-critical tmux operations

### DIFF
--- a/src/__tests__/suppress-timeouts.test.ts
+++ b/src/__tests__/suppress-timeouts.test.ts
@@ -1,0 +1,91 @@
+/**
+ * suppress-timeouts.test.ts — Tests for TmuxTimeoutError suppression.
+ *
+ * Verifies that timeouts during non-critical tmux read operations
+ * (capture-pane, list-windows, monitor.checkSession) are suppressible,
+ * while timeouts during critical operations are not.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isSuppressible, suppressedCatch, _resetSuppressRateLimit } from '../suppress.js';
+import { TmuxTimeoutError } from '../tmux.js';
+
+beforeEach(() => {
+  _resetSuppressRateLimit();
+  vi.restoreAllMocks();
+});
+
+describe('isSuppressible — TmuxTimeoutError', () => {
+  it('suppresses TmuxTimeoutError on tmux.capturePane', () => {
+    const err = new TmuxTimeoutError(['capture-pane', '-t', 'sess'], 10_000);
+    expect(isSuppressible(err, 'tmux.capturePane')).toBe(true);
+  });
+
+  it('suppresses TmuxTimeoutError on tmux.listWindows', () => {
+    const err = new TmuxTimeoutError(['list-windows', '-t', 'sess'], 10_000);
+    expect(isSuppressible(err, 'tmux.listWindows')).toBe(true);
+  });
+
+  it('suppresses TmuxTimeoutError on monitor.checkSession', () => {
+    const err = new TmuxTimeoutError(['capture-pane', '-t', 'sess'], 10_000);
+    expect(isSuppressible(err, 'monitor.checkSession')).toBe(true);
+  });
+
+  it('does NOT suppress TmuxTimeoutError on critical contexts', () => {
+    const err = new TmuxTimeoutError(['send-keys', '-t', 'sess', 'C-c'], 10_000);
+    expect(isSuppressible(err, 'tmux.sendKeys')).toBe(false);
+  });
+
+  it('does NOT suppress TmuxTimeoutError on monitor.checkDeadSessions.killSession', () => {
+    const err = new TmuxTimeoutError(['kill-session', '-t', 'sess'], 10_000);
+    expect(isSuppressible(err, 'monitor.checkDeadSessions.killSession')).toBe(false);
+  });
+
+  it('does NOT suppress TmuxTimeoutError on session.cleanup', () => {
+    const err = new TmuxTimeoutError(['kill-session', '-t', 'sess'], 10_000);
+    expect(isSuppressible(err, 'session.cleanup')).toBe(false);
+  });
+
+  it('does NOT suppress TmuxTimeoutError on unknown tmux context', () => {
+    const err = new TmuxTimeoutError(['new-session', '-d'], 10_000);
+    expect(isSuppressible(err, 'tmux.newSession')).toBe(false);
+  });
+});
+
+describe('suppressedCatch — TmuxTimeoutError', () => {
+  it('emits console.debug for non-critical timeout', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const err = new TmuxTimeoutError(['capture-pane', '-t', 'sess'], 10_000);
+    suppressedCatch(err, 'tmux.capturePane');
+
+    expect(debug).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug.mock.calls[0][0]).toContain('[suppress] tmux.capturePane');
+    expect(debug.mock.calls[0][0]).toContain('timed out');
+  });
+
+  it('emits console.warn for critical timeout', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const err = new TmuxTimeoutError(['send-keys', '-t', 'sess', 'msg'], 10_000);
+    suppressedCatch(err, 'tmux.sendKeys');
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(debug).not.toHaveBeenCalled();
+    expect(warn.mock.calls[0][0]).toContain('[unexpected] tmux.sendKeys');
+  });
+
+  it('rate-limits suppressed timeout debug events', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    const err = new TmuxTimeoutError(['capture-pane', '-t', 'sess'], 10_000);
+    for (let i = 0; i < 20; i++) {
+      suppressedCatch(err, 'tmux.capturePane');
+    }
+
+    expect(debug.mock.calls.length).toBe(10);
+  });
+});

--- a/src/suppress.ts
+++ b/src/suppress.ts
@@ -3,9 +3,12 @@
  *
  * Issue #882: Replaces silent empty catches with a documented, testable
  * suppression contract. Suppressible errors (expected races, killed sessions,
- * missing tmux panes) are forwarded as rate-limited diagnostics events.
- * Non-suppressible errors are surfaced at warn level.
+ * missing tmux panes, tmux timeouts on non-critical ops) are forwarded as
+ * rate-limited diagnostics events. Non-suppressible errors are surfaced at
+ * warn level.
  */
+
+import { TmuxTimeoutError } from './tmux.js';
 
 /** Contexts where suppressible races may occur. */
 export type SuppressContext =
@@ -14,7 +17,15 @@ export type SuppressContext =
   | 'monitor.checkStopSignals.parseEntry'
   | 'session.cleanup'
   | 'tmux.capturePane'
+  | 'tmux.listWindows'
   | string;
+
+/** Tmux operation contexts where a timeout is non-critical and safe to suppress. */
+const TMUX_TIMEOUT_SUPPRESSIBLE_CONTEXTS: readonly string[] = [
+  'tmux.capturePane',
+  'tmux.listWindows',
+  'monitor.checkSession',
+];
 
 /** Rate-limit state: max N suppressed debug events per context per minute. */
 const suppressRateLimit = new Map<string, { count: number; resetAt: number }>();
@@ -34,9 +45,15 @@ const SUPPRESS_MAX_PER_MINUTE = 10;
  * - File not found (ENOENT) — session JSONL removed after kill
  * - Tmux pane/window gone — dead-session race
  * - SyntaxError from truncated JSONL reads during rotation
+ * - TmuxTimeoutError during non-critical read-only operations (capture-pane, list-windows)
  */
-export function isSuppressible(error: unknown, _context: SuppressContext): boolean {
+export function isSuppressible(error: unknown, context: SuppressContext): boolean {
   if (error instanceof SyntaxError) return true;
+
+  // Timeouts during non-critical tmux read operations are transient and safe to suppress.
+  if (error instanceof TmuxTimeoutError && TMUX_TIMEOUT_SUPPRESSIBLE_CONTEXTS.includes(context)) {
+    return true;
+  }
 
   if (error instanceof Error) {
     const code = (error as NodeJS.ErrnoException).code;


### PR DESCRIPTION
## Summary

Improve error suppression in src/suppress.ts to handle TmuxTimeoutError.

**Problem:** TmuxTimeoutError from non-critical operations (capture-pane, list-windows) was not being suppressed, causing spurious warnings during transient tmux slowness.

**Solution:** Add TmuxTimeoutError to isSuppressible() with context filtering — only suppress timeouts in non-critical tmux read contexts.

**Tests:** New test file covering TmuxTimeoutError suppression patterns.

## CI
- [x] `npm test -- --run`
- [x] `npm run build`