### PR TITLE
fix(validation): reject env var values that are only CR/LF/whitespace

### DIFF
--- a/src/__tests__/env-denylist-1392.test.ts
+++ b/src/__tests__/env-denylist-1392.test.ts
@@ -255,6 +255,11 @@ describe('Env var denylist — live Zod schema (Issues #1392 + #1908)', () => {
       expectRejection({ MY_VAR: 'val\x1Fue' }, 'control characters');
     });
 
+    it('rejects values that are only CR, LF, or CRLF', () => {
+      expectRejection({ MY_VAR: '\r\n' }, 'only whitespace or control characters');
+      expectRejection({ MY_VAR: '\r' }, 'only whitespace or control characters');
+      expectRejection({ MY_VAR: '\n' }, 'only whitespace or control characters');
+    });
     it('allows TAB in values', () => {
       expectSuccess({ MY_VAR: 'hello\tworld' });
     });

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -530,6 +530,14 @@ export function buildEnvSchema(
       }
       // Value hardening
       const value = stripCrLf(rawValue);
+      if (value.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Forbidden env var value for "${key}" — value is only whitespace or control characters`,
+        });
+        continue;
+      }
       if (hasControlChars(value)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## Summary

Fixes CR/LF injection vulnerability in env var validation (QA Round 6 bug).

**Problem:** Values containing only CR/LF (e.g. `\r\n`) were being stripped to an empty string and accepted as valid. Attackers could bypass validation.

**Fix:** After stripping CR/LF, reject values that become empty. Added check: `if (value.length === 0)` → error.

**Files changed:**
- `src/validation.ts` — add empty-value guard
- `src/__tests__/env-denylist-1392.test.ts` — 3 new test cases

**Tests:** 64 passed (env-denylist)

Verification:
- Only CR/LF: REJECTED ✅
- Only spaces: accepted ✅
- `hello\r\nworld`: stripped and accepted ✅
- Null byte: rejected ✅