### PR TITLE
feat: improve mobile dashboard session workflows

### DIFF
--- a/dashboard/e2e/helpers/dashboard-fixtures.ts
+++ b/dashboard/e2e/helpers/dashboard-fixtures.ts
@@ -1,0 +1,337 @@
+import type { Page, Route } from '@playwright/test';
+import { authenticate } from './auth';
+
+export const MOBILE_SESSION_ID = 'sess-mobile';
+export const QUESTION_SESSION_ID = 'sess-question';
+
+function json(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+export async function mockDashboardFixtures(page: Page): Promise<void> {
+  const now = Date.now();
+
+  const makeSession = (
+    id: string,
+    status: 'permission_prompt' | 'ask_question' | 'idle',
+    overrides: Record<string, unknown> = {},
+  ) => ({
+    id,
+    windowId: `@${id}`,
+    windowName: id === MOBILE_SESSION_ID
+      ? 'Mobile dashboard pass'
+      : id === QUESTION_SESSION_ID
+        ? 'Answer product question'
+        : 'Quiet docs sync',
+    workDir: 'D:\\src\\aegis\\dashboard',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status,
+    createdAt: now - 45 * 60 * 1000,
+    lastActivity: now - 45 * 1000,
+    stallThresholdMs: 300000,
+    permissionMode: 'default',
+    ownerKeyId: `${id}-owner`,
+    ...overrides,
+  });
+
+  const sessions = [
+    makeSession(MOBILE_SESSION_ID, 'permission_prompt', {
+      permissionPromptAt: now - 2_000,
+      pendingPermission: {
+        toolName: 'Bash',
+        prompt: 'Allow Claude to run npm run deploy in D:\\src\\aegis\\dashboard?',
+        startedAt: now - 2_000,
+        timeoutMs: 10_000,
+        expiresAt: now + 8_000,
+        remainingMs: 8_000,
+      },
+    }),
+    makeSession(QUESTION_SESSION_ID, 'ask_question', {
+      createdAt: now - 90 * 60 * 1000,
+      lastActivity: now - 2 * 60 * 1000,
+      pendingQuestion: {
+        toolUseId: 'tool-question',
+        content: 'What should the empty state CTA say on mobile?',
+        options: ['Ship it', 'Revise copy'],
+        since: now - 2 * 60 * 1000,
+      },
+    }),
+    makeSession('sess-idle', 'idle', {
+      createdAt: now - 3 * 60 * 60 * 1000,
+      lastActivity: now - 9 * 60 * 1000,
+      permissionMode: 'plan',
+    }),
+  ];
+
+  const sessionById = Object.fromEntries(sessions.map((session) => [session.id, session]));
+
+  const sessionHealthById = {
+    [MOBILE_SESSION_ID]: {
+      alive: true,
+      windowExists: true,
+      claudeRunning: true,
+      paneCommand: 'claude',
+      status: 'permission_prompt',
+      hasTranscript: true,
+      lastActivity: now - 45_000,
+      lastActivityAgo: 45_000,
+      sessionAge: 45 * 60 * 1000,
+      details: 'Allow Claude to run npm run deploy in D:\\src\\aegis\\dashboard?',
+      actionHints: {
+        approve: { method: 'POST', url: `/v1/sessions/${MOBILE_SESSION_ID}/approve`, description: 'Approve the pending permission' },
+        reject: { method: 'POST', url: `/v1/sessions/${MOBILE_SESSION_ID}/reject`, description: 'Reject the pending permission' },
+      },
+    },
+    [QUESTION_SESSION_ID]: {
+      alive: true,
+      windowExists: true,
+      claudeRunning: true,
+      paneCommand: 'claude',
+      status: 'ask_question',
+      hasTranscript: true,
+      lastActivity: now - 2 * 60 * 1000,
+      lastActivityAgo: 2 * 60 * 1000,
+      sessionAge: 90 * 60 * 1000,
+      details: 'Claude is waiting for an answer before continuing.',
+    },
+    'sess-idle': {
+      alive: true,
+      windowExists: true,
+      claudeRunning: true,
+      paneCommand: 'claude',
+      status: 'idle',
+      hasTranscript: true,
+      lastActivity: now - 9 * 60 * 1000,
+      lastActivityAgo: 9 * 60 * 1000,
+      sessionAge: 3 * 60 * 60 * 1000,
+      details: 'Claude is idle, awaiting input.',
+    },
+  };
+
+  const sessionMetricsById = {
+    [MOBILE_SESSION_ID]: {
+      durationSec: 2700,
+      messages: 28,
+      toolCalls: 14,
+      approvals: 3,
+      autoApprovals: 0,
+      statusChanges: ['working', 'permission_prompt'],
+      tokenUsage: { inputTokens: 2200, outputTokens: 1300, cacheCreationTokens: 100, cacheReadTokens: 50, estimatedCostUsd: 0.31 },
+    },
+    [QUESTION_SESSION_ID]: {
+      durationSec: 4200,
+      messages: 33,
+      toolCalls: 18,
+      approvals: 1,
+      autoApprovals: 0,
+      statusChanges: ['working', 'ask_question'],
+      tokenUsage: { inputTokens: 2800, outputTokens: 1600, cacheCreationTokens: 120, cacheReadTokens: 60, estimatedCostUsd: 0.42 },
+    },
+    'sess-idle': {
+      durationSec: 10800,
+      messages: 12,
+      toolCalls: 6,
+      approvals: 0,
+      autoApprovals: 1,
+      statusChanges: ['working', 'idle'],
+      tokenUsage: { inputTokens: 1400, outputTokens: 900, cacheCreationTokens: 40, cacheReadTokens: 20, estimatedCostUsd: 0.12 },
+    },
+  };
+
+  const latencyById = Object.fromEntries(
+    Object.keys(sessionHealthById).map((id) => [
+      id,
+      {
+        sessionId: id,
+        realtime: { hook_latency_ms: 18, state_change_detection_ms: 26, permission_response_ms: id === MOBILE_SESSION_ID ? 1800 : null },
+        aggregated: {
+          hook_latency_ms: { min: 12, max: 28, avg: 18, count: 6 },
+          state_change_detection_ms: { min: 20, max: 40, avg: 29, count: 6 },
+          permission_response_ms: { min: 1800, max: 1800, avg: 1800, count: id === MOBILE_SESSION_ID ? 1 : 0 },
+          channel_delivery_ms: { min: 9, max: 15, avg: 11, count: 6 },
+        },
+      },
+    ]),
+  );
+
+  const messagesById = {
+    [MOBILE_SESSION_ID]: {
+      messages: [
+        { role: 'assistant', contentType: 'text', text: 'Ready to continue once you approve this command.', timestamp: new Date(now - 120_000).toISOString() },
+        { role: 'assistant', contentType: 'permission_request', text: 'npm run deploy', timestamp: new Date(now - 45_000).toISOString() },
+      ],
+      status: 'permission_prompt',
+      statusText: 'Permission required',
+      interactiveContent: 'Allow Claude to run npm run deploy in D:\\src\\aegis\\dashboard?',
+    },
+    [QUESTION_SESSION_ID]: {
+      messages: [
+        { role: 'assistant', contentType: 'text', text: 'What should the empty state CTA say on mobile?', timestamp: new Date(now - 180_000).toISOString() },
+      ],
+      status: 'ask_question',
+      statusText: 'Awaiting answer',
+      interactiveContent: 'What should the empty state CTA say on mobile?',
+    },
+    'sess-idle': {
+      messages: [
+        { role: 'assistant', contentType: 'text', text: 'Docs sync completed successfully.', timestamp: new Date(now - 540_000).toISOString() },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    },
+  };
+
+  await authenticate(page);
+
+  await page.addInitScript(() => {
+    class MockEventSource {
+      url: string;
+      readyState = 1;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string) {
+        this.url = url;
+        window.setTimeout(() => this.onopen?.(new Event('open')), 10);
+      }
+
+      close() {
+        this.readyState = 2;
+      }
+    }
+
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      url: string;
+      readyState = MockWebSocket.OPEN;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onclose: ((event: Event) => void) | null = null;
+
+      constructor(url: string) {
+        this.url = url;
+        window.setTimeout(() => this.onopen?.(new Event('open')), 10);
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.(new Event('close'));
+      }
+    }
+
+    Object.defineProperty(window, 'EventSource', { value: MockEventSource, configurable: true });
+    Object.defineProperty(window, 'WebSocket', { value: MockWebSocket, configurable: true });
+  });
+
+  await page.route('https://registry.npmjs.org/@onestepat4time/aegis/latest', (route) =>
+    json(route, { version: '0.5.3-alpha' }),
+  );
+  await page.route('**/v1/auth/sse-token', (route) =>
+    json(route, { token: 'e2e-sse-token', expiresAt: now + 60_000 }),
+  );
+  await page.route('**/v1/health', (route) =>
+    json(route, {
+      status: 'ok',
+      version: '0.5.3-alpha',
+      platform: 'win32',
+      uptime: 7200,
+      sessions: { active: sessions.length, total: 12 },
+      tmux: { healthy: true, error: null },
+      claude: { available: true, healthy: true, version: '1.0.0', minimumVersion: '1.0.0', error: null },
+      timestamp: new Date(now).toISOString(),
+    }),
+  );
+  await page.route('**/v1/metrics', (route) =>
+    json(route, {
+      uptime: 7200,
+      sessions: {
+        total_created: 12,
+        currently_active: sessions.length,
+        completed: 9,
+        failed: 0,
+        avg_duration_sec: 1800,
+        avg_messages_per_session: 24,
+      },
+      auto_approvals: 2,
+      webhooks_sent: 0,
+      webhooks_failed: 0,
+      screenshots_taken: 3,
+      pipelines_created: 1,
+      batches_created: 0,
+      prompt_delivery: {
+        sent: 48,
+        delivered: 47,
+        failed: 1,
+        success_rate: 97.9,
+      },
+      latency: {
+        hook_latency_ms: { min: 12, max: 40, avg: 22, count: 8 },
+        state_change_detection_ms: { min: 20, max: 60, avg: 33, count: 8 },
+        permission_response_ms: { min: 1000, max: 5000, avg: 2100, count: 3 },
+        channel_delivery_ms: { min: 10, max: 18, avg: 13, count: 8 },
+      },
+    }),
+  );
+  await page.route('**/v1/sessions/stats', (route) =>
+    json(route, {
+      active: sessions.length,
+      totalCreated: 12,
+      totalCompleted: 9,
+      totalFailed: 0,
+      byStatus: { idle: 1, permission_prompt: 1, ask_question: 1 },
+    }),
+  );
+  await page.route('**/v1/sessions/health', (route) => json(route, sessionHealthById));
+  await page.route(/\/v1\/sessions(\?.*)?$/, (route) =>
+    json(route, {
+      sessions,
+      pagination: { page: 1, limit: 20, total: sessions.length, totalPages: 1 },
+    }),
+  );
+  await page.route(/\/v1\/sessions\/sess-[^/]+$/, (route) => {
+    if (route.request().method() === 'DELETE') {
+      return json(route, { ok: true });
+    }
+    const id = route.request().url().split('/').at(-1) as string;
+    return json(route, sessionById[id]);
+  });
+  await page.route(/\/v1\/sessions\/sess-[^/]+\/health$/, (route) => {
+    const id = route.request().url().split('/').at(-2) as string;
+    return json(route, sessionHealthById[id]);
+  });
+  await page.route(/\/v1\/sessions\/sess-[^/]+\/read$/, (route) => {
+    const id = route.request().url().split('/').at(-2) as string;
+    return json(route, messagesById[id]);
+  });
+  await page.route(/\/v1\/sessions\/sess-[^/]+\/pane$/, (route) =>
+    json(route, { pane: '$ claude\n> Waiting for input\n' }),
+  );
+  await page.route(/\/v1\/sessions\/sess-[^/]+\/metrics$/, (route) => {
+    const id = route.request().url().split('/').at(-2) as string;
+    return json(route, sessionMetricsById[id]);
+  });
+  await page.route(/\/v1\/sessions\/sess-[^/]+\/latency$/, (route) => {
+    const id = route.request().url().split('/').at(-2) as string;
+    return json(route, latencyById[id]);
+  });
+  await page.route(/\/v1\/sessions\/sess-[^/]+\/(send|command|bash)$/, (route) =>
+    json(route, { ok: true, delivered: true, attempts: 1 }),
+  );
+  await page.route(/\/v1\/sessions\/sess-[^/]+\/(approve|reject|interrupt|escape)$/, (route) =>
+    json(route, { ok: true }),
+  );
+}

