### PR TITLE
test: server smoke test — full HTTP flow

### DIFF
--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -1,0 +1,359 @@
+/**
+ * server-smoke.test.ts — Full server smoke test (Issue #1899).
+ *
+ * Spins up the Aegis Fastify server with real route modules and mocked
+ * infrastructure (tmux, filesystem), then exercises the core flow:
+ *   1. GET  /v1/health
+ *   2. POST /v1/sessions         — create session
+ *   3. POST /v1/sessions/:id/send — send message
+ *   4. GET  /v1/sessions/:id/summary — verify response
+ */
+
+import Fastify from 'fastify';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+import { SessionManager } from '../session.js';
+import { AuthManager } from '../services/auth/index.js';
+import { MetricsCollector } from '../metrics.js';
+import { SessionMonitor } from '../monitor.js';
+import { SessionEventBus } from '../events.js';
+import { ChannelManager } from '../channels/index.js';
+import { JsonlWatcher } from '../jsonl-watcher.js';
+import { PipelineManager } from '../pipeline.js';
+import { ToolRegistry } from '../tool-registry.js';
+import { AlertManager } from '../alerting.js';
+import { SwarmMonitor } from '../swarm-monitor.js';
+import { SSEConnectionLimiter } from '../sse-limiter.js';
+
+import {
+  registerHealthRoutes,
+  registerSessionRoutes,
+  registerSessionActionRoutes,
+  registerSessionDataRoutes,
+  registerAuthRoutes,
+  registerAuditRoutes,
+  registerEventRoutes,
+  registerTemplateRoutes,
+  registerPipelineRoutes,
+  type RouteContext,
+} from '../routes/index.js';
+
+import { createMockTmuxManager, type MockTmuxManager } from './helpers/mock-tmux.js';
+import type { Config } from '../config.js';
+
+const MASTER_TOKEN = 'aegis-master-token-2026';
+
+/** Build a lightweight RouteContext with all mocked dependencies. */
+async function buildRouteContext(tmpDir: string): Promise<{
+  ctx: RouteContext;
+  mockTmux: MockTmuxManager;
+  sessions: SessionManager;
+  auth: AuthManager;
+}> {
+  const mockTmux = createMockTmuxManager();
+
+  const config = {
+    port: 0,
+    host: '127.0.0.1',
+    authToken: MASTER_TOKEN,
+    tmuxSession: 'test-aegis',
+    stateDir: tmpDir,
+    claudeProjectsDir: join(tmpDir, 'projects'),
+    maxSessionAgeMs: 2 * 60 * 60 * 1000,
+    reaperIntervalMs: 60 * 60 * 1000,
+    continuationPointerTtlMs: 24 * 60 * 60 * 1000,
+    tgBotToken: '',
+    tgGroupId: '',
+    tgAllowedUsers: [],
+    tgTopicTtlMs: 0,
+    tgTopicAutoDelete: true,
+    tgTopicTTLHours: 0,
+    stallThresholdMs: 5 * 60 * 1000,
+    defaultPermissionMode: 'default',
+    allowedWorkDirs: [],
+    defaultSessionEnv: {},
+    metricsToken: '',
+    hookSecretHeaderOnly: false,
+    pipelineStageTimeoutMs: 30_000,
+    webhooks: [],
+    sseMaxConnections: 100,
+    sseMaxPerIp: 10,
+    memoryBridge: { enabled: false },
+    worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+    verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
+    alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
+  } satisfies Config;
+
+  const sessions = new SessionManager(
+    mockTmux as unknown as import('../tmux.js').TmuxManager,
+    config,
+  );
+  await sessions.load();
+
+  const auth = new AuthManager(join(tmpDir, 'keys.json'), MASTER_TOKEN);
+  auth.setHost('127.0.0.1');
+
+  const metrics = new MetricsCollector(join(tmpDir, 'metrics.json'));
+  await metrics.load();
+
+  const eventBus = new SessionEventBus();
+  const channels = new ChannelManager();
+  const monitor = new SessionMonitor(sessions, channels);
+
+  const jsonlWatcher = new JsonlWatcher();
+  const toolRegistry = new ToolRegistry();
+  const alertManager = new AlertManager({ webhooks: [] });
+  const swarmMonitor = new SwarmMonitor(sessions);
+  const sseLimiter = new SSEConnectionLimiter();
+
+  const pipelines = new PipelineManager(
+    sessions,
+    eventBus,
+    tmpDir,
+    config.pipelineStageTimeoutMs,
+  );
+
+  const requestKeyMap = new Map<string, string>();
+
+  const ctx: RouteContext = {
+    sessions,
+    tmux: mockTmux as unknown as import('../tmux.js').TmuxManager,
+    auth,
+    config,
+    metrics,
+    monitor,
+    eventBus,
+    channels,
+    jsonlWatcher,
+    pipelines,
+    toolRegistry,
+    getAuditLogger: () => undefined,
+    alertManager,
+    swarmMonitor,
+    sseLimiter,
+    memoryBridge: null,
+    requestKeyMap,
+    validateWorkDir: async (wd: string) => wd,
+  };
+
+  return { ctx, mockTmux, sessions, auth };
+}
+
+describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
+  let app: ReturnType<typeof Fastify>;
+  let tmpDir: string;
+  let routeContext: Awaited<ReturnType<typeof buildRouteContext>>;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-smoke-'));
+    routeContext = await buildRouteContext(tmpDir);
+
+    app = Fastify({ logger: false });
+
+    // #1108: Decorate request with authKeyId (required by route guards)
+    app.decorateRequest('authKeyId', null as unknown as string);
+
+    // Auth middleware — mirrors server.ts setupAuth() in simplified form.
+    // For the smoke test, validate against the master token only.
+    app.addHook('onRequest', async (req: FastifyRequest, reply: FastifyReply) => {
+      const urlPath = req.url?.split('?')[0] ?? '';
+
+      // Public routes — skip auth
+      if (urlPath === '/health' || urlPath === '/v1/health') return;
+      if (urlPath === '/v1/auth/verify') return;
+      if (urlPath === '/dashboard' || urlPath.startsWith('/dashboard/')) return;
+
+      // Hook routes — not under test
+      if (/^\/v1\/hooks\/[A-Za-z]+$/.test(urlPath)) return;
+
+      // WS terminal — not under test
+      if (/^\/v1\/sessions\/[^/]+\/terminal$/.test(urlPath)) return;
+
+      const header = req.headers.authorization;
+      const token = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
+
+      if (!token) {
+        return reply.status(401).send({ error: 'Unauthorized — Bearer token required' });
+      }
+
+      const result = routeContext.auth.validate(token);
+      if (!result.valid) {
+        return reply.status(401).send({ error: 'Unauthorized — invalid API key' });
+      }
+
+      req.authKeyId = result.keyId;
+    });
+
+    // UUID validation hook — mirrors server.ts
+    app.addHook('onRequest', async (req: FastifyRequest, reply: FastifyReply) => {
+      const id = (req.params as Record<string, string | undefined>).id;
+      if (id !== undefined) {
+        const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidRe.test(id)) {
+          return reply.status(400).send({ error: 'Invalid session ID — must be a UUID' });
+        }
+      }
+    });
+
+    // Register all route modules
+    const { ctx } = routeContext;
+    registerHealthRoutes(app, ctx);
+    registerAuthRoutes(app, ctx);
+    registerAuditRoutes(app, ctx);
+    registerSessionRoutes(app, ctx);
+    registerSessionActionRoutes(app, ctx);
+    registerSessionDataRoutes(app, ctx);
+    registerEventRoutes(app, ctx);
+    registerTemplateRoutes(app, ctx);
+    registerPipelineRoutes(app, ctx);
+
+    // Listen on random free port
+    await app.listen({ port: 0, host: '127.0.0.1' });
+  });
+
+  afterEach(async () => {
+    // Kill any sessions created during each test to avoid cross-contamination
+    const all = routeContext.sessions.listSessions();
+    for (const s of all) {
+      try { await routeContext.sessions.killSession(s.id); } catch { /* best effort */ }
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  /** Helper to inject authenticated requests. */
+  function authHeaders(): Record<string, string> {
+    return { Authorization: `Bearer ${MASTER_TOKEN}` };
+  }
+
+  // ── Step 1: Health check ──────────────────────────────────────────
+  it('GET /v1/health returns ok', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/health',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe('ok');
+    expect(body.version).toBeDefined();
+    expect(body.sessions).toBeDefined();
+  });
+
+  // ── Step 2: Create session ────────────────────────────────────────
+  it('POST /v1/sessions creates a session', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      payload: { workDir: tmpDir },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.id).toBeDefined();
+    expect(body.workDir).toBe(tmpDir);
+    expect(body.windowId).toBeDefined();
+    expect(body.windowName).toBeDefined();
+    expect(typeof body.createdAt).toBe('number');
+
+    // Verify session appears in listing
+    const listRes = await app.inject({
+      method: 'GET',
+      url: '/v1/sessions',
+      headers: authHeaders(),
+    });
+    expect(listRes.statusCode).toBe(200);
+    const list = listRes.json();
+    expect(list.sessions.length).toBeGreaterThanOrEqual(1);
+    expect(list.sessions.some((s: { id: string }) => s.id === body.id)).toBe(true);
+  });
+
+  // ── Step 3: Send message ──────────────────────────────────────────
+  it('POST /v1/sessions/:id/send delivers a message', async () => {
+    // Create session first
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      payload: { workDir: tmpDir },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const { id } = createRes.json();
+
+    // Send message
+    const sendRes = await app.inject({
+      method: 'POST',
+      url: `/v1/sessions/${id}/send`,
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      payload: { text: 'Hello from smoke test' },
+    });
+
+    expect(sendRes.statusCode).toBe(200);
+    const sendBody = sendRes.json();
+    expect(sendBody.ok).toBe(true);
+    expect(typeof sendBody.delivered).toBe('boolean');
+    expect(typeof sendBody.attempts).toBe('number');
+  });
+
+  // ── Step 4: Get summary ───────────────────────────────────────────
+  it('GET /v1/sessions/:id/summary returns session summary', async () => {
+    // Create session
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      payload: { workDir: tmpDir },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const { id } = createRes.json();
+
+    // Get summary
+    const summaryRes = await app.inject({
+      method: 'GET',
+      url: `/v1/sessions/${id}/summary`,
+      headers: authHeaders(),
+    });
+
+    expect(summaryRes.statusCode).toBe(200);
+    const summary = summaryRes.json();
+    expect(summary.sessionId).toBe(id);
+    expect(summary.windowName).toBeDefined();
+    expect(summary.status).toBeDefined();
+    expect(typeof summary.totalMessages).toBe('number');
+    expect(Array.isArray(summary.messages)).toBe(true);
+    expect(typeof summary.createdAt).toBe('number');
+    expect(typeof summary.lastActivity).toBe('number');
+  });
+
+  // ── Auth enforcement ──────────────────────────────────────────────
+  it('rejects unauthenticated requests to protected routes', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      headers: { 'Content-Type': 'application/json' },
+      payload: { workDir: tmpDir },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects invalid bearer tokens', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      headers: {
+        Authorization: 'Bearer wrong-token',
+        'Content-Type': 'application/json',
+      },
+      payload: { workDir: tmpDir },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds integration smoke test (`src/__tests__/server-smoke.test.ts`) for the full server HTTP flow (Issue #1899)
- Spins up Fastify with real route modules and mocked tmux infrastructure
- Exercises: `GET /v1/health` → `POST /v1/sessions` → `POST /v1/sessions/:id/send` → `GET /v1/sessions/:id/summary`
- Verifies auth enforcement (missing token → 401, invalid token → 401)

## Aegis version
**Developed with:** v0.5.3-alpha

## Gate output

```
$ npx tsc --noEmit
EXIT: 0

$ npm run build
> npm run build
EXIT: 0

$ npm test
 Test Files  169 passed | 1 skipped (170)
      Tests  2981 passed | 25 skipped (3006)
   Duration  43.02s

$ npm run gate
EXIT: 0
```

## Smoke test output

```
$ npm test -- src/__tests__/server-smoke.test.ts
 ✓ GET /v1/health returns ok
 ✓ POST /v1/sessions creates a session
 ✓ POST /v1/sessions/:id/send delivers a message
 ✓ GET /v1/sessions/:id/summary returns session summary
 ✓ rejects unauthenticated requests to protected routes
 ✓ rejects invalid bearer tokens
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Closes #1899

## Test plan
- [x] `npm run gate` passes
- [x] No trash/untracked artifacts
- [x] No obsolete references to removed files

Generated by Hephaestus (Aegis dev agent)