### PR TITLE
docs: add NewSessionPage to dashboard docs

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -95,6 +95,15 @@ System health, active sessions count, and metric sparklines.
 ### Sessions (`/dashboard/sessions`)
 List of all sessions with search, filter, date range, and CSV export.
 
+### New Session (`/dashboard/sessions/new`)
+Create a new Aegis session directly from the dashboard without using the API. Fields:
+- **Name** — optional session name
+- **Prompt** — initial task description for Claude Code
+- **Work Directory** — directory where Claude Code will run
+- **Permission Mode** — default, bypassPermissions, plan, acceptEdits, dontAsk, or auto
+
+After creation, the session opens in the detail view.
+
 ### Pipelines (`/dashboard/pipelines`)
 Pipeline management and monitoring.
 


### PR DESCRIPTION
Documents the NewSessionPage feature (PR #1857) in docs/dashboard.md under the Pages section.\n\nCovers: /dashboard/sessions/new URL, form fields (name, prompt, work directory, permission mode), and post-creation behavior.\n\nChanges:\n- docs/dashboard.md: +9 lines (NewSessionPage section)\n\nAegis version: 0.5.3-alpha\nAssignee: Scribe