### PR TITLE
fix(validation): reject env var values containing CR/LF (#2065 follow-up)

### DIFF
--- a/src/__tests__/env-denylist-1392.test.ts
+++ b/src/__tests__/env-denylist-1392.test.ts
@@ -237,14 +237,11 @@ describe('Env var denylist — live Zod schema (Issues #1392 + #1908)', () => {
   });
 
   describe('Value hardening', () => {
-    it('strips CR/LF from values', () => {
+    it('rejects values containing CR/LF (Issue #2065 follow-up)', () => {
       const schema = buildEnvSchema();
-      const result = schema.safeParse({ MY_VAR: 'hello\r\nworld' });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const data = result.data as Record<string, string>;
-        expect(data.MY_VAR).toBe('helloworld');
-      }
+      expectRejection({ MY_VAR: 'hello\r\nworld' }, 'CR/LF');
+      expectRejection({ MY_VAR: 'hello\rworld' }, 'CR/LF');
+      expectRejection({ MY_VAR: 'hello\nworld' }, 'CR/LF');
     });
 
     it('rejects values with control characters', () => {
@@ -256,9 +253,9 @@ describe('Env var denylist — live Zod schema (Issues #1392 + #1908)', () => {
     });
 
     it('rejects values that are only CR, LF, or CRLF', () => {
-      expectRejection({ MY_VAR: '\r\n' }, 'only whitespace or control characters');
-      expectRejection({ MY_VAR: '\r' }, 'only whitespace or control characters');
-      expectRejection({ MY_VAR: '\n' }, 'only whitespace or control characters');
+      expectRejection({ MY_VAR: '\r\n' }, 'CR/LF');
+      expectRejection({ MY_VAR: '\r' }, 'CR/LF');
+      expectRejection({ MY_VAR: '\n' }, 'CR/LF');
     });
     it('allows TAB in values', () => {
       expectSuccess({ MY_VAR: 'hello\tworld' });

--- a/src/session.ts
+++ b/src/session.ts
@@ -781,15 +781,17 @@ export class SessionManager {
       if (DANGEROUS_ENV_VARS.has(key)) {
         throw new Error(`Forbidden env var: "${key}" — cannot override dangerous environment variables`);
       }
-      // Value hardening (Issue #1908)
-      const cleaned = stripCrLf(value);
-      if (hasControlChars(cleaned)) {
+      // Value hardening (Issue #1908): reject CR/LF and control chars
+      if (/[\r\n]/.test(value)) {
+        throw new Error(`Forbidden env var value for "${key}" — contains CR/LF characters`);
+      }
+      if (hasControlChars(value)) {
         throw new Error(`Forbidden env var value for "${key}" — contains control characters`);
       }
-      if (Buffer.byteLength(cleaned, 'utf-8') > ENV_VALUE_MAX_BYTES) {
+      if (Buffer.byteLength(value, 'utf-8') > ENV_VALUE_MAX_BYTES) {
         throw new Error(`Env var "${key}" value exceeds ${ENV_VALUE_MAX_BYTES} byte limit`);
       }
-      mergedEnv[key] = cleaned;
+      mergedEnv[key] = value;
     }
     const hasEnv = Object.keys(mergedEnv).length > 0;
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -528,21 +528,29 @@ export function buildEnvSchema(
         });
         continue;
       }
-      // Value hardening
-      const value = stripCrLf(rawValue);
-      if (value.length === 0) {
+      // Value hardening: reject CR/LF and other control characters
+      if (/[\r\n]/.test(rawValue)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: [key],
-          message: `Forbidden env var value for "${key}" — value is only whitespace or control characters`,
+          message: `Forbidden env var value for "${key}" — contains CR/LF characters`,
         });
         continue;
       }
-      if (hasControlChars(value)) {
+      if (hasControlChars(rawValue)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: [key],
           message: `Forbidden env var value for "${key}" — contains control characters`,
+        });
+        continue;
+      }
+      const value = rawValue;
+      if (value.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Forbidden env var value for "${key}" — value is empty`,
         });
         continue;
       }


### PR DESCRIPTION
## Summary

Follow-up to #2070 — the previous CR/LF fix was incomplete.

**Problem:** Values like `hello\r\nworld` were stripped to `hello\nworld` and accepted. Attackers could still inject CRLF.

**Fix:** Reject ANY value containing CR or LF at validation layer (src/validation.ts) AND runtime env prep (src/session.ts).

**Files changed:**
- `src/validation.ts` — reject CR/LF at Zod schema validation
- `src/session.ts` — reject CR/LF at runtime env merge
- `src/__tests__/env-denylist-1392.test.ts` — updated tests for new behavior

**Tests:** 3253 passed (64 env-denylist suite)