### PR TITLE
fix: enforce env-var denylist at Zod validation layer (#1908)

### DIFF
--- a/src/__tests__/env-denylist-1392.test.ts
+++ b/src/__tests__/env-denylist-1392.test.ts
@@ -1,167 +1,344 @@
 /**
- * env-denylist-1392.test.ts — Tests for Issue #1392: Env var injection denylist.
+ * env-denylist-1392.test.ts — Tests for Issue #1392 + #1908: Env var injection denylist.
  *
- * Validates that CreateSessionRequest.env rejects dangerous env vars
- * including AI provider keys, application secrets, and credential-leaking vars.
+ * Validates that the live Zod schema (buildEnvSchema) rejects dangerous env vars
+ * including AI provider keys, application secrets, credential-leaking vars,
+ * platform-specific vars (Linux, macOS, Windows), and enforces value hardening.
  */
 
 import { describe, it, expect } from 'vitest';
+import {
+  buildEnvSchema,
+  ENV_DENYLIST,
+  ENV_DANGEROUS_PREFIXES,
+  ENV_BYO_LLM_WHITELIST,
+  stripCrLf,
+  hasControlChars,
+} from '../validation.js';
+import { z } from 'zod';
 
-// Extract the denylist logic to test it in isolation.
-// We replicate the validation rules from session.ts to keep tests independent
-// of SessionManager instantiation (which requires tmux, config, etc.).
-
-const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
-
-const DANGEROUS_ENV_VARS = new Set([
-  'PATH', 'LD_PRELOAD', 'LD_LIBRARY_PATH', 'NODE_OPTIONS',
-  'DYLD_INSERT_LIBRARIES', 'IFS', 'SHELL', 'ENV', 'BASH_ENV',
-  'PYTHONPATH', 'PERL5LIB', 'RUBYLIB', 'CLASSPATH',
-  'NODE_PATH', 'PYTHONHOME', 'PYTHONSTARTUP',
-  'PROMPT_COMMAND', 'GIT_SSH_COMMAND', 'EDITOR', 'VISUAL',
-  'SUDO_ASKPASS', 'GIT_EXEC_PATH', 'NODE_ENV',
-  'GITHUB_TOKEN', 'NPM_TOKEN', 'GITLAB_TOKEN',
-  'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN',
-  'AZURE_CLIENT_SECRET', 'GOOGLE_APPLICATION_CREDENTIALS',
-  'DOCKER_TOKEN', 'HEROKU_API_KEY',
-  // Issue #1392
-  'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'CLAUDE_API_KEY',
-  'GOOGLE_AI_API_KEY', 'MISTRAL_API_KEY', 'DEEPSEEK_API_KEY',
-  'AEGIS_SECRET', 'DATABASE_URL', 'SECRET_KEY', 'JWT_SECRET',
-  'SESSION_SECRET', 'ENCRYPTION_KEY',
-]);
-
-const DANGEROUS_ENV_PREFIXES = [
-  'npm_config_', 'BASH_FUNC_', 'SSH_', 'GITHUB_', 'GITLAB_',
-  'AWS_', 'AZURE_', 'TF_', 'CI_', 'DOCKER_',
-];
-
-function validateEnv(env: Record<string, string>): string | null {
-  for (const key of Object.keys(env)) {
-    if (DANGEROUS_ENV_PREFIXES.some(prefix => key.startsWith(prefix))) {
-      const matchedPrefix = DANGEROUS_ENV_PREFIXES.find(p => key.startsWith(p))!;
-      return `Forbidden env var: "${key}" — cannot override dangerous environment variable prefix "${matchedPrefix}"`;
-    }
-    if (!ENV_NAME_RE.test(key)) {
-      return `Invalid env var name: "${key}" — must match /^[A-Z_][A-Z0-9_]*$/`;
-    }
-    if (DANGEROUS_ENV_VARS.has(key)) {
-      return `Forbidden env var: "${key}" — cannot override dangerous environment variables`;
-    }
+/** Helper: parse env through the live Zod schema and expect failure. */
+function expectRejection(env: Record<string, string>, messageFragment?: string) {
+  const schema = buildEnvSchema();
+  const result = schema.safeParse(env);
+  expect(result.success).toBe(false);
+  if (messageFragment && !result.success) {
+    const messages = result.error.issues.map(i => i.message).join('; ');
+    expect(messages).toContain(messageFragment);
   }
-  return null;
 }
 
-describe('Env var injection denylist (Issue #1392)', () => {
+/** Helper: parse env through the live Zod schema and expect success. */
+function expectSuccess(env: Record<string, string>) {
+  const schema = buildEnvSchema();
+  const result = schema.safeParse(env);
+  expect(result.success).toBe(true);
+}
+
+describe('Env var denylist — live Zod schema (Issues #1392 + #1908)', () => {
   describe('AI provider API keys', () => {
     it('rejects ANTHROPIC_API_KEY', () => {
-      expect(validateEnv({ ANTHROPIC_API_KEY: 'sk-ant-...' })).toContain('Forbidden');
+      expectRejection({ ANTHROPIC_API_KEY: 'sk-ant-...' }, 'denylisted');
     });
 
     it('rejects OPENAI_API_KEY', () => {
-      expect(validateEnv({ OPENAI_API_KEY: 'sk-...' })).toContain('Forbidden');
+      expectRejection({ OPENAI_API_KEY: 'sk-...' }, 'denylisted');
     });
 
     it('rejects CLAUDE_API_KEY', () => {
-      expect(validateEnv({ CLAUDE_API_KEY: 'sk-ant-...' })).toContain('Forbidden');
+      expectRejection({ CLAUDE_API_KEY: 'sk-ant-...' }, 'denylisted');
     });
 
     it('rejects GOOGLE_AI_API_KEY', () => {
-      expect(validateEnv({ GOOGLE_AI_API_KEY: 'AIza...' })).toContain('Forbidden');
+      expectRejection({ GOOGLE_AI_API_KEY: 'AIza...' }, 'denylisted');
     });
 
     it('rejects MISTRAL_API_KEY', () => {
-      expect(validateEnv({ MISTRAL_API_KEY: 'mist-...' })).toContain('Forbidden');
+      expectRejection({ MISTRAL_API_KEY: 'mist-...' }, 'denylisted');
     });
 
     it('rejects DEEPSEEK_API_KEY', () => {
-      expect(validateEnv({ DEEPSEEK_API_KEY: 'dsk-...' })).toContain('Forbidden');
+      expectRejection({ DEEPSEEK_API_KEY: 'dsk-...' }, 'denylisted');
     });
   });
 
   describe('Application secrets', () => {
     it('rejects AEGIS_SECRET', () => {
-      expect(validateEnv({ AEGIS_SECRET: 'super-secret' })).toContain('Forbidden');
+      expectRejection({ AEGIS_SECRET: 'super-secret' }, 'denylisted');
     });
 
     it('rejects DATABASE_URL', () => {
-      expect(validateEnv({ DATABASE_URL: 'postgres://...' })).toContain('Forbidden');
+      expectRejection({ DATABASE_URL: 'postgres://...' }, 'denylisted');
     });
 
     it('rejects SECRET_KEY', () => {
-      expect(validateEnv({ SECRET_KEY: 'abc123' })).toContain('Forbidden');
+      expectRejection({ SECRET_KEY: 'abc123' }, 'denylisted');
     });
 
     it('rejects JWT_SECRET', () => {
-      expect(validateEnv({ JWT_SECRET: 'jwt-secret' })).toContain('Forbidden');
+      expectRejection({ JWT_SECRET: 'jwt-secret' }, 'denylisted');
     });
 
     it('rejects SESSION_SECRET', () => {
-      expect(validateEnv({ SESSION_SECRET: 'sess-secret' })).toContain('Forbidden');
+      expectRejection({ SESSION_SECRET: 'sess-secret' }, 'denylisted');
     });
 
     it('rejects ENCRYPTION_KEY', () => {
-      expect(validateEnv({ ENCRYPTION_KEY: 'enc-key' })).toContain('Forbidden');
+      expectRejection({ ENCRYPTION_KEY: 'enc-key' }, 'denylisted');
     });
   });
 
-  describe('Existing dangerous vars (regression)', () => {
+  describe('Core dangerous vars (regression)', () => {
     it('rejects PATH injection', () => {
-      expect(validateEnv({ PATH: '/evil' })).toContain('Forbidden');
+      expectRejection({ PATH: '/evil' }, 'denylisted');
     });
 
     it('rejects LD_PRELOAD injection', () => {
-      expect(validateEnv({ LD_PRELOAD: '/evil.so' })).toContain('Forbidden');
+      expectRejection({ LD_PRELOAD: '/evil.so' }, 'denylisted');
     });
 
     it('rejects NODE_OPTIONS injection', () => {
-      expect(validateEnv({ NODE_OPTIONS: '--require /evil.js' })).toContain('Forbidden');
+      expectRejection({ NODE_OPTIONS: '--require /evil.js' }, 'denylisted');
     });
 
     it('rejects GITHUB_TOKEN', () => {
-      expect(validateEnv({ GITHUB_TOKEN: 'ghp_...' })).toContain('Forbidden');
+      expectRejection({ GITHUB_TOKEN: 'ghp_...' }, 'GITHUB_');
+    });
+
+    it('rejects HOME', () => {
+      expectRejection({ HOME: '/evil' }, 'denylisted');
     });
   });
 
-  describe('Dangerous prefixes (regression)', () => {
+  describe('Dangerous prefixes', () => {
     it('rejects AWS_ prefix', () => {
-      expect(validateEnv({ AWS_CUSTOM_VAR: 'val' })).toContain('prefix "AWS_"');
+      expectRejection({ AWS_CUSTOM_VAR: 'val' }, 'prefix "AWS_"');
     });
 
     it('rejects GITHUB_ prefix', () => {
-      expect(validateEnv({ GITHUB_CUSTOM_VAR: 'val' })).toContain('prefix "GITHUB_"');
+      expectRejection({ GITHUB_CUSTOM_VAR: 'val' }, 'prefix "GITHUB_"');
     });
 
-    it('rejects npm_config_ prefix (case-insensitive)', () => {
-      expect(validateEnv({ npm_config_registry: 'http://evil' })).toContain('prefix "npm_config_"');
+    it('rejects npm_config_ prefix', () => {
+      expectRejection({ npm_config_registry: 'http://evil' }, 'prefix "npm_config_"');
+    });
+
+    it('rejects SSH_ prefix', () => {
+      expectRejection({ SSH_PRIVATE_KEY: 'key' }, 'prefix "SSH_"');
+    });
+
+    it('rejects CI_ prefix', () => {
+      expectRejection({ CI_JOB_TOKEN: 'tok' }, 'prefix "CI_"');
+    });
+
+    it('rejects DOCKER_ prefix', () => {
+      expectRejection({ DOCKER_TOKEN: 'tok' }, 'prefix "DOCKER_"');
+    });
+  });
+
+  describe('Linux-specific dangerous vars', () => {
+    it('rejects LD_AUDIT', () => {
+      expectRejection({ LD_AUDIT: 'audit.so' }, 'denylisted');
+    });
+
+    it('rejects LD_DEBUG', () => {
+      expectRejection({ LD_DEBUG: 'all' }, 'denylisted');
+    });
+
+    it('rejects LD_BIND_NOW', () => {
+      expectRejection({ LD_BIND_NOW: '1' }, 'denylisted');
+    });
+  });
+
+  describe('macOS-specific dangerous vars', () => {
+    it('rejects DYLD_LIBRARY_PATH', () => {
+      expectRejection({ DYLD_LIBRARY_PATH: '/evil' }, 'denylisted');
+    });
+
+    it('rejects DYLD_FRAMEWORK_PATH', () => {
+      expectRejection({ DYLD_FRAMEWORK_PATH: '/evil' }, 'denylisted');
+    });
+
+    it('rejects DYLD_ROOT_PATH', () => {
+      expectRejection({ DYLD_ROOT_PATH: '/evil' }, 'denylisted');
+    });
+  });
+
+  describe('Windows-specific dangerous vars', () => {
+    it('rejects COMSPEC', () => {
+      expectRejection({ COMSPEC: 'cmd.exe' }, 'denylisted');
+    });
+
+    it('rejects WINDIR', () => {
+      expectRejection({ WINDIR: 'C:\\Windows' }, 'denylisted');
+    });
+
+    it('rejects SYSTEMROOT', () => {
+      expectRejection({ SYSTEMROOT: 'C:\\Windows' }, 'denylisted');
+    });
+
+    it('rejects APPDATA', () => {
+      expectRejection({ APPDATA: 'C:\\Users\\x\\AppData' }, 'denylisted');
+    });
+
+    it('rejects USERPROFILE', () => {
+      expectRejection({ USERPROFILE: 'C:\\Users\\evil' }, 'denylisted');
+    });
+  });
+
+  describe('BYO-LLM whitelist', () => {
+    it('allows ANTHROPIC_BASE_URL', () => {
+      expectSuccess({ ANTHROPIC_BASE_URL: 'https://api.openrouter.ai' });
+    });
+
+    it('allows ANTHROPIC_AUTH_TOKEN', () => {
+      expectSuccess({ ANTHROPIC_AUTH_TOKEN: 'tok-123' });
+    });
+
+    it('allows ANTHROPIC_DEFAULT_FAST_MODEL', () => {
+      expectSuccess({ ANTHROPIC_DEFAULT_FAST_MODEL: 'claude-haiku-4-5-20251001' });
+    });
+
+    it('allows ANTHROPIC_DEFAULT_MODEL', () => {
+      expectSuccess({ ANTHROPIC_DEFAULT_MODEL: 'claude-sonnet-4-20250514' });
+    });
+
+    it('allows API_TIMEOUT_MS', () => {
+      expectSuccess({ API_TIMEOUT_MS: '30000' });
     });
   });
 
   describe('Valid env vars pass', () => {
     it('allows MY_CUSTOM_VAR', () => {
-      expect(validateEnv({ MY_CUSTOM_VAR: 'value' })).toBeNull();
+      expectSuccess({ MY_CUSTOM_VAR: 'value' });
     });
 
     it('allows PROJECT_NAME', () => {
-      expect(validateEnv({ PROJECT_NAME: 'aegis' })).toBeNull();
+      expectSuccess({ PROJECT_NAME: 'aegis' });
     });
 
     it('allows multiple safe vars', () => {
-      expect(validateEnv({ FOO: 'bar', BAZ: 'qux', MY_TOKEN: 'safe' })).toBeNull();
+      expectSuccess({ FOO: 'bar', BAZ: 'qux', MY_TOKEN: 'safe' });
     });
 
     it('allows _ prefixed vars', () => {
-      expect(validateEnv({ _MY_VAR: 'val' })).toBeNull();
+      expectSuccess({ _MY_VAR: 'val' });
     });
   });
 
   describe('Invalid env var names', () => {
     it('rejects lowercase names', () => {
-      expect(validateEnv({ my_var: 'val' })).toContain('Invalid');
+      expectRejection({ my_var: 'val' }, 'Invalid env var name');
     });
 
     it('rejects names starting with digits', () => {
-      expect(validateEnv({ '1BAD': 'val' })).toContain('Invalid');
+      expectRejection({ '1BAD': 'val' }, 'Invalid env var name');
+    });
+  });
+
+  describe('Value hardening', () => {
+    it('strips CR/LF from values', () => {
+      const schema = buildEnvSchema();
+      const result = schema.safeParse({ MY_VAR: 'hello\r\nworld' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as Record<string, string>;
+        expect(data.MY_VAR).toBe('helloworld');
+      }
+    });
+
+    it('rejects values with control characters', () => {
+      expectRejection({ MY_VAR: 'hello\x00world' }, 'control characters');
+    });
+
+    it('rejects values with TAB以外的控制字符', () => {
+      expectRejection({ MY_VAR: 'val\x1Fue' }, 'control characters');
+    });
+
+    it('allows TAB in values', () => {
+      expectSuccess({ MY_VAR: 'hello\tworld' });
+    });
+
+    it('rejects values exceeding 8 KiB', () => {
+      const longValue = 'A'.repeat(8193);
+      expectRejection({ MY_VAR: longValue }, 'exceeds');
+    });
+
+    it('allows values at exactly 8 KiB', () => {
+      const exactValue = 'A'.repeat(8192);
+      expectSuccess({ MY_VAR: exactValue });
+    });
+  });
+
+  describe('Config overrides', () => {
+    it('additive denylist via extraDenylist', () => {
+      const schema = buildEnvSchema(['MY_EXTRA_DENIED_VAR']);
+      const result = schema.safeParse({ MY_EXTRA_DENIED_VAR: 'val' });
+      expect(result.success).toBe(false);
+    });
+
+    it('admin allowlist exempts denylisted vars', () => {
+      const schema = buildEnvSchema([], ['NODE_OPTIONS']);
+      const result = schema.safeParse({ NODE_OPTIONS: '--max-old-space-size=4096' });
+      expect(result.success).toBe(true);
+    });
+
+    it('admin allowlist exempts prefix-blocked vars', () => {
+      const schema = buildEnvSchema([], ['GITHUB_MY_SAFE_VAR']);
+      const result = schema.safeParse({ GITHUB_MY_SAFE_VAR: 'val' });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Exported constants match live schema', () => {
+    it('ENV_DENYLIST contains expected entries', () => {
+      expect(ENV_DENYLIST).toContain('PATH');
+      expect(ENV_DENYLIST).toContain('HOME');
+      expect(ENV_DENYLIST).toContain('LD_PRELOAD');
+      expect(ENV_DENYLIST).toContain('NODE_OPTIONS');
+      expect(ENV_DENYLIST).toContain('DYLD_INSERT_LIBRARIES');
+      expect(ENV_DENYLIST).toContain('LD_LIBRARY_PATH');
+      expect(ENV_DENYLIST).toContain('ANTHROPIC_API_KEY');
+      expect(ENV_DENYLIST).toContain('COMSPEC');
+      expect(ENV_DENYLIST).toContain('DYLD_FRAMEWORK_PATH');
+    });
+
+    it('ENV_DANGEROUS_PREFIXES contains expected entries', () => {
+      expect(ENV_DANGEROUS_PREFIXES).toContain('AWS_');
+      expect(ENV_DANGEROUS_PREFIXES).toContain('SSH_');
+      expect(ENV_DANGEROUS_PREFIXES).toContain('npm_config_');
+    });
+
+    it('ENV_BYO_LLM_WHITELIST contains expected entries', () => {
+      expect(ENV_BYO_LLM_WHITELIST).toContain('ANTHROPIC_BASE_URL');
+      expect(ENV_BYO_LLM_WHITELIST).toContain('ANTHROPIC_AUTH_TOKEN');
+      expect(ENV_BYO_LLM_WHITELIST).toContain('API_TIMEOUT_MS');
+    });
+  });
+
+  describe('stripCrLf and hasControlChars helpers', () => {
+    it('stripCrLf removes carriage returns', () => {
+      expect(stripCrLf('hello\rworld')).toBe('helloworld');
+    });
+
+    it('stripCrLf removes newlines', () => {
+      expect(stripCrLf('hello\nworld')).toBe('helloworld');
+    });
+
+    it('stripCrLf removes CRLF', () => {
+      expect(stripCrLf('hello\r\nworld')).toBe('helloworld');
+    });
+
+    it('hasControlChars detects null bytes', () => {
+      expect(hasControlChars('hello\x00')).toBe(true);
+    });
+
+    it('hasControlChars allows plain strings', () => {
+      expect(hasControlChars('hello world')).toBe(false);
+    });
+
+    it('hasControlChars allows TAB', () => {
+      expect(hasControlChars('hello\tworld')).toBe(false);
     });
   });
 });

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -206,6 +206,8 @@ async function buildTestServer(): Promise<{
     metricsToken: '',
     pipelineStageTimeoutMs: 0,
     alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
+    envDenylist: [],
+    envAdminAllowlist: [],
   };
 
   const auth = new AuthManager('/tmp/aegis-test-keys.json', AUTH_TOKEN);

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -87,6 +87,8 @@ async function buildRouteContext(tmpDir: string): Promise<{
     worktreeSiblingDirs: [],
     verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
     alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
+    envDenylist: [],
+    envAdminAllowlist: [],
   } satisfies Config;
 
   const sessions = new SessionManager(

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -42,6 +42,7 @@ export type AuditAction =
   | 'key.revoke'
   | 'session.create'
   | 'session.kill'
+  | 'session.env.rejected'
   | 'permission.approve'
   | 'permission.reject'
   | 'api.authenticated';

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,6 +104,10 @@ export interface Config {
     /** Cooldown period in ms between alerts for the same type (default: 10 min). */
     cooldownMs: number;
   };
+  /** Issue #1908: Additional env var names to deny (additive to built-in denylist). */
+  envDenylist: string[];
+  /** Issue #1908: Admin-defined env var names exempt from denylist. */
+  envAdminAllowlist: string[];
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -149,6 +153,8 @@ const defaults: Config = {
   metricsToken: '',
   pipelineStageTimeoutMs: 0,
   alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 10 * 60 * 1000 },
+  envDenylist: [],
+  envAdminAllowlist: [],
 };
 
 /** Parse CLI args for --config flag */
@@ -359,6 +365,19 @@ function applyEnvOverrides(config: Config): Config {
   return config;
 }
 
+/** Issue #1908: Apply env-denylist-specific overrides. */
+function applyEnvDenylistOverrides(config: Config): Config {
+  const denylistRaw = process.env.AEGIS_ENV_DENYLIST;
+  if (denylistRaw) {
+    config.envDenylist = denylistRaw.split(',').map(s => s.trim().toUpperCase()).filter(Boolean);
+  }
+  const allowlistRaw = process.env.AEGIS_ENV_ADMIN_ALLOWLIST;
+  if (allowlistRaw) {
+    config.envAdminAllowlist = allowlistRaw.split(',').map(s => s.trim().toUpperCase()).filter(Boolean);
+  }
+  return config;
+}
+
 /** Apply alerting-specific env overrides (nested config). */
 function applyAlertingEnvOverrides(config: Config): Config {
   const alertWebhooksRaw = process.env.AEGIS_ALERT_WEBHOOKS ?? process.env.MANUS_ALERT_WEBHOOKS;
@@ -410,6 +429,7 @@ export async function loadConfig(): Promise<Config> {
   let config: Config = { ...defaults, ...fileConfig };
   config = applyEnvOverrides(config);
   config = applyAlertingEnvOverrides(config);
+  config = applyEnvDenylistOverrides(config);
   // Issue #1889: If tgTopicTTLHours is set (> 0), convert and override tgTopicTtlMs
   if (config.tgTopicTTLHours > 0) {
     config.tgTopicTtlMs = config.tgTopicTTLHours * 60 * 60 * 1000;

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -6,7 +6,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { compareSemver, extractCCVersion, MIN_CC_VERSION } from '../validation.js';
+import { compareSemver, extractCCVersion, MIN_CC_VERSION, buildEnvSchema } from '../validation.js';
 import { cleanupTerminatedSessionState } from '../session-cleanup.js';
 import {
   type RouteContext,
@@ -19,20 +19,25 @@ const execFileAsync = promisify(execFile);
 // #1393: claudeCommand must not contain shell metacharacters
 const SAFE_COMMAND_RE = /^[a-zA-Z0-9_./@:= -]+$/;
 
-const createSessionSchema = z.object({
-  workDir: z.string().min(1),
-  name: z.string().max(200).optional(),
-  prompt: z.string().max(100_000).optional(),
-  prd: z.string().max(100_000).optional(),
-  resumeSessionId: z.string().uuid().optional(),
-  claudeCommand: z.string().max(500).regex(SAFE_COMMAND_RE).optional(),
-  env: z.record(z.string(), z.string()).optional(),
-  stallThresholdMs: z.number().int().positive().max(3_600_000).optional(),
-  permissionMode: z.enum(['default', 'bypassPermissions', 'plan', 'acceptEdits', 'dontAsk', 'auto']).optional(),
-  autoApprove: z.boolean().optional(),
-  parentId: z.string().uuid().optional(),
-  memoryKeys: z.array(z.string()).max(50).optional(),
-}).strict();
+/** Build the create-session schema with config-driven env denylist. */
+function buildCreateSessionSchema(ctx: RouteContext) {
+  const extraDenylist = ctx.config.envDenylist ?? [];
+  const adminAllowlist = ctx.config.envAdminAllowlist ?? [];
+  return z.object({
+    workDir: z.string().min(1),
+    name: z.string().max(200).optional(),
+    prompt: z.string().max(100_000).optional(),
+    prd: z.string().max(100_000).optional(),
+    resumeSessionId: z.string().uuid().optional(),
+    claudeCommand: z.string().max(500).regex(SAFE_COMMAND_RE).optional(),
+    env: buildEnvSchema(extraDenylist, adminAllowlist).optional(),
+    stallThresholdMs: z.number().int().positive().max(3_600_000).optional(),
+    permissionMode: z.enum(['default', 'bypassPermissions', 'plan', 'acceptEdits', 'dontAsk', 'auto']).optional(),
+    autoApprove: z.boolean().optional(),
+    parentId: z.string().uuid().optional(),
+    memoryKeys: z.array(z.string()).max(50).optional(),
+  }).strict();
+}
 
 const batchDeleteSchema = z.object({
   ids: z.array(z.string().uuid()).max(100).optional(),
@@ -56,6 +61,9 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     sessions, auth, metrics, monitor, eventBus, channels,
     memoryBridge, toolRegistry, getAuditLogger, validateWorkDir,
   } = ctx;
+
+  // Build schema once with config-driven env denylist (Issue #1908)
+  const createSessionSchema = buildCreateSessionSchema(ctx);
 
   // Session history (created/killed + active), paginated.
   registerWithLegacy(app, 'get', '/v1/sessions/history', async (req: FastifyRequest, reply: FastifyReply) => {
@@ -307,7 +315,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       }
     }
 
-    const session = await sessions.createSession({ workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId });
+    const session = await sessions.createSession({ workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env: env as Record<string, string> | undefined, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId });
     metrics.sessionCreated(session.id);
 
     const auditLogger = getAuditLogger();
@@ -346,7 +354,26 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         timeWindow: '1 minute',
       },
     },
-    handler: withValidation(createSessionSchema, createSessionHandler),
+    // Issue #1908: Custom handler wraps withValidation to emit audit on env rejection
+    handler: async (req: FastifyRequest, reply: FastifyReply) => {
+      const parsed = createSessionSchema.safeParse(req.body);
+      if (!parsed.success) {
+        // Emit audit record for env-related rejections (Issue #1908)
+        const envErrors = parsed.error.issues.filter(i => i.path.length >= 2 && i.path[0] === 'env');
+        if (envErrors.length > 0) {
+          const auditLogger = getAuditLogger();
+          if (auditLogger) {
+            void auditLogger.log(
+              req.authKeyId ?? 'anonymous',
+              'session.env.rejected',
+              envErrors.map(e => e.message).join('; '),
+            );
+          }
+        }
+        return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+      }
+      return createSessionHandler(req, reply, parsed.data);
+    },
   });
 
   // Get session (Issue #20: includes actionHints)

--- a/src/session.ts
+++ b/src/session.ts
@@ -18,7 +18,7 @@ import { SessionDiscovery } from './session-discovery.js';
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
 import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
-import { persistedStateSchema, type PermissionPolicy, type PermissionProfile } from './validation.js';
+import { persistedStateSchema, type PermissionPolicy, type PermissionProfile, ENV_NAME_RE, ENV_DENYLIST, ENV_DANGEROUS_PREFIXES, stripCrLf, hasControlChars, ENV_VALUE_MAX_BYTES } from './validation.js';
 import type { z } from 'zod';
 import { writeHookSettingsFile, cleanupHookSettingsFile, cleanupStaleSessionHooks } from './hook-settings.js';
 import { PermissionRequestManager, type PermissionDecision } from './permission-request-manager.js';
@@ -648,43 +648,8 @@ export class SessionManager {
 
     // Merge defaultSessionEnv (from config) with per-session env (per-session wins)
     // Security: validate env var names to prevent injection attacks
-    const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
-    // Issue #630: Expanded blocklist with additional dangerous env vars
-    const DANGEROUS_ENV_VARS = new Set([
-      // Dynamic loader / library injection
-      'PATH', 'LD_PRELOAD', 'LD_LIBRARY_PATH', 'NODE_OPTIONS',
-      'DYLD_INSERT_LIBRARIES', 'IFS', 'SHELL', 'ENV', 'BASH_ENV',
-      // Language-specific library paths
-      'PYTHONPATH', 'PERL5LIB', 'RUBYLIB', 'CLASSPATH',
-      'NODE_PATH', 'PYTHONHOME', 'PYTHONSTARTUP',
-      // Issue #630: Shell command injection vectors
-      'PROMPT_COMMAND', 'GIT_SSH_COMMAND', 'EDITOR', 'VISUAL',
-      'SUDO_ASKPASS', 'GIT_EXEC_PATH', 'NODE_ENV',
-      // Issue #630: Token/credential leakage
-      'GITHUB_TOKEN', 'NPM_TOKEN', 'GITLAB_TOKEN',
-      'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN',
-      'AZURE_CLIENT_SECRET', 'GOOGLE_APPLICATION_CREDENTIALS',
-      'DOCKER_TOKEN', 'HEROKU_API_KEY',
-      // Issue #1392: AI provider API keys — prevent credential hijacking
-      'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'CLAUDE_API_KEY',
-      'GOOGLE_AI_API_KEY', 'MISTRAL_API_KEY', 'DEEPSEEK_API_KEY',
-      // Issue #1392: Application secrets — prevent privilege escalation
-      'AEGIS_SECRET', 'DATABASE_URL', 'SECRET_KEY', 'JWT_SECRET',
-      'SESSION_SECRET', 'ENCRYPTION_KEY',
-    ]);
-    // Issue #630: Dangerous env var prefixes (prefix match)
-    const DANGEROUS_ENV_PREFIXES = [
-      'npm_config_',    // npm configuration override
-      'BASH_FUNC_',     // bash function export
-      'SSH_',           // SSH keys/agent config (SSH_AUTH_SOCK, SSH_PRIVATE_KEY, etc.)
-      'GITHUB_',        // GitHub tokens/keys (except GITHUB_PATH which is benign)
-      'GITLAB_',        // GitLab tokens
-      'AWS_',           // AWS credentials
-      'AZURE_',         // Azure credentials
-      'TF_',            // Terraform tokens
-      'CI_',            // CI tokens (CI_JOB_TOKEN, CI_BUILD_TOKEN, etc.)
-      'DOCKER_',        // Docker registry tokens
-    ];
+    const DANGEROUS_ENV_VARS = new Set(ENV_DENYLIST);
+    const DANGEROUS_ENV_PREFIXES = ENV_DANGEROUS_PREFIXES;
     const mergedEnv: Record<string, string> = {};
     const allEnv = { ...this.config.defaultSessionEnv, ...opts.env };
     for (const [key, value] of Object.entries(allEnv)) {
@@ -700,7 +665,15 @@ export class SessionManager {
       if (DANGEROUS_ENV_VARS.has(key)) {
         throw new Error(`Forbidden env var: "${key}" — cannot override dangerous environment variables`);
       }
-      mergedEnv[key] = value;
+      // Value hardening (Issue #1908)
+      const cleaned = stripCrLf(value);
+      if (hasControlChars(cleaned)) {
+        throw new Error(`Forbidden env var value for "${key}" — contains control characters`);
+      }
+      if (Buffer.byteLength(cleaned, 'utf-8') > ENV_VALUE_MAX_BYTES) {
+        throw new Error(`Env var "${key}" value exceeds ${ENV_VALUE_MAX_BYTES} byte limit`);
+      }
+      mergedEnv[key] = cleaned;
     }
     const hasEnv = Object.keys(mergedEnv).length > 0;
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -403,6 +403,152 @@ export const ccSettingsSchema = z.object({
   }).passthrough().optional(),
 }).passthrough();
 
+// ── Env var denylist (Issue #1908) ─────────────────────────────────────
+
+/** Dangerous env var names that must never be injected into sessions. */
+export const ENV_DENYLIST: readonly string[] = [
+  // Dynamic loader / library injection
+  'PATH', 'LD_PRELOAD', 'LD_LIBRARY_PATH', 'NODE_OPTIONS',
+  'DYLD_INSERT_LIBRARIES', 'IFS', 'SHELL', 'ENV', 'BASH_ENV',
+  // Language-specific library paths
+  'PYTHONPATH', 'PERL5LIB', 'RUBYLIB', 'CLASSPATH',
+  'NODE_PATH', 'PYTHONHOME', 'PYTHONSTARTUP',
+  // Shell command injection vectors
+  'PROMPT_COMMAND', 'GIT_SSH_COMMAND', 'EDITOR', 'VISUAL',
+  'SUDO_ASKPASS', 'GIT_EXEC_PATH', 'NODE_ENV',
+  // Token / credential leakage
+  'GITHUB_TOKEN', 'NPM_TOKEN', 'GITLAB_TOKEN',
+  'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN',
+  'AZURE_CLIENT_SECRET', 'GOOGLE_APPLICATION_CREDENTIALS',
+  'DOCKER_TOKEN', 'HEROKU_API_KEY',
+  // AI provider API keys — prevent credential hijacking
+  'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'CLAUDE_API_KEY',
+  'GOOGLE_AI_API_KEY', 'MISTRAL_API_KEY', 'DEEPSEEK_API_KEY',
+  // Application secrets — prevent privilege escalation
+  'AEGIS_SECRET', 'DATABASE_URL', 'SECRET_KEY', 'JWT_SECRET',
+  'SESSION_SECRET', 'ENCRYPTION_KEY',
+  // Home / user identity
+  'HOME', 'USER', 'LOGNAME', 'USERNAME',
+  // Windows-specific
+  'COMSPEC', 'WINDIR', 'SYSTEMROOT', 'SYSTEMDRIVE',
+  'PROGRAMFILES', 'PROGRAMFILES(X86)', 'PROGRAMDATA',
+  'APPDATA', 'LOCALAPPDATA', 'TEMP', 'TMP',
+  'HOMEDRIVE', 'HOMEPATH', 'USERPROFILE', 'USERDOMAIN',
+  // macOS-specific
+  'DYLD_LIBRARY_PATH', 'DYLD_FRAMEWORK_PATH', 'DYLD_ROOT_PATH',
+  'DYLD_IMAGE_SUFFIX', 'DYLD_INSERT_LIBRARIES',
+  // Linux-specific
+  'LD_AUDIT', 'LD_DEBUG', 'LD_TRACE_LOADED_OBJECTS',
+  'LD_BIND_NOW', 'LD_PROFILE', 'LD_ORIGIN_PATH',
+  'LD_USE_LOAD_BIAS', 'LD_VERBOSE', 'LD_PREFER_MAP_32BIT',
+];
+
+/** Dangerous env var prefixes — any key starting with these is blocked. */
+export const ENV_DANGEROUS_PREFIXES: readonly string[] = [
+  'npm_config_',    // npm configuration override
+  'BASH_FUNC_',     // bash function export
+  'SSH_',           // SSH keys/agent config
+  'GITHUB_',        // GitHub tokens/keys
+  'GITLAB_',        // GitLab tokens
+  'AWS_',           // AWS credentials
+  'AZURE_',         // Azure credentials
+  'TF_',            // Terraform tokens
+  'CI_',            // CI tokens
+  'DOCKER_',        // Docker registry tokens
+];
+
+/** BYO-LLM variables explicitly allowed despite general credential restrictions.
+ *  These control model routing / endpoint configuration, not secrets. */
+export const ENV_BYO_LLM_WHITELIST: readonly string[] = [
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_DEFAULT_FAST_MODEL',
+  'ANTHROPIC_DEFAULT_MODEL',
+  'API_TIMEOUT_MS',
+];
+
+/** Valid env var name pattern: uppercase letters, digits, underscores. */
+export const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+/** Max size of a single env var value (8 KiB). */
+export const ENV_VALUE_MAX_BYTES = 8192;
+
+/** Strip CR/LF from env var values (header injection defense). */
+export function stripCrLf(value: string): string {
+  return value.replace(/[\r\n]/g, '');
+}
+
+/** Reject strings containing ASCII control characters (0x00–0x1F, 0x7F), except TAB. */
+export function hasControlChars(value: string): boolean {
+  return /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.test(value);
+}
+
+/**
+ * Build a refined Zod schema for session env vars.
+ * Accepts optional additive denylist and admin allowlist from config.
+ */
+export function buildEnvSchema(
+  extraDenylist: readonly string[] = [],
+  adminAllowlist: readonly string[] = [],
+) {
+  const denySet = new Set([...ENV_DENYLIST, ...extraDenylist]);
+  const allowSet = new Set([...ENV_BYO_LLM_WHITELIST, ...adminAllowlist]);
+  const prefixList = [...ENV_DANGEROUS_PREFIXES];
+
+  return z.record(z.string(), z.string()).superRefine((env: Record<string, string>, ctx) => {
+    for (const [key, rawValue] of Object.entries(env)) {
+      // Check dangerous prefixes first (some are lowercase like npm_config_)
+      const matchedPrefix = prefixList.find(p => key.startsWith(p));
+      if (matchedPrefix && !allowSet.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Forbidden env var: "${key}" — cannot override dangerous environment variable prefix "${matchedPrefix}"`,
+        });
+        continue;
+      }
+      // Name format
+      if (!ENV_NAME_RE.test(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Invalid env var name: "${key}" — must match ${ENV_NAME_RE.source}`,
+        });
+        continue;
+      }
+      // Exact denylist (skip if admin-allowlisted)
+      if (denySet.has(key) && !allowSet.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Forbidden env var: "${key}" — denylisted`,
+        });
+        continue;
+      }
+      // Value hardening
+      const value = stripCrLf(rawValue);
+      if (hasControlChars(value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Forbidden env var value for "${key}" — contains control characters`,
+        });
+        continue;
+      }
+      if (Buffer.byteLength(value, 'utf-8') > ENV_VALUE_MAX_BYTES) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Env var "${key}" value exceeds ${ENV_VALUE_MAX_BYTES} byte limit`,
+        });
+        continue;
+      }
+      // Mutate to stripped value
+      env[key] = value;
+    }
+  });
+}
+
 /** Helper: extract error message from unknown catch value. */
 export function getErrorMessage(e: unknown): string {
   if (e instanceof Error) return e.message;


### PR DESCRIPTION
## Summary

- Add `ENV_DENYLIST` constant in `src/validation.ts` with platform-specific dangerous vars (Linux: `LD_AUDIT`, `LD_DEBUG`; macOS: `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`; Windows: `COMSPEC`, `WINDIR`, `SYSTEMROOT`, `APPDATA`, `USERPROFILE`)
- Add `ENV_BYO_LLM_WHITELIST` for BYO-LLM vars (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_DEFAULT_*_MODEL`, `API_TIMEOUT_MS`)
- Add `superRefine()` on env Zod schema with denylist + prefix + name + value validation
- Value hardening: strip CR/LF, reject control chars, 8 KiB cap per value
- Config overrides: `AEGIS_ENV_DENYLIST` (additive), `AEGIS_ENV_ADMIN_ALLOWLIST` (exempt)
- Audit record on every rejection with action `session.env.rejected`
- `session.ts` now uses shared `ENV_DENYLIST` constant instead of inline copy
- Rewrote `env-denylist-1392.test.ts` to test live Zod schema, not replicated copy

Closes #1908

## Aegis version
**Developed with:** v0.5.3-alpha

## Gate output

```
Hygiene check passed.
Security check passed: no "shell: true" occurrences in src/.
 Test Files  171 passed | 1 skipped (172)
      Tests  3045 passed | 25 skipped (3070)
```

## Test plan
- [x] All AI provider API keys rejected (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
- [x] All application secrets rejected (AEGIS_SECRET, DATABASE_URL, JWT_SECRET, etc.)
- [x] Linux-specific vars rejected (LD_AUDIT, LD_DEBUG, LD_BIND_NOW)
- [x] macOS-specific vars rejected (DYLD_LIBRARY_PATH, DYLD_FRAMEWORK_PATH, DYLD_ROOT_PATH)
- [x] Windows-specific vars rejected (COMSPEC, WINDIR, SYSTEMROOT, APPDATA, USERPROFILE)
- [x] BYO-LLM whitelist allows ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, API_TIMEOUT_MS
- [x] Value hardening: CR/LF stripped, control chars rejected, 8 KiB cap enforced
- [x] Config overrides: additive denylist + admin allowlist work
- [x] Dangerous prefixes still blocked (AWS_, SSH_, GITHUB_, etc.)

Generated by Hephaestus (Aegis dev agent)