### PR TITLE
docs: scaffold phase 2/3/4 epics and open GitHub planning tree

### DIFF
--- a/.claude/epics/README.md
+++ b/.claude/epics/README.md
@@ -1,0 +1,39 @@
+# Aegis Epics
+
+Phase-level epics map the [ROADMAP](../../ROADMAP.md) to concrete scope. Each
+epic file lists the items in that phase with labels, ADR references, and
+acceptance criteria.
+
+## Index
+
+| Phase | Epic | Status | GitHub tracker |
+|-------|------|--------|----------------|
+| 1 | [Phase 1 — Foundations](./phase-1-foundations/epic.md) | **Active** | [#1915](https://github.com/OneStepAt4time/aegis/issues/1915) |
+| 2 | [Phase 2 — Developer Delight + Team-Ready](./phase-2-developer-delight/epic.md) | Not active | — |
+| 3 | [Phase 3 — Team & Early-Enterprise](./phase-3-team-early-enterprise/epic.md) | Not active | — |
+| 4 | [Phase 4 — Enterprise GA](./phase-4-enterprise-ga/epic.md) | Not active | — |
+
+Other epics (not phase-bound):
+
+- [server-decomposition](./server-decomposition/) — internal refactor epic.
+
+## Rules
+
+1. **All phase planning issues are open on GitHub up front.** Non-active
+   phases carry the `status: not-active` label on their tracker and all
+   sub-issues, so the dependency tree is public but the work is gated.
+2. **`status: not-active` means "do not start work".** Opening a PR that
+   closes such an issue requires the maintainer to first remove the label
+   (activation PR).
+3. **A phase is activated** when the previous phase's exit criterion is met
+   (see [ROADMAP Graduation Signals](../../ROADMAP.md#graduation-signals-alpha--preview--ga))
+   AND the activation checklist in that phase's `epic.md` is ticked.
+4. **Status transitions require a PR.** Changing an epic from "Not active"
+   to "Active" happens in the same PR that removes the label on GitHub and
+   updates `ROADMAP.md`.
+5. **No speculative work.** Do not propose PRs for items outside the active
+   phase without explicit maintainer assignment. See
+   [.claude/rules/positioning.md](../rules/positioning.md).
+6. **Scope stays in sync with the gap analysis.** Every item links back to
+   its P0 / P1 / P2 id in
+   [docs/enterprise/00-gap-analysis.md](../../docs/enterprise/00-gap-analysis.md).

--- a/.claude/epics/phase-2-developer-delight/epic.md
+++ b/.claude/epics/phase-2-developer-delight/epic.md
@@ -1,0 +1,81 @@
+# EPIC: Phase 2 — Developer Delight + Team-Ready
+
+**Phase:** 2
+**Status:** ⏸ **NOT ACTIVE — do not open GitHub issues yet**
+**Activation trigger:** Phase 1 at ≥ 80 % closed (≥ 7 of 8 issues merged) AND
+an external user has installed Aegis from a signed release.
+**Wall-clock target:** 2–3 months part-time after activation
+**Parent roadmap:** [ROADMAP.md](../../../ROADMAP.md)
+**Positioning:** [ADR-0023](../../../docs/adr/0023-positioning-claude-code-control-plane.md)
+**Gap analysis:** [docs/enterprise/00-gap-analysis.md](../../../docs/enterprise/00-gap-analysis.md)
+
+## Goal
+
+Make Aegis the tool friends recommend, and good enough for a 10-person team
+to adopt. Exit criterion: a new user can go from zero to a running,
+mobile-approvable session in under 5 minutes, and a team can deploy Aegis on
+a shared host with per-action RBAC and audit export.
+
+## Scope
+
+Two parallel tracks. Both must be green before graduating to Phase 3.
+
+### Track A — Developer Delight
+
+Audience: the single developer with a team of 5–10 agents.
+
+| # | Item | Gap ref |
+|---|---|---|
+| 2.A.1 | `ag` alias as primary CLI; `aegis` retained | ADR-0023 |
+| 2.A.2 | Interactive `ag init` (config, dashboard, first session) | — |
+| 2.A.3 | `ag doctor` diagnostics (tmux, Claude CLI, network, perms) | — |
+| 2.A.4 | Official BYO LLM support: docs + `examples/byo-llm/` + CI mock smoke | ADR-0023 |
+| 2.A.5 | Agent / skill / slash-command template gallery (`ag init --from-template`) | — |
+| 2.A.6 | Remote-access guide (Tailscale, Cloudflare Tunnel, ngrok) | — |
+| 2.A.7 | Mobile-first dashboard pass | P1-7 |
+| 2.A.8 | Dashboard home / onboarding flow | — |
+
+### Track B — Team-Ready
+
+Audience: the 10-person team sharing one deployment.
+
+| # | Item | Gap ref |
+|---|---|---|
+| 2.B.1 | Helm chart v1 (StatefulSet, PVC, liveness/readiness) | P1-9 |
+| 2.B.2 | Per-action RBAC: `send`, `approve`, `reject`, `kill`, `create` | P0-6 |
+| 2.B.3 | Audit export API + base filter UI | P1-8 |
+| 2.B.4 | CSP + move dashboard token out of `localStorage` | P0-8 |
+| 2.B.5 | Fault-injection harness in release gate (tag-only) | P1-6 |
+| 2.B.6 | Prompt-injection hardening for MCP prompts | P2-3 |
+| 2.B.7 | Windows/macOS smoke on `develop` (subset; full matrix on tag) | P1-5 |
+
+## Explicitly out of scope for Phase 2
+
+The following items look tempting here but belong to Phase 3 or later:
+
+- SSO / OIDC (Phase 3)
+- Multi-tenancy primitives — `tenantId` on keys/sessions (Phase 3)
+- Postgres `SessionStore` (Phase 3)
+- OpenTelemetry end-to-end wiring (Phase 3)
+- Language SDKs (Phase 3)
+- Any Redis-backed / horizontal-scaling work (Phase 4)
+
+## Activation checklist
+
+Before opening GitHub issues for Phase 2, the maintainer must:
+
+- [ ] Confirm Phase 1 exit checklist is satisfied.
+- [ ] Update this file: change status to **ACTIVE** and set activation date.
+- [ ] Open one tracking issue **"EPIC: Phase 2 — Developer Delight +
+  Team-Ready"** with labels `phase-2`, `epic`.
+- [ ] Open sub-issues (2.A.1 … 2.B.6) referencing this epic.
+- [ ] Update the ROADMAP.md phase status markers.
+
+## Exit checklist
+
+- [ ] All track A items shipped.
+- [ ] All track B items shipped.
+- [ ] Public demo video of the mobile approval flow recorded.
+- [ ] Incident / rollback runbook validated at least once.
+- [ ] Rename alpha dist-tag / version suffix to `preview`.
+- [ ] At least one external team (not the maintainer) has deployed Aegis.

--- a/.claude/epics/phase-3-team-early-enterprise/epic.md
+++ b/.claude/epics/phase-3-team-early-enterprise/epic.md
@@ -1,0 +1,74 @@
+# EPIC: Phase 3 — Team & Early-Enterprise
+
+**Phase:** 3
+**Status:** ⏸ **NOT ACTIVE — do not open GitHub issues yet**
+**Activation trigger:** Phase 2 closed AND at least one external team has
+requested at least one of: SSO, multi-tenancy, or Postgres persistence.
+**Wall-clock target:** 3–6 months part-time after activation, demand-driven
+**Parent roadmap:** [ROADMAP.md](../../../ROADMAP.md)
+**Positioning:** [ADR-0023](../../../docs/adr/0023-positioning-claude-code-control-plane.md)
+**Gap analysis:** [docs/enterprise/00-gap-analysis.md](../../../docs/enterprise/00-gap-analysis.md)
+
+## Goal
+
+Let a real external team of 10 + people run Aegis in production under their
+existing identity provider, with trace-level observability and language SDKs
+for their internal tooling.
+
+Exit criterion: a team can deploy Aegis, connect it to their IdP (Entra ID /
+Google Workspace / Okta / Keycloak / Authentik), enforce per-tenant
+isolation, and generate a TypeScript or Python SDK from the OpenAPI contract.
+
+## Scope
+
+Demand-driven. Every item below must be justified by at least one real user
+request before work begins; speculative work is deferred to Phase 4.
+
+| # | Item | Gap ref |
+|---|---|---|
+| 3.1 | Pluggable `SessionStore` interface + `PostgresStore` | P0-5 |
+| 3.2 | Pipeline state persistence on the same interface | P0-5 |
+| 3.3 | OpenTelemetry end-to-end: HTTP → service → tmux → channels | P1-3 / ADR-0017 |
+| 3.4 | Generated TypeScript SDK from OpenAPI | P2-5 |
+| 3.5 | Generated Python SDK from OpenAPI | P2-5 |
+| 3.6 | SSO / OIDC for dashboard (Entra ID, Google, Okta, Keycloak, Authentik) | P1-2 |
+| 3.7 | OAuth2 device flow for CLI (`ag login`) | P1-2 |
+| 3.8 | Multi-tenancy primitives: `tenantId` on keys / sessions / audit | P1-1 |
+| 3.9 | Workdir namespacing per tenant | P1-1 |
+| 3.10 | Dashboard list virtualization (transcripts, session history) | P1-7 |
+| 3.11 | Dashboard full a11y pass (focus traps, ARIA, contrast) | P1-7 |
+| 3.12 | i18n scaffolding (EN + IT to start) | — |
+
+## Architectural decisions to formalise during Phase 3
+
+Each of these needs its own ADR before implementation:
+
+- ADR-TBD: `SessionStore` interface and lifecycle semantics.
+- ADR-TBD: Tenant-aware authorization model (extension of ADR-0019).
+- ADR-TBD: OIDC trust model, claim mapping, and logout semantics.
+- ADR-TBD: SDK generation pipeline and release cadence.
+
+## Explicitly out of scope for Phase 3
+
+- Redis-backed state or horizontal scaling (Phase 4).
+- SaaS / hosted offering (off the table).
+- SOC2 / compliance artefacts (Phase 4).
+- Secrets-manager integrations beyond environment variables (Phase 4).
+
+## Activation checklist
+
+- [ ] Phase 2 exit checklist satisfied.
+- [ ] At least one external user request for an SSO, multi-tenancy, or
+  Postgres feature is on record (GitHub issue or documented conversation).
+- [ ] Update this file: status → **ACTIVE**, activation date set.
+- [ ] Open tracking issue **"EPIC: Phase 3 — Team & Early-Enterprise"**.
+- [ ] Open sub-issues referencing this epic.
+- [ ] ROADMAP.md updated.
+
+## Exit checklist
+
+- [ ] All items shipped, or consciously demoted to Phase 4 with written
+  rationale.
+- [ ] OpenAPI is the single source of truth; SDK releases are automated.
+- [ ] At least one external team is running Aegis in production under their
+  IdP.

--- a/.claude/epics/phase-4-enterprise-ga/epic.md
+++ b/.claude/epics/phase-4-enterprise-ga/epic.md
@@ -1,0 +1,67 @@
+# EPIC: Phase 4 — Enterprise GA
+
+**Phase:** 4
+**Status:** ⏸ **NOT ACTIVE — do not open GitHub issues yet**
+**Activation trigger:** Phase 3 closed AND at least one enterprise evaluator
+has produced a written requirement (security questionnaire, procurement
+checklist, or signed LOI) that cannot be satisfied by Phase 3 features.
+**Wall-clock target:** 6–12 + months part-time after activation, strictly
+demand-driven
+**Parent roadmap:** [ROADMAP.md](../../../ROADMAP.md)
+**Positioning:** [ADR-0023](../../../docs/adr/0023-positioning-claude-code-control-plane.md)
+**Gap analysis:** [docs/enterprise/00-gap-analysis.md](../../../docs/enterprise/00-gap-analysis.md)
+
+## Goal
+
+Close the remaining P2 items from the gap analysis so Aegis can pass a
+standard enterprise procurement and security review. Nothing here should be
+built speculatively — each item activates only on documented demand.
+
+Exit criterion: Aegis can be handed to an enterprise evaluator with a
+one-page security overview, a filled SIG-Lite, a Helm chart, a verified
+signed release, and a DR runbook, and the answer comes back within a week.
+
+## Scope
+
+| # | Item | Gap ref |
+|---|---|---|
+| 4.1 | Horizontal scaling: Redis-backed session state, sticky routing, tmux-socket affinity | P2-1 |
+| 4.2 | Compliance scaffolding: SOC2 control mapping, data-retention policy, DPA template, extended SBOM retention | P2-2 |
+| 4.3 | Disaster-recovery runbook: export / import session state, audit-chain backup, key-material recovery | P2-6 |
+| 4.4 | Secrets-manager integrations: Vault / AWS KMS / Azure Key Vault | P2-7 |
+| 4.5 | Observability bundles: Grafana dashboards, alert rules, OTLP exporter docs, Datadog integration | P2-8 |
+| 4.6 | Air-gapped deployment guide | P2-9 |
+| 4.7 | Per-tenant quotas: concurrent sessions, token cap, USD spend cap | P2-10 |
+| 4.8 | Billing / metering hooks (usage records from per-session token cost) | P2-11 |
+| 4.9 | Webhook signature-verification helper SDK | P2-12 |
+| 4.10 | API versioning policy + deprecation headers + `/v2/` migration doc | P2-4 |
+
+## Explicitly out of scope, permanently
+
+Locked decisions from ADR-0023 and the positioning rule; will not be
+reopened inside Phase 4 without a maintainer-approved ADR amendment:
+
+- Rewrite in another language. Rust is the only candidate if it ever
+  happens, and only on proven demand.
+- Open-core `AEGIS_EDITION` flag. Aegis stays single-edition MIT.
+- First-class integrations with Claude Code competitors (Gemini CLI, etc.).
+- A SaaS / hosted offering before external funding exists.
+
+## Activation checklist
+
+- [ ] Phase 3 exit checklist satisfied.
+- [ ] Written enterprise requirement on record (issue link, procurement doc,
+  or LOI reference).
+- [ ] Legal review of licensing implications for paid support / SLAs if
+  relevant.
+- [ ] Update this file: status → **ACTIVE**, activation date set.
+- [ ] Open tracking issue **"EPIC: Phase 4 — Enterprise GA"**.
+- [ ] Open sub-issues referencing this epic.
+- [ ] ROADMAP.md updated.
+
+## Exit checklist
+
+- [ ] All demand-justified items shipped.
+- [ ] Version graduates from `preview` to stable `1.0.0`.
+- [ ] At least one enterprise customer is running Aegis under a documented
+  SLA or support arrangement.

--- a/.claude/rules/positioning.md
+++ b/.claude/rules/positioning.md
@@ -56,6 +56,21 @@ maintainer assigns the issue from the right phase.
 If you think one of those items is unavoidable sooner, open an issue with
 the label `needs-human` and stop there.
 
+## Issue visibility vs. work-start
+
+Planning issues for every phase are open on GitHub in advance so the
+dependency tree is public and searchable. They are labelled
+`status: not-active` until their phase is activated.
+
+**Having an issue open does NOT mean you may start work on it.**
+
+Rule: do not start any PR for an issue that still carries `status: not-active`.
+Activation happens via a maintainer-approved PR that:
+
+1. Removes `status: not-active` from the phase's epic + sub-issues.
+2. Flips the phase status in the relevant `.claude/epics/phase-*/epic.md`.
+3. Updates [ROADMAP.md](../../ROADMAP.md) phase markers.
+
 ## Current phase
 
 Phase 1 — Foundations. Scope is defined in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,6 +67,7 @@ contract, and run Aegis without exposing the host to env-based RCE.
 - [ ] CSP + token out of localStorage (P0-8)
 - [ ] Fault-injection harness in release gate (P1-6)
 - [ ] Prompt-injection hardening for MCP prompts (P2-3)
+- [ ] Windows/macOS smoke on `develop` (subset; full matrix on tag) (P1-5)
 
 ---
 
@@ -97,6 +98,7 @@ All remaining P2 items from the gap analysis:
 - [ ] Per-tenant quotas (sessions / tokens / USD spend cap) (P2-10)
 - [ ] Billing / metering hooks (P2-11)
 - [ ] Webhook signature-verification helper SDK (P2-12)
+- [ ] API versioning policy + deprecation headers + `/v2/` migration doc (P2-4)
 
 ---
 

--- a/docs/enterprise/00-gap-analysis.md
+++ b/docs/enterprise/00-gap-analysis.md
@@ -269,16 +269,18 @@ CLI            ────┘                       │
 
 ---
 
-## 11. Suggested 3-Phase Roadmap
+## 11. Suggested 3-Phase Roadmap (SUPERSEDED)
+
+> ⚠️ **Superseded by [§15 Positioning & Phasing](#15-positioning--phasing).** The 3-phase grouping below was the original proposal from 2026-04-16. After the positioning lock-in we moved to a 4-phase model with sustainable-pace, part-time calibration. Kept here for traceability.
 
 **Phase 1 — Enterprise Pilot (≈6 weeks)**
-P0-1, P0-2, P0-3, P0-4, P0-7, P0-8, P1-4, P2-3. Mostly S/M efforts; closes the "single-key owns everything" gap, ships a real API contract, removes the most visible security foot-guns.
+P0-1, P0-2, P0-3, P0-4, P0-7, P0-8, P1-4, P2-3.
 
 **Phase 2 — Multi-team GA (≈3 months)**
-P0-5, P0-6, P1-1, P1-2, P1-3, P1-7, P1-8, P1-9, P1-10. Delivers tenancy, SSO, Helm, tracing, and production dashboard UX.
+P0-5, P0-6, P1-1, P1-2, P1-3, P1-7, P1-8, P1-9, P1-10.
 
 **Phase 3 — Enterprise GA (≈1–2 quarters)**
-P2-1, P2-2, P2-5, P2-6, P2-7, P2-8, P2-10, P2-11. Horizontal scaling, compliance, SDKs, DR, secret backends, billing hooks.
+P2-1, P2-2, P2-5, P2-6, P2-7, P2-8, P2-10, P2-11.
 
 ---
 


### PR DESCRIPTION
## Summary

Scaffolds the long-term planning tree for phases 2, 3, and 4, and publishes the
corresponding GitHub issues so the dependency graph is searchable in advance.
Per the rule introduced here, issues stay labelled `status: not-active` and
must not be picked up until their phase is activated by a maintainer-approved
PR. Work continues on Phase 1 in the meantime.

This is a docs/policy-only PR — no runtime code is touched.

## Changes

### New files

- `.claude/epics/README.md` — index of all phase epics with the variant-B
  rule ("issues visible, work gated").
- `.claude/epics/phase-2-developer-delight/epic.md` — Track A (developer
  delight) + Track B (team-ready), activation + exit checklists.
- `.claude/epics/phase-3-team-early-enterprise/epic.md` — SessionStore,
  OpenTelemetry, SSO, multi-tenancy, SDK generation.
- `.claude/epics/phase-4-enterprise-ga/epic.md` — horizontal scaling,
  compliance, secrets managers, quotas, API versioning.

### Modified files

- `.claude/rules/positioning.md` — new "Issue visibility vs. work-start"
  section explicitly stating that an open issue does not authorize work
  until `status: not-active` is removed.
- `ROADMAP.md` — added P1-5 (Windows/macOS smoke on `develop`) to Phase 2
  and P2-4 (API versioning policy) to Phase 4 so every P* gap item has a
  phase home.
- `docs/enterprise/00-gap-analysis.md` — marked section 11 as
  **SUPERSEDED** by section 15 (the strategic roadmap in ADR-0023 shape);
  prevents divergence between the two.

## Companion GitHub planning tree

Opened on GitHub as part of this work (all labelled `status: not-active`):

| Phase | Epic | Sub-issues | Total |
|---|---|---|---|
| 2 — Developer Delight + Team-Ready | [#1917](https://github.com/OneStepAt4time/aegis/issues/1917) | #1920-#1926, #1929-#1936 | 16 |
| 3 — Team & Early-Enterprise | [#1918](https://github.com/OneStepAt4time/aegis/issues/1918) | #1927, #1937-#1947 | 13 |
| 4 — Enterprise GA | [#1919](https://github.com/OneStepAt4time/aegis/issues/1919) | #1928, #1948-#1956 | 11 |

Each sub-issue body contains: scope, acceptance criteria, gap-analysis
reference, dependency notes, and an explicit "do not start yet" banner.

## Why variant B

The alternative ("open epic issues only, open sub-issues at phase
activation") was rejected because it hides dependencies and makes it harder
for contributors to see the long-term plan. Opening everything up-front with
a not-active gate preserves visibility without risking premature work.

## Non-goals

This PR does not:

- Change any runtime code, tests, or build config.
- Activate any phase — Phase 1 remains the only active phase.
- Supersede ADR-0023; it complements it.

## Verification

- `npm run gate` — passes locally (3003 tests passed / 29 skipped, lint + typecheck + build green).
- No `status: not-active` label was removed from any issue.
- No direct commits on `develop`.

## Aegis version

**Developed with:** v0.5.3-alpha

## Related

- Closes: none (this is planning work, not a bug/feature fix).
- Refs: [ADR-0023](../blob/develop/docs/adr/0023-positioning-claude-code-control-plane.md),
  [docs/enterprise/00-gap-analysis.md section 15](../blob/develop/docs/enterprise/00-gap-analysis.md).
- Epics: #1917, #1918, #1919.
