### PR TITLE
feat: add audit export dashboard UI

### DIFF
--- a/dashboard/e2e/audit.spec.ts
+++ b/dashboard/e2e/audit.spec.ts
@@ -1,7 +1,54 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { authenticate } from './helpers/auth';
 
 const DASHBOARD_BASE_URL = 'http://localhost:5173/dashboard/';
+
+const mockRecords = [
+  {
+    ts: '2026-04-16T10:30:00.000Z',
+    actor: 'admin-key',
+    action: 'session.create',
+    sessionId: '11111111-1111-1111-1111-111111111111',
+    detail: 'Created session one',
+    prevHash: '',
+    hash: 'hash-1',
+  },
+  {
+    ts: '2026-04-16T10:35:00.000Z',
+    actor: 'admin-key',
+    action: 'permission.approve',
+    sessionId: '11111111-1111-1111-1111-111111111111',
+    detail: 'Approved session one',
+    prevHash: 'hash-1',
+    hash: 'hash-2',
+  },
+];
+
+function createAuditResponse(records = mockRecords, total = records.length) {
+  const first = records[0];
+  const last = records[records.length - 1];
+
+  return JSON.stringify({
+    count: records.length,
+    total,
+    records,
+    filters: {},
+    pagination: {
+      limit: 25,
+      hasMore: false,
+      nextCursor: null,
+      reverse: true,
+    },
+    chain: {
+      count: records.length,
+      firstHash: first?.hash ?? null,
+      lastHash: last?.hash ?? null,
+      badgeHash: 'badge-hash',
+      firstTs: first?.ts ?? null,
+      lastTs: last?.ts ?? null,
+    },
+  });
+}
 
 test.describe('Audit Trail Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,29 +58,7 @@ test.describe('Audit Trail Page', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          records: [
-            {
-              id: 'audit-1',
-              ts: '2026-04-16T10:30:00Z',
-              actor: 'admin-key',
-              action: 'create',
-              sessionId: 'sess-abc123',
-              detail: 'Created session',
-            },
-            {
-              id: 'audit-2',
-              ts: '2026-04-16T10:35:00Z',
-              actor: 'admin-key',
-              action: 'send',
-              sessionId: 'sess-abc123',
-              detail: 'Sent message',
-            },
-          ],
-          total: 2,
-          page: 1,
-          pageSize: 10,
-        }),
+        body: createAuditResponse(),
       });
     });
 
