### PR TITLE
feat(ci): add npm Sigstore attestation to release pipeline (Phase 1.8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,81 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  generate-predicate:
+    needs: [publish-npm, generate-checksums]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: checksums
+          path: /tmp
+      - name: Generate attestation predicate
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          CHECKSUM=$(grep '.tgz$' /tmp/checksums.txt | awk '{print $1}')
+          cat > /tmp/predicate.json << EOF
+          {
+            "packageName": "@onestepat4time/aegis",
+            "version": "${TAG#v}",
+            "digest": "sha256:${CHECKSUM}",
+            "registry": "registry.npmjs.org",
+            "workflow": "https://github.com/OneStepAt4time/aegis/.github/workflows/release.yml"
+          }
+          EOF
+          cat /tmp/predicate.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: predicate
+          path: /tmp/predicate.json
+          retention-days: 365
+
+  attest-npm:
+    needs: [generate-predicate, ensure-github-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - uses: actions/download-artifact@v8
+        with:
+          name: package
+          path: /tmp
+      - uses: actions/download-artifact@v8
+        with:
+          name: predicate
+          path: /tmp
+      - name: Attest npm package with Sigstore
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE=$(ls /tmp/onestepat4time-aegis-*.tgz | head -1)
+          cosign attest-blob \
+            --yes \
+            --certificate-identity-regexp 'https://github.com/OneStepAt4time/aegis/.github/workflows/release\\.yml@' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --bundle /tmp/package.sigstore \
+            --predicate /tmp/predicate.json \
+            "file:///tmp/${PACKAGE##*/}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-attestation
+          path: /tmp/package.sigstore
+          retention-days: 365
+
+  attach-attestation:
+    needs: [attest-npm, ensure-github-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: npm-attestation
+          path: .
+      - name: Attach Sigstore attestation to GitHub Release
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          gh release upload "$TAG" package.sigstore --repo "$GITHUB_REPOSITORY" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-clawhub:
     needs: publish-npm
     runs-on: ubuntu-latest

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -34,27 +34,42 @@ npm pack @onestepat4time/aegis --dry-run
 
 ## Sigstore Attestations (Beta)
 
-Aegis releases include Sigstore attestations that verify the build process ran on GitHub Actions.
+Aegis releases include Sigstore attestations for npm packages, verifiable against the GitHub Actions OIDC identity.
 
 ### Install cosign
 
 ```bash
 brew install cosign  # macOS
 # or: go install github.com/sigstore/cosign/cmd/cosign@latest
+# or: curl -sSL https://raw.githubusercontent.com/sigstore/cosign/main/release/install.sh | sh
 ```
 
-### Verify an Attestation
+### Verify npm Package Attestation
+
+Download the Sigstore attestation bundle from the release assets, then verify:
 
 ```bash
-# Get the attestation digest for a release
-gh release view v0.5.3-alpha --json assets --jq '.assets[] | select(.name | contains("intoto.jsonl"))'
+# Download release assets
+gh release download v0.5.3-alpha --pattern '*.sigstore' --pattern 'checksums.txt' --dir /tmp
 
-# Verify the attestation
-cosign verify-attestation \
-  --certificate-identity-regexp="https://github.com/OneStepAt4time/aegis" \
-  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  ghcr.io/onestepat4time/aegis@v0.5.3-alpha
+# Verify the attestation against the npm registry tarball
+cosign verify-blob-attestation \
+  --certificate-identity-regexp 'https://github.com/OneStepAt4time/aegis/.github/workflows/release\\.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --bundle /tmp/package.sigstore \
+  "https://registry.npmjs.org/@onestepat4time/aegis/-/aegis-0.5.3-alpha.tgz"
 ```
+
+### What the Attestation Proves
+
+The Sigstore attestation binds the npm tarball SHA256 digest to the GitHub Actions workflow run that published it. Verification succeeds only if:
+- The bundle was signed by GitHub Actions OIDC (GITHUB_TOKEN)
+- The workflow identity matches `https://github.com/OneStepAt4time/aegis/.github/workflows/release.yml@refs/tags/v*`
+- The digest in the predicate matches the downloaded tarball
+
+### Container Images (not yet implemented)
+
+Container image signing will be added once the container build pipeline is in place.
 
 ## Verifying the GitHub Release
 


### PR DESCRIPTION
## Summary — Phase 1.8: Sigstore Attestations

Scope: npm Sigstore attestation only (container build/deploy not present in this repo — deferred to infra phase).

### What changed

.github/workflows/release.yml — three new jobs added:

1. generate-predicate — extracts SHA256 from checksums.txt, writes predicate.json with packageName/version/digest/registry/workflow, uploads artifact (365-day retention)

2. attest-npm — runs cosign attest-blob with keyless OIDC (sigstore/cosign-installer@v3), certificate identity matches release workflow, attaches DSSE envelope predicate, uploads .sigstore bundle artifact

3. attach-attestation — attaches package.sigstore bundle to GitHub Release

docs/verify-release.md — updated with npm attestation verification instructions using cosign verify-blob-attestation.

### Container signing note
Container signing (ADR-0022 Containers section) deferred — no container build step exists in this repo. Will revisit when infra team adds ghcr.io build/push.

cc @AG Argus for review