### PR TITLE
feat: SSE idle timeout, hook abort, and HTTP drain on shutdown (#1911)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,6 +19,11 @@ This guide covers deploying Aegis in development, CI/CD, and production environm
 | `AEGIS_DATA_DIR` | No | `~/.aegis` | Session data storage |
 | `AEGIS_DASHBOARD_URL` | No | `http://localhost:9100/dashboard` | Dashboard URL |
 | `CLAUDE_DATA_DIR` | No | `~/.claude` | Claude Code data directory |
+| `AEGIS_SSE_IDLE_MS` | No | `120000` | SSE heartbeat interval — emit a `:ping` comment after this many ms of write-idle silence (Issue #1911) |
+| `AEGIS_SSE_CLIENT_TIMEOUT_MS` | No | `300000` | SSE client idle timeout — destroy the connection if no event is sent for this many ms (Issue #1911) |
+| `AEGIS_HOOK_TIMEOUT_MS` | No | `10000` | Outgoing webhook / hook fetch timeout in ms; timed-out deliveries are pushed to the dead-letter queue (Issue #1911) |
+| `AEGIS_SHUTDOWN_GRACE_MS` | No | `15000` | Grace period in ms for `app.close()` to drain in-flight HTTP requests on SIGTERM/SIGINT (Issue #1911) |
+| `AEGIS_SHUTDOWN_HARD_MS` | No | `20000` | Hard cap in ms for the entire graceful shutdown sequence; `process.exit(1)` is called if exceeded (Issue #1911) |
 
 ## Quick Start
 

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -209,6 +209,11 @@ async function buildTestServer(): Promise<{
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+    sseIdleMs: 120_000,
+    sseClientTimeoutMs: 300_000,
+    hookTimeoutMs: 10_000,
+    shutdownGraceMs: 15_000,
+    shutdownHardMs: 20_000,
   };
 
   const auth = new AuthManager('/tmp/aegis-test-keys.json', AUTH_TOKEN);
@@ -269,6 +274,7 @@ async function buildTestServer(): Promise<{
     memoryBridge: null,
     requestKeyMap: new Map(),
     validateWorkDir: async (wd: string) => wd,
+    serverState: { draining: false },
   };
 
   registerHealthRoutes(app, routeCtx);

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -90,6 +90,11 @@ async function buildRouteContext(tmpDir: string): Promise<{
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+    sseIdleMs: 120_000,
+    sseClientTimeoutMs: 300_000,
+    hookTimeoutMs: 10_000,
+    shutdownGraceMs: 15_000,
+    shutdownHardMs: 20_000,
   } satisfies Config;
 
   const sessions = new SessionManager(
@@ -142,6 +147,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     memoryBridge: null,
     requestKeyMap,
     validateWorkDir: async (wd: string) => wd,
+    serverState: { draining: false },
   };
 
   return { ctx, mockTmux, sessions, auth };

--- a/src/__tests__/sse-drain-1911.test.ts
+++ b/src/__tests__/sse-drain-1911.test.ts
@@ -1,0 +1,175 @@
+/**
+ * sse-drain-1911.test.ts — Tests for Issue #1911:
+ *   - SSE heartbeat/idle-timeout uses config values (sseIdleMs / sseClientTimeoutMs)
+ *   - SessionEventBus.emitShutdown() broadcasts to global subscribers
+ *   - AuditLogger.flush() resolves after pending writes
+ *   - Config defaults for the five new #1911 fields
+ *   - Health draining state flag
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ServerResponse, IncomingMessage } from 'node:http';
+import { SSEWriter } from '../sse-writer.js';
+import { SessionEventBus } from '../events.js';
+import { AuditLogger } from '../audit.js';
+import { loadConfig } from '../config.js';
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createMockRes(): { res: ServerResponse; written: string[] } {
+  const written: string[] = [];
+  const res = {
+    write(chunk: string): boolean {
+      written.push(chunk);
+      return true;
+    },
+    end(): void {},
+  } as unknown as ServerResponse;
+  return { res, written };
+}
+
+function createMockReq(onClose?: () => void): IncomingMessage {
+  return {
+    on(event: string, handler: () => void): IncomingMessage {
+      if (event === 'close' && onClose) onClose();
+      return this as unknown as IncomingMessage;
+    },
+  } as unknown as IncomingMessage;
+}
+
+// ── SSEWriter: config-driven heartbeat interval ────────────────────
+
+describe('Issue #1911: SSEWriter respects configurable heartbeat intervals', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('emits heartbeat at the configured sseIdleMs interval (not hardcoded 30_000)', () => {
+    const { res, written } = createMockRes();
+    const req = createMockReq();
+    const writer = new SSEWriter(res, req, vi.fn());
+
+    const customIdleMs = 5_000;
+    writer.startHeartbeat(customIdleMs, 300_000, () => 'data: {"event":"heartbeat"}\n\n');
+
+    // No heartbeat yet
+    expect(written.filter(w => w.includes('"heartbeat"'))).toHaveLength(0);
+
+    // Advance past the custom interval
+    vi.advanceTimersByTime(customIdleMs + 1);
+    expect(written.filter(w => w.includes('"heartbeat"'))).toHaveLength(1);
+  });
+
+  it('destroys connection after sseClientTimeoutMs idle (not hardcoded 90_000)', () => {
+    const { res } = createMockRes();
+    // Make writes fail so lastWrite is never updated
+    vi.spyOn(res, 'write').mockReturnValue(false);
+    const req = createMockReq();
+    const onCleanup = vi.fn();
+    const writer = new SSEWriter(res, req, onCleanup);
+
+    const customIdleMs = 5_000;
+    const customClientTimeoutMs = 15_000;
+    writer.startHeartbeat(customIdleMs, customClientTimeoutMs, () => ':ping\n\n');
+
+    // First heartbeat fires at 5_001ms. lastWrite is at t=0, so elapsed = 5_001 > 15_000? No.
+    vi.advanceTimersByTime(customIdleMs + 1);
+    expect(onCleanup).not.toHaveBeenCalled();
+
+    // Advance to exceed client timeout
+    vi.advanceTimersByTime(customClientTimeoutMs);
+    expect(onCleanup).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── SessionEventBus.emitShutdown() ────────────────────────────────
+
+describe('Issue #1911: SessionEventBus.emitShutdown() broadcasts shutdown frame', () => {
+  it('delivers shutdown event to all global subscribers', () => {
+    const bus = new SessionEventBus();
+    const received: string[] = [];
+
+    const unsub = bus.subscribeGlobal((event) => {
+      received.push(event.event);
+    });
+
+    bus.emitShutdown();
+    unsub();
+
+    expect(received).toContain('shutdown');
+  });
+
+  it('is a no-op when there are no global subscribers', () => {
+    const bus = new SessionEventBus();
+    // Should not throw
+    expect(() => bus.emitShutdown()).not.toThrow();
+  });
+
+  it('shutdown event has an empty sessionId and a timestamp', () => {
+    const bus = new SessionEventBus();
+    let captured: { event: string; sessionId: string; timestamp: string } | undefined;
+
+    const unsub = bus.subscribeGlobal((event) => {
+      captured = event;
+    });
+
+    bus.emitShutdown();
+    unsub();
+
+    expect(captured).toBeDefined();
+    expect(captured!.event).toBe('shutdown');
+    expect(captured!.sessionId).toBe('');
+    expect(captured!.timestamp).toBeTruthy();
+  });
+});
+
+// ── AuditLogger.flush() ───────────────────────────────────────────
+
+describe('Issue #1911: AuditLogger.flush() awaits pending writes', () => {
+  it('resolves immediately when there are no pending writes', async () => {
+    const logger = new AuditLogger();
+    await expect(logger.flush()).resolves.toBeUndefined();
+  });
+});
+
+// ── Config defaults ────────────────────────────────────────────────
+
+describe('Issue #1911: Config defaults for new timeout fields', () => {
+  it('loadConfig returns correct defaults for #1911 fields', async () => {
+    const config = await loadConfig();
+    expect(config.sseIdleMs).toBe(120_000);
+    expect(config.sseClientTimeoutMs).toBe(300_000);
+    expect(config.hookTimeoutMs).toBe(10_000);
+    expect(config.shutdownGraceMs).toBe(15_000);
+    expect(config.shutdownHardMs).toBe(20_000);
+  });
+
+  it('AEGIS_SSE_IDLE_MS env var overrides sseIdleMs', async () => {
+    process.env.AEGIS_SSE_IDLE_MS = '60000';
+    try {
+      const config = await loadConfig();
+      expect(config.sseIdleMs).toBe(60_000);
+    } finally {
+      delete process.env.AEGIS_SSE_IDLE_MS;
+    }
+  });
+
+  it('AEGIS_HOOK_TIMEOUT_MS env var overrides hookTimeoutMs', async () => {
+    process.env.AEGIS_HOOK_TIMEOUT_MS = '5000';
+    try {
+      const config = await loadConfig();
+      expect(config.hookTimeoutMs).toBe(5_000);
+    } finally {
+      delete process.env.AEGIS_HOOK_TIMEOUT_MS;
+    }
+  });
+
+  it('AEGIS_SHUTDOWN_GRACE_MS env var overrides shutdownGraceMs', async () => {
+    process.env.AEGIS_SHUTDOWN_GRACE_MS = '8000';
+    try {
+      const config = await loadConfig();
+      expect(config.shutdownGraceMs).toBe(8_000);
+    } finally {
+      delete process.env.AEGIS_SHUTDOWN_GRACE_MS;
+    }
+  });
+});

--- a/src/alerting.ts
+++ b/src/alerting.ts
@@ -30,8 +30,8 @@ export interface AlertingConfig {
   /** Number of consecutive failures before triggering an alert. */
   failureThreshold: number;
   /** Cooldown period in ms between alerts for the same type. */
-  cooldownMs: number;
-}
+  cooldownMs: number;  /** Issue #1911: Outgoing alert webhook fetch timeout in ms (default: 10_000). Env: AEGIS_HOOK_TIMEOUT_MS */
+  hookTimeoutMs: number;}
 
 /** Per-type failure tracking state. */
 interface FailureTracker {
@@ -44,6 +44,7 @@ const DEFAULT_CONFIG: AlertingConfig = {
   webhooks: [],
   failureThreshold: 5,
   cooldownMs: 10 * 60 * 1000,
+  hookTimeoutMs: 10_000,
 };
 
 export class AlertManager {
@@ -204,7 +205,7 @@ export class AlertManager {
         'X-Aegis-Alert-Type': alertType,
       },
       body,
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(this.config.hookTimeoutMs),
     });
 
     if (!res.ok) {

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -195,7 +195,9 @@ export type GlobalSSEEventType =
   | 'session_dead'
   | 'session_subagent_start'
   | 'session_subagent_stop'
-  | 'session_verification';
+  | 'session_verification'
+  /** Issue #1911: Emitted to all global SSE subscribers during graceful shutdown. */
+  | 'shutdown';
 
 export interface GlobalSSEEvent {
   event: GlobalSSEEventType;

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -162,6 +162,14 @@ export class AuditLogger {
     }
   }
 
+  /**
+   * Flush pending audit writes — awaits the current write lock.
+   * Safe to call during graceful shutdown to ensure all in-flight log() calls complete.
+   */
+  async flush(): Promise<void> {
+    await this.writeLock.catch(() => {});
+  }
+
   /** Get the file path for a given date. */
   private filePath(d: Date): string {
     return join(this.logDir, `audit-${dateToFileDate(d)}.log`);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -32,6 +32,8 @@ export interface TelegramChannelConfig {
   allowedUserIds: number[];
   topicTtlMs?: number;
   topicAutoDelete?: boolean;
+  /** Issue #1911: Outgoing Telegram API fetch timeout in ms (default: 10_000). */
+  hookTimeoutMs?: number;
 }
 
 interface SessionTopic {
@@ -665,6 +667,7 @@ export class TelegramChannel implements Channel {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(this.config.hookTimeoutMs ?? 10_000),
       });
       const data = (await res.json()) as {
         ok: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,6 +111,16 @@ export interface Config {
   /** Issue #1910: Enforce session ownership on action routes (default: true).
    *  When false, any authenticated key can operate on any session. */
   enforceSessionOwnership: boolean;
+  /** Issue #1911: SSE heartbeat interval — emit a ping after this many ms of idle (default: 120_000). Env: AEGIS_SSE_IDLE_MS */
+  sseIdleMs: number;
+  /** Issue #1911: SSE client timeout — destroy the connection if idle for this many ms (default: 300_000). Env: AEGIS_SSE_CLIENT_TIMEOUT_MS */
+  sseClientTimeoutMs: number;
+  /** Issue #1911: Outgoing hook/webhook fetch timeout in ms (default: 10_000). Env: AEGIS_HOOK_TIMEOUT_MS */
+  hookTimeoutMs: number;
+  /** Issue #1911: Shutdown grace period — how long app.close() waits for in-flight requests (default: 15_000). Env: AEGIS_SHUTDOWN_GRACE_MS */
+  shutdownGraceMs: number;
+  /** Issue #1911: Hard shutdown cap — max ms to wait for audit flush before process.exit (default: 20_000). Env: AEGIS_SHUTDOWN_HARD_MS */
+  shutdownHardMs: number;
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -159,6 +169,11 @@ const defaults: Config = {
   envDenylist: [],
   envAdminAllowlist: [],
   enforceSessionOwnership: true,
+  sseIdleMs: 120_000,
+  sseClientTimeoutMs: 300_000,
+  hookTimeoutMs: 10_000,
+  shutdownGraceMs: 15_000,
+  shutdownHardMs: 20_000,
 };
 
 /** Parse CLI args for --config flag */
@@ -233,7 +248,12 @@ type NumericConfigEnvKey =
   | 'tgTopicTTLHours'
   | 'sseMaxConnections'
   | 'sseMaxPerIp'
-  | 'pipelineStageTimeoutMs';
+  | 'pipelineStageTimeoutMs'
+  | 'sseIdleMs'
+  | 'sseClientTimeoutMs'
+  | 'hookTimeoutMs'
+  | 'shutdownGraceMs'
+  | 'shutdownHardMs';
 
 const MAX_ENV_INT = Number.MAX_SAFE_INTEGER;
 
@@ -247,6 +267,11 @@ const numericEnvBounds: Record<NumericConfigEnvKey, { min: number; max: number }
   sseMaxConnections: { min: 1, max: MAX_ENV_INT },
   sseMaxPerIp: { min: 1, max: MAX_ENV_INT },
   pipelineStageTimeoutMs: { min: 0, max: MAX_ENV_INT },
+  sseIdleMs: { min: 1_000, max: MAX_ENV_INT },
+  sseClientTimeoutMs: { min: 1_000, max: MAX_ENV_INT },
+  hookTimeoutMs: { min: 100, max: MAX_ENV_INT },
+  shutdownGraceMs: { min: 100, max: MAX_ENV_INT },
+  shutdownHardMs: { min: 100, max: MAX_ENV_INT },
 };
 
 function parseNumericEnvOverride(
@@ -311,6 +336,11 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_PIPELINE_STAGE_TIMEOUT_MS', manus: 'MANUS_PIPELINE_STAGE_TIMEOUT_MS', key: 'pipelineStageTimeoutMs' },
     { aegis: 'AEGIS_HOOK_SECRET_HEADER_ONLY', manus: 'MANUS_HOOK_SECRET_HEADER_ONLY', key: 'hookSecretHeaderOnly' },
     { aegis: 'AEGIS_ENFORCE_SESSION_OWNERSHIP', manus: '', key: 'enforceSessionOwnership' },
+    { aegis: 'AEGIS_SSE_IDLE_MS', manus: '', key: 'sseIdleMs' },
+    { aegis: 'AEGIS_SSE_CLIENT_TIMEOUT_MS', manus: '', key: 'sseClientTimeoutMs' },
+    { aegis: 'AEGIS_HOOK_TIMEOUT_MS', manus: '', key: 'hookTimeoutMs' },
+    { aegis: 'AEGIS_SHUTDOWN_GRACE_MS', manus: '', key: 'shutdownGraceMs' },
+    { aegis: 'AEGIS_SHUTDOWN_HARD_MS', manus: '', key: 'shutdownHardMs' },
   ];
 
   for (const { aegis, manus, key } of envMappings) {
@@ -329,6 +359,11 @@ function applyEnvOverrides(config: Config): Config {
       case 'sseMaxConnections':
       case 'sseMaxPerIp':
       case 'pipelineStageTimeoutMs':
+      case 'sseIdleMs':
+      case 'sseClientTimeoutMs':
+      case 'hookTimeoutMs':
+      case 'shutdownGraceMs':
+      case 'shutdownHardMs':
         config[key] = parseNumericEnvOverride(envName, value, config[key], numericEnvBounds[key]);
         break;
       case 'hookSecretHeaderOnly':

--- a/src/events.ts
+++ b/src/events.ts
@@ -34,7 +34,7 @@ export interface VerificationResult {
 }
 
 export interface GlobalSSEEvent {
-  event: 'session_status_change' | 'session_message' | 'session_approval' | 'session_ended' | 'session_created' | 'session_stall' | 'session_dead' | 'session_subagent_start' | 'session_subagent_stop' | 'session_verification';
+  event: 'session_status_change' | 'session_message' | 'session_approval' | 'session_ended' | 'session_created' | 'session_stall' | 'session_dead' | 'session_subagent_start' | 'session_subagent_stop' | 'session_verification' | 'shutdown';
   sessionId: string;
   timestamp: string;
   data: Record<string, unknown>;
@@ -435,6 +435,20 @@ export class SessionEventBus {
   /** Get global events emitted after the given event ID (Issue #301). */
   getGlobalEventsSince(lastEventId: number): Array<{ id: number; event: GlobalSSEEvent }> {
     return this.globalEventBuffer.toArray().filter(e => e.id > lastEventId);
+  }
+
+  /** Issue #1911: Broadcast a final shutdown frame to all active global SSE subscribers.
+   *  Called during graceful shutdown before app.close() so connected clients receive
+   *  the event and can reconnect/exit gracefully. */
+  emitShutdown(): void {
+    if (!this.globalEmitter) return;
+    const shutdownEvent: GlobalSSEEvent = {
+      event: 'shutdown',
+      sessionId: '',
+      timestamp: new Date().toISOString(),
+      data: {},
+    };
+    this.globalEmitter.emit('event', shutdownEvent);
   }
 
   /** #398: Clean up per-session state (call when session is killed). */

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -56,6 +56,8 @@ export interface RouteContext {
   requestKeyMap: Map<string, string>;
   /** Validate workDir against allowed dirs config */
   validateWorkDir: (workDir: string) => Promise<string | { error: string; code: string }>;
+  /** Issue #1911: Mutable server draining state — flipped to true before app.close() during graceful shutdown. */
+  serverState: { draining: boolean };
 }
 
 /**

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -79,7 +79,7 @@ export function registerEventRoutes(app: FastifyInstance, ctx: RouteContext): vo
       }
     }
 
-    writer.startHeartbeat(30_000, 90_000, () =>
+    writer.startHeartbeat(ctx.config.sseIdleMs, ctx.config.sseClientTimeoutMs, () =>
       `data: ${JSON.stringify({ event: 'heartbeat', timestamp: new Date().toISOString() })}\n\n`
     );
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -18,10 +18,21 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
   } as const;
 
   // Health — Issue #397: includes tmux server health check
+  // Issue #1911: returns 'draining' when server is shutting down
   async function healthHandler(): Promise<Record<string, unknown>> {
     const pkg = await import('../../package.json', { with: { type: 'json' } });
     const activeCount = sessions.listSessions().length;
     const totalCount = metrics.getTotalSessionsCreated();
+    if (ctx.serverState.draining) {
+      return {
+        status: 'draining',
+        version: pkg.default.version,
+        platform: process.platform,
+        uptime: process.uptime(),
+        sessions: { active: activeCount, total: totalCount },
+        timestamp: new Date().toISOString(),
+      };
+    }
     const tmuxHealth = await tmux.isServerHealthy();
     const status = tmuxHealth.healthy ? 'ok' : 'degraded';
     return {

--- a/src/routes/session-data.ts
+++ b/src/routes/session-data.ts
@@ -219,7 +219,7 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
       }
     }
 
-    writer.startHeartbeat(30_000, 90_000, () =>
+    writer.startHeartbeat(ctx.config.sseIdleMs, ctx.config.sseClientTimeoutMs, () =>
       `data: ${JSON.stringify({ event: 'heartbeat', sessionId: session.id, timestamp: new Date().toISOString() })}\n\n`
     );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -531,6 +531,7 @@ function registerChannels(cfg: Config): void {
       allowedUserIds: cfg.tgAllowedUsers,
       topicTtlMs: cfg.tgTopicTtlMs,
       topicAutoDelete: cfg.tgTopicAutoDelete,
+      hookTimeoutMs: cfg.hookTimeoutMs,
     }));
   }
 
@@ -678,7 +679,7 @@ async function main(): Promise<void> {
   auth.setAuditLogger(auditLogger);
 
   // Issue #1418: Initialize production alerting
-  alertManager = new AlertManager(config.alerting);
+  alertManager = new AlertManager({ ...config.alerting, hookTimeoutMs: config.hookTimeoutMs });
   if (config.alerting.webhooks.length > 0) {
     logger.info({
       component: 'server',
@@ -801,11 +802,14 @@ async function main(): Promise<void> {
   swarmMonitor = new SwarmMonitor(sessions);
   toolRegistry = new ToolRegistry();
 
+  const serverState = { draining: false };
+
   const routeCtx: RouteContext = {
     sessions, tmux, auth, config, metrics, monitor, eventBus, channels,
     jsonlWatcher, pipelines, toolRegistry, getAuditLogger: () => auditLogger,
     alertManager, swarmMonitor, sseLimiter, memoryBridge, requestKeyMap,
     validateWorkDir: validateWorkDirWithConfig,
+    serverState,
   };
   registerHealthRoutes(app, routeCtx);
   registerAuthRoutes(app, routeCtx);
@@ -836,7 +840,10 @@ async function main(): Promise<void> {
   // Issue #361: Graceful shutdown handler
   // Issue #415: Reentrance guard at handler level prevents double execution on rapid SIGINT
   let shuttingDown = false;
-  const shutdownTimeoutMs = parseShutdownTimeoutMs(process.env.AEGIS_SHUTDOWN_TIMEOUT_MS);
+  // Issue #1911: use config values for shutdown timeouts; fall back to legacy env var for compat.
+  const shutdownTimeoutMs = config.shutdownHardMs > 0
+    ? config.shutdownHardMs
+    : parseShutdownTimeoutMs(process.env.AEGIS_SHUTDOWN_TIMEOUT_MS);
   async function gracefulShutdown(signal: string): Promise<void> {
     logger.info({
       component: 'server',
@@ -857,9 +864,16 @@ async function main(): Promise<void> {
 
     try {
 
-      // 1. Stop accepting new requests
+      // 1. Flip health to draining and broadcast shutdown SSE frame
+      serverState.draining = true;
+      eventBus.emitShutdown();
+
+      // 2. Stop accepting new requests (waits up to shutdownGraceMs for in-flight requests)
       try {
-        await app.close();
+        await Promise.race([
+          app.close(),
+          new Promise<void>(resolve => setTimeout(resolve, config.shutdownGraceMs)),
+        ]);
       } catch (e) {
         logger.error({
           component: 'server',
@@ -1002,6 +1016,22 @@ async function main(): Promise<void> {
 
       // 7. Cleanup PID file
       removePidFile(pidFilePath);
+
+      // 8. Issue #1911: Flush pending audit log writes with a hard cap of shutdownHardMs
+      try {
+        const auditFlushMs = Math.max(0, shutdownTimeoutMs - 1_000);
+        await Promise.race([
+          auditLogger?.flush() ?? Promise.resolve(),
+          new Promise<void>(resolve => setTimeout(resolve, auditFlushMs)),
+        ]);
+      } catch (e) {
+        logger.error({
+          component: 'server',
+          operation: 'graceful_shutdown_flush_audit',
+          errorCode: 'SHUTDOWN_FLUSH_AUDIT_FAILED',
+          attributes: { error: e instanceof Error ? e.message : String(e) },
+        });
+      }
 
       logger.info({
         component: 'server',


### PR DESCRIPTION
## Summary

Implements ADR-0021: SSE idle timeout and HTTP drain on shutdown.

### Changes

- **config.ts**: add five new knobs with \AEGIS_*\ env overrides
  - \AEGIS_SSE_IDLE_MS\ (default 120 000) — heartbeat interval
  - \AEGIS_SSE_CLIENT_TIMEOUT_MS\ (default 300 000) — idle destroy timeout
  - \AEGIS_HOOK_TIMEOUT_MS\ (default 10 000) — outgoing hook fetch timeout
  - \AEGIS_SHUTDOWN_GRACE_MS\ (default 15 000) — app.close() grace window
  - \AEGIS_SHUTDOWN_HARD_MS\ (default 20 000) — hard shutdown cap / force-exit timer
- **routes/events.ts, routes/session-data.ts**: replace hardcoded \30_000 / 90_000\ with \config.sseIdleMs / config.sseClientTimeoutMs\
- **channels/telegram.ts**: add \AbortSignal.timeout(hookTimeoutMs)\ to Telegram API fetch
- **alerting.ts**: make hook timeout configurable via \AlertingConfig.hookTimeoutMs\
- **audit.ts**: add \lush()\ public method to await writeLock during graceful shutdown
- **events.ts**: add \'shutdown'\ to \GlobalSSEEvent\ union; add \mitShutdown()\ to \SessionEventBus\
- **api-contracts.ts**: add \'shutdown'\ to \GlobalSSEEventType\ (keeps contract typecheck passing)
- **routes/context.ts**: add \serverState: { draining: boolean }\ to \RouteContext\
- **routes/health.ts**: return \status: 'draining'\ when \serverState.draining\ is true (skip tmux health check during drain)
- **server.ts**: create \serverState\; \gracefulShutdown()\ now:
  1. Flips \serverState.draining = true\
  2. Broadcasts \vent: shutdown\ to all global SSE subscribers
  3. Races \pp.close()\ against \shutdownGraceMs\
  4. Uses \shutdownHardMs\ as the force-exit timer cap
  5. Flushes audit log before \process.exit(0)\
- **docs/deployment.md**: documents all five new \AEGIS_*\ env vars

### Tests

New file \src/__tests__/sse-drain-1911.test.ts\ (10 tests):
- SSEWriter emits heartbeat at configured \sseIdleMs\ interval
- SSEWriter destroys connection after \sseClientTimeoutMs\ idle
- \SessionEventBus.emitShutdown()\ delivers to all global subscribers
- \SessionEventBus.emitShutdown()\ is safe no-op when no subscribers
- \AuditLogger.flush()\ resolves when no pending writes
- Config defaults for all five #1911 fields
- Three env var override tests

Gate: \
px tsc --noEmit\ ✓ · \
pm run build\ ✓ · \
pm test\ 3099 passed ✓

## Aegis version
**Developed with:** v0.5.3-alpha

Closes #1911