### PR TITLE
feat: add interactive ag init bootstrap flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,13 @@
 ## Quick Start
 
 ```bash
-# Install and start
+# Install, bootstrap, and start
 npm install -g @onestepat4time/aegis
+ag init
 ag
 
 # Create a session
-curl -X POST http://localhost:9100/v1/sessions \
-  -H "Content-Type: application/json" \
-  -d '{"name": "feature-auth", "workDir": "/home/user/my-project", "prompt": "Build a login page with email/password fields."}'
-
-# Send a follow-up
-curl -X POST http://localhost:9100/v1/sessions/abc123/send \
-  -H "Content-Type: application/json" \
-  -d '{"text": "Add form validation: email must contain @, password min 8 chars."}'
+ag create "Build a login page with email/password fields." --cwd /path/to/project
 ```
 
 > **CLI naming:** the primary command is `ag` (e.g. `ag`, `ag mcp`, `ag create "brief"`). The legacy name `aegis` is preserved as an alias, so any existing scripts using `aegis` keep working.
@@ -390,13 +384,15 @@ Aegis includes built-in security defaults:
 
 ## Configuration
 
-**Priority:** CLI `--config` > `./aegis.config.json` > `~/.aegis/config.json` > defaults
+**Priority:** CLI `--config` > `./.aegis/config.yaml` > `./aegis.config.json` > `~/.aegis/config.yaml` > `~/.aegis/config.json` > defaults
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `AEGIS_BASE_URL` | `http://127.0.0.1:9100` | Preferred API origin for hooks, CLI clients, and dashboard links |
 | `AEGIS_PORT` | 9100 | Server port |
 | `AEGIS_HOST` | 127.0.0.1 | Server host |
 | `AEGIS_AUTH_TOKEN` | — | Bearer token for API auth |
+| `AEGIS_DASHBOARD_ENABLED` | `true` | Serve the bundled dashboard |
 | `AEGIS_PERMISSION_MODE` | default | `default`, `bypassPermissions`, `plan`, `acceptEdits`, `dontAsk`, `auto` |
 | `AEGIS_TMUX_SESSION` | aegis | tmux session name |
 | `AEGIS_TG_TOKEN` | — | Telegram bot token |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,18 +12,19 @@ Get from zero to orchestrating Claude Code sessions in under 5 minutes.
 
 > **Windows users:** Install [psmux](https://github.com/nicknisi/psmux) instead of tmux. See [Windows Setup](./windows-setup.md) for details.
 
-## 1. Start Aegis
+## 1. Bootstrap and Start Aegis
 
-Install once, then start Aegis with the primary `ag` CLI:
+Install once, bootstrap `.aegis/config.yaml`, then start Aegis with the primary `ag` CLI:
 
 ```bash
 npm install -g @onestepat4time/aegis
+ag init
 ag
 ```
 
 > The primary CLI command is `ag`. The legacy name `aegis` is kept as an alias for backward compatibility — both resolve to the same binary.
 
-Aegis starts on **http://localhost:9100**. Verify it's running:
+Aegis starts on **http://localhost:9100** by default. Verify it's running:
 
 ```bash
 curl http://localhost:9100/v1/health
@@ -73,7 +74,7 @@ curl -H "Authorization: Bearer your-secret-token" http://localhost:9100/v1/sessi
 
 Visit **http://localhost:9100/dashboard/** in your browser. The dashboard shows all sessions, their status, and activity in real time.
 
-> **Note:** The dashboard requires authentication. Set `AEGIS_AUTH_TOKEN` before starting Aegis, then log in with your token. See [Authentication](#1-start-with-authentication) above.
+> **Note:** `ag init` can create an admin API token and save it in `.aegis/config.yaml`. Use that token to sign in, or keep using `AEGIS_AUTH_TOKEN` if you prefer an environment-based setup.
 
 ## 3. Dashboard Keyboard Shortcuts
 
@@ -95,30 +96,24 @@ The dashboard displays the shortcut hint in the sidebar footer.
 ## 4. Create Your First Session
 
 ```bash
-curl -X POST http://localhost:9100/v1/sessions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "explore-project",
-    "workDir": "/path/to/your/project",
-    "prompt": "Analyze this project. List the main technologies, directory structure, and any issues you spot.",
-    "permissionMode": "default"
-  }'
+ag create "Analyze this project. List the main technologies, directory structure, and any issues you spot." --cwd /path/to/your/project
 ```
 
-The response includes the session ID:
+`ag create` prints the session ID and next-step curl commands for you:
 
-```json
-{
-  "id": "a1b2c3d4",
-  "name": "explore-project",
-  "status": "working",
-  "workDir": "/path/to/your/project"
-}
+```text
+✅ Session created: cc-analyze-this-projec
+   ID: a1b2c3d4
+
+Next steps:
+  Status:   curl http://127.0.0.1:9100/v1/sessions/a1b2c3d4/health
+  Read:     curl http://127.0.0.1:9100/v1/sessions/a1b2c3d4/read
+  Kill:     curl -X DELETE http://127.0.0.1:9100/v1/sessions/a1b2c3d4
 ```
 
 Save the `id` — you'll need it for follow-up commands.
 
-> **Note:** `workDir` must be under an allowed directory. By default, Aegis allows `$HOME`, `/tmp`, and the current working directory. To restrict sessions to specific directories, set `allowedWorkDirs` in `aegis.config.json`. Changes are hot-reloaded without restart.
+> **Note:** `workDir` must be under an allowed directory. By default, Aegis allows `$HOME`, `/tmp`, and the current working directory. To restrict sessions to specific directories, set `allowedWorkDirs` in `.aegis/config.yaml` (or `aegis.config.json`). Changes are hot-reloaded without restart.
 
 ## 4. Monitor Progress
 
@@ -224,16 +219,14 @@ Aegis is configured via environment variables:
 | `AEGIS_STATE_DIR` | `~/.aegis` | State directory |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity |
 
-Or use a config file (`aegis.config.json`):
+Or use a config file (`.aegis/config.yaml` is the preferred bootstrap path, and `aegis.config.json` remains supported):
 
-```json
-{
-  "port": 9100,
-  "authToken": "your-token",
-  "memoryBridge": {
-    "enabled": true
-  }
-}
+```yaml
+baseUrl: http://127.0.0.1:9100
+dashboardEnabled: true
+clientAuthToken: your-token
+memoryBridge:
+  enabled: true
 ```
 
 For the full configuration reference, see [Enterprise Deployment](./enterprise.md#configuration-reference).

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -14,6 +14,17 @@ npx --package=@onestepat4time/aegis ag
 
 ## Commands
 
+### `ag init` — Bootstrap a Project
+
+Create `.aegis/config.yaml` with an API token, preferred base URL, optional BYO-LLM defaults, and dashboard settings.
+
+```bash
+ag init
+ag init --yes            # Non-interactive defaults for CI
+```
+
+The interactive flow is idempotent: if `.aegis/config.yaml` already exists, `ag init` keeps it unless you confirm an overwrite.
+
 ### `ag` — Start Server
 
 Start the Aegis HTTP server (port 9100).
@@ -34,9 +45,11 @@ AEGIS_AUTH_TOKEN=secret ag
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `AEGIS_BASE_URL` | `http://127.0.0.1:9100` | Preferred API origin for hooks + CLI clients |
 | `AEGIS_PORT` | `9100` | HTTP server port |
 | `AEGIS_HOST` | `127.0.0.1` | Bind address |
 | `AEGIS_AUTH_TOKEN` | _(none)_ | Bearer token (required for production) |
+| `AEGIS_DASHBOARD_ENABLED` | `true` | Serve the bundled dashboard |
 | `AEGIS_STATE_DIR` | `~/.aegis` | Session state directory |
 | `AEGIS_TMUX_SESSION` | `aegis` | Base tmux session name |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Max concurrent sessions |
