### PR TITLE
fix: add dashboard shutdown SSE mapping after accidental merge

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -297,6 +297,7 @@ const GlobalSSEEventType = z.enum([
   'session_subagent_start',
   'session_subagent_stop',
   'session_verification',
+  'shutdown',
 ]);
 
 export const GlobalSSEEventSchema = z.object({

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -87,6 +87,8 @@ export function describeEvent(event: GlobalSSEEvent): string {
       return `Subagent finished: ${safeStr(d.name)}`;
     case 'session_verification':
       return `Verification: ${safeStr(d.summary ?? d.status, 'completed')}`;
+    case 'shutdown':
+      return 'Server is shutting down';
     default:
       return safeDisplayJson(d);
   }


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.5.3-alpha

## What
Re-opens the dashboard follow-up fix after the previous PR was merged by mistake without preserving this branch context. This patch ensures the dashboard fully supports the shutdown global SSE event added by the backend.

- add shutdown to dashboard zod enum for GlobalSSEEventType
- add shutdown metadata entry in ActivityStream event map
- keep shutdown event rendering in activity descriptions

## Verification
- npm --prefix dashboard run typecheck
- npx tsc --noEmit
- npm test
