### PR TITLE
test(dashboard): add SettingsPage test coverage

### DIFF
--- a/dashboard/src/__tests__/SettingsPage.test.tsx
+++ b/dashboard/src/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SettingsPage from '../pages/SettingsPage';
+
+const STORAGE_KEY = 'aegis-dashboard-settings';
+const THEME_KEY = 'aegis-dashboard-theme';
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(Storage.prototype, 'getItem');
+    vi.spyOn(Storage.prototype, 'setItem');
+    // Mock matchMedia for useTheme hook
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderPage(): void {
+    render(<SettingsPage />);
+  }
+
+  it('renders the settings page with header and sections', () => {
+    renderPage();
+
+    expect(screen.getByText('Settings')).toBeDefined();
+    expect(screen.getByText('Dashboard preferences')).toBeDefined();
+    expect(screen.getByText('Display')).toBeDefined();
+    expect(screen.getByText('Auto-Refresh')).toBeDefined();
+  });
+
+  it('loads default settings when localStorage is empty', () => {
+    renderPage();
+
+    const pageSizeSelect = screen.getByDisplayValue('25');
+    expect(pageSizeSelect).toBeDefined();
+
+    // Auto-refresh toggle is on by default (aria-checked=true)
+    const toggle = screen.getByRole('switch');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+
+    // Refresh interval select is visible (auto-refresh is on) with default 30s
+    expect(screen.getByDisplayValue('30 seconds')).toBeDefined();
+  });
+
+  it('loads persisted settings from localStorage', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ autoRefresh: false, refreshIntervalSec: 60, defaultPageSize: 50 }),
+    );
+
+    renderPage();
+
+    expect(screen.getByDisplayValue('50')).toBeDefined();
+
+    // Auto-refresh is off — toggle should show false
+    const toggle = screen.getByRole('switch');
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+
+    // Refresh interval select should NOT be visible when auto-refresh is off
+    expect(screen.queryByText('Refresh interval')).toBeNull();
+  });
+
+  it('persists settings to localStorage on change', () => {
+    renderPage();
+
+    const pageSizeSelect = screen.getByDisplayValue('25');
+    fireEvent.change(pageSizeSelect, { target: { value: '100' } });
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      JSON.stringify({ autoRefresh: true, refreshIntervalSec: 30, defaultPageSize: 100 }),
+    );
+  });
+
+  it('toggles theme between dark and light', () => {
+    renderPage();
+
+    // Default theme depends on system preference / localStorage — find the button
+    const themeButton = screen.getByRole('button', { name: /Dark|Light/ });
+
+    // Click to toggle
+    fireEvent.click(themeButton);
+
+    // Theme is persisted via useTheme hook
+    expect(localStorage.setItem).toHaveBeenCalledWith(THEME_KEY, expect.any(String));
+  });
+
+  it('toggles auto-refresh switch off and hides refresh interval', () => {
+    renderPage();
+
+    // auto-refresh is on by default
+    expect(screen.getByText('Refresh interval')).toBeDefined();
+
+    const toggle = screen.getByRole('switch');
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+    expect(screen.queryByText('Refresh interval')).toBeNull();
+
+    // Verify persisted with autoRefresh: false
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      expect.stringContaining('"autoRefresh":false'),
+    );
+  });
+
+  it('toggles auto-refresh back on and shows refresh interval', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ autoRefresh: false, refreshIntervalSec: 60, defaultPageSize: 25 }),
+    );
+
+    renderPage();
+
+    // auto-refresh is off
+    expect(screen.queryByText('Refresh interval')).toBeNull();
+
+    const toggle = screen.getByRole('switch');
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByText('Refresh interval')).toBeDefined();
+  });
+
+  it('changes refresh interval and persists', () => {
+    renderPage();
+
+    const intervalSelect = screen.getByDisplayValue('30 seconds');
+    fireEvent.change(intervalSelect, { target: { value: '120' } });
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      JSON.stringify({ autoRefresh: true, refreshIntervalSec: 120, defaultPageSize: 25 }),
+    );
+  });
+
+  it('handles corrupt localStorage gracefully', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-valid-json');
+
+    renderPage();
+
+    // Should fall back to defaults
+    expect(screen.getByDisplayValue('25')).toBeDefined();
+    const toggle = screen.getByRole('switch');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders all page size options', () => {
+    renderPage();
+
+    const pageSizeSelect = screen.getByDisplayValue('25');
+    const options = pageSizeSelect.querySelectorAll('option');
+    const values = Array.from(options).map((o) => o.getAttribute('value'));
+
+    expect(values).toEqual(['10', '25', '50', '100']);
+  });
+
+  it('renders all refresh interval options', () => {
+    renderPage();
+
+    const intervalSelect = screen.getByDisplayValue('30 seconds');
+    const options = intervalSelect.querySelectorAll('option');
+    const values = Array.from(options).map((o) => o.getAttribute('value'));
+
+    expect(values).toEqual(['10', '30', '60', '120', '300']);
+  });
+});


### PR DESCRIPTION
## Summary

11 Vitest tests for SettingsPage component:
- Renders settings page with header, Display section, and Auto-Refresh section
- Loads default settings when localStorage is empty
- Loads persisted settings from localStorage
- Persists settings to localStorage on change
- Toggles theme between dark and light (via useTheme hook)
- Toggles auto-refresh switch off and hides refresh interval
- Toggles auto-refresh back on and shows refresh interval
- Changes refresh interval and persists
- Handles corrupt localStorage gracefully (falls back to defaults)
- Renders all page size options (10, 25, 50, 100)
- Renders all refresh interval options (10s, 30s, 1m, 2m, 5m)

**Tests:** 11 new tests, all pass.
**Build:** passes