### PR TITLE
refactor(dashboard): remove cursor transcript API, migrate to getSessionMessages

### DIFF
--- a/dashboard/src/__tests__/TranscriptViewer.test.tsx
+++ b/dashboard/src/__tests__/TranscriptViewer.test.tsx
@@ -3,11 +3,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 
 import { TranscriptViewer } from '../components/session/TranscriptViewer';
 
-const mockGetSessionTranscript = vi.fn();
+const mockGetSessionMessages = vi.fn();
 const mockSubscribeSSE = vi.fn();
 
 vi.mock('../api/client', () => ({
-  getSessionTranscript: (...args: unknown[]) => mockGetSessionTranscript(...args),
+  getSessionMessages: (...args: unknown[]) => mockGetSessionMessages(...args),
   subscribeSSE: (...args: unknown[]) => mockSubscribeSSE(...args),
 }));
 
@@ -18,11 +18,11 @@ vi.mock('../store/useStore', () => ({
 describe('TranscriptViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetSessionTranscript.mockResolvedValue({
+    mockGetSessionMessages.mockResolvedValue({
       messages: [],
-      has_more: false,
-      oldest_id: null,
-      newest_id: null,
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
     });
     mockSubscribeSSE.mockReturnValue(() => {});
   });
@@ -35,6 +35,6 @@ describe('TranscriptViewer', () => {
     });
 
     expect(screen.queryByText('Loading transcript…')).toBeNull();
-    expect(mockGetSessionTranscript).toHaveBeenCalledWith('session-1', 1000);
+    expect(mockGetSessionMessages).toHaveBeenCalledWith('session-1');
   });
 });

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -224,66 +224,6 @@ describe('getSessionStatusCounts', () => {
   });
 });
 
