### PR TITLE
docs: fix stale refs, Phase 1 checkboxes, add onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Or via `.mcp.json`:
 
 Without a global install, use `"command": "npx"` with `["--package=@onestepat4time/aegis", "ag", "mcp"]` instead.
 
-**25 tools** — `create_session`, `send_message`, `get_transcript`, `approve_permission`, `batch_create_sessions`, `create_pipeline`, `state_set`, and more.
+**24 tools** — `create_session`, `send_message`, `get_transcript`, `approve_permission`, `batch_create_sessions`, `create_pipeline`, `state_set`, and more.
 
 **4 resources** — `aegis://sessions`, `aegis://sessions/{id}/transcript`, `aegis://sessions/{id}/pane`, `aegis://health`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,18 +32,18 @@ to Claude Code.
 
 ---
 
-## Phase 1 — Foundations (current, 1–2 months part-time)
+## Phase 1 — Foundations ✅ COMPLETE
 
 **Goal:** Aegis safe, contract-first, and supply-chain-verifiable.
 
-- [ ] Session ownership authz on action routes ([ADR-0019](docs/adr/0019-session-ownership-authz.md))
-- [ ] Env-var denylist at session create ([ADR-0020](docs/adr/0020-env-var-denylist.md))
-- [ ] Credential scan in `hygiene-check`
-- [ ] OpenAPI 3.1 spec generated from Zod ([ADR-0018](docs/adr/0018-openapi-spec-from-zod.md))
-- [ ] SSE idle timeout + HTTP drain on shutdown ([ADR-0021](docs/adr/0021-sse-and-http-drain-timeouts.md))
-- [ ] Dashboard E2E active on PRs to `develop`
-- [ ] Branch coverage raised from 60 % to 65 %
-- [ ] Sigstore attestations on npm + container images ([ADR-0022](docs/adr/0022-sigstore-attestations.md))
+- [x] Session ownership authz on action routes ([ADR-0019](docs/adr/0019-session-ownership-authz.md))
+- [x] Env-var denylist at session create ([ADR-0020](docs/adr/0020-env-var-denylist.md))
+- [x] Credential scan in `hygiene-check`
+- [x] OpenAPI 3.1 spec generated from Zod ([ADR-0018](docs/adr/0018-openapi-spec-from-zod.md))
+- [x] SSE idle timeout + HTTP drain on shutdown ([ADR-0021](docs/adr/0021-sse-and-http-drain-timeouts.md))
+- [x] Dashboard E2E active on PRs to `develop`
+- [x] Branch coverage raised from 60 % to 65 %
+- [x] Sigstore attestations on npm + container images ([ADR-0022](docs/adr/0022-sigstore-attestations.md))
 
 Exit criterion: an external reviewer can verify the release, read an OpenAPI
 contract, and run Aegis without exposing the host to env-based RCE.
@@ -55,7 +55,7 @@ contract, and run Aegis without exposing the host to env-based RCE.
 **Goal:** the tool friends recommend; good enough for a 10-person team.
 
 - [ ] `ag` alias + interactive `ag init` ([ADR-0023](docs/adr/0023-positioning-claude-code-control-plane.md))
-- [ ] `ag doctor` diagnostics command
+- [x] `ag doctor` diagnostics command
 - [ ] Official BYO LLM support: docs, `examples/byo-llm/`, CI mock smoke
 - [ ] Agent / skill / slash-command template gallery (`ag init --from-template`)
 - [ ] Remote-access guide (Tailscale, Cloudflare Tunnel, ngrok)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,7 +115,7 @@ Save the `id` — you'll need it for follow-up commands.
 
 > **Note:** `workDir` must be under an allowed directory. By default, Aegis allows `$HOME`, `/tmp`, and the current working directory. To restrict sessions to specific directories, set `allowedWorkDirs` in `.aegis/config.yaml` (or `aegis.config.json`). Changes are hot-reloaded without restart.
 
-## 4. Monitor Progress
+## 5. Monitor Progress
 
 Watch the session in the dashboard, or poll the API:
 
