### PR TITLE
feat: add dashboard home onboarding overview

### DIFF
--- a/dashboard/e2e/helpers/auth.ts
+++ b/dashboard/e2e/helpers/auth.ts
@@ -1,14 +1,13 @@
 import type { Page } from '@playwright/test';
 
+const DASHBOARD_LOGIN_URL = 'http://localhost:5173/dashboard/login';
+const TEST_TOKEN = 'e2e-test-token';
+
 /**
- * Authenticate the dashboard by injecting a token and mocking the verify endpoint.
+ * Authenticate the dashboard through the current memory-only token flow.
  * Required before navigating to protected pages in smoke tests.
  */
 export async function authenticate(page: Page): Promise<void> {
-  await page.addInitScript(() => {
-    localStorage.setItem('aegis_token', 'e2e-test-token');
-  });
-
   await page.route('**/v1/auth/verify', async (route) => {
     await route.fulfill({
       status: 200,
@@ -16,4 +15,9 @@ export async function authenticate(page: Page): Promise<void> {
       body: JSON.stringify({ valid: true, role: 'admin' }),
     });
   });
+
+  await page.goto(DASHBOARD_LOGIN_URL);
+  await page.getByLabel(/api token/i).fill(TEST_TOKEN);
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await page.waitForURL(/\/dashboard\/?$/);
 }

--- a/dashboard/e2e/helpers/auth.ts
+++ b/dashboard/e2e/helpers/auth.ts
@@ -1,13 +1,53 @@
 import type { Page } from '@playwright/test';
 
-const DASHBOARD_LOGIN_URL = 'http://localhost:5173/dashboard/login';
 const TEST_TOKEN = 'e2e-test-token';
 
 /**
  * Authenticate the dashboard through the current memory-only token flow.
+ * The helper replays login on every full document load so tests can safely
+ * navigate with page.goto() without losing auth state.
  * Required before navigating to protected pages in smoke tests.
  */
 export async function authenticate(page: Page): Promise<void> {
+  await page.addInitScript((token: string) => {
+    const startedAt = Date.now();
+
+    const tryAutoLogin = () => {
+      const input = document.querySelector('#token, input[name="token"]');
+      const button = Array.from(document.querySelectorAll('button'))
+        .find(candidate => /sign in/i.test(candidate.textContent ?? ''));
+
+      if (!(input instanceof HTMLInputElement) || !(button instanceof HTMLButtonElement)) {
+        if (Date.now() - startedAt < 10_000) {
+          window.setTimeout(tryAutoLogin, 50);
+        }
+        return;
+      }
+
+      const nativeValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      nativeValueSetter?.call(input, token);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      if (button.disabled) {
+        if (Date.now() - startedAt < 10_000) {
+          window.setTimeout(tryAutoLogin, 50);
+        }
+        return;
+      }
+
+      button.click();
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => {
+        window.setTimeout(tryAutoLogin, 0);
+      }, { once: true });
+      return;
+    }
+
+    window.setTimeout(tryAutoLogin, 0);
+  }, TEST_TOKEN);
+
   await page.route('**/v1/auth/verify', async (route) => {
     await route.fulfill({
       status: 200,
@@ -15,9 +55,4 @@ export async function authenticate(page: Page): Promise<void> {
       body: JSON.stringify({ valid: true, role: 'admin' }),
     });
   });
-
-  await page.goto(DASHBOARD_LOGIN_URL);
-  await page.getByLabel(/api token/i).fill(TEST_TOKEN);
-  await page.getByRole('button', { name: /sign in/i }).click();
-  await page.waitForURL(/\/dashboard\/?$/);
 }

--- a/dashboard/src/__tests__/ActivityStream.test.ts
+++ b/dashboard/src/__tests__/ActivityStream.test.ts
@@ -145,3 +145,38 @@ describe('ActivityStream degraded SSE state', () => {
     expect(screen.getByText('Real-time activity is paused while the SSE connection recovers.')).toBeDefined();
   });
 });
