### PR TITLE
fix(health): strip sensitive fields for unauthenticated requests

### DIFF
--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -244,7 +244,21 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
   }
 
   // ── Step 1: Health check ──────────────────────────────────────────
-  it('GET /v1/health returns ok', async () => {
+  it('GET /v1/health returns ok (authenticated, full data)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/health',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe('ok');
+    expect(body.version).toBeDefined();
+    expect(body.sessions).toBeDefined();
+  });
+
+  it('GET /v1/health unauthenticated returns minimal data (Issue #2066)', async () => {
     const res = await app.inject({
       method: 'GET',
       url: '/v1/health',
@@ -253,8 +267,10 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.status).toBe('ok');
-    expect(body.version).toBeDefined();
+    expect(body.version).toBeUndefined(); // stripped for unauthenticated
     expect(body.sessions).toBeDefined();
+    expect(body.sessions.active).toBeDefined();
+    expect(body.sessions.total).toBeUndefined(); // stripped for unauthenticated
   });
 
   // ── Step 2: Create session ────────────────────────────────────────

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -76,7 +76,8 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
 
   // Health — Issue #397: includes tmux server health check
   // Issue #1911: returns 'draining' when server is shutting down
-  async function healthHandler(): Promise<Record<string, unknown>> {
+  // Issue #2066: strip sensitive fields (version, uptime, tmux, claude) for unauthenticated requests
+  async function healthHandler(req: FastifyRequest): Promise<Record<string, unknown>> {
     const pkg = await import('../../package.json', { with: { type: 'json' } });
     const activeCount = sessions.listSessions().length;
     const totalCount = metrics.getTotalSessionsCreated();
@@ -90,15 +91,27 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
         ? 'ok'
         : 'degraded';
 
+    // Check if request is authenticated
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+    const isAuthenticated = token ? (await ctx.auth.validate(token)).valid : false;
+
+    const base = { status, timestamp: new Date().toISOString() };
+
+    // Unauthenticated: return minimal info (load-balancer friendly)
+    if (!isAuthenticated) {
+      return { ...base, sessions: { active: activeCount } };
+    }
+
+    // Authenticated: return full health details
     return {
-      status,
+      ...base,
       version: pkg.default.version,
       platform: process.platform,
       uptime: process.uptime(),
       sessions: { active: activeCount, total: totalCount },
       tmux: tmuxHealth,
       claude: claudeStatus,
-      timestamp: new Date().toISOString(),
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #2066: Health endpoint leaked version, uptime, claude version, session count to unauthenticated users.

**Before:** Anyone hitting `/v1/health` got full server details.

**After:** 
- Unauthenticated → `{status, timestamp, sessions: {active}}` (load-balancer friendly)
- Authenticated → full health data including version, uptime, tmux, claude

**Files changed:**
- `src/routes/health.ts` — check auth, strip sensitive fields for unauthenticated
- `src/__tests__/server-smoke.test.ts` — updated test + added unauthenticated case

**Tests:** 7 passed (server-smoke), 4 passed (health)