@@ -129,7 +129,7 @@ For real-time updates, use the SSE event stream:
 curl -N http://localhost:9100/v1/events
 ```
 
-## 5. Send a Follow-Up
+## 6. Send a Follow-Up
 
 ```bash
 curl -X POST http://localhost:9100/v1/sessions/a1b2c3d4/send \
@@ -137,7 +137,7 @@ curl -X POST http://localhost:9100/v1/sessions/a1b2c3d4/send \
   -d '{"text": "Now create a detailed plan to fix the issues you found."}'
 ```
 
-## 6. Read the Results
+## 7. Read the Results
 
 ```bash
 curl http://localhost:9100/v1/sessions/a1b2c3d4/read
@@ -145,7 +145,7 @@ curl http://localhost:9100/v1/sessions/a1b2c3d4/read
 
 This returns the parsed transcript — Claude Code's full response in structured JSON.
 
-## 7. Handle Permission Prompts
+## 8. Handle Permission Prompts
 
 When Claude Code asks for approval (e.g., to run a shell command or write a file), the session status changes to `permission_prompt`. Approve or reject:
 
@@ -168,7 +168,7 @@ You can also set `permissionMode` when creating a session to control approval be
 | `dontAsk` | Disables all permission prompts (fails on dangerous ops) |
 | `auto` | Claude decides when to prompt (context-dependent) |
 
-## 8. Run Multiple Sessions in Parallel
+## 9. Run Multiple Sessions in Parallel
 
 Aegis is designed for parallel orchestration. Each session runs in its own tmux window:
 