@@ -43,62 +68,44 @@ test.describe('Audit Trail Page', () => {
 
   test('renders audit trail heading', async ({ page }) => {
     await expect(page.getByRole('heading', { name: /audit trail/i })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Review system actions')).toBeVisible();
+    await expect(page.getByText('Query admin audit events')).toBeVisible();
   });
 
-  test('renders filter section with inputs', async ({ page }) => {
+  test('renders filter inputs and export actions', async ({ page }) => {
     await expect(page.getByLabel(/actor/i)).toBeVisible();
     await expect(page.getByLabel(/action/i)).toBeVisible();
     await expect(page.getByLabel(/session id/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /apply/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /clear/i })).toBeVisible();
+    await expect(page.getByLabel(/^from$/i)).toBeVisible();
+    await expect(page.getByLabel(/^to$/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /^apply$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^clear$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /export csv/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /export ndjson/i })).toBeVisible();
   });
 
-  test('renders refresh button', async ({ page }) => {
-    await expect(page.getByRole('button', { name: /refresh/i })).toBeVisible();
+  test('renders audit records from the API', async ({ page }) => {
+    await expect(page.getByText('Created session one')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Approved session one')).toBeVisible();
+    await expect(page.getByText('admin-key').first()).toBeVisible();
   });
 
-  test('renders table with column headers', async ({ page }) => {
-    const headers = ['Timestamp', 'Actor', 'Action', 'Session ID', 'Detail'];
-    for (const header of headers) {
-      await expect(page.getByText(header, { exact: true }).first()).toBeVisible({ timeout: 5_000 });
-    }
-  });
-
-  test('renders audit records from API', async ({ page }) => {
-    await expect(page.getByText('admin-key').first()).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText('sess-abc123').first()).toBeVisible();
-  });
-
-  test('action badges are color-coded', async ({ page }) => {
-    const createAction = page.locator('span', { hasText: 'create' }).first();
-    await expect(createAction).toBeVisible();
-    const sendAction = page.locator('span', { hasText: 'send' }).first();
-    await expect(sendAction).toBeVisible();
-  });
-
-  test('pagination controls are visible', async ({ page }) => {
-    await expect(page.getByText(/2 records/)).toBeVisible({ timeout: 5_000 });
+  test('renders pagination controls', async ({ page }) => {
+    await expect(page.getByText(/2 records/)).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText(/page 1 of 1/i)).toBeVisible();
     await expect(page.getByLabel(/previous page/i)).toBeVisible();
     await expect(page.getByLabel(/next page/i)).toBeVisible();
   });
-
-  test('page size selector works', async ({ page }) => {
-    const pageSizeSelect = page.getByLabel(/page size/i);
-    await expect(pageSizeSelect).toBeVisible();
-  });
 });
 
 test.describe('Audit Trail Page — empty state', () => {
-  test('shows empty state when no records', async ({ page }) => {
+  test('shows empty state when no records match', async ({ page }) => {
     await authenticate(page);
 
     await page.route('**/v1/audit**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ records: [], total: 0, page: 1, pageSize: 10 }),
+        body: createAuditResponse([], 0),
       });
     });
 

--- a/dashboard/src/__tests__/AuditPage.test.tsx
+++ b/dashboard/src/__tests__/AuditPage.test.tsx
@@ -1,42 +1,97 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AuditPage from '../pages/AuditPage';
 
 const mockFetchAuditLogs = vi.fn();
+const mockExportAuditLogs = vi.fn();
 
 vi.mock('../api/client', () => ({
   fetchAuditLogs: (...args: unknown[]) => mockFetchAuditLogs(...args),
+  exportAuditLogs: (...args: unknown[]) => mockExportAuditLogs(...args),
 }));
 
 const mockRecords = [
   {
-    id: 'audit-1',
-    ts: '2026-04-09T10:00:00Z',
-    actor: 'key-abc123',
-    action: 'create',
-    sessionId: 'sess-1',
-    detail: 'Created session "build-agent"',
+    ts: '2026-04-17T10:00:00.000Z',
+    actor: 'admin-key',
+    action: 'session.create',
+    sessionId: '11111111-1111-1111-1111-111111111111',
+    detail: 'Created session one',
+    prevHash: '',
+    hash: 'hash-1',
   },
   {
-    id: 'audit-2',
-    ts: '2026-04-09T10:05:00Z',
-    actor: 'key-def456',
-    action: 'send',
-    sessionId: 'sess-1',
-    detail: 'Sent message to session',
+    ts: '2026-04-17T10:20:00.000Z',
+    actor: 'admin-key',
+    action: 'permission.approve',
+    sessionId: '11111111-1111-1111-1111-111111111111',
+    detail: 'Approved session one',
+    prevHash: 'hash-1',
+    hash: 'hash-2',
   },
   {
-    id: 'audit-3',
-    ts: '2026-04-09T10:10:00Z',
-    actor: 'key-abc123',
-    action: 'kill',
-    sessionId: 'sess-2',
-    detail: undefined,
+    ts: '2026-04-17T10:30:00.000Z',
+    actor: 'viewer-key',
+    action: 'session.kill',
+    sessionId: '22222222-2222-2222-2222-222222222222',
+    detail: 'Killed session two',
+    prevHash: 'hash-2',
+    hash: 'hash-3',
   },
 ];
 
-const emptyResponse = { records: [], total: 0, page: 1, pageSize: 10 };
+function createAuditPageResponse(overrides?: {
+  records?: typeof mockRecords;
+  total?: number;
+  filters?: {
+    actor?: string;
+    action?: string;
+    sessionId?: string;
+    from?: string;
+    to?: string;
+  };
+  pagination?: {
+    limit?: number;
+    hasMore?: boolean;
+    nextCursor?: string | null;
+    reverse?: boolean;
+  };
+  chain?: {
+    count?: number;
+    firstHash?: string | null;
+    lastHash?: string | null;
+    badgeHash?: string | null;
+    firstTs?: string | null;
+    lastTs?: string | null;
+  };
+}) {
+  const records = overrides?.records ?? mockRecords;
+  const first = records[0];
+  const last = records[records.length - 1];
+
+  return {
+    count: records.length,
+    total: overrides?.total ?? records.length,
+    records,
+    filters: overrides?.filters ?? {},
+    pagination: {
+      limit: overrides?.pagination?.limit ?? 25,
+      hasMore: overrides?.pagination?.hasMore ?? false,
+      nextCursor: overrides?.pagination?.nextCursor ?? null,
+      reverse: overrides?.pagination?.reverse ?? true,
+    },
+    chain: {
+      count: overrides?.chain?.count ?? records.length,
+      firstHash: overrides?.chain?.firstHash ?? first?.hash ?? null,
+      lastHash: overrides?.chain?.lastHash ?? last?.hash ?? null,
+      badgeHash: overrides?.chain?.badgeHash ?? 'badge-hash',
+      firstTs: overrides?.chain?.firstTs ?? first?.ts ?? null,
+      lastTs: overrides?.chain?.lastTs ?? last?.ts ?? null,
+    },
+    integrity: undefined,
+  };
+}
 
 function renderPage(): void {
   render(
@@ -51,105 +106,226 @@ describe('AuditPage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders table headers', async () => {
-    mockFetchAuditLogs.mockResolvedValue({ ...emptyResponse, records: mockRecords, total: 3 });
+  it('renders filters, export actions, and audit records', async () => {
+    mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse());
+
     renderPage();
+
     await waitFor(() => {
-      const headers = screen.getAllByRole('columnheader');
-      expect(headers.map((h) => h.textContent)).toEqual(['Timestamp', 'Actor', 'Action', 'Session ID', 'Detail']);
+      expect(screen.getByRole('heading', { name: 'Audit Trail' })).toBeDefined();
+      expect(screen.getByLabelText('Actor')).toBeDefined();
+      expect(screen.getByLabelText('Action')).toBeDefined();
+      expect(screen.getByLabelText('Session ID')).toBeDefined();
+      expect(screen.getByLabelText('From')).toBeDefined();
+      expect(screen.getByLabelText('To')).toBeDefined();
+      expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDefined();
+      expect(screen.getByRole('button', { name: 'Export NDJSON' })).toBeDefined();
+      expect(screen.getByText('Created session one')).toBeDefined();
+      expect(screen.getByText('Killed session two')).toBeDefined();
     });
   });
 
-  it('renders empty state when no records', async () => {
-    mockFetchAuditLogs.mockResolvedValue(emptyResponse);
+  it('renders empty state when no records match', async () => {
+    mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse({ records: [], total: 0 }));
+
     renderPage();
+
     await waitFor(() => {
       expect(screen.getByText('No audit records found')).toBeDefined();
     });
   });
 
-  it('renders loading skeleton', () => {
-    mockFetchAuditLogs.mockReturnValue(new Promise(() => {}));
-    renderPage();
-    expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
-  });
-
-  it('renders error state with retry button', async () => {
-    mockFetchAuditLogs.mockRejectedValue(new Error('Network error'));
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText('Failed to load audit logs')).toBeDefined();
-      expect(screen.getByText('Retry')).toBeDefined();
-    });
-  });
-
-  it('shows 404 message when endpoint is not implemented', async () => {
+  it('shows a dedicated message when the endpoint is unavailable', async () => {
     const error = new Error('HTTP 404') as Error & { statusCode: number };
     error.statusCode = 404;
     mockFetchAuditLogs.mockRejectedValue(error);
+
     renderPage();
+
     await waitFor(() => {
       expect(screen.getByText('Audit endpoint not available yet')).toBeDefined();
     });
   });
 
-  it('renders pagination controls when records exist', async () => {
-    mockFetchAuditLogs.mockResolvedValue({ records: mockRecords, total: 3, page: 1, pageSize: 10 });
+  it('applies actor, action, session, and time range filters with ISO timestamps', async () => {
+    mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse());
+
     renderPage();
+
     await waitFor(() => {
-      expect(screen.getByText('3 records')).toBeDefined();
-      expect(screen.getByLabelText('Previous page')).toBeDefined();
-      expect(screen.getByLabelText('Next page')).toBeDefined();
+      expect(mockFetchAuditLogs).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByLabelText('Actor'), { target: { value: 'admin-key ' } });
+    fireEvent.change(screen.getByLabelText('Action'), { target: { value: 'session.kill' } });
+    fireEvent.change(screen.getByLabelText('Session ID'), { target: { value: '22222222-2222-2222-2222-222222222222' } });
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-04-17T10:15' } });
+    fireEvent.change(screen.getByLabelText('To'), { target: { value: '2026-04-17T10:45' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(mockFetchAuditLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        actor: 'admin-key',
+        action: 'session.kill',
+        sessionId: '22222222-2222-2222-2222-222222222222',
+        from: new Date('2026-04-17T10:15').toISOString(),
+        to: new Date('2026-04-17T10:45').toISOString(),
+        limit: 25,
+        reverse: true,
+      }));
     });
   });
 
-  it('disables previous button on first page', async () => {
-    mockFetchAuditLogs.mockResolvedValue({ records: mockRecords, total: 3, page: 1, pageSize: 10 });
+  it('validates the time range before refetching', async () => {
+    mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse());
+
     renderPage();
+
     await waitFor(() => {
-      expect(screen.getByLabelText('Previous page').hasAttribute('disabled')).toBe(true);
+      expect(mockFetchAuditLogs).toHaveBeenCalledTimes(1);
     });
+
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-04-17T11:00' } });
+    fireEvent.change(screen.getByLabelText('To'), { target: { value: '2026-04-17T10:00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(screen.getByText('From must be earlier than or equal to To.')).toBeDefined();
+    expect(mockFetchAuditLogs).toHaveBeenCalledTimes(1);
   });
 
-  it('renders audit records with action badges', async () => {
-    mockFetchAuditLogs.mockResolvedValue({ records: mockRecords, total: 3, page: 1, pageSize: 10 });
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getAllByText('key-abc123').length).toBe(2);
-      // Actions appear in both the select dropdown and the table badges
-      expect(screen.getAllByText('create').length).toBeGreaterThanOrEqual(2);
-      expect(screen.getAllByText('send').length).toBeGreaterThanOrEqual(2);
-      expect(screen.getAllByText('kill').length).toBeGreaterThanOrEqual(2);
-    });
-  });
-
-  it('navigates to next page when Next is clicked', async () => {
+  it('uses cursor pagination metadata for the next page', async () => {
     mockFetchAuditLogs
-      .mockResolvedValueOnce({ records: mockRecords, total: 15, page: 1, pageSize: 10 })
-      .mockResolvedValueOnce({ records: mockRecords.slice(0, 1), total: 15, page: 2, pageSize: 10 });
+      .mockResolvedValueOnce(createAuditPageResponse({
+        total: 30,
+        pagination: {
+          limit: 25,
+          hasMore: true,
+          nextCursor: 'cursor-page-2',
+          reverse: true,
+        },
+      }))
+      .mockResolvedValueOnce(createAuditPageResponse({
+        records: [mockRecords[2]],
+        total: 30,
+        pagination: {
+          limit: 25,
+          hasMore: false,
+          nextCursor: null,
+          reverse: true,
+        },
+      }));
+
     renderPage();
+
     await waitFor(() => {
       expect(screen.getByText('Page 1 of 2')).toBeDefined();
     });
+
     fireEvent.click(screen.getByLabelText('Next page'));
+
     await waitFor(() => {
+      expect(mockFetchAuditLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        cursor: 'cursor-page-2',
+        limit: 25,
+        reverse: true,
+      }));
       expect(screen.getByText('Page 2 of 2')).toBeDefined();
     });
   });
 
-  it('applies filters and resets to page 1', async () => {
-    mockFetchAuditLogs.mockResolvedValue(emptyResponse);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText('No audit records found')).toBeDefined();
+  it('exports CSV and renders chain-integrity metadata from the response', async () => {
+    mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse());
+    mockExportAuditLogs.mockResolvedValue({
+      filename: 'audit-export-2026-04-17.csv',
+      format: 'csv',
+      mimeType: 'text/csv; charset=utf-8',
+      chain: {
+        count: 2,
+        firstHash: 'first-hash',
+        lastHash: 'last-hash',
+        badgeHash: 'badge-hash-export',
+        firstTs: '2026-04-17T10:00:00.000Z',
+        lastTs: '2026-04-17T10:30:00.000Z',
+      },
+      integrity: {
+        valid: true,
+        file: 'audit-2026-04-17.log',
+      },
     });
-    const actorInput = screen.getByPlaceholderText('e.g. key-abc123');
-    fireEvent.change(actorInput, { target: { value: 'key-abc123' } });
-    fireEvent.click(screen.getByText('Apply'));
+
+    renderPage();
+
     await waitFor(() => {
-      expect(mockFetchAuditLogs).toHaveBeenCalledWith(
-        expect.objectContaining({ actor: 'key-abc123', page: 1 }),
-      );
+      expect(screen.getByText('3 records')).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText('Actor'), { target: { value: 'admin-key' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(mockFetchAuditLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        actor: 'admin-key',
+      }));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+
+    await waitFor(() => {
+      expect(mockExportAuditLogs).toHaveBeenCalledWith(expect.objectContaining({
+        actor: 'admin-key',
+        format: 'csv',
+        reverse: true,
+        verify: true,
+      }));
+      expect(screen.getByText('Latest export metadata')).toBeDefined();
+      expect(screen.getByText('Integrity verified')).toBeDefined();
+      expect(screen.getByText('badge-hash-export')).toBeDefined();
+      expect(screen.getByText('audit-export-2026-04-17.csv · CSV')).toBeDefined();
+    });
+  });
+
+  it('exports NDJSON with the applied filters', async () => {
+    mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse());
+    mockExportAuditLogs.mockResolvedValue({
+      filename: 'audit-export-2026-04-17.ndjson',
+      format: 'ndjson',
+      mimeType: 'application/x-ndjson; charset=utf-8',
+      chain: {
+        count: 1,
+        firstHash: 'only-hash',
+        lastHash: 'only-hash',
+        badgeHash: 'ndjson-badge',
+        firstTs: '2026-04-17T10:30:00.000Z',
+        lastTs: '2026-04-17T10:30:00.000Z',
+      },
+      integrity: {
+        valid: true,
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('3 records')).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText('Action'), { target: { value: 'session.kill' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    await waitFor(() => {
+      expect(mockFetchAuditLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        action: 'session.kill',
+      }));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export NDJSON' }));
+
+    await waitFor(() => {
+      expect(mockExportAuditLogs).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'session.kill',
+        format: 'ndjson',
+        reverse: true,
+        verify: true,
+      }));
     });
   });
 });

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -5,6 +5,168 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { checkForUpdates, isRetryableError } from '../api/client';
 
+describe('audit client helpers (#1923)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('fetchAuditLogs sends API-compatible filters and cursor params', async () => {
+    const from = '2026-04-17T10:15:00.000Z';
+    const to = '2026-04-17T10:45:00.000Z';
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      count: 1,
+      total: 1,
+      records: [{
+        ts: '2026-04-17T10:30:00.000Z',
+        actor: 'admin-key',
+        action: 'session.kill',
+        sessionId: '22222222-2222-2222-2222-222222222222',
+        detail: 'Killed session two',
+        prevHash: 'hash-1',
+        hash: 'hash-2',
+      }],
+      filters: {
+        actor: 'admin-key',
+        action: 'session.kill',
+        sessionId: '22222222-2222-2222-2222-222222222222',
+        from,
+        to,
+      },
+      pagination: {
+        limit: 25,
+        hasMore: true,
+        nextCursor: 'cursor-page-2',
+        reverse: true,
+      },
+      chain: {
+        count: 1,
+        firstHash: 'hash-2',
+        lastHash: 'hash-2',
+        badgeHash: 'badge-hash',
+        firstTs: '2026-04-17T10:30:00.000Z',
+        lastTs: '2026-04-17T10:30:00.000Z',
+      },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { fetchAuditLogs } = await import('../api/client');
+
+    await expect(fetchAuditLogs({
+      limit: 25,
+      cursor: 'cursor-page-1',
+      actor: 'admin-key',
+      action: 'session.kill',
+      sessionId: '22222222-2222-2222-2222-222222222222',
+      from,
+      to,
+      reverse: true,
+    })).resolves.toMatchObject({
+      total: 1,
+      pagination: { nextCursor: 'cursor-page-2' },
+      chain: { badgeHash: 'badge-hash' },
+    });
+
+    const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const url = new URL(requestUrl, 'http://localhost');
+    expect(url.pathname).toBe('/v1/audit');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('cursor')).toBe('cursor-page-1');
+    expect(url.searchParams.get('actor')).toBe('admin-key');
+    expect(url.searchParams.get('action')).toBe('session.kill');
+    expect(url.searchParams.get('sessionId')).toBe('22222222-2222-2222-2222-222222222222');
+    expect(url.searchParams.get('from')).toBe(from);
+    expect(url.searchParams.get('to')).toBe(to);
+    expect(url.searchParams.get('reverse')).toBe('true');
+    expect(url.searchParams.get('format')).toBe('json');
+    expect(requestInit.headers).toEqual(expect.not.objectContaining({ Accept: expect.anything() }));
+  });
+
+  it('exportAuditLogs downloads the file and returns header metadata', async () => {
+    localStorage.setItem('aegis_token', 'stored-token');
+
+    fetchMock.mockResolvedValueOnce(new Response('ts,actor,action,sessionId,detail,prevHash,hash\n', {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': 'attachment; filename="audit-export-2026-04-17.csv"',
+        'X-Aegis-Audit-Record-Count': '1',
+        'X-Aegis-Audit-First-Hash': 'first-hash',
+        'X-Aegis-Audit-Last-Hash': 'last-hash',
+        'X-Aegis-Audit-Chain-Badge': 'badge-hash',
+        'X-Aegis-Audit-First-Ts': '2026-04-17T10:00:00.000Z',
+        'X-Aegis-Audit-Last-Ts': '2026-04-17T10:30:00.000Z',
+        'X-Aegis-Audit-Integrity-Valid': 'true',
+        'X-Aegis-Audit-Integrity-File': 'audit-2026-04-17.log',
+      },
+    }));
+
+    const link = document.createElement('a');
+    const clickSpy = vi.spyOn(link, 'click').mockImplementation(() => {});
+    const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(link);
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost/fake');
+    const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const { exportAuditLogs } = await import('../api/client');
+
+    await expect(exportAuditLogs({
+      format: 'csv',
+      actor: 'admin-key',
+      action: 'session.kill',
+      sessionId: '22222222-2222-2222-2222-222222222222',
+      verify: true,
+      reverse: true,
+    })).resolves.toEqual({
+      filename: 'audit-export-2026-04-17.csv',
+      format: 'csv',
+      mimeType: 'text/csv; charset=utf-8',
+      chain: {
+        count: 1,
+        firstHash: 'first-hash',
+        lastHash: 'last-hash',
+        badgeHash: 'badge-hash',
+        firstTs: '2026-04-17T10:00:00.000Z',
+        lastTs: '2026-04-17T10:30:00.000Z',
+      },
+      integrity: {
+        valid: true,
+        file: 'audit-2026-04-17.log',
+      },
+    });
+
+    const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const url = new URL(requestUrl, 'http://localhost');
+    expect(url.searchParams.get('format')).toBe('csv');
+    expect(url.searchParams.get('verify')).toBe('true');
+    expect(url.searchParams.get('actor')).toBe('admin-key');
+    expect(url.searchParams.get('action')).toBe('session.kill');
+    expect(url.searchParams.get('sessionId')).toBe('22222222-2222-2222-2222-222222222222');
+    expect(requestInit.headers).toEqual(expect.objectContaining({
+      Accept: 'text/csv',
+      Authorization: 'Bearer stored-token',
+    }));
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(link.download).toBe('audit-export-2026-04-17.csv');
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:http://localhost/fake');
+  });
+});
+
 describe('getSessionStatusCounts', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -97,8 +97,6 @@ describe('audit client helpers (#1923)', () => {
   });
 
   it('exportAuditLogs downloads the file and returns header metadata', async () => {
-    localStorage.setItem('aegis_token', 'stored-token');
-
     fetchMock.mockResolvedValueOnce(new Response('ts,actor,action,sessionId,detail,prevHash,hash\n', {
       status: 200,
       headers: {
@@ -121,7 +119,8 @@ describe('audit client helpers (#1923)', () => {
     const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost/fake');
     const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
 
-    const { exportAuditLogs } = await import('../api/client');
+    const { exportAuditLogs, setTokenAccessor } = await import('../api/client');
+    setTokenAccessor(() => 'stored-token');
 
     await expect(exportAuditLogs({
       format: 'csv',

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -30,8 +30,13 @@ import type {
   VerifyTokenResponse,
   CreatedAuthKey,
 } from '../types';
-import type { AuditPageResponse } from '../types/index.js';
+import type {
+  AuditChainMetadata,
+  AuditIntegrityMetadata,
+  AuditPageResponse,
+} from '../types/index.js';
 import {
+  AuditPageResponseSchema,
   AuthKeySummarySchema,
   CreatedAuthKeySchema,
   HealthResponseSchema,
@@ -128,10 +133,10 @@ interface RequestOptions extends RequestInit {
   schemaContext?: string;
 }
 
-async function request<T>(
+async function requestResponse(
   path: string,
   options: RequestOptions = {},
-): Promise<T> {
+): Promise<Response> {
   const token = tokenAccessor();
   const headers: Record<string, string> = {
     ...(options.body ? { 'Content-Type': 'application/json' } : {}),
@@ -139,7 +144,7 @@ async function request<T>(
     ...headersToObject(options.headers),
   };
 
-  const { retries = 0, schema, schemaContext, ...fetchOptions } = options;
+  const { retries = 0, schema: _schema, schemaContext: _schemaContext, ...fetchOptions } = options;
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt <= retries; attempt++) {
@@ -158,9 +163,7 @@ async function request<T>(
         err.statusCode = res.status;
         throw err;
       }
-      const data = await res.json();
-      if (schema) return validateResponse(data, schema as z.ZodType<T>, schemaContext ?? path);
-      return data as T;
+      return res;
     } catch (e) {
       lastError = e as Error;
       // Retry only on transient network errors (not HTTP errors or AbortError)
@@ -171,8 +174,18 @@ async function request<T>(
       }
     }
   }
-  throw lastError;
-  // Error handling moved into retry loop above
+  throw lastError ?? new Error(`Request failed for ${path}`);
+}
+
+async function request<T>(
+  path: string,
+  options: RequestOptions = {},
+): Promise<T> {
+  const { schema, schemaContext, ...requestOptions } = options;
+  const res = await requestResponse(path, requestOptions);
+  const data = await res.json();
+  if (schema) return validateResponse(data, schema as z.ZodType<T>, schemaContext ?? path);
+  return data as T;
 }
 
 // ── Health ──────────────────────────────────────────────────────
@@ -730,26 +743,151 @@ export function deleteTemplate(id: string): Promise<OkResponse> {
 // ── Audit Trail ──────────────────────────────────────────────────
 
 export interface FetchAuditLogsParams {
-  page?: number;
-  pageSize?: number;
+  limit?: number;
+  cursor?: string;
   actor?: string;
   action?: string;
   sessionId?: string;
+  from?: string;
+  to?: string;
+  reverse?: boolean;
+  verify?: boolean;
   signal?: AbortSignal;
+}
+
+export type AuditExportFormat = 'csv' | 'ndjson';
+
+export interface ExportAuditLogsParams extends Omit<FetchAuditLogsParams, 'limit' | 'cursor'> {
+  format: AuditExportFormat;
+}
+
+export interface AuditExportResult {
+  filename: string;
+  format: AuditExportFormat;
+  mimeType: string;
+  chain: AuditChainMetadata;
+  integrity?: AuditIntegrityMetadata;
+}
+
+interface AuditQueryParams extends Omit<FetchAuditLogsParams, 'signal'> {
+  format?: 'json' | AuditExportFormat;
+}
+
+function buildAuditSearchParams(params: AuditQueryParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  if (params.limit !== undefined) searchParams.set('limit', String(params.limit));
+  if (params.cursor) searchParams.set('cursor', params.cursor);
+  if (params.actor) searchParams.set('actor', params.actor);
+  if (params.action) searchParams.set('action', params.action);
+  if (params.sessionId) searchParams.set('sessionId', params.sessionId);
+  if (params.from) searchParams.set('from', params.from);
+  if (params.to) searchParams.set('to', params.to);
+  if (params.reverse !== undefined) searchParams.set('reverse', String(params.reverse));
+  if (params.verify !== undefined) searchParams.set('verify', String(params.verify));
+  if (params.format) searchParams.set('format', params.format);
+  return searchParams;
+}
+
+function parseAuditExportFilename(headers: Headers, format: AuditExportFormat): string {
+  const disposition = headers.get('Content-Disposition') ?? '';
+  const encodedMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (encodedMatch) {
+    try {
+      return decodeURIComponent(encodedMatch[1]);
+    } catch {
+      return encodedMatch[1];
+    }
+  }
+
+  const quotedMatch = disposition.match(/filename="([^"]+)"/i);
+  if (quotedMatch) return quotedMatch[1];
+
+  const plainMatch = disposition.match(/filename=([^;]+)/i);
+  if (plainMatch) return plainMatch[1].trim();
+
+  return `audit-export.${format}`;
+}
+
+function parseAuditChainMetadata(headers: Headers): AuditChainMetadata {
+  const count = Number.parseInt(headers.get('X-Aegis-Audit-Record-Count') ?? '0', 10);
+  return {
+    count: Number.isFinite(count) ? count : 0,
+    firstHash: headers.get('X-Aegis-Audit-First-Hash'),
+    lastHash: headers.get('X-Aegis-Audit-Last-Hash'),
+    badgeHash: headers.get('X-Aegis-Audit-Chain-Badge'),
+    firstTs: headers.get('X-Aegis-Audit-First-Ts'),
+    lastTs: headers.get('X-Aegis-Audit-Last-Ts'),
+  };
+}
+
+function parseAuditIntegrityMetadata(headers: Headers): AuditIntegrityMetadata | undefined {
+  const validHeader = headers.get('X-Aegis-Audit-Integrity-Valid');
+  if (validHeader === null) return undefined;
+
+  const brokenAtHeader = headers.get('X-Aegis-Audit-Integrity-Broken-At');
+  const brokenAtValue = brokenAtHeader ? Number.parseInt(brokenAtHeader, 10) : undefined;
+  const file = headers.get('X-Aegis-Audit-Integrity-File');
+
+  return {
+    valid: validHeader === 'true',
+    ...(brokenAtValue !== undefined && Number.isFinite(brokenAtValue) ? { brokenAt: brokenAtValue } : {}),
+    ...(file ? { file } : {}),
+  };
+}
+
+function downloadText(content: string, mimeType: string, filename: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
 }
 
 export function fetchAuditLogs(params: FetchAuditLogsParams = {}): Promise<AuditPageResponse> {
   const { signal, ...queryParams } = params;
-  const searchParams = new URLSearchParams();
-  if (queryParams.page !== undefined) searchParams.set('page', String(queryParams.page));
-  if (queryParams.pageSize !== undefined) searchParams.set('pageSize', String(queryParams.pageSize));
-  if (queryParams.actor) searchParams.set('actor', queryParams.actor);
-  if (queryParams.action) searchParams.set('action', queryParams.action);
-  if (queryParams.sessionId) searchParams.set('sessionId', queryParams.sessionId);
-
+  const searchParams = buildAuditSearchParams({ ...queryParams, format: 'json' });
   const query = searchParams.toString();
   const path = query ? `/v1/audit?${query}` : '/v1/audit';
-  return request<AuditPageResponse>(path, { signal });
+  return request<AuditPageResponse>(path, {
+    signal,
+    schema: AuditPageResponseSchema,
+    schemaContext: 'fetchAuditLogs',
+  });
+}
+
+export async function exportAuditLogs(params: ExportAuditLogsParams): Promise<AuditExportResult> {
+  const { signal, format, ...queryParams } = params;
+  const searchParams = buildAuditSearchParams({
+    ...queryParams,
+    format,
+    verify: queryParams.verify ?? true,
+  });
+  const query = searchParams.toString();
+  const path = query ? `/v1/audit?${query}` : '/v1/audit';
+  const accept = format === 'csv' ? 'text/csv' : 'application/x-ndjson';
+  const response = await requestResponse(path, {
+    signal,
+    headers: {
+      Accept: accept,
+    },
+  });
+  const content = await response.text();
+  const mimeType = response.headers.get('Content-Type') ?? accept;
+  const filename = parseAuditExportFilename(response.headers, format);
+
+  downloadText(content, mimeType, filename);
+
+  return {
+    filename,
+    format,
+    mimeType,
+    chain: parseAuditChainMetadata(response.headers),
+    integrity: parseAuditIntegrityMetadata(response.headers),
+  };
 }
 
 // ── Users & Session History ─────────────────────────────────────

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -7,6 +7,10 @@
 
 import { z } from 'zod';
 import type {
+  AuditChainMetadata,
+  AuditIntegrityMetadata,
+  AuditPageResponse,
+  AuditRecord,
   HealthResponse,
   SessionInfo,
   SessionStats,
@@ -78,6 +82,54 @@ export const CreatedAuthKeySchema: z.ZodType<CreatedAuthKey> = z.object({
   expiresAt: z.number().nullable(),
   role: z.enum(['admin', 'operator', 'viewer']),
   permissions: z.array(ApiKeyPermissionSchema),
+});
+
+// ── Audit Trail ──────────────────────────────────────────────────
+
+export const AuditRecordSchema: z.ZodType<AuditRecord> = z.object({
+  ts: z.string(),
+  actor: z.string(),
+  action: z.string(),
+  sessionId: z.string().optional(),
+  detail: z.string(),
+  prevHash: z.string(),
+  hash: z.string(),
+});
+
+export const AuditChainMetadataSchema: z.ZodType<AuditChainMetadata> = z.object({
+  count: z.number().int().nonnegative(),
+  firstHash: z.string().nullable(),
+  lastHash: z.string().nullable(),
+  badgeHash: z.string().nullable(),
+  firstTs: z.string().nullable(),
+  lastTs: z.string().nullable(),
+});
+
+export const AuditIntegrityMetadataSchema: z.ZodType<AuditIntegrityMetadata> = z.object({
+  valid: z.boolean(),
+  brokenAt: z.number().int().positive().optional(),
+  file: z.string().optional(),
+});
+
+export const AuditPageResponseSchema: z.ZodType<AuditPageResponse> = z.object({
+  count: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+  records: z.array(AuditRecordSchema),
+  filters: z.object({
+    actor: z.string().optional(),
+    action: z.string().optional(),
+    sessionId: z.string().optional(),
+    from: z.string().optional(),
+    to: z.string().optional(),
+  }),
+  pagination: z.object({
+    limit: z.number().int().positive(),
+    hasMore: z.boolean(),
+    nextCursor: z.string().nullable(),
+    reverse: z.boolean(),
+  }),
+  chain: AuditChainMetadataSchema,
+  integrity: AuditIntegrityMetadataSchema.optional(),
 });
 
 // ── SendResponse ────────────────────────────────────────────────

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -1,50 +1,147 @@
 /**
- * pages/AuditPage.tsx — Audit trail with paginated table, filters, and search.
+ * pages/AuditPage.tsx — Audit trail query and export UI.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  Shield,
-  Filter,
-  RefreshCw,
+  AlertCircle,
   ChevronLeft,
   ChevronRight,
+  Download,
+  Filter,
+  RefreshCw,
   SearchX,
-  AlertCircle,
+  Shield,
 } from 'lucide-react';
 import EmptyState from '../components/shared/EmptyState';
-import { fetchAuditLogs, type FetchAuditLogsParams } from '../api/client';
+import {
+  exportAuditLogs,
+  fetchAuditLogs,
+  type AuditExportFormat,
+  type AuditExportResult,
+  type FetchAuditLogsParams,
+} from '../api/client';
 import type { AuditRecord } from '../types';
 
-const ACTION_OPTIONS = [
-  { value: '', label: 'All actions' },
-  { value: 'create', label: 'create' },
-  { value: 'kill', label: 'kill' },
-  { value: 'send', label: 'send' },
-  { value: 'approve', label: 'approve' },
-  { value: 'reject', label: 'reject' },
+const ACTION_SUGGESTIONS = [
+  'key.create',
+  'key.revoke',
+  'session.create',
+  'session.kill',
+  'session.env.rejected',
+  'session.action.allowed',
+  'session.action.denied',
+  'permission.approve',
+  'permission.reject',
+  'api.authenticated',
 ] as const;
 
-const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
+const PAGE_SIZE_OPTIONS = [25, 50, 100] as const;
 
-function formatTimestamp(ts: string): string {
-  try {
-    return new Date(ts).toLocaleString();
-  } catch {
-    return ts;
+interface AuditFilterState {
+  actor: string;
+  action: string;
+  sessionId: string;
+  from: string;
+  to: string;
+}
+
+const EMPTY_FILTERS: AuditFilterState = {
+  actor: '',
+  action: '',
+  sessionId: '',
+  from: '',
+  to: '',
+};
+
+function formatTimestamp(ts?: string | null): string {
+  if (!ts) return '—';
+
+  const parsed = new Date(ts);
+  if (Number.isNaN(parsed.getTime())) return ts;
+
+  return parsed.toLocaleString();
+}
+
+function toIsoTimestamp(value: string): string | undefined {
+  if (!value) return undefined;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+
+  return parsed.toISOString();
+}
+
+function trimFilters(filters: AuditFilterState): AuditFilterState {
+  return {
+    actor: filters.actor.trim(),
+    action: filters.action.trim(),
+    sessionId: filters.sessionId.trim(),
+    from: filters.from,
+    to: filters.to,
+  };
+}
+
+function validateFilters(filters: AuditFilterState): string | null {
+  const from = toIsoTimestamp(filters.from);
+  const to = toIsoTimestamp(filters.to);
+
+  if (filters.from && !from) return 'From must be a valid date and time.';
+  if (filters.to && !to) return 'To must be a valid date and time.';
+  if (from && to && Date.parse(from) > Date.parse(to)) {
+    return 'From must be earlier than or equal to To.';
   }
+
+  return null;
+}
+
+function buildAuditParams(filters: AuditFilterState): Omit<FetchAuditLogsParams, 'cursor' | 'limit' | 'signal'> {
+  const actor = filters.actor.trim();
+  const action = filters.action.trim();
+  const sessionId = filters.sessionId.trim();
+  const from = toIsoTimestamp(filters.from);
+  const to = toIsoTimestamp(filters.to);
+
+  return {
+    ...(actor ? { actor } : {}),
+    ...(action ? { action } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+    reverse: true,
+  };
+}
+
+function hasActiveFilters(filters: AuditFilterState): boolean {
+  return Object.values(filters).some((value) => value !== '');
+}
+
+function actionBadgeClass(action: string): string {
+  if (action.includes('deny') || action.includes('kill')) {
+    return 'border border-rose-500/30 bg-rose-500/10 text-rose-300';
+  }
+  if (action.includes('reject')) {
+    return 'border border-amber-500/30 bg-amber-500/10 text-amber-300';
+  }
+  if (action.includes('approve') || action.includes('allowed')) {
+    return 'border border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+  }
+  if (action.includes('create') || action.includes('authenticated')) {
+    return 'border border-cyan-500/30 bg-cyan-500/10 text-cyan-300';
+  }
+  return 'border border-zinc-700 bg-zinc-700/40 text-zinc-300';
 }
 
 function SkeletonRows({ count }: { count: number }) {
   return (
     <>
-      {Array.from({ length: count }).map((_, i) => (
-        <tr key={i} className="border-b border-zinc-800">
-          <td className="px-4 py-3"><div className="h-4 w-36 animate-pulse rounded bg-zinc-800" /></td>
-          <td className="px-4 py-3"><div className="h-4 w-24 animate-pulse rounded bg-zinc-800" /></td>
-          <td className="px-4 py-3"><div className="h-4 w-16 animate-pulse rounded bg-zinc-800" /></td>
-          <td className="px-4 py-3"><div className="h-4 w-28 animate-pulse rounded bg-zinc-800" /></td>
+      {Array.from({ length: count }).map((_, index) => (
+        <tr key={index} className="border-b border-zinc-800">
           <td className="px-4 py-3"><div className="h-4 w-40 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-28 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-32 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-40 animate-pulse rounded bg-zinc-800" /></td>
+          <td className="px-4 py-3"><div className="h-4 w-48 animate-pulse rounded bg-zinc-800" /></td>
         </tr>
       ))}
     </>
@@ -52,55 +149,112 @@ function SkeletonRows({ count }: { count: number }) {
 }
 
 function AuditRow({ record }: { record: AuditRecord }) {
-  const actionColor: Record<string, string> = {
-    create: 'text-emerald-400 bg-emerald-400/10',
-    kill: 'text-red-400 bg-red-400/10',
-    send: 'text-blue-400 bg-blue-400/10',
-    approve: 'text-green-400 bg-green-400/10',
-    reject: 'text-amber-400 bg-amber-400/10',
-  };
-
-  const colorClass = actionColor[record.action] ?? 'text-zinc-300 bg-zinc-700/50';
-
   return (
-    <tr className="border-b border-zinc-800 hover:bg-zinc-800/40 transition-colors">
-      <td className="px-4 py-3 text-sm text-zinc-400 whitespace-nowrap">
+    <tr className="border-b border-zinc-800 transition-colors hover:bg-zinc-800/40">
+      <td className="whitespace-nowrap px-4 py-3 text-sm text-zinc-400">
         {formatTimestamp(record.ts)}
       </td>
-      <td className="px-4 py-3 text-sm text-zinc-200 font-mono">
+      <td className="px-4 py-3 font-mono text-sm text-zinc-200">
         {record.actor}
       </td>
       <td className="px-4 py-3">
-        <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${colorClass}`}>
+        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${actionBadgeClass(record.action)}`}>
           {record.action}
         </span>
       </td>
-      <td className="px-4 py-3 text-sm text-zinc-300 font-mono">
+      <td className="px-4 py-3 font-mono text-sm text-zinc-300">
         {record.sessionId ?? '—'}
       </td>
-      <td className="px-4 py-3 text-sm text-zinc-400 max-w-xs truncate">
-        {record.detail ?? '—'}
+      <td className="max-w-xl px-4 py-3 text-sm text-zinc-400">
+        {record.detail || '—'}
       </td>
     </tr>
   );
 }
 
+function MetadataField({
+  label,
+  value,
+  monospace = false,
+}: {
+  label: string;
+  value: string;
+  monospace?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-950/50 p-3">
+      <p className="text-xs uppercase tracking-wide text-zinc-500">{label}</p>
+      <p className={`mt-1 text-sm text-zinc-200 ${monospace ? 'break-all font-mono text-xs' : ''}`}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function ExportMetadataCard({ result }: { result: AuditExportResult }) {
+  const integrityTone = result.integrity?.valid
+    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+    : 'border-rose-500/30 bg-rose-500/10 text-rose-300';
+  const integrityLabel = result.integrity?.valid ? 'Integrity verified' : 'Integrity check failed';
+
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-zinc-100">Latest export metadata</p>
+          <p className="mt-1 text-xs text-zinc-500">
+            {result.filename} · {result.format.toUpperCase()}
+          </p>
+        </div>
+        {result.integrity ? (
+          <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${integrityTone}`}>
+            {integrityLabel}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <MetadataField label="Records" value={String(result.chain.count)} />
+        <MetadataField label="First record" value={formatTimestamp(result.chain.firstTs)} />
+        <MetadataField label="Last record" value={formatTimestamp(result.chain.lastTs)} />
+        <MetadataField
+          label="Integrity file"
+          value={result.integrity?.file ?? '—'}
+        />
+      </div>
+
+      <div className="mt-3 grid gap-3 lg:grid-cols-3">
+        <MetadataField label="Chain badge" value={result.chain.badgeHash ?? '—'} monospace />
+        <MetadataField label="First hash" value={result.chain.firstHash ?? '—'} monospace />
+        <MetadataField label="Last hash" value={result.chain.lastHash ?? '—'} monospace />
+      </div>
+
+      {result.integrity && result.integrity.brokenAt !== undefined ? (
+        <p className="mt-3 text-xs text-rose-300">
+          Chain verification failed at line {result.integrity.brokenAt}.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export default function AuditPage() {
+  const cursorStackRef = useRef<Array<string | null>>([null]);
+
   const [records, setRecords] = useState<AuditRecord[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(25);
+  const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [endpointMissing, setEndpointMissing] = useState(false);
-
-  const [filterActor, setFilterActor] = useState('');
-  const [filterAction, setFilterAction] = useState('');
-  const [filterSessionId, setFilterSessionId] = useState('');
-
-  const [appliedActor, setAppliedActor] = useState('');
-  const [appliedAction, setAppliedAction] = useState('');
-  const [appliedSessionId, setAppliedSessionId] = useState('');
+  const [filters, setFilters] = useState<AuditFilterState>(EMPTY_FILTERS);
+  const [appliedFilters, setAppliedFilters] = useState<AuditFilterState>(EMPTY_FILTERS);
+  const [filterError, setFilterError] = useState<string | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportingFormat, setExportingFormat] = useState<AuditExportFormat | null>(null);
+  const [latestExport, setLatestExport] = useState<AuditExportResult | null>(null);
 
   const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -108,154 +262,251 @@ export default function AuditPage() {
     setEndpointMissing(false);
 
     const params: FetchAuditLogsParams = {
-      page,
-      pageSize,
+      ...buildAuditParams(appliedFilters),
+      limit: pageSize,
+      cursor: page > 1 ? cursorStackRef.current[page - 1] ?? undefined : undefined,
     };
-    if (appliedActor) params.actor = appliedActor;
-    if (appliedAction) params.action = appliedAction;
-    if (appliedSessionId) params.sessionId = appliedSessionId;
 
     try {
-      const data = await fetchAuditLogs({ ...params, signal: signal as AbortSignal });
+      const data = await fetchAuditLogs({ ...params, signal });
       setRecords(data.records);
       setTotal(data.total);
-    } catch (e: unknown) {
-      const err = e as Error & { statusCode?: number };
-      // Ignore aborts caused by navigating away — not a real error
+      setHasMore(data.pagination.hasMore);
+
+      if (data.pagination.nextCursor) {
+        cursorStackRef.current[page] = data.pagination.nextCursor;
+      } else {
+        cursorStackRef.current = cursorStackRef.current.slice(0, page);
+      }
+    } catch (caught: unknown) {
+      const err = caught as Error & { statusCode?: number };
       if ((err as DOMException).name === 'AbortError') return;
+
       if (err.statusCode === 404) {
         setEndpointMissing(true);
         setRecords([]);
         setTotal(0);
+        setHasMore(false);
       } else {
         setError(err.message ?? 'Failed to fetch audit logs');
       }
     } finally {
       setLoading(false);
     }
-  }, [page, pageSize, appliedActor, appliedAction, appliedSessionId]);
+  }, [appliedFilters, page, pageSize]);
 
   useEffect(() => {
-    const ac = new AbortController();
-    void fetchData(ac.signal);
-    return () => ac.abort();
+    const controller = new AbortController();
+    void fetchData(controller.signal);
+    return () => controller.abort();
   }, [fetchData]);
 
   const applyFilters = () => {
+    const nextFilters = trimFilters(filters);
+    const validationError = validateFilters(nextFilters);
+
+    if (validationError) {
+      setFilterError(validationError);
+      return;
+    }
+
+    cursorStackRef.current = [null];
+    setFilterError(null);
+    setExportError(null);
     setPage(1);
-    setAppliedActor(filterActor);
-    setAppliedAction(filterAction);
-    setAppliedSessionId(filterSessionId);
+    setAppliedFilters(nextFilters);
   };
 
   const clearFilters = () => {
-    setFilterActor('');
-    setFilterAction('');
-    setFilterSessionId('');
+    cursorStackRef.current = [null];
+    setFilters({ ...EMPTY_FILTERS });
+    setAppliedFilters({ ...EMPTY_FILTERS });
+    setFilterError(null);
+    setExportError(null);
     setPage(1);
-    setAppliedActor('');
-    setAppliedAction('');
-    setAppliedSessionId('');
+  };
+
+  const handleExport = async (format: AuditExportFormat) => {
+    setExportingFormat(format);
+    setExportError(null);
+
+    try {
+      const result = await exportAuditLogs({
+        ...buildAuditParams(appliedFilters),
+        format,
+        verify: true,
+      });
+      setLatestExport(result);
+    } catch (caught: unknown) {
+      const err = caught as Error;
+      setExportError(err.message ?? `Failed to export audit log as ${format.toUpperCase()}`);
+    } finally {
+      setExportingFormat(null);
+    }
   };
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const hasFilters = hasActiveFilters(appliedFilters);
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold text-gray-100">Audit Trail</h2>
           <p className="mt-1 text-sm text-gray-500">
-            Review system actions and API key activity
+            Query admin audit events, export CSV or NDJSON, and review chain-integrity metadata.
           </p>
         </div>
-        <button
-          onClick={() => { void fetchData(); }}
-          disabled={loading}
-          className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded bg-[var(--color-accent-cyan)]]/10 hover:bg-[var(--color-accent-cyan)]]/20 text-[var(--color-accent-cyan)]] border border-[var(--color-accent-cyan)]]/30 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
-          Refresh
-        </button>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={() => { void fetchData(); }}
+            disabled={loading}
+            className="flex items-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-50"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+          <button
+            onClick={() => { void handleExport('csv'); }}
+            disabled={loading || exportingFormat !== null}
+            className="flex items-center gap-1.5 rounded border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 disabled:opacity-50"
+            aria-label="Export CSV"
+          >
+            <Download className="h-3.5 w-3.5" />
+            {exportingFormat === 'csv' ? 'Exporting CSV…' : 'Export CSV'}
+          </button>
+          <button
+            onClick={() => { void handleExport('ndjson'); }}
+            disabled={loading || exportingFormat !== null}
+            className="flex items-center gap-1.5 rounded border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 disabled:opacity-50"
+            aria-label="Export NDJSON"
+          >
+            <Download className="h-3.5 w-3.5" />
+            {exportingFormat === 'ndjson' ? 'Exporting NDJSON…' : 'Export NDJSON'}
+          </button>
+        </div>
       </div>
 
-      {/* Filters */}
       <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
-        <div className="flex items-center gap-2 mb-3">
+        <div className="mb-3 flex items-center gap-2">
           <Filter className="h-4 w-4 text-zinc-400" />
           <span className="text-sm font-medium text-zinc-300">Filters</span>
         </div>
-        <div className="flex flex-wrap items-end gap-3">
+
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
           <div className="flex flex-col gap-1">
-            <label htmlFor="filter-actor" className="text-xs text-zinc-500">Actor (Key ID)</label>
+            <label htmlFor="audit-filter-actor" className="text-xs text-zinc-500">Actor</label>
             <input
-              id="filter-actor"
+              id="audit-filter-actor"
               type="text"
-              placeholder="e.g. key-abc123"
-              value={filterActor}
-              onChange={(e) => setFilterActor(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
-              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]]/50 focus:outline-none"
+              placeholder="e.g. admin-key"
+              value={filters.actor}
+              onChange={(event) => setFilters((current) => ({ ...current, actor: event.target.value }))}
+              onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
+              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
+
           <div className="flex flex-col gap-1">
-            <label htmlFor="filter-action" className="text-xs text-zinc-500">Action</label>
-            <select
-              id="filter-action"
-              value={filterAction}
-              onChange={(e) => setFilterAction(e.target.value)}
-              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 focus:border-[var(--color-accent-cyan)]]/50 focus:outline-none"
-            >
-              {ACTION_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
+            <label htmlFor="audit-filter-action" className="text-xs text-zinc-500">Action</label>
+            <input
+              id="audit-filter-action"
+              type="text"
+              list="audit-action-suggestions"
+              placeholder="e.g. session.kill"
+              value={filters.action}
+              onChange={(event) => setFilters((current) => ({ ...current, action: event.target.value }))}
+              onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
+              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+            />
+            <datalist id="audit-action-suggestions">
+              {ACTION_SUGGESTIONS.map((action) => (
+                <option key={action} value={action} />
               ))}
-            </select>
+            </datalist>
           </div>
+
           <div className="flex flex-col gap-1">
-            <label htmlFor="filter-session" className="text-xs text-zinc-500">Session ID</label>
+            <label htmlFor="audit-filter-session" className="text-xs text-zinc-500">Session ID</label>
             <input
-              id="filter-session"
+              id="audit-filter-session"
               type="text"
-              placeholder="e.g. sess-xyz"
-              value={filterSessionId}
-              onChange={(e) => setFilterSessionId(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
-              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]]/50 focus:outline-none"
+              placeholder="e.g. 11111111-1111-1111-1111-111111111111"
+              value={filters.sessionId}
+              onChange={(event) => setFilters((current) => ({ ...current, sessionId: event.target.value }))}
+              onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
+              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="audit-filter-from" className="text-xs text-zinc-500">From</label>
+            <input
+              id="audit-filter-from"
+              type="datetime-local"
+              value={filters.from}
+              onChange={(event) => setFilters((current) => ({ ...current, from: event.target.value }))}
+              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="audit-filter-to" className="text-xs text-zinc-500">To</label>
+            <input
+              id="audit-filter-to"
+              type="datetime-local"
+              value={filters.to}
+              onChange={(event) => setFilters((current) => ({ ...current, to: event.target.value }))}
+              className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
           <button
             onClick={applyFilters}
-            className="rounded bg-[var(--color-accent-cyan)]]/10 hover:bg-[var(--color-accent-cyan)]]/20 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)]] border border-[var(--color-accent-cyan)]]/30 transition-colors"
+            className="rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
           >
             Apply
           </button>
           <button
             onClick={clearFilters}
-            className="rounded bg-zinc-800 hover:bg-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-400 border border-zinc-700 transition-colors"
+            className="rounded border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:bg-zinc-700"
           >
             Clear
           </button>
+          <p className="text-xs text-zinc-500">
+            CSV and NDJSON exports use the currently applied filters.
+          </p>
         </div>
+
+        {filterError ? (
+          <p className="mt-3 text-xs text-rose-400">{filterError}</p>
+        ) : null}
+        {exportError ? (
+          <p className="mt-3 text-xs text-rose-400">{exportError}</p>
+        ) : null}
       </div>
 
-      {/* Content */}
+      {latestExport ? <ExportMetadataCard result={latestExport} /> : null}
+
       {endpointMissing ? (
-        <div className="rounded-lg border border-zinc-800 bg-[var(--color-surface)]] p-12 text-center">
-          <Shield className="mx-auto h-10 w-10 text-zinc-600 mb-3" />
-          <p className="text-zinc-400 font-medium">Audit endpoint not available yet</p>
+        <div className="rounded-lg border border-zinc-800 bg-[var(--color-surface)] p-12 text-center">
+          <Shield className="mx-auto mb-3 h-10 w-10 text-zinc-600" />
+          <p className="font-medium text-zinc-400">Audit endpoint not available yet</p>
           <p className="mt-1 text-xs text-zinc-600">
             The /v1/audit endpoint has not been implemented on the server.
           </p>
         </div>
       ) : error ? (
         <div className="rounded-lg border border-red-900/50 bg-red-950/20 p-12 text-center">
-          <AlertCircle className="mx-auto h-10 w-10 text-red-500 mb-3" />
-          <p className="text-red-400 font-medium">Failed to load audit logs</p>
+          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-500" />
+          <p className="font-medium text-red-400">Failed to load audit logs</p>
           <p className="mt-1 text-xs text-zinc-500">{error}</p>
           <button
             onClick={() => { void fetchData(); }}
-            className="mt-4 rounded bg-red-500/10 hover:bg-red-500/20 px-4 py-2 text-xs font-medium text-red-400 border border-red-500/30 transition-colors"
+            className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-4 py-2 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
           >
             Retry
           </button>
@@ -273,26 +524,23 @@ export default function AuditPage() {
               </tr>
             </thead>
             <tbody>
-              <SkeletonRows count={pageSize} />
+              <SkeletonRows count={Math.min(pageSize, 5)} />
             </tbody>
           </table>
         </div>
       ) : records.length === 0 ? (
-        <div className="rounded-lg border border-zinc-800 bg-[var(--color-surface)]] p-12 text-center">
+        <div className="rounded-lg border border-zinc-800 bg-[var(--color-surface)] p-12 text-center">
           <EmptyState
             icon={<SearchX className="h-10 w-10" />}
             title="No audit records found"
             description="Audit logs will appear here when actions are performed."
           />
           <p className="mt-1 text-xs text-zinc-600">
-            {(appliedActor || appliedAction || appliedSessionId)
-              ? 'Try adjusting your filters.'
-              : 'Audit records will appear here once actions are performed.'}
+            {hasFilters ? 'Try adjusting your filters.' : 'Audit records will appear here once actions are performed.'}
           </p>
         </div>
       ) : (
         <>
-          {/* Table */}
           <div className="overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-900/50">
             <table className="w-full text-left">
               <thead>
@@ -305,46 +553,50 @@ export default function AuditPage() {
                 </tr>
               </thead>
               <tbody>
-                {records.map((record, idx) => (
-                  <AuditRow key={record.id ?? `${record.ts}-${record.actor}-${idx}`} record={record} />
+                {records.map((record) => (
+                  <AuditRow key={record.hash} record={record} />
                 ))}
               </tbody>
             </table>
           </div>
 
-          {/* Pagination */}
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-2 text-sm text-zinc-500">
               <span>{total} record{total !== 1 ? 's' : ''}</span>
               <span className="text-zinc-700">|</span>
-              <label htmlFor="page-size" className="sr-only">Page size</label>
+              <label htmlFor="audit-page-size" className="sr-only">Page size</label>
               <select
-                id="page-size"
+                id="audit-page-size"
                 value={pageSize}
-                onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}
-                className="rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:border-[var(--color-accent-cyan)]]/50 focus:outline-none"
+                onChange={(event) => {
+                  cursorStackRef.current = [null];
+                  setPageSize(Number(event.target.value));
+                  setPage(1);
+                }}
+                className="rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
               >
                 {PAGE_SIZE_OPTIONS.map((size) => (
                   <option key={size} value={size}>{size} / page</option>
                 ))}
               </select>
             </div>
+
             <div className="flex items-center gap-2">
               <span className="text-xs text-zinc-500">
                 Page {page} of {totalPages}
               </span>
               <button
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
                 disabled={page <= 1}
-                className="inline-flex items-center rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                className="inline-flex items-center rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label="Previous page"
               >
                 <ChevronLeft className="h-3.5 w-3.5" />
               </button>
               <button
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page >= totalPages}
-                className="inline-flex items-center rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                onClick={() => setPage((current) => current + 1)}
+                disabled={!hasMore || page >= totalPages}
+                className="inline-flex items-center rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label="Next page"
               >
                 <ChevronRight className="h-3.5 w-3.5" />

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -45,20 +45,54 @@ export type {
 // ── Audit Trail ─────────────────────────────────────────────────
 
 export interface AuditRecord {
-  id?: string;
   /** ISO 8601 timestamp — field name matches backend `ts` */
   ts: string;
   actor: string;
   action: string;
   sessionId?: string;
-  detail?: string;
+  detail: string;
+  prevHash: string;
+  hash: string;
+}
+
+export interface AuditFilters {
+  actor?: string;
+  action?: string;
+  sessionId?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface AuditPagination {
+  limit: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+  reverse: boolean;
+}
+
+export interface AuditChainMetadata {
+  count: number;
+  firstHash: string | null;
+  lastHash: string | null;
+  badgeHash: string | null;
+  firstTs: string | null;
+  lastTs: string | null;
+}
+
+export interface AuditIntegrityMetadata {
+  valid: boolean;
+  brokenAt?: number;
+  file?: string;
 }
 
 export interface AuditPageResponse {
+  count: number;
   records: AuditRecord[];
   total: number;
-  page: number;
-  pageSize: number;
+  filters: AuditFilters;
+  pagination: AuditPagination;
+  chain: AuditChainMetadata;
+  integrity?: AuditIntegrityMetadata;
 }
 
 // ── Users & Session History ────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the dashboard half of the audit export feature: filter controls, cursor navigation, CSV/NDJSON export actions, and latest-export integrity metadata.

## Aegis version

**Developed with:** v0.5.3-alpha
**Tested with:** v0.5.3-alpha

## Change type

- [ ] ix — Bug fix
- [ ] efactor — Code restructuring with no behavior change
- [ ] perf — Performance improvement
- [ ] 	est — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, tooling
- [x] eat — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

Dashboard audit page, dashboard API client/types, UI coverage, and e2e audit flow updates.

## Linked issue

Part of #1923

## Test plan

Repository gate passed (
pm run gate).

- [x] Unit tests pass (
pm test)
- [x] Type-check passes (
px tsc --noEmit)
- [x] Build succeeds (
pm run build)
- [ ] Manually tested (describe below)

## Security impact

Keeps audit export controls on the authenticated dashboard and surfaces integrity metadata from the backend.

## Dependency notes

Draft while #1998 and #1991 remain open; this branch is stacked on the backend export slice and RBAC changes.