### PR TITLE
feat: add Helm deployment chart and release publishing

### DIFF
--- a/.github/workflows/helm-smoke.yml
+++ b/.github/workflows/helm-smoke.yml
@@ -1,0 +1,128 @@
+name: Helm Smoke
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  helm-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build Aegis
+        run: npm run build
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+      - name: Helm lint
+        run: helm lint deploy/helm/aegis
+      - name: Helm template
+        run: helm template aegis deploy/helm/aegis --set image.repository=aegis-helm-smoke --set image.tag=ci
+      - name: Create k3d cluster
+        uses: AbsaOSS/k3d-action@v2
+        with:
+          cluster-name: aegis-helm-smoke
+          args: --agents 1
+      - name: Prepare smoke image assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .helm-smoke
+          cat > .dockerignore <<'EOF'
+          .git
+          .github
+          coverage
+          dashboard/node_modules
+          dist
+          node_modules
+          EOF
+          cat > .helm-smoke/claude <<'EOF'
+          #!/bin/sh
+          set -eu
+
+          case "${1:-}" in
+            --version)
+              echo "claude-code 2.1.80"
+              ;;
+            auth)
+              if [ "${2:-}" = "status" ]; then
+                echo '{"loggedIn":true,"authMethod":"stub","apiProvider":"ci","subscriptionType":"stub"}'
+              else
+                echo "unsupported claude subcommand: $*" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "unsupported claude command: $*" >&2
+              exit 1
+              ;;
+          esac
+          EOF
+          cat > .helm-smoke/aegis <<'EOF'
+          #!/bin/sh
+          exec node /app/dist/cli.js "$@"
+          EOF
+          chmod +x .helm-smoke/claude .helm-smoke/aegis
+      - name: Build smoke image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build -t "aegis-helm-smoke:${GITHUB_SHA}" -f - . <<'EOF'
+          FROM node:20-bookworm-slim AS build
+          WORKDIR /app
+          COPY package*.json ./
+          RUN npm ci
+          COPY . .
+          RUN npm run build
+
+          FROM node:20-bookworm-slim
+          WORKDIR /app
+          COPY package*.json ./
+          RUN npm ci --omit=dev \
+            && apt-get update \
+            && apt-get install -y --no-install-recommends tmux ca-certificates \
+            && rm -rf /var/lib/apt/lists/*
+          COPY --from=build /app/dist ./dist
+          COPY .helm-smoke/claude /usr/local/bin/claude
+          COPY .helm-smoke/aegis /usr/local/bin/aegis
+          RUN chmod +x /usr/local/bin/claude /usr/local/bin/aegis \
+            && ln -s /usr/local/bin/aegis /usr/local/bin/ag
+          EXPOSE 9100
+          ENTRYPOINT ["node", "/app/dist/cli.js"]
+          EOF
+      - name: Import smoke image into k3d
+        run: k3d image import "aegis-helm-smoke:${GITHUB_SHA}" -c aegis-helm-smoke
+      - name: Deploy chart to k3d
+        shell: bash
+        run: |
+          set -euo pipefail
+          helm upgrade --install aegis deploy/helm/aegis \
+            --namespace aegis \
+            --create-namespace \
+            --wait \
+            --timeout 5m \
+            --set image.repository=aegis-helm-smoke \
+            --set image.tag="${GITHUB_SHA}" \
+            --set image.pullPolicy=IfNotPresent
+      - name: Run ag doctor in cluster
+        run: kubectl exec -n aegis aegis-0 -- ag doctor --port 9100
+      - name: Dump Helm diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          helm status aegis -n aegis || true
+          kubectl get all,pvc -n aegis || true
+          kubectl describe statefulset -n aegis aegis || true
+          kubectl describe pod -n aegis aegis-0 || true
+          kubectl logs -n aegis aegis-0 || true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+      - name: Check out published Helm repo
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: published
+          fetch-depth: 1
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -38,8 +45,19 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm run docs
+      - name: Assemble Pages site
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf site
+          mkdir -p site
+          cp -R docs/api/. site/
+          if [ -d published/helm ]; then
+            mkdir -p site/helm
+            cp -R published/helm/. site/helm/
+          fi
       - uses: actions/upload-pages-artifact@v4
         with:
-          path: docs/api
+          path: site
       - id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
 
 permissions:
+  actions: write
   contents: write
   id-token: write
 
@@ -289,6 +290,99 @@ jobs:
           gh release upload "$TAG" package.sigstore --repo "$GITHUB_REPOSITORY" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-helm-chart:
+    needs: [publish-npm, ensure-github-release]
+    runs-on: ubuntu-latest
+    outputs:
+      pages_updated: ${{ steps.publish.outputs.pages_updated }}
+      pages_sha: ${{ steps.publish.outputs.pages_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: azure/setup-helm@v4
+      - name: Publish Helm repo contents
+        id: publish
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          OWNER_LOWER=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          ROOT_URL="https://${OWNER_LOWER}.github.io/${REPO_NAME}/helm"
+          REMOTE_URL="$(git config --get remote.origin.url)"
+
+          rm -rf chart-artifacts pages-repo
+          mkdir -p chart-artifacts
+
+          helm lint deploy/helm/aegis
+          helm package deploy/helm/aegis --destination chart-artifacts
+
+          git fetch origin gh-pages --depth=1 >/dev/null 2>&1 || true
+          git clone "${REMOTE_URL}" pages-repo >/dev/null 2>&1
+          cd pages-repo
+
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git checkout -B gh-pages origin/gh-pages
+          else
+            git checkout --orphan gh-pages
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            echo "# Aegis Helm repository storage" > README.md
+          fi
+
+          mkdir -p helm
+          cp ../chart-artifacts/*.tgz helm/
+
+          if [ -f helm/index.yaml ]; then
+            helm repo index helm --url "${ROOT_URL}" --merge helm/index.yaml
+          else
+            helm repo index helm --url "${ROOT_URL}"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+
+          if git diff --cached --quiet; then
+            echo "pages_updated=false" >> "$GITHUB_OUTPUT"
+            echo "pages_sha=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TAG=${GITHUB_REF#refs/tags/}
+          git commit -m "chore(release): publish Helm chart ${TAG}"
+          PAGES_SHA=$(git rev-parse HEAD)
+          git push origin gh-pages
+          echo "pages_updated=true" >> "$GITHUB_OUTPUT"
+          echo "pages_sha=${PAGES_SHA}" >> "$GITHUB_OUTPUT"
+
+  refresh-pages:
+    needs: publish-helm-chart
+    if: needs.publish-helm-chart.outputs.pages_updated == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for gh-pages branch to reach the published commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ needs.publish-helm-chart.outputs.pages_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 20); do
+            CURRENT_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/branches/gh-pages" --jq '.commit.sha')
+            if [ "${CURRENT_SHA}" = "${TARGET_SHA}" ]; then
+              exit 0
+            fi
+            sleep 3
+          done
+
+          echo "gh-pages did not update to ${TARGET_SHA} before dispatching Pages." >&2
+          exit 1
+      - name: Trigger GitHub Pages rebuild
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref main
 
   publish-clawhub:
     needs: publish-npm

--- a/deploy/helm/aegis/.helmignore
+++ b/deploy/helm/aegis/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.gitignore
+.github/
+.idea/
+*.swp
+*.tmp
+*.bak

--- a/deploy/helm/aegis/Chart.yaml
+++ b/deploy/helm/aegis/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: aegis
+description: Deploy Aegis on Kubernetes or k3s with persistent session state.
+type: application
+version: 0.5.3-alpha
+appVersion: "0.5.3-alpha"
+home: https://github.com/OneStepAt4time/aegis
+sources:
+  - https://github.com/OneStepAt4time/aegis
+keywords:
+  - aegis
+  - claude-code
+  - mcp
+  - tmux
+maintainers:
+  - name: OneStepAt4time
+    url: https://github.com/OneStepAt4time

--- a/deploy/helm/aegis/templates/NOTES.txt
+++ b/deploy/helm/aegis/templates/NOTES.txt
@@ -1,0 +1,10 @@
+1. Aegis has been deployed as a StatefulSet named {{ include "aegis.fullname" . }}.
+
+2. The Kubernetes Service is available at:
+   http://{{ include "aegis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+3. Health checks are wired to:
+   {{ .Values.probes.path }}
+
+4. If you enabled API auth, retrieve the token from:
+   Secret {{ include "aegis.authSecretName" . }} key {{ .Values.auth.existingSecretKey }}

--- a/deploy/helm/aegis/templates/_helpers.tpl
+++ b/deploy/helm/aegis/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{- define "aegis.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "aegis.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "aegis.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "aegis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "aegis.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aegis.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "aegis.labels" -}}
+helm.sh/chart: {{ include "aegis.chart" . }}
+{{ include "aegis.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "aegis.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "aegis.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "aegis.headlessServiceName" -}}
+{{- printf "%s-headless" (include "aegis.fullname" .) -}}
+{{- end -}}
+
+{{- define "aegis.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{- define "aegis.stateVolumeName" -}}data{{- end -}}
+
+{{- define "aegis.authSecretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "aegis.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "aegis.validate" -}}
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "Aegis currently supports replicaCount=1 only because session state is local to the pod." -}}
+{{- end -}}
+{{- if and (not .Values.persistence.enabled) .Values.persistence.existingClaim -}}
+{{- fail "persistence.existingClaim requires persistence.enabled=true." -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/aegis/templates/headless-service.yaml
+++ b/deploy/helm/aegis/templates/headless-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aegis.headlessServiceName" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.headlessService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.portName }}
+      protocol: TCP
+  selector:
+    {{- include "aegis.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/aegis/templates/ingress.yaml
+++ b/deploy/helm/aegis/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "aegis.fullname" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "aegis.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/aegis/templates/secret.yaml
+++ b/deploy/helm/aegis/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (not .Values.auth.existingSecret) .Values.auth.token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "aegis.authSecretName" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.existingSecretKey }}: {{ .Values.auth.token | quote }}
+{{- end }}

--- a/deploy/helm/aegis/templates/service.yaml
+++ b/deploy/helm/aegis/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aegis.fullname" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.portName }}
+      protocol: TCP
+  selector:
+    {{- include "aegis.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/aegis/templates/serviceaccount.yaml
+++ b/deploy/helm/aegis/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aegis.serviceAccountName" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/aegis/templates/statefulset.yaml
+++ b/deploy/helm/aegis/templates/statefulset.yaml
@@ -1,0 +1,171 @@
+{{- include "aegis.validate" . -}}
+{{- $usesGeneratedClaim := and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- $mountPath := .Values.aegis.stateDir }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "aegis.fullname" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "aegis.headlessServiceName" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "aegis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "aegis.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or (and (not .Values.auth.existingSecret) .Values.auth.token) .Values.podAnnotations }}
+      annotations:
+        {{- if and (not .Values.auth.existingSecret) .Values.auth.token }}
+        checksum/auth-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "aegis.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: aegis
+          image: {{ include "aegis.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.aegis.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.aegis.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: {{ .Values.service.portName }}
+              containerPort: {{ .Values.aegis.port }}
+              protocol: TCP
+          env:
+            - name: AEGIS_HOST
+              value: {{ .Values.aegis.host | quote }}
+            - name: AEGIS_PORT
+              value: {{ printf "%v" .Values.aegis.port | quote }}
+            - name: AEGIS_STATE_DIR
+              value: {{ $mountPath | quote }}
+            - name: AEGIS_TMUX_SESSION
+              value: {{ .Values.aegis.tmuxSession | quote }}
+            {{- if or .Values.auth.token .Values.auth.existingSecret }}
+            - name: AEGIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aegis.authSecretName" . }}
+                  key: {{ .Values.auth.existingSecretKey }}
+            {{- end }}
+            {{- with .Values.aegis.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.aegis.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.path | quote }}
+              port: {{ .Values.service.portName }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.liveness.successThreshold }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.path | quote }}
+              port: {{ .Values.service.portName }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          volumeMounts:
+            - name: {{ include "aegis.stateVolumeName" . }}
+              mountPath: {{ $mountPath | quote }}
+              {{- with .Values.persistence.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if or (not $usesGeneratedClaim) .Values.extraVolumes }}
+      volumes:
+        {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+        - name: {{ include "aegis.stateVolumeName" . }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+        {{- else if not .Values.persistence.enabled }}
+        - name: {{ include "aegis.stateVolumeName" . }}
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if $usesGeneratedClaim }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "aegis.stateVolumeName" . }}
+        labels:
+          {{- include "aegis.selectorLabels" . | nindent 10 }}
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        volumeMode: {{ .Values.persistence.volumeMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/deploy/helm/aegis/values.yaml
+++ b/deploy/helm/aegis/values.yaml
@@ -1,0 +1,169 @@
+# -- Override the chart name used for resource names.
+nameOverride: ""
+
+# -- Override the fully qualified app name.
+fullnameOverride: ""
+
+# -- Number of Aegis replicas. Keep this at 1 because Aegis still relies on local state.
+replicaCount: 1
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+
+image:
+  # -- Container image repository.
+  repository: ghcr.io/onestepat4time/aegis
+  # -- Container image tag. When empty, the chart appVersion is used.
+  tag: ""
+  # -- Container image pull policy.
+  pullPolicy: IfNotPresent
+
+aegis:
+  # -- Bind host passed to `AEGIS_HOST`.
+  host: 0.0.0.0
+  # -- HTTP port passed to `AEGIS_PORT`.
+  port: 9100
+  # -- tmux session prefix passed to `AEGIS_TMUX_SESSION`.
+  tmuxSession: aegis
+  # -- Stateful data directory mounted from the PVC and passed to `AEGIS_STATE_DIR`.
+  stateDir: /var/lib/aegis
+  # -- Override the container entrypoint. Leave empty to use the image default.
+  command: []
+  # -- Override container arguments. Leave empty to use the image default.
+  args: []
+  # -- Additional environment variables appended to the Aegis container.
+  extraEnv: []
+  # -- Additional `envFrom` entries appended to the Aegis container.
+  extraEnvFrom: []
+
+auth:
+  # -- Inline API token stored in a generated Secret and exposed as `AEGIS_AUTH_TOKEN`.
+  token: ""
+  # -- Existing Secret name containing the API token. When set, it takes precedence over `auth.token`.
+  existingSecret: ""
+  # -- Secret key containing the API token inside `auth.existingSecret` or the generated Secret.
+  existingSecretKey: AEGIS_AUTH_TOKEN
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount for the StatefulSet.
+  create: true
+  # -- Annotations applied to the ServiceAccount.
+  annotations: {}
+  # -- Existing ServiceAccount name to use when `serviceAccount.create=false`.
+  name: ""
+  # -- Mount a Kubernetes service account token into the pod.
+  automountServiceAccountToken: false
+
+# -- Extra annotations for the Aegis pod template.
+podAnnotations: {}
+
+# -- Extra labels for the Aegis pod template.
+podLabels: {}
+
+# -- Pod-level security context.
+podSecurityContext: {}
+
+# -- Container-level security context.
+securityContext: {}
+
+service:
+  # -- Annotations applied to the client-facing Service.
+  annotations: {}
+  # -- Service type used to expose Aegis inside or outside the cluster.
+  type: ClusterIP
+  # -- Port exposed by the client-facing Service.
+  port: 9100
+  # -- Named port used by the Service and probes.
+  portName: http
+
+headlessService:
+  # -- Annotations applied to the StatefulSet governing Service.
+  annotations: {}
+
+ingress:
+  # -- Create an Ingress for the Aegis Service.
+  enabled: false
+  # -- Ingress class name.
+  className: ""
+  # -- Annotations applied to the Ingress resource.
+  annotations: {}
+  # -- Host and path rules for the Ingress.
+  hosts:
+    - host: aegis.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS entries for the Ingress resource.
+  tls: []
+
+persistence:
+  # -- Provision persistent storage for session state and audit logs.
+  enabled: true
+  # -- Use an existing PVC instead of creating a new StatefulSet volumeClaimTemplate.
+  existingClaim: ""
+  # -- Annotations applied to the generated PVC.
+  annotations: {}
+  # -- Requested access modes for the generated PVC.
+  accessModes:
+    - ReadWriteOnce
+  # -- Requested storage size for the generated PVC.
+  size: 10Gi
+  # -- StorageClass name for the generated PVC. Leave empty to use the cluster default.
+  storageClass: ""
+  # -- Volume mode for the generated PVC.
+  volumeMode: Filesystem
+  # -- Optional subPath mounted from the persistent volume.
+  subPath: ""
+
+probes:
+  # -- HTTP path used by readiness and liveness probes.
+  path: /v1/health
+  liveness:
+    # -- Seconds to wait before starting liveness checks.
+    initialDelaySeconds: 20
+    # -- Seconds between liveness checks.
+    periodSeconds: 10
+    # -- Liveness probe timeout in seconds.
+    timeoutSeconds: 3
+    # -- Number of successful liveness checks required.
+    successThreshold: 1
+    # -- Number of failed liveness checks before restarting the container.
+    failureThreshold: 3
+  readiness:
+    # -- Seconds to wait before starting readiness checks.
+    initialDelaySeconds: 5
+    # -- Seconds between readiness checks.
+    periodSeconds: 5
+    # -- Readiness probe timeout in seconds.
+    timeoutSeconds: 3
+    # -- Number of successful readiness checks required.
+    successThreshold: 1
+    # -- Number of failed readiness checks before marking the pod unready.
+    failureThreshold: 3
+
+# -- Pod resource requests and limits.
+resources: {}
+
+# -- Node selector labels for the pod.
+nodeSelector: {}
+
+# -- Tolerations applied to the pod.
+tolerations: []
+
+# -- Affinity rules applied to the pod.
+affinity: {}
+
+# -- Topology spread constraints applied to the pod.
+topologySpreadConstraints: []
+
+# -- PriorityClass assigned to the pod.
+priorityClassName: ""
+
+# -- Pod termination grace period in seconds.
+terminationGracePeriodSeconds: 30
+
+# -- Additional volumes injected into the pod (for example Claude auth, SSH keys, or custom CA bundles).
+extraVolumes: []
+
+# -- Additional volume mounts appended to the Aegis container.
+extraVolumeMounts: []

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,7 +16,7 @@ This guide covers deploying Aegis in development, CI/CD, and production environm
 | `AEGIS_AUTH_TOKEN` | Yes | - | Bearer token for API authentication |
 | `AEGIS_PORT` | No | `9100` | HTTP server port |
 | `AEGIS_HOST` | No | `0.0.0.0` | Bind address |
-| `AEGIS_DATA_DIR` | No | `~/.aegis` | Session data storage |
+| `AEGIS_STATE_DIR` | No | `~/.aegis` | Session state, audit logs, and runtime metadata storage |
 | `AEGIS_DASHBOARD_URL` | No | `http://localhost:9100/dashboard` | Dashboard URL |
 | `CLAUDE_DATA_DIR` | No | `~/.claude` | Claude Code data directory |
 | `AEGIS_SSE_IDLE_MS` | No | `120000` | SSE heartbeat interval — emit a `:ping` comment after this many ms of write-idle silence (Issue #1911) |
@@ -127,6 +127,40 @@ services:
 volumes:
   aegis-data:
   claude-data:
+```
+
+### Helm (Kubernetes / k3s)
+
+The chart source lives in `deploy/helm/aegis`, and release tags publish a Helm repo at:
+
+```text
+https://onestepat4time.github.io/aegis/helm
+```
+
+Install or upgrade Aegis with:
+
+```bash
+helm repo add aegis https://onestepat4time.github.io/aegis/helm
+helm repo update
+
+helm upgrade --install aegis aegis/aegis \
+  --namespace aegis \
+  --create-namespace
+```
+
+Key chart behaviours:
+
+- Runs as a **single-replica StatefulSet** (Aegis is not horizontally scalable yet).
+- Persists `AEGIS_STATE_DIR` on a **PVC** mounted at `/var/lib/aegis` by default.
+- Wires **liveness** and **readiness** probes to `GET /v1/health`.
+- Supports existing Secrets, PVCs, ingress, and raw `extraEnv` / `extraVolumes` / `extraVolumeMounts` overrides for cluster-specific needs such as Claude auth material.
+
+Override `image.repository` or `image.tag` only when you need to pin a mirrored or custom image.
+
+Inspect every supported value with:
+
+```bash
+helm show values aegis/aegis
 ```
 
 ## Reverse Proxy

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,18 @@
       "prereleaseType": "alpha",
       "include-sha-in-tag": false,
       "tag-separator": "-",
-      "extra-files": []
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "deploy/helm/aegis/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "deploy/helm/aegis/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ]
     }
   }
 }

--- a/src/__tests__/session-persistence.test.ts
+++ b/src/__tests__/session-persistence.test.ts
@@ -173,6 +173,38 @@ describe('Session persistence and resume (Issue #35)', () => {
 
       expect(knownWindowIds.has(window.windowId)).toBe(true);
     });
+
+    it('should ignore windows with a missing name during load', async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), 'aegis-missing-window-name-'));
+      try {
+        const manager = new SessionManager(
+          {
+            listWindows: async () => [{ windowId: '@3', windowName: undefined, cwd: '/tmp/project' }],
+          } as any,
+          {
+            stateDir,
+            host: '127.0.0.1',
+            port: 9100,
+            tmuxSession: 'aegis',
+            claudeProjectsDir: '/tmp/.claude/projects',
+            maxSessionAgeMs: 7_200_000,
+            reaperIntervalMs: 60_000,
+            defaultPermissionMode: 'default',
+            defaultSessionEnv: {},
+            allowedWorkDirs: [],
+            sseMaxConnections: 50,
+            sseMaxPerIp: 5,
+            worktreeAwareContinuation: false,
+            worktreeSiblingDirs: [],
+          } as any,
+        );
+
+        await expect(manager.load()).resolves.toBeUndefined();
+        expect(manager.listSessions()).toHaveLength(0);
+      } finally {
+        rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('Session info for adopted orphans', () => {

--- a/src/session.ts
+++ b/src/session.ts
@@ -303,15 +303,16 @@ export class SessionManager {
     const knownWindowIds = new Set(Object.values(this.state.sessions).map(s => s.windowId));
     const knownWindowNames = new Set(Object.values(this.state.sessions).map(s => s.windowName));
     for (const win of windows) {
-      if (knownWindowIds.has(win.windowId) || knownWindowNames.has(win.windowName)) continue;
+      const windowName = win.windowName ?? '';
+      if (knownWindowIds.has(win.windowId) || knownWindowNames.has(windowName)) continue;
       // Only adopt windows that look like Aegis-created sessions (cc-* prefix or _bridge_ prefix)
-      if (!win.windowName.startsWith('cc-') && !win.windowName.startsWith('_bridge_')) continue;
+      if (!windowName.startsWith('cc-') && !windowName.startsWith('_bridge_')) continue;
 
       const id = crypto.randomUUID();
       const session: SessionInfo = {
         id,
         windowId: win.windowId,
-        windowName: win.windowName,
+        windowName,
         workDir: win.cwd || homedir(),
         byteOffset: 0,
         monitorOffset: 0,
@@ -324,7 +325,7 @@ export class SessionManager {
       };
       this.state.sessions[id] = session;
       this.invalidateSessionsListCache();
-      console.log(`Reconcile: adopted orphaned window ${win.windowName} (${win.windowId}) as ${id.slice(0, 8)}`);
+      console.log(`Reconcile: adopted orphaned window ${windowName} (${win.windowId}) as ${id.slice(0, 8)}`);
       this.discovery.startDiscoveryPolling(id, session.workDir);
       changed = true;
     }

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -53,7 +53,7 @@ export interface TmuxWindow {
 const WINDOW_LIST_FORMAT = '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{pane_current_command}\t#{pane_dead}';
 
 function parseWindowListLine(line: string): TmuxWindow {
-  const [windowId, windowName, cwd, paneCommand, paneDeadRaw] = line.split('\t');
+  const [windowId = '', windowName = '', cwd = '', paneCommand = '', paneDeadRaw] = line.split('\t');
   return {
     windowId,
     windowName,


### PR DESCRIPTION
## Summary

Adds a Helm chart for Aegis, CI smoke validation for cluster deploys, GitHub Pages chart publishing, and deployment documentation.

## Aegis version

**Developed with:** v0.5.3-alpha
**Tested with:** v0.5.3-alpha

## Change type

- [ ] ix — Bug fix
- [ ] efactor — Code restructuring with no behavior change
- [ ] perf — Performance improvement
- [ ] 	est — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, tooling
- [x] eat — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

Helm chart files, release/pages workflows, Helm smoke CI, and deployment docs.

## Linked issue

Closes #1935

## Test plan

Repository gate passed (
pm run gate).

- [x] Unit tests pass (
pm test)
- [x] Type-check passes (
px tsc --noEmit)
- [x] Build succeeds (
pm run build)
- [ ] Manually tested (describe below)

## Security impact

Documents deployment defaults and validates production packaging in CI; no new runtime privilege bypasses.

## Dependency notes

Draft while #1994 and #2001 remain open because this branch was stacked after the g alias and g doctor CLI work.