@@ -195,7 +195,7 @@ List all sessions:
 curl http://localhost:9100/v1/sessions
 ```
 
-## 9. Set Up MCP Integration
+## 10. Set Up MCP Integration
 
 Connect Aegis to Claude Code for native tool access:
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,249 @@
+# Aegis Onboarding Guide
+
+Welcome to Aegis. This guide gets you from zero to running your first session in 5 minutes.
+
+## What is Aegis?
+
+Aegis is a **Claude Code control plane** — a self-hosted server that wraps Claude Code sessions in tmux and exposes them via REST API, MCP tools, CLI, and a web dashboard. You orchestrate AI coding work programmatically or visually.
+
+**Use cases:**
+- Run multiple Claude Code sessions in parallel, monitored from one dashboard
+- Integrate Claude Code into your CI/CD pipelines via REST API
+- Give non-technical teammates a dashboard to monitor AI-assisted development
+- Build multi-agent workflows that delegate to Claude Code sessions
+
+## Prerequisites
+
+- **Node.js 20+**
+- **tmux 3.2+** (or psmux on Windows)
+- **Claude Code CLI** installed and configured (`claude --version`)
+
+Install tmux:
+```bash
+# Linux
+sudo apt install tmux
+
+# macOS
+brew install tmux
+
+# Windows (WSL2)
+sudo apt install tmux
+```
+
+## Quick Start
+
+```bash
+# 1. Install Aegis
+npm install -g @onestepat4time/aegis
+
+# 2. Bootstrap configuration (creates ~/.aegis/config.json)
+ag init
+
+# 3. Start the server
+ag
+```
+
+The server starts on `http://localhost:9100`. Open `http://localhost:9100/dashboard/` for the web UI.
+
+## Core Concepts
+
+### Sessions
+
+A **session** is one Claude Code process running in a tmux window. Each session has:
+- A unique ID (UUID)
+- A display name (e.g., `cc-my-task`)
+- A working directory
+- A JSONL transcript file
+
+Create a session:
+```bash
+curl -X POST http://localhost:9100/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"workDir": "/path/to/project", "prompt": "Review the PR and summarize the changes"}'
+```
+
+The response includes a session ID. Save it for subsequent API calls.
+
+### Session Lifecycle
+
+```
+create → working → permission_prompt? → idle → done
+                    ↑_______________|
+```
+
+1. **create** — Session starts, Claude Code initializes
+2. **working** — Claude Code is processing
+3. **permission_prompt** — Waiting for approval (see Permission Modes below)
+4. **idle** — Claude Code finished, ready for next prompt
+5. **done** — Session terminated
+
+Poll for status:
+```bash
+curl http://localhost:9100/v1/sessions/{id}
+```
+
+Read the transcript when idle:
+```bash
+curl http://localhost:9100/v1/sessions/{id}/read
+```
+
+Send a follow-up:
+```bash
+curl -X POST http://localhost:9100/v1/sessions/{id}/send \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Now implement the fix"}'
+```
+
+### Permission Modes
+
+When creating a session, choose how Claude Code handles sensitive operations:
+
+| Mode | Behavior |
+|------|----------|
+| `default` | Prompts for dangerous operations (recommended) |
+| `bypassPermissions` | Auto-approves every operation |
+| `plan` | Runs in plan mode first, waits for confirmation |
+| `acceptEdits` | Auto-accepts non-destructive edits only |
+| `dontAsk` | No prompts — fails on dangerous operations |
+| `auto` | Claude Code decides (context-dependent) |
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"workDir": "/path", "prompt": "...", "permissionMode": "bypassPermissions"}'
+```
+
+## CLI Reference
+
+```bash
+ag                          # Start the server
+ag "do something"           # Create session + send brief (shorthand)
+ag init                     # Bootstrap config interactively
+ag init --list-templates    # List available templates
+ag init --from-template X   # Scaffold from a template
+ag doctor                   # Run diagnostics
+ag mcp                      # Start MCP server (stdio mode)
+```
+
+### Built-in Templates
+
+Scaffold predefined Claude Code configurations:
+
+```bash
+ag init --list-templates    # See all templates
+ag init --from-template code-reviewer   # Review agent
+ag init --from-template pr-reviewer     # PR review agent
+ag init --from-template ci-runner       # CI quality gate
+ag init --from-template docs-writer     # Documentation agent
+```
+
+## MCP Integration
+
+Connect Aegis tools directly inside Claude Code. This lets Claude Code create sub-sessions, send prompts, and orchestrate other agents.
+
+```bash
+# Register Aegis MCP tools in Claude Code
+claude mcp add aegis -- npx @onestepat4time/aegis mcp
+```
+
+Aegis exposes **24 MCP tools** covering:
+- Session management (create, send, kill, interrupt, approve, reject)
+- Observability (transcript, metrics, SSE events, screenshots)
+- State (key-value memory bridge)
+- Orchestration (batch create, pipelines)
+
+See [MCP Tools](mcp-tools.md) for the full reference.
+
+## REST API
+
+All endpoints are under `/v1/`. Base URL: `http://localhost:9100`
+
+**Key endpoints:**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/health` | Server health check |
+| `POST` | `/v1/sessions` | Create a session |
+| `GET` | `/v1/sessions` | List all sessions |
+| `GET` | `/v1/sessions/:id` | Get session status |
+| `POST` | `/v1/sessions/:id/send` | Send a message |
+| `GET` | `/v1/sessions/:id/read` | Read transcript |
+| `DELETE` | `/v1/sessions/:id` | Kill session |
+| `GET` | `/v1/sessions/:id/sse` | SSE event stream |
+| `POST` | `/v1/sessions/:id/approve` | Approve permission |
+| `POST` | `/v1/sessions/:id/reject` | Reject permission |
+| `GET` | `/v1/metrics` | Prometheus metrics |
+| `GET` | `/v1/openapi.json` | OpenAPI 3.1 spec |
+
+See [API Reference](api-reference.md) for the full endpoint documentation.
+
+## Dashboard
+
+The web dashboard is at `http://localhost:9100/dashboard/`.
+
+Features:
+- Session list with live status
+- Session detail with transcript viewer
+- New session creation
+- Audit log
+- Settings
+
+The dashboard requires authentication. Run `ag init` to set up your auth token.
+
+## Configuration
+
+Config file: `~/.aegis/config.json`
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 9100,
+  "authToken": "your-secret-token",
+  "allowedWorkDirs": ["~/projects", "/tmp"],
+  "tmux": {
+    "socketName": "aegis"
+  }
+}
+```
+
+Environment variables override config values. Prefix with `AEGIS_`:
+- `AEGIS_HOST`, `AEGIS_PORT`, `AEGIS_AUTH_TOKEN`, `AEGIS_STATE_DIR`
+
+See [Configuration Reference](getting-started.md#configuration) for all options.
+
+## Troubleshooting
+
+**Server won't start:**
+```bash
+ag doctor   # Run diagnostics
+# Check: tmux installed? port 9100 free? Claude Code available?
+```
+
+**Session stuck on `permission_prompt`:**
+```bash
+curl -X POST http://localhost:9100/v1/sessions/{id}/approve
+# or reject:
+curl -X POST http://localhost:9100/v1/sessions/{id}/reject
+```
+
+**Claude Code not found:**
+```bash
+claude --version   # Verify installation
+export PATH="$PATH:$(which claude)"   # Add to PATH
+```
+
+**tmux not found:**
+```bash
+tmux -V   # Should print tmux version
+# If not: sudo apt install tmux (Linux) or brew install tmux (macOS)
+```
+
+See the [Troubleshooting](troubleshooting.md) guide for more.
+
+## Next Steps
+
+- [Getting Started](getting-started.md) — Full walkthrough
+- [API Reference](api-reference.md) — All REST endpoints
+- [MCP Tools](mcp-tools.md) — All MCP tool definitions
+- [Advanced Features](advanced.md) — Pipelines, templates, memory bridge
+- [Deployment Guide](deployment.md) — Production deployment

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -12,10 +12,10 @@ Download the release and verify its SHA-256 hash:
 
 ```bash
 # Download the release tarball
