### PR TITLE
fix(dashboard): replace ALPHA badge with PREVIEW in header

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -365,8 +365,8 @@ export default function Layout() {
             </div>
 
             <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
-              <span className="rounded-md border border-yellow-500/50 bg-yellow-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-yellow-500">
-                ALPHA
+              <span className="rounded-md border border-blue-500/50 bg-blue-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-blue-400">
+                PREVIEW
               </span>
 
               {/* Cmd+K Palette trigger */}


### PR DESCRIPTION
## Summary

Replaces the hardcoded ALPHA badge text in Layout.tsx with PREVIEW, and changes the colour from yellow to blue to match the preview channel branding.

## Before / After

- **Before:** Yellow ALPHA badge
- **After:** Blue PREVIEW badge (consistent with \0.6.0-preview\ version string)

## Testing

Visual verification in browser — badge renders correctly in both light and dark mode.