### PR TITLE
feat: promote ag as the primary CLI alias

### DIFF
--- a/.claude/skills/using-aegis/SKILL.md
+++ b/.claude/skills/using-aegis/SKILL.md
@@ -21,14 +21,14 @@ Aegis is a self-hosted HTTP server (default `http://localhost:9100`) that spawns
 
 ## Access paths
 
-- **MCP (preferred):** `create_session`, `send_message`, etc. Setup: `claude mcp add aegis -- npx @onestepat4time/aegis mcp`.
+- **MCP (preferred):** `create_session`, `send_message`, etc. Setup: `claude mcp add aegis -- ag mcp` (or `claude mcp add aegis -- npx --package=@onestepat4time/aegis ag mcp` without a global install).
 - **REST (fallback):** `http://localhost:9100/v1/*`. Add `Authorization: Bearer $AEGIS_AUTH_TOKEN` if configured.
 
 ## Bootstrap — verify availability first
 
 1. MCP host lists an `aegis` server → use MCP.
 2. Else `curl -s http://localhost:9100/v1/health` returns `ok` → use REST.
-3. Neither → ask the user to start `npx @onestepat4time/aegis`. Do **not** silently spawn it.
+3. Neither → ask the user to start `ag` (or `npx --package=@onestepat4time/aegis ag`). Do **not** silently spawn it.
 
 ## Session states
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
       label: Steps to reproduce
       description: How can we reproduce this?
       placeholder: |
-        1. Start Aegis with `npx @onestepat4time/aegis`
+        1. Start Aegis with `ag` (or `npx --package=@onestepat4time/aegis ag`)
         2. Create a session via `POST /v1/sessions`
         3. ...
     validations:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ src/
 ## Package
 
 - **Name:** `@onestepat4time/aegis`
