### PR TITLE
test(dashboard): add OverviewPage test coverage

### DIFF
--- a/dashboard/src/__tests__/OverviewPage.test.tsx
+++ b/dashboard/src/__tests__/OverviewPage.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import OverviewPage from '../pages/OverviewPage';
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+vi.mock('../components/overview/MetricCards', () => ({
+  default: () => <div data-testid="metric-cards">MetricCards</div>,
+}));
+
+vi.mock('../components/overview/MetricsPanel', () => ({
+  default: () => <div data-testid="metrics-panel">MetricsPanel</div>,
+}));
+
+vi.mock('../components/overview/SessionTable', () => ({
+  default: () => <div data-testid="session-table">SessionTable</div>,
+}));
+
+vi.mock('../components/ActivityStream', () => ({
+  default: () => <div data-testid="activity-stream">ActivityStream</div>,
+}));
+
+vi.mock('../components/CreateSessionModal', () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="create-session-modal">
+        <button onClick={onClose}>Close Modal</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../components/shared/LiveStatusIndicator', () => ({
+  default: () => <span data-testid="live-status">Live</span>,
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function renderPage(): void {
+  render(
+    <MemoryRouter>
+      <OverviewPage />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('OverviewPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the Overview heading', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeDefined();
+    });
+  });
+
+  it('renders subtitle text', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Aegis session monitoring and metrics/)).toBeDefined();
+    });
+  });
+
+  it('renders the New Session button', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('New Session')).toBeDefined();
+    });
+  });
+
+  it('renders all child components', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-panel')).toBeDefined();
+      expect(screen.getByTestId('metric-cards')).toBeDefined();
+      expect(screen.getByTestId('session-table')).toBeDefined();
+      expect(screen.getByTestId('activity-stream')).toBeDefined();
+      expect(screen.getByTestId('live-status')).toBeDefined();
+    });
+  });
+
+  it('renders the Sessions section heading', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Sessions')).toBeDefined();
+    });
+  });
+
+  it('opens create session modal when New Session button is clicked', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('New Session')).toBeDefined();
+    });
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    fireEvent.click(screen.getByText('New Session'));
+    await waitFor(() => {
+      expect(screen.getByTestId('create-session-modal')).toBeDefined();
+    });
+  });
+
+  it('closes the modal when onClose is called', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('New Session')).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('New Session'));
+    await waitFor(() => {
+      expect(screen.getByTestId('create-session-modal')).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('Close Modal'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    });
+  });
+
+  it('opens modal on "n" key press', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeDefined();
+    });
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    fireEvent.keyDown(window, { key: 'n' });
+    await waitFor(() => {
+      expect(screen.getByTestId('create-session-modal')).toBeDefined();
+    });
+  });
+
+  it('does not open modal on "n" with modifier keys', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeDefined();
+    });
+    fireEvent.keyDown(window, { key: 'n', ctrlKey: true });
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    fireEvent.keyDown(window, { key: 'n', metaKey: true });
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    fireEvent.keyDown(window, { key: 'n', altKey: true });
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+  });
+
+  it('does not open modal when typing in an input', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeDefined();
+    });
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'n' });
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    document.body.removeChild(input);
+  });
+
+  it('does not open modal when typing in a textarea', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeDefined();
+    });
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    fireEvent.focus(textarea);
+    fireEvent.keyDown(textarea, { key: 'n' });
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    document.body.removeChild(textarea);
+  });
+
+  it('cleans up keydown listener on unmount', async () => {
+    const { unmount } = render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeDefined();
+    });
+    unmount();
+    fireEvent.keyDown(window, { key: 'n' });
+    // Modal should not appear since listener was removed
+    expect(screen.queryByTestId('create-session-modal')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

12 Vitest tests for OverviewPage component:
- Renders heading, subtitle, New Session button
- Renders child components (MetricCards, MetricsPanel, SessionTable, ActivityStream, LiveStatusIndicator)
- Opens/closes CreateSessionModal via button click
- Keyboard shortcut n opens modal, ignores with Ctrl/Meta/Alt modifiers
- Ignores n key when focus is in input or textarea

**Tests:** 12 new tests, all pass.
**Build:** passes