@@ -141,6 +154,7 @@ AEGIS_AUTH_TOKEN=secret ag mcp
 
 ```
 ag                     Start HTTP server
+ag init                Bootstrap .aegis/config.yaml
 ag --port 3000         Custom port
 ag mcp                 Start MCP server
 ag create "brief"      Create + send

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,12 @@
         "fastify": "^5.8.2",
         "nodemailer": "^8.0.5",
         "prom-client": "^15.1.3",
+        "yaml": "^2.8.3",
         "zod": "^4.3.6"
       },
       "bin": {
-        "aegis": "dist/cli.js"
+        "aegis": "dist/cli.js",
+        "ag": "dist/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "fastify": "^5.8.2",
     "nodemailer": "^8.0.5",
     "prom-client": "^15.1.3",
+    "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
   "overrides": {

--- a/src/__tests__/base-url.test.ts
+++ b/src/__tests__/base-url.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveBaseUrl, getConfiguredBaseUrl, getDashboardUrl, normalizeBaseUrl } from '../base-url.js';
+
+describe('base URL helpers', () => {
+  it('normalizes wildcard hosts to localhost-safe origins', () => {
+    expect(normalizeBaseUrl('http://0.0.0.0:9100')).toBe('http://127.0.0.1:9100');
+    expect(normalizeBaseUrl('http://[::]:9100')).toBe('http://127.0.0.1:9100');
+  });
+
+  it('derives a default origin from host and port', () => {
+    expect(deriveBaseUrl('127.0.0.1', 9100)).toBe('http://127.0.0.1:9100');
+    expect(deriveBaseUrl('0.0.0.0', 9200)).toBe('http://127.0.0.1:9200');
+  });
+
+  it('prefers an explicit config baseUrl when present', () => {
+    expect(getConfiguredBaseUrl({
+      baseUrl: 'https://aegis.example.com/',
+      host: '127.0.0.1',
+      port: 9100,
+    })).toBe('https://aegis.example.com');
+  });
+
+  it('builds dashboard URLs from normalized origins', () => {
+    expect(getDashboardUrl('http://127.0.0.1:9100')).toBe('http://127.0.0.1:9100/dashboard/');
+  });
+});

--- a/src/__tests__/cli-init.test.ts
+++ b/src/__tests__/cli-init.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough, Writable } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+import { runCli } from '../cli.js';
+
+class CaptureStream extends Writable {
+  private chunks: string[] = [];
+
+  override _write(
+    chunk: string | Buffer,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
+    callback();
+  }
+
+  text(): string {
+    return this.chunks.join('');
+  }
+}
+
+describe('ag init', () => {
+  let originalCwd: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalEnv = { ...process.env };
+    projectDir = mkdtempSync(join(tmpdir(), 'aegis-cli-init-'));
+    stateDir = join(projectDir, 'state');
+    process.chdir(projectDir);
+
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('AEGIS_') || key.startsWith('MANUS_')) {
+        delete process.env[key];
+      }
+    }
+
+    process.env.AEGIS_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env = originalEnv;
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  async function runInit(argv: string[], answers?: string): Promise<{ code: number; stdout: string; stderr: string }> {
+    const stdin = new PassThrough();
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+
+    const runPromise = runCli(argv, { stdin, stdout, stderr });
+    setImmediate(() => {
+      if (answers !== undefined) {
+        stdin.end(`${answers}\n`);
+      } else {
+        stdin.end();
+      }
+    });
+
+    const code = await runPromise;
+    return { code, stdout: stdout.text(), stderr: stderr.text() };
+  }
+
+  it('bootstraps .aegis/config.yaml from interactive answers', async () => {
+    const result = await runInit(['init'], [
+      'y',
+      'http://127.0.0.1:9200',
+      'y',
+      'https://openrouter.example/api/anthropic',
+      'test-byo-token',
+      'claude-sonnet-4',
+      '',
+      '25000',
+      'n',
+    ].join('\n'));
+
+    const configPath = join(projectDir, '.aegis', 'config.yaml');
+    const keysPath = join(stateDir, 'keys.json');
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(existsSync(configPath)).toBe(true);
+    expect(existsSync(keysPath)).toBe(true);
+
+    const config = parseYaml(readFileSync(configPath, 'utf-8')) as {
+      baseUrl?: string;
+      clientAuthToken?: string;
+      dashboardEnabled?: boolean;
+      defaultSessionEnv?: Record<string, string>;
+    };
+    expect(config.baseUrl).toBe('http://127.0.0.1:9200');
+    expect(config.dashboardEnabled).toBe(false);
+    expect(config.clientAuthToken?.startsWith('aegis_')).toBe(true);
+    expect(config.defaultSessionEnv).toMatchObject({
+      ANTHROPIC_BASE_URL: 'https://openrouter.example/api/anthropic',
+      ANTHROPIC_AUTH_TOKEN: 'test-byo-token',
+      ANTHROPIC_DEFAULT_MODEL: 'claude-sonnet-4',
+      API_TIMEOUT_MS: '25000',
+    });
+
+    const keyStore = JSON.parse(readFileSync(keysPath, 'utf-8')) as {
+      keys: Array<{ name: string; role?: string }>;
+    };
+    expect(keyStore.keys).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'ag-init-admin', role: 'admin' }),
+      ]),
+    );
+
+    expect(result.stdout).toContain('Next steps:');
+    expect(result.stdout).toContain('Dashboard:  disabled in config');
+    expect(result.stdout).toContain('Session:    ag create "Describe your first task" --cwd .');
+    expect(result.stdout).toContain(config.clientAuthToken!);
+  });
+
+  it('supports non-interactive --yes bootstrap', async () => {
+    const result = await runInit(['init', '--yes']);
+    const configPath = join(projectDir, '.aegis', 'config.yaml');
+    const config = parseYaml(readFileSync(configPath, 'utf-8')) as {
+      baseUrl?: string;
+      clientAuthToken?: string;
+      dashboardEnabled?: boolean;
+      defaultSessionEnv?: Record<string, string>;
+    };
+
+    expect(result.code).toBe(0);
+    expect(config.baseUrl).toBe('http://127.0.0.1:9100');
+    expect(config.dashboardEnabled).toBe(true);
+    expect(config.clientAuthToken?.startsWith('aegis_')).toBe(true);
+    expect(config.defaultSessionEnv).toBeUndefined();
+    expect(result.stdout).toContain('Created admin API token');
+  });
+
+  it('does not overwrite an existing config without confirmation', async () => {
+    const firstRun = await runInit(['init', '--yes']);
+    const configPath = join(projectDir, '.aegis', 'config.yaml');
+    const initialConfig = readFileSync(configPath, 'utf-8');
+
+    expect(firstRun.code).toBe(0);
+
+    const secondRun = await runInit(['init'], [
+      'n',
+      'http://127.0.0.1:9300',
+      'n',
+      'y',
+      'n',
+    ].join('\n'));
+
+    expect(secondRun.code).toBe(0);
+    expect(readFileSync(configPath, 'utf-8')).toBe(initialConfig);
+    expect(secondRun.stdout).toContain('Using existing');
+  });
+});

--- a/src/__tests__/config-yaml.test.ts
+++ b/src/__tests__/config-yaml.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { findConfigFilePath, readConfigFile, reloadAllowedWorkDirs } from '../config.js';
+
+describe('yaml config support', () => {
+  let originalArgv: string[];
+  let originalCwd: string;
+  let testDir: string;
+
+  beforeEach(() => {
+    originalArgv = [...process.argv];
+    originalCwd = process.cwd();
+    testDir = mkdtempSync(join(tmpdir(), 'aegis-config-yaml-'));
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.chdir(originalCwd);
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('reads .aegis/config.yaml files', async () => {
+    const configDir = join(testDir, '.aegis');
+    const configPath = join(configDir, 'config.yaml');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(configPath, [
+      'baseUrl: http://127.0.0.1:9200',
+      'dashboardEnabled: false',
+      'allowedWorkDirs:',
+      '  - ./workspace',
+    ].join('\n'));
+
+    const config = await readConfigFile(configPath);
+    expect(config).toMatchObject({
+      baseUrl: 'http://127.0.0.1:9200',
+      dashboardEnabled: false,
+      allowedWorkDirs: ['./workspace'],
+    });
+  });
+
+  it('prefers .aegis/config.yaml in config discovery', () => {
+    const configDir = join(testDir, '.aegis');
+    const configPath = join(configDir, 'config.yaml');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(configPath, 'baseUrl: http://127.0.0.1:9100\n');
+
+    expect(findConfigFilePath()).toBe(configPath);
+  });
+
+  it('reloads allowedWorkDirs from yaml config files', async () => {
+    const configDir = join(testDir, '.aegis');
+    const configPath = join(configDir, 'config.yaml');
+    const workspaceDir = join(testDir, 'workspace');
+    mkdirSync(configDir, { recursive: true });
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(configPath, [
+      'allowedWorkDirs:',
+      '  - ./workspace',
+      '  - ./nested',
+    ].join('\n'));
+
+    const dirs = await reloadAllowedWorkDirs(configPath);
+
+    expect(dirs).toEqual([
+      resolve(workspaceDir),
+      resolve(join(testDir, 'nested')),
+    ]);
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -39,9 +39,12 @@ describe('config', () => {
     it('returns default values when no env overrides', () => {
       const config = getConfig();
 
+      expect(config.baseUrl).toBe('http://127.0.0.1:9100');
       expect(config.port).toBe(9100);
       expect(config.host).toBe('127.0.0.1');
       expect(config.authToken).toBe('');
+      expect(config.clientAuthToken).toBe('');
+      expect(config.dashboardEnabled).toBe(true);
       expect(config.tmuxSession).toBe('aegis');
       expect(config.maxSessionAgeMs).toBe(2 * 60 * 60 * 1000);
       expect(config.reaperIntervalMs).toBe(5 * 60 * 1000);
@@ -58,12 +61,20 @@ describe('config', () => {
       process.env.AEGIS_PORT = '3000';
       const config = getConfig();
       expect(config.port).toBe(3000);
+      expect(config.baseUrl).toBe('http://127.0.0.1:3000');
     });
 
     it('overrides host via AEGIS_HOST', () => {
       process.env.AEGIS_HOST = '0.0.0.0';
       const config = getConfig();
       expect(config.host).toBe('0.0.0.0');
+      expect(config.baseUrl).toBe('http://127.0.0.1:9100');
+    });
+
+    it('overrides baseUrl via AEGIS_BASE_URL', () => {
+      process.env.AEGIS_BASE_URL = 'https://aegis.example.com/';
+      const config = getConfig();
+      expect(config.baseUrl).toBe('https://aegis.example.com');
     });
 
     it('overrides authToken via AEGIS_AUTH_TOKEN', () => {
@@ -112,6 +123,12 @@ describe('config', () => {
       process.env.AEGIS_HOOK_SECRET_HEADER_ONLY = 'true';
       const config = getConfig();
       expect(config.hookSecretHeaderOnly).toBe(true);
+    });
+
+    it('overrides dashboard enablement via AEGIS_DASHBOARD_ENABLED', () => {
+      process.env.AEGIS_DASHBOARD_ENABLED = 'false';
+      const config = getConfig();
+      expect(config.dashboardEnabled).toBe(false);
     });
   });
 

--- a/src/base-url.ts
+++ b/src/base-url.ts
@@ -1,0 +1,44 @@
+export interface BaseUrlConfig {
+  host: string;
+  port: number;
+  baseUrl?: string;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function normalizeHostname(hostname: string): string {
+  if (hostname === '0.0.0.0' || hostname === '::' || hostname === '[::]') {
+    return '127.0.0.1';
+  }
+  return hostname;
+}
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.protocol = url.protocol || 'http:';
+  url.hostname = normalizeHostname(url.hostname);
+  url.pathname = '/';
+  url.search = '';
+  url.hash = '';
+  return trimTrailingSlash(url.toString());
+}
+
+export function deriveBaseUrl(host: string, port: number): string {
+  const url = new URL('http://127.0.0.1');
+  url.hostname = normalizeHostname(host);
+  url.port = String(port);
+  return trimTrailingSlash(url.toString());
+}
+
+export function getConfiguredBaseUrl(config: BaseUrlConfig): string {
+  if (config.baseUrl) {
+    return normalizeBaseUrl(config.baseUrl);
+  }
+  return deriveBaseUrl(config.host, config.port);
+}
+
+export function getDashboardUrl(baseUrl: string): string {
+  return `${normalizeBaseUrl(baseUrl)}/dashboard/`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,22 +3,62 @@
  * cli.ts — CLI entry point for Aegis.
  *
  * `ag` is the primary CLI command and `aegis` remains an alias. Both start the
- * server with sensible defaults. Auto-detects tmux and claude CLI, prints
- * helpful startup message.
+ * server with sensible defaults and support interactive project bootstrap via
+ * `ag init`.
  */
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 
-import { parseIntSafe, getErrorMessage } from './validation.js';
+import { deriveBaseUrl, getConfiguredBaseUrl, getDashboardUrl, normalizeBaseUrl } from './base-url.js';
+import { loadConfig, readConfigFile, serializeConfigFile, writeConfigFile, type Config } from './config.js';
+import { AuthManager } from './services/auth/index.js';
+import { buildEnvSchema, ENV_BYO_LLM_WHITELIST, getErrorMessage, parseIntSafe } from './validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')) as { version: string };
 /** Current aegis version read from package.json at startup. */
 const VERSION: string = pkg.version;
+
+const BYO_ENV_FIELDS = [
+  { key: 'ANTHROPIC_BASE_URL', label: 'ANTHROPIC base URL' },
+  { key: 'ANTHROPIC_AUTH_TOKEN', label: 'ANTHROPIC auth token' },
+  { key: 'ANTHROPIC_DEFAULT_MODEL', label: 'ANTHROPIC default model' },
+  { key: 'ANTHROPIC_DEFAULT_FAST_MODEL', label: 'ANTHROPIC fast model' },
+  { key: 'API_TIMEOUT_MS', label: 'API timeout (ms)' },
+] as const;
+
+interface CliIO {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+interface InitSummary {
+  authToken: string;
+  baseUrl: string;
+  commandPrefix: string;
+  configPath: string;
+  dashboardEnabled: boolean;
+  tokenCreated: boolean;
+  wroteConfig: boolean;
+}
+
+interface Prompter {
+  close(): void;
+  question(prompt: string): Promise<string>;
+}
+
+const defaultCliIO: CliIO = {
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr,
+};
 
 /** Check whether a required external dependency can be executed. */
 function checkDependency(command: string, args: string[]): boolean {
@@ -45,9 +85,17 @@ function checkTmuxVersion(minMajor: number = 3, minMinor: number = 3): { ok: boo
   }
 }
 
+function write(stream: NodeJS.WritableStream, text: string): void {
+  stream.write(text);
+}
+
+function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
+  stream.write(`${text}\n`);
+}
+
 /** Render the startup banner shown when launching the HTTP server. */
-function printBanner(_port: number): void {
-  console.log(`
+function printBanner(io: CliIO, _port: number): void {
+  write(io.stdout, `
   ┌─────────────────────────────────────────┐
   │          ⚡ Aegis v${VERSION}               │
   │    Claude Code Session Bridge            │
@@ -55,19 +103,209 @@ function printBanner(_port: number): void {
   `);
 }
 
