### PR TITLE
fix: harden dashboard CSP and auth token storage

### DIFF
--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -450,19 +450,35 @@ describe('401 unauthorized handling (#1567)', () => {
     vi.restoreAllMocks();
   });
 
-  it('clears token and triggers unauthorized handler when API returns 401', async () => {
-    localStorage.setItem('aegis_token', 'stale-token');
+  it('uses the registered in-memory token accessor for authenticated requests', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { getPipelines, setTokenAccessor } = await import('../api/client');
+    setTokenAccessor(() => 'memory-token');
+
+    await expect(getPipelines()).resolves.toEqual([]);
+    expect(fetchMock).toHaveBeenCalledWith('/v1/pipelines', expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer memory-token',
+      }),
+    }));
+  });
+
+  it('triggers unauthorized handler when API returns 401', async () => {
     fetchMock.mockResolvedValue(new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },
     }));
 
-    const { getSessions, setUnauthorizedHandler } = await import('../api/client');
+    const { getPipelines, setTokenAccessor, setUnauthorizedHandler } = await import('../api/client');
     const onUnauthorized = vi.fn();
+    setTokenAccessor(() => 'stale-token');
     setUnauthorizedHandler(onUnauthorized);
 
-    await expect(getSessions()).rejects.toThrow('Unauthorized');
+    await expect(getPipelines()).rejects.toThrow('Unauthorized');
     expect(onUnauthorized).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem('aegis_token')).toBeNull();
   });
 });

--- a/dashboard/src/__tests__/useAuthStore.test.ts
+++ b/dashboard/src/__tests__/useAuthStore.test.ts
@@ -6,14 +6,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockVerifyToken = vi.fn();
 const mockSetUnauthorizedHandler = vi.fn();
+const mockSetTokenAccessor = vi.fn();
 
 vi.mock('../api/client', () => ({
   verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
   setUnauthorizedHandler: (...args: unknown[]) => mockSetUnauthorizedHandler(...args),
+  setTokenAccessor: (...args: unknown[]) => mockSetTokenAccessor(...args),
 }));
 
 // Lazy import so mock is in place
 import { useAuthStore } from '../store/useAuthStore';