--- a/dashboard/e2e/mobile-dashboard.spec.ts
+++ b/dashboard/e2e/mobile-dashboard.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  mockDashboardFixtures,
+  MOBILE_SESSION_ID,
+  QUESTION_SESSION_ID,
+} from './helpers/dashboard-fixtures';
+
+async function assertNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const main = document.querySelector('main');
+    return {
+      documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      mainOverflow: main ? main.scrollWidth - main.clientWidth : 0,
+    };
+  });
+
+  expect(overflow.documentOverflow).toBeLessThanOrEqual(1);
+  expect(overflow.mainOverflow).toBeLessThanOrEqual(1);
+}
+
+test.describe('Mobile dashboard flow', () => {
+  test.use({
+    viewport: { width: 375, height: 667 },
+    isMobile: true,
+    hasTouch: true,
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await mockDashboardFixtures(page);
+  });
+
+  test('overview and permission detail avoid horizontal overflow on 375x667', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'Overview', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Mobile dashboard pass' })).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    await page.getByRole('link', { name: 'Mobile dashboard pass' }).click();
+
+    const permissionDialog = page.getByRole('dialog', { name: 'Permission prompt' });
+    await expect(permissionDialog).toBeVisible();
+    await expect(permissionDialog).toContainText('TTL');
+    await expect(permissionDialog.getByText(/\d+:\d\d|expired/)).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+
+    for (const label of ['Approve', 'Reject', 'Escape', 'Kill']) {
+      const box = await permissionDialog.getByRole('button', { name: label }).boundingBox();
+      expect(box).not.toBeNull();
+      expect((box?.y ?? 0) + (box?.height ?? 0)).toBeLessThanOrEqual(viewport!.height);
+    }
+  });
+
+  test('question detail keeps reply controls ready for one-thumb answers', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Answer product question' }).click();
+
+    await expect(page.getByText('Claude needs an answer').last()).toBeVisible();
+    await expect(page.getByText('What should the empty state CTA say on mobile?').last()).toBeVisible();
+
+    await page.getByRole('button', { name: 'Ship it' }).last().click();
+    await expect(page.locator('#session-message-input-mobile')).toHaveValue('Ship it');
+    const sendButton = page.getByRole('button', { name: 'Send message' }).last();
+    await expect(sendButton).toBeVisible();
+
+    const sendBox = await sendButton.boundingBox();
+    const viewport = page.viewportSize();
+    expect(sendBox).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    expect((sendBox?.y ?? 0) + (sendBox?.height ?? 0)).toBeLessThanOrEqual(viewport!.height);
+    await assertNoHorizontalOverflow(page);
+  });
+});

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Aegis Dashboard</title>
     <meta
       name="description"

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Aegis Dashboard</title>
+    <meta
+      name="description"
+      content="Mobile-friendly Aegis dashboard for monitoring Claude Code sessions, approving prompts, and replying to questions."
+    />
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🛡️</text></svg>" />
   </head>
   <body class="bg-[#0a0a0f] text-gray-200 antialiased">