+
+describe('ActivityStream recent-events variant', () => {
+  it('supports a compact recent-events view without filters', () => {
+    useStore.setState({
+      activities: [
+        {
+          event: 'session_status_change',
+          sessionId: 'sess-1',
+          timestamp: '2026-03-29T00:00:01Z',
+          data: { status: 'working' },
+          renderKey: 'evt-1',
+        },
+        {
+          event: 'session_message',
+          sessionId: 'sess-2',
+          timestamp: '2026-03-29T00:00:00Z',
+          data: { role: 'assistant', text: 'done' },
+          renderKey: 'evt-2',
+        },
+      ],
+      sessions: [],
+      sseConnected: true,
+      sseError: null,
+      activityFilterSession: 'filtered-out',
+      activityFilterType: 'session_ended',
+    });
+
+    render(createElement(ActivityStream, { title: 'Recent events', showFilters: false, maxItems: 1 }));
+
+    expect(screen.getByText('Recent events')).toBeDefined();
+    expect(screen.queryAllByRole('combobox').length).toBe(0);
+    expect(screen.getByText('Status -> working')).toBeDefined();
+    expect(screen.queryByText('Claude: done')).toBeNull();
+  });
+});

--- a/dashboard/src/__tests__/HomeStatusPanel.test.tsx
+++ b/dashboard/src/__tests__/HomeStatusPanel.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import HomeStatusPanel from '../components/overview/HomeStatusPanel';
+import { useStore } from '../store/useStore';
+import type { GlobalSSEEvent } from '../types';
+
+const mockGetHealth = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getHealth: (...args: unknown[]) => mockGetHealth(...args),
+}));
+
+function makeHealth(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    status: 'ok',
+    version: '0.5.3-alpha',
+    platform: 'win32',
+    uptime: 120,
+    sessions: {
+      active: 0,
+      total: 0,
+    },
+    tmux: {
+      healthy: true,
+      error: null,
+    },
+    claude: {
+      available: true,
+      healthy: true,
+      version: '2.1.90',
+      minimumVersion: '2.1.80',
+      error: null,
+    },
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('HomeStatusPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    useStore.setState({
+      activities: [],
+      sseConnected: false,
+      sseError: null,
+    });
+    mockGetHealth.mockResolvedValue(makeHealth());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders tmux, Claude CLI, and active session cards', async () => {
+    render(<HomeStatusPanel onCreateFirstSession={vi.fn()} />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(screen.getByRole('article', { name: 'Tmux status: Ready' })).toBeDefined();
+    expect(screen.getByRole('article', { name: 'Claude CLI: Ready' })).toBeDefined();
+    expect(screen.getByRole('article', { name: 'Active sessions: 0' })).toBeDefined();
+    expect(screen.getByText('Claude CLI 2.1.90 is available.')).toBeDefined();
+  });
+
+  it('shows a create first session CTA when no sessions exist', async () => {
+    const onCreateFirstSession = vi.fn();
+
+    render(<HomeStatusPanel onCreateFirstSession={onCreateFirstSession} />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    const button = screen.getByRole('button', { name: 'Create first session' });
+    fireEvent.click(button);
+
+    expect(button).toBeDefined();
+    expect(onCreateFirstSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the onboarding CTA after sessions have been created', async () => {
+    mockGetHealth.mockResolvedValue(makeHealth({
+      sessions: {
+        active: 2,
+        total: 5,
+      },
+    }));
+
+    render(<HomeStatusPanel onCreateFirstSession={vi.fn()} />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Create first session' })).toBeNull();
+    expect(screen.getByRole('article', { name: 'Active sessions: 2' })).toBeDefined();
+  });
+
+  it('refreshes status cards via polling without a full page reload', async () => {
+    mockGetHealth
+      .mockResolvedValueOnce(makeHealth({
+        sessions: {
+          active: 0,
+          total: 0,
+        },
+      }))
+      .mockResolvedValueOnce(makeHealth({
+        sessions: {
+          active: 3,
+          total: 3,
+        },
+      }));
+
+    render(<HomeStatusPanel onCreateFirstSession={vi.fn()} />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(screen.getByRole('article', { name: 'Active sessions: 0' })).toBeDefined();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetHealth).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('article', { name: 'Active sessions: 3' })).toBeDefined();
+  });
+
+  it('debounces SSE-driven refreshes while connected', async () => {
+    useStore.setState({ sseConnected: true, activities: [] });
+    mockGetHealth
+      .mockResolvedValueOnce(makeHealth({
+        sessions: {
+          active: 1,
+          total: 1,
+        },
+      }))
+      .mockResolvedValueOnce(makeHealth({
+        sessions: {
+          active: 2,
+          total: 2,
+        },
+      }));
+
+    render(<HomeStatusPanel onCreateFirstSession={vi.fn()} />);
+
+    await act(async () => {
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    const event: GlobalSSEEvent = {
+      event: 'session_message',
+      sessionId: 'session-1',
+      timestamp: new Date().toISOString(),
+      data: { text: 'hello' },
+    };
+
+    await act(async () => {
+      useStore.getState().addActivity(event);
+      await vi.advanceTimersByTimeAsync(999);
+    });
+
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.runAllTicks();
+    });
+
+    expect(mockGetHealth).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('article', { name: 'Active sessions: 2' })).toBeDefined();
+  });
+});