-describe('getSessionTranscript', () => {
-  let fetchMock: ReturnType<typeof vi.fn>;
-  let originalFetch: typeof globalThis.fetch;
-
-  beforeEach(() => {
-    vi.resetModules();
-    originalFetch = globalThis.fetch;
-    fetchMock = vi.fn();
-    globalThis.fetch = fetchMock as typeof globalThis.fetch;
-    localStorage.clear();
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-    vi.restoreAllMocks();
-  });
-
-  it('uses the cursor transcript endpoint for non-destructive replay', async () => {
-    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
-      messages: [
-        {
-          _cursor_id: 7,
-          role: 'assistant',
-          contentType: 'text',
-          text: 'READY',
-        },
-      ],
-      has_more: false,
-      oldest_id: 7,
-      newest_id: 7,
-    }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }));
-
-    const { getSessionTranscript } = await import('../api/client');
-
-    await expect(getSessionTranscript('session-1', 25, 50)).resolves.toEqual({
-      messages: [
-        {
-          _cursor_id: 7,
-          role: 'assistant',
-          contentType: 'text',
-          text: 'READY',
-        },
-      ],
-      has_more: false,
-      oldest_id: 7,
-      newest_id: 7,
-    });
-
-    const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
-    const url = new URL(requestUrl, 'http://localhost');
-    expect(url.pathname).toBe('/v1/sessions/session-1/transcript/cursor');
-    expect(url.searchParams.get('limit')).toBe('25');
-    expect(url.searchParams.get('before_id')).toBe('50');
-    expect(requestInit.headers).toEqual(expect.not.objectContaining({ 'Content-Type': 'application/json' }));
-  });
-});
-
 describe('isRetryableError', () => {
   it('returns false for AbortError (should not retry)', () => {
     const error = new DOMException('The operation was aborted', 'AbortError');

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -10,7 +10,6 @@ import { z } from 'zod';
 import type {
   HealthResponse,
   GlobalMetrics,
-  ParsedEntry,
   SessionInfo,
   SessionHealth,
   MessagesResponse,
@@ -50,7 +49,6 @@ import {
   SessionMetricsSchema,
   SessionLatencySchema,
   SessionMessagesSchema,
-  SessionTranscriptCursorResponseSchema,
   GlobalMetricsSchema,
   GlobalSSEEventSchema,
   AllSessionsHealthSchema,
@@ -353,24 +351,6 @@ export function getSessionMessages(id: string): Promise<MessagesResponse> {
   return request(`/v1/sessions/${encodeURIComponent(id)}/read`, {
     schema: SessionMessagesSchema,
     schemaContext: 'getSessionMessages',
-  });
-}
-
-export interface SessionTranscriptCursorResponse {
-  messages: Array<ParsedEntry & { _cursor_id: number }>;
-  has_more: boolean;
-  oldest_id: number | null;
-  newest_id: number | null;
-}
-
-export function getSessionTranscript(id: string, limit = 200, beforeId?: number): Promise<SessionTranscriptCursorResponse> {
-  const searchParams = new URLSearchParams();
-  searchParams.set('limit', String(limit));
-  if (beforeId !== undefined) searchParams.set('before_id', String(beforeId));
-  const query = searchParams.toString();
-  return request(`/v1/sessions/${encodeURIComponent(id)}/transcript/cursor${query ? `?${query}` : ''}`, {
-    schema: SessionTranscriptCursorResponseSchema,
-    schemaContext: 'getSessionTranscript',
   });
 }
 

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -307,15 +307,6 @@ export const ParsedEntrySchema = z.object({
   timestamp: z.string().optional(),
 });
 
-export const SessionTranscriptCursorResponseSchema = z.object({
-  messages: z.array(ParsedEntrySchema.extend({
-    _cursor_id: z.number().int().positive(),
-  })),
-  has_more: z.boolean(),
-  oldest_id: z.number().int().positive().nullable(),
-  newest_id: z.number().int().positive().nullable(),
-});
-
 // ── SessionMessages (Issue #407) ────────────────────────────────
 
 export const SessionMessagesSchema: z.ZodType<MessagesResponse> = z.object({

--- a/dashboard/src/components/session/SessionPreviewCard.tsx
+++ b/dashboard/src/components/session/SessionPreviewCard.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useEffect, useState, useRef } from 'react';
-import { getSessionTranscript } from '../../api/client';
+import { getSessionMessages } from '../../api/client';
 import type { ParsedEntry } from '../../types';
 import type { SessionInfo } from '../../types';
 import { formatTimeAgo } from '../../utils/format';
@@ -68,10 +68,10 @@ export function SessionPreviewCard({ session, anchorRef, onClose }: SessionPrevi
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    getSessionTranscript(session.id, PREVIEW_MESSAGE_COUNT)
+    getSessionMessages(session.id)
       .then((data) => {
         if (cancelled) return;
-        const msgs = (data.messages ?? []).map(({ _cursor_id: _cursorId, ...entry }) => entry);
+        const msgs = (data.messages ?? []).slice(-PREVIEW_MESSAGE_COUNT);
         setMessages(msgs);
       })
       .catch(() => {

--- a/dashboard/src/components/session/TranscriptViewer.tsx
+++ b/dashboard/src/components/session/TranscriptViewer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { ParsedEntry } from '../../types';
-import { getSessionTranscript, subscribeSSE } from '../../api/client';
+import { getSessionMessages, subscribeSSE } from '../../api/client';
 import { useStore } from '../../store/useStore';
 import { MessageBubble } from './MessageBubble';
 import { SessionSSEEventDataSchema } from '../../api/schemas';
@@ -42,10 +42,10 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
   useEffect(() => {
     let cancelled = false;
 
-    getSessionTranscript(sessionId, MAX_SESSION_MESSAGES)
+    getSessionMessages(sessionId)
       .then(data => {
         if (!cancelled) {
-          const msgs = (data.messages ?? []).map(({ _cursor_id: _cursorId, ...entry }) => entry);
+          const msgs = data.messages ?? [];
           const capped = msgs.length > MAX_SESSION_MESSAGES
             ? msgs.slice(msgs.length - MAX_SESSION_MESSAGES)
             : msgs;


### PR DESCRIPTION
## Summary

Completes the UI glamour rework by removing the deprecated cursor-based transcript API and fully migrating to \getSessionMessages\.

## Changes

- **\pi/client.ts\** — remove \getSessionTranscript()\, \SessionTranscriptCursorResponse\ interface, and \ParsedEntry\ import
- **\pi/schemas.ts\** — remove \SessionTranscriptCursorResponseSchema\
- **\TranscriptViewer.tsx\** — use \getSessionMessages()\ instead of cursor endpoint; strip \_cursor_id\ map
- **\SessionPreviewCard.tsx\** — use \getSessionMessages().slice(-N)\ for preview messages
- **Tests** — update \TranscriptViewer.test.tsx\ mock; remove \getSessionTranscript\ describe block from \client.test.ts\

## Test Results

All 3192 tests pass. \
pm run gate\ clean.

Closes part of #2014