-/** Resolve auth token for CLI commands.
- *  Priority: AEGIS_AUTH_TOKEN env var > authToken in ~/.aegis/config.json > legacy ~/.manus/config.json.
- *  Returns empty string if no token found (server may not require auth). */
-function resolveAuthToken(): string {
-  const envToken = process.env.AEGIS_AUTH_TOKEN;
+function defaultInitConfigPath(): string {
+  return join(process.cwd(), '.aegis', 'config.yaml');
+}
+
+function resolveInitConfigPath(args: string[]): string {
+  const idx = args.indexOf('--config');
+  if (idx !== -1 && idx + 1 < args.length) {
+    return resolve(args[idx + 1]!);
+  }
+  return defaultInitConfigPath();
+}
+
+function formatConfigPath(configPath: string): string {
+  const relativePath = relative(process.cwd(), configPath);
+  if (!relativePath || relativePath.startsWith('..')) {
+    return configPath;
+  }
+  return relativePath;
+}
+
+function commandPrefixForConfig(configPath: string): string {
+  if (configPath === defaultInitConfigPath()) {
+    return 'ag';
+  }
+  return `ag --config "${configPath}"`;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(entry => stableStringify(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function validateBaseUrl(input: string): string {
+  const url = new URL(input);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Base URL must use http:// or https://');
+  }
+  if (url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('Base URL must not include a path, query string, or hash');
+  }
+  return normalizeBaseUrl(input);
+}
+
+function filterByoEnv(env: Record<string, string> | undefined): Record<string, string> {
+  if (!env) return {};
+  const allowed = new Set<string>(ENV_BYO_LLM_WHITELIST);
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => allowed.has(key)),
+  );
+}
+
+function resolveExistingToken(config: Partial<Config> | null): string {
+  if (!config) return '';
+  return config.clientAuthToken || config.authToken || '';
+}
+
+function buildInitComparisonConfig(
+  config: Partial<Config>,
+  hasGeneratedToken: boolean,
+): Partial<Config> {
+  if (!hasGeneratedToken) {
+    return config;
+  }
+  return { ...config, clientAuthToken: '__generated__' };
+}
+
+function formatPromptDefault(defaultValue: string): string {
+  return defaultValue ? ` [${defaultValue}]` : '';
+}
+
+async function readBufferedInput(input: NodeJS.ReadableStream): Promise<string[]> {
+  let text = '';
+  for await (const chunk of input) {
+    text += typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+  }
+  return text.split(/\r?\n/);
+}
+
+function createPrompter(io: CliIO): Prompter {
+  if ('isTTY' in io.stdin && io.stdin.isTTY) {
+    const rl = createInterface({
+      input: io.stdin,
+      output: io.stdout,
+      terminal: true,
+    });
+    return {
+      close: () => rl.close(),
+      question: (prompt) => rl.question(prompt),
+    };
+  }
+
+  const bufferedLinesPromise = readBufferedInput(io.stdin);
+  let index = 0;
+  return {
+    close: () => {},
+    async question(prompt: string): Promise<string> {
+      write(io.stdout, prompt);
+      const lines = await bufferedLinesPromise;
+      const answer = lines[index] ?? '';
+      index += 1;
+      return answer;
+    },
+  };
+}
+
+async function promptLine(prompter: Prompter, label: string, defaultValue: string = ''): Promise<string> {
+  const answer = await prompter.question(`${label}${formatPromptDefault(defaultValue)}: `);
+  const trimmed = answer.trim();
+  return trimmed || defaultValue;
+}
+
+async function promptBoolean(
+  prompter: Prompter,
+  io: CliIO,
+  label: string,
+  defaultValue: boolean,
+): Promise<boolean> {
+  for (;;) {
+    const suffix = defaultValue ? '[Y/n]' : '[y/N]';
+    const answer = (await prompter.question(`${label} ${suffix}: `)).trim().toLowerCase();
+    if (!answer) return defaultValue;
+    if (answer === 'y' || answer === 'yes') return true;
+    if (answer === 'n' || answer === 'no') return false;
+    writeLine(io.stderr, '  ❌ Please answer y or n.');
+  }
+}
+
+async function promptBaseUrl(
+  prompter: Prompter,
+  io: CliIO,
+  defaultValue: string,
+): Promise<string> {
+  for (;;) {
+    const answer = await promptLine(prompter, 'Base URL', defaultValue);
+    try {
+      return validateBaseUrl(answer);
+    } catch (error) {
+      writeLine(io.stderr, `  ❌ ${getErrorMessage(error)}`);
+    }
+  }
+}
+
+async function promptByoEnv(
+  prompter: Prompter,
+  io: CliIO,
+  existingByoEnv: Record<string, string>,
+): Promise<Record<string, string> | undefined> {
+  const shouldConfigure = await promptBoolean(
+    prompter,
+    io,
+    'Configure optional BYO-LLM defaults for every session?',
+    Object.keys(existingByoEnv).length > 0,
+  );
+  if (!shouldConfigure) {
+    return undefined;
+  }
+
+  const nextEnv: Record<string, string> = { ...existingByoEnv };
+  for (const field of BYO_ENV_FIELDS) {
+    for (;;) {
+      const answer = await promptLine(prompter, `  ${field.label}`, existingByoEnv[field.key] ?? '');
+      if (field.key === 'API_TIMEOUT_MS' && answer && !/^[1-9]\d*$/.test(answer)) {
+        writeLine(io.stderr, '  ❌ API timeout must be a positive integer.');
+        continue;
+      }
+      if (answer) {
+        nextEnv[field.key] = answer;
+      } else {
+        delete nextEnv[field.key];
+      }
+      break;
+    }
+  }
+
+  const parsed = buildEnvSchema().safeParse(nextEnv);
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues.map(issue => issue.message).join('; '));
+  }
+  return parsed.data;
+}
+
+async function resolveAuthToken(): Promise<string> {
+  const envToken = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN;
   if (envToken) return envToken;
 
-  const configPaths = [
+  const config = await loadConfig();
+  if (config.clientAuthToken) return config.clientAuthToken;
+  if (config.authToken) return config.authToken;
+
+  const legacyPaths = [
     join(homedir(), '.aegis', 'config.json'),
     join(homedir(), '.manus', 'config.json'),
   ];
 
-  for (const configPath of configPaths) {
+  for (const configPath of legacyPaths) {
     try {
       const raw = readFileSync(configPath, 'utf-8');
       const parsed = JSON.parse(raw) as { authToken?: string };
@@ -78,35 +316,238 @@ function resolveAuthToken(): string {
   return '';
 }
 
+function printInitSummary(io: CliIO, summary: InitSummary): void {
+  writeLine(io.stdout);
+  writeLine(io.stdout, summary.wroteConfig
+    ? `  ✅ Wrote ${summary.configPath}`
+    : `  ✅ Using existing ${summary.configPath}`);
+  writeLine(io.stdout, summary.tokenCreated
+    ? '  ✅ Created admin API token'
+    : summary.authToken
+      ? '  ✅ Reusing existing API token'
+      : '  ⚠️  No API token configured');
+  writeLine(io.stdout);
+  writeLine(io.stdout, '  Next steps:');
+  writeLine(io.stdout, `    Start:      ${summary.commandPrefix}`);
+  if (summary.dashboardEnabled) {
+    writeLine(io.stdout, `    Dashboard:  ${getDashboardUrl(summary.baseUrl)}`);
+  } else {
+    writeLine(io.stdout, '    Dashboard:  disabled in config');
+  }
+  if (summary.authToken) {
+    writeLine(io.stdout, `    API token:  ${summary.authToken}`);
+  } else {
+    writeLine(io.stdout, '    API token:  set AEGIS_AUTH_TOKEN or re-run ag init to create one');
+  }
+  writeLine(io.stdout, `    Session:    ${summary.commandPrefix} create "Describe your first task" --cwd .`);
+}
+
+async function handleInit(args: string[], io: CliIO): Promise<number> {
+  const yes = args.includes('--yes') || args.includes('-y');
+  const configPath = resolveInitConfigPath(args);
+  const displayConfigPath = formatConfigPath(configPath);
+  const commandPrefix = commandPrefixForConfig(configPath);
+  const existingConfigText = existsSync(configPath)
+    ? await readFile(configPath, 'utf-8').catch(() => null)
+    : null;
+  const existingConfig = await readConfigFile(configPath);
+  const existingToken = resolveExistingToken(existingConfig);
+  const existingByoEnv = filterByoEnv(existingConfig?.defaultSessionEnv);
+  const currentConfig = await loadConfig();
+
+  if (existingConfigText !== null && existingConfig === null && yes) {
+    writeLine(
+      io.stderr,
+      `  ❌ ${displayConfigPath} already exists but could not be parsed. Re-run without --yes to confirm overwrite.`,
+    );
+    return 1;
+  }
+
+  let createAdminToken = existingToken ? false : true;
+  let baseUrl = existingConfig?.baseUrl
+    ? normalizeBaseUrl(existingConfig.baseUrl)
+    : getConfiguredBaseUrl(currentConfig);
+  let byoEnv: Record<string, string> | undefined;
+  let dashboardEnabled = existingConfig?.dashboardEnabled ?? true;
+
+  if (!yes) {
+    const prompter = createPrompter(io);
+
+    try {
+      writeLine(io.stdout, `  Bootstrap config: ${displayConfigPath}`);
+      writeLine(io.stdout);
+      createAdminToken = await promptBoolean(
+        prompter,
+        io,
+        existingToken
+          ? 'Create a fresh admin API token for dashboard + CLI access?'
+          : 'Create an admin API token for dashboard + CLI access?',
+        !existingToken,
+      );
+      baseUrl = await promptBaseUrl(prompter, io, baseUrl);
+      byoEnv = await promptByoEnv(prompter, io, existingByoEnv);
+      dashboardEnabled = await promptBoolean(prompter, io, 'Enable the bundled dashboard?', dashboardEnabled);
+    } finally {
+      prompter.close();
+    }
+  }
+
+  const nextConfig: Partial<Config> = { ...(existingConfig ?? {}) };
+  nextConfig.baseUrl = baseUrl;
+  nextConfig.dashboardEnabled = dashboardEnabled;
+
+  if (byoEnv) {
+    nextConfig.defaultSessionEnv = {
+      ...(existingConfig?.defaultSessionEnv ?? {}),
+      ...byoEnv,
+    };
+  }
+
+  if (!nextConfig.defaultSessionEnv || Object.keys(nextConfig.defaultSessionEnv).length === 0) {
+    delete nextConfig.defaultSessionEnv;
+  }
+
+  const generatedTokenRequested = createAdminToken;
+  const desiredComparison = stableStringify(
+    buildInitComparisonConfig(nextConfig, generatedTokenRequested),
+  );
+  const existingComparison = existingConfig
+    ? stableStringify(existingConfig)
+    : '';
+  const needsWrite = existingConfigText === null || existingConfig === null || desiredComparison !== existingComparison;
+
+  if (existingConfigText !== null && needsWrite) {
+    if (yes) {
+      writeLine(io.stdout, `  ℹ️  Left ${displayConfigPath} unchanged because --yes never overwrites existing files.`);
+      printInitSummary(io, {
+        authToken: existingToken,
+        baseUrl: existingConfig?.baseUrl ? normalizeBaseUrl(existingConfig.baseUrl) : baseUrl,
+        commandPrefix,
+        configPath: displayConfigPath,
+        dashboardEnabled: existingConfig?.dashboardEnabled ?? dashboardEnabled,
+        tokenCreated: false,
+        wroteConfig: false,
+      });
+      return 0;
+    }
+
+    const prompter = createPrompter(io);
+    try {
+      const overwrite = await promptBoolean(prompter, io, `Overwrite ${displayConfigPath}?`, false);
+      if (!overwrite) {
+        if (!existingConfig) {
+          writeLine(io.stderr, `  ❌ Existing ${displayConfigPath} was left unchanged and is still invalid.`);
+          return 1;
+        }
+        printInitSummary(io, {
+          authToken: existingToken,
+          baseUrl: existingConfig.baseUrl ? normalizeBaseUrl(existingConfig.baseUrl) : baseUrl,
+          commandPrefix,
+          configPath: displayConfigPath,
+          dashboardEnabled: existingConfig.dashboardEnabled ?? dashboardEnabled,
+          tokenCreated: false,
+          wroteConfig: false,
+        });
+        return 0;
+      }
+    } finally {
+      prompter.close();
+    }
+  }
+
+  if (!needsWrite && !generatedTokenRequested) {
+    printInitSummary(io, {
+      authToken: existingToken,
+      baseUrl,
+      commandPrefix,
+      configPath: displayConfigPath,
+      dashboardEnabled,
+      tokenCreated: false,
+      wroteConfig: false,
+    });
+    return 0;
+  }
+
+  let authToken = existingToken;
+  let tokenCreated = false;
+  let createdKeyId: string | null = null;
+  const authManager = new AuthManager(join(currentConfig.stateDir, 'keys.json'), currentConfig.authToken);
+  await authManager.load();
+
+  if (generatedTokenRequested) {
+    const createdKey = await authManager.createKey('ag-init-admin', 100, undefined, 'admin');
+    authToken = createdKey.key;
+    createdKeyId = createdKey.id;
+    nextConfig.clientAuthToken = createdKey.key;
+    tokenCreated = true;
+  }
+
+  const finalConfigText = serializeConfigFile(nextConfig, configPath);
+  if (existingConfigText !== null && existingConfigText === finalConfigText && !tokenCreated) {
+    printInitSummary(io, {
+      authToken,
+      baseUrl,
+      commandPrefix,
+      configPath: displayConfigPath,
+      dashboardEnabled,
+      tokenCreated: false,
+      wroteConfig: false,
+    });
+    return 0;
+  }
+
+  try {
+    await writeConfigFile(configPath, nextConfig);
+  } catch (error) {
+    if (createdKeyId) {
+      await authManager.revokeKey(createdKeyId);
+    }
+    writeLine(io.stderr, `  ❌ Failed to write ${displayConfigPath}: ${getErrorMessage(error)}`);
+    return 1;
+  }
+
+  printInitSummary(io, {
+    authToken,
+    baseUrl,
+    commandPrefix,
+    configPath: displayConfigPath,
+    dashboardEnabled,
+    tokenCreated,
+    wroteConfig: true,
+  });
+  return 0;
+}
+
 /** Issue #5 stretch: create a session from CLI. */
-async function handleCreate(args: string[]): Promise<void> {
-  // Parse brief text (first non-flag argument)
+async function handleCreate(args: string[], io: CliIO): Promise<number> {
   let brief = '';
   let cwd = process.cwd();
-  let port = parseIntSafe(process.env.AEGIS_PORT, 9100);
+  let portOverride: number | null = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--cwd' && args[i + 1]) {
-      cwd = args[++i];
+      cwd = args[++i]!;
     } else if (args[i] === '--port' && args[i + 1]) {
-      port = parseIntSafe(args[++i], 9100);
+      portOverride = parseIntSafe(args[++i], 9100);
     } else if (!args[i].startsWith('-')) {
       brief = args[i];
     }
   }
 
   if (!brief) {
-    console.error('  ❌ Missing brief. Usage: ag create "Build a login page"');
-    process.exit(1);
+    writeLine(io.stderr, '  ❌ Missing brief. Usage: ag create "Build a login page"');
+    return 1;
   }
 
-  const baseUrl = `http://127.0.0.1:${port}`;
+  const config = await loadConfig();
+  const baseUrl = portOverride === null
+    ? getConfiguredBaseUrl(config)
+    : deriveBaseUrl('127.0.0.1', portOverride);
   const sessionName = `cc-${brief.slice(0, 20).replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase()}`;
-  const authToken = resolveAuthToken();
+  const authToken = await resolveAuthToken();
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
 
-  // Create session
   let sessionId: string;
   try {
     const res = await fetch(`${baseUrl}/v1/sessions`, {
@@ -117,26 +558,25 @@ async function handleCreate(args: string[]): Promise<void> {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({ error: res.statusText }));
-      console.error(`  ❌ Failed to create session: ${(err as { error?: string }).error || res.statusText}`);
-      process.exit(1);
+      writeLine(io.stderr, `  ❌ Failed to create session: ${(err as { error?: string }).error || res.statusText}`);
+      return 1;
     }
 
     const session = await res.json() as { id: string; windowName: string };
     sessionId = session.id;
-    console.log(`  ✅ Session created: ${session.windowName}`);
-    console.log(`     ID: ${sessionId}`);
+    writeLine(io.stdout, `  ✅ Session created: ${session.windowName}`);
+    writeLine(io.stdout, `     ID: ${sessionId}`);
   } catch (e: unknown) {
     const cause = (e as { cause?: { code?: string } }).cause;
     if (cause?.code === 'ECONNREFUSED') {
-      console.error(`  ❌ Cannot connect to Aegis on port ${port}.`);
-      console.error(`     Start the server first: ag`);
+      writeLine(io.stderr, `  ❌ Cannot connect to Aegis at ${baseUrl}.`);
+      writeLine(io.stderr, '     Start the server first: ag');
     } else {
-      console.error(`  ❌ ${getErrorMessage(e)}`);
+      writeLine(io.stderr, `  ❌ ${getErrorMessage(e)}`);
     }
-    process.exit(1);
+    return 1;
   }
 
-  // Send brief
   try {
     const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/send`, {
       method: 'POST',
@@ -146,38 +586,39 @@ async function handleCreate(args: string[]): Promise<void> {
 
     const result = await res.json() as { delivered?: boolean; attempts?: number };
     if (result.delivered) {
-      console.log(`  ✅ Brief delivered (attempt ${result.attempts})`);
+      writeLine(io.stdout, `  ✅ Brief delivered (attempt ${result.attempts})`);
     } else {
-      console.log(`  ⚠️  Brief sent but delivery not confirmed after ${result.attempts} attempts`);
+      writeLine(io.stdout, `  ⚠️  Brief sent but delivery not confirmed after ${result.attempts} attempts`);
     }
   } catch (e: unknown) {
-    console.error(`  ⚠️  Failed to send brief: ${getErrorMessage(e)}`);
+    writeLine(io.stderr, `  ⚠️  Failed to send brief: ${getErrorMessage(e)}`);
   }
 
-  // Print next steps
-  console.log('');
-  console.log('  Next steps:');
-  console.log(`    Status:   curl ${baseUrl}/v1/sessions/${sessionId}/health`);
-  console.log(`    Read:     curl ${baseUrl}/v1/sessions/${sessionId}/read`);
-  console.log(`    Kill:     curl -X DELETE ${baseUrl}/v1/sessions/${sessionId}`);
+  writeLine(io.stdout);
+  writeLine(io.stdout, '  Next steps:');
+  writeLine(io.stdout, `    Status:   curl ${baseUrl}/v1/sessions/${sessionId}/health`);
+  writeLine(io.stdout, `    Read:     curl ${baseUrl}/v1/sessions/${sessionId}/read`);
+  writeLine(io.stdout, `    Kill:     curl -X DELETE ${baseUrl}/v1/sessions/${sessionId}`);
+  return 0;
 }
 
-/** Main CLI entry point that dispatches subcommands and bootstraps the server. */
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-
-  // Help
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(`
+function printHelp(io: CliIO): void {
+  write(io.stdout, `
   ag — Claude Code session bridge (alias: aegis)
 
   Usage:
     ag                     Start the server (port 9100)
+    ag init                Bootstrap .aegis/config.yaml
+    ag init --yes          Non-interactive bootstrap for CI
     ag "brief"             Create a session and send brief (shorthand)
     ag --port 3000         Custom port
     ag create "brief"      Create a session and send brief
     ag mcp                 Start MCP server (stdio transport)
     ag --help              Show this help
+
+  Init:
+    ag init
+    ag init --yes
 
   Create:
     ag create "Build a login page" --cwd /path/to/project
@@ -189,15 +630,17 @@ async function main(): Promise<void> {
     claude mcp add aegis -- ag mcp
 
   Environment variables:
-    AEGIS_PORT                    Server port (default: 9100)
-    AEGIS_HOST                    Server host (default: 127.0.0.1)
-    AEGIS_AUTH_TOKEN              Bearer token for API auth
-    AEGIS_TMUX_SESSION            tmux session name (default: aegis)
-    AEGIS_STATE_DIR               State directory (default: ~/.aegis)
-    AEGIS_TG_TOKEN                Telegram bot token
-    AEGIS_TG_GROUP                Telegram group chat ID
-    AEGIS_TG_ALLOWED_USERS        Allowed Telegram user IDs (comma-separated)
-    AEGIS_WEBHOOKS                Webhook URLs (comma-separated)
+    AEGIS_BASE_URL                 Preferred API base URL for hooks + CLI
+    AEGIS_PORT                     Server port (default: 9100)
+    AEGIS_HOST                     Server host (default: 127.0.0.1)
+    AEGIS_AUTH_TOKEN               Bearer token for API auth
+    AEGIS_TMUX_SESSION             tmux session name (default: aegis)
+    AEGIS_STATE_DIR                State directory (default: ~/.aegis)
+    AEGIS_DASHBOARD_ENABLED        Serve dashboard assets (default: true)
+    AEGIS_TG_TOKEN                 Telegram bot token
+    AEGIS_TG_GROUP                 Telegram group chat ID
+    AEGIS_TG_ALLOWED_USERS         Allowed Telegram user IDs (comma-separated)
+    AEGIS_WEBHOOKS                 Webhook URLs (comma-separated)
 
   API:
     POST /v1/sessions             Create a session
@@ -210,55 +653,56 @@ async function main(): Promise<void> {
     GET  /v1/health               Server health
 
   Docs: https://github.com/OneStepAt4time/aegis
-    `);
-    process.exit(0);
+  `);
+}
+
+/** Main CLI entry point that dispatches subcommands and bootstraps the server. */
+export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO = defaultCliIO): Promise<number> {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp(io);
+    return 0;
   }
 
-  // Version
-  if (args.includes('--version') || args.includes('-v')) {
-    console.log(`ag v${VERSION}`);
-    process.exit(0);
+  if (argv.includes('--version') || argv.includes('-v')) {
+    writeLine(io.stdout, `ag v${VERSION}`);
+    return 0;
   }
 
-  // Subcommand: mcp
-  if (args[0] === 'mcp') {
-    const mcpArgs = args.slice(1);
-    let mcpPort = parseIntSafe(process.env.AEGIS_PORT, 9100);
-    const mcpPortIdx = mcpArgs.indexOf('--port');
-    if (mcpPortIdx !== -1 && mcpArgs[mcpPortIdx + 1]) {
-      mcpPort = parseIntSafe(mcpArgs[mcpPortIdx + 1], 9100);
-    }
-    const mcpAuth = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN || resolveAuthToken();
+  if (argv[0] === 'mcp') {
+    const mcpArgs = argv.slice(1);
+    const portIdx = mcpArgs.indexOf('--port');
+    const baseUrl = portIdx !== -1 && mcpArgs[portIdx + 1]
+      ? deriveBaseUrl('127.0.0.1', parseIntSafe(mcpArgs[portIdx + 1], 9100))
+      : getConfiguredBaseUrl(await loadConfig());
+    const mcpAuth = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN || await resolveAuthToken();
     const { startMcpServer } = await import('./mcp-server.js');
-    await startMcpServer(mcpPort, mcpAuth);
-    return; // stdio server runs until stdin closes
+    await startMcpServer(baseUrl, mcpAuth);
+    return 0;
   }
 
-  // Subcommand: create
-  if (args[0] === 'create') {
-    await handleCreate(args.slice(1));
-    process.exit(0);
+  if (argv[0] === 'init') {
+    return handleInit(argv.slice(1), io);
   }
 
-  // Shorthand: single non-flag, non-subcommand arg = brief for session creation
-  if (args.length === 1 && !args[0].startsWith('-')) {
-    await handleCreate(args);
-    process.exit(0);
+  if (argv[0] === 'create') {
+    return handleCreate(argv.slice(1), io);
   }
 
-  // Port override from CLI
-  const portIdx = args.indexOf('--port');
-  if (portIdx !== -1 && args[portIdx + 1]) {
-    process.env.AEGIS_PORT = args[portIdx + 1];
+  if (argv.length === 1 && !argv[0].startsWith('-')) {
+    return handleCreate(argv, io);
   }
 
-  // Check dependencies
+  const portIdx = argv.indexOf('--port');
+  if (portIdx !== -1 && argv[portIdx + 1]) {
+    process.env.AEGIS_PORT = argv[portIdx + 1];
+  }
+
   const hasTmux = checkDependency('tmux', ['-V']);
   const hasClaude = checkDependency('claude', ['--version']);
   const tmuxVersion = hasTmux ? checkTmuxVersion(3, 3) : { ok: false, version: null };
 
   if (!hasTmux) {
-    console.error(`
+    write(io.stderr, `
   ❌ tmux not found.
 
   Install tmux:
@@ -266,20 +710,20 @@ async function main(): Promise<void> {
     macOS:          brew install tmux
     Windows:        winget install psmux
     `);
-    process.exit(1);
+    return 1;
   }
 
   if (!tmuxVersion.ok) {
-    console.error(`
+    write(io.stderr, `
   ❌ Unsupported tmux version${tmuxVersion.version ? ` (${tmuxVersion.version})` : ''}.
 
   Aegis requires tmux/psmux 3.3 or newer.
   `);
-    process.exit(1);
+    return 1;
   }
 
   if (!hasClaude) {
-    console.error(`
+    write(io.stderr, `
   ⚠️  Claude Code CLI not found.
 
   Install Claude Code:
@@ -287,22 +731,33 @@ async function main(): Promise<void> {
 
   Sessions will fail to start without the 'claude' command.
     `);
-    // Don't exit — server can still start, just sessions won't work
   }
 
-  const port = parseIntSafe(process.env.AEGIS_PORT, 9100);
-  printBanner(port);
+  const config = await loadConfig();
+  printBanner(io, config.port);
 
-  console.log(`  Dependencies:`);
-  console.log(`    tmux:   ${hasTmux ? '✅' : '❌'}`);
-  console.log(`    claude: ${hasClaude ? '✅' : '❌'}`);
-  console.log('');
+  writeLine(io.stdout, '  Dependencies:');
+  writeLine(io.stdout, `    tmux:   ${hasTmux ? '✅' : '❌'}`);
+  writeLine(io.stdout, `    claude: ${hasClaude ? '✅' : '❌'}`);
+  writeLine(io.stdout);
 
-  // Start the server
   await import('./server.js');
+  return 0;
 }
 
-main().catch(err => {
-  console.error('Failed to start Aegis:', err);
-  process.exit(1);
-});
+const isMainModule = (() => {
+  try {
+    return fileURLToPath(import.meta.url) === process.argv[1];
+  } catch {
+    return false;
+  }
+})();
+
+if (isMainModule) {
+  void runCli().then((code) => {
+    process.exitCode = code;
+  }).catch((error) => {
+    console.error('Failed to start Aegis:', error);
+    process.exitCode = 1;
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,20 +11,27 @@
  * AEGIS_* env vars take priority; MANUS_* still supported for backward compat.
  */
 
-import { readFile, realpath } from 'node:fs/promises';
+import { mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import { existsSync, watch, type FSWatcher } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { parseIntSafe } from './validation.js';
 import { configFileSchema } from './validation.js';
+import { getConfiguredBaseUrl } from './base-url.js';
+import { secureFilePermissions } from './file-utils.js';
 
 export interface Config {
+  /** Preferred origin URL for API clients, hooks, and dashboard links. */
+  baseUrl?: string;
   /** HTTP server port */
   port: number;
   /** HTTP server host */
   host: string;
   /** Bearer auth token (empty = no auth) */
   authToken: string;
+  /** Plaintext API token stored for local CLI/dashboard bootstrap flows. */
+  clientAuthToken?: string;
   /** tmux session name */
   tmuxSession: string;
   /** Directory for bridge state (state.json, session_map.json) */
@@ -121,6 +128,8 @@ export interface Config {
   shutdownGraceMs: number;
   /** Issue #1911: Hard cap in ms for total shutdown sequence before process.exit. Default: 20000 (20 s). */
   shutdownHardMs: number;
+  /** Whether to serve the bundled dashboard. Default: true. */
+  dashboardEnabled?: boolean;
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -136,9 +145,11 @@ export function computeStallThreshold(): number {
 
 /** Default configuration values */
 const defaults: Config = {
+  baseUrl: '',
   port: 9100,
   host: '127.0.0.1',
   authToken: '',
+  clientAuthToken: '',
   tmuxSession: 'aegis',
   stateDir: join(homedir(), '.aegis'),
   claudeProjectsDir: join(homedir(), '.claude', 'projects'),
@@ -174,6 +185,7 @@ const defaults: Config = {
   hookTimeoutMs: 10_000,
   shutdownGraceMs: 15_000,
   shutdownHardMs: 20_000,
+  dashboardEnabled: true,
 };
 
 /** Parse CLI args for --config flag */
@@ -185,47 +197,104 @@ function getConfigPathFromArgv(): string | null {
   return null;
 }
 
-/** Find and load config file from possible locations.
- *  Checks aegis paths first, falls back to manus paths for backward compat.
- */
-async function loadConfigFile(): Promise<Partial<Config>> {
-  const locations = [
+function getConfigSearchLocations(): string[] {
+  return [
     getConfigPathFromArgv(),
     // New aegis paths (preferred)
+    resolve('.aegis', 'config.yaml'),
+    resolve('.aegis', 'config.yml'),
     resolve('aegis.config.json'),
+    join(homedir(), '.aegis', 'config.yaml'),
+    join(homedir(), '.aegis', 'config.yml'),
     join(homedir(), '.aegis', 'config.json'),
     // Legacy manus paths (backward compat)
     resolve('manus.config.json'),
     join(homedir(), '.manus', 'config.json'),
   ].filter(Boolean) as string[];
+}
 
-  for (const path of locations) {
-    if (existsSync(path)) {
-      try {
-        const data = await readFile(path, 'utf-8');
-        const raw = JSON.parse(data);
-        if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-          console.warn(`Config file ${path} is not a JSON object, ignoring`);
-          continue;
-        }
-        // Expand ~ in paths before validation
-        if (typeof raw.stateDir === 'string') raw.stateDir = expandTilde(raw.stateDir);
-        if (typeof raw.claudeProjectsDir === 'string') raw.claudeProjectsDir = expandTilde(raw.claudeProjectsDir);
+function isYamlConfigPath(filePath: string): boolean {
+  return filePath.endsWith('.yaml') || filePath.endsWith('.yml');
+}
 
-        const parsed = configFileSchema.safeParse(raw);
-        if (!parsed.success) {
-          console.warn(`Config file ${path} has invalid fields, ignoring:`, parsed.error.format());
-          continue;
-        }
-        // Log if using legacy path
-        if (path.includes('manus')) {
-          console.log(`Config: loaded from legacy path ${path} — consider migrating to aegis paths`);
-        }
-        return parsed.data as Partial<Config>;
-      } catch (e) {
-        console.warn(`Failed to parse config file ${path}:`, e);
-      }
+function isLegacyManusConfigPath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, '/');
+  return normalized.endsWith('/manus.config.json') || normalized.includes('/.manus/');
+}
+
+function normalizeConfigFileObject(raw: unknown, filePath: string): Partial<Config> | null {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    console.warn(`Config file ${filePath} is not an object, ignoring`);
+    return null;
+  }
+
+  const candidate = { ...raw } as Record<string, unknown>;
+  if (typeof candidate.stateDir === 'string') candidate.stateDir = expandTilde(candidate.stateDir);
+  if (typeof candidate.claudeProjectsDir === 'string') candidate.claudeProjectsDir = expandTilde(candidate.claudeProjectsDir);
+
+  const parsed = configFileSchema.safeParse(candidate);
+  if (!parsed.success) {
+    console.warn(`Config file ${filePath} has invalid fields, ignoring:`, parsed.error.format());
+    return null;
+  }
+
+  return parsed.data as Partial<Config>;
+}
+
+function parseConfigText(filePath: string, data: string): unknown {
+  return isYamlConfigPath(filePath) ? parseYaml(data) : JSON.parse(data);
+}
+
+export async function readConfigFile(filePath: string): Promise<Partial<Config> | null> {
+  if (!existsSync(filePath)) return null;
+  try {
+    const data = await readFile(filePath, 'utf-8');
+    return normalizeConfigFileObject(parseConfigText(filePath, data), filePath);
+  } catch (e) {
+    console.warn(`Failed to parse config file ${filePath}:`, e);
+    return null;
+  }
+}
+
+function pruneUndefinedConfig<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(entry => pruneUndefinedConfig(entry)) as T;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .map(([key, entryValue]) => [key, pruneUndefinedConfig(entryValue)]);
+    return Object.fromEntries(entries) as T;
+  }
+  return value;
+}
+
+export function serializeConfigFile(config: Partial<Config>, filePath: string): string {
+  const cleaned = pruneUndefinedConfig(config);
+  if (isYamlConfigPath(filePath)) {
+    return stringifyYaml(cleaned, { lineWidth: 0 }).trimEnd() + '\n';
+  }
+  return `${JSON.stringify(cleaned, null, 2)}\n`;
+}
+
+export async function writeConfigFile(filePath: string, config: Partial<Config>): Promise<void> {
+  const content = serializeConfigFile(config, filePath);
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, { mode: 0o600 });
+  await secureFilePermissions(filePath);
+}
+
+/** Find and load config file from possible locations.
+ *  Checks aegis paths first, falls back to manus paths for backward compat.
+ */
+async function loadConfigFile(): Promise<Partial<Config>> {
+  for (const path of getConfigSearchLocations()) {
+    const parsed = await readConfigFile(path);
+    if (!parsed) continue;
+    if (isLegacyManusConfigPath(path)) {
+      console.log(`Config: loaded from legacy path ${path} — consider migrating to aegis paths`);
     }
+    return parsed;
   }
 
   return {};
@@ -314,6 +383,7 @@ function parseTgAllowedUsers(envName: string, value: string): number[] {
 function applyEnvOverrides(config: Config): Config {
   // AEGIS_* (new, preferred) and MANUS_* (legacy, backward compat)
   const envMappings: Array<{ aegis: string; manus: string; key: keyof Config }> = [
+    { aegis: 'AEGIS_BASE_URL', manus: '', key: 'baseUrl' },
     { aegis: 'AEGIS_PORT', manus: 'MANUS_PORT', key: 'port' },
     { aegis: 'AEGIS_HOST', manus: 'MANUS_HOST', key: 'host' },
     { aegis: 'AEGIS_AUTH_TOKEN', manus: 'MANUS_AUTH_TOKEN', key: 'authToken' },
@@ -340,6 +410,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_SHUTDOWN_GRACE_MS', manus: 'MANUS_SHUTDOWN_GRACE_MS', key: 'shutdownGraceMs' },
     { aegis: 'AEGIS_SHUTDOWN_HARD_MS', manus: 'MANUS_SHUTDOWN_HARD_MS', key: 'shutdownHardMs' },
     { aegis: 'AEGIS_HOOK_SECRET_HEADER_ONLY', manus: 'MANUS_HOOK_SECRET_HEADER_ONLY', key: 'hookSecretHeaderOnly' },
+    { aegis: 'AEGIS_DASHBOARD_ENABLED', manus: '', key: 'dashboardEnabled' },
     { aegis: 'AEGIS_ENFORCE_SESSION_OWNERSHIP', manus: '', key: 'enforceSessionOwnership' },
   ];
 
@@ -349,7 +420,7 @@ function applyEnvOverrides(config: Config): Config {
     if (value === undefined) continue;
     const envName = process.env[aegis] !== undefined ? aegis : manus;
 
-    switch (key) {
+      switch (key) {
       case 'port':
       case 'maxSessionAgeMs':
       case 'reaperIntervalMs':
@@ -368,6 +439,7 @@ function applyEnvOverrides(config: Config): Config {
         break;
       case 'hookSecretHeaderOnly':
       case 'tgTopicAutoDelete':
+      case 'dashboardEnabled':
         if (value === 'true' || value === 'false') {
           config[key] = value === 'true';
         } else {
@@ -390,6 +462,7 @@ function applyEnvOverrides(config: Config): Config {
         break;
       // All remaining env-mapped keys are string-typed — assign directly.
       case 'host':
+      case 'baseUrl':
       case 'authToken':
       case 'metricsToken':
       case 'tmuxSession':
@@ -466,6 +539,17 @@ function resolveStateDir(config: Config): Config {
   return config;
 }
 
+function finalizeDerivedConfig(config: Config): Config {
+  config.baseUrl = getConfiguredBaseUrl(config);
+  if (config.clientAuthToken === undefined) {
+    config.clientAuthToken = '';
+  }
+  if (config.dashboardEnabled === undefined) {
+    config.dashboardEnabled = true;
+  }
+  return config;
+}
+
 /** Load and merge configuration from all sources */
 export async function loadConfig(): Promise<Config> {
   const fileConfig = await loadConfigFile();
@@ -490,7 +574,7 @@ export async function loadConfig(): Promise<Config> {
       }),
     );
   }
-  return config;
+  return finalizeDerivedConfig(config);
 }
 
 /** Get config without async file loading (for tests or synchronous contexts) */
@@ -498,20 +582,12 @@ export function getConfig(): Config {
   // This returns defaults + env overrides only (no file loading)
   let config: Config = { ...defaults };
   config = applyEnvOverrides(config);
-  return config;
+  return finalizeDerivedConfig(config);
 }
 
 /** Find the config file path that loadConfig() would use (or null if none found). */
 export function findConfigFilePath(): string | null {
-  const locations = [
-    getConfigPathFromArgv(),
-    resolve('aegis.config.json'),
-    join(homedir(), '.aegis', 'config.json'),
-    resolve('manus.config.json'),
-    join(homedir(), '.manus', 'config.json'),
-  ].filter(Boolean) as string[];
-
-  for (const p of locations) {
+  for (const p of getConfigSearchLocations()) {
     if (existsSync(p)) return p;
   }
   return null;
@@ -519,19 +595,7 @@ export function findConfigFilePath(): string | null {
 
 /** Load and parse a specific config file, returning parsed data or null. */
 async function loadSpecificConfigFile(filePath: string): Promise<Partial<Config> | null> {
-  if (!existsSync(filePath)) return null;
-  try {
-    const data = await readFile(filePath, 'utf-8');
-    const raw = JSON.parse(data);
-    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null;
-    if (typeof raw.stateDir === 'string') raw.stateDir = expandTilde(raw.stateDir);
-    if (typeof raw.claudeProjectsDir === 'string') raw.claudeProjectsDir = expandTilde(raw.claudeProjectsDir);
-    const parsed = configFileSchema.safeParse(raw);
-    if (!parsed.success) return null;
-    return parsed.data as Partial<Config>;
-  } catch {
-    return null;
-  }
+  return readConfigFile(filePath);
 }
 
 /** Reload only allowedWorkDirs from the config file, resolving paths via realpath.

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -20,6 +20,7 @@ import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { ccSettingsSchema, containsTraversalSegment } from './validation.js';
+import { normalizeBaseUrl } from './base-url.js';
 import { secureFilePermissions } from './file-utils.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -36,18 +37,6 @@ function parseSettingsWithFallback(raw: string): Record<string, unknown> | undef
 
   // Preserve unknown/extra fields (including env vars) even when schema validation fails.
   return json;
-}
-
-function normalizeHookBaseUrl(baseUrl: string): string {
-  try {
-    const url = new URL(baseUrl);
-    if (url.hostname === '0.0.0.0' || url.hostname === '::' || url.hostname === '[::]') {
-      url.hostname = '127.0.0.1';
-    }
-    return url.origin;
-  } catch {
-    return baseUrl.replace('0.0.0.0', '127.0.0.1');
-  }
 }
 
 /** Build a normalized path to .claude/settings.local.json for Unix and Windows workDirs. */
@@ -150,7 +139,7 @@ export interface HookSettings {
  */
 export function generateHookSettings(baseUrl: string, sessionId: string, hookSecret?: string): HookSettings {
   const hooks: HookSettings['hooks'] = {};
-  const callbackBaseUrl = normalizeHookBaseUrl(baseUrl);
+  const callbackBaseUrl = normalizeBaseUrl(baseUrl);
 
   for (const event of HTTP_HOOK_EVENTS) {
     const hookConfig: HttpHookConfig = {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -43,13 +43,16 @@ export function createMcpServerFromBackend(backend: IAegisBackend): McpServer {
 }
 
 /** Create an MCP server using the remote HTTP client (backward-compatible). */
-export function createMcpServer(aegisPort: number, authToken?: string): McpServer {
-  const client = new AegisClient(`http://127.0.0.1:${aegisPort}`, authToken);
+export function createMcpServer(aegisBaseUrlOrPort: number | string, authToken?: string): McpServer {
+  const baseUrl = typeof aegisBaseUrlOrPort === 'number'
+    ? `http://127.0.0.1:${aegisBaseUrlOrPort}`
+    : aegisBaseUrlOrPort;
+  const client = new AegisClient(baseUrl, authToken);
   return createMcpServerFromBackend(client);
 }
 
-export async function startMcpServer(port: number, authToken?: string): Promise<void> {
-  const server = createMcpServer(port, authToken);
+export async function startMcpServer(baseUrlOrPort: number | string, authToken?: string): Promise<void> {
+  const server = createMcpServer(baseUrlOrPort, authToken);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // Server runs until stdin closes

--- a/src/server.ts
+++ b/src/server.ts
@@ -1169,20 +1169,23 @@ async function main(): Promise<void> {
   // Issue #539: Dashboard is copied into dist/dashboard/ during build
   // Issue #1699: Validates index.html presence for clearer diagnostics
   const dashboardRoot = path.join(__dirname, "dashboard");
+  const dashboardEnabled = config.dashboardEnabled !== false;
   let dashboardAvailable = false;
-  try {
-    await fs.access(path.join(dashboardRoot, 'index.html'));
-    dashboardAvailable = true;
-  } catch {
-    logger.warn({
-      component: 'server',
-      operation: 'dashboard_static_unavailable',
-      errorCode: 'DASHBOARD_DIR_MISSING',
-      attributes: {
-        dashboardRoot,
-        hint: 'Run "npm run build:dashboard && npm run build:copy-dashboard" to populate dist/dashboard/',
-      },
-    });
+  if (dashboardEnabled) {
+    try {
+      await fs.access(path.join(dashboardRoot, 'index.html'));
+      dashboardAvailable = true;
+    } catch {
+      logger.warn({
+        component: 'server',
+        operation: 'dashboard_static_unavailable',
+        errorCode: 'DASHBOARD_DIR_MISSING',
+        attributes: {
+          dashboardRoot,
+          hint: 'Run "npm run build:dashboard && npm run build:copy-dashboard" to populate dist/dashboard/',
+        },
+      });
+    }
   }
 
   if (dashboardAvailable) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,6 +17,7 @@ import { SessionTranscripts } from './session-transcripts.js';
 import { SessionDiscovery } from './session-discovery.js';
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
+import { getConfiguredBaseUrl } from './base-url.js';
 import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
 import { persistedStateSchema, type PermissionPolicy, type PermissionProfile, ENV_NAME_RE, ENV_DENYLIST, ENV_DANGEROUS_PREFIXES, stripCrLf, hasControlChars, ENV_VALUE_MAX_BYTES } from './validation.js';
 import type { z } from 'zod';
@@ -720,7 +721,7 @@ export class SessionManager {
 
     let hookSettingsFile: string | undefined;
     try {
-      const baseUrl = `http://${this.config.host}:${this.config.port}`;
+      const baseUrl = getConfiguredBaseUrl(this.config);
       hookSettingsFile = await writeHookSettingsFile(baseUrl, id, hookSecret, opts.workDir);
     } catch (e) {
       console.error(`Hook settings: failed to generate settings file: ${(e as Error).message}`);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -714,9 +714,11 @@ export async function validateWorkDir(
 
 /** Schema for aegis config file (Issue #1109). */
 export const configFileSchema = z.object({
+  baseUrl: z.string().url().optional(),
   port: z.number().int().positive().optional(),
   host: z.string().optional(),
   authToken: z.string().optional(),
+  clientAuthToken: z.string().optional(),
   tmuxSession: z.string().optional(),
   stateDir: z.string().optional(),
   claudeProjectsDir: z.string().optional(),
@@ -758,5 +760,6 @@ export const configFileSchema = z.object({
   hookTimeoutMs: z.number().int().positive().optional(),
   shutdownGraceMs: z.number().int().positive().optional(),
   shutdownHardMs: z.number().int().positive().optional(),
+  dashboardEnabled: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Summary

Adds an interactive `ag init` flow with YAML config support, non-interactive `--yes`, admin token/bootstrap prompts, BYO-LLM configuration prompts, and a next-step summary.

## Aegis version

**Developed with:** v0.5.3-alpha
**Tested with:** v0.5.3-alpha

## Change type

- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring with no behavior change
- [ ] `perf` — Performance improvement
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling
- [x] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

CLI bootstrap flow, config discovery/loading, base URL handling, docs, and init-focused integration coverage.

## Linked issue

Closes #1930

## Test plan

Repository gate passed (`npm run gate`).

- [x] Unit tests pass (`npm test`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Manually tested (describe below)

## Security impact

Bootstraps client auth/admin token flow explicitly and keeps defaults in project-local config.

## Dependency notes

Draft while #1994 remains open because this branch was stacked after the `ag` alias transition.