### PR TITLE
fix: MCP auth config.json fallback and Windows idle detection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -227,7 +227,7 @@ async function main(): Promise<void> {
     if (mcpPortIdx !== -1 && mcpArgs[mcpPortIdx + 1]) {
       mcpPort = parseIntSafe(mcpArgs[mcpPortIdx + 1], 9100);
     }
-    const mcpAuth = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN;
+    const mcpAuth = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN || resolveAuthToken();
     const { startMcpServer } = await import('./mcp-server.js');
     await startMcpServer(mcpPort, mcpAuth);
     return; // stdio server runs until stdin closes

--- a/src/terminal-parser.ts
+++ b/src/terminal-parser.ts
@@ -143,7 +143,16 @@ export function detectUIState(paneText: string): UIState {
     if (/^Worked for/i.test(statusText) || /^Compacted/i.test(statusText) || /aborted/i.test(statusText)) {
       return hasPrompt ? 'idle' : 'unknown';
     }
-    // Active spinner text = working regardless of prompt
+    // Pure turn counter "4" is a stale spinner, not active work
+    if (/^\d+$/.test(statusText) && hasPrompt && hasChrome) {
+      return 'idle';
+    }
+    // Prompt + chrome separator present means CC is actually idle,
+    // even if parseStatusLine found a stale spinner from scrollback
+    if (hasPrompt && hasChrome) {
+      return 'idle';
+    }
+    // Active spinner text = working
     return 'working';
   }
 
@@ -193,6 +202,8 @@ function hasSpinnerAnywhere(lines: string[]): boolean {
       // For `*` (also a markdown bullet), require `* ` + ellipsis/dots to avoid false positives
       if (firstChar === '*') {
         if (stripped[1] !== ' ' || !(stripped.includes('…') || stripped.includes('...'))) continue;
+      } else if (firstChar === '●' && /^\d+\s*$/.test(stripped.slice(1).trim())) {
+        continue;
       } else if (!(stripped.includes('…') || stripped.includes('...') || /[^\s\u00a0]/.test(stripped.slice(1)))) {
         continue;
       }
@@ -308,11 +319,19 @@ export function parseStatusLine(paneText: string): string | null {
   // Check lines above separator for spinner
   for (let i = chromeIdx - 1; i > Math.max(chromeIdx - 10, -1); i--) {
     const line = lines[i].trim();
+    // Stop at the top chrome separator — don't scan into previous turn's scrollback
+    if (line.length >= 20 && /^─+$/.test(line)) {
+      break;
+    }
     if (!line) continue;
     if (STATUS_SPINNERS.has(line[0])) {
       // For `*`, require `* ` + ellipsis/dots to avoid matching markdown bullets
       if (line[0] === '*' && (line[1] !== ' ' || !(line.includes('…') || line.includes('...')))) {
         // Not a real spinner line — skip
+        continue;
+      }
+      // Exclude bare bullet + number (turn counter, e.g. "● 4") — not an active spinner
+      if (line[0] === '●' && /^\d+\s*$/.test(line.slice(1).trim())) {
         continue;
       }
       return line.slice(1).trim();


### PR DESCRIPTION
## Summary

Two bugs found during e2e testing of the using-aegis skill (#1973):

1. **MCP auth ignores config.json** — `cli.ts` line 230 resolved auth token from env vars only, not using the same `resolveAuthToken()` fallback chain as the REST server. MCP clients that store auth in `~/.aegis/config.json` (without env var) got auth failures.

2. **Windows idle detection false-positive** — `terminal-parser.ts` reported `working` for sessions that were actually `idle`. Three root causes:
   - `parseStatusLine` scanned past the top chrome separator into previous turn's scrollback
   - Turn counter `● 4` was misread as an active spinner
   - When prompt (`❯`) + chrome separator are both present, the session is definitely idle regardless of stale spinner text

## Aegis version
**Developed with:** v0.5.3-alpha

## Test plan
- [x] `npm run gate` passes (172 test files, 3089 tests)
- [x] Terminal-parser tests pass (74/74)
- [x] MCP auth: verified `resolveAuthToken()` is called with correct fallback chain
- [x] Idle detection: three targeted fixes verified independently

Closes #1986
Closes #1987

Generated by Hephaestus (Aegis dev agent)