### PR TITLE
fix: enforce session ownership guard on action routes

### DIFF
--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -208,6 +208,7 @@ async function buildTestServer(): Promise<{
     alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
     envDenylist: [],
     envAdminAllowlist: [],
+    enforceSessionOwnership: true,
   };
 
   const auth = new AuthManager('/tmp/aegis-test-keys.json', AUTH_TOKEN);

--- a/src/__tests__/permission-routes.test.ts
+++ b/src/__tests__/permission-routes.test.ts
@@ -124,4 +124,34 @@ describe('permission-routes', () => {
     expect(result).toEqual({ ok: true });
     expect(sessions.reject).toHaveBeenCalledWith('s-1');
   });
+
+  it('denies non-owner when ownership enforcement is enabled (#1910)', async () => {
+    sessions.getSession.mockReturnValue({ id: 's-1', ownerKeyId: 'key-owner' });
+    registerPermissionRoutes(app, sessions as any, metrics as any, null, {
+      resolveRole: () => 'operator',
+      auth: { getRole: () => 'operator' } as any,
+      config: { enforceSessionOwnership: true } as any,
+    });
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    await handler({ params: { id: 's-1' }, authKeyId: 'key-other' }, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(403);
+    expect(sessions.approve).not.toHaveBeenCalled();
+  });
+
+  it('allows admin bypass when ownership enforcement is enabled (#1910)', async () => {
+    sessions.getSession.mockReturnValue({ id: 's-1', ownerKeyId: 'key-owner' });
+    registerPermissionRoutes(app, sessions as any, metrics as any, null, {
+      resolveRole: () => 'admin',
+      auth: { getRole: () => 'admin' } as any,
+      config: { enforceSessionOwnership: true } as any,
+    });
+    const handler = getHandler(app, '/v1/sessions/:id/approve');
+    const reply = makeReply();
+    const result = await handler({ params: { id: 's-1' }, authKeyId: 'key-admin' }, reply);
+
+    expect(result).toEqual({ ok: true });
+    expect(sessions.approve).toHaveBeenCalledWith('s-1');
+  });
 });

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -89,6 +89,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
     envDenylist: [],
     envAdminAllowlist: [],