-- **CLI binary:** `aegis` (today). `ag` becomes the primary alias in Phase 2 — see [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
-- **MCP:** `claude mcp add aegis -- npx @onestepat4time/aegis mcp`
+- **CLI binary:** `ag` (primary). `aegis` remains supported as a compatibility alias — see [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
+- **MCP:** `claude mcp add aegis -- ag mcp` (or `claude mcp add aegis -- npx --package=@onestepat4time/aegis ag mcp` without a global install)
 - **Deprecated:** `aegis-bridge` (do not use in new code)
 
 ## Positioning (read before proposing features)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Or via `.mcp.json`:
 }
 ```
 
+Without a global install, use `"command": "npx"` with `["--package=@onestepat4time/aegis", "ag", "mcp"]` instead.
+
 **25 tools** — `create_session`, `send_message`, `get_transcript`, `approve_permission`, `batch_create_sessions`, `create_pipeline`, `state_set`, and more.
 
 **4 resources** — `aegis://sessions`, `aegis://sessions/{id}/transcript`, `aegis://sessions/{id}/pane`, `aegis://health`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 
 ```bash
 # Install and start
-npx @onestepat4time/aegis
+npm install -g @onestepat4time/aegis
+ag
 
 # Create a session
 curl -X POST http://localhost:9100/v1/sessions \
@@ -43,6 +44,8 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/send \
   -d '{"text": "Add form validation: email must contain @, password min 8 chars."}'
 ```
 
+> **CLI naming:** the primary command is `ag` (e.g. `ag`, `ag mcp`, `ag create "brief"`). The legacy name `aegis` is preserved as an alias, so any existing scripts using `aegis` keep working.
+
 > **Prerequisites:** [tmux](https://github.com/tmux/tmux) and [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code).
 
 ### Windows Setup
@@ -51,7 +54,8 @@ On Windows, use psmux as the tmux-compatible backend before starting Aegis.
 
 ```powershell
 choco install psmux -y
-npx @onestepat4time/aegis
+npm install -g @onestepat4time/aegis
+ag
 ```
 
 For full setup, verification, and troubleshooting, see [Windows Setup](docs/windows-setup.md).
@@ -89,10 +93,10 @@ Connect any MCP-compatible agent to Claude Code — the fastest way to build mul
 
 ```bash
 # Start standalone
-@onestepat4time/aegis mcp
+ag mcp
 
 # Add to Claude Code
-claude mcp add --scope user aegis -- npx @onestepat4time/aegis mcp
+claude mcp add --scope user aegis -- ag mcp
 ```
 
 Or via `.mcp.json`:
@@ -101,8 +105,8 @@ Or via `.mcp.json`:
 {
   "mcpServers": {
     "aegis": {
-      "command": "npx",
-      "args": ["@onestepat4time/aegis", "mcp"]
+      "command": "ag",
+      "args": ["mcp"]
     }
   }
 }
@@ -118,7 +122,7 @@ Or via `.mcp.json`:
 
 Aegis works beyond Claude Code anywhere an MCP host can launch a local stdio server.
 
-- [CLI Reference](docs/integrations/cli.md) — `aegis` command-line tool
+- [CLI Reference](docs/integrations/cli.md) — `ag` command-line tool (alias: `aegis`)
 - [Notification Channels](docs/integrations/notifications.md) — Telegram, Slack, Email, Webhooks
 - [Cursor integration](docs/integrations/cursor.md)
 - [Windsurf integration](docs/integrations/windsurf.md)
@@ -331,7 +335,7 @@ Aegis ships with a built-in dashboard at `http://localhost:9100/dashboard/` — 
 - Toast notifications for user feedback
 
 ```bash
-npx @onestepat4time/aegis          # visit http://localhost:9100/dashboard/
+ag                                 # visit http://localhost:9100/dashboard/
 ```
 
 ---
@@ -344,7 +348,7 @@ Aegis serves three deployment scenarios:
 **Single developer.** Run Claude Code tasks in the background, monitor via dashboard, approve via Telegram.
 
 ```bash
-aegis
+ag
 # Dashboard: http://localhost:9100/dashboard/
 # Telegram approvals while AFK
 ```
@@ -418,7 +422,7 @@ npx tsc --noEmit     # type-check
 
 ```
 src/
-├── cli.ts                # CLI entry (npx @onestepat4time/aegis)
+├── cli.ts                # CLI entry (`ag`; alias: `aegis`)
 ├── server.ts             # Fastify HTTP server + routes
 ├── session.ts            # Session lifecycle
 ├── tmux.ts               # tmux operations

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -35,7 +35,8 @@ AlertManager tracks failure events in sliding windows. When a failure type excee
 AEGIS_ALERT_WEBHOOKS="https://example.com/alerts,https://backup.com/alerts" \
 AEGIS_ALERT_FAILURE_THRESHOLD=3 \
 AEGIS_ALERT_COOLDOWN_MS=300000 \
-aegis --auth-token my-secret
+AEGIS_AUTH_TOKEN=my-secret \
+ag
 ```
 
 ### Programmatic Configuration

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -14,7 +14,7 @@ For a full enterprise technical review and gap analysis set, see
 Set `AEGIS_AUTH_TOKEN` to enable authentication on all endpoints except `/v1/health`:
 
 ```bash
-AEGIS_AUTH_TOKEN=your-secret-token npx @onestepat4time/aegis
+AEGIS_AUTH_TOKEN=your-secret-token ag
 ```
 
 Clients must include the header in every request:
@@ -185,7 +185,7 @@ WorkingDirectory=/opt/aegis
 Environment=AEGIS_AUTH_TOKEN=your-production-token
 Environment=AEGIS_PORT=9100
 Environment=AEGIS_HOST=127.0.0.1
-ExecStart=/usr/bin/npx @onestepat4time/aegis
+ExecStart=/usr/bin/env ag
 Restart=on-failure
 RestartSec=5
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,11 +14,14 @@ Get from zero to orchestrating Claude Code sessions in under 5 minutes.
 
 ## 1. Start Aegis
 
-No install required — run directly with npx:
+Install once, then start Aegis with the primary `ag` CLI:
 
 ```bash
-npx @onestepat4time/aegis
+npm install -g @onestepat4time/aegis
+ag
 ```
+
+> The primary CLI command is `ag`. The legacy name `aegis` is kept as an alias for backward compatibility — both resolve to the same binary.
 
 Aegis starts on **http://localhost:9100**. Verify it's running:
 
@@ -27,11 +30,10 @@ curl http://localhost:9100/v1/health
 ```
 
 <details>
-<summary>Install globally (optional)</summary>
+<summary>Run without a global install (optional)</summary>
 
 ```bash
-npm install -g @onestepat4time/aegis
-aegis
+npx --package=@onestepat4time/aegis ag
 ```
 
 </details>
@@ -43,7 +45,7 @@ aegis
 docker run -it --rm \
   -v $(pwd):/workspace \
   -p 9100:9100 \
-  node:20-slim bash -c "apt-get update && apt-get install -y tmux > /dev/null 2>&1 && npm install -g @anthropic-ai/claude-code && npx @onestepat4time/aegis"
+  node:20-slim bash -c "apt-get update && apt-get install -y tmux > /dev/null 2>&1 && npm install -g @anthropic-ai/claude-code @onestepat4time/aegis && ag"
 ```
 
 > Docker requires Claude Code CLI to be installed and authenticated inside the container.
@@ -56,7 +58,7 @@ docker run -it --rm \
 Set a bearer token to protect all endpoints (except `/v1/health`):
 
 ```bash
-AEGIS_AUTH_TOKEN=your-secret-token npx @onestepat4time/aegis
+AEGIS_AUTH_TOKEN=your-secret-token ag
 ```
 
 Then include the token in every request:
@@ -203,7 +205,7 @@ curl http://localhost:9100/v1/sessions
 Connect Aegis to Claude Code for native tool access:
 
 ```bash
-claude mcp add aegis -- npx @onestepat4time/aegis mcp
+claude mcp add aegis -- ag mcp
 ```
 
 This registers 24 MCP tools (session management, transcript reading, pipeline orchestration, etc.). Restart Claude Code to load the tools.
@@ -271,8 +273,8 @@ See the [Worktree Guide](./worktree-guide.md) for detailed setup instructions.
 | `Claude Code CLI not found` | Install Claude Code: `npm install -g @anthropic-ai/claude-code` and run `claude` to authenticate |
 | `401 Unauthorized` | Set `AEGIS_AUTH_TOKEN` or include `Authorization: Bearer <token>` header |
 | Session stuck on `stalled` | Send an interrupt: `curl -X POST http://localhost:9100/v1/sessions/:id/interrupt` |
-| MCP tools not showing in Claude Code | Re-run `claude mcp add aegis -- npx @onestepat4time/aegis mcp` and restart Claude Code |
+| MCP tools not showing in Claude Code | Re-run `claude mcp add aegis -- ag mcp` and restart Claude Code |
 | Dashboard won't load | Verify Aegis is running on port 9100: `curl http://localhost:9100/v1/health` |
-| `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 npx @onestepat4time/aegis` |
+| `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 ag` |
 | Screenshot returns 501 | Install Playwright: `npx playwright install chromium` |
 | No output from `/read` | Wait for transcript entries, or check raw terminal: `curl /v1/sessions/:id/pane` |

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -1,31 +1,33 @@
 # CLI Reference
 
-The `aegis` command-line tool starts the Aegis server, launches MCP sessions, and provides quick session management.
+The `ag` command-line tool starts the Aegis server, launches MCP sessions, and provides quick session management.
+
+> The primary CLI command is `ag`. The legacy name `aegis` is kept as an alias for backward compatibility — both resolve to the same binary, so any existing scripts using `aegis` keep working.
 
 ## Installation
 
 ```bash
 npm install -g @onestepat4time/aegis
-# or via npx:
-npx @onestepat4time/aegis
+# or without a global install:
+npx --package=@onestepat4time/aegis ag
 ```
 
 ## Commands
 
-### `aegis` — Start Server
+### `ag` — Start Server
 
 Start the Aegis HTTP server (port 9100).
 
 ```bash
-aegis                     # Default: port 9100, 127.0.0.1
-aegis --port 3000         # Custom port
-aegis --host 0.0.0.0      # Bind to all interfaces
+ag                     # Default: port 9100, 127.0.0.1
+ag --port 3000         # Custom port
+ag --host 0.0.0.0      # Bind to all interfaces
 ```
 
 Requires `AEGIS_AUTH_TOKEN` for production use:
 
 ```bash
-AEGIS_AUTH_TOKEN=secret aegis
+AEGIS_AUTH_TOKEN=secret ag
 ```
 
 **Environment variables:**
@@ -41,36 +43,36 @@ AEGIS_AUTH_TOKEN=secret aegis
 | `AEGIS_IDLE_TIMEOUT_MS` | `600000` | Idle timeout (10 min) |
 | `AEGIS_STALL_THRESHOLD_MS` | `120000` | Stall threshold (2 min) |
 
-### `aegis mcp` — Start MCP Server
+### `ag mcp` — Start MCP Server
 
 Start Aegis as an MCP stdio server for Claude Code, Cursor, Windsurf, and other MCP hosts.
 
 ```bash
-aegis mcp                    # Default: connects to localhost:9100
-AEGIS_PORT=3000 aegis mcp    # Custom API port
+ag mcp                    # Default: connects to localhost:9100
+AEGIS_PORT=3000 ag mcp    # Custom API port
 ```
 
 The MCP server wraps the REST API as tools — authenticate with:
 
 ```bash
-AEGIS_AUTH_TOKEN=secret aegis mcp
+AEGIS_AUTH_TOKEN=secret ag mcp
 ```
 
 For Claude Code:
 
 ```bash
-claude mcp add aegis -- npx @onestepat4time/aegis mcp
+claude mcp add aegis -- ag mcp
 ```
 
 For other MCP hosts (Cursor, Windsurf), see the [Cursor integration](./cursor.md) or [Windsurf integration](./windsurf.md).
 
-### `aegis create "brief"` — Quick Session
+### `ag create "brief"` — Quick Session
 
 Create a session and send a brief in one command.
 
 ```bash
-aegis create "Build a login page with email and password" --cwd /path/to/project
-aegis create "Fix the failing tests"                     # Uses current directory
+ag create "Build a login page with email and password" --cwd /path/to/project
+ag create "Fix the failing tests"                     # Uses current directory
 ```
 
 **Options:**
@@ -105,7 +107,7 @@ This is a convenience wrapper that:
 **Start server with auth:**
 
 ```bash
-AEGIS_AUTH_TOKEN=my-secret aegis --port 9100
+AEGIS_AUTH_TOKEN=my-secret ag --port 9100
 ```
 
 **Start with notification channels:**
@@ -119,29 +121,31 @@ AEGIS_EMAIL_HOST=smtp.example.com \
 AEGIS_EMAIL_USER=alerts@example.com \
 AEGIS_EMAIL_PASS=app-password \
 AEGIS_EMAIL_TO=ops@example.com \
-aegis
+ag
 ```
 
 **Quick session from project directory:**
 
 ```bash
 cd /path/to/project
-AEGIS_AUTH_TOKEN=secret aegis create "Review the code and suggest improvements"
+AEGIS_AUTH_TOKEN=secret ag create "Review the code and suggest improvements"
 ```
 
 **Start MCP server for Claude Code:**
 
 ```bash
-AEGIS_AUTH_TOKEN=secret aegis mcp
+AEGIS_AUTH_TOKEN=secret ag mcp
 ```
 
 ## Quick Reference
 
 ```
-aegis                     Start HTTP server
-aegis --port 3000         Custom port
-aegis mcp                 Start MCP server
-aegis create "brief"      Create + send
-aegis --help              Show all options
-aegis --version           Show version
+ag                     Start HTTP server
+ag --port 3000         Custom port
+ag mcp                 Start MCP server
+ag create "brief"      Create + send
+ag --help              Show all options
+ag --version           Show version
 ```
+
+> `aegis` remains available as an alias for every command above (e.g. `aegis mcp` still works).

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -23,6 +23,19 @@ Add an MCP server entry in your Cursor settings (`~/.cursor/settings.json` or th
 }
 ```
 
+Without a global install, use:
+
+```json
+{
+  "mcpServers": {
+    "aegis": {
+      "command": "npx",
+      "args": ["--package=@onestepat4time/aegis", "ag", "mcp"]
+    }
+  }
+}
+```
+
 Then restart Cursor.
 
 ## Setup

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -4,7 +4,7 @@ Use Aegis as an MCP server inside Cursor.
 
 ## Prerequisites
 
-- [Aegis installed](https://github.com/OneStepAt4time/aegis#installation) (or use `npx @onestepat4time/aegis`)
+- [Aegis installed](https://github.com/OneStepAt4time/aegis#installation) so the primary `ag` CLI is on your PATH
 - Cursor with MCP support enabled
 - Aegis server running on `127.0.0.1:9100`
 
@@ -16,8 +16,8 @@ Add an MCP server entry in your Cursor settings (`~/.cursor/settings.json` or th
 {
   "mcpServers": {
     "aegis": {
-      "command": "npx",
-      "args": ["@onestepat4time/aegis", "mcp"]
+      "command": "ag",
+      "args": ["mcp"]
     }
   }
 }
@@ -29,9 +29,9 @@ Then restart Cursor.
 
 1. Start the Aegis server (in a terminal):
    ```bash
-   aegis
+   ag
    # or with custom port:
-   aegis --port 9100
+   ag --port 9100
    ```
 2. Verify Aegis is running:
    ```bash

--- a/docs/integrations/mcp-registry.md
+++ b/docs/integrations/mcp-registry.md
@@ -14,7 +14,7 @@ This document tracks the metadata needed to publish Aegis to an MCP registry.
 
 - Tags: `mcp`, `claude-code`, `orchestration`, `automation`, `sessions`
 - Transport: `stdio`
-- Launch command: `npx @onestepat4time/aegis mcp`
+- Launch command: `ag mcp`
 - Health endpoint: `GET /v1/health`
 
 ## Registry Checklist

--- a/docs/integrations/notifications.md
+++ b/docs/integrations/notifications.md
@@ -267,7 +267,7 @@ GET /v1/channels/health
 Or via CLI:
 
 ```bash
-aegis channels dlq list
-aegis channels dlq retry <channel>
-aegis channels dlq clear <channel>
+ag channels dlq list
+ag channels dlq retry <channel>
+ag channels dlq clear <channel>
 ```

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -5,7 +5,7 @@ Use Aegis from Windsurf as a local MCP server.
 ## Prerequisites
 
 - Windsurf with MCP support enabled
-- [Aegis installed](https://github.com/OneStepAt4time/aegis#installation) or accessible via `npx`
+- [Aegis installed](https://github.com/OneStepAt4time/aegis#installation) so `ag` is on your PATH
 - Aegis server running on `127.0.0.1:9100`
 
 ## Configuration
@@ -16,8 +16,8 @@ Add to your Windsurf MCP settings:
 {
   "mcpServers": {
     "aegis": {
-      "command": "npx",
-      "args": ["@onestepat4time/aegis", "mcp"]
+      "command": "ag",
+      "args": ["mcp"]
     }
   }
 }
@@ -29,9 +29,9 @@ Then reload Windsurf.
 
 1. Start the Aegis server:
    ```bash
-   AEGIS_AUTH_TOKEN=your-token aegis
+   AEGIS_AUTH_TOKEN=your-token ag
    # or without auth:
-   aegis
+   ag
    ```
 2. Verify it's running:
    ```bash
@@ -53,7 +53,7 @@ Same 24 tools as the Cursor integration. See [MCP Tools](../mcp-tools.md) for th
 
 | Problem | Solution |
 |---------|---------|
-| "Connection refused" | Start Aegis first: `aegis` |
+| "Connection refused" | Start Aegis first: `ag` |
 | 401 Unauthorized | Set `AEGIS_AUTH_TOKEN` env var before starting Aegis |
 | Tools not loading | Reload Windsurf after saving MCP config |
 | Stale schemas | Remove the `aegis` entry, restart Windsurf, re-add |

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -23,6 +23,19 @@ Add to your Windsurf MCP settings:
 }
 ```
 
+Without a global install, use:
+
+```json
+{
+  "mcpServers": {
+    "aegis": {
+      "command": "npx",
+      "args": ["--package=@onestepat4time/aegis", "ag", "mcp"]
+    }
+  }
+}
+```
+
 Then reload Windsurf.
 
 ## Setup

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -5,7 +5,7 @@ Aegis exposes 24 tools and 3 prompts via the MCP (Model Context Protocol) server
 ## Setup
 
 ```bash
-claude mcp add aegis -- npx @onestepat4time/aegis mcp
+claude mcp add aegis -- ag mcp
 ```
 
 This connects Claude Code to the Aegis MCP server running on `localhost:9100`.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -2,6 +2,8 @@
 
 This guide covers migrating from the deprecated `aegis-bridge` package to the new `@onestepat4time/aegis` package.
 
+> The primary CLI command is now `ag`. The legacy name `aegis` remains available as an alias for backward compatibility.
+
 ---
 
 ## What Changed
@@ -10,9 +12,9 @@ This guide covers migrating from the deprecated `aegis-bridge` package to the ne
 |---|---|---|
 | Package name | `aegis-bridge` | `@onestepat4time/aegis` |
 | npm install | `npm install -g aegis-bridge` | `npm install -g @onestepat4time/aegis` |
-| npx run | `npx aegis-bridge` | `npx @onestepat4time/aegis` |
-| CLI binary | `aegis-bridge` | `aegis` |
-| MCP setup | `npx aegis-bridge mcp` | `npx @onestepat4time/aegis mcp` |
+| npx run | `npx aegis-bridge` | `npx --package=@onestepat4time/aegis ag` |
+| CLI binary | `aegis-bridge` | `ag` (alias: `aegis`) |
+| MCP setup | `npx aegis-bridge mcp` | `ag mcp` |
 
 The old `aegis-bridge` package is deprecated but remains available on npm. It will not receive updates.
 
@@ -35,7 +37,7 @@ npm install -g @onestepat4time/aegis
 ### 3. Verify Installation
 
 ```bash
-aegis --version
+ag --version
 ```
 
 ### 4. Update MCP Configuration
@@ -47,7 +49,7 @@ If you use Claude Code with the MCP integration:
 claude mcp remove aegis
 
 # Add new MCP config
-claude mcp add aegis -- npx @onestepat4time/aegis mcp
+claude mcp add aegis -- ag mcp
 ```
 
 ### 5. Update Scripts and CI
@@ -60,9 +62,9 @@ grep -r "aegis-bridge" --include="*.yml" --include="*.yaml" --include="*.json" -
 
 Replace all occurrences:
 
-- `npx aegis-bridge` → `npx @onestepat4time/aegis`
+- `npx aegis-bridge` → `npx --package=@onestepat4time/aegis ag`
 - `npm install aegis-bridge` → `npm install @onestepat4time/aegis`
-- `aegis-bridge` (as CLI command) → `aegis`
+- `aegis-bridge` (as CLI command) → `ag` (or `aegis` if you prefer the legacy alias)
 
 ### 6. Update Docker Images
 
@@ -73,7 +75,7 @@ CMD ["aegis-bridge"]
 
 # After
 RUN npm install -g @onestepat4time/aegis
-CMD ["aegis"]
+CMD ["ag"]
 ```
 
 ### 7. Update systemd Services
@@ -83,9 +85,7 @@ CMD ["aegis"]
 ExecStart=/usr/bin/aegis-bridge
 
 # After
-ExecStart=/usr/bin/npx @onestepat4time/aegis
-# Or if installed globally:
-ExecStart=/usr/bin/aegis
+ExecStart=/usr/bin/env ag
 ```
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,7 @@ lsof -i :9100
 # Kill it
 kill -9 <PID>
 # Or start Aegis on a different port
-AEGIS_PORT=9200 npx @onestepat4time/aegis
+AEGIS_PORT=9200 ag
 ```
 
 ---
@@ -98,7 +98,7 @@ curl -X POST http://localhost:9100/v1/auth/keys \
 # Find and kill the process
 pkill -f "aegis" && sleep 2
 # Restart
-npx @onestepat4time/aegis
+ag
 ```
 
 ---
@@ -213,7 +213,7 @@ curl http://localhost:9100/v1/health
 **Fix:**
 ```bash
 # Configure webhooks
-AEGIS_WEBHOOKS="https://example.com/hook" npx @onestepat4time/aegis
+AEGIS_WEBHOOKS="https://example.com/hook" ag
 
 # Test webhook delivery manually
 curl -X POST http://localhost:9100/v1/alerts/test \
@@ -252,7 +252,7 @@ export AEGIS_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/UR
 curl http://localhost:9100/v1/health
 
 # Try with explicit URL
-AEGIS_URL=http://localhost:9100 npx @onestepat4time/aegis sessions list
+AEGIS_URL=http://localhost:9100 ag sessions list
 ```
 
 ---
@@ -279,10 +279,10 @@ echo $AEGIS_AUTH_TOKEN
 **Fix:**
 ```bash
 # Set idle timeout (default: 10 minutes)
-AEGIS_IDLE_TIMEOUT_MS=300000 npx @onestepat4time/aegis
+AEGIS_IDLE_TIMEOUT_MS=300000 ag
 
 # Set max sessions
-AEGIS_MAX_SESSIONS=10 npx @onestepat4time/aegis
+AEGIS_MAX_SESSIONS=10 ag
 ```
 
 ---
@@ -318,5 +318,5 @@ docker run --network=host \
 If this guide doesn't resolve your issue:
 
 1. **Check the logs:** Aegis outputs structured JSON logs. Look for `errorCode` fields.
-2. **Enable debug mode:** `AEGIS_LOG_LEVEL=debug npx @onestepat4time/aegis`
+2. **Enable debug mode:** `AEGIS_LOG_LEVEL=debug ag`
 3. **Open an issue:** Include server logs, OS version, and reproduction steps.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -23,7 +23,8 @@ Aegis sits in front of Claude Code; it doesn't replace it. Your sessions still r
 ### 1. Start Aegis
 
 ```bash
-npx @onestepat4time/aegis
+npm install -g @onestepat4time/aegis
+ag
 ```
 
 Aegis starts on **http://localhost:9100**. Verify:
@@ -78,7 +79,7 @@ curl -X POST http://localhost:9100/v1/sessions/<session-id>/interrupt
 By default, Aegis has no authentication. To enable it:
 
 ```bash
-AEGIS_AUTH_TOKEN=my-secret-token npx @onestepat4time/aegis
+AEGIS_AUTH_TOKEN=my-secret-token ag
 ```
 
 Then include the token in every request:
@@ -195,7 +196,7 @@ Children are listed in the parent's `/sessions/:id/children` endpoint.
 Connect Aegis tools directly inside Claude Code sessions:
 
 ```bash
-claude mcp add aegis -- npx @onestepat4time/aegis mcp
+claude mcp add aegis -- ag mcp
 ```
 
 This registers 24 Aegis MCP tools in Claude Code, covering:
@@ -269,7 +270,7 @@ curl -X DELETE "http://localhost:9100/v1/sessions/batch?status=error" \
 | `404 Session not found` | Session was cleaned up | Sessions are auto-cleaned after termination; check `/v1/sessions` |
 | `/read` returns empty | Transcript not yet written | Wait for session to reach `idle`, or check `/v1/sessions/:id/pane` for live output |
 | Dashboard shows no sessions | tmux not installed or not in PATH | `tmux -V` to check; install via `apt install tmux` or `brew install tmux` |
-| MCP tools not registered | MCP server command was wrong | Use `claude mcp add aegis -- npx @onestepat4time/aegis mcp`, then restart Claude Code |
+| MCP tools not registered | MCP server command was wrong | Use `claude mcp add aegis -- ag mcp`, then restart Claude Code |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     }
   },
   "bin": {
+    "ag": "dist/cli.js",
     "aegis": "dist/cli.js"
   },
   "files": [

--- a/src/__tests__/bin-resolution.test.ts
+++ b/src/__tests__/bin-resolution.test.ts
@@ -1,0 +1,42 @@
+/**
+ * bin-resolution.test.ts — Issue #1929.
+ *
+ * Ensures both `ag` (primary) and `aegis` (alias) bin entries resolve to the
+ * same CLI entry point, so existing scripts using `aegis` keep working after
+ * the primary CLI switch to `ag`.
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..');
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')) as {
+  bin?: Record<string, string>;
+};
+const agBin = pkg.bin?.ag ? join(repoRoot, pkg.bin.ag) : '';
+const aegisBin = pkg.bin?.aegis ? join(repoRoot, pkg.bin.aegis) : '';
+
+describe('package.json bin entries (#1929)', () => {
+  it('exposes the `ag` primary bin', () => {
+    expect(pkg.bin).toBeDefined();
+    expect(pkg.bin?.ag).toBe('dist/cli.js');
+  });
+
+  it('retains the `aegis` alias bin for backward compatibility', () => {
+    expect(pkg.bin?.aegis).toBe('dist/cli.js');
+  });
+
+  it('points both bins at the same CLI entry point', () => {
+    expect(pkg.bin?.ag).toBe(pkg.bin?.aegis);
+  });
+
+  it('resolves both bins to the same existing CLI file', () => {
+    expect(existsSync(agBin)).toBe(true);
+    expect(existsSync(aegisBin)).toBe(true);
+    expect(realpathSync(agBin)).toBe(realpathSync(aegisBin));
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,9 @@
 /**
  * cli.ts — CLI entry point for Aegis.
  *
- * `npx @onestepat4time/aegis` or `aegis` starts the server with sensible defaults.
- * Auto-detects tmux and claude CLI, prints helpful startup message.
+ * `ag` is the primary CLI command and `aegis` remains an alias. Both start the
+ * server with sensible defaults. Auto-detects tmux and claude CLI, prints
+ * helpful startup message.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -95,7 +96,7 @@ async function handleCreate(args: string[]): Promise<void> {
   }
 
   if (!brief) {
-    console.error('  ❌ Missing brief. Usage: aegis create "Build a login page"');
+    console.error('  ❌ Missing brief. Usage: ag create "Build a login page"');
     process.exit(1);
   }
 
@@ -128,7 +129,7 @@ async function handleCreate(args: string[]): Promise<void> {
     const cause = (e as { cause?: { code?: string } }).cause;
     if (cause?.code === 'ECONNREFUSED') {
       console.error(`  ❌ Cannot connect to Aegis on port ${port}.`);
-      console.error(`     Start the server first: aegis`);
+      console.error(`     Start the server first: ag`);
     } else {
       console.error(`  ❌ ${getErrorMessage(e)}`);
     }
@@ -168,24 +169,24 @@ async function main(): Promise<void> {
   // Help
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`
-  aegis — Claude Code session bridge
+  ag — Claude Code session bridge (alias: aegis)
 
   Usage:
-    aegis                  Start the server (port 9100)
-    aegis "brief"          Create a session and send brief (shorthand)
-    aegis --port 3000      Custom port
-    aegis create "brief"   Create a session and send brief
-    aegis mcp              Start MCP server (stdio transport)
-    aegis --help           Show this help
+    ag                     Start the server (port 9100)
+    ag "brief"             Create a session and send brief (shorthand)
+    ag --port 3000         Custom port
+    ag create "brief"      Create a session and send brief
+    ag mcp                 Start MCP server (stdio transport)
+    ag --help              Show this help
 
   Create:
-    aegis create "Build a login page" --cwd /path/to/project
-    aegis create "Fix the tests"      (uses current directory)
+    ag create "Build a login page" --cwd /path/to/project
+    ag create "Fix the tests"      (uses current directory)
 
   MCP server:
-    aegis mcp              Start MCP stdio server
-    aegis mcp --port 3000  Custom Aegis API port
-    claude mcp add aegis -- npx @onestepat4time/aegis mcp
+    ag mcp                 Start MCP stdio server
+    ag mcp --port 3000     Custom Aegis API port
+    claude mcp add aegis -- ag mcp
 
   Environment variables:
     AEGIS_PORT                    Server port (default: 9100)
@@ -215,7 +216,7 @@ async function main(): Promise<void> {
 
   // Version
   if (args.includes('--version') || args.includes('-v')) {
-    console.log(`aegis v${VERSION}`);
+    console.log(`ag v${VERSION}`);
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary

Adds `ag` as a first-class CLI alias, updates documentation and getting-started examples to prefer it, and keeps `aegis` fully compatible with a shared entrypoint test.

## Aegis version

**Developed with:** v0.5.3-alpha
**Tested with:** v0.5.3-alpha

## Change type

- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring with no behavior change
- [ ] `perf` — Performance improvement
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling
- [x] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

CLI packaging, README/getting-started/integration docs, and bin resolution coverage.

## Linked issue

Closes #1929

## Test plan

Repository gate passed (`npm run gate`).

- [x] Unit tests pass (`npm test`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Manually tested (describe below)

## Security impact

None.