### PR TITLE
fix(metrics): call sessionCompleted/sessionFailed to update counters (#2067)

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -23,6 +23,7 @@ import { suppressedCatch } from './suppress.js';
 import { logger } from './logger.js';
 import { maybeInjectFault } from './fault-injection.js';
 import { type AlertManager } from './alerting.js';
+import { type MetricsCollector } from './metrics.js';
 
 export interface MonitorConfig {
   pollIntervalMs: number;       // Base poll interval (default: 30000 — hooks are primary signal)
@@ -153,6 +154,7 @@ export class SessionMonitor {
 
   /** Issue #1418: Alert manager for production alerting. */
   private alertManager?: AlertManager;
+  private metrics?: MetricsCollector;
 
   setTmuxManager(tmuxManager: TmuxManager): void {
     this.tmux = tmuxManager;
@@ -161,6 +163,11 @@ export class SessionMonitor {
   /** Issue #1418: Set the AlertManager for production alerting. */
   setAlertManager(alertManager: AlertManager): void {
     this.alertManager = alertManager;
+  }
+
+  /** Issue #2067: Set the MetricsCollector for completed/failed session counters. */
+  setMetrics(metrics: MetricsCollector): void {
+    this.metrics = metrics;
   }
 
   /** Issue #84: Set the JSONL watcher for fs.watch-based message detection. */
@@ -562,6 +569,8 @@ export class SessionMonitor {
             // Issue #1418: Report session failure to alerting
             this.alertManager?.recordFailure('session_failure',
               `Session "${session.windowName}" failed: ${errorDetail}`);
+            // Issue #2067: record session as failed
+            this.metrics?.sessionFailed(session.id);
           }
         } else if (signal.event === 'Stop') {
           logger.info({
@@ -577,6 +586,8 @@ export class SessionMonitor {
             this.makePayload('status.stopped', session,
               'Claude Code session ended normally'),
           );
+          // Issue #2067: record session as completed
+          this.metrics?.sessionCompleted(session.id);
         }
       }
     } catch (e) { suppressedCatch(e, 'monitor.checkStopSignals.parseEntry'); }

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -197,6 +197,8 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     if (!requirePermission(auth, req, reply, 'kill')) return;
     try {
       await sessions.killSession(session.id);
+      // Issue #2067: record session as failed before cleanup
+      metrics.sessionFailed(session.id);
       eventBus.emitEnded(session.id, 'killed');
       const auditLogger = getAuditLogger();
       if (auditLogger) void auditLogger.log(resolveAuditActor(auth, req.authKeyId, 'system'), 'session.kill', `Session killed: ${session.id} (permission=${req.matchedPermission ?? 'kill'})`, session.id);

--- a/src/server.ts
+++ b/src/server.ts
@@ -731,6 +731,7 @@ async function main(): Promise<void> {
   monitor.setTmuxManager(tmux);
   monitor.setAlertManager(alertManager);
   jsonlWatcher = new JsonlWatcher();
+  monitor.setMetrics(metrics);
   monitor.setJsonlWatcher(jsonlWatcher);
 
   container.register('tmuxManager', tmux, {


### PR DESCRIPTION
## Summary

Fixes #2067: Completed/Failed counters stuck at 0.

**Root cause:** `MetricsCollector.sessionCompleted()` and `sessionFailed()` existed but were never called — dead code.

**Fix:**
1. `session-actions.ts`: call `metrics.sessionFailed(session.id)` on DELETE /sessions/:id
2. `monitor.ts`: call `metrics.sessionCompleted()` on natural Stop signal; `sessionFailed()` on StopFailure/error signals
3. `monitor.ts`: added `setMetrics()` method (following existing pattern for setEventBus, setAlertManager)
4. `server.ts`: wired `monitor.setMetrics(metrics)`

**Tests:** 3233 passed