--- a/dashboard/src/__tests__/OverviewPage.test.tsx
+++ b/dashboard/src/__tests__/OverviewPage.test.tsx
@@ -13,12 +13,20 @@ vi.mock('../components/overview/MetricsPanel', () => ({
   default: () => <div data-testid="metrics-panel">MetricsPanel</div>,
 }));
 
+vi.mock('../components/overview/HomeStatusPanel', () => ({
+  default: ({ onCreateFirstSession }: { onCreateFirstSession: () => void }) => (
+    <div data-testid="home-status-panel">
+      <button onClick={onCreateFirstSession}>Create first session</button>
+    </div>
+  ),
+}));
+
 vi.mock('../components/overview/SessionTable', () => ({
   default: () => <div data-testid="session-table">SessionTable</div>,
 }));
 
 vi.mock('../components/ActivityStream', () => ({
-  default: () => <div data-testid="activity-stream">ActivityStream</div>,
+  default: ({ title }: { title?: string }) => <div data-testid="activity-stream">{title ?? 'ActivityStream'}</div>,
 }));
 
 vi.mock('../components/CreateSessionModal', () => ({
@@ -61,7 +69,7 @@ describe('OverviewPage', () => {
   it('renders subtitle text', async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText(/Aegis session monitoring and metrics/)).toBeDefined();
+      expect(screen.getByText(/System health, recent events, and a fast path to your first session/)).toBeDefined();
     });
   });
 
@@ -79,6 +87,7 @@ describe('OverviewPage', () => {
       expect(screen.getByTestId('metric-cards')).toBeDefined();
       expect(screen.getByTestId('session-table')).toBeDefined();
       expect(screen.getByTestId('activity-stream')).toBeDefined();
+      expect(screen.getByTestId('home-status-panel')).toBeDefined();
       expect(screen.getByTestId('live-status')).toBeDefined();
     });
   });
@@ -87,6 +96,13 @@ describe('OverviewPage', () => {
     renderPage();
     await waitFor(() => {
       expect(screen.getByText('Sessions')).toBeDefined();
+    });
+  });
+
+  it('renders the Recent events section heading', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Recent events')).toBeDefined();
     });
   });
 
@@ -114,6 +130,17 @@ describe('OverviewPage', () => {
     fireEvent.click(screen.getByText('Close Modal'));
     await waitFor(() => {
       expect(screen.queryByTestId('create-session-modal')).toBeNull();
+    });
+  });
+
+  it('opens create session modal when Create first session CTA is clicked', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Create first session')).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('Create first session'));
+    await waitFor(() => {
+      expect(screen.getByTestId('create-session-modal')).toBeDefined();
     });
   });
 

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -88,6 +88,17 @@ export const HealthResponseSchema: z.ZodType<HealthResponse> = z.object({
     active: z.number(),
     total: z.number(),
   }),
+  tmux: z.object({
+    healthy: z.boolean(),
+    error: z.string().nullable(),
+  }).optional(),
+  claude: z.object({
+    available: z.boolean(),
+    healthy: z.boolean(),
+    version: z.string().nullable(),
+    minimumVersion: z.string(),
+    error: z.string().nullable(),
+  }).optional(),
   timestamp: z.string(),
 });
 

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -20,6 +20,13 @@ import { useStore } from '../store/useStore';
 import type { GlobalSSEEventType, GlobalSSEEvent } from '../types';
 import RealtimeBadge from './overview/RealtimeBadge';
 
