### PR TITLE
docs: lock phase-1 positioning, roadmap, and agent workflow

### DIFF
--- a/.claude/epics/phase-1-foundations/epic.md
+++ b/.claude/epics/phase-1-foundations/epic.md
@@ -1,0 +1,134 @@
+# EPIC: Phase 1 — Foundations
+
+**Phase:** 1 (Foundations)
+**Wall-clock target:** 1–2 months part-time
+**Parent roadmap:** [ROADMAP.md](../../ROADMAP.md)
+**Positioning:** [ADR-0023](../../docs/adr/0023-positioning-claude-code-control-plane.md)
+
+## Goal
+
+Make Aegis safe, contract-first, and supply-chain-verifiable. Exit criterion:
+an external reviewer can verify the release, read an OpenAPI contract, and run
+Aegis without exposing the host to env-based RCE.
+
+## Issues
+
+> These are opened on GitHub as individual issues, all linked to the Epic
+> tracker issue titled **"EPIC: Phase 1 — Foundations"**. Labels:
+> `phase-1`, plus `security`, `api`, or `supply-chain` as appropriate.
+
+### 1.1 — Credential scan in `hygiene-check`
+**Labels:** `phase-1`, `security`, `quick-win`
+**Acceptance criteria:**
+- [ ] `scripts/hygiene-check.cjs` fails the gate when tracked files contain
+  patterns for `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_BASE_URL` values (not names), generic bearer tokens, and common
+  cloud-provider credentials.
+- [ ] False-positive denylist for documentation examples (explicit allow
+  markers).
+- [ ] Test fixtures covering positive and negative cases.
+- [ ] Runs in < 2 s on the full tree.
+
+### 1.2 — Env-var denylist at session create
+**Labels:** `phase-1`, `security`
+**ADR:** [ADR-0020](../../docs/adr/0020-env-var-denylist.md)
+**Acceptance criteria:**
+- [ ] Constant `ENV_DENYLIST` plus `refine()` on the `env` Zod schema in
+  `src/validation.ts`.
+- [ ] Whitelist for BYO-LLM variables (`ANTHROPIC_BASE_URL`,
+  `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_DEFAULT_*_MODEL`, `API_TIMEOUT_MS`).
+- [ ] Value hardening: strip CR/LF, reject control chars, cap at 8 KiB.
+- [ ] Config overrides: `AEGIS_ENV_DENYLIST` (additive),
+  `AEGIS_ENV_ADMIN_ALLOWLIST`.
+- [ ] Audit record on every rejection with action `session.env.rejected`.
+- [ ] Tests covering all sensitive variables on Linux/macOS/Windows names.
+
+### 1.3 — Session ownership authz on action routes
+**Labels:** `phase-1`, `security`
+**ADR:** [ADR-0019](../../docs/adr/0019-session-ownership-authz.md)
+**Acceptance criteria:**
+- [ ] `requireSessionOwnership()` helper in `src/routes/context.ts`.
+- [ ] Applied to `send`, `command`, `bash`, `approve`, `reject`, `kill`,
+  `interrupt`, `escape`.
+- [ ] Admin role bypasses the check.
+- [ ] Config flag `AEGIS_ENFORCE_SESSION_OWNERSHIP` (default `true`).
+- [ ] Audit emission for allowed and denied attempts.
+- [ ] Tests extending `session-ownership-*.test.ts`.
+
+### 1.4 — OpenAPI 3.1 generated from Zod
+**Labels:** `phase-1`, `api`
+**ADR:** [ADR-0018](../../docs/adr/0018-openapi-spec-from-zod.md)
+**Acceptance criteria:**
+- [ ] `@asteasolutions/zod-to-openapi` (or `zod-openapi`) wired in.
+- [ ] All routes register an OpenAPI descriptor alongside the Zod schema.
+- [ ] `GET /v1/openapi.json` serves the document.
+- [ ] Build writes `openapi.yaml` at repo root.
+- [ ] CI contract job diffs served doc vs committed `openapi.yaml`.
+- [ ] `docs/api-reference.md` links to the generated contract as source of
+  truth.
+
+### 1.5 — SSE idle timeout and HTTP drain on shutdown
+**Labels:** `phase-1`, `reliability`
+**ADR:** [ADR-0021](../../docs/adr/0021-sse-and-http-drain-timeouts.md)
+**Acceptance criteria:**
+- [ ] SSE per-connection last-write tracking; heartbeat after
+  `AEGIS_SSE_IDLE_MS`, close after `AEGIS_SSE_CLIENT_TIMEOUT_MS`.
+- [ ] Outgoing hook / webhook calls wrapped with `AbortSignal.timeout`.
+- [ ] Shutdown sequence: flip health to `draining` → `app.close()` with grace
+  → emit `event: shutdown` on SSE → kill sessions → flush audit → exit.
+- [ ] All timeouts configurable under `AEGIS_*` in `src/config.ts` and
+  documented in `docs/deployment.md`.
+
+### 1.6 — Dashboard E2E in PR CI
+**Labels:** `phase-1`, `ci`
+**Acceptance criteria:**
+- [ ] Playwright suite runs on PRs targeting `develop`.
+- [ ] At least the `login`, `session-list`, `audit` specs are required.
+- [ ] Matrix restricted to one browser (Chromium) for PR; full matrix on tag.
+- [ ] Failing screenshots uploaded as artefacts.
+
+### 1.7 — Branch coverage ≥ 65 %
+**Labels:** `phase-1`, `ci`
+**Acceptance criteria:**
+- [ ] `vitest.config.ts` raised: `branches: 65`.
+- [ ] Dashboard `vitest.config.ts` unchanged (already 70).
+- [ ] Any file below threshold is either excluded with justification or given
+  new tests.
+
+### 1.8 — Sigstore attestations for npm and container images
+**Labels:** `phase-1`, `supply-chain`
+**ADR:** [ADR-0022](../../docs/adr/0022-sigstore-attestations.md)
+**Acceptance criteria:**
+- [ ] `cosign attest-blob` over the published npm tarball; bundle attached to
+  the GitHub release.
+- [ ] `cosign sign` on `ghcr.io/onestepat4time/aegis@<digest>`.
+- [ ] `cosign attest --type cyclonedx --predicate sbom.json` attached.
+- [ ] New `docs/verify-release.md` with copy-pasteable verification commands.
+- [ ] CI `verify` matrix job re-runs verification after publish.
+
+## Issue opening plan
+
+The suggested order for opening PRs:
+
+1. **1.1** (credential scan) — smallest, unblocks the rest by making secrets
+   leaking impossible to accidentally commit.
+2. **1.2** (env-var denylist).
+3. **1.3** (session ownership authz) — builds on the denylist mindset.
+4. **1.4** (OpenAPI) — larger; can be split into scaffolding + per-route
+   sub-PRs.
+5. **1.5** (SSE + drain).
+6. **1.6** + **1.7** (CI hardening) — can ship together.
+7. **1.8** (Sigstore) — last; benefits from a green CI baseline.
+
+Each PR targets `develop`, follows the rules in
+[.claude/rules/branching.md](../rules/branching.md),
+[.claude/rules/commits.md](../rules/commits.md), and
+[.claude/rules/prs.md](../rules/prs.md).
+
+## Exit checklist
+
+- [ ] All eight issues closed.
+- [ ] `ROADMAP.md` Phase 1 checklist all ticked.
+- [ ] `CHANGELOG.md` updated via release-please.
+- [ ] An external tester (one of Emanuele's friends) has installed Aegis from
+  the signed release and reported their experience.

--- a/.claude/rules/positioning.md
+++ b/.claude/rules/positioning.md
@@ -1,0 +1,62 @@
+# Positioning (what Aegis is and is not)
+
+Authoritative source: [ADR-0023](../../docs/adr/0023-positioning-claude-code-control-plane.md)
+and [docs/enterprise/00-gap-analysis.md §15](../../docs/enterprise/00-gap-analysis.md).
+
+## What Aegis is
+
+- **The control plane of Claude Code.** REST, MCP, SSE, WebSocket, CLI, and
+  notification channels on a single self-hosted server.
+- **A bridge, not an orchestrator.** Claude Code does the agent work. Aegis
+  exposes, governs, observes, and approves it.
+- **MIT, single edition.** No open-core, no BUSL, no paid tier flag.
+- **BYO LLM first-class.** Claude Code can point at Anthropic, z.ai GLM,
+  OpenRouter, LM Studio, Ollama, Azure OpenAI, etc. Aegis owns no LLM cost.
+
+## Target users (in order of priority)
+
+1. The solo developer who runs a team of 1–100 agents and approves from their
+   phone.
+2. The small / medium team that shares one self-hosted Aegis deployment.
+3. The enterprise that wants SSO + multi-tenancy on the same product, later.
+
+Same architecture at every scale. No fork, no edition split, no rewrite.
+
+## What Aegis is NOT
+
+- Not an agent framework. We do not write agents, prompts, or LLM calls.
+- Not a SaaS. Self-hosted first; SaaS is off the table until demand + funding.
+- Not Claude-only at runtime. The LLM endpoint is configurable.
+- Not a general-purpose tmux manager. tmux is an implementation detail.
+
+## What to NOT build without explicit maintainer approval
+
+The roadmap locks these in. Do not propose or start PRs for them unless a
+maintainer assigns the issue from the right phase.
+
+**Never** (out of scope):
+- Open-core edition flag (`AEGIS_EDITION`) — decided against in ADR-0023.
+- Rewrite in another language — not under consideration.
+- First-class integrations with competing CLIs (e.g. Gemini CLI) —
+  Claude Code is the single target runtime.
+
+**Not before Phase 3** (team & early-enterprise):
+- SSO / OIDC providers.
+- Multi-tenancy primitives (tenant IDs on keys, sessions, audit).
+- Pluggable `SessionStore` with Postgres.
+- OpenTelemetry end-to-end wiring beyond the existing placeholder.
+
+**Not before Phase 4** (enterprise GA, demand-driven):
+- Redis as default state store.
+- Kubernetes as default deployment target (Helm chart ships in Phase 2 but
+  systemd / Docker Compose remain the default path).
+- Compliance scaffolding (SOC2, DPA templates).
+- Per-tenant quotas and billing hooks.
+
+If you think one of those items is unavoidable sooner, open an issue with
+the label `needs-human` and stop there.
+
+## Current phase
+
+Phase 1 — Foundations. Scope is defined in
+[.claude/epics/phase-1-foundations/epic.md](../epics/phase-1-foundations/epic.md).

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,65 @@
+# Workflow
+
+End-to-end path every contributor (human or agent) follows on Aegis.
+
+```
+Roadmap phase  →  Epic  →  Issue  →  Worktree branch  →  PR to develop
+                                          │
+                                          └──> local gate (npm run gate) before push
+```
+
+## 1. Pick work from the current phase
+
+- Read [ROADMAP.md](../../ROADMAP.md) — only pick items from the **current phase**.
+- Open [.claude/epics/](../epics/) for the phase-level breakdown.
+- Confirm the item is not already covered by an open PR: `gh pr list --search "<keyword>"`.
+
+## 2. Issue first
+
+- Every change of non-trivial size maps to a GitHub issue.
+- Use the right template and labels: phase (`phase-1`, `phase-2`, …), type (`bug`, `enhancement`, `security`, …), priority (`P0`–`P3`).
+- For issues that come straight from an epic, reference the epic file:
+  `Epic: .claude/epics/phase-1-foundations/epic.md` in the issue body.
+
+## 3. Worktree, not main checkout
+
+- Never develop inside the main clone directory.
+- Create one worktree per task:
+
+```bash
+mkdir -p .claude/worktrees
+git fetch origin
+git worktree add .claude/worktrees/<slug> -b <type>/<slug> origin/develop
+```
+
+## 4. Work in small steps
+
+- Target < 500 lines changed per PR (docs PRs may be larger).
+- Split multi-concern work into multiple PRs.
+- Do not batch unrelated fixes.
+
+## 5. Local gate before push
+
+```bash
+npm run gate
+```
+
+If it fails: fix or escalate with `needs-human`. Never `--no-verify`.
+
+## 6. PR targeting develop
+
+- Base branch: `develop`.
+- Link the issue with `Closes #<n>` in the PR body.
+- PR body must include the "Aegis version" field (see [prs.md](./prs.md)).
+- Argus (`aegis-gh-agent[bot]`) reviews and merges. Never self-merge.
+
+## 7. After merge
+
+- Remove the worktree: `git worktree remove .claude/worktrees/<slug>`.
+- The issue transitions automatically: `in-develop` → `in-main` → `released`.
+
+## Rules of thumb
+
+- When in doubt about whether an item belongs to the current phase, do **not** start it — ask or add `needs-human`.
+- When in doubt about whether a change is user-visible (for `feat:`), choose `fix:` or `refactor:`.
+- When in doubt about documentation alignment, run the pre-PR hygiene check from [AGENTS.md](../../AGENTS.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# GitHub Copilot Instructions
+
+This file is a pointer. The authoritative rules live in:
+
+- [../AGENTS.md](../AGENTS.md) — repository policy (entry point)
+- [../CLAUDE.md](../CLAUDE.md) — project-wide quick reference
+- [../.claude/rules/](../.claude/rules/) — scoped rules
+
+Before proposing changes, read `AGENTS.md` and the scoped rules linked from
+it. Do not start work on items outside the current phase declared in
+`AGENTS.md` and `ROADMAP.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,29 @@
 # AGENTS.md — Aegis Repository Agent Policy
 
 This file defines repository-level rules for human and AI contributors.
+It is the entry point for any agent (Claude Code, Copilot, Cursor, Codex,
+Windsurf, Aider, etc.) working on this repository.
+
+## Current Phase
+
+Aegis is in **Phase 1 — Foundations**. Pick work only from:
+
+- [ROADMAP.md](./ROADMAP.md) → Phase 1 checklist
+- [.claude/epics/phase-1-foundations/epic.md](./.claude/epics/phase-1-foundations/epic.md)
+
+Do **not** start work on Phase 2, 3, or 4 items without a maintainer
+explicitly assigning the issue.
+
+## Scoped Rules (load on demand)
+
+- [.claude/rules/workflow.md](./.claude/rules/workflow.md) — worktree → epic → issue → PR flow
+- [.claude/rules/branching.md](./.claude/rules/branching.md) — branch names + targets
+- [.claude/rules/commits.md](./.claude/rules/commits.md) — Conventional Commits and `feat:` gate
+- [.claude/rules/prs.md](./.claude/rules/prs.md) — PR body, size, review
+- [.claude/rules/positioning.md](./.claude/rules/positioning.md) — what Aegis is and what NOT to build
+- [.claude/rules/typescript.md](./.claude/rules/typescript.md) — TS conventions
+
+Authoritative strategic source: [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
 
 ## Mandatory Gate Before Push/PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,16 @@ src/
 ## Package
 
 - **Name:** `@onestepat4time/aegis`
-- **CLI binary:** `aegis`
+- **CLI binary:** `aegis` (today). `ag` becomes the primary alias in Phase 2 — see [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
 - **MCP:** `claude mcp add aegis -- npx @onestepat4time/aegis mcp`
 - **Deprecated:** `aegis-bridge` (do not use in new code)
+
+## Positioning (read before proposing features)
+
+- Aegis is the **control plane of Claude Code** — a bridge, not an orchestrator. See [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
+- MIT, single edition. BYO LLM is first-class.
+- Current phase and what NOT to build: [.claude/rules/positioning.md](./.claude/rules/positioning.md).
+- End-to-end workflow: [.claude/rules/workflow.md](./.claude/rules/workflow.md).
 
 ## Key Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,17 @@
 # Contributing to Aegis
 
-Welcome! Aegis is an open-source bridge that orchestrates Claude Code sessions via REST API, MCP, CLI, webhooks, and Telegram. Contributions of all kinds are welcome — code, docs, bug reports, feature requests.
+Welcome! Aegis is an open-source **control plane for Claude Code** — it
+bridges Claude Code sessions to REST, MCP, SSE, WebSocket, CLI, and
+notification channels on a single self-hosted server. It does not orchestrate
+agents itself. Contributions of all kinds are welcome — code, docs, bug
+reports, feature requests.
+
+Before starting any work, please read:
+
+- [AGENTS.md](./AGENTS.md) — repository-level policy for humans and AI agents
+- [ROADMAP.md](./ROADMAP.md) — current phase and what is in / out of scope
+- [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md) — product positioning (authoritative)
+- [.claude/rules/](./.claude/rules/) — scoped rules (branching, commits, PRs, workflow, positioning, TypeScript)
 
 ## Quick Start
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,65 +1,138 @@
 # Aegis Roadmap
 
-> **Aegis is in Alpha only.** Legacy release tracks are retired; planning is focused on alpha hardening and graduation readiness.
+> **Aegis is in Alpha.** Planning is organised into four phases driven by
+> audience scale (single dev → team → enterprise). The positioning is locked
+> in [ADR-0023](docs/adr/0023-positioning-claude-code-control-plane.md) and
+> the complete gap analysis lives in
+> [docs/enterprise/00-gap-analysis.md](docs/enterprise/00-gap-analysis.md).
 
 ---
 
 ## North Star
 
-Become the most reliable orchestration bridge for Claude Code across Linux, macOS, and Windows, with security-first defaults and deterministic CI gates.
+Be the most reliable, pleasant, self-hosted **control plane for Claude Code**
+— used by a single developer orchestrating agents from a phone, a 10-person
+team sharing a deployment, or an enterprise adopting it under SSO.
+
+The orchestration pattern is the same at every scale; Aegis scales up with the
+audience without rewrites. Aegis never orchestrates agents — it bridges them
+to Claude Code.
 
 ---
 
-## Alpha Priorities (Current)
+## Positioning (locked)
 
-### A1: Reliability Gates
-
-**Goal:** No broken code reaches `develop`.
-
-- [ ] Mandatory local gate in contributor workflow (`npm run gate`)
-- [ ] Pre-push hook adoption in active worktrees
-- [ ] CI pass-rate baseline tracked weekly
-- [ ] Flaky test budget defined and enforced
-
-### A2: Security Hardening
-
-**Goal:** Strong pre-merge and pre-release safeguards.
-
-- [ ] Branch protection parity on `main` and `develop`
-- [ ] Required checks include lint, test matrix, dashboard tests, CodeQL
-- [ ] Secret scanning and push-protection monitoring loop
-- [ ] Security documentation aligned with alpha lifecycle
-
-### A3: Release Integrity
-
-**Goal:** Reproducible, verifiable alpha releases.
-
-- [ ] Keep npm provenance enabled for all releases
-- [ ] Maintain SBOM + checksum publication on every tag
-- [ ] Validate release-please flow on each promotion cycle
-
-### A4: Developer and Agent Workflow
-
-**Goal:** AI-assisted development that is safe by default.
-
-- [ ] Agent policies aligned (no push/PR with red gate)
-- [ ] Escalation pattern standardized (`needs-human`)
-- [ ] Worktree-first workflow enforced in docs and practice
+- **Aegis is the control plane of Claude Code.** REST, MCP, SSE, WS, CLI, and
+  notification channels on one server.
+- **MIT, single edition.** No open-core, no BUSL.
+- **BYO LLM is first-class.** Claude Code can point at Anthropic, GLM,
+  OpenRouter, LM Studio, Ollama, Azure OpenAI, etc. Aegis owns no LLM cost.
+- **Primary CLI command is `ag`**; `aegis` remains as alias.
+- Self-hosted first. SaaS is off the table until there is demand and funding.
 
 ---
 
-## Graduation Signals (Alpha -> Next Phase)
+## Phase 1 — Foundations (current, 1–2 months part-time)
 
-- [ ] Stable CI on protected branches across required jobs
-- [ ] No unresolved high-priority security gaps
-- [ ] Documented incident/rollback playbook validated
-- [ ] Core docs remain current and free of placeholder content
+**Goal:** Aegis safe, contract-first, and supply-chain-verifiable.
+
+- [ ] Session ownership authz on action routes ([ADR-0019](docs/adr/0019-session-ownership-authz.md))
+- [ ] Env-var denylist at session create ([ADR-0020](docs/adr/0020-env-var-denylist.md))
+- [ ] Credential scan in `hygiene-check`
+- [ ] OpenAPI 3.1 spec generated from Zod ([ADR-0018](docs/adr/0018-openapi-spec-from-zod.md))
+- [ ] SSE idle timeout + HTTP drain on shutdown ([ADR-0021](docs/adr/0021-sse-and-http-drain-timeouts.md))
+- [ ] Dashboard E2E active on PRs to `develop`
+- [ ] Branch coverage raised from 60 % to 65 %
+- [ ] Sigstore attestations on npm + container images ([ADR-0022](docs/adr/0022-sigstore-attestations.md))
+
+Exit criterion: an external reviewer can verify the release, read an OpenAPI
+contract, and run Aegis without exposing the host to env-based RCE.
+
+---
+
+## Phase 2 — Developer Delight + Team-Ready (2–3 months)
+
+**Goal:** the tool friends recommend; good enough for a 10-person team.
+
+- [ ] `ag` alias + interactive `ag init` ([ADR-0023](docs/adr/0023-positioning-claude-code-control-plane.md))
+- [ ] `ag doctor` diagnostics command
+- [ ] Official BYO LLM support: docs, `examples/byo-llm/`, CI mock smoke
+- [ ] Agent / skill / slash-command template gallery (`ag init --from-template`)
+- [ ] Remote-access guide (Tailscale, Cloudflare Tunnel, ngrok)
+- [ ] Mobile-first dashboard pass
+- [ ] Dashboard home / onboarding flow
+- [ ] Helm chart v1 (P1-9)
+- [ ] Per-action RBAC: `send`, `approve`, `reject`, `kill`, `create` (P0-6)
+- [ ] Audit export API + base UI (P1-8)
+- [ ] CSP + token out of localStorage (P0-8)
+- [ ] Fault-injection harness in release gate (P1-6)
+- [ ] Prompt-injection hardening for MCP prompts (P2-3)
+
+---
+
+## Phase 3 — Team & Early-Enterprise (3–6 months, demand-driven)
+
+**Goal:** first external team of 10 + can run Aegis in production.
+
+- [ ] Pluggable `SessionStore` with Postgres implementation (P0-5)
+- [ ] OpenTelemetry wired end-to-end ([ADR-0017](docs/adr/0017-opentelemetry-tracing.md), P1-3)
+- [ ] SDKs for TypeScript and Python generated from OpenAPI (P2-5)
+- [ ] SSO / OIDC (Entra ID, Google, Okta, Keycloak, Authentik) (P1-2)
+- [ ] Multi-tenancy primitives: `tenantId` on keys / sessions / audit (P1-1)
+- [ ] Dashboard virtualization + full a11y pass (P1-7)
+- [ ] i18n scaffolding (EN + IT to start)
+
+---
+
+## Phase 4 — Enterprise GA (6–12 + months, demand-driven)
+
+All remaining P2 items from the gap analysis:
+
+- [ ] Horizontal scaling (Redis-backed state, sticky routing) (P2-1)
+- [ ] Compliance scaffolding (SOC2 control mapping, DPA template, retention policy) (P2-2)
+- [ ] Disaster-recovery runbook (export/import, audit-chain backup) (P2-6)
+- [ ] Secrets-manager integrations (Vault / AWS KMS / Azure KV) (P2-7)
+- [ ] Observability bundles (Grafana dashboards, alert rules, OTLP / Datadog docs) (P2-8)
+- [ ] Air-gapped deployment guide (P2-9)
+- [ ] Per-tenant quotas (sessions / tokens / USD spend cap) (P2-10)
+- [ ] Billing / metering hooks (P2-11)
+- [ ] Webhook signature-verification helper SDK (P2-12)
+
+---
+
+## Explicitly Deferred / Dropped
+
+- `AEGIS_EDITION` open-core flag — dropped. Single MIT edition.
+- SaaS / hosted offering — off the table until demand and funding exist.
+- Redis as default state store — deferred to Phase 4; Postgres in Phase 3.
+- Kubernetes-as-default deployment — downgraded; systemd / Docker Compose
+  remain the default path. Helm chart ships in Phase 2 for users who want it.
+- Rewrite in Rust or Go — not under consideration. If a rewrite ever happens,
+  Rust is the only candidate, and only on proven demand.
+
+---
+
+## Graduation Signals (alpha → preview → GA)
+
+**Alpha → Preview** (end of Phase 1):
+- [ ] All Phase 1 items shipped
+- [ ] CI green on `develop` for 4 consecutive weeks
+- [ ] At least one external user beyond the maintainer has run Aegis in anger
+
+**Preview → GA** (end of Phase 2):
+- [ ] All Phase 2 items shipped
+- [ ] Rename "alpha" dist-tag and version suffix to "preview"
+- [ ] Public demo video of the mobile approval flow
+- [ ] Incident / rollback runbook validated at least once
 
 ---
 
 ## Principles
 
-1. **Quality over velocity**: every merged PR must improve reliability or clarity.
-2. **Security before convenience**: defaults must prevent risky behavior.
-3. **Deterministic gates**: local + CI checks are non-optional.
-4. **Docs as contract**: behavior and policy must match documentation.
+1. **Quality over velocity** — every merged PR improves reliability or clarity.
+2. **Security before convenience** — defaults must prevent risky behaviour.
+3. **Deterministic gates** — local + CI checks are non-optional.
+4. **Docs as contract** — behaviour and policy must match documentation.
+5. **Same pattern at every scale** — no fork, no edition split, no rewrite.
+6. **Sustainable pace** — this is a part-time maintainer project; the roadmap
+   is calibrated to that reality.

--- a/docs/adr/0018-openapi-spec-from-zod.md
+++ b/docs/adr/0018-openapi-spec-from-zod.md
@@ -1,0 +1,56 @@
+# ADR-0018: OpenAPI 3.1 Spec Generated from Zod Schemas
+
+## Status
+Proposed
+
+## Context
+
+Aegis exposes 45+ REST endpoints under `/v1/` plus SSE and WebSocket surfaces. Today the API is documented in three places that drift independently:
+
+1. Hand-written Markdown in [docs/api-reference.md](../api-reference.md)
+2. Zod schemas in [src/validation.ts](../../src/validation.ts), [src/api-contracts.ts](../../src/api-contracts.ts), and per-route files under [src/routes/](../../src/routes/)
+3. Route handlers in [src/server.ts](../../src/server.ts) and [src/routes/](../../src/routes/)
+
+There is **no machine-readable OpenAPI contract**. This blocks:
+
+- Auto-generated SDKs for Python, Go, Rust, and external TypeScript consumers.
+- Contract tests that catch breaking changes before merge.
+- API-gateway integration (Kong, Tyk, APIM) that most enterprise deployments require.
+- IDE tooling (Swagger UI, Postman import, Stoplight) used by evaluators.
+
+The gap was identified as **P0-4** in [docs/enterprise/00-gap-analysis.md](../enterprise/00-gap-analysis.md).
+
+## Decision
+
+Generate an OpenAPI 3.1 document from the existing Zod schemas using a single toolchain and publish it at both build time and runtime.
+
+### Toolchain
+
+- Use `@asteasolutions/zod-to-openapi` (or `zod-openapi`) to describe each route's request body, query params, path params, and response envelope alongside the existing Zod schema.
+- Register route descriptions centrally via the [RouteContext](../../src/routes/) pattern so route modules stay the source of truth.
+- Emit `openapi.yaml` at the repo root on build; serve the same document at `GET /v1/openapi.json` (and optionally `GET /v1/docs` as Swagger UI).
+
+### CI contract test
+
+Add a CI job that:
+
+1. Builds the server.
+2. Starts it against an ephemeral port.
+3. Fetches `/v1/openapi.json`.
+4. Diffs it against the committed `openapi.yaml` — fails if out of sync.
+
+### Scope
+
+In scope: REST endpoints and SSE event envelope types.
+Out of scope (phase 1): MCP tool schemas (already described via MCP SDK), WebSocket binary framing.
+
+## Consequences
+
+- **Pros:** eliminates doc drift, unlocks SDK generation (P2-5), enables gateway deployments, provides a normalized deprecation-header model (P2-4).
+- **Cons:** every route must register an OpenAPI descriptor; small per-route tax. Zod → OpenAPI conversion has edge cases for `z.passthrough()` and recursive schemas that we must handle explicitly (notably in hook-body validation, see Issue #665).
+- **Migration:** existing hand-written [docs/api-reference.md](../api-reference.md) becomes narrative prose; generated OpenAPI becomes the contract.
+
+## Related
+
+- Gap analysis: P0-4 in [00-gap-analysis.md](../enterprise/00-gap-analysis.md)
+- Companion ADRs: [ADR-0019](0019-session-ownership-authz.md), [ADR-0020](0020-env-var-denylist.md)

--- a/docs/adr/0019-session-ownership-authz.md
+++ b/docs/adr/0019-session-ownership-authz.md
@@ -1,0 +1,56 @@
+# ADR-0019: Explicit Session Ownership Authz on Action Routes
+
+## Status
+Proposed
+
+## Context
+
+Aegis identifies API keys with a role (`admin`, `operator`, `viewer`) and records `ownerKeyId` on sessions they create. However, action routes — `POST /v1/sessions/:id/send`, `/approve`, `/reject`, `/kill`, `/interrupt`, `/escape`, `/command`, `/bash` — currently rely on bearer-token authentication alone and do not verify that the caller owns (or is otherwise entitled to) the target session.
+
+In a single-user deployment this is fine. In any shared deployment it means:
+
+- Any valid `operator` key can interact with, kill, or approve prompts in any other operator's sessions.
+- Audit attribution is correct (we record actor) but prevention is absent.
+- Multi-tenancy (P1-1) cannot be layered on cleanly without this boundary.
+
+Issue #1429 started the ownership plumbing; this ADR formalises the enforcement layer.
+
+Referenced as **P0-1** in [docs/enterprise/00-gap-analysis.md](../enterprise/00-gap-analysis.md).
+
+## Decision
+
+Enforce explicit ownership/authorization on every session-mutating route.
+
+### Authorization rule (phase 1)
+
+A request to an action route for session `S` is allowed iff:
+
+1. The caller key role is `admin`, **or**
+2. `S.ownerKeyId === caller.keyId`, **or**
+3. The session has been explicitly shared with the caller via a share grant (phase 2 placeholder; not shipped in phase 1).
+
+### Implementation
+
+- Add `requireSessionOwnership()` helper in [src/routes/context.ts](../../src/routes/context.ts) alongside `requireRole()`.
+- Apply to all session-mutating routes listed above. Read routes (`GET /v1/sessions/:id`, `/read`, `/transcript`, `/pane`, `/summary`, `/health`) continue to require role-level access until the multi-tenancy decision lands.
+- Return `403 FORBIDDEN` with error code `SESSION_FORBIDDEN` and an audit entry.
+
+### Configuration flag
+
+Ship behind `AEGIS_ENFORCE_SESSION_OWNERSHIP` (default `true`) for one minor release to give deployments a one-line rollback if edge cases surface, then remove the flag.
+
+### Audit
+
+Emit audit records for both allowed and denied attempts with action `session.action.denied`/`session.action.allowed` so compliance reviewers can prove enforcement.
+
+## Consequences
+
+- **Pros:** closes the main silent-authz gap; prerequisite for multi-tenancy (P1-1) and granular RBAC (P0-6).
+- **Cons:** existing integrations that assumed a shared pool of keys may need to adjust: either use one admin key or adopt the explicit share grant in phase 2.
+- **Testing:** requires adding ownership bypass/denial tests to the existing `auth-bypass-*`/`session-ownership-*` files.
+
+## Related
+
+- Gap analysis: P0-1 in [00-gap-analysis.md](../enterprise/00-gap-analysis.md)
+- Issue #1429 (ownership tracking groundwork)
+- Companion ADRs: [ADR-0018](0018-openapi-spec-from-zod.md), [ADR-0020](0020-env-var-denylist.md)

--- a/docs/adr/0020-env-var-denylist.md
+++ b/docs/adr/0020-env-var-denylist.md
@@ -1,0 +1,61 @@
+# ADR-0020: Env-Var Denylist on Session Create
+
+## Status
+Proposed
+
+## Context
+
+`POST /v1/sessions` accepts an optional `env` record that is forwarded to the Claude Code process via tmux. Env var **names** are validated by the regex `^[A-Z_][A-Z0-9_]*$` in [src/validation.ts](../../src/validation.ts). Values are not escaped or filtered.
+
+That leaves a sensitive attack surface:
+
+- `PATH` / `PATHEXT` — redirect `claude`, `git`, `bash` to attacker binaries.
+- `LD_PRELOAD` / `LD_LIBRARY_PATH` (Linux), `DYLD_INSERT_LIBRARIES` (macOS) — load attacker shared objects.
+- `NODE_OPTIONS` — `--require` arbitrary modules into the Claude runtime (if it is Node-based) or into Aegis-spawned helpers.
+- `ANTHROPIC_API_KEY` — silently replace the upstream key for a session; session output is attacker-controlled.
+- `GIT_SSH_COMMAND`, `GIT_EXEC_PATH`, `GIT_CONFIG_*` — hijack any `git` call made by the session.
+- `PYTHONSTARTUP`, `PYTHONPATH` — inject code into any Python subprocess.
+- Windows equivalents: `ComSpec`, `SystemRoot`, `APPDATA`, `USERPROFILE`, `PSModulePath`.
+
+A single compromised `operator` key is enough to gain RCE on the Aegis host via any of the above.
+
+Referenced as **P0-2** in [docs/enterprise/00-gap-analysis.md](../enterprise/00-gap-analysis.md).
+
+## Decision
+
+Introduce a denylist of environment variable names that are rejected at request time, with an optional allowlist override for admin keys.
+
+### Default denylist (indicative, not exhaustive)
+
+```
+PATH, PATHEXT, LD_PRELOAD, LD_LIBRARY_PATH, LD_AUDIT,
+DYLD_INSERT_LIBRARIES, DYLD_LIBRARY_PATH, DYLD_FRAMEWORK_PATH,
+NODE_OPTIONS, NODE_PATH,
+ANTHROPIC_API_KEY, ANTHROPIC_*,
+GIT_SSH_COMMAND, GIT_EXEC_PATH, GIT_CONFIG_SYSTEM, GIT_CONFIG_GLOBAL,
+PYTHONSTARTUP, PYTHONPATH, PYTHONUSERBASE,
+ComSpec, SystemRoot, APPDATA, USERPROFILE, PSModulePath, PROCESSOR_ARCHITECTURE
+```
+
+### Implementation
+
+- Add `ENV_DENYLIST` and a `refine()` on the `env` Zod schema in [src/validation.ts](../../src/validation.ts). Reject with error code `ENV_VAR_FORBIDDEN` and include the offending name.
+- Value-side hardening: strip CR/LF, reject control chars, cap length at 8 KiB.
+- Config override: `AEGIS_ENV_DENYLIST` (additive), `AEGIS_ENV_ADMIN_ALLOWLIST` (names admins may still set).
+- Audit every rejected attempt so abuse is visible in the chain.
+
+### Test coverage
+
+Reuse the existing [src/__tests__/env-denylist-1392.test.ts](../../src/__tests__/env-denylist-1392.test.ts) style: case-insensitive on Windows, wildcard support (`ANTHROPIC_*`), override behaviour for admin keys, audit emission.
+
+## Consequences
+
+- **Pros:** removes the most direct RCE vector for a compromised non-admin key; aligns with SSRF and workdir allowlists as a coherent boundary model.
+- **Cons:** denylists are never complete. This ADR treats it as a defence-in-depth layer, not the only control. Admin keys must remain trusted; the allowlist is explicitly a privileged escape hatch.
+- **Operator experience:** a small number of existing scripts relying on `PATH` overrides will need to use a wrapper workdir or switch to admin keys.
+
+## Related
+
+- Gap analysis: P0-2 in [00-gap-analysis.md](../enterprise/00-gap-analysis.md)
+- [ADR-0001](0001-windows-env-injection-strategy.md) — prior Windows-specific env work
+- Companion ADRs: [ADR-0019](0019-session-ownership-authz.md), [ADR-0021](0021-sse-and-http-drain-timeouts.md)

--- a/docs/adr/0021-sse-and-http-drain-timeouts.md
+++ b/docs/adr/0021-sse-and-http-drain-timeouts.md
@@ -1,0 +1,54 @@
+# ADR-0021: SSE Idle Timeout and HTTP Drain on Shutdown
+
+## Status
+Proposed
+
+## Context
+
+Aegis currently has two resource-leak / abrupt-shutdown footguns in the HTTP layer:
+
+1. **SSE has no idle timeout.** `/v1/events/subscribe` keeps a long-lived response open. If a client connects but stops reading, the socket sits in the kernel send buffer until TCP keep-alive reaps it (often >2h). Under load this leaks file descriptors and memory from the per-session event buffer.
+2. **No graceful HTTP drain on SIGTERM/SIGINT.** [src/signal-cleanup-helper.ts](../../src/signal-cleanup-helper.ts) kills tmux sessions, but Fastify sockets are closed hard. In-flight `POST /v1/sessions/:id/approve` requests can be aborted mid-response, leaving the caller unable to tell whether the approval was delivered. Hook-delivery channels are also not drained.
+
+Referenced as **P0-7** in [docs/enterprise/00-gap-analysis.md](../enterprise/00-gap-analysis.md).
+
+## Decision
+
+Introduce three coordinated timeouts and a drain sequence.
+
+### 1. SSE idle timeout
+
+- Track per-connection last-write time in [src/sse-writer.ts](../../src/sse-writer.ts).
+- If no event is sent for `AEGIS_SSE_IDLE_MS` (default 120 000), emit a heartbeat comment `:ping\n\n`.
+- If the client does not consume the heartbeat within `AEGIS_SSE_CLIENT_TIMEOUT_MS` (default 300 000 — detected via `socket.writableEnded` / backpressure), close the response and decrement the per-key SSE counter.
+
+### 2. Hook-delivery timeout
+
+- All outgoing hook/webhook HTTP calls run with an `AbortSignal.timeout(AEGIS_HOOK_TIMEOUT_MS)` wrapper (default 10 000).
+- On timeout, push to the existing DLQ rather than blocking the monitor loop.
+
+### 3. HTTP drain on shutdown
+
+Shutdown sequence on SIGTERM/SIGINT becomes:
+
+1. Flip health endpoint to `draining`.
+2. Call `app.close()` — stops accepting new connections, waits up to `AEGIS_SHUTDOWN_GRACE_MS` (default 15 000) for in-flight requests.
+3. Abort remaining SSE streams with a final `event: shutdown` frame.
+4. `killAllSessions()` (existing behaviour).
+5. Wait for audit/log flush with a hard cap (`AEGIS_SHUTDOWN_HARD_MS`, default 20 000) then `process.exit(0)`.
+
+### Config
+
+All three timeouts live in [src/config.ts](../../src/config.ts) under the `AEGIS_*` namespace, documented in [docs/deployment.md](../deployment.md).
+
+## Consequences
+
+- **Pros:** bounded resource usage; predictable shutdown for rolling deployments (required for Kubernetes P1-9); eliminates the class of "approval sent but never confirmed" bugs during restarts.
+- **Cons:** clients that rely on the current "infinite" SSE behaviour must accept periodic heartbeats and handle `event: shutdown`; documented in the SSE section of the API reference.
+- **Testing:** extends existing `sse-limiter` / `resilient-eventsource` suites with idle-timeout, drain-during-request, and hook-timeout cases.
+
+## Related
+
+- Gap analysis: P0-7 in [00-gap-analysis.md](../enterprise/00-gap-analysis.md)
+- Issues #308, #640 (resilient reconnection), #297 (SSE token lifecycle)
+- Companion ADRs: [ADR-0019](0019-session-ownership-authz.md), [ADR-0022](0022-sigstore-attestations.md)

--- a/docs/adr/0022-sigstore-attestations.md
+++ b/docs/adr/0022-sigstore-attestations.md
@@ -1,0 +1,60 @@
+# ADR-0022: Sigstore Attestations for npm and Container Artifacts
+
+## Status
+Proposed
+
+## Context
+
+The release pipeline already generates a CycloneDX SBOM, SHA-256 checksums, and publishes to npm with provenance using OIDC (`id-token: write`). Container images are pushed to `ghcr.io/onestepat4time/aegis` but are not signed, and there is no public attestation artifact consumers can verify offline.
+
+For enterprise procurement and regulated environments (SOC2, ISO 27001, FedRAMP-lite), downstream teams expect:
+
+- **npm provenance** — already present.
+- **Sigstore `.sigstore` attestations** for both npm tarballs and container images, verifiable against the GitHub workflow identity.
+- A documented verifier script so consumers can gate their CI on attestation validity without learning cosign semantics.
+
+Referenced as **P1-10** in [docs/enterprise/00-gap-analysis.md](../enterprise/00-gap-analysis.md) and identified as a quick win in §12.
+
+## Decision
+
+Sign and attest both artifact classes using Sigstore tooling driven by the existing workflow OIDC identity.
+
+### npm
+
+- Continue using `npm publish --provenance` (already enabled).
+- Additionally generate a `.sigstore` bundle with `cosign attest-blob` over the published tarball and attach it to the GitHub release.
+
+### Containers
+
+- Build with `docker/build-push-action` (already in use).
+- Sign with `cosign sign --yes ghcr.io/onestepat4time/aegis@<digest>` using keyless OIDC.
+- Generate an SBOM attestation: `cosign attest --predicate sbom.json --type cyclonedx …`.
+
+### Verifier documentation
+
+Add a `docs/verify-release.md` (separate PR) showing:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/OneStepAt4time/aegis/\.github/workflows/release\.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/onestepat4time/aegis:<tag>
+```
+
+and the equivalent `npm` tarball verification flow.
+
+### CI
+
+A matrix `verify` job re-runs the verification on every tag to prove the attestations are valid before announcing the release in Discord / GitHub Pages.
+
+## Consequences
+
+- **Pros:** satisfies supply-chain requirements common in enterprise procurement; complements existing SBOM and checksum artifacts; low effort thanks to existing OIDC permissions.
+- **Cons:** adds ~30–60 s to release jobs and one additional required check; consumers with air-gapped environments must fetch Sigstore's public good-instance roots out-of-band (documented in verify guide).
+- **Retention:** bump SBOM / attestation artifact retention to 365 days as part of P2-2 compliance scaffolding.
+
+## Related
+
+- Gap analysis: P1-10 and §12 quick win in [00-gap-analysis.md](../enterprise/00-gap-analysis.md)
+- [ADR-0016](0016-release-please-github-app-token.md) — current release token model
+- Companion ADRs: [ADR-0018](0018-openapi-spec-from-zod.md), [ADR-0021](0021-sse-and-http-drain-timeouts.md)

--- a/docs/adr/0023-positioning-claude-code-control-plane.md
+++ b/docs/adr/0023-positioning-claude-code-control-plane.md
@@ -1,0 +1,120 @@
+# ADR-0023: Positioning — Claude Code Control Plane, MIT, BYO LLM, `ag` CLI
+
+## Status
+Proposed
+
+## Context
+
+Aegis has been shaped incrementally as a Fastify + tmux HTTP bridge for Claude
+Code sessions. Over time, reviews have suggested multiple possible product
+framings (enterprise orchestrator, multi-agent framework, managed SaaS). The
+project currently has a small audience (≈ 8 GitHub stars as of 2026-04-16) and
+a part-time maintainer, so we need an unambiguous positioning that keeps the
+codebase focused and the roadmap tractable.
+
+Three independent decisions were deferred across ADR-0006 and the 2026-04-16
+gap analysis and are collected and formalised here.
+
+## Decisions
+
+### 1. Product framing — "Claude Code Control Plane"
+
+Aegis is the control plane of Claude Code. It exposes Claude Code sessions as
+a programmable, observable, multi-channel service over REST, MCP, SSE,
+WebSocket, CLI, and notification channels.
+
+Aegis **does not** orchestrate agents. Users build their agents (as Claude
+Code sub-agents, skills, or external MCP clients); Aegis provides the
+primitives (`create_session`, `send_message`, `approve_permission`,
+`events_subscribe`, `pipelines`, templates) and the observability to
+orchestrate them.
+
+This formalises [ADR-0006](0006-aegis-middleware-not-agent-framework.md) as
+the product-level positioning, not just an architectural note.
+
+Consequence: the `consensus`, `swarm-monitor`, and `memory-bridge` modules are
+kept but flagged experimental; no further investment until a clear user need
+surfaces.
+
+### 2. Target-user scope — three scales, one product
+
+| Scale | Primary today? | Examples |
+|---|---|---|
+| Single developer running a team of AI agents | **Yes** | the maintainer, indie devs, vibe coders |
+| Team of humans each with their own agents | **Next 2–3 months** | 5–20-person dev teams |
+| Enterprise | **Demand-driven** | multi-team deployments needing SSO/tenancy |
+
+The orchestration pattern is the same at every scale, so one codebase serves
+all three. Enterprise features (SSO, multi-tenancy, compliance) are built as
+extensions of the same primitives, never as a fork.
+
+### 3. Licensing — MIT, single edition
+
+Aegis remains MIT-licensed with a single edition. No open-core, no BUSL, no
+private enterprise repository. If a commercial contract, external funding, or
+regulatory requirement later demands a different structure, it will be
+re-evaluated with legal counsel at that point — not before.
+
+Consequence: no `AEGIS_EDITION` flag. All features ship to every user.
+
+### 4. LLM backend — BYO LLM is first-class
+
+Aegis orchestrates Claude Code as a runtime. Claude Code already supports
+pluggable LLM backends via `ANTHROPIC_BASE_URL` and related environment
+variables (GLM via `api.z.ai`, OpenRouter, local LM Studio / Ollama, Azure
+OpenAI, etc.). Aegis treats this as an **officially supported** configuration,
+not a tolerated side-effect.
+
+Obligations that fall out of this decision:
+
+- `docs/advanced.md` gains a "BYO LLM" section with verified configurations.
+- `examples/byo-llm/` provides runnable samples for at least: GLM, OpenRouter,
+  Ollama.
+- CI gains a smoke suite that points Claude Code (or a mock) at an
+  OpenAI-compatible mock server and verifies an end-to-end session.
+- The env-var denylist in [ADR-0020](0020-env-var-denylist.md) explicitly
+  whitelists `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`,
+  `ANTHROPIC_DEFAULT_*_MODEL`, and related variables (they are the opposite of
+  the denylist targets).
+
+Aegis ships **no default LLM credentials**. It does not proxy, cache, or own
+cost for LLM calls. Users pay their provider; Aegis stays zero-variable-cost
+to operate.
+
+### 5. CLI binary — `ag` is primary, `aegis` is an alias
+
+The npm `bin` entry gains `ag` alongside `aegis`. Documentation, examples,
+README, and generated help use `ag` as the canonical command. `aegis` remains
+for discoverability, muscle memory, and backward compatibility.
+
+```json
+"bin": {
+  "aegis": "dist/cli.js",
+  "ag": "dist/cli.js"
+}
+```
+
+All new subcommands in Phase 2 (`init`, `doctor`, `templates`) are documented
+under `ag`. No subcommands are renamed or removed.
+
+## Consequences
+
+- **Narrative**: README and `docs/` top copy are rewritten in Phase 2 to lead
+  with "control plane for Claude Code" and to feature BYO LLM and `ag`
+  prominently.
+- **Roadmap**: see §15 of [docs/enterprise/00-gap-analysis.md](../enterprise/00-gap-analysis.md).
+- **Dropped plans**: open-core edition flag, Redis-first horizontal scaling,
+  Kubernetes-as-default deployment. All become Phase 4 or later, demand-driven.
+- **Maintainer posture**: realistic pace for a part-time maintainer. Phase 1
+  is the only current commitment; Phases 2–4 are *plans*, not promises.
+
+## Related
+
+- [ADR-0006](0006-aegis-middleware-not-agent-framework.md) — Aegis as
+  middleware, not agent framework (architectural predecessor)
+- [ADR-0017](0017-opentelemetry-tracing.md) — Tracing strategy (enables
+  Phase 3 observability)
+- [ADR-0018](0018-openapi-spec-from-zod.md) — Unblocks SDK generation that
+  this positioning depends on
+- [ADR-0020](0020-env-var-denylist.md) — Must whitelist BYO-LLM variables
+- [docs/enterprise/00-gap-analysis.md](../enterprise/00-gap-analysis.md) §15

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,12 @@ ADRs document significant architectural decisions made during Aegis development.
 | [ADR-0014](0014-multi-line-message-sending-via-tmux.md) | Multi-line Message Sending via tmux Line-by-Line | Accepted | 2026-04-14 | #1770, #1815 |
 | [ADR-0016](0016-release-please-github-app-token.md) | Release-please with GitHub App Token | Accepted | 2026-04-10 | — |
 | [ADR-0017](0017-opentelemetry-tracing.md) | OpenTelemetry Distributed Tracing | Accepted | 2026-04-08 | — |
+| [ADR-0018](0018-openapi-spec-from-zod.md) | OpenAPI 3.1 Spec Generated from Zod Schemas | Proposed | 2026-04-16 | — |
+| [ADR-0019](0019-session-ownership-authz.md) | Explicit Session Ownership Authz on Action Routes | Proposed | 2026-04-16 | #1429 |
+| [ADR-0020](0020-env-var-denylist.md) | Env-Var Denylist on Session Create | Proposed | 2026-04-16 | — |
+| [ADR-0021](0021-sse-and-http-drain-timeouts.md) | SSE Idle Timeout and HTTP Drain on Shutdown | Proposed | 2026-04-16 | — |
+| [ADR-0022](0022-sigstore-attestations.md) | Sigstore Attestations for npm and Container Artifacts | Proposed | 2026-04-16 | — |
+| [ADR-0023](0023-positioning-claude-code-control-plane.md) | Positioning: Claude Code Control Plane, MIT, BYO LLM, `ag` CLI | Proposed | 2026-04-16 | — |
 
 ## Creating a New ADR
 

--- a/docs/enterprise/00-gap-analysis.md
+++ b/docs/enterprise/00-gap-analysis.md
@@ -1,0 +1,434 @@
+# 00 — Enterprise Gap Analysis (Follow-up Pass)
+
+**Date:** 2026-04-16
+**Reviewer:** GitHub Copilot (Claude Opus 4.7)
+**Version reviewed:** `@onestepat4time/aegis` 0.5.3-alpha on `develop`
+**Scope:** Full codebase — `src/`, `dashboard/`, `docs/`, `scripts/`, `.github/workflows/`, `examples/`, `skill/`, `packages/client/`
+**Relationship to prior review:** Follow-up to the 2026-04-08 pass indexed in [index.md](./index.md). Confirms which gaps closed, which remain, and introduces an updated P0/P1/P2 scorecard plus companion ADR stubs.
+
+> This document is a requested publication (review artifact), not a trash/report file. It follows the `docs/enterprise/` series and is referenced from [index.md](./index.md).
+
+---
+
+## Executive Summary
+
+Aegis is a well-architected alpha that does one thing elegantly: it turns Claude Code + tmux into a first-class, scriptable orchestration substrate accessible via REST, MCP, CLI, SSE, WS, and multiple notification channels. Engineering quality is notably high for alpha — strict TS, Zod validation, SSRF hardening, SHA-256-chained audit log, mutex-guarded session lifecycle, Prometheus metrics, CodeQL, Dependabot, release-please with SBOM + npm provenance, CycloneDX, hygiene gate, and ~185 tests.
+
+The gap to enterprise is not quality — it is **posture**: the product is single-tenant by design, lacks SSO/OIDC, has no horizontal-scaling story (file-backed state), no OpenAPI contract, limited granular RBAC, no Kubernetes/Helm packaging, no data retention/DR policy, and only partial per-action audit logging. Closing those gaps is a 1–2 quarter scope, not a rewrite.
+
+---
+
+## 1. Product Idea
+
+> **Aegis is the control plane for Claude Code.** It turns an interactive CLI coding agent into a programmable, observable, multi-channel service — so humans and other agents can drive Claude Code over REST/MCP instead of over a keyboard.
+
+### Core value propositions
+
+1. **No SDK lock-in, no browser automation** — pure tmux + JSONL parsing of Claude Code's native transcript.
+2. **Unified bridge** — one server exposes the same sessions to REST, MCP tools, SSE, WebSocket, CLI, Telegram, Slack, Email, and webhooks.
+3. **Deterministic state machine** — sessions classified as `working | idle | asking | permission_prompt | stalled` via regex-based terminal parsing, not LLM-parsing.
+4. **Multi-agent orchestration primitives** — pipelines, batches, consensus, memory bridge, templates, capability handshake.
+5. **Security-first defaults** — API-key RBAC, path allowlists, SSRF blocklist, hook-secret encryption, audit trail with SHA-256 chaining.
+
+### Target personas
+
+| Persona | Use case | Primary surface |
+|---|---|---|
+| AI-agent builder | Spawn and coordinate parallel CC sessions | MCP tools + SSE |
+| DevOps / CI | Run CC headless inside pipelines | REST + CLI |
+| Internal automation | Supervised coding with approvals | Dashboard + Telegram |
+| SaaS integrator | Whitelabel Claude Code as a service | REST + API keys + dashboard |
+
+**Ecosystem position:** Aegis sits between MCP hosts (Claude Code, Cursor, Windsurf) and Claude Code itself. Closest conceptual adjacency is Replit Agent APIs / OpenDevin, but Aegis is self-hosted, open-source, transport-agnostic, and CC-native.
+
+---
+
+## 2. Architecture Snapshot
+
+```
+HTTP (Fastify 5) ──┐
+MCP (stdio)    ────┤
+WS/SSE         ────┼─► RouteContext (DI) ─► Services (Auth, Sessions, Pipelines, Memory, Channels)
+CLI            ────┘                       │
+                                           ▼
+                              tmux serialized queue ─► Claude Code processes
+                                           │
+                                           ▼
+                     JSONL watcher + terminal-parser ─► Monitor loop ─► EventBus
+                                           │                               │
+                                           ▼                               ▼
+                                      Audit log                   Channels (TG/Slack/Email/Webhook)
+                                       + Metrics + Prometheus + Structured logs
+```
+
+### Strengths
+
+- Clean layering: [src/server.ts](../../src/server.ts) → [src/routes/](../../src/routes/) → [src/services/](../../src/services/) → [src/platform/](../../src/platform/)/[src/tmux.ts](../../src/tmux.ts).
+- DI via [src/container.ts](../../src/container.ts) with lifecycle + dependency ordering.
+- Serialized tmux CLI queue with 10s default timeout prevents hung commands from blocking.
+- Hook-driven discovery (push) with polling fallback (pull).
+- Dual-offset transcript model (monitor vs. API read) allows independent consumption.
+- Cross-platform shell abstraction in [src/platform/shell.ts](../../src/platform/shell.ts).
+
+### Hotspots / smells
+
+- [src/server.ts](../../src/server.ts) still bundles middleware + route registration + global wiring (~800 LOC). Decomposition tracked by [ADR-0007](../adr/0007-server-decomposition-fastify-plugins.md).
+- [src/session.ts](../../src/session.ts) (~500 LOC) mixes lifecycle, persistence, and orchestration despite helpers.
+- [src/monitor.ts](../../src/monitor.ts) polling loop carries many side effects (offset updates, events, metrics) in one function.
+- [src/permission-guard.ts](../../src/permission-guard.ts) scans three settings locations — correct but fragile.
+- Legacy [src/auth.ts](../../src/auth.ts) re-exports [src/services/auth/AuthManager.ts](../../src/services/auth/AuthManager.ts) — source of confusion.
+- Pipeline state is in-memory only (TODO at [src/pipeline.ts](../../src/pipeline.ts) referencing #1665).
+
+---
+
+## 3. API Surface
+
+- **REST** under `/v1/`: sessions (CRUD + batch + history), actions (send/command/bash/approve/reject/escape/interrupt), transcripts (cursor pagination), hooks (inbound CC events), auth keys (CRUD + SSE tokens), health + diagnostics + `/metrics`, pipelines, channels health + DLQ, swarm, memory, templates.
+- **MCP:** 24 tools, 4 resources, 3 prompts; handshake with capability negotiation ([src/handshake.ts](../../src/handshake.ts)).
+- **SSE:** `/v1/events/subscribe?sessionId=…` with short-lived (60s) SSE tokens.
+- **WebSocket:** `/ws/terminal/:sessionId` with first-message auth handshake (Issue #503).
+
+**Gaps:** no OpenAPI/Swagger, no deprecation-header policy, WebSocket route is undocumented in [docs/api-reference.md](../api-reference.md). See [ADR-0018](../adr/0018-openapi-spec-from-zod.md).
+
+---
+
+## 4. Security Posture
+
+### Strong
+
+- API keys hashed (SHA-256); roles: admin/operator/viewer; rate limit + TTL per key.
+- Tamper-evident audit chain (SHA-256, v3 after Issue #1642 to avoid PBKDF2 stalls) with daily rotation ([src/audit.ts](../../src/audit.ts)).
+- Zod schemas on all POST bodies; workdir traversal protection; `claudeCommand` restricted via `SAFE_COMMAND_RE`.
+- SSRF blocklist covers RFC1918, loopback, link-local, IPv6 ULA, IPv4-mapped IPv6, CGNAT, multicast, docs, benchmarking ([src/ssrf.ts](../../src/ssrf.ts)).
+- `execFile()` only — no `exec()`; repo-wide [scripts/check-no-shell-true.cjs](../../scripts/check-no-shell-true.cjs) bans `shell: true`.
+- Hook secrets encrypted at rest with AES-256-GCM (derived from master token).
+- Log redaction of auth tokens via [src/utils/redact-headers.ts](../../src/utils/redact-headers.ts).
+- SSE token scheme: short TTL, max 5 per key, separate prefix from bearer tokens.
+
+### Gaps
+
+- **Implicit session ownership** on action routes — bearer token gates access but there is no explicit `ownerKeyId` check in `send/approve/reject/kill`. Partial work under Issue #1429. See [ADR-0019](../adr/0019-session-ownership-authz.md).
+- **Coarse RBAC** — three roles; no per-action permission (e.g., "can approve but not kill").
+- **Tool-input passthrough** — hook bodies accept arbitrary `tool_input` via `.passthrough()` (Issue #665); may leak sensitive fields via SSE.
+- **Master-token single key** — all hook-secret encryption derives from one key; no rotation mechanism.
+- **No per-IP rate limit** — only per-key; leaked key still rate-limited, but unauthenticated endpoints lean on per-route config.
+- **CORS default permissive** in dev — must be locked down in prod.
+- **Env passthrough** — env var names validated (`^[A-Z_][A-Z0-9_]*$`), but values not escaped; no denylist for `PATH`, `LD_PRELOAD`, `ANTHROPIC_API_KEY`, `NODE_OPTIONS`, `DYLD_*` (RCE risk if an admin key is compromised). See [ADR-0020](../adr/0020-env-var-denylist.md).
+- **Token in localStorage** on the dashboard (XSS exposure).
+- **No CSP** headers in `dashboard/index.html`.
+
+---
+
+## 5. Reliability
+
+- Structured error categories + retry with exponential backoff + jitter ([src/retry.ts](../../src/retry.ts)).
+- Mutexes: per-session acquire (`async-mutex`), audit write lock, SSE-token issuance lock, tmux global serialization queue.
+- Stall threshold default 2 min (Issue #392), permission timeout auto-reject at 10 min, unknown-state timeout 3 min.
+- JSONL watcher restart with exponential backoff on `fs.watch` errors (Issue #1420).
+- Graceful shutdown: `killAllSessions()` on SIGTERM/SIGINT; Windows WM_QUERYENDSESSION handled.
+
+### Weaknesses
+
+- No **HTTP drain** on shutdown — in-flight approvals can be hard-closed. See [ADR-0021](../adr/0021-sse-and-http-drain-timeouts.md).
+- **Channel deliveries are fire-and-forget** — errors silently dropped unless DLQ hits.
+- **No SSE idle timeout** — hung clients keep sockets alive.
+- **Hook handling lacks per-request timeout** — a 30s webhook can stall the monitor loop.
+- Offset mutation in [src/monitor.ts](../../src/monitor.ts) is "best effort" without a lock — documented, but still a foot-gun.
+
+---
+
+## 6. Observability
+
+- Metrics: per-global and per-session (duration, messages, tool calls, token cost in USD, Issue #488); Prometheus exporter at `/metrics` ([src/prometheus.ts](../../src/prometheus.ts)).
+- Structured logs (JSON) with redaction.
+- Audit trail with chain integrity (v3).
+- **Tracing:** OpenTelemetry is designed in [ADR-0017](../adr/0017-opentelemetry-tracing.md) but [src/tracing.ts](../../src/tracing.ts) is effectively a placeholder — OpenTelemetry deps are installed but not wired end-to-end.
+
+---
+
+## 7. Frontend (Dashboard)
+
+**Stack:** React 19 + RR v7 + Zustand + Tailwind v4 + xterm.js, Vitest + Playwright, Vite with vendor-chunking and hidden sourcemaps.
+
+### What's done well
+
+- Lazy-loaded pages, code splitting, ErrorBoundary, ToastContainer.
+- Resilient SSE ([dashboard/src/api/resilient-eventsource.ts](../../dashboard/src/api/resilient-eventsource.ts)) and resilient WS ([dashboard/src/api/resilient-websocket.ts](../../dashboard/src/api/resilient-websocket.ts)) with capped retries and give-up signals (Issues #308, #503, #640, #641).
+- Zod validation in API client, automatic bearer injection, 401 → logout.
+- XSS tests across every transcript entry type ([dashboard/src/__tests__/sanitization-all-entry-types.test.tsx](../../dashboard/src/__tests__/sanitization-all-entry-types.test.tsx)).
+- 70% coverage threshold enforced in [dashboard/vitest.config.ts](../../dashboard/vitest.config.ts).
+
+### Dashboard gaps
+
+- No focus trap / focus restore in modals; partial ARIA.
+- No i18n — English hardcoded.
+- No virtualization on transcript and session-history lists; potential OOM on large sessions (TanStack Virtual is installed but unused).
+- Token in localStorage (XSS risk).
+- No CSP, no light-theme contrast audit.
+- No memoization on hot list items (`MessageBubble`, `SessionTable` rows).
+- No multi-select / batch actions on sessions.
+- No RBAC UI although backend supports roles.
+- No "last updated" / staleness indicators on metrics.
+- No permission-prompt TTL countdown in UI.
+
+---
+
+## 8. Testing & CI/CD
+
+### Test inventory (~185 files)
+
+- **Unit:** config, metrics, auth, logger, container, path/utils, safe-json, circular-buffer.
+- **Security:** auth-bypass, RBAC, webhook SSRF, screenshot SSRF, env-denylist, permission-evaluator ×7, input-validation, SSRF.
+- **Session/tmux:** 7 tmux-* files, session-dedup/mutex/ownership/persistence, zombie-reaper, pane-exit, dead-session.
+- **Webhooks:** retry, SSRF, DNS rebinding, DLQ, header redaction.
+- **Integration:** 4 files (SSE, lifecycle, permission flow, auth ratelimit).
+- **Fault injection:** 1 harness, manual-run only.
+- **Dashboard unit:** ~10; Playwright E2E: 5 specs.
+
+**Coverage:** 70% lines/functions/statements, **60% branches** — below CLAUDE.md M1 goal (≥65%). LCOV emitted, not uploaded / trended.
+
+### CI (13 workflows)
+
+- **On PR to `develop`:** ESLint + hygiene + security grep + `tsc --noEmit` + build + `npm test` + CI smoke, matrix Ubuntu × Node 20,22. **No dashboard E2E, no Windows/macOS.**
+- **On tag:** full Ubuntu/Windows/macOS matrix (Node 22), dashboard E2E, SBOM (CycloneDX), SHA-256 checksums, npm publish with provenance.
+- **Scheduled/triggered:** CodeQL (JS/TS), Dependabot (weekly npm + dashboard + actions), stale, rollback, Discord notify, pages, auto-triage/label.
+
+**Release:** release-please (prerelease `alpha`), SBOM + checksums (30-day retention), npm provenance via OIDC (`id-token: write`), no Sigstore attestation file, no package signing. See [ADR-0022](../adr/0022-sigstore-attestations.md).
+
+**Gate:** `npm run gate` = hygiene + security-check + tsc + build + test. Hygiene detects a denylist of retired filenames, dated analysis artefacts, and enforces SECURITY.md alpha alignment. Weaknesses: no staged mode, no bundle/latency budgets, `--no-verify` not blocked at repo level, fault harness not in CI, no coverage diff tracking.
+
+---
+
+## 9. Documentation & Packaging
+
+**Covered:** Getting Started, Architecture, API Reference (hand-authored), MCP Tools, Advanced (memory bridge, templates, verification), Dashboard, Windows setup + dev, Worktree, Alerting, Troubleshooting, Deployment (systemd/Docker), Enterprise, Migration guide, Integrations (Telegram/Slack/Email/Webhooks/Cursor/Windsurf/CLI/MCP Registry).
+
+### Missing / thin
+
+- No OpenAPI / Swagger (`openapi.yaml` is empty/absent at repo root).
+- No Kubernetes / Helm / StatefulSet guide.
+- No air-gap deployment guide.
+- No SLA / uptime / deprecation / API-versioning doc.
+- No data-retention / archival policy.
+- No DR runbook or backup/restore.
+- Alpha lifecycle language drifts in [enterprise.md](../enterprise.md) (reads "production-ready" in places).
+- [skill/SKILL.md](../../skill/SKILL.md) still references old `aegis-bridge` name in spots.
+
+**Packaging present:** npm main (`@onestepat4time/aegis`), npm client (`@onestepat4time/aegis-client`), Docker image (ghcr), CLI bin `aegis`, Claude skill. **Missing:** Helm chart, Terraform module, Homebrew/APT, PyPI/Go/Rust SDK, container image signing/attestations.
+
+---
+
+## 10. Enterprise Gap Scorecard
+
+**Legend:** Impact ∈ {S, M, L}. Effort ∈ {S ≤ 1w, M 1–3w, L > 3w}.
+
+### P0 — Ship blockers for any enterprise pilot
+
+| # | Gap | Impact | Effort |
+|---|---|---|---|
+| P0-1 | Explicit session ownership authz on send/approve/reject/kill/interrupt | L | M |
+| P0-2 | Env-var denylist (PATH, LD_PRELOAD, ANTHROPIC_API_KEY, NODE_OPTIONS, DYLD_*) at session create | L | S |
+| P0-3 | API-key expiry + rotation (`expiresAt`, admin rotation endpoint, per-key revocation audit) | M | S |
+| P0-4 | OpenAPI 3.1 spec generated from Zod/route definitions; CI contract test | M | M |
+| P0-5 | Session + pipeline state persistence (pluggable store: JSON today, Redis/Postgres tomorrow) | L | L |
+| P0-6 | Per-action RBAC matrix beyond three roles | M | M |
+| P0-7 | SSE idle timeout + hook-delivery timeout + HTTP drain on shutdown | M | S |
+| P0-8 | CSP + move token out of localStorage (HttpOnly cookie or in-memory + refresh endpoint) | M | M |
+
+### P1 — Required for multi-team / regulated rollout
+
+| # | Gap | Impact | Effort |
+|---|---|---|---|
+| P1-1 | Multi-tenancy primitives: tenantId on keys/sessions/audit, workdir namespacing, resource quotas | L | L |
+| P1-2 | SSO / OIDC (OAuth2 device flow for CLI, OIDC for dashboard) | L | L |
+| P1-3 | OpenTelemetry traces wired end-to-end (spans across HTTP → service → tmux queue → channel delivery) | L | M |
+| P1-4 | Dashboard E2E in PR CI + raise branch coverage to ≥65% + coverage diff gating | M | S |
+| P1-5 | Windows/macOS smoke on `develop` (subset of tests; full matrix on tag) | M | S |
+| P1-6 | Fault-injection harness in release gate (chaos suite run on tag, not just manual) | M | M |
+| P1-7 | Dashboard: focus traps, ARIA labels, list virtualization, RBAC UI, batch ops, staleness badges | M | M |
+| P1-8 | Audit log export + query UI (time-series download, filter by actor/action/tenant) | M | M |
+| P1-9 | Kubernetes packaging: Helm chart, StatefulSet (state PVC), liveness/readiness endpoints, HPA hints | L | M |
+| P1-10 | Sigstore / attestations on npm and container images; verifier script documented | M | S |
+
+### P2 — Required to position as GA enterprise product
+
+| # | Gap | Impact | Effort |
+|---|---|---|---|
+| P2-1 | Horizontal scaling: Redis-backed session state, sticky routing, tmux-socket affinity | L | L |
+| P2-2 | Compliance scaffolding: SOC2 control mapping, data-retention policy, DPA template, SBOM retention > 30d | L | M |
+| P2-3 | Prompt-injection hardening for MCP prompts (implement_issue, review_pr, debug_session) | M | S |
+| P2-4 | API versioning policy + deprecation headers + `/v2/` migration doc | M | S |
+| P2-5 | SDKs for Python and Go generated from OpenAPI | M | M |
+| P2-6 | Disaster-recovery runbook: export/import session state, backup of audit chain, key-material recovery | L | M |
+| P2-7 | Secrets integration: HashiCorp Vault / AWS KMS / Azure KV backends for master token and hook secrets | L | M |
+| P2-8 | Observability bundles: Grafana dashboards, alert rules, OTLP exporter docs, Datadog integration | M | M |
+| P2-9 | Air-gapped deployment guide with offline install, license notes, bundled dashboard assets | M | M |
+| P2-10 | Rate-limit / quota per tenant (concurrent sessions, tokens, USD spend cap) | L | M |
+| P2-11 | Billing/metering hooks (per-session token cost already tracked — expose as usage records) | M | S |
+| P2-12 | Webhook signature verification helper SDK (consumers currently roll their own) | S | S |
+
+---
+
+## 11. Suggested 3-Phase Roadmap
+
+**Phase 1 — Enterprise Pilot (≈6 weeks)**
+P0-1, P0-2, P0-3, P0-4, P0-7, P0-8, P1-4, P2-3. Mostly S/M efforts; closes the "single-key owns everything" gap, ships a real API contract, removes the most visible security foot-guns.
+
+**Phase 2 — Multi-team GA (≈3 months)**
+P0-5, P0-6, P1-1, P1-2, P1-3, P1-7, P1-8, P1-9, P1-10. Delivers tenancy, SSO, Helm, tracing, and production dashboard UX.
+
+**Phase 3 — Enterprise GA (≈1–2 quarters)**
+P2-1, P2-2, P2-5, P2-6, P2-7, P2-8, P2-10, P2-11. Horizontal scaling, compliance, SDKs, DR, secret backends, billing hooks.
+
+---
+
+## 12. Key Quick Wins (under 1 week each)
+
+1. Emit OpenAPI 3.1 from existing Zod schemas (`zod-to-openapi`) → publish at `/v1/openapi.json`. See [ADR-0018](../adr/0018-openapi-spec-from-zod.md).
+2. Add `ownerKeyId` guard to action routes behind a config flag; default-on. See [ADR-0019](../adr/0019-session-ownership-authz.md).
+3. Env-var denylist constant + Zod refine on session create. See [ADR-0020](../adr/0020-env-var-denylist.md).
+4. SSE idle timeout + `server.close()` drain with grace period. See [ADR-0021](../adr/0021-sse-and-http-drain-timeouts.md).
+5. CSP meta in `dashboard/index.html` + document Fastify header injection for prod.
+6. Raise branch coverage threshold to 65% and add dashboard E2E to PR CI.
+7. Sigstore attestations on npm publish (already have OIDC) and on container push. See [ADR-0022](../adr/0022-sigstore-attestations.md).
+8. Keep ADR index current as new decisions land; align with the lifecycle docs listed in [AGENTS.md](../../AGENTS.md).
+
+---
+
+## 13. Where Aegis Is Already Ahead of Most Alpha Products
+
+- Tamper-evident audit log with chain integrity.
+- SSRF matrix coverage incl. IPv4-mapped-IPv6 and hex forms.
+- Hook-secret encryption at rest.
+- Capability handshake for protocol negotiation.
+- Token cost & latency tracking per session.
+- Worktree-aware session discovery.
+- Formal hygiene gate preventing dated artifacts and legacy files.
+- Release-please + SBOM + checksums + npm provenance in the default release path.
+
+These are rare in alpha and justify pursuing the enterprise path incrementally rather than rewriting.
+
+---
+
+## 14. Companion ADRs
+
+The five new ADRs below capture the architectural decisions implied by the P0 quick wins in §12:
+
+| ADR | Title | Status |
+|---|---|---|
+| [ADR-0018](../adr/0018-openapi-spec-from-zod.md) | OpenAPI 3.1 spec generated from Zod schemas | Proposed |
+| [ADR-0019](../adr/0019-session-ownership-authz.md) | Explicit session ownership authz on action routes | Proposed |
+| [ADR-0020](../adr/0020-env-var-denylist.md) | Env-var denylist on session create | Proposed |
+| [ADR-0021](../adr/0021-sse-and-http-drain-timeouts.md) | SSE idle timeout and HTTP drain on shutdown | Proposed |
+| [ADR-0022](../adr/0022-sigstore-attestations.md) | Sigstore attestations for npm and container artifacts | Proposed |
+| [ADR-0023](../adr/0023-positioning-claude-code-control-plane.md) | Positioning: Claude Code Control Plane, MIT, BYO LLM, `ag` CLI | Proposed |
+
+---
+
+## 15. Positioning & Phasing (2026-04-16 decision)
+
+This section locks in the product direction that shapes the roadmap below. It
+supersedes any prior "enterprise-first" framing in earlier reviews.
+
+### Target users (same pattern at every scale)
+
+Aegis serves the same orchestration pattern across three scales:
+
+1. **Individual developer running a team of AI agents** (primary, today).
+   A single human driving 1–10+ Claude Code agents doing vibe-coding,
+   CI tasks, reviews, docs, and automation. Aegis is the bridge they use to
+   send, approve, monitor, and orchestrate those sessions from anywhere
+   (including mobile).
+2. **Team of humans, each with their own agents** (next 2–3 months).
+   5–20 developers sharing an Aegis deployment. Needs per-action RBAC, audit
+   export, Helm, reliable remote access — but not yet SSO or tenancy.
+3. **Enterprise** (6–12 months, demand-driven).
+   Multi-team with SSO/OIDC, multi-tenancy, compliance scaffolding.
+
+The pattern is the same everywhere: **Aegis is the control plane of
+Claude Code; the agents are built by the user.** Aegis never orchestrates
+agents itself. It provides the primitives (sessions, sends, approvals, events,
+pipelines) and optional reusable templates.
+
+See [ADR-0006](../adr/0006-aegis-middleware-not-agent-framework.md) and
+[ADR-0023](../adr/0023-positioning-claude-code-control-plane.md).
+
+### Licensing
+
+**MIT, single edition.** No open-core, no BUSL, no enterprise-only modules.
+Revisit only if and when a commercial contract or funding requires it.
+
+### LLM backend
+
+**BYO LLM is a first-class, supported feature.** Aegis orchestrates Claude Code
+as a *runtime*; the user is free to point Claude Code at any
+Anthropic-compatible endpoint (GLM via `api.z.ai`, OpenRouter, local models via
+LM Studio or Ollama, etc.). Aegis ships no default credentials and never owns
+LLM cost. This keeps Aegis self-hosted with zero variable cost.
+
+See [ADR-0023](../adr/0023-positioning-claude-code-control-plane.md).
+
+### CLI binary
+
+Primary command is **`ag`**. The long form `aegis` remains as an alias for
+discoverability and backward compatibility.
+
+### Revised 4-phase roadmap
+
+The original "3-phase roadmap" in §11 is superseded by the 4-phase plan below.
+Every gap from §10 is re-assigned to a phase.
+
+#### Phase 1 — Foundations (1–2 months wall-clock of part-time work)
+
+Make Aegis safe, contract-first, and supply-chain-verifiable. Ships quickly.
+
+- P0-1 Session ownership authz — [ADR-0019](../adr/0019-session-ownership-authz.md)
+- P0-2 Env-var denylist — [ADR-0020](../adr/0020-env-var-denylist.md)
+- P0-4 OpenAPI 3.1 from Zod — [ADR-0018](../adr/0018-openapi-spec-from-zod.md)
+- P0-7 SSE idle timeout + HTTP drain — [ADR-0021](../adr/0021-sse-and-http-drain-timeouts.md)
+- P1-4 Dashboard E2E in PR CI + branch coverage ≥ 65%
+- P1-10 Sigstore attestations — [ADR-0022](../adr/0022-sigstore-attestations.md)
+- Credential scan in `hygiene-check`
+
+#### Phase 2 — Developer Delight + Team-Ready (2–3 months)
+
+Make Aegis the tool friends recommend, and good enough for a team of 10.
+
+- `ag` alias + `ag init` interactive setup — [ADR-0023](../adr/0023-positioning-claude-code-control-plane.md)
+- `ag doctor` diagnostics
+- BYO LLM official support + `examples/byo-llm/` + CI mock coverage
+- Agent / skill / slash-command template gallery (`ag init --from-template`)
+- Remote-access guide (Tailscale, Cloudflare Tunnel, ngrok)
+- Mobile-first dashboard pass
+- Dashboard home / onboarding
+- P1-9 Helm chart v1
+- P0-6 Per-action RBAC (`send`, `approve`, `reject`, `kill`, `create`)
+- P1-8 Audit export API + basic UI
+- P0-8 CSP + token out of localStorage
+- P1-6 Fault-injection harness in release gate
+- P2-3 Prompt-injection hardening for MCP prompts
+
+#### Phase 3 — Team & Early-Enterprise (3–6 months)
+
+Arrives when the first external team of 10+ asks for it.
+
+- P0-5 Pluggable `SessionStore` + Postgres implementation
+- P1-3 OpenTelemetry wired end-to-end
+- P2-5 SDKs (TypeScript, Python) generated from OpenAPI
+- P1-2 SSO / OIDC (Entra ID, Google, Okta, Keycloak, Authentik)
+- P1-1 Multi-tenancy primitives (tenantId on keys / sessions / audit)
+- P1-7 Dashboard virtualization + full a11y pass
+- i18n scaffolding (EN + IT)
+
+#### Phase 4 — Enterprise GA (6–12 months, demand-driven)
+
+All remaining P2 items: horizontal scaling, compliance scaffolding, DR runbook,
+secrets-manager integrations, Grafana bundle, air-gapped install,
+per-tenant quotas, billing hooks, webhook-verification SDK.
+
+### Deferred from earlier plans
+
+- `AEGIS_EDITION` flag and open-core split — **dropped**. Single MIT edition.
+- Horizontal scaling via Redis — deferred to Phase 4, only on real demand.
+- Kubernetes-first deployment story — downgraded: Helm is Phase 2, but
+  single-binary / systemd / Docker Compose remain the default path.

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -42,6 +42,7 @@ It is **not yet enterprise-ready**. The following critical gaps stand between cu
 | [03 — Testing & Observability](./03-testing-observability.md) | CI/CD, coverage, metrics, logging, error handling, transcript | 20 findings |
 | [04 — MCP, Dashboard & Integrations](./04-mcp-integrations.md) | MCP tools, API contracts, dashboard, WebSocket, channels | 22 findings |
 | [05 — Enterprise Gap Roadmap](./05-enterprise-roadmap.md) | Prioritised backlog to reach enterprise grade | All findings mapped to milestones |
+| [00 — Gap Analysis (2026-04-16 follow-up)](./00-gap-analysis.md) | Updated P0/P1/P2 scorecard, 3-phase roadmap, ADR links | P0 ×8, P1 ×10, P2 ×12 |
 
 ---
 


### PR DESCRIPTION
## Summary

This PR locks in Aegis product positioning, rewrites the roadmap around a
four-phase plan, adds the first Phase 1 epic, and extends the agent policy
surface so any AI contributor (Claude Code, Copilot, Cursor, Codex,
Windsurf, …) aligns on the same rules and current phase.

All changes are documentation and policy artefacts. No `src/` files touched.

## What changes

### New strategic docs

- `docs/enterprise/00-gap-analysis.md` — full codebase + enterprise gap
  analysis with §15 "Positioning & Phasing" locking the 4-phase roadmap.
- `docs/adr/0018-openapi-spec-from-zod.md` — ADR for Phase 1 OpenAPI work.
- `docs/adr/0019-session-ownership-authz.md` — ADR for session ownership
  authz (formalises existing practice + Phase 1 scope).
- `docs/adr/0020-env-var-denylist.md` — ADR for env-var denylist with BYO-LLM
  allowlist exemptions.
- `docs/adr/0021-sse-and-http-drain-timeouts.md` — ADR for SSE idle timeout
  and HTTP drain on shutdown.
- `docs/adr/0022-sigstore-attestations.md` — ADR for npm + container
  attestations.
- `docs/adr/0023-positioning-claude-code-control-plane.md` — ADR covering the
  five positioning decisions: Claude Code control plane (bridge, not
  orchestrator), 3-scale target users, MIT single edition, BYO LLM
  first-class, `ag` primary CLI.

### Updated roadmap and index

- `ROADMAP.md` — rewritten. Replaces the A1–A4 alpha track with four
  demand-driven phases and an explicit "deferred / dropped" section.
- `docs/adr/README.md` — ADR index extended with rows 0018–0023.
- `docs/enterprise/index.md` — pointer to the new gap analysis.

### Agent policy surface

- `AGENTS.md` — new "Current Phase" section + index to `.claude/rules/` +
  reference to ADR-0023. Any agent hitting the repo now knows which phase
  is active and where the scoped rules live.
- `CLAUDE.md` — positioning section added; CLI binary line clarified
  (`aegis` today, `ag` in Phase 2).
- `CONTRIBUTING.md` — opening rewritten to match the "control plane,
  bridge-not-orchestrator" framing. Links to AGENTS / ROADMAP / ADR-0023 /
  `.claude/rules/` up front.
- `.claude/rules/workflow.md` — new scoped rule with the end-to-end flow:
  phase → epic → issue → worktree → PR → local gate.
- `.claude/rules/positioning.md` — new scoped rule that states what Aegis
  is, is not, and what NOT to build without maintainer approval (explicit
  phase gates on SSO, multi-tenancy, Redis, Kubernetes-as-default, …).
- `.github/copilot-instructions.md` — pointer file so GitHub Copilot reads
  the same rules as every other agent.

### Phase 1 epic

- `.claude/epics/phase-1-foundations/epic.md` — breaks Phase 1 into eight
  issue-ready items (credential scan, env denylist, session ownership
  authz, OpenAPI from Zod, SSE+drain, dashboard E2E, coverage→65%, Sigstore
  attestations) with acceptance criteria and suggested open order.

## Why

Until this PR the repo had no single source of truth for:

- what Aegis is positioned as (it had been drifting between "orchestrator"
  and "bridge");
- what scale of user it serves today vs later;
- what phase work is in;
- which strategic items are explicitly **not** in scope.

The gap analysis, ADR-0023, and the new `positioning.md` rule fix that.

## Verification

- Hygiene: `git grep -n "UAT_BUG_REPORT.md|UAT_CHECKLIST.md|UAT_PLAN.md|DEPLOYMENT.md|coverage-gap-analysis.md"`
  shows only the pattern definition in `scripts/hygiene-check.cjs`. No stray
  artefacts added.
- Local gate: `npm run gate` → **2998 passed | 29 skipped (3027)**, exit 0.
  (This is the first PR that sees the merge of #1903, which unblocked the
  Windows test failures on `develop`.)

## Scope

Docs + policy only. Zero production code changed.

## Aegis version

**Developed with:** v0.5.3-alpha
