### PR TITLE
feat: rename alpha dist-tag and version suffix to preview

### DIFF
--- a/.github/workflows/graduation-check.yml
+++ b/.github/workflows/graduation-check.yml
@@ -39,7 +39,7 @@ jobs:
             const config = JSON.parse(fs.readFileSync('release-please-config.json', 'utf8'));
             const pkg = config.packages['.'];
             const currentPhase = pkg.prerelease ? pkg.prereleaseType : 'stable';
-            const nextPhaseMap = { alpha: 'beta', beta: 'rc', rc: 'stable' };
+            const nextPhaseMap = { preview: 'beta', beta: 'rc', rc: 'stable' };
             const nextPhase = nextPhaseMap[currentPhase] || '';
 
             async function countOpenIssues(labelName) {
@@ -84,7 +84,7 @@ jobs:
             const docsComplete = docsPresent && !docsHaveTodo;
 
             const criteria = [];
-            if (currentPhase === 'alpha') {
+            if (currentPhase === 'preview') {
               criteria.push({ name: 'Zero open P0 issues', pass: openP0 === 0, evidence: `open P0 issues: ${openP0}` });
               criteria.push({ name: 'Latest develop CI is green', pass: ciGreen, evidence: latestCiRun ? `${latestCiRun.html_url} (${latestCiRun.conclusion})` : 'No completed CI run found on develop' });
               criteria.push({ name: 'Core docs are present and free of TODO/TBD markers', pass: docsComplete, evidence: docsComplete ? 'README, CONTRIBUTING, getting-started, and advanced docs look complete.' : 'Docs missing or still contain TODO/TBD markers.' });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "$TAG" == *-alpha* || "$TAG" == *-beta* || "$TAG" == *-rc* ]]; then
+          if [[ "$TAG" == *-preview* || "$TAG" == *-alpha* || "$TAG" == *-beta* || "$TAG" == *-rc* ]]; then
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease --generate-notes
           else
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --generate-notes

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       target_ref:
-        description: Commit SHA or tag to revert from main (for example `abc1234` or `v0.2.0-alpha`)
+        description: Commit SHA or tag to revert from main (for example `abc1234` or `v0.2.0-preview`)
         required: true
       reason:
         description: Why is this rollback needed?

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
   <img src="https://img.shields.io/npm/l/@onestepat4time/aegis.svg" alt="license" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.0.0-blue.svg" alt="node" />
   <img src="https://img.shields.io/badge/MCP-ready-green.svg" alt="MCP ready" />
-  <a href="https://github.com/OneStepAt4time/aegis/blob/main/ROADMAP.md"><img src="https://img.shields.io/badge/roadmap-alpha-orange" alt="Roadmap" /></a>
+  <a href="https://github.com/OneStepAt4time/aegis/blob/main/ROADMAP.md"><img src="https://img.shields.io/badge/roadmap-preview-blue" alt="Roadmap" /></a>
 </p>
 
-> ⚠️ **Aegis is in Alpha.** APIs may change. See [ROADMAP.md](./ROADMAP.md) for the path to stable.
-> Current release channel remains `alpha` until graduation criteria are explicitly met.
+> ⚠️ **Aegis is in Preview.** APIs may change. See [ROADMAP.md](./ROADMAP.md) for the path to stable.
+> Current release channel is `preview`.
 >
 > 📦 **Package renamed:** `aegis-bridge` → [`@onestepat4time/aegis`](https://www.npmjs.com/package/@onestepat4time/aegis). See [Migration Guide](docs/migration-guide.md) if you're upgrading.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Aegis Roadmap
 
-> **Aegis is in Alpha.** Planning is organised into four phases driven by
+> **Aegis is in Preview.** Planning is organised into four phases driven by
 > audience scale (single dev → team → enterprise). The positioning is locked
 > in [ADR-0023](docs/adr/0023-positioning-claude-code-control-plane.md) and
 > the complete gap analysis lives in
@@ -123,7 +123,7 @@ All remaining P2 items from the gap analysis:
 
 **Preview → GA** (end of Phase 2):
 - [ ] All Phase 2 items shipped
-- [ ] Rename "alpha" dist-tag and version suffix to "preview"
+- [x] Rename "alpha" dist-tag and version suffix to "preview"
 - [ ] Public demo video of the mobile approval flow
 - [ ] Incident / rollback runbook validated at least once
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -4,7 +4,7 @@ Aegis provides orchestration primitives beyond basic session management. This gu
 
 For OpenAI-compatible model routing via Claude Code (`ANTHROPIC_BASE_URL` + custom models), see [BYO LLM](./byo-llm.md).
 
-> **Note:** These features are available in v0.3.0-alpha. APIs may change between releases.
+> **Note:** These features are available in v0.3.0-preview. APIs may change between releases.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -52,7 +52,7 @@ Performs capability negotiation with Aegis. Returns server capabilities and comp
 ```json
 {
   "compatible": true,
-  "serverVersion": "0.5.3-alpha",
+  "serverVersion": "0.5.3-preview",
   "capabilities": ["streamable-events", "tool-use", "permission-requests"]
 }
 ```
@@ -72,7 +72,7 @@ curl http://localhost:9100/v1/health
 ```json
 {
   "status": "ok",
-  "version": "0.3.0-alpha",
+  "version": "0.3.0-preview",
   "platform": "linux",
   "uptime": 3600,
   "sessions": { "active": 3, "total": 42 },
@@ -889,3 +889,4 @@ All endpoints return errors in a consistent format:
 | 409 | Conflict (session already exists, etc.) |
 | 429 | Rate limited |
 | 500 | Internal server error |
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,7 +197,7 @@ Response:
 ```json
 {
   "status": "ok",
-  "version": "0.5.3-alpha",
+  "version": "0.5.3-preview",
   "uptime": 3600
 }
 ```
@@ -226,3 +226,4 @@ sudo systemctl restart aegis
 ## Troubleshooting
 
 See [Troubleshooting Guide](./troubleshooting.md) for common deployment issues.
+

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -306,7 +306,7 @@ Returns server status, version, uptime, active session count, and tmux health. *
 ```json
 {
   "status": "ok",
-  "version": "0.3.2-alpha",
+  "version": "0.3.2-preview",
   "platform": "linux",
   "uptime": 86400,
   "sessions": {
@@ -556,3 +556,4 @@ curl -sf http://localhost:9100/v1/metrics | \
 | High memory usage | Reduce `AEGIS_MAX_SESSIONS` or increase `AEGIS_IDLE_TIMEOUT_MS` |
 | tmux errors | Verify tmux is installed: `tmux -V` (requires ≥ 3.2) |
 | Rate limited (429) | Wait for the rate limit window to reset or increase limits |
+

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -12,10 +12,10 @@ Download the release and verify its SHA-256 hash:
 
 ```bash
 # Download the release tarball
-curl -LO https://github.com/OneStepAt4time/aegis/releases/download/v0.5.3-alpha/aegis-0.5.3-alpha.tgz
+curl -LO https://github.com/OneStepAt4time/aegis/releases/download/v0.5.3-preview/aegis-0.5.3-preview.tgz
 
 # Verify the hash
-sha256sum aegis-0.5.3-alpha.tgz
+sha256sum aegis-0.5.3-preview.tgz
 ```
 
 Compare the output against the `SHA256SUMS` file published in the release assets.
@@ -50,14 +50,14 @@ Download the Sigstore attestation bundle from the release assets, then verify:
 
 ```bash
 # Download release assets
-gh release download v0.5.3-alpha --pattern '*.sigstore' --pattern 'checksums.txt' --dir /tmp
+gh release download v0.5.3-preview --pattern '*.sigstore' --pattern 'checksums.txt' --dir /tmp
 
 # Verify the attestation against the npm registry tarball
 cosign verify-blob-attestation \
   --certificate-identity-regexp 'https://github.com/OneStepAt4time/aegis/.github/workflows/release\\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --bundle /tmp/package.sigstore \
-  "https://registry.npmjs.org/@onestepat4time/aegis/-/aegis-0.5.3-alpha.tgz"
+  "https://registry.npmjs.org/@onestepat4time/aegis/-/aegis-0.5.3-preview.tgz"
 ```
 
 ### What the Attestation Proves
@@ -104,12 +104,12 @@ All Aegis releases are recorded in the public GitHub release changelog. The `CHA
 
 ## Version Numbering
 
-Aegis uses semantic versioning: `MAJOR.MINOR.PATCH-alpha`
+Aegis uses semantic versioning: `MAJOR.MINOR.PATCH-preview`
 
 | Version | Meaning |
 |---------|---------|
-| `0.5.3-alpha` | Pre-release, v0.5.3 with alpha qualifier |
+| `0.5.3-preview` | Pre-release, v0.5.3 with preview qualifier |
 | `0.5.3` | Stable release |
 | `1.0.0` | First stable major release |
 
-The `alpha` suffix indicates the API may change. Production deployments should pin to exact versions.
+The `preview` suffix indicates the API may change. Production deployments should pin to exact versions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onestepat4time/aegis",
-  "version": "0.5.3-alpha",
+  "version": "0.5.3-preview",
   "type": "module",
   "description": "Orchestrate Claude Code sessions via API. Create, brief, monitor, refine, ship.",
   "main": "dist/server.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "draft": false,
       "prerelease": true,
-      "prereleaseType": "alpha",
+      "prereleaseType": "preview",
       "include-sha-in-tag": false,
       "tag-separator": "-",
       "extra-files": [


### PR DESCRIPTION
## Summary

Renames the \lpha\ release channel to \preview\ across all release-facing surfaces, completing the Phase 2 exit criterion from [#2009].

## Changes

### Package metadata
- \package.json\: \