### PR TITLE
fix(test): make config-hot-reload test cross-platform

### DIFF
--- a/src/__tests__/config-hot-reload-1753.test.ts
+++ b/src/__tests__/config-hot-reload-1753.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+
+// Use path.resolve('/tmp') so expectations match the implementation on every
+// platform: on POSIX this is '/tmp'; on Windows it becomes '<cwd-drive>:\\tmp'.
+const TMP_DIR = resolve('/tmp');
 import {
   findConfigFilePath,
   reloadAllowedWorkDirs,
@@ -44,7 +48,7 @@ describe('config hot-reload (Issue #1753)', () => {
       const dirs = await reloadAllowedWorkDirs();
       expect(dirs).not.toBeNull();
       expect(dirs!.length).toBe(2);
-      expect(dirs).toContain('/tmp');
+      expect(dirs).toContain(TMP_DIR);
       expect(dirs).toContain(testDir);
     });
 
@@ -116,7 +120,7 @@ describe('config hot-reload (Issue #1753)', () => {
 
       expect(onChange).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith(
-        expect.arrayContaining(['/tmp', testDir]),
+        expect.arrayContaining([TMP_DIR, testDir]),
       );
     });
 


### PR DESCRIPTION
## Summary

Two tests in `src/__tests__/config-hot-reload-1753.test.ts` failed on Windows
because they assert on the string literal `'/tmp'` while the production code
normalises paths via `path.resolve('/tmp')`, which evaluates to
`<drive>:\tmp` on Windows (e.g. `D:\tmp`).

## Fix

Compute `TMP_DIR = path.resolve('/tmp')` once at the top of the test file and
use it in the two assertions. This keeps the test platform-neutral: on POSIX
it collapses to `'/tmp'`; on Windows it becomes the same drive-prefixed form
the code produces.

## Failing tests (before fix)

- `config hot-reload (Issue #1753) > reloadAllowedWorkDirs > returns resolved allowedWorkDirs from config file`
- `config hot-reload (Issue #1753) > watchConfigFile > invokes callback with updated allowedWorkDirs after file change`

Both pass after the fix.

## Verification

Local gate on Windows (Node 22):

```
Test Files  169 passed | 2 skipped (171)
     Tests  2998 passed | 29 skipped (3027)
```

`npm run gate` exits 0.

## Scope

Test-only change. No production code touched.

## Aegis version

**Developed with:** v0.5.3-alpha