+interface ActivityStreamProps {
+  title?: string;
+  showFilters?: boolean;
+  maxItems?: number;
+  emptyMessage?: string;
+}
+
 const EVENT_META: Record<GlobalSSEEventType, { icon: typeof Activity; label: string; color: string }> = {
   session_status_change: { icon: RefreshCw, label: 'Status', color: 'var(--color-accent)' },
   session_message: { icon: MessageSquare, label: 'Message', color: 'var(--color-success)' },
@@ -107,7 +114,12 @@ function formatTime(ts: string): string {
   }
 }
 
-export default function ActivityStream() {
+export default function ActivityStream({
+  title = 'Activity Stream',
+  showFilters = true,
+  maxItems,
+  emptyMessage,
+}: ActivityStreamProps) {
   const activities = useStore((s) => s.activities);
   const sseConnected = useStore((s) => s.sseConnected);
   const sseError = useStore((s) => s.sseError);
@@ -119,11 +131,17 @@ export default function ActivityStream() {
 
   const filtered = useMemo(() => {
     return activities.filter((e) => {
-      if (filterSession && e.sessionId !== filterSession) return false;
-      if (filterType && e.event !== filterType) return false;
+      if (showFilters) {
+        if (filterSession && e.sessionId !== filterSession) return false;
+        if (filterType && e.event !== filterType) return false;
+      }
       return true;
     });
-  }, [activities, filterSession, filterType]);
+  }, [activities, filterSession, filterType, showFilters]);
+
+  const visibleEvents = useMemo(() => (
+    typeof maxItems === 'number' ? filtered.slice(0, maxItems) : filtered
+  ), [filtered, maxItems]);
 
   // Build a lookup map once instead of O(n) find per event
   const sessionNameMap = useMemo(() => {
@@ -142,58 +160,60 @@ export default function ActivityStream() {
     <div className="bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg w-full">
       {/* Header + filters */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-3 sm:px-4 py-3 border-b border-[var(--color-void-lighter)]">
-        <h3 className="text-sm font-semibold text-gray-200">Activity Stream</h3>
-        <div className="flex items-center gap-2">
-          {!sseConnected && sseError && <RealtimeBadge mode="paused" message={sseError} />}
+        <h3 className="text-sm font-semibold text-gray-200">{title}</h3>
+        {showFilters && (
+          <div className="flex items-center gap-2">
+            {!sseConnected && sseError && <RealtimeBadge mode="paused" message={sseError} />}
 
-          {/* Session filter */}
-          <select
-            value={filterSession ?? ''}
-            onChange={(e) => setFilterSession(e.target.value || null)}
-            className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-gray-400 focus:outline-none focus:border-[var(--color-accent)]"
-          >
-            <option value="">All sessions</option>
-            {sessions.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.windowName || s.id.slice(0, 8)}
-              </option>
-            ))}
-          </select>
-
-          {/* Type filter */}
-          <select
-            value={filterType ?? ''}
-            onChange={(e) => setFilterType((e.target.value || null) as GlobalSSEEventType | null)}
-            className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-gray-400 focus:outline-none focus:border-[var(--color-accent)]"
-          >
-            <option value="">All types</option>
-            {Object.entries(EVENT_META).map(([key, meta]) => (
-              <option key={key} value={key}>{meta.label}</option>
-            ))}
-          </select>
-
-          {/* Clear filters */}
-          {(filterSession || filterType) && (
-            <button
-              onClick={() => { setFilterSession(null); setFilterType(null); }}
-              className="min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 hover:text-gray-300"
+            {/* Session filter */}
+            <select
+              value={filterSession ?? ''}
+              onChange={(e) => setFilterSession(e.target.value || null)}
+              className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-gray-400 focus:outline-none focus:border-[var(--color-accent)]"
             >
-              <X className="h-4 w-4" />
-            </button>
-          )}
-        </div>
+              <option value="">All sessions</option>
+              {sessions.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.windowName || s.id.slice(0, 8)}
+                </option>
+              ))}
+            </select>
+
+            {/* Type filter */}
+            <select
+              value={filterType ?? ''}
+              onChange={(e) => setFilterType((e.target.value || null) as GlobalSSEEventType | null)}
+              className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-gray-400 focus:outline-none focus:border-[var(--color-accent)]"
+            >
+              <option value="">All types</option>
+              {Object.entries(EVENT_META).map(([key, meta]) => (
+                <option key={key} value={key}>{meta.label}</option>
+              ))}
+            </select>
+
+            {/* Clear filters */}
+            {(filterSession || filterType) && (
+              <button
+                onClick={() => { setFilterSession(null); setFilterType(null); }}
+                className="min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 hover:text-gray-300"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Event list */}
       <div className="max-h-[360px] overflow-y-auto divide-y divide-[var(--color-void-lighter)]/50">
-        {filtered.length === 0 && (
+        {visibleEvents.length === 0 && (
           <div className="px-4 py-8 text-center text-sm text-[#555]">
-            {!sseConnected && sseError
+            {emptyMessage ?? (!sseConnected && sseError
               ? 'Real-time activity is paused while the SSE connection recovers.'
-              : 'No activity yet'}
+              : 'No activity yet')}
           </div>
         )}
-        {filtered.map((event) => {
+        {visibleEvents.map((event) => {
           const meta = EVENT_META[event.event] ?? EVENT_META.session_status_change;
           const Icon = meta.icon;
           return (

--- a/dashboard/src/components/overview/HomeStatusPanel.tsx
+++ b/dashboard/src/components/overview/HomeStatusPanel.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useState, type ReactNode } from 'react';
+import { Activity, Bot, Plus, Terminal } from 'lucide-react';
+import { getHealth } from '../../api/client.js';
+import { useSseAwarePolling } from '../../hooks/useSseAwarePolling.js';
+import { useStore } from '../../store/useStore.js';
+import type { HealthResponse } from '../../types';
+import RealtimeBadge from './RealtimeBadge.js';
+
+const FALLBACK_POLL_INTERVAL_MS = 10_000;
+const SSE_HEALTHY_POLL_INTERVAL_MS = 30_000;
+
+type StatusTone = 'blue' | 'green' | 'amber' | 'red';
+
+interface StatusCardProps {
+  label: string;
+  value: string | number;
+  detail: string;
+  tone: StatusTone;
+  icon: ReactNode;
+}
+
+interface HomeStatusPanelProps {
+  onCreateFirstSession: () => void;
+}
+
+function getErrorMessage(prefix: string, error: unknown): string {
+  return error instanceof Error && error.message
+    ? `${prefix}: ${error.message}`
+    : prefix;
+}
+
+function StatusCard({ label, value, detail, tone, icon }: StatusCardProps) {
+  const toneStyles: Record<StatusTone, { border: string; icon: string; value: string }> = {
+    blue: {
+      border: 'border-cyan-500/20',
+      icon: 'text-cyan-300',
+      value: 'text-cyan-200',
+    },
+    green: {
+      border: 'border-emerald-500/20',
+      icon: 'text-emerald-300',
+      value: 'text-emerald-200',
+    },
+    amber: {
+      border: 'border-amber-500/20',
+      icon: 'text-amber-300',
+      value: 'text-amber-200',
+    },
+    red: {
+      border: 'border-red-500/20',
+      icon: 'text-red-300',
+      value: 'text-red-200',
+    },
+  };
+
+  return (
+    <article
+      aria-label={`${label}: ${value}`}
+      className={`rounded-xl border bg-[var(--color-surface)] p-4 ${toneStyles[tone].border}`}
+    >
+      <div className="mb-3 flex items-center gap-2 text-sm text-gray-400">
+        <span className={toneStyles[tone].icon}>{icon}</span>
+        <span>{label}</span>
+      </div>
+      <div className={`font-mono text-2xl font-semibold ${toneStyles[tone].value}`}>
+        {value}
+      </div>
+      <p className="mt-2 text-sm text-gray-500">{detail}</p>
+    </article>
+  );
+}
+
+function getTmuxCard(health: HealthResponse | null, isLoading: boolean, loadError: string | null): Omit<StatusCardProps, 'icon' | 'label'> {
+  if (isLoading && !health) {
+    return {
+      value: 'Checking…',
+      detail: 'Verifying that the tmux server is responding.',
+      tone: 'blue',
+    };
+  }
+
+  if (!health?.tmux) {
+    return {
+      value: 'Unavailable',
+      detail: loadError ?? 'Tmux status has not been reported yet.',
+      tone: 'red',
+    };
+  }
+
+  if (!health.tmux.healthy) {
+    return {
+      value: 'Degraded',
+      detail: health.tmux.error ?? 'Tmux is not responding to health checks.',
+      tone: 'red',
+    };
+  }
+
+  return {
+    value: 'Ready',
+    detail: 'Tmux server is reachable and ready for new sessions.',
+    tone: 'green',
+  };
+}
+
+function getClaudeCard(health: HealthResponse | null, isLoading: boolean, loadError: string | null): Omit<StatusCardProps, 'icon' | 'label'> {
+  if (isLoading && !health) {
+    return {
+      value: 'Checking…',
+      detail: 'Inspecting the installed Claude Code CLI.',
+      tone: 'blue',
+    };
+  }
+
+  if (!health?.claude) {
+    return {
+      value: 'Unavailable',
+      detail: loadError ?? 'Claude CLI status has not been reported yet.',
+      tone: 'red',
+    };
+  }
+
+  if (!health.claude.available) {
+    return {
+      value: 'Unavailable',
+      detail: health.claude.error ?? 'Claude CLI could not be found on this host.',
+      tone: 'red',
+    };
+  }
+
+  if (!health.claude.healthy) {
+    return {
+      value: 'Needs upgrade',
+      detail: health.claude.error ?? `Minimum supported version is ${health.claude.minimumVersion}.`,
+      tone: 'amber',
+    };
+  }
+
+  return {
+    value: 'Ready',
+    detail: health.claude.version
+      ? `Claude CLI ${health.claude.version} is available.`
+      : 'Claude CLI is installed and responding.',
+    tone: 'green',
+  };
+}
+
+function getActiveSessionsCard(health: HealthResponse | null, isLoading: boolean, loadError: string | null): Omit<StatusCardProps, 'icon' | 'label'> {
+  if (isLoading && !health) {
+    return {
+      value: 'Checking…',
+      detail: 'Loading the current session count.',
+      tone: 'blue',
+    };
+  }
+
+  if (!health) {
+    return {
+      value: '—',
+      detail: loadError ?? 'Session totals are temporarily unavailable.',
+      tone: 'red',
+    };
+  }
+
+  const totalSessions = health.sessions.total;
+  const activeSessions = health.sessions.active;
+
+  return {
+    value: activeSessions,
+    detail: totalSessions === 0
+      ? 'No sessions created yet.'
+      : `${totalSessions} total session${totalSessions === 1 ? '' : 's'} created.`,
+    tone: activeSessions > 0 ? 'green' : 'blue',
+  };
+}
+
+export default function HomeStatusPanel({ onCreateFirstSession }: HomeStatusPanelProps) {
+  const latestActivity = useStore((s) => s.activities[0] ?? null);
+  const sseConnected = useStore((s) => s.sseConnected);
+  const sseError = useStore((s) => s.sseError);
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const next = await getHealth();
+      setHealth(next);
+      setLoadError(null);
+    } catch (error) {
+      setLoadError(getErrorMessage('Unable to load home status', error));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useSseAwarePolling({
+    refresh: fetchData,
+    sseConnected,
+    eventTrigger: latestActivity,
+    fallbackPollIntervalMs: FALLBACK_POLL_INTERVAL_MS,
+    healthyPollIntervalMs: SSE_HEALTHY_POLL_INTERVAL_MS,
+  });
+
+  const totalSessions = health?.sessions.total;
+  const showFirstSessionCta = !isLoading && totalSessions === 0;
+  const showStatusRow = Boolean(loadError) || Boolean(!sseConnected && sseError);
+
+  const tmuxCard = getTmuxCard(health, isLoading, loadError);
+  const claudeCard = getClaudeCard(health, isLoading, loadError);
+  const activeSessionsCard = getActiveSessionsCard(health, isLoading, loadError);
+
+  return (
+    <section className="space-y-4" aria-label="System health">
+      {showStatusRow && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-void-lighter bg-[var(--color-surface)] px-4 py-3"
+        >
+          <div className="text-xs text-gray-400">
+            {loadError ?? 'Using the latest available home status data.'}
+          </div>
+          {!sseConnected && sseError && <RealtimeBadge mode="polling" message={sseError} />}
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <StatusCard
+          label="Tmux status"
+          icon={<Terminal className="h-4 w-4" />}
+          {...tmuxCard}
+        />
+        <StatusCard
+          label="Claude CLI"
+          icon={<Bot className="h-4 w-4" />}
+          {...claudeCard}
+        />
+        <StatusCard
+          label="Active sessions"
+          icon={<Activity className="h-4 w-4" />}
+          {...activeSessionsCard}
+        />
+      </div>
+
+      {showFirstSessionCta && (
+        <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/5 p-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-100">Create your first session</h3>
+              <p className="mt-1 text-sm text-gray-400">
+                Aegis is healthy. Start a Claude Code session in a working directory to unlock live activity and session controls.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onCreateFirstSession}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-cyan-400 px-4 py-2.5 text-sm font-medium text-slate-950 transition-opacity hover:opacity-90"
+            >
+              <Plus className="h-4 w-4" />
+              Create first session
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -1,9 +1,10 @@
 /**
- * pages/OverviewPage.tsx — Main overview with metrics, session table, and activity stream.
+ * pages/OverviewPage.tsx — Dashboard home with system health, onboarding, and live activity.
  */
 
 import { useEffect, useState } from 'react';
 import { Plus } from 'lucide-react';
+import HomeStatusPanel from '../components/overview/HomeStatusPanel';
 import MetricCards from '../components/overview/MetricCards';
 import MetricsPanel from '../components/overview/MetricsPanel';
 import SessionTable from '../components/overview/SessionTable';
@@ -34,33 +35,41 @@ export default function OverviewPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h2 className="text-2xl font-bold text-gray-100">Overview</h2>
           <p className="mt-1 text-sm text-gray-500">
-            Aegis session monitoring and metrics
-          <LiveStatusIndicator />
+            System health, recent events, and a fast path to your first session.{` `}
+            <LiveStatusIndicator />
           </p>
         </div>
         <button
           onClick={() => setModalOpen(true)}
-          className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded bg-[var(--color-accent-cyan)]]/10 hover:bg-[var(--color-accent-cyan)]]/20 text-[var(--color-accent-cyan)]] border border-[var(--color-accent-cyan)]]/30 transition-colors"
+          className="flex items-center gap-1.5 rounded border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-300 transition-colors hover:bg-cyan-500/20"
         >
           <Plus className="h-3.5 w-3.5" />
           New Session
         </button>
       </div>
 
-      <MetricsPanel />
+      <HomeStatusPanel onCreateFirstSession={() => setModalOpen(true)} />
 
-      <MetricCards />
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
+        <div className="order-2 flex flex-col gap-6 xl:order-1">
+          <div>
+            <h3 className="mb-3 text-lg font-semibold text-gray-200">Sessions</h3>
+            <SessionTable />
+          </div>
 
-      <div>
-        <h3 className="mb-3 text-lg font-semibold text-gray-200">Sessions</h3>
-        <SessionTable />
+          <MetricsPanel />
+
+          <MetricCards />
+        </div>
+
+        <div className="order-1 xl:order-2">
+          <ActivityStream title="Recent events" showFilters={false} maxItems={8} />
+        </div>
       </div>
-
-      <ActivityStream />
 
       <CreateSessionModal open={modalOpen} onClose={() => setModalOpen(false)} />
     </div>

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -73,6 +73,17 @@ export interface HealthResponse {
     active: number;
     total: number;
   };
+  tmux?: {
+    healthy: boolean;
+    error: string | null;
+  };
+  claude?: {
+    available: boolean;
+    healthy: boolean;
+    version: string | null;
+    minimumVersion: string;
+    error: string | null;
+  };
   timestamp: string;
 }
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -2,12 +2,69 @@
  * routes/health.ts — Health, prometheus, handshake, swarm, channels, alerts.
  */
 
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import { negotiate, type HandshakeRequest } from '../handshake.js';
 import { promRegistry, METRICS_CONTENT_TYPE } from '../prometheus.js';
+import { MIN_CC_VERSION, compareSemver, extractCCVersion } from '../validation.js';
 import { handshakeRequestSchema } from '../validation.js';
 import { type RouteContext, requireRole, registerWithLegacy, withValidation } from './context.js';
+
+const execFileAsync = promisify(execFile);
+const CLAUDE_STATUS_CACHE_TTL_MS = 30_000;
+
+interface ClaudeCliStatus {
+  available: boolean;
+  healthy: boolean;
+  version: string | null;
+  minimumVersion: string;
+  error: string | null;
+}
+
+let cachedClaudeStatus: { expiresAt: number; value: ClaudeCliStatus } | null = null;
+
+async function getClaudeCliStatus(): Promise<ClaudeCliStatus> {
+  const now = Date.now();
+  if (cachedClaudeStatus && cachedClaudeStatus.expiresAt > now) {
+    return cachedClaudeStatus.value;
+  }
+
+  let value: ClaudeCliStatus;
+  try {
+    const { stdout } = await execFileAsync('claude', ['--version'], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    });
+    const version = extractCCVersion(stdout);
+    const healthy = version === null || compareSemver(version, MIN_CC_VERSION) >= 0;
+
+    value = {
+      available: true,
+      healthy,
+      version,
+      minimumVersion: MIN_CC_VERSION,
+      error: healthy
+        ? null
+        : `Installed version ${version ?? 'unknown'} is below the minimum supported version ${MIN_CC_VERSION}.`,
+    };
+  } catch (error) {
+    value = {
+      available: false,
+      healthy: false,
+      version: null,
+      minimumVersion: MIN_CC_VERSION,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  cachedClaudeStatus = {
+    expiresAt: now + CLAUDE_STATUS_CACHE_TTL_MS,
+    value,
+  };
+  return value;
+}
 
 export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): void {
   const { sessions, tmux, metrics, channels, alertManager, swarmMonitor, auth } = ctx;
@@ -23,18 +80,16 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
     const pkg = await import('../../package.json', { with: { type: 'json' } });
     const activeCount = sessions.listSessions().length;
     const totalCount = metrics.getTotalSessionsCreated();
-    if (ctx.serverState.draining) {
-      return {
-        status: 'draining',
-        version: pkg.default.version,
-        platform: process.platform,
-        uptime: process.uptime(),
-        sessions: { active: activeCount, total: totalCount },
-        timestamp: new Date().toISOString(),
-      };
-    }
-    const tmuxHealth = await tmux.isServerHealthy();
-    const status = tmuxHealth.healthy ? 'ok' : 'degraded';
+    const [tmuxHealth, claudeStatus] = await Promise.all([
+      tmux.isServerHealthy(),
+      getClaudeCliStatus(),
+    ]);
+    const status = ctx.serverState.draining
+      ? 'draining'
+      : tmuxHealth.healthy
+        ? 'ok'
+        : 'degraded';
+
     return {
       status,
       version: pkg.default.version,
@@ -42,6 +97,7 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
       uptime: process.uptime(),
       sessions: { active: activeCount, total: totalCount },
       tmux: tmuxHealth,
+      claude: claudeStatus,
       timestamp: new Date().toISOString(),
     };
   }

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -674,7 +674,7 @@ export function registerOpenApiSpec(): void {
     method: 'get',
     path: '/v1/health',
     summary: 'Health check',
-    description: 'Server health including tmux status, version, uptime.',
+    description: 'Server health including tmux status, Claude CLI status, version, uptime.',
     tags: ['Health'],
     responses: { '200': okJsonResponse(z.any()) },
   });


### PR DESCRIPTION
## Summary

Adds a dedicated dashboard home experience with onboarding/status panels, richer overview activity, and health surfaces that expose Claude CLI readiness for first-run setup.

## Aegis version

**Developed with:** v0.5.3-alpha
**Tested with:** v0.5.3-alpha

## Change type

- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring with no behavior change
- [ ] `perf` — Performance improvement
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling
- [x] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

Dashboard overview UX, onboarding/status presentation, recent activity display, and health API payloads.

## Linked issue

Closes #1921

## Test plan

Repository gate passed (`npm run gate`).

- [x] Unit tests pass (`npm test`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Manually tested (describe below)

## Security impact

None.