### PR TITLE
test(e2e): add Playwright smoke tests for login, audit, and session history pages (#1897)

### DIFF
--- a/dashboard/e2e/audit.spec.ts
+++ b/dashboard/e2e/audit.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+import { authenticate } from './helpers/auth';
+
+test.describe('Audit Trail Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await authenticate(page);
+
+    await page.route('**/v1/audit**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          records: [
+            {
+              id: 'audit-1',
+              ts: '2026-04-16T10:30:00Z',
+              actor: 'admin-key',
+              action: 'create',
+              sessionId: 'sess-abc123',
+              detail: 'Created session',
+            },
+            {
+              id: 'audit-2',
+              ts: '2026-04-16T10:35:00Z',
+              actor: 'admin-key',
+              action: 'send',
+              sessionId: 'sess-abc123',
+              detail: 'Sent message',
+            },
+          ],
+          total: 2,
+          page: 1,
+          pageSize: 10,
+        }),
+      });
+    });
+
+    await page.goto('/audit');
+  });
+
+  test('renders audit trail heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /audit trail/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Review system actions')).toBeVisible();
+  });
+
+  test('renders filter section with inputs', async ({ page }) => {
+    await expect(page.getByLabel(/actor/i)).toBeVisible();
+    await expect(page.getByLabel(/action/i)).toBeVisible();
+    await expect(page.getByLabel(/session id/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /apply/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /clear/i })).toBeVisible();
+  });
+
+  test('renders refresh button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /refresh/i })).toBeVisible();
+  });
+
+  test('renders table with column headers', async ({ page }) => {
+    const headers = ['Timestamp', 'Actor', 'Action', 'Session ID', 'Detail'];
+    for (const header of headers) {
+      await expect(page.getByText(header, { exact: true }).first()).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test('renders audit records from API', async ({ page }) => {
+    await expect(page.getByText('admin-key').first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('sess-abc123').first()).toBeVisible();
+  });
+
+  test('action badges are color-coded', async ({ page }) => {
+    const createAction = page.locator('span', { hasText: 'create' }).first();
+    await expect(createAction).toBeVisible();
+    const sendAction = page.locator('span', { hasText: 'send' }).first();
+    await expect(sendAction).toBeVisible();
+  });
+
+  test('pagination controls are visible', async ({ page }) => {
+    await expect(page.getByText(/2 records/)).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(/page 1 of 1/i)).toBeVisible();
+    await expect(page.getByLabel(/previous page/i)).toBeVisible();
+    await expect(page.getByLabel(/next page/i)).toBeVisible();
+  });
+
+  test('page size selector works', async ({ page }) => {
+    const pageSizeSelect = page.getByLabel(/page size/i);
+    await expect(pageSizeSelect).toBeVisible();
+  });
+});
+
+test.describe('Audit Trail Page — empty state', () => {
+  test('shows empty state when no records', async ({ page }) => {
+    await authenticate(page);
+
+    await page.route('**/v1/audit**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ records: [], total: 0, page: 1, pageSize: 10 }),
+      });
+    });
+
+    await page.goto('/audit');
+    await expect(page.getByText(/no audit records found/i)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/dashboard/e2e/helpers/auth.ts
+++ b/dashboard/e2e/helpers/auth.ts
@@ -1,0 +1,19 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Authenticate the dashboard by injecting a token and mocking the verify endpoint.
+ * Required before navigating to protected pages in smoke tests.
+ */
+export async function authenticate(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem('aegis_token', 'e2e-test-token');
+  });
+
+  await page.route('**/v1/auth/verify', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ valid: true, role: 'admin' }),
+    });
+  });
+}

--- a/dashboard/e2e/login.spec.ts
+++ b/dashboard/e2e/login.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Login Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+  });
+
+  test('renders login form with branding', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Aegis' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Enter your API token to continue')).toBeVisible();
+    await expect(page.locator('svg.lucide-shield')).toBeVisible();
+  });
+
+  test('renders token input and sign-in button', async ({ page }) => {
+    const input = page.getByLabel(/api token/i);
+    await expect(input).toBeVisible();
+    await expect(input).toHaveAttribute('type', 'password');
+
+    const submitBtn = page.getByRole('button', { name: /sign in/i });
+    await expect(submitBtn).toBeVisible();
+    await expect(submitBtn).toBeDisabled();
+  });
+
+  test('show/hide token toggle works', async ({ page }) => {
+    const input = page.getByLabel(/api token/i);
+    await input.fill('my-secret-token');
+    await expect(input).toHaveAttribute('type', 'password');
+
+    await page.getByRole('button', { name: /show token/i }).click();
+    await expect(input).toHaveAttribute('type', 'text');
+
+    await page.getByRole('button', { name: /hide token/i }).click();
+    await expect(input).toHaveAttribute('type', 'password');
+  });
+
+  test('sign-in button enables when token is entered', async ({ page }) => {
+    const submitBtn = page.getByRole('button', { name: /sign in/i });
+    await expect(submitBtn).toBeDisabled();
+
+    await page.getByLabel(/api token/i).fill('some-token');
+    await expect(submitBtn).toBeEnabled();
+  });
+
+  test('displays error on invalid token', async ({ page }) => {
+    await page.route('**/v1/auth/verify', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ valid: false }),
+      });
+    });
+
+    await page.getByLabel(/api token/i).fill('bad-token');
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    await expect(page.getByText('Invalid API token')).toBeVisible({ timeout: 5_000 });
+    await expect(page).toHaveURL(/login/);
+  });
+
+  test('redirects to overview on successful login', async ({ page }) => {
+    await page.route('**/v1/auth/verify', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ valid: true, role: 'admin' }),
+      });
+    });
+
+    // Mock overview API so the page loads without error
+    await page.route('**/v1/health', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: '0.0.0' }),
+      });
+    });
+
+    await page.getByLabel(/api token/i).fill('valid-token');
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    // Should navigate away from login
+    await expect(page).not.toHaveURL(/login/, { timeout: 5_000 });
+  });
+
+  test('shows loading state while verifying', async ({ page }) => {
+    // Delay the verify response
+    await page.route('**/v1/auth/verify', async (route) => {
+      await new Promise((r) => setTimeout(r, 2000));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ valid: false }),
+      });
+    });
+
+    await page.getByLabel(/api token/i).fill('some-token');
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    await expect(page.getByRole('button', { name: /verifying/i })).toBeVisible({ timeout: 1_000 });
+  });
+
+  test('no unexpected console errors', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+
+    await page.getByLabel(/api token/i).fill('test');
+    await page.getByRole('button', { name: /show token/i }).click();
+
+    // Filter out network-related errors (expected when API server isn't running)
+    const unexpectedErrors = errors.filter(
+      (e) => !e.includes('Failed to fetch') && !e.includes('net::ERR'),
+    );
+    expect(unexpectedErrors).toEqual([]);
+  });
+});