-curl -LO https://github.com/OneStepAt4time/aegis/releases/download/v0.5.3-preview/aegis-0.5.3-preview.tgz
+curl -LO https://github.com/OneStepAt4time/aegis/releases/download/v0.6.0-preview/aegis-0.6.0-preview.tgz
 
 # Verify the hash
-sha256sum aegis-0.5.3-preview.tgz
+sha256sum aegis-0.6.0-preview.tgz
 ```
 
 Compare the output against the `SHA256SUMS` file published in the release assets.
@@ -50,14 +50,14 @@ Download the Sigstore attestation bundle from the release assets, then verify:
 
 ```bash
 # Download release assets
-gh release download v0.5.3-preview --pattern '*.sigstore' --pattern 'checksums.txt' --dir /tmp
+gh release download v0.6.0-preview --pattern '*.sigstore' --pattern 'checksums.txt' --dir /tmp
 
 # Verify the attestation against the npm registry tarball
 cosign verify-blob-attestation \
   --certificate-identity-regexp 'https://github.com/OneStepAt4time/aegis/.github/workflows/release\\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --bundle /tmp/package.sigstore \
-  "https://registry.npmjs.org/@onestepat4time/aegis/-/aegis-0.5.3-preview.tgz"
+  "https://registry.npmjs.org/@onestepat4time/aegis/-/aegis-0.6.0-preview.tgz"
 ```
 
 ### What the Attestation Proves
@@ -108,7 +108,7 @@ Aegis uses semantic versioning: `MAJOR.MINOR.PATCH-preview`
 
 | Version | Meaning |
 |---------|---------|
-| `0.5.3-preview` | Pre-release, v0.5.3 with preview qualifier |
+| `0.6.0-preview` | Pre-release, v0.6.0 with preview qualifier |
 | `0.5.3` | Stable release |
 | `1.0.0` | First stable major release |
 


### PR DESCRIPTION
## Summary

Fixes 4 stale-reference bugs found during QA, updates ROADMAP Phase 1 status, and adds a new onboarding guide.

### Changes

**README.md**
- Fix "25 tools" → "24 tools" (actual MCP tool count)

**docs/getting-started.md**
- Fix duplicate `## 4.` heading (was lines 96 & 118)
- Renumber sections 4→10 correctly

**docs/verify-release.md**
- Update all `v0.5.3-preview` references to `v0.6.0-preview` (lines 15, 18, 53, 60, 111)

**ROADMAP.md**
- Mark all 8 Phase 1 items as complete ✅
- Mark `ag doctor` as done (Phase 2)

**docs/onboarding.md** (new)
- Getting-started guide for new users
- Covers: prerequisites, quick start, CLI reference, MCP, REST API, dashboard, troubleshooting, next steps

### Testing
- No code changes — docs only
- All version references verified against package.json v0.6.0-preview
- Section numbering verified contiguous

### Linked issues
- Fixes part of QA bug tracker (docs accuracy issues)