--- a/dashboard/src/__tests__/PendingQuestionCard.test.tsx
+++ b/dashboard/src/__tests__/PendingQuestionCard.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PendingQuestionCard } from '../components/session/PendingQuestionCard';
+
+describe('PendingQuestionCard', () => {
+  it('renders question copy and quick reply options', () => {
+    const onSelectOption = vi.fn();
+
+    render(
+      <PendingQuestionCard
+        pendingQuestion={{
+          toolUseId: 'tool-1',
+          content: 'What label should we use on mobile?',
+          options: ['Ship it', 'Revise copy'],
+          since: Date.now(),
+        }}
+        onSelectOption={onSelectOption}
+      />,
+    );
+
+    expect(screen.getByText('What label should we use on mobile?')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Ship it' }));
+
+    expect(onSelectOption).toHaveBeenCalledWith('Ship it');
+  });
+});

--- a/dashboard/src/__tests__/PermissionPromptSheet.test.tsx
+++ b/dashboard/src/__tests__/PermissionPromptSheet.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { PermissionPromptSheet } from '../components/session/PermissionPromptSheet';
+
+describe('PermissionPromptSheet', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-17T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows a live TTL countdown', () => {
+    render(
+      <PermissionPromptSheet
+        prompt="Allow Claude to deploy?"
+        pendingPermission={{
+          toolName: 'Bash',
+          prompt: 'npm run deploy',
+          startedAt: Date.now(),
+          timeoutMs: 10_000,
+          expiresAt: Date.now() + 10_000,
+          remainingMs: 10_000,
+        }}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onEscape={vi.fn()}
+        onKill={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('0:10')).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+
+    expect(screen.getByText('0:07')).toBeDefined();
+  });
+
+  it('wires all action buttons', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    const onEscape = vi.fn();
+    const onKill = vi.fn();
+
+    render(
+      <PermissionPromptSheet
+        prompt="Allow Claude to deploy?"
+        pendingPermission={{
+          toolName: 'Bash',
+          prompt: 'npm run deploy',
+          startedAt: Date.now(),
+          timeoutMs: 10_000,
+          expiresAt: Date.now() + 10_000,
+          remainingMs: 10_000,
+        }}
+        onApprove={onApprove}
+        onReject={onReject}
+        onEscape={onEscape}
+        onKill={onKill}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Escape' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Kill' }));
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+    expect(onReject).toHaveBeenCalledTimes(1);
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(onKill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/__tests__/SessionDetailPage.test.tsx
+++ b/dashboard/src/__tests__/SessionDetailPage.test.tsx
@@ -121,7 +121,7 @@ describe('SessionDetailPage quick actions', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Insert Slash' }));
 
-    expect((screen.getByPlaceholderText('Send a message to Claude…') as HTMLInputElement).value).toBe('/config');
+    expect((screen.getAllByPlaceholderText('Send a message to Claude…')[0] as HTMLInputElement).value).toBe('/config');
   });
 
   it('sends the selected slash command immediately', async () => {

--- a/dashboard/src/__tests__/schemas.test.ts
+++ b/dashboard/src/__tests__/schemas.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { SessionMessagesSchema, GlobalMetricsSchema } from '../api/schemas';
+import { SessionInfoSchema, SessionMessagesSchema, GlobalMetricsSchema } from '../api/schemas';
 
 // ── SessionMessagesSchema ────────────────────────────────────────
 
@@ -64,6 +64,53 @@ describe('SessionMessagesSchema', () => {
     const result = SessionMessagesSchema.safeParse({
       ...validPayload,
       statusText: 123,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('SessionInfoSchema', () => {
+  const validPayload = {
+    id: 'sess-1',
+    windowId: '@1',
+    windowName: 'Mobile dashboard pass',
+    workDir: 'D:\\src\\aegis\\dashboard',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'permission_prompt',
+    createdAt: 1,
+    lastActivity: 2,
+    stallThresholdMs: 300000,
+    permissionMode: 'default',
+    permissionPromptAt: 3,
+    pendingPermission: {
+      toolName: 'Bash',
+      prompt: 'npm run deploy',
+      startedAt: 3,
+      timeoutMs: 10000,
+      expiresAt: 10003,
+      remainingMs: 9000,
+    },
+    pendingQuestion: {
+      toolUseId: 'tool-1',
+      content: 'What label should we use?',
+      options: ['Ship it', 'Revise copy'],
+      since: 4,
+    },
+  };
+
+  it('accepts pending interaction metadata', () => {
+    const result = SessionInfoSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects malformed pending permission metadata', () => {
+    const result = SessionInfoSchema.safeParse({
+      ...validPayload,
+      pendingPermission: {
+        ...validPayload.pendingPermission,
+        expiresAt: 'soon',
+      },
     });
     expect(result.success).toBe(false);
   });

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -114,6 +114,22 @@ export const HealthResponseSchema: z.ZodType<HealthResponse> = z.object({
 
 // ── SessionInfo ─────────────────────────────────────────────────
 
+const PendingPermissionInfoSchema = z.object({
+  toolName: z.string().optional(),
+  prompt: z.string().optional(),
+  startedAt: z.number(),
+  timeoutMs: z.number(),
+  expiresAt: z.number(),
+  remainingMs: z.number(),
+});
+
+const PendingQuestionInfoSchema = z.object({
+  toolUseId: z.string(),
+  content: z.string(),
+  options: z.array(z.string()).nullable(),
+  since: z.number(),
+});
+
 export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
   id: z.string(),
   windowId: z.string(),
@@ -130,6 +146,10 @@ export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
   permissionMode: z.string(),
   autoApprove: z.boolean().optional(),
   settingsPatched: z.boolean().optional(),
+  permissionPromptAt: z.number().optional(),
+  permissionRespondedAt: z.number().optional(),
+  pendingPermission: PendingPermissionInfoSchema.optional(),
+  pendingQuestion: PendingQuestionInfoSchema.optional(),
   promptDelivery: z.object({ delivered: z.boolean(), attempts: z.number() }).optional(),
   actionHints: z.record(z.string(), z.object({
     method: z.string(),

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -334,81 +334,96 @@ export default function Layout() {
       {/* ── Main area ───────────────────────────────────────── */}
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Header */}
-        <header className="flex items-center justify-between border-b border-void-lighter bg-void-light px-6 py-3 shrink-0">
-          <div className="flex items-center gap-3">
-            {/* Hamburger — mobile only */}
-            <button
-              type="button"
-              onClick={toggleMobile}
-              className="lg:hidden inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 hover:bg-void-lighter hover:text-gray-200 transition-colors"
-              aria-label="Open menu"
-            >
-              <Menu className="h-5 w-5" />
-            </button>
-            <Breadcrumb />
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 text-xs text-gray-400">
-              <span className="rounded-md border border-yellow-500/50 px-2 py-1 bg-yellow-500/10 text-yellow-500 font-semibold text-[10px] uppercase tracking-wider mr-1">ALPHA</span><span className="rounded-md border border-void-lighter px-2 py-1 bg-void">
-              <button onClick={toggleTheme} className="ml-2 rounded p-1.5 text-zinc-400 hover:text-zinc-200 hover:bg-void-lighter transition-colors" aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'} title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>{theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}</button>
-                Version {aegisVersion}
+        <header className="shrink-0 border-b border-void-lighter bg-void-light px-3 py-3 sm:px-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              {/* Hamburger — mobile only */}
+              <button
+                type="button"
+                onClick={toggleMobile}
+                className="lg:hidden inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 hover:bg-void-lighter hover:text-gray-200 transition-colors"
+                aria-label="Open menu"
+              >
+                <Menu className="h-5 w-5" />
+              </button>
+              <div className="min-w-0 flex-1">
+                <Breadcrumb />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
+              <span className="rounded-md border border-yellow-500/50 bg-yellow-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-yellow-500">
+                ALPHA
               </span>
+
+              <div className="inline-flex items-center gap-2 rounded-md border border-void-lighter bg-void px-2 py-1 text-xs text-gray-300">
+                <span className="truncate">Version {aegisVersion}</span>
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  className="rounded p-1.5 text-zinc-400 transition-colors hover:bg-void-lighter hover:text-zinc-200"
+                  aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                  title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                >
+                  {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+                </button>
+              </div>
+
               <button
                 type="button"
                 onClick={handleCheckUpdates}
                 disabled={updateCheckLoading || aegisVersion === '...'}
-                className="inline-flex items-center gap-1 rounded-md border border-void-lighter px-2 py-1 text-gray-300 hover:bg-void-lighter disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex items-center gap-1 rounded-md border border-void-lighter px-2 py-1 text-xs text-gray-300 hover:bg-void-lighter disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RefreshCw className={`h-3 w-3 ${updateCheckLoading ? 'animate-spin' : ''}`} />
-                {updateCheckLoading ? 'Checking...' : 'Check updates'}
+                {updateCheckLoading ? 'Checking…' : 'Check updates'}
               </button>
-            </div>
 
-            {updateResult && (
-              <div className="text-xs text-gray-400">
-                {updateResult.updateAvailable ? (
-                  <a
-                    href={updateResult.releaseUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-cyan hover:underline"
-                  >
-                    Update available: v{updateResult.latestVersion}
-                  </a>
+              {updateResult && (
+                <div className="hidden text-xs text-gray-400 sm:block">
+                  {updateResult.updateAvailable ? (
+                    <a
+                      href={updateResult.releaseUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-cyan hover:underline"
+                    >
+                      Update available: v{updateResult.latestVersion}
+                    </a>
+                  ) : (
+                    <span>Up to date (v{updateResult.currentVersion})</span>
+                  )}
+                </div>
+              )}
+
+              {updateCheckError && (
+                <div className="text-xs text-amber-500" title={updateCheckError}>
+                  Update check failed
+                </div>
+              )}
+
+              <div className="flex items-center gap-1.5 text-xs text-gray-500" title={sseError ?? undefined}>
+                {sseError ? (
+                  <>
+                    <AlertTriangle className="h-3 w-3 text-amber-500" />
+                    <span className="text-amber-500">{sseIndicatorLabel}</span>
+                  </>
                 ) : (
-                  <span>Up to date (v{updateResult.currentVersion})</span>
+                  <>
+                    <span
+                      className={`status-dot ${sseConnected ? 'status-dot--idle' : ''}`}
+                      style={sseConnected ? undefined : { backgroundColor: '#666' }}
+                    />
+                    {sseIndicatorLabel}
+                  </>
                 )}
               </div>
-            )}
-
-            {updateCheckError && (
-              <div className="text-xs text-amber-500" title={updateCheckError}>
-                Update check failed
-              </div>
-            )}
-
-            {/* SSE indicator */}
-            <div className="flex items-center gap-1.5 text-xs text-gray-500" title={sseError ?? undefined}>
-              {sseError ? (
-                <>
-                  <AlertTriangle className="h-3 w-3 text-amber-500" />
-                  <span className="text-amber-500">{sseIndicatorLabel}</span>
-                </>
-              ) : (
-                <>
-                  <span
-                    className={`status-dot ${sseConnected ? 'status-dot--idle' : ''}`}
-                    style={sseConnected ? undefined : { backgroundColor: '#666' }}
-                  />
-                  {sseIndicatorLabel}
-                </>
-              )}
             </div>
           </div>
         </header>
 
         {/* Content */}
-        <main id="main-content" className="flex-1 overflow-auto overscroll-contain p-6 touch-pan-y">
+        <main id="main-content" className="flex-1 overflow-auto overscroll-contain p-4 touch-pan-y sm:p-6">
           <ErrorBoundary>
             <Outlet />
           </ErrorBoundary>

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -341,7 +341,7 @@ export default function Layout() {
               <button
                 type="button"
                 onClick={toggleMobile}
-                className="lg:hidden inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 hover:bg-void-lighter hover:text-gray-200 transition-colors"
+                className="md:hidden inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 hover:bg-void-lighter hover:text-gray-200 transition-colors"
                 aria-label="Open menu"
               >
                 <Menu className="h-5 w-5" />

--- a/dashboard/src/components/session/ApprovalBanner.tsx
+++ b/dashboard/src/components/session/ApprovalBanner.tsx
@@ -1,54 +1,80 @@
-﻿import { useState } from 'react';
+import { useState } from 'react';
 
-const AUTO_APPROVE_MODES = new Set(['bypassPermissions', 'dontAsk', 'acceptEdits', 'plan', 'auto']);
+const AUTO_APPROVE_MODES = new Set([
+  'bypassPermissions',
+  'dontAsk',
+  'acceptEdits',
+  'plan',
+  'auto',
+]);
 
 interface ApprovalBannerProps {
   prompt: string;
   permissionMode?: string;
+  countdownLabel?: string | null;
   onApprove?: () => void;
   onReject?: () => void;
 }
 
-export function ApprovalBanner({ prompt, permissionMode, onApprove, onReject }: ApprovalBannerProps) {
+export function ApprovalBanner({
+  prompt,
+  permissionMode,
+  countdownLabel,
+  onApprove,
+  onReject,
+}: ApprovalBannerProps) {
   const [expanded, setExpanded] = useState(false);
+
   if (permissionMode && permissionMode !== 'default' && AUTO_APPROVE_MODES.has(permissionMode)) {
     return (
-      <div className="flex items-center gap-2 px-4 py-2 bg-[var(--color-success-bg)]/50 border border-[var(--color-success)]/30 rounded-lg text-sm">
-        <span className="text-[var(--color-success)] font-semibold text-xs uppercase tracking-wider">
-          AUTO-APPROVED ({permissionMode})
+      <div className="flex items-center gap-2 rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success-bg)]/50 px-4 py-2 text-sm">
+        <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-success)]">
+          Auto-approved ({permissionMode})
         </span>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 px-3 sm:px-4 py-3 bg-[var(--color-warning-dark)]/60 border border-[var(--color-warning)]/40 rounded-lg">
-      <div className="flex items-center gap-3 sm:gap-2 min-w-0">
-        <span className="text-[var(--color-warning)] text-lg shrink-0">âš </span>
-        <div className="flex-1 min-w-0">
-          <div className="text-xs text-[var(--color-warning)] font-semibold uppercase tracking-wider mb-0.5">
-            Permission Required
-          </div>
-          <div
-            className={`text-sm text-[var(--color-text-primary)] font-mono cursor-pointer ${expanded ? '' : 'truncate'}`}
-            onClick={() => setExpanded(!expanded)}
-            title={expanded ? undefined : 'Click to expand'}
-          >
-            {prompt}
-            {!expanded && prompt.length > 60 && <span className="text-[#888] ml-1">...</span>}
-          </div>
+    <div className="flex flex-col gap-3 rounded-lg border border-[var(--color-warning)]/40 bg-[var(--color-warning-dark)]/60 px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="shrink-0 text-lg text-[var(--color-warning)]">⚠</span>
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-warning)]">
+            Permission required
+          </span>
+          {countdownLabel && (
+            <span className="rounded-full border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 px-2 py-0.5 font-mono text-[11px] text-[var(--color-text-primary)]">
+              TTL {countdownLabel}
+            </span>
+          )}
         </div>
-      </div>
-      <div className="flex items-center gap-2 shrink-0">
+
         <button
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+          className={`mt-2 w-full cursor-pointer text-left font-mono text-sm text-[var(--color-text-primary)] ${
+            expanded ? 'break-words' : 'truncate'
+          }`}
+          title={expanded ? 'Collapse prompt' : 'Expand prompt'}
+        >
+          {prompt}
+          {!expanded && prompt.length > 60 && <span className="ml-1 text-[#888]">…</span>}
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
           onClick={onApprove}
-          className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-success-bg)] hover:bg-[var(--color-success-bg-hover)] text-[var(--color-success)] border border-[var(--color-success)]/30 transition-colors"
+          className="min-h-[44px] rounded border border-[var(--color-success)]/30 bg-[var(--color-success-bg)] px-3 py-2 text-xs font-medium text-[var(--color-success)] transition-colors hover:bg-[var(--color-success-bg-hover)]"
         >
           Approve
         </button>
         <button
+          type="button"
           onClick={onReject}
-          className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-error-bg)] hover:bg-[var(--color-error-bg-hover)] text-[var(--color-error)] border border-[var(--color-error)]/30 transition-colors"
+          className="min-h-[44px] rounded border border-[var(--color-error)]/30 bg-[var(--color-error-bg)] px-3 py-2 text-xs font-medium text-[var(--color-error)] transition-colors hover:bg-[var(--color-error-bg-hover)]"
         >
           Reject
         </button>
@@ -56,4 +82,3 @@ export function ApprovalBanner({ prompt, permissionMode, onApprove, onReject }: 
     </div>
   );
 }
-

--- a/dashboard/src/components/session/PendingQuestionCard.tsx
+++ b/dashboard/src/components/session/PendingQuestionCard.tsx
@@ -1,0 +1,45 @@
+import type { PendingQuestionInfo } from '../../types';
+
+interface PendingQuestionCardProps {
+  pendingQuestion: PendingQuestionInfo;
+  onSelectOption?: (option: string) => void;
+}
+
+export function PendingQuestionCard({
+  pendingQuestion,
+  onSelectOption,
+}: PendingQuestionCardProps) {
+  return (
+    <div className="rounded-lg border border-[var(--color-info)]/30 bg-[var(--color-info-bg)]/60 p-3">
+      <div className="flex flex-col gap-2">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wider text-[var(--color-accent-cyan)]">
+            Claude needs an answer
+          </div>
+          <p className="mt-1 text-sm text-[var(--color-text-primary)]">
+            {pendingQuestion.content}
+          </p>
+        </div>
+
+        {pendingQuestion.options && pendingQuestion.options.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {pendingQuestion.options.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => onSelectOption?.(option)}
+                className="min-h-[40px] rounded-full border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <p className="text-xs text-gray-400">
+          Reply below to keep the session moving.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/session/PermissionPromptSheet.tsx
+++ b/dashboard/src/components/session/PermissionPromptSheet.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { PendingPermissionInfo } from '../../types';
+
+const FALLBACK_PERMISSION_TIMEOUT_MS = 10 * 60 * 1000;
+
+function clampRemaining(deadline: number | null): number | null {
+  if (deadline === null) return null;
+  return Math.max(0, deadline - Date.now());
+}
+
+function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+interface PermissionPromptSheetProps {
+  prompt: string;
+  pendingPermission?: PendingPermissionInfo;
+  permissionPromptAt?: number;
+  onApprove: () => void;
+  onReject: () => void;
+  onEscape: () => void;
+  onKill: () => void;
+}
+
+export function PermissionPromptSheet({
+  prompt,
+  pendingPermission,
+  permissionPromptAt,
+  onApprove,
+  onReject,
+  onEscape,
+  onKill,
+}: PermissionPromptSheetProps) {
+  const deadline = useMemo(() => {
+    if (pendingPermission) return pendingPermission.expiresAt;
+    if (permissionPromptAt) return permissionPromptAt + FALLBACK_PERMISSION_TIMEOUT_MS;
+    return null;
+  }, [pendingPermission, permissionPromptAt]);
+
+  const [remainingMs, setRemainingMs] = useState<number | null>(() => clampRemaining(deadline));
+
+  useEffect(() => {
+    setRemainingMs(clampRemaining(deadline));
+    if (deadline === null) return undefined;
+
+    const timer = window.setInterval(() => {
+      setRemainingMs(clampRemaining(deadline));
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, [deadline]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Permission prompt"
+      className="rounded-t-2xl border border-[var(--color-warning)]/35 bg-[var(--color-surface)] p-4 shadow-2xl"
+    >
+      <div className="mx-auto mb-3 h-1.5 w-12 rounded-full bg-[var(--color-void-lighter)]" />
+
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--color-warning)]">
+            Permission required
+          </div>
+          <h2 className="mt-1 text-base font-semibold text-[var(--color-text-primary)]">
+            Review before continuing
+          </h2>
+        </div>
+
+        {remainingMs !== null && (
+          <div className="rounded-full border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 px-3 py-1 text-right">
+            <div className="text-[10px] uppercase tracking-wider text-[var(--color-warning)]">
+              TTL
+            </div>
+            <div className="font-mono text-sm text-[var(--color-text-primary)]">
+              {remainingMs > 0 ? formatCountdown(remainingMs) : 'expired'}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-3 break-words rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-3 font-mono text-sm text-[var(--color-text-primary)]">
+        {pendingPermission?.prompt ?? prompt}
+      </p>
+
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={onApprove}
+          className="min-h-[48px] rounded-xl border border-[var(--color-success)]/30 bg-[var(--color-success-bg)] px-4 py-3 text-sm font-semibold text-[var(--color-success)] transition-colors hover:bg-[var(--color-success-bg-hover)]"
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          onClick={onReject}
+          className="min-h-[48px] rounded-xl border border-[var(--color-error)]/30 bg-[var(--color-error-bg)] px-4 py-3 text-sm font-semibold text-[var(--color-error)] transition-colors hover:bg-[var(--color-error-bg-hover)]"
+        >
+          Reject
+        </button>
+        <button
+          type="button"
+          onClick={onEscape}
+          className="min-h-[48px] rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-4 py-3 text-sm font-medium text-gray-200 transition-colors hover:bg-[var(--color-surface-hover)]"
+        >
+          Escape
+        </button>
+        <button
+          type="button"
+          onClick={onKill}
+          className="min-h-[48px] rounded-xl border border-[var(--color-error)]/30 bg-[var(--color-error-bg)]/20 px-4 py-3 text-sm font-medium text-[var(--color-error)] transition-colors hover:bg-[var(--color-error-bg)]/35"
+        >
+          Kill
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -1,7 +1,7 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-﻿import { useState } from 'react';
-import { Copy, Check, ArrowLeft } from 'lucide-react';
-import type { SessionInfo, SessionHealth, UIState } from '../../types';
+import { ArrowLeft, Check, Copy, GitFork } from 'lucide-react';
+import type { SessionHealth, SessionInfo, UIState } from '../../types';
 import StatusDot from '../overview/StatusDot';
 
 interface SessionHeaderProps {
@@ -14,7 +14,6 @@ interface SessionHeaderProps {
   onSaveTemplate?: () => void;
   onFork?: () => void;
 }
-
 
 const STATUS_LABELS: Record<UIState, string> = {
   idle: 'Idle',
@@ -33,19 +32,39 @@ const STATUS_LABELS: Record<UIState, string> = {
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
-  const copy = () => { navigator.clipboard.writeText(text).then(() => { setCopied(true); setTimeout(() => setCopied(false), 1500); }); };
-  return <button onClick={copy} className="inline-flex items-center text-[var(--color-accent-cyan)]/60 hover:text-[var(--color-accent-cyan)] transition-colors ml-1" aria-label="Copy session ID">{copied ? <Check className="h-3 w-3 text-[var(--color-success)]" /> : <Copy className="h-3 w-3" />}</button>;
+
+  const copy = () => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="inline-flex items-center text-[var(--color-accent-cyan)]/60 transition-colors hover:text-[var(--color-accent-cyan)]"
+      aria-label="Copy session ID"
+    >
+      {copied ? (
+        <Check className="h-3 w-3 text-[var(--color-success)]" />
+      ) : (
+        <Copy className="h-3 w-3" />
+      )}
+    </button>
+  );
 }
 
-function truncateMiddle(s: string, maxLen: number): string {
-  if (s.length <= maxLen) return s;
-  const start = s.slice(0, Math.ceil(maxLen / 2) - 1);
-  const end = s.slice(-(Math.floor(maxLen / 2) - 2));
-  return `${start}â€¦${end}`;
+function truncateMiddle(value: string, maxLen: number): string {
+  if (value.length <= maxLen) return value;
+  const start = value.slice(0, Math.ceil(maxLen / 2) - 1);
+  const end = value.slice(-(Math.floor(maxLen / 2) - 2));
+  return `${start}…${end}`;
 }
 
-function formatDate(ts: number): string {
-  return new Date(ts).toLocaleString([], {
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString([], {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
@@ -53,74 +72,94 @@ function formatDate(ts: number): string {
   });
 }
 
-export function SessionHeader({ session, health, onApprove, onReject, onInterrupt, onKill, onSaveTemplate, onFork }: SessionHeaderProps) {
-  const [confirmKill, setConfirmKill] = useState(false);
+export function SessionHeader({
+  session,
+  health,
+  onApprove,
+  onReject,
+  onInterrupt,
+  onKill,
+  onSaveTemplate,
+  onFork,
+}: SessionHeaderProps) {
   const needsApproval = health.status === 'permission_prompt' || health.status === 'bash_approval';
 
   return (
-    <div className="bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg p-3 sm:p-4">
-      <Link to="/sessions/history" className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300 transition-colors mb-3"><ArrowLeft className="h-3 w-3" /> Back to Sessions</Link>
-      {/* Top row: status + name + badges */}
-      <div className="flex items-start gap-3 mb-3">
-        <div className="flex items-center gap-2 mt-1">
+    <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-3 sm:p-4">
+      <Link
+        to="/sessions/history"
+        className="mb-3 inline-flex items-center gap-1 text-xs text-zinc-500 transition-colors hover:text-zinc-300"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        Back to Sessions
+      </Link>
+
+      <div className="mb-3 flex items-start gap-3">
+        <div className="mt-1 flex items-center gap-2">
           <StatusDot status={health.status} />
           <span className="text-sm font-medium text-[var(--color-text-primary)]">
             {STATUS_LABELS[health.status]}
           </span>
         </div>
 
-        <div className="flex-1 min-w-0">
-          <h1 className="text-base sm:text-lg font-semibold text-[var(--color-text-primary)] truncate">
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-base font-semibold text-[var(--color-text-primary)] sm:text-lg">
             {session.windowName || 'Untitled Session'}
           </h1>
-          <div className="text-xs text-[#555] font-mono truncate mt-0.5">
+          <div className="mt-0.5 truncate text-xs font-mono text-[#555]">
             {truncateMiddle(session.workDir, 40)}
           </div>
         </div>
-
-        {/* Badges */}
-        <div className="hidden sm:flex items-center gap-2 shrink-0">
-          {session.permissionMode && session.permissionMode !== 'default' && (
-            <span className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded bg-[var(--color-success-bg)] text-[var(--color-success)] border border-[var(--color-success)]/30">
-              {session.permissionMode}
-            </span>
-          )}
-          {health.alive ? (
-            <span className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded bg-[var(--color-surface)] text-[#888] border border-[var(--color-void-lighter)]">
-              Alive
-            </span>
-          ) : (
-            <span className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded bg-[var(--color-error-bg)] text-[var(--color-error)] border border-[var(--color-error)]/30">
-              Dead
-            </span>
-          )}
-        </div>
       </div>
 
-      {/* Metadata row */}
-      <div className="flex items-center gap-3 sm:gap-4 text-[11px] text-[#555] mb-3 flex-wrap">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        {session.permissionMode && session.permissionMode !== 'default' && (
+          <span className="rounded-full border border-[var(--color-success)]/30 bg-[var(--color-success-bg)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-success)]">
+            {session.permissionMode}
+          </span>
+        )}
+        <span
+          className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${
+            health.alive
+              ? 'border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-[#888]'
+              : 'border-[var(--color-error)]/30 bg-[var(--color-error-bg)] text-[var(--color-error)]'
+          }`}
+        >
+          {health.alive ? 'Alive' : 'Dead'}
+        </span>
+      </div>
+
+      <div className="mb-3 flex flex-wrap items-center gap-3 text-[11px] text-[#555]">
         <span>Created: {formatDate(session.createdAt)}</span>
         <span className="hidden sm:inline">Last activity: {formatDate(session.lastActivity)}</span>
-        <span className="font-mono hidden sm:inline">ID: {truncateMiddle(session.id, 16)}</span><CopyButton text={session.id} />
+        <span className="inline-flex items-center gap-1 font-mono">
+          <span className="hidden sm:inline">ID:</span>
+          {truncateMiddle(session.id, 16)}
+          <CopyButton text={session.id} />
+        </span>
         {session.ownerKeyId && (
-          <span className="font-mono hidden sm:inline">Owner: {session.ownerKeyId.slice(0, 8)}{session.ownerKeyId.length > 8 ? '…' : ''}</span>
+          <span className="hidden font-mono sm:inline">
+            Owner: {session.ownerKeyId.slice(0, 8)}
+            {session.ownerKeyId.length > 8 ? '…' : ''}
+          </span>
         )}
-        {health.details && <span className="text-[#888] italic">{health.details}</span>}
+        {health.details && <span className="hidden italic text-[#888] sm:inline">{health.details}</span>}
       </div>
 
-      {/* Quick actions â€” wrap on mobile */}
       <div className="flex flex-wrap items-center gap-2">
         {needsApproval && (
           <>
             <button
+              type="button"
               onClick={onApprove}
-              className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-success-bg)] hover:bg-[var(--color-success-bg-hover)] text-[var(--color-success)] border border-[var(--color-success)]/30 transition-colors"
+              className="hidden min-h-[44px] rounded border border-[var(--color-success)]/30 bg-[var(--color-success-bg)] px-3 py-2 text-xs font-medium text-[var(--color-success)] transition-colors hover:bg-[var(--color-success-bg-hover)] sm:inline-flex"
             >
               Approve
             </button>
             <button
+              type="button"
               onClick={onReject}
-              className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-error-bg)] hover:bg-[var(--color-error-bg-hover)] text-[var(--color-error)] border border-[var(--color-error)]/30 transition-colors"
+              className="hidden min-h-[44px] rounded border border-[var(--color-error)]/30 bg-[var(--color-error-bg)] px-3 py-2 text-xs font-medium text-[var(--color-error)] transition-colors hover:bg-[var(--color-error-bg-hover)] sm:inline-flex"
             >
               Reject
             </button>
@@ -128,69 +167,40 @@ export function SessionHeader({ session, health, onApprove, onReject, onInterrup
         )}
 
         <button
+          type="button"
           onClick={onInterrupt}
-          className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-text-primary)] border border-[var(--color-void-lighter)] transition-colors"
+          className="hidden min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-surface-hover)] sm:inline-flex"
         >
           Interrupt
         </button>
 
         <button
+          type="button"
           onClick={onSaveTemplate}
-          className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-text-primary)] border border-[var(--color-void-lighter)] transition-colors"
+          className="min-h-[44px] flex-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-surface-hover)] sm:flex-none"
           title="Save this session as a template"
         >
           Save as Template
         </button>
 
         <button
+          type="button"
           onClick={onFork}
-          className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-text-primary)] border border-[var(--color-void-lighter)] transition-colors"
+          className="inline-flex min-h-[44px] flex-1 items-center justify-center gap-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-surface-hover)] sm:flex-none"
           title="Fork this session"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="w-4 h-4 inline mr-1"
-          >
-            <line x1="6" y1="3" x2="6" y2="15" />
-            <circle cx="18" cy="6" r="3" />
-            <circle cx="6" cy="18" r="3" />
-            <path d="M18 9a9 9 0 0 1-9 9" />
-          </svg>
+          <GitFork className="h-4 w-4" />
           Fork
         </button>
 
-        {!confirmKill ? (
-          <button
-            onClick={() => setConfirmKill(true)}
-            className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-text-primary)] border border-[var(--color-void-lighter)] transition-colors ml-auto"
-          >
-            Kill
-          </button>
-        ) : (
-          <div className="flex items-center gap-2 ml-auto">
-            <span className="text-xs text-[var(--color-error)]">Confirm kill?</span>
-            <button
-              onClick={() => { onKill?.(); setConfirmKill(false); }}
-              className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-error-bg)] text-[var(--color-error)] border border-[var(--color-error)]/30 transition-colors"
-            >
-              Yes, Kill
-            </button>
-            <button
-              onClick={() => setConfirmKill(false)}
-              className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-text-primary)] border border-[var(--color-void-lighter)] transition-colors"
-            >
-              Cancel
-            </button>
-          </div>
-        )}
+        <button
+          type="button"
+          onClick={onKill}
+          className="hidden min-h-[44px] rounded border border-[var(--color-error)]/30 bg-[var(--color-error-bg)]/20 px-3 py-2 text-xs font-medium text-[var(--color-error)] transition-colors hover:bg-[var(--color-error-bg)]/35 sm:ml-auto sm:inline-flex"
+        >
+          Kill
+        </button>
       </div>
     </div>
   );
 }
-

--- a/dashboard/src/components/session/TranscriptViewer.tsx
+++ b/dashboard/src/components/session/TranscriptViewer.tsx
@@ -182,7 +182,7 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
   return (
     <div className="flex flex-col h-full relative">
       {/* Filter bar */}
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-[var(--color-void-lighter)] bg-[var(--color-void)] shrink-0">
+      <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-[var(--color-void-lighter)] bg-[var(--color-void)] shrink-0">
         <span className="text-[10px] text-[#555] uppercase tracking-wider">Filter:</span>
         {(['thinking', 'tool_use', 'tool_result'] as const).map(key => (
           <button
@@ -198,7 +198,7 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
             {key === 'tool_use' ? 'Tools' : key === 'tool_result' ? 'Results' : key}
           </button>
         ))}
-        <span className="text-[10px] text-[#444] ml-auto">
+        <span className="ml-auto text-[10px] text-[#444]">
           {filteredMessages.length} / {messages.length}
         </span>
       </div>

--- a/dashboard/src/components/shared/Breadcrumb.tsx
+++ b/dashboard/src/components/shared/Breadcrumb.tsx
@@ -57,20 +57,20 @@ export default function Breadcrumb() {
   const crumbs = buildCrumbs(location.pathname);
 
   return (
-    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-zinc-500">
+    <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1 overflow-hidden text-sm text-zinc-500">
       {crumbs.map((crumb, i) => (
-        <span key={i} className="flex items-center gap-1">
+        <span key={i} className="flex min-w-0 items-center gap-1">
           {i > 0 && <ChevronRight className="h-3 w-3 text-zinc-600" />}
           {i === 0 && <Home className="h-3.5 w-3.5 text-zinc-500" />}
           {crumb.path ? (
             <Link
               to={crumb.path}
-              className="text-zinc-400 hover:text-zinc-200 transition-colors"
+              className="truncate text-zinc-400 transition-colors hover:text-zinc-200"
             >
               {crumb.label}
             </Link>
           ) : (
-            <span className="text-zinc-300 font-medium">{crumb.label}</span>
+            <span className="truncate font-medium text-zinc-300">{crumb.label}</span>
           )}
         </span>
       ))}

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -54,8 +54,8 @@ export default function OverviewPage() {
 
       <HomeStatusPanel onCreateFirstSession={() => setModalOpen(true)} />
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
-        <div className="order-2 flex flex-col gap-6 xl:order-1">
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
+        <div className="order-2 min-w-0 flex flex-col gap-6 xl:order-1">
           <div>
             <h3 className="mb-3 text-lg font-semibold text-gray-200">Sessions</h3>
             <SessionTable />
@@ -66,7 +66,7 @@ export default function OverviewPage() {
           <MetricCards />
         </div>
 
-        <div className="order-1 xl:order-2">
+        <div className="order-1 min-w-0 xl:order-2">
           <ActivityStream title="Recent events" showFilters={false} maxItems={8} />
         </div>
       </div>

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -1,10 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import {
-  Camera,
   Send,
-  Octagon,
-  CornerDownLeft,
 } from 'lucide-react';
 import {
   sendMessage,
@@ -26,6 +23,9 @@ import { TranscriptViewer } from '../components/session/TranscriptViewer';
 import { SessionMetricsPanel } from '../components/session/SessionMetricsPanel';
 import { LatencyPanel } from '../components/metrics/LatencyPanel';
 import { ApprovalBanner } from '../components/session/ApprovalBanner';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+import { PendingQuestionCard } from '../components/session/PendingQuestionCard';
+import { PermissionPromptSheet } from '../components/session/PermissionPromptSheet';
 import SaveTemplateModal from '../components/SaveTemplateModal';
 
 interface ScreenshotState {
@@ -62,14 +62,26 @@ export default function SessionDetailPage() {
   const [bashInput, setBashInput] = useState('');
   const [bashConfirming, setBashConfirming] = useState(false);
   const [bashSending, setBashSending] = useState(false);
+  const [mobileToolsOpen, setMobileToolsOpen] = useState(false);
+  const [killConfirmOpen, setKillConfirmOpen] = useState(false);
   const [capturingScreenshot, setCapturingScreenshot] = useState(false);
   const [screenshotUnsupported, setScreenshotUnsupported] = useState(false);
   const [screenshot, setScreenshot] = useState<ScreenshotState | null>(null);
-  const msgInputRef = useRef<HTMLInputElement>(null);
+  const [mobileFooterHeight, setMobileFooterHeight] = useState(0);
+  const desktopMsgInputRef = useRef<HTMLInputElement>(null);
+  const mobileMsgInputRef = useRef<HTMLInputElement>(null);
+  const mobileFooterRef = useRef<HTMLDivElement>(null);
   const sendingRef = useRef(false);
   const handleSendRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const handleInterruptRef = useRef<() => void>(() => {});
   const addToast = useToastStore((t) => t.addToast);
+
+  function getVisibleMessageInput(): HTMLInputElement | null {
+    const candidates = [desktopMsgInputRef.current, mobileMsgInputRef.current].filter(
+      (input): input is HTMLInputElement => input !== null,
+    );
+    return candidates.find((input) => input.offsetParent !== null) ?? candidates[0] ?? null;
+  }
 
   // Register global shortcuts unconditionally so hook order never changes
   // across loading/notFound/session renders.
@@ -80,7 +92,7 @@ export default function SessionDetailPage() {
 
       // Ctrl/Cmd+Enter: submit message (only when message input is focused)
       if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-        if (document.activeElement === msgInputRef.current) {
+        if (document.activeElement === getVisibleMessageInput()) {
           e.preventDefault();
           void handleSendRef.current();
         }
@@ -97,11 +109,29 @@ export default function SessionDetailPage() {
       // / key: focus message input (skip if user is already typing)
       if (e.key === '/' && !isTyping) {
         e.preventDefault();
-        msgInputRef.current?.focus();
+        getVisibleMessageInput()?.focus();
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') return undefined;
+
+    const node = mobileFooterRef.current;
+    if (!node) return undefined;
+
+    const updateHeight = () => {
+      setMobileFooterHeight(node.getBoundingClientRect().height);
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(() => updateHeight());
+    observer.observe(node);
+
+    return () => observer.disconnect();
   }, []);
 
   if (loading) {
@@ -145,6 +175,17 @@ export default function SessionDetailPage() {
   const s = session;
   const h = health;
   const needsApproval = h.status === 'permission_prompt' || h.status === 'bash_approval';
+  const pendingPermission = s.pendingPermission;
+  const pendingQuestion = s.pendingQuestion ?? (
+    h.status === 'ask_question'
+      ? {
+          toolUseId: 'pending-question',
+          content: 'Claude is waiting for your answer. Reply below to continue.',
+          options: null,
+          since: s.lastActivity,
+        }
+      : undefined
+  );
 
   function handleApprove() {
     approve(s.id).catch((e: unknown) =>
@@ -175,7 +216,11 @@ export default function SessionDetailPage() {
       addToast('error', 'Escape failed', e instanceof Error ? e.message : undefined),
     );
   }
+  function handleKillRequest() {
+    setKillConfirmOpen(true);
+  }
   async function handleKill() {
+    setKillConfirmOpen(false);
     try {
       await killSession(s.id);
       navigate('/');
@@ -225,13 +270,13 @@ export default function SessionDetailPage() {
     } finally {
       setSending(false);
       sendingRef.current = false;
-      msgInputRef.current?.focus();
+      getVisibleMessageInput()?.focus();
     }
   }
 
   function handleInsertSlashCommand() {
     setMsgInput(selectedSlashCommand);
-    msgInputRef.current?.focus();
+    getVisibleMessageInput()?.focus();
   }
 
   async function handleSendSlashCommand() {
@@ -274,6 +319,11 @@ export default function SessionDetailPage() {
     }
   }
 
+  function handleSelectQuestionOption(option: string) {
+    setMsgInput(option);
+    getVisibleMessageInput()?.focus();
+  }
+
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -285,237 +335,318 @@ export default function SessionDetailPage() {
   handleSendRef.current = handleSend;
   handleInterruptRef.current = handleInterrupt;
 
-  return (
-    <div className="min-h-screen bg-[var(--color-void)]">
-      <div className="max-w-6xl mx-auto px-3 sm:px-4 py-3 sm:py-4 space-y-3 sm:space-y-4">
-        {/* Breadcrumb */}
-        <nav className="text-xs text-[#555] flex items-center gap-1">
-          <Link to="/" className="hover:text-[var(--color-accent-cyan)] transition-colors">
-            Overview
-          </Link>
-          <span className="text-[#333]">/</span>
-          <span className="text-[var(--color-text-primary)] truncate max-w-[160px] sm:max-w-xs">
-            {s.windowName || s.id}
-          </span>
-        </nav>
+  function renderCommandTools(layout: 'desktop' | 'mobile') {
+    const isMobile = layout === 'mobile';
+    const idSuffix = isMobile ? 'mobile' : 'desktop';
+    const containerClass = isMobile
+      ? 'grid gap-2'
+      : 'flex flex-wrap items-center gap-2';
+    const selectClass = isMobile
+      ? 'min-h-[44px] w-full rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-gray-200 focus:border-[var(--color-accent-cyan)] focus:outline-none disabled:opacity-50'
+      : 'min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-gray-200 focus:border-[var(--color-accent-cyan)] focus:outline-none disabled:opacity-50';
+    const buttonClass = isMobile
+      ? 'min-h-[44px] w-full rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-[var(--color-surface-hover)] disabled:cursor-not-allowed disabled:opacity-30'
+      : 'min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-[var(--color-surface-hover)] disabled:cursor-not-allowed disabled:opacity-30';
+    const accentButtonClass = isMobile
+      ? 'min-h-[44px] w-full rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-info-bg-dark)] px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-info-bg)] disabled:cursor-not-allowed disabled:opacity-30'
+      : 'min-h-[44px] rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-info-bg-dark)] px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-info-bg)] disabled:cursor-not-allowed disabled:opacity-30';
+    const bashInputClass = isMobile
+      ? 'min-h-[44px] w-full rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs text-gray-200 placeholder-gray-600 focus:border-[var(--color-warning-amber)] focus:outline-none font-mono disabled:opacity-50'
+      : 'min-h-[44px] min-w-[220px] flex-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs text-gray-200 placeholder-gray-600 focus:border-[var(--color-warning-amber)] focus:outline-none font-mono disabled:opacity-50';
 
-        {/* Header */}
-        <SessionHeader
-          session={s}
-          health={h}
-          onApprove={handleApprove}
-          onReject={handleReject}
-          onInterrupt={handleInterrupt}
-          onFork={handleFork}
-          onKill={handleKill}
-          onSaveTemplate={() => setSaveTemplateModalOpen(true)}
+    return (
+      <div className={containerClass}>
+        <label className="sr-only" htmlFor={`slash-command-select-${idSuffix}`}>
+          Common slash command
+        </label>
+        <select
+          id={`slash-command-select-${idSuffix}`}
+          value={selectedSlashCommand}
+          onChange={(e) => setSelectedSlashCommand(e.target.value)}
+          disabled={slashSending || !h.alive}
+          className={selectClass}
+        >
+          {COMMON_SLASH_COMMANDS.map((command) => (
+            <option key={command} value={command}>
+              {command}
+            </option>
+          ))}
+        </select>
+
+        <button
+          type="button"
+          onClick={handleInsertSlashCommand}
+          disabled={slashSending || !h.alive}
+          className={buttonClass}
+          title="Insert selected slash command into the message input"
+        >
+          Insert Slash
+        </button>
+
+        <button
+          type="button"
+          onClick={handleSendSlashCommand}
+          disabled={slashSending || !h.alive}
+          className={accentButtonClass}
+          title="Send selected slash command immediately"
+        >
+          {slashSending ? 'Sending Slash…' : 'Run Slash'}
+        </button>
+
+        <label className="sr-only" htmlFor={`bash-command-input-${idSuffix}`}>
+          Bash command
+        </label>
+        <input
+          id={`bash-command-input-${idSuffix}`}
+          type="text"
+          value={bashInput}
+          onChange={(e) => handleBashInputChange(e.target.value)}
+          placeholder="Bash command (requires confirmation)…"
+          disabled={bashSending || !h.alive}
+          className={bashInputClass}
         />
 
-        {/* Tab bar — full-width stretch on mobile */}
-        <div className="flex border-b border-[var(--color-void-lighter)]" role="tablist">
-          {TABS.map(tab => (
+        {!bashConfirming ? (
+          <button
+            type="button"
+            onClick={handleReviewBashCommand}
+            disabled={bashSending || !bashInput.trim() || !h.alive}
+            className={buttonClass.replace(
+              'border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)] text-gray-300',
+              'border-[var(--color-warning-amber)]/30 bg-[var(--color-amber-darkest)] text-[var(--color-warning-amber)]',
+            )}
+            title="Review bash command before sending"
+          >
+            Review Bash
+          </button>
+        ) : (
+          <>
+            <span className="text-[11px] italic text-[var(--color-warning-amber)]">
+              Confirm bash command execution.
+            </span>
             <button
-              key={tab.id}
-              id={`tab-${tab.id}`}
-              onClick={() => setActiveTab(tab.id)}
-              role="tab"
-              aria-selected={activeTab === tab.id}
-              aria-controls={`panel-${tab.id}`}
-              tabIndex={activeTab === tab.id ? 0 : -1}
-              className={`flex-1 min-h-[44px] text-sm font-medium transition-colors relative ${
-                activeTab === tab.id
-                  ? 'text-[var(--color-accent-cyan)]'
-                  : 'text-[#555] hover:text-[#888]'
-              }`}
-            >
-              {tab.label}
-              {activeTab === tab.id && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--color-accent-cyan)]" />
+              type="button"
+              onClick={handleConfirmBashCommand}
+              disabled={bashSending || !bashInput.trim() || !h.alive}
+              className={buttonClass.replace(
+                'border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)] text-gray-300',
+                'border-[var(--color-warning-amber)]/30 bg-[var(--color-amber-dark)] text-[var(--color-warning-amber)]',
               )}
-            </button>
-          ))}
-        </div>
-
-        {/* Tab content */}
-        <div className="bg-[var(--color-void)] rounded-lg min-h-[300px] sm:min-h-[400px]">
-          {/* Approval banner */}
-          {needsApproval && (
-            <div className="p-3 sm:p-4 pb-0">
-              <ApprovalBanner
-                prompt={h.details}
-                permissionMode={s.permissionMode}
-                onApprove={handleApprove}
-                onReject={handleReject}
-              />
-            </div>
-          )}
-
-          {activeTab === 'session' && (
-            <div id="panel-session" role="tabpanel" aria-labelledby="tab-session" tabIndex={0} className="h-[calc(100vh-300px)] sm:h-[calc(100vh-420px)] min-h-[200px] sm:min-h-[300px] overflow-auto">
-              <TerminalPassthrough sessionId={s.id} status={h.status} />
-            </div>
-          )}
-
-          {activeTab === 'transcript' && (
-            <div id="panel-transcript" role="tabpanel" aria-labelledby="tab-transcript" tabIndex={0} className="h-[calc(100vh-300px)] sm:h-[calc(100vh-420px)] min-h-[200px] sm:min-h-[300px] overflow-auto">
-              <TranscriptViewer sessionId={s.id} />
-            </div>
-          )}
-
-          {activeTab === 'metrics' && (
-            <div id="panel-metrics" role="tabpanel" aria-labelledby="tab-metrics" tabIndex={0} className="p-3 sm:p-4 overflow-auto">
-              <SessionMetricsPanel metrics={metrics} loading={metricsLoading} />
-              <div className="mt-4">
-                <LatencyPanel latency={latency} loading={latencyLoading} />
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Message input + action bar */}
-        <div className="bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg p-3">
-          <div className="flex items-center gap-2">
-            {/* Message input */}
-            <label htmlFor="session-message-input" className="sr-only">
-              Session message input
-            </label>
-            <input
-              id="session-message-input"
-              ref={msgInputRef}
-              type="text"
-              value={msgInput}
-              onChange={(e) => setMsgInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Send a message to Claude…"
-              disabled={sending || !h.alive}
-              className="flex-1 min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-gray-200 placeholder-gray-600 focus:outline-none focus:border-[var(--color-accent-cyan)] font-mono disabled:opacity-50"
-            />
-
-            {/* Send button */}
-            <button
-              onClick={handleSend}
-              disabled={sending || !msgInput.trim() || !h.alive}
-              className="min-h-[44px] min-w-[44px] flex items-center justify-center p-2.5 rounded bg-[var(--color-accent-cyan)]/10 hover:bg-[var(--color-accent-cyan)]/20 text-[var(--color-accent-cyan)] border border-[var(--color-accent-cyan)]/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-              title="Send message"
+              title="Send bash command"
             >
-              <Send className="h-4 w-4" />
-            </button>
-          </div>
-
-          {/* Action buttons row — wrap on mobile */}
-          <div className="flex flex-wrap items-center gap-2 mt-2 pt-2 border-t border-[var(--color-void-lighter)]/50">
-            <label className="sr-only" htmlFor="slash-command-select">Common slash command</label>
-            <select
-              id="slash-command-select"
-              value={selectedSlashCommand}
-              onChange={(e) => setSelectedSlashCommand(e.target.value)}
-              disabled={slashSending || !h.alive}
-              className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-gray-200 focus:outline-none focus:border-[var(--color-accent-cyan)] disabled:opacity-50"
-            >
-              {COMMON_SLASH_COMMANDS.map((command) => (
-                <option key={command} value={command}>
-                  {command}
-                </option>
-              ))}
-            </select>
-            <button
-              onClick={handleInsertSlashCommand}
-              disabled={slashSending || !h.alive}
-              className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-gray-300 border border-[var(--color-void-lighter)] transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-              title="Insert selected slash command into the message input"
-            >
-              Insert Slash
+              {bashSending ? 'Sending Bash…' : 'Confirm Bash'}
             </button>
             <button
-              onClick={handleSendSlashCommand}
-              disabled={slashSending || !h.alive}
-              className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-info-bg-dark)] hover:bg-[var(--color-info-bg)] text-[var(--color-accent-cyan)] border border-[var(--color-accent-cyan)]/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-              title="Send selected slash command immediately"
+              type="button"
+              onClick={() => setBashConfirming(false)}
+              disabled={bashSending}
+              className={buttonClass}
             >
-              {slashSending ? 'Sending Slash…' : 'Run Slash'}
+              Cancel Bash
             </button>
-            <label className="sr-only" htmlFor="bash-command-input">Bash command</label>
-            <input
-              id="bash-command-input"
-              type="text"
-              value={bashInput}
-              onChange={(e) => handleBashInputChange(e.target.value)}
-              placeholder="Bash command (requires confirmation)…"
-              disabled={bashSending || !h.alive}
-              className="min-h-[44px] min-w-[220px] flex-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-[var(--color-warning-amber)] font-mono disabled:opacity-50"
-            />
-            {!bashConfirming ? (
-              <button
-                onClick={handleReviewBashCommand}
-                disabled={bashSending || !bashInput.trim() || !h.alive}
-                className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-amber-darkest)] hover:bg-[var(--color-amber-dark)] text-[var(--color-warning-amber)] border border-[var(--color-warning-amber)]/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                title="Review bash command before sending"
-              >
-                Review Bash
-              </button>
-            ) : (
-              <>
-                <span className="text-[11px] text-[var(--color-warning-amber)] italic">
-                  Confirm bash command execution.
-                </span>
-                <button
-                  onClick={handleConfirmBashCommand}
-                  disabled={bashSending || !bashInput.trim() || !h.alive}
-                  className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-amber-dark)] hover:bg-[var(--color-amber-darker)] text-[var(--color-warning-amber)] border border-[var(--color-warning-amber)]/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                  title="Send bash command"
-                >
-                  {bashSending ? 'Sending Bash…' : 'Confirm Bash'}
-                </button>
-                <button
-                  onClick={() => setBashConfirming(false)}
-                  disabled={bashSending}
-                  className="min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-gray-300 border border-[var(--color-void-lighter)] transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                >
-                  Cancel Bash
-                </button>
-              </>
-            )}
-            {!screenshotUnsupported && (
-              <button
-                onClick={handleCaptureScreenshot}
-                disabled={capturingScreenshot || !h.alive}
-                className="flex items-center gap-1.5 min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-gray-300 border border-[var(--color-void-lighter)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                title="Capture screenshot"
-              >
-                <Camera className="h-3.5 w-3.5" />
-                {capturingScreenshot ? 'Capturing…' : 'Screenshot'}
-              </button>
-            )}
+          </>
+        )}
+
+        {!screenshotUnsupported && (
+          <button
+            type="button"
+            onClick={handleCaptureScreenshot}
+            disabled={capturingScreenshot || !h.alive}
+            className={buttonClass}
+            title="Capture screenshot"
+          >
+            {capturingScreenshot ? 'Capturing…' : 'Screenshot'}
+          </button>
+        )}
+
+        {!isMobile && (
+          <>
             <button
+              type="button"
               onClick={handleInterrupt}
               aria-label="Interrupt session with Ctrl+C"
-              className="flex items-center gap-1.5 min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-gray-300 border border-[var(--color-void-lighter)] transition-colors"
+              className={buttonClass}
               title="Interrupt (Ctrl+C)"
             >
-              <Octagon className="h-3.5 w-3.5" />
               Interrupt
             </button>
             <button
+              type="button"
               onClick={handleEscape}
               aria-label="Send Escape to session"
-              className="flex items-center gap-1.5 min-h-[44px] px-3 py-2 text-xs font-medium rounded bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-gray-300 border border-[var(--color-void-lighter)] transition-colors"
+              className={buttonClass}
               title="Send Escape"
             >
-              <CornerDownLeft className="h-3.5 w-3.5" />
               Escape
             </button>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--color-void)]">
+      {needsApproval && (
+        <div className="fixed inset-0 z-30 bg-black/40 sm:hidden" aria-hidden="true" />
+      )}
+
+      <div
+        className="mx-auto max-w-6xl px-3 py-3 sm:px-4 sm:py-4"
+        style={mobileFooterHeight > 0 ? { paddingBottom: mobileFooterHeight + 16 } : undefined}
+      >
+        <div className="space-y-3 sm:space-y-4">
+          <nav className="hidden items-center gap-1 text-xs text-[#555] sm:flex">
+            <Link to="/" className="transition-colors hover:text-[var(--color-accent-cyan)]">
+              Overview
+            </Link>
+            <span className="text-[#333]">/</span>
+            <span className="max-w-xs truncate text-[var(--color-text-primary)]">
+              {s.windowName || s.id}
+            </span>
+          </nav>
+
+          <SessionHeader
+            session={s}
+            health={h}
+            onApprove={handleApprove}
+            onReject={handleReject}
+            onInterrupt={handleInterrupt}
+            onFork={handleFork}
+            onKill={handleKillRequest}
+            onSaveTemplate={() => setSaveTemplateModalOpen(true)}
+          />
+
+          <div className="flex border-b border-[var(--color-void-lighter)]" role="tablist">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                id={`tab-${tab.id}`}
+                onClick={() => setActiveTab(tab.id)}
+                role="tab"
+                aria-selected={activeTab === tab.id}
+                aria-controls={`panel-${tab.id}`}
+                tabIndex={activeTab === tab.id ? 0 : -1}
+                className={`relative flex-1 min-h-[44px] text-sm font-medium transition-colors ${
+                  activeTab === tab.id
+                    ? 'text-[var(--color-accent-cyan)]'
+                    : 'text-[#555] hover:text-[#888]'
+                }`}
+              >
+                {tab.label}
+                {activeTab === tab.id && (
+                  <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--color-accent-cyan)]" />
+                )}
+              </button>
+            ))}
+          </div>
+
+          <div className="min-h-[300px] rounded-lg bg-[var(--color-void)] sm:min-h-[400px]">
+            {needsApproval && (
+              <div className="hidden p-3 pb-0 sm:block sm:p-4">
+                <ApprovalBanner
+                  prompt={pendingPermission?.prompt ?? h.details}
+                  permissionMode={s.permissionMode}
+                  onApprove={handleApprove}
+                  onReject={handleReject}
+                />
+              </div>
+            )}
+
+            {activeTab === 'session' && (
+              <div
+                id="panel-session"
+                role="tabpanel"
+                aria-labelledby="tab-session"
+                tabIndex={0}
+                className="h-[calc(100vh-300px)] min-h-[200px] overflow-auto sm:h-[calc(100vh-420px)] sm:min-h-[300px]"
+              >
+                <TerminalPassthrough sessionId={s.id} status={h.status} />
+              </div>
+            )}
+
+            {activeTab === 'transcript' && (
+              <div
+                id="panel-transcript"
+                role="tabpanel"
+                aria-labelledby="tab-transcript"
+                tabIndex={0}
+                className="h-[calc(100vh-300px)] min-h-[200px] overflow-auto sm:h-[calc(100vh-420px)] sm:min-h-[300px]"
+              >
+                <TranscriptViewer sessionId={s.id} />
+              </div>
+            )}
+
+            {activeTab === 'metrics' && (
+              <div
+                id="panel-metrics"
+                role="tabpanel"
+                aria-labelledby="tab-metrics"
+                tabIndex={0}
+                className="overflow-auto p-3 sm:p-4"
+              >
+                <SessionMetricsPanel metrics={metrics} loading={metricsLoading} />
+                <div className="mt-4">
+                  <LatencyPanel latency={latency} loading={latencyLoading} />
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="hidden rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-3 sm:block">
+            {pendingQuestion && (
+              <PendingQuestionCard
+                pendingQuestion={pendingQuestion}
+                onSelectOption={handleSelectQuestionOption}
+              />
+            )}
+
+            <div className={`flex items-center gap-2 ${pendingQuestion ? 'mt-3' : ''}`}>
+              <label htmlFor="session-message-input-desktop" className="sr-only">
+                Session message input
+              </label>
+              <input
+                id="session-message-input-desktop"
+                ref={desktopMsgInputRef}
+                type="text"
+                value={msgInput}
+                onChange={(e) => setMsgInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Send a message to Claude…"
+                disabled={sending || !h.alive}
+                className="flex-1 min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2.5 font-mono text-sm text-gray-200 placeholder-gray-600 focus:border-[var(--color-accent-cyan)] focus:outline-none disabled:opacity-50"
+              />
+
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={sending || !msgInput.trim() || !h.alive}
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 p-2.5 text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:cursor-not-allowed disabled:opacity-30"
+                title="Send message"
+              >
+                <Send className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="mt-2 border-t border-[var(--color-void-lighter)]/50 pt-2">
+              {renderCommandTools('desktop')}
+            </div>
           </div>
 
           {screenshot && (
-            <div className="mt-3 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-3">
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400">Latest screenshot</h3>
-                <span className="text-[11px] text-gray-500">{new Date(screenshot.capturedAt).toLocaleTimeString()}</span>
+            <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-3">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                  Latest screenshot
+                </h3>
+                <span className="text-[11px] text-gray-500">
+                  {new Date(screenshot.capturedAt).toLocaleTimeString()}
+                </span>
               </div>
               <img
                 src={screenshot.image}
                 alt="Session screenshot preview"
-                className="max-h-[420px] w-full rounded border border-[var(--color-void-lighter)] object-contain bg-black"
+                className="max-h-[420px] w-full rounded border border-[var(--color-void-lighter)] bg-black object-contain"
               />
               <div className="mt-2 text-[11px] text-gray-500">
                 {screenshot.mimeType ?? 'image/png'}
@@ -524,6 +655,118 @@ export default function SessionDetailPage() {
           )}
         </div>
       </div>
+
+      <div
+        ref={mobileFooterRef}
+        className="fixed inset-x-0 bottom-0 z-40 border-t border-[var(--color-void-lighter)] bg-[var(--color-surface)]/95 backdrop-blur sm:hidden"
+      >
+        <div className="mx-auto max-w-6xl space-y-3 px-3 py-3">
+          {pendingQuestion && (
+            <PendingQuestionCard
+              pendingQuestion={pendingQuestion}
+              onSelectOption={handleSelectQuestionOption}
+            />
+          )}
+
+          {needsApproval ? (
+            <PermissionPromptSheet
+              prompt={h.details}
+              pendingPermission={pendingPermission}
+              permissionPromptAt={s.permissionPromptAt}
+              onApprove={handleApprove}
+              onReject={handleReject}
+              onEscape={handleEscape}
+              onKill={handleKillRequest}
+            />
+          ) : (
+            <div className="grid grid-cols-3 gap-2 rounded-2xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-2">
+              <button
+                type="button"
+                onClick={handleInterrupt}
+                className="min-h-[48px] rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-3 text-sm font-medium text-gray-200 transition-colors hover:bg-[var(--color-surface-hover)]"
+              >
+                Interrupt
+              </button>
+              <button
+                type="button"
+                onClick={handleEscape}
+                className="min-h-[48px] rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-3 text-sm font-medium text-gray-200 transition-colors hover:bg-[var(--color-surface-hover)]"
+              >
+                Escape
+              </button>
+              <button
+                type="button"
+                onClick={handleKillRequest}
+                className="min-h-[48px] rounded-xl border border-[var(--color-error)]/30 bg-[var(--color-error-bg)]/20 px-3 py-3 text-sm font-medium text-[var(--color-error)] transition-colors hover:bg-[var(--color-error-bg)]/35"
+              >
+                Kill
+              </button>
+            </div>
+          )}
+
+          <div className="rounded-2xl border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-3 shadow-xl">
+            <div className="flex items-center gap-2">
+              <label htmlFor="session-message-input-mobile" className="sr-only">
+                Mobile session message input
+              </label>
+              <input
+                id="session-message-input-mobile"
+                ref={mobileMsgInputRef}
+                type="text"
+                value={msgInput}
+                onChange={(e) => setMsgInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Send a message to Claude…"
+                disabled={sending || !h.alive}
+                className="flex-1 min-h-[48px] rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-3 font-mono text-sm text-gray-200 placeholder-gray-600 focus:border-[var(--color-accent-cyan)] focus:outline-none disabled:opacity-50"
+              />
+
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={sending || !msgInput.trim() || !h.alive}
+                className="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-xl border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 p-3 text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:cursor-not-allowed disabled:opacity-30"
+                title="Send message"
+              >
+                <Send className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setMobileToolsOpen((current) => !current)}
+                className="min-h-[44px] rounded-full border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-[var(--color-surface-hover)]"
+              >
+                {mobileToolsOpen ? 'Hide tools' : 'More tools'}
+              </button>
+              <span className="text-xs text-gray-500">
+                {needsApproval
+                  ? 'Approve, reject, escape, and kill stay pinned above.'
+                  : 'Quick actions stay within thumb reach.'}
+              </span>
+            </div>
+
+            {mobileToolsOpen && (
+              <div className="mt-3 border-t border-[var(--color-void-lighter)]/50 pt-3">
+                {renderCommandTools('mobile')}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={killConfirmOpen}
+        title="Kill session?"
+        message="This will stop the Claude Code session and close the terminal."
+        confirmLabel="Kill"
+        variant="danger"
+        onConfirm={() => {
+          void handleKill();
+        }}
+        onCancel={() => setKillConfirmOpen(false)}
+      />
 
       <SaveTemplateModal
         open={saveTemplateModalOpen}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -658,7 +658,7 @@ export default function SessionDetailPage() {
 
       <div
         ref={mobileFooterRef}
-        className="fixed inset-x-0 bottom-0 z-40 border-t border-[var(--color-void-lighter)] bg-[var(--color-surface)]/95 backdrop-blur sm:hidden"
+        className="fixed inset-x-0 bottom-0 z-40 border-t border-[var(--color-void-lighter)] bg-[var(--color-surface)]/95 pb-[max(0px,env(safe-area-inset-bottom))] backdrop-blur sm:hidden"
       >
         <div className="mx-auto max-w-6xl space-y-3 px-3 py-3">
           {pendingQuestion && (

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -36,6 +36,8 @@ export type {
   ApiError,
   SessionsListResponse,
   SessionStatusCounts,
+  PendingPermissionInfo,
+  PendingQuestionInfo,
   BatchDeleteRequest,
   BatchDeleteResponse,
 } from '../../../src/api-contracts';

--- a/src/__tests__/permission-request-manager.test.ts
+++ b/src/__tests__/permission-request-manager.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PermissionRequestManager } from '../permission-request-manager.js';
+
+describe('PermissionRequestManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-17T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('exposes countdown metadata for pending permissions', async () => {
+    const manager = new PermissionRequestManager();
+    const startedAt = Date.now();
+    const decision = manager.waitForPermissionDecision('sess-1', 10_000, 'Bash', 'npm run deploy');
+
+    expect(manager.getPendingPermissionInfo('sess-1')).toEqual({
+      toolName: 'Bash',
+      prompt: 'npm run deploy',
+      startedAt,
+      timeoutMs: 10_000,
+      expiresAt: startedAt + 10_000,
+      remainingMs: 10_000,
+    });
+
+    vi.advanceTimersByTime(2_500);
+
+    expect(manager.getPendingPermissionInfo('sess-1')?.remainingMs).toBe(7_500);
+    expect(manager.resolvePendingPermission('sess-1', 'allow')).toBe(true);
+    await expect(decision).resolves.toBe('allow');
+    expect(manager.getPendingPermissionInfo('sess-1')).toBeNull();
+  });
+});

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -23,6 +23,22 @@ export type UIState =
 
 export type SessionStatusFilter = 'all' | UIState;
 
+export interface PendingPermissionInfo {
+  toolName?: string;
+  prompt?: string;
+  startedAt: number;
+  timeoutMs: number;
+  expiresAt: number;
+  remainingMs: number;
+}
+
+export interface PendingQuestionInfo {
+  toolUseId: string;
+  content: string;
+  options: string[] | null;
+  since: number;
+}
+
 export interface SessionInfo {
   id: string;
   windowId: string;
@@ -39,6 +55,10 @@ export interface SessionInfo {
   permissionMode: string;
   autoApprove?: boolean;
   settingsPatched?: boolean;
+  permissionPromptAt?: number;
+  permissionRespondedAt?: number;
+  pendingPermission?: PendingPermissionInfo;
+  pendingQuestion?: PendingQuestionInfo;
   promptDelivery?: { delivered: boolean; attempts: number };
   actionHints?: Record<string, {
     method: string;

--- a/src/permission-request-manager.ts
+++ b/src/permission-request-manager.ts
@@ -1,3 +1,5 @@
+import type { PendingPermissionInfo } from './api-contracts.js';
+
 export type PermissionDecision = 'allow' | 'deny';
 
 interface PendingPermission {
@@ -5,6 +7,8 @@ interface PendingPermission {
   timer: NodeJS.Timeout;
   toolName?: string;
   prompt?: string;
+  createdAt: number;
+  timeoutMs: number;
 }
 
 export class PermissionRequestManager {
@@ -17,13 +21,21 @@ export class PermissionRequestManager {
     prompt?: string,
   ): Promise<PermissionDecision> {
     return new Promise<PermissionDecision>((resolve) => {
+      const createdAt = Date.now();
       const timer = setTimeout(() => {
         this.pendingPermissions.delete(sessionId);
         console.log(`Hooks: PermissionRequest timeout for session ${sessionId} - auto-rejecting`);
         resolve('deny');
       }, timeoutMs);
 
-      this.pendingPermissions.set(sessionId, { resolve, timer, toolName, prompt });
+      this.pendingPermissions.set(sessionId, {
+        resolve,
+        timer,
+        toolName,
+        prompt,
+        createdAt,
+        timeoutMs,
+      });
     });
   }
 
@@ -31,9 +43,19 @@ export class PermissionRequestManager {
     return this.pendingPermissions.has(sessionId);
   }
 
-  getPendingPermissionInfo(sessionId: string): { toolName?: string; prompt?: string } | null {
+  getPendingPermissionInfo(sessionId: string): PendingPermissionInfo | null {
     const pending = this.pendingPermissions.get(sessionId);
-    return pending ? { toolName: pending.toolName, prompt: pending.prompt } : null;
+    if (!pending) return null;
+
+    const expiresAt = pending.createdAt + pending.timeoutMs;
+    return {
+      toolName: pending.toolName,
+      prompt: pending.prompt,
+      startedAt: pending.createdAt,
+      timeoutMs: pending.timeoutMs,
+      expiresAt,
+      remainingMs: Math.max(0, expiresAt - Date.now()),
+    };
   }
 
   resolvePendingPermission(sessionId: string, decision: PermissionDecision): boolean {

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -211,6 +211,12 @@ export function addActionHints(
       approve: { method: 'POST', url: `/v1/sessions/${session.id}/approve`, description: 'Approve the pending permission' },
       reject: { method: 'POST', url: `/v1/sessions/${session.id}/reject`, description: 'Reject the pending permission' },
     };
+    if (sessions) {
+      const info = sessions.getPendingPermissionInfo(session.id);
+      if (info) {
+        result.pendingPermission = info;
+      }
+    }
   }
   if (session.status === 'ask_question' && sessions) {
     const info = sessions.getPendingQuestionInfo(session.id);

--- a/src/session.ts
+++ b/src/session.ts
@@ -26,6 +26,7 @@ import { PermissionRequestManager, type PermissionDecision } from './permission-
 import { QuestionManager } from './question-manager.js';
 import { Mutex } from 'async-mutex';
 import { maybeInjectFault } from './fault-injection.js';
+import type { PendingPermissionInfo } from './api-contracts.js';
 
 /** Convert parsed JSON arrays to Sets for activeSubagents (#668). */
 // Cache for hook cleanup to avoid running on every createSession (Issue #1134).
@@ -1307,7 +1308,7 @@ export class SessionManager {
   }
 
   /** Get info about a pending permission (for API responses). */
-  getPendingPermissionInfo(sessionId: string): { toolName?: string; prompt?: string } | null {
+  getPendingPermissionInfo(sessionId: string): PendingPermissionInfo | null {
     return this.permissionRequests.getPendingPermissionInfo(sessionId);
   }
 


### PR DESCRIPTION
## Summary

Adapts the dashboard session flow for mobile approval use: one-thumb approval UI, TTL countdowns, mobile-friendly question replies, and narrow-viewport coverage.

## Aegis version

**Developed with:** v0.5.3-alpha
**Tested with:** v0.5.3-alpha

## Change type

- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring with no behavior change
- [ ] `perf` — Performance improvement
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling
- [x] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

Dashboard session detail/overview layout, permission prompt UX, question response UX, session data plumbing, and mobile/e2e coverage.

## Linked issue

Closes #1920

## Test plan

Repository gate passed (`npm run gate`).

- [x] Unit tests pass (`npm test`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Manually tested (describe below)

## Security impact

None.

## Dependency notes

Draft while #1996 remains open because this branch was stacked after the dashboard home/onboarding work.