### PR TITLE
feat: complete SSE shutdown sequence (graceful drain, draining health, audit flush) (#1911)

### DIFF
--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -31,6 +31,7 @@ const EVENT_META: Record<GlobalSSEEventType, { icon: typeof Activity; label: str
   session_subagent_start: { icon: Users, label: 'Subagent', color: 'var(--color-accent)' },
   session_subagent_stop: { icon: UserCheck, label: 'Subagent Done', color: 'var(--color-success)' },
   session_verification: { icon: ShieldAlert, label: 'Verification', color: 'var(--color-info)' },
+  shutdown: { icon: Power, label: 'Shutdown', color: 'var(--color-accent)' },
 };
 
 export function safeStr(val: unknown, fallback: string = 'unknown'): string {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,6 +19,11 @@ This guide covers deploying Aegis in development, CI/CD, and production environm
 | `AEGIS_DATA_DIR` | No | `~/.aegis` | Session data storage |
 | `AEGIS_DASHBOARD_URL` | No | `http://localhost:9100/dashboard` | Dashboard URL |
 | `CLAUDE_DATA_DIR` | No | `~/.claude` | Claude Code data directory |
+| `AEGIS_SSE_IDLE_MS` | No | `120000` | SSE heartbeat interval — emit a `:ping` comment after this many ms of write-idle silence (Issue #1911) |
+| `AEGIS_SSE_CLIENT_TIMEOUT_MS` | No | `300000` | SSE client idle timeout — destroy the connection if no event is sent for this many ms (Issue #1911) |
+| `AEGIS_HOOK_TIMEOUT_MS` | No | `10000` | Outgoing webhook / hook fetch timeout in ms; timed-out deliveries are pushed to the dead-letter queue (Issue #1911) |
+| `AEGIS_SHUTDOWN_GRACE_MS` | No | `15000` | Grace period in ms for `app.close()` to drain in-flight HTTP requests on SIGTERM/SIGINT (Issue #1911) |
+| `AEGIS_SHUTDOWN_HARD_MS` | No | `20000` | Hard cap in ms for the entire graceful shutdown sequence; `process.exit(1)` is called if exceeded (Issue #1911) |
 
 ## Quick Start
 

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -273,6 +273,7 @@ async function buildTestServer(): Promise<{
     sseLimiter,
     memoryBridge: null,
     requestKeyMap: new Map(),
+    serverState: { draining: false },
     validateWorkDir: async (wd: string) => wd,
   };
 

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -146,6 +146,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     sseLimiter,
     memoryBridge: null,
     requestKeyMap,
+    serverState: { draining: false },
     validateWorkDir: async (wd: string) => wd,
   };
 

--- a/src/alerting.ts
+++ b/src/alerting.ts
@@ -30,8 +30,8 @@ export interface AlertingConfig {
   /** Number of consecutive failures before triggering an alert. */
   failureThreshold: number;
   /** Cooldown period in ms between alerts for the same type. */
-  cooldownMs: number;
-}
+  cooldownMs: number;  /** Issue #1911: Outgoing alert webhook fetch timeout in ms (default: 10_000). Env: AEGIS_HOOK_TIMEOUT_MS */
+  hookTimeoutMs: number;}
 
 /** Per-type failure tracking state. */
 interface FailureTracker {
@@ -44,6 +44,7 @@ const DEFAULT_CONFIG: AlertingConfig = {
   webhooks: [],
   failureThreshold: 5,
   cooldownMs: 10 * 60 * 1000,
+  hookTimeoutMs: 10_000,
 };
 
 export class AlertManager {
@@ -204,7 +205,7 @@ export class AlertManager {
         'X-Aegis-Alert-Type': alertType,
       },
       body,
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(this.config.hookTimeoutMs),
     });
 
     if (!res.ok) {

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -195,7 +195,9 @@ export type GlobalSSEEventType =
   | 'session_dead'
   | 'session_subagent_start'
   | 'session_subagent_stop'
-  | 'session_verification';
+  | 'session_verification'
+  /** Issue #1911: Emitted to all global SSE subscribers during graceful shutdown. */
+  | 'shutdown';
 
 export interface GlobalSSEEvent {
   event: GlobalSSEEventType;

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -162,6 +162,14 @@ export class AuditLogger {
     }
   }
 
+  /**
+   * Flush pending audit writes — awaits the current write lock.
+   * Safe to call during graceful shutdown to ensure all in-flight log() calls complete.
+   */
+  async flush(): Promise<void> {
+    await this.writeLock.catch(() => {});
+  }
+
   /** Get the file path for a given date. */
   private filePath(d: Date): string {
     return join(this.logDir, `audit-${dateToFileDate(d)}.log`);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -32,6 +32,8 @@ export interface TelegramChannelConfig {
   allowedUserIds: number[];
   topicTtlMs?: number;
   topicAutoDelete?: boolean;
+  /** Issue #1911: Outgoing Telegram API fetch timeout in ms (default: 10_000). */
+  hookTimeoutMs?: number;
 }
 
 interface SessionTopic {
@@ -665,6 +667,7 @@ export class TelegramChannel implements Channel {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(this.config.hookTimeoutMs ?? 10_000),
       });
       const data = (await res.json()) as {
         ok: boolean;

--- a/src/events.ts
+++ b/src/events.ts
@@ -34,7 +34,7 @@ export interface VerificationResult {
 }
 
 export interface GlobalSSEEvent {
-  event: 'session_status_change' | 'session_message' | 'session_approval' | 'session_ended' | 'session_created' | 'session_stall' | 'session_dead' | 'session_subagent_start' | 'session_subagent_stop' | 'session_verification';
+  event: 'session_status_change' | 'session_message' | 'session_approval' | 'session_ended' | 'session_created' | 'session_stall' | 'session_dead' | 'session_subagent_start' | 'session_subagent_stop' | 'session_verification' | 'shutdown';
   sessionId: string;
   timestamp: string;
   data: Record<string, unknown>;
@@ -435,6 +435,20 @@ export class SessionEventBus {
   /** Get global events emitted after the given event ID (Issue #301). */
   getGlobalEventsSince(lastEventId: number): Array<{ id: number; event: GlobalSSEEvent }> {
     return this.globalEventBuffer.toArray().filter(e => e.id > lastEventId);
+  }
+
+  /** Issue #1911: Broadcast a final shutdown frame to all active global SSE subscribers.
+   *  Called during graceful shutdown before app.close() so connected clients receive
+   *  the event and can reconnect/exit gracefully. */
+  emitShutdown(): void {
+    if (!this.globalEmitter) return;
+    const shutdownEvent: GlobalSSEEvent = {
+      event: 'shutdown',
+      sessionId: '',
+      timestamp: new Date().toISOString(),
+      data: {},
+    };
+    this.globalEmitter.emit('event', shutdownEvent);
   }
 
   /** #398: Clean up per-session state (call when session is killed). */

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -56,6 +56,8 @@ export interface RouteContext {
   requestKeyMap: Map<string, string>;
   /** Validate workDir against allowed dirs config */
   validateWorkDir: (workDir: string) => Promise<string | { error: string; code: string }>;
+  /** Issue #1911: Mutable server draining state — flipped to true before app.close() during graceful shutdown. */
+  serverState: { draining: boolean };
 }
 
 /**

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -18,10 +18,21 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
   } as const;
 
   // Health — Issue #397: includes tmux server health check
+  // Issue #1911: returns 'draining' when server is shutting down
   async function healthHandler(): Promise<Record<string, unknown>> {
     const pkg = await import('../../package.json', { with: { type: 'json' } });
     const activeCount = sessions.listSessions().length;
     const totalCount = metrics.getTotalSessionsCreated();
+    if (ctx.serverState.draining) {
+      return {
+        status: 'draining',
+        version: pkg.default.version,
+        platform: process.platform,
+        uptime: process.uptime(),
+        sessions: { active: activeCount, total: totalCount },
+        timestamp: new Date().toISOString(),
+      };
+    }
     const tmuxHealth = await tmux.isServerHealthy();
     const status = tmuxHealth.healthy ? 'ok' : 'degraded';
     return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -531,6 +531,7 @@ function registerChannels(cfg: Config): void {
       allowedUserIds: cfg.tgAllowedUsers,
       topicTtlMs: cfg.tgTopicTtlMs,
       topicAutoDelete: cfg.tgTopicAutoDelete,
+      hookTimeoutMs: cfg.hookTimeoutMs,
     }));
   }
 
@@ -678,7 +679,7 @@ async function main(): Promise<void> {
   auth.setAuditLogger(auditLogger);
 
   // Issue #1418: Initialize production alerting
-  alertManager = new AlertManager(config.alerting);
+  alertManager = new AlertManager({ ...config.alerting, hookTimeoutMs: config.hookTimeoutMs });
   if (config.alerting.webhooks.length > 0) {
     logger.info({
       component: 'server',
@@ -801,11 +802,14 @@ async function main(): Promise<void> {
   swarmMonitor = new SwarmMonitor(sessions);
   toolRegistry = new ToolRegistry();
 
+  const serverState = { draining: false };
+
   const routeCtx: RouteContext = {
     sessions, tmux, auth, config, metrics, monitor, eventBus, channels,
     jsonlWatcher, pipelines, toolRegistry, getAuditLogger: () => auditLogger,
     alertManager, swarmMonitor, sseLimiter, memoryBridge, requestKeyMap,
     validateWorkDir: validateWorkDirWithConfig,
+    serverState,
   };
   registerHealthRoutes(app, routeCtx);
   registerAuthRoutes(app, routeCtx);
@@ -836,7 +840,10 @@ async function main(): Promise<void> {
   // Issue #361: Graceful shutdown handler
   // Issue #415: Reentrance guard at handler level prevents double execution on rapid SIGINT
   let shuttingDown = false;
-  const shutdownTimeoutMs = parseShutdownTimeoutMs(process.env.AEGIS_SHUTDOWN_TIMEOUT_MS);
+  // Issue #1911: use config values for shutdown timeouts; fall back to legacy env var for compat.
+  const shutdownTimeoutMs = config.shutdownHardMs > 0
+    ? config.shutdownHardMs
+    : parseShutdownTimeoutMs(process.env.AEGIS_SHUTDOWN_TIMEOUT_MS);
   async function gracefulShutdown(signal: string): Promise<void> {
     logger.info({
       component: 'server',
@@ -857,9 +864,16 @@ async function main(): Promise<void> {
 
     try {
 
-      // 1. Stop accepting new requests
+      // 1. Flip health to draining and broadcast shutdown SSE frame
+      serverState.draining = true;
+      eventBus.emitShutdown();
+
+      // 2. Stop accepting new requests (waits up to shutdownGraceMs for in-flight requests)
       try {
-        await app.close();
+        await Promise.race([
+          app.close(),
+          new Promise<void>(resolve => setTimeout(resolve, config.shutdownGraceMs)),
+        ]);
       } catch (e) {
         logger.error({
           component: 'server',
@@ -1002,6 +1016,22 @@ async function main(): Promise<void> {
 
       // 7. Cleanup PID file
       removePidFile(pidFilePath);
+
+      // 8. Issue #1911: Flush pending audit log writes with a hard cap of shutdownHardMs
+      try {
+        const auditFlushMs = Math.max(0, shutdownTimeoutMs - 1_000);
+        await Promise.race([
+          auditLogger?.flush() ?? Promise.resolve(),
+          new Promise<void>(resolve => setTimeout(resolve, auditFlushMs)),
+        ]);
+      } catch (e) {
+        logger.error({
+          component: 'server',
+          operation: 'graceful_shutdown_flush_audit',
+          errorCode: 'SHUTDOWN_FLUSH_AUDIT_FAILED',
+          attributes: { error: e instanceof Error ? e.message : String(e) },
+        });
+      }
 
       logger.info({
         component: 'server',


### PR DESCRIPTION
## What
Completes the SSE shutdown sequence that was partially merged via PR #1971. The shutdown sequence ensures:

1. **Graceful drain**: `serverState.draining` is flipped before shutdown; health endpoint returns `status:'draining'`
2. **SSE shutdown frame**: All SSE clients receive a final `event: shutdown` frame before connections close
3. **Shutdown timeout**: `app.close()` is raced against `shutdownGraceMs` (15s); if it exceeds, hard exit after `shutdownHardMs` (20s)
4. **Audit flush**: Audit log write buffer is flushed before process exits
5. **Hook timeout**: Telegram webhooks and alerting hooks fail fast with `AbortSignal.timeout(hookTimeoutMs)` instead of hanging

## Verification
```
npm run gate  ✓  (3093 tests passed)
```

## Files changed
- `src/server.ts` — gracefulShutdown() with serverState, drain race, audit flush
- `src/routes/health.ts` — status:'draining' when serverState.draining
- `src/audit.ts` — add flush() for shutdown
- `src/routes/context.ts` — add serverState:{draining} to RouteContext
- `src/events.ts` — add 'shutdown' event + emitShutdown()
- `src/api-contracts.ts` — add 'shutdown' to GlobalSSEEventType
- `src/alerting.ts` — make hookTimeoutMs configurable (was 5000ms hardcoded)
- `src/channels/telegram.ts` — AbortSignal.timeout(hookTimeoutMs)
- `docs/deployment.md` — document AEGIS_SHUTDOWN_GRACE_MS, AEGIS_SHUTDOWN_HARD_MS, AEGIS_HOOK_TIMEOUT_MS

## Issue
#1911