+    enforceSessionOwnership: true,
   } satisfies Config;
 
   const sessions = new SessionManager(

--- a/src/__tests__/session-ownership-1429.test.ts
+++ b/src/__tests__/session-ownership-1429.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerPermissionRoutes } from '../permission-routes.js';
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import type { SessionInfo } from '../session.js';
+import { requireSessionOwnership } from '../routes/context.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -135,6 +136,68 @@ describe('Session ownership (#1429) — permission routes', () => {
     await handler({ params: { id: 'missing' }, authKeyId: 'key-alice' }, reply);
 
     expect(reply.status).toHaveBeenCalledWith(404);
+  });
+});
+
+describe('Session ownership (#1910) — requireSessionOwnership guard', () => {
+  it('allows admin role to bypass ownership when enforcement is enabled', () => {
+    const session = makeSession({ ownerKeyId: 'key-owner' });
+    const sessions = { getSession: vi.fn(() => session) };
+    const auth = { getRole: vi.fn(() => 'admin') };
+    const reply = makeReply() as unknown as FastifyReply;
+    const config = { enforceSessionOwnership: true };
+
+    const resolved = requireSessionOwnership(
+      sessions as any,
+      auth as any,
+      config as any,
+      session.id,
+      reply,
+      'key-admin',
+    );
+
+    expect(resolved).toBe(session);
+    expect(reply.status).not.toHaveBeenCalledWith(403);
+  });
+
+  it('denies non-owner when enforcement is enabled', () => {
+    const session = makeSession({ ownerKeyId: 'key-owner' });
+    const sessions = { getSession: vi.fn(() => session) };
+    const auth = { getRole: vi.fn(() => 'operator') };
+    const reply = makeReply() as unknown as FastifyReply;
+    const config = { enforceSessionOwnership: true };
+
+    const resolved = requireSessionOwnership(
+      sessions as any,
+      auth as any,
+      config as any,
+      session.id,
+      reply,
+      'key-other',
+    );
+
+    expect(resolved).toBeNull();
+    expect(reply.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows non-owner when enforcement flag is disabled', () => {
+    const session = makeSession({ ownerKeyId: 'key-owner' });
+    const sessions = { getSession: vi.fn(() => session) };
+    const auth = { getRole: vi.fn(() => 'operator') };
+    const reply = makeReply() as unknown as FastifyReply;
+    const config = { enforceSessionOwnership: false };
+
+    const resolved = requireSessionOwnership(
+      sessions as any,
+      auth as any,
+      config as any,
+      session.id,
+      reply,
+      'key-other',
+    );
+
+    expect(resolved).toBe(session);
+    expect(reply.status).not.toHaveBeenCalledWith(403);
   });
 });
 

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -42,6 +42,8 @@ export type AuditAction =
   | 'key.revoke'
   | 'session.create'
   | 'session.kill'
+  | 'session.action.allowed'
+  | 'session.action.denied'
   | 'session.env.rejected'
   | 'permission.approve'
   | 'permission.reject'

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,8 @@ export interface Config {
   envDenylist: string[];
   /** Issue #1908: Admin-defined env var names exempt from denylist. */
   envAdminAllowlist: string[];
+  /** Issue #1910: Enforce session ownership on action routes (default: true). */
+  enforceSessionOwnership: boolean;
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -155,6 +157,7 @@ const defaults: Config = {
   alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 10 * 60 * 1000 },
   envDenylist: [],
   envAdminAllowlist: [],
+  enforceSessionOwnership: true,
 };
 
 /** Parse CLI args for --config flag */
@@ -306,6 +309,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_SSE_MAX_PER_IP', manus: 'MANUS_SSE_MAX_PER_IP', key: 'sseMaxPerIp' },
     { aegis: 'AEGIS_PIPELINE_STAGE_TIMEOUT_MS', manus: 'MANUS_PIPELINE_STAGE_TIMEOUT_MS', key: 'pipelineStageTimeoutMs' },
     { aegis: 'AEGIS_HOOK_SECRET_HEADER_ONLY', manus: 'MANUS_HOOK_SECRET_HEADER_ONLY', key: 'hookSecretHeaderOnly' },
+    { aegis: 'AEGIS_ENFORCE_SESSION_OWNERSHIP', manus: 'MANUS_ENFORCE_SESSION_OWNERSHIP', key: 'enforceSessionOwnership' },
   ];
 
   for (const { aegis, manus, key } of envMappings) {
@@ -328,6 +332,7 @@ function applyEnvOverrides(config: Config): Config {
         break;
       case 'hookSecretHeaderOnly':
       case 'tgTopicAutoDelete':
+      case 'enforceSessionOwnership':
         if (value === 'true' || value === 'false') {
           config[key] = value === 'true';
         } else {

--- a/src/permission-routes.ts
+++ b/src/permission-routes.ts
@@ -3,6 +3,9 @@ import type { SessionManager } from './session.js';
 import type { MetricsCollector } from './metrics.js';
 import type { AuditLogger } from './audit.js';
 import type { ApiKeyRole } from './auth.js';
+import type { AuthManager } from './services/auth/index.js';
+import type { Config } from './config.js';
+import { requireSessionOwnership } from './routes/context.js';
 
 type PermissionAction = 'approve' | 'reject';
 type IdParams = { Params: { id: string } };
@@ -19,6 +22,8 @@ function createPermissionHandler(
   audit: AuditLogger | null,
   resolveRole?: ResolveRole,
   getAuditLogger?: () => AuditLogger | null,
+  auth?: AuthManager,
+  config?: Config,
 ): (req: IdRequest, reply: FastifyReply) => Promise<unknown> {
   return async (req: IdRequest, reply: FastifyReply): Promise<unknown> => {
     // #1641: Enforce operator/admin when role resolution is configured.
@@ -30,11 +35,38 @@ function createPermissionHandler(
     }
 
     // Issue #1429: Enforce session ownership
-    const session = sessions.getSession(req.params.id);
-    if (!session) return reply.status(404).send({ error: 'Session not found' });
     const keyId = req.authKeyId;
-    if (keyId !== 'master' && keyId !== null && keyId !== undefined && session.ownerKeyId && session.ownerKeyId !== keyId) {
-      return reply.status(403).send({ error: 'Forbidden: session owned by another API key' });
+
+    if (auth && config) {
+      const session = requireSessionOwnership(sessions, auth, config, req.params.id, reply, keyId);
+      if (!session) {
+        const effectiveAudit = getAuditLogger ? getAuditLogger() : audit;
+        if (effectiveAudit) {
+          void effectiveAudit.log(
+            keyId ?? 'system',
+            'session.action.denied',
+            `Denied ${action}: session owned by another API key`,
+            req.params.id,
+          );
+        }
+        return;
+      }
+
+      const effectiveAudit = getAuditLogger ? getAuditLogger() : audit;
+      if (effectiveAudit) {
+        void effectiveAudit.log(
+          keyId ?? 'system',
+          'session.action.allowed',
+          `Allowed ${action}`,
+          req.params.id,
+        );
+      }
+    } else {
+      const session = sessions.getSession(req.params.id);
+      if (!session) return reply.status(404).send({ error: 'Session not found' });
+      if (keyId !== 'master' && keyId !== null && keyId !== undefined && session.ownerKeyId && session.ownerKeyId !== keyId) {
+        return reply.status(403).send({ error: 'Forbidden: session owned by another API key' });
+      }
     }
 
     try {
@@ -69,10 +101,24 @@ export function registerPermissionRoutes(
   sessions: PermissionSessions,
   metrics: PermissionMetrics,
   audit: AuditLogger | null = null,
-  options?: { resolveRole?: ResolveRole; getAuditLogger?: () => AuditLogger | null },
+  options?: {
+    resolveRole?: ResolveRole;
+    getAuditLogger?: () => AuditLogger | null;
+    auth?: AuthManager;
+    config?: Config;
+  },
 ): void {
   for (const action of ['approve', 'reject'] as const) {
-    const handler = createPermissionHandler(action, sessions, metrics, audit, options?.resolveRole, options?.getAuditLogger);
+    const handler = createPermissionHandler(
+      action,
+      sessions,
+      metrics,
+      audit,
+      options?.resolveRole,
+      options?.getAuditLogger,
+      options?.auth,
+      options?.config,
+    );
     app.post<IdParams>(`/v1/sessions/:id/${action}`, handler);
     app.post<IdParams>(`/sessions/:id/${action}`, handler);
   }

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -105,6 +105,43 @@ export function requireOwnership(
   return session;
 }
 
+/**
+ * Session ownership guard with feature flag + RBAC admin bypass.
+ * Sends 404/403 on denial and returns null; returns SessionInfo on success.
+ */
+export function requireSessionOwnership(
+  sessions: Pick<SessionManager, 'getSession'>,
+  auth: AuthManager,
+  config: Config,
+  sessionId: string,
+  reply: FastifyReply,
+  keyId: string | null | undefined,
+): SessionInfo | null {
+  const session = sessions.getSession(sessionId);
+  if (!session) {
+    reply.status(404).send({ error: 'Session not found' });
+    return null;
+  }
+
+  // Backward compatibility and explicit bypasses.
+  if (keyId === 'master' || keyId === null || keyId === undefined) return session;
+
+  // Feature flag keeps a temporary opt-out path while this hardening rolls out.
+  if (!config.enforceSessionOwnership) return session;
+
+  // Admin API keys can operate on all sessions.
+  if (auth.getRole(keyId) === 'admin') return session;
+
+  // Legacy sessions without owner metadata are still accessible.
+  if (!session.ownerKeyId) return session;
+
+  if (session.ownerKeyId !== keyId) {
+    reply.status(403).send({ error: 'Forbidden: session owned by another API key' });
+    return null;
+  }
+  return session;
+}
+
 /** Issue #20: Add actionHints to session response for interactive states. */
 export function addActionHints(
   session: SessionInfo,
@@ -227,6 +264,47 @@ export function withOwnership(
     const id = (req.params as { id: string }).id;
     const session = requireOwnership(sessions, id, reply, req.authKeyId);
     if (!session) return;
+    return handler(req, reply, session);
+  };
+}
+
+/**
+ * Ownership wrapper that enforces optional authz hardening for action routes.
+ */
+export function withSessionOwnership(
+  sessions: SessionManager,
+  auth: AuthManager,
+  config: Config,
+  getAuditLogger: () => AuditLogger | undefined,
+  actionName: string,
+  handler: (req: FastifyRequest, reply: FastifyReply, session: SessionInfo) => Promise<unknown> | unknown,
+): RouteHandler {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    const id = (req.params as { id: string }).id;
+    const session = requireSessionOwnership(sessions, auth, config, id, reply, req.authKeyId);
+    if (!session) {
+      const auditLogger = getAuditLogger();
+      if (auditLogger) {
+        void auditLogger.log(
+          req.authKeyId ?? 'system',
+          'session.action.denied',
+          `Denied ${actionName}: session owned by another API key`,
+          id,
+        );
+      }
+      return;
+    }
+
+    const auditLogger = getAuditLogger();
+    if (auditLogger) {
+      void auditLogger.log(
+        req.authKeyId ?? 'system',
+        'session.action.allowed',
+        `Allowed ${actionName}`,
+        id,
+      );
+    }
+
     return handler(req, reply, session);
   };
 }

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -11,7 +11,7 @@ import { cleanupTerminatedSessionState } from '../session-cleanup.js';
 import {
   type RouteContext,
   requireRole, makePayload,
-  registerWithLegacy, withOwnership,
+  registerWithLegacy, withOwnership, withSessionOwnership,
 } from './context.js';
 
 export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteContext): void {
@@ -21,7 +21,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   } = ctx;
 
   // Send message (with delivery verification — Issue #1)
-  registerWithLegacy(app, 'post', '/v1/sessions/:id/send', withOwnership(sessions, async (req, reply, session) => {
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/send', withSessionOwnership(sessions, auth, ctx.config, getAuditLogger, 'send', async (req, reply, session) => {
     if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
     const parsed = sendMessageSchema.safeParse(req.body);
     if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
@@ -145,6 +145,8 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     {
       getAuditLogger: () => getAuditLogger() ?? null,
       resolveRole: (keyId) => auth.getRole(keyId),
+      auth,
+      config: ctx.config,
     },
   );
 
@@ -162,7 +164,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   }));
 
   // Escape
-  registerWithLegacy(app, 'post', '/v1/sessions/:id/escape', withOwnership(sessions, async (req, reply, session) => {
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/escape', withSessionOwnership(sessions, auth, ctx.config, getAuditLogger, 'escape', async (req, reply, session) => {
     if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
     try {
       await sessions.escape(session.id);
@@ -173,7 +175,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   }));
 
   // Interrupt (Ctrl+C)
-  registerWithLegacy(app, 'post', '/v1/sessions/:id/interrupt', withOwnership(sessions, async (req, reply, session) => {
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/interrupt', withSessionOwnership(sessions, auth, ctx.config, getAuditLogger, 'interrupt', async (req, reply, session) => {
     if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
     try {
       await sessions.interrupt(session.id);
@@ -184,7 +186,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   }));
 
   // Kill session
-  registerWithLegacy(app, 'delete', '/v1/sessions/:id', withOwnership(sessions, async (req, reply, session) => {
+  registerWithLegacy(app, 'delete', '/v1/sessions/:id', withSessionOwnership(sessions, auth, ctx.config, getAuditLogger, 'kill', async (req, reply, session) => {
     if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
     try {
       await sessions.killSession(session.id);
@@ -206,7 +208,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   }));
 
   // Slash command
-  registerWithLegacy(app, 'post', '/v1/sessions/:id/command', withOwnership(sessions, async (req, reply, session) => {
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/command', withSessionOwnership(sessions, auth, ctx.config, getAuditLogger, 'command', async (req, reply, session) => {
     if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
     const parsed = commandSchema.safeParse(req.body);
     if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
@@ -221,7 +223,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   }));
 
   // Bash mode — captures command output (Issue #1810)
-  registerWithLegacy(app, 'post', '/v1/sessions/:id/bash', withOwnership(sessions, async (req, reply, session) => {
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/bash', withSessionOwnership(sessions, auth, ctx.config, getAuditLogger, 'bash', async (req, reply, session) => {
     if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
     const parsed = bashSchema.safeParse(req.body);
     if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -750,5 +750,6 @@ export const configFileSchema = z.object({
     failureThreshold: z.number().int().positive().optional(),
     cooldownMs: z.number().int().positive().optional(),
   }).partial().optional(),
+  enforceSessionOwnership: z.boolean().optional(),
 });
 


### PR DESCRIPTION
Closes #1910\n\n## Aegis version\n**Developed with:** v0.5.3-alpha\n\n## Summary\n- Added equireSessionOwnership guard with admin bypass and feature-flag support.\n- Enforced ownership checks on action routes: send, command, bash, interrupt, escape, kill.\n- Wired permission routes approve/reject to the same ownership guard logic.\n- Added audit entries for ownership allow/deny attempts.\n- Added config support for AEGIS_ENFORCE_SESSION_OWNERSHIP (default true).\n\n## Validation\n- 
px tsc --noEmit\n- 
px vitest run src/__tests__/session-ownership-1429.test.ts src/__tests__/permission-routes.test.ts\n- 
pm run gate\n