+import { useStore } from '../store/useStore';
 
 describe('useAuthStore', () => {
   beforeEach(() => {
@@ -25,23 +28,27 @@ describe('useAuthStore', () => {
       isVerifying: false,
       lastVerifiedAt: null,
     });
+    useStore.getState().clearToken();
   });
 
   afterEach(() => {
     localStorage.removeItem('aegis_token');
+    useStore.getState().clearToken();
     vi.restoreAllMocks();
   });
 
   describe('login', () => {
-    it('stores token and sets authenticated on success', async () => {
+    it('stores token in memory and sets authenticated on success', async () => {
       mockVerifyToken.mockResolvedValue({ valid: true, role: 'admin' });
+      localStorage.setItem('aegis_token', 'legacy-token');
 
       const success = await useAuthStore.getState().login('my-token');
 
       expect(success).toBe(true);
       expect(useAuthStore.getState().token).toBe('my-token');
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
-      expect(localStorage.getItem('aegis_token')).toBe('my-token');
+      expect(useStore.getState().token).toBe('my-token');
+      expect(localStorage.getItem('aegis_token')).toBeNull();
     });
 
     it('does not store token on failure', async () => {
@@ -52,6 +59,7 @@ describe('useAuthStore', () => {
       expect(success).toBe(false);
       expect(useAuthStore.getState().token).toBeNull();
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
+      expect(useStore.getState().token).toBeNull();
       expect(localStorage.getItem('aegis_token')).toBeNull();
     });
 
@@ -62,6 +70,7 @@ describe('useAuthStore', () => {
 
       expect(success).toBe(false);
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
+      expect(useStore.getState().token).toBeNull();
     });
   });
 
@@ -77,42 +86,72 @@ describe('useAuthStore', () => {
 
       expect(useAuthStore.getState().token).toBeNull();
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
+      expect(useStore.getState().token).toBeNull();
       expect(localStorage.getItem('aegis_token')).toBeNull();
     });
   });
 
   describe('init', () => {
-    it('validates stored token and sets authenticated', async () => {
+    it('cleans up the legacy localStorage token and leaves reloads signed out', async () => {
       localStorage.setItem('aegis_token', 'stored-token');
-      mockVerifyToken.mockResolvedValue({ valid: true });
-
-      await useAuthStore.getState().init();
-
-      expect(useAuthStore.getState().token).toBe('stored-token');
-      expect(useAuthStore.getState().isAuthenticated).toBe(true);
-      expect(useAuthStore.getState().isVerifying).toBe(false);
-    });
-
-    it('clears invalid stored token', async () => {
-      localStorage.setItem('aegis_token', 'expired-token');
-      mockVerifyToken.mockResolvedValue({ valid: false });
 
       await useAuthStore.getState().init();
 
       expect(useAuthStore.getState().token).toBeNull();
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
+      expect(useAuthStore.getState().isVerifying).toBe(false);
       expect(localStorage.getItem('aegis_token')).toBeNull();
+      expect(mockVerifyToken).not.toHaveBeenCalled();
+      expect(mockSetUnauthorizedHandler).toHaveBeenCalledTimes(1);
+      expect(mockSetTokenAccessor).toHaveBeenCalledTimes(1);
     });
 
-    it('handles missing stored token without API call', async () => {
+    it('preserves an authenticated in-memory token across route changes', async () => {
+      useAuthStore.setState({
+        token: 'live-token',
+        isAuthenticated: true,
+        isVerifying: false,
+        lastVerifiedAt: Date.now(),
+      });
+
+      await useAuthStore.getState().init();
+
+      expect(useAuthStore.getState().token).toBe('live-token');
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useStore.getState().token).toBe('live-token');
+      expect(mockVerifyToken).not.toHaveBeenCalled();
+    });
+
+    it('handles missing in-memory token without API call', async () => {
       await useAuthStore.getState().init();
 
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
       expect(mockVerifyToken).not.toHaveBeenCalled();
     });
 
-    it('handles API error during init', async () => {
-      localStorage.setItem('aegis_token', 'some-token');
+    it('revalidates an in-memory token when auth state is incomplete', async () => {
+      useAuthStore.setState({
+        token: 'some-token',
+        isAuthenticated: false,
+        isVerifying: false,
+        lastVerifiedAt: null,
+      });
+      mockVerifyToken.mockResolvedValue({ valid: true, role: 'admin' });
+
+      await useAuthStore.getState().init();
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useAuthStore.getState().token).toBe('some-token');
+      expect(useStore.getState().token).toBe('some-token');
+    });
+
+    it('keeps the in-memory token on non-401 verify errors during init', async () => {
+      useAuthStore.setState({
+        token: 'some-token',
+        isAuthenticated: false,
+        isVerifying: false,
+        lastVerifiedAt: null,
+      });
       mockVerifyToken.mockRejectedValue(new Error('Server error'));
 
       await useAuthStore.getState().init();
@@ -120,6 +159,7 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().isVerifying).toBe(false);
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
       expect(useAuthStore.getState().token).toBe('some-token');
+      expect(useStore.getState().token).toBe('some-token');
     });
   });
 });

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -2,7 +2,7 @@
  * api/client.ts — Aegis API client.
  *
  * Typed fetch wrapper for all Aegis v1 endpoints.
- * Reads Bearer token from localStorage on every request.
+ * Reads Bearer token from an in-memory accessor registered by the auth store (#1924).
  */
 
 import { z } from 'zod';
@@ -68,6 +68,14 @@ export function setUnauthorizedHandler(handler: (() => void) | null): void {
   unauthorizedHandler = handler;
 }
 
+// #1924: Token is held in memory by the auth store and read via this accessor.
+// No persistence to localStorage — reduces XSS token-theft exposure.
+let tokenAccessor: (() => string | null) = () => null;
+
+export function setTokenAccessor(fn: () => string | null): void {
+  tokenAccessor = fn;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 function headersToObject(h: HeadersInit | undefined): Record<string, string> {
@@ -122,7 +130,7 @@ async function request<T>(
   path: string,
   options: RequestOptions = {},
 ): Promise<T> {
-  const token = localStorage.getItem('aegis_token');
+  const token = tokenAccessor();
   const headers: Record<string, string> = {
     ...(options.body ? { 'Content-Type': 'application/json' } : {}),
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -137,7 +145,6 @@ async function request<T>(
       const res = await fetch(`${BASE_URL}${path}`, { ...fetchOptions, headers });
       if (!res.ok) {
         if (res.status === 401) {
-          localStorage.removeItem('aegis_token');
           unauthorizedHandler?.();
           if (!unauthorizedHandler && window.location.pathname !== '/dashboard/login') {
             window.location.assign('/dashboard/login');

--- a/dashboard/src/store/useAuthStore.ts
+++ b/dashboard/src/store/useAuthStore.ts
@@ -1,9 +1,12 @@
 /**
  * store/useAuthStore.ts — Zustand store for authentication state.
+ *
+ * #1924: Token is held in memory only. Clearing on tab close / reload is
+ * intentional; users re-authenticate via the login form. See ADR-0024.
  */
 
 import { create } from 'zustand';
-import { setUnauthorizedHandler, verifyToken } from '../api/client.js';
+import { setTokenAccessor, setUnauthorizedHandler, verifyToken } from '../api/client.js';
 import { useStore } from './useStore.js';
 
 interface AuthState {
@@ -17,31 +20,49 @@ interface AuthState {
   revalidate: (force?: boolean) => Promise<boolean>;
 }
 
-const TOKEN_KEY = 'aegis_token';
+// #1924: Legacy key — kept only to purge any token that older dashboard
+// versions wrote to localStorage. Never written to after migration.
+const LEGACY_TOKEN_KEY = 'aegis_token';
 const REVALIDATE_TTL_MS = 60_000;
 
 let inFlightValidation: Promise<boolean> | null = null;
-let unauthorizedHandlerRegistered = false;
+
+function purgeLegacyToken(): void {
+  try {
+    localStorage.removeItem(LEGACY_TOKEN_KEY);
+  } catch {
+    // ignore storage access errors (e.g., disabled in browser)
+  }
+}
+
+function syncAuthToken(token: string | null): void {
+  if (token) {
+    useStore.getState().setToken(token);
+    return;
+  }
+  useStore.getState().clearToken();
+}
 
 function clearAuthState(set: (partial: Partial<AuthState>) => void): void {
-  localStorage.removeItem(TOKEN_KEY);
-  useStore.getState().clearToken();
+  purgeLegacyToken();
+  syncAuthToken(null);
   set({ token: null, isAuthenticated: false, isVerifying: false, lastVerifiedAt: null });
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
-  token: localStorage.getItem(TOKEN_KEY),
+  token: null,
   isAuthenticated: false,
   isVerifying: false,
   lastVerifiedAt: null,
 
   login: async (token: string): Promise<boolean> => {
+    purgeLegacyToken();
+
     try {
       const result = await verifyToken(token);
       if (result.valid) {
-        localStorage.setItem(TOKEN_KEY, token);
-        useStore.getState().setToken(token);
-        set({ token, isAuthenticated: true, lastVerifiedAt: Date.now() });
+        syncAuthToken(token);
+        set({ token, isAuthenticated: true, isVerifying: false, lastVerifiedAt: Date.now() });
         return true;
       }
       clearAuthState(set);
@@ -57,31 +78,39 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   init: async () => {
-    if (!unauthorizedHandlerRegistered) {
-      setUnauthorizedHandler(() => {
-        clearAuthState(set);
-      });
-      unauthorizedHandlerRegistered = true;
-    }
+    purgeLegacyToken();
 
-    const stored = localStorage.getItem(TOKEN_KEY);
-    if (!stored) {
+    setUnauthorizedHandler(() => {
+      clearAuthState(set);
+    });
+    setTokenAccessor(() => get().token);
+
+    const state = get();
+    if (!state.token) {
+      // No persisted token to restore — user must re-authenticate on reload.
       clearAuthState(set);
       return;
     }
 
-    useStore.getState().setToken(stored);
-    set({ token: stored });
+    syncAuthToken(state.token);
+
+    if (state.isAuthenticated) {
+      set({ isVerifying: false });
+      return;
+    }
+
     await get().revalidate();
   },
 
   revalidate: async (force = false): Promise<boolean> => {
     const state = get();
-    const token = state.token ?? localStorage.getItem(TOKEN_KEY);
+    const token = state.token;
     if (!token) {
       clearAuthState(set);
       return false;
     }
+
+    syncAuthToken(token);
 
     if (!force && state.lastVerifiedAt && (Date.now() - state.lastVerifiedAt) < REVALIDATE_TTL_MS) {
       return state.isAuthenticated;
@@ -96,7 +125,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       try {
         const result = await verifyToken(token);
         if (result.valid) {
-          useStore.getState().setToken(token);
+          syncAuthToken(token);
           set({ token, isAuthenticated: true, isVerifying: false, lastVerifiedAt: Date.now() });
           return true;
         }
@@ -108,7 +137,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           return false;
         }
         // Network/server errors: keep existing token and avoid hard logout.
-        useStore.getState().setToken(token);
+        syncAuthToken(token);
         set({ token, isAuthenticated: true, isVerifying: false });
         return true;
       } finally {

--- a/dashboard/src/store/useStore.ts
+++ b/dashboard/src/store/useStore.ts
@@ -117,14 +117,12 @@ export interface AppState {
 }
 
 export const useStore = create<AppState>((set) => ({
-  // Auth
-  token: localStorage.getItem('aegis_token'),
+  // Auth (#1924: in-memory only — no localStorage persistence)
+  token: null,
   setToken: (token) => {
-    localStorage.setItem('aegis_token', token);
     set({ token });
   },
   clearToken: () => {
-    localStorage.removeItem('aegis_token');
     set({ token: null });
   },
 

--- a/docs/adr/0024-dashboard-token-in-memory.md
+++ b/docs/adr/0024-dashboard-token-in-memory.md
@@ -1,0 +1,47 @@
+# ADR-0024: Dashboard API Token Stays In Memory
+
+## Status
+Accepted
+
+## Context
+
+Issue [#1924](https://github.com/OneStepAt4time/aegis/issues/1924) hardens the
+dashboard against XSS token theft. Older dashboard builds stored the long-lived
+API bearer token in `localStorage` so the SPA could survive reloads. That made
+any successful XSS bug a token-exfiltration bug.
+
+The acceptance criteria allowed either:
+
+1. an HttpOnly Secure cookie plus silent refresh, or
+2. in-memory storage with the decision captured in a short ADR.
+
+Aegis already uses bearer-token auth on the API and short-lived SSE tokens for
+EventSource subscriptions. Switching the dashboard to cookie auth now would add
+cookie issuance, CSRF handling, and reverse-proxy semantics that are unrelated
+to the immediate hardening goal.
+
+## Decision
+
+- Keep the existing bearer-token API model for dashboard requests.
+- Store the dashboard bearer token in Zustand memory only.
+- Keep the existing short-lived SSE token exchange unchanged.
+- Remove any legacy `aegis_token` entry from `localStorage` during dashboard
+  startup and never write auth tokens back to browser storage.
+- Serve the dashboard with a tighter CSP so the browser only allows the assets,
+  connections, and inline styles the current runtime needs.
+
+## Consequences
+
+- **Pros:** no auth secret at rest in browser storage; smaller change than a
+  cookie redesign; same-tab navigation keeps working; existing SSE flow stays
+  intact.
+- **Cons:** reloading the page or closing the tab clears the dashboard login and
+  requires the user to paste the API token again.
+- **Operational note:** reverse proxies must preserve the dashboard CSP header
+  and WebSocket/SSE connectivity.
+
+## Related
+
+- Issue [#1924](https://github.com/OneStepAt4time/aegis/issues/1924)
+- Issue #297 — short-lived SSE tokens
+- [ADR-0023](0023-positioning-claude-code-control-plane.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ ADRs document significant architectural decisions made during Aegis development.
 | [ADR-0021](0021-sse-and-http-drain-timeouts.md) | SSE Idle Timeout and HTTP Drain on Shutdown | Proposed | 2026-04-16 | — |
 | [ADR-0022](0022-sigstore-attestations.md) | Sigstore Attestations for npm and Container Artifacts | Proposed | 2026-04-16 | — |
 | [ADR-0023](0023-positioning-claude-code-control-plane.md) | Positioning: Claude Code Control Plane, MIT, BYO LLM, `ag` CLI | Proposed | 2026-04-16 | — |
+| [ADR-0024](0024-dashboard-token-in-memory.md) | Dashboard API Token Stays In Memory | Accepted | 2026-04-17 | #1924 |
 
 ## Creating a New ADR
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,6 +35,28 @@ node dist/server.js
 
 Visit `http://localhost:9100/dashboard/` to access the dashboard.
 
+## Dashboard Security Defaults
+
+Aegis serves `/dashboard` static assets and SPA fallback routes with a strict
+Content Security Policy:
+
+```text
+default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ws: wss: https://registry.npmjs.org; frame-ancestors 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; object-src 'none'
+```
+
+Notes:
+
+- `style-src 'unsafe-inline'` remains enabled because the current Tailwind/xterm
+  runtime injects inline styles.
+- Reverse proxies should preserve this header (or an equally strict override)
+  and must continue to allow same-origin HTTP, WebSocket, and SSE traffic. If
+  you keep dashboard update checks enabled, also allow
+  `https://registry.npmjs.org`.
+- The dashboard API token is stored in memory only. Reloading the page or
+  closing the tab clears the login session. Upgraded clients also remove any
+  legacy `aegis_token` entry from `localStorage` during startup. See
+  [ADR-0024](./adr/0024-dashboard-token-in-memory.md).
+
 ## Production Deployment
 
 ### Systemd Service

--- a/src/__tests__/content-length-static.test.ts
+++ b/src/__tests__/content-length-static.test.ts
@@ -78,4 +78,22 @@ describe('Content-Length correctness (static assets)', () => {
     expect(resAsset.statusCode).toBe(200);
     expect(Number(resAsset.headers['content-length'])).toBe(Buffer.byteLength(resAsset.body, 'utf8'));
   });
+
+  it('serves the dashboard with the hardened CSP on static and SPA fallback routes', async () => {
+    const app = capturedApp as FastifyInstance;
+
+    const staticRes = await app.inject({ method: 'GET', url: '/dashboard/index.html' });
+    expect(staticRes.statusCode).toBe(200);
+    expect(staticRes.headers['content-security-policy']).toContain("script-src 'self'");
+    expect(staticRes.headers['content-security-policy']).toContain("font-src 'self' data:");
+    expect(staticRes.headers['content-security-policy']).toContain("frame-ancestors 'none'");
+    expect(staticRes.headers['content-security-policy']).toContain("frame-src 'none'");
+    expect(staticRes.headers['content-security-policy']).toContain("base-uri 'self'");
+    expect(staticRes.headers['content-security-policy']).toContain("form-action 'self'");
+    expect(staticRes.headers['content-security-policy']).toContain("object-src 'none'");
+
+    const spaRes = await app.inject({ method: 'GET', url: '/dashboard/settings' });
+    expect(spaRes.statusCode).toBe(200);
+    expect(spaRes.headers['content-security-policy']).toBe(staticRes.headers['content-security-policy']);
+  });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,8 +97,36 @@ declare module 'fastify' {
 
 // ── Configuration ────────────────────────────────────────────────────
 
-// Issue #349: CSP policy for dashboard responses (shared between static and SPA fallback)
-const DASHBOARD_CSP = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss: https://registry.npmjs.org";
+// Issue #349 / #1924: CSP policy for dashboard responses (shared between static and SPA fallback).
+// Tightened in #1924: adds frame-ancestors, base-uri, form-action, object-src.
+// 'unsafe-inline' remains on style-src because Tailwind / xterm inject inline styles;
+// script-src deliberately excludes 'unsafe-inline' and 'unsafe-eval'.
+const DASHBOARD_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self' data:",
+  "connect-src 'self' ws: wss: https://registry.npmjs.org",
+  "frame-ancestors 'none'",
+  "frame-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join('; ');
+
+const DASHBOARD_RESPONSE_HEADERS = {
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Content-Security-Policy': DASHBOARD_CSP,
+} as const;
+
+function applyDashboardResponseHeaders(reply: FastifyReply): void {
+  for (const [header, value] of Object.entries(DASHBOARD_RESPONSE_HEADERS)) {
+    reply.header(header, value);
+  }
+}
 
 // Config loaded at startup; env vars override file values
 let config: Config;
@@ -1156,12 +1184,9 @@ async function main(): Promise<void> {
       prefix: "/dashboard/",
       // #146: Cache hashed assets aggressively, no-cache for index.html
       setHeaders: (reply, pathname) => {
-        // Security headers (#145)
-        reply.setHeader('X-Frame-Options', 'DENY');
-        reply.setHeader('X-Content-Type-Options', 'nosniff');
-        reply.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
-        // Issue #349: Content-Security-Policy for dashboard
-        reply.setHeader('Content-Security-Policy', DASHBOARD_CSP);
+        for (const [header, value] of Object.entries(DASHBOARD_RESPONSE_HEADERS)) {
+          reply.setHeader(header, value);
+        }
         // Cache control (#146)
         if (pathname === '/index.html' || pathname === '/') {
           reply.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
@@ -1188,8 +1213,7 @@ async function main(): Promise<void> {
   // SPA fallback for dashboard routes (Issue #105)
   app.setNotFoundHandler(async (req, reply) => {
     if (dashboardAvailable && (req.url === "/dashboard" || req.url?.startsWith("/dashboard/") || req.url?.startsWith("/dashboard?"))) {
-      // Issue #349: CSP header for SPA dashboard responses
-      reply.header('Content-Security-Policy', DASHBOARD_CSP);
+      applyDashboardResponseHeaders(reply);
       return reply.sendFile("index.html", dashboardRoot);
     }
     return reply.status(404).send({ error: "Not found" });


### PR DESCRIPTION
## Summary

Adds dashboard CSP response headers, switches dashboard auth to in-memory token storage, removes localStorage token usage, and documents the storage decision in an ADR.

## Aegis version

**Developed with:** v0.5.3-alpha
**Tested with:** v0.5.3-alpha

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring with no behavior change
- [ ] `perf` — Performance improvement
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling
- [ ] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

Dashboard auth state, dashboard asset response headers, and deployment/ADR documentation.

## Linked issue

Closes #1924

## Test plan

Repository gate passed (`npm run gate`).

- [x] Unit tests pass (`npm test`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Manually tested (describe below)

## Security impact

Reduces XSS token-exfiltration risk by removing persistent browser token storage and enforcing CSP for dashboard assets.