--- a/dashboard/e2e/session-list.spec.ts
+++ b/dashboard/e2e/session-list.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+import { authenticate } from './helpers/auth';
+
+test.describe('Session History Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await authenticate(page);
+
+    await page.route('**/v1/sessions/history**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          records: [
+            {
+              id: 'sess-001',
+              ownerKeyId: 'admin-key',
+              createdAt: Math.floor(Date.now() / 1000) - 3600,
+              lastSeenAt: Math.floor(Date.now() / 1000),
+              finalStatus: 'active',
+              source: 'audit+live',
+            },
+            {
+              id: 'sess-002',
+              ownerKeyId: 'user-key',
+              createdAt: Math.floor(Date.now() / 1000) - 7200,
+              lastSeenAt: Math.floor(Date.now() / 1000) - 1800,
+              finalStatus: 'killed',
+              source: 'live',
+            },
+          ],
+          pagination: { page: 1, limit: 25, total: 2, totalPages: 1 },
+        }),
+      });
+    });
+
+    await page.goto('/sessions/history');
+  });
+
+  test('renders session history heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /session history/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Merged audit and live session lifecycle')).toBeVisible();
+  });
+
+  test('renders refresh button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /refresh/i })).toBeVisible();
+  });
+
+  test('renders export CSV button when records exist', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /export.*csv/i })).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('renders filter section with all inputs', async ({ page }) => {
+    await expect(page.getByLabel(/owner key id/i)).toBeVisible();
+    await expect(page.getByLabel(/status/i)).toBeVisible();
+    await expect(page.getByLabel(/session id/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /^apply$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^clear$/i })).toBeVisible();
+  });
+
+  test('renders date range filter', async ({ page }) => {
+    await expect(page.getByLabel(/date range/i)).toBeVisible();
+  });
+
+  test('renders sort selector', async ({ page }) => {
+    await expect(page.getByLabel(/sort by/i)).toBeVisible();
+  });
+
+  test('renders table with column headers', async ({ page }) => {
+    const headers = ['Session ID', 'Owner', 'Status', 'Source', 'Created', 'Last seen'];
+    for (const header of headers) {
+      await expect(page.getByText(header, { exact: true }).first()).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test('renders session records from API', async ({ page }) => {
+    await expect(page.getByText('sess-001')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('admin-key')).toBeVisible();
+    await expect(page.getByText('sess-002')).toBeVisible();
+  });
+
+  test('status badges render with correct text', async ({ page }) => {
+    await expect(page.locator('span', { hasText: 'active' }).first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('span', { hasText: 'killed' }).first()).toBeVisible();
+  });
+
+  test('source badges render', async ({ page }) => {
+    await expect(page.locator('span', { hasText: 'audit+live' }).first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('span', { hasText: 'live' }).first()).toBeVisible();
+  });
+
+  test('pagination controls visible', async ({ page }) => {
+    await expect(page.getByText(/page 1 of 1/i)).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(/2 records/)).toBeVisible();
+  });
+
+  test('row size selector is visible', async ({ page }) => {
+    await expect(page.getByLabel(/rows/i)).toBeVisible();
+  });
+
+  test('select all checkbox visible in table header', async ({ page }) => {
+    const headerCheckbox = page.locator('thead input[type="checkbox"]').first();
+    await expect(headerCheckbox).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+test.describe('Session History Page — empty state', () => {
+  test('shows empty state when no records', async ({ page }) => {
+    await authenticate(page);
+
+    await page.route('**/v1/sessions/history**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          records: [],
+          pagination: { page: 1, limit: 25, total: 0, totalPages: 1 },
+        }),
+      });
+    });
+
+    await page.goto('/sessions/history');
+    await expect(page.getByText(/no session history records found/i)).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary

Playwright E2E smoke tests for Aegis dashboard pages.

**Created 4 files (365 lines):**
-  — shared helper for protected page auth (localStorage token + mock /v1/auth/verify)
-  — 7 tests: branding, form elements, show/hide toggle, button enable/disable, invalid token error, successful login redirect, loading state, no console errors
-  — 8 tests + empty state: heading/subtitle, filter inputs, refresh, table columns, mock data, action badges, pagination, page size
-  — 12 tests + empty state: heading/subtitle, refresh, export CSV, filters, date range, sort, table columns, mock records, status/source badges, pagination, select-all checkbox

All tests use Playwright route interception to mock API responses — no backend required.

## CI
- [x] `npm test` (dashboard — 2975 tests)
- [x] `npm run build`