### PR TITLE
feat(dashboard): Phase 2 polish — empty state CTAs, coach chips, e2e fixes

### DIFF
--- a/dashboard/e2e/helpers/dashboard-fixtures.ts
+++ b/dashboard/e2e/helpers/dashboard-fixtures.ts
@@ -3,6 +3,7 @@ import { authenticate } from './auth';
 
 export const MOBILE_SESSION_ID = 'sess-mobile';
 export const QUESTION_SESSION_ID = 'sess-question';
+export const SESSION_COCKPIT_ID = 'sess-cockpit';
 
 function json(route: Route, body: unknown): Promise<void> {
   return route.fulfill({
@@ -26,7 +27,9 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
       ? 'Mobile dashboard pass'
       : id === QUESTION_SESSION_ID
         ? 'Answer product question'
-        : 'Quiet docs sync',
+        : id === SESSION_COCKPIT_ID
+          ? 'Cockpit regression'
+          : 'Quiet docs sync',
     workDir: 'D:\\src\\aegis\\dashboard',
     byteOffset: 0,
     monitorOffset: 0,
@@ -65,6 +68,11 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
       createdAt: now - 3 * 60 * 60 * 1000,
       lastActivity: now - 9 * 60 * 1000,
       permissionMode: 'plan',
+    }),
+    makeSession(SESSION_COCKPIT_ID, 'idle', {
+      createdAt: now - 2 * 60 * 1000,
+      lastActivity: now - 30 * 1000,
+      permissionMode: 'bypassPermissions',
     }),
   ];
 
@@ -111,6 +119,18 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
       sessionAge: 3 * 60 * 60 * 1000,
       details: 'Claude is idle, awaiting input.',
     },
+    [SESSION_COCKPIT_ID]: {
+      alive: true,
+      windowExists: true,
+      claudeRunning: true,
+      paneCommand: 'claude',
+      status: 'idle',
+      hasTranscript: true,
+      lastActivity: now - 30_000,
+      lastActivityAgo: 30_000,
+      sessionAge: 2 * 60 * 1000,
+      details: null,
+    },
   };
 
   const sessionMetricsById = {
@@ -140,6 +160,15 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
       autoApprovals: 1,
       statusChanges: ['working', 'idle'],
       tokenUsage: { inputTokens: 1400, outputTokens: 900, cacheCreationTokens: 40, cacheReadTokens: 20, estimatedCostUsd: 0.12 },
+    },
+    [SESSION_COCKPIT_ID]: {
+      durationSec: 124,
+      messages: 3,
+      toolCalls: 1,
+      approvals: 0,
+      autoApprovals: 0,
+      statusChanges: [],
+      tokenUsage: { inputTokens: 116800, outputTokens: 1700, cacheCreationTokens: 0, cacheReadTokens: 129700, estimatedCostUsd: 0.414 },
     },
   };
 
@@ -180,6 +209,16 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
     'sess-idle': {
       messages: [
         { role: 'assistant', contentType: 'text', text: 'Docs sync completed successfully.', timestamp: new Date(now - 540_000).toISOString() },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    },
+    [SESSION_COCKPIT_ID]: {
+      messages: [
+        { role: 'user', contentType: 'text', text: 'Review the README.', timestamp: new Date(now - 60_000).toISOString() },
+        { role: 'assistant', contentType: 'text', text: 'Here is the review…', timestamp: new Date(now - 50_000).toISOString() },
+        { role: 'assistant', contentType: 'tool_use', text: '', toolName: 'Read', timestamp: new Date(now - 45_000).toISOString() },
       ],
       status: 'idle',
       statusText: null,

--- a/dashboard/e2e/session-cockpit.spec.ts
+++ b/dashboard/e2e/session-cockpit.spec.ts
@@ -29,27 +29,49 @@ const DASHBOARD_BASE_URL = 'http://localhost:5200/dashboard/';
 const SESSION_ID = 'sess-cockpit';
 
 async function mockSessionCockpit(page: import('@playwright/test').Page): Promise<void> {
-  await mockDashboardFixtures(page);
+  // Inject fetch mock BEFORE page loads — intercepts all session requests.
+  await page.addInitScript(() => {
+    const SESSION_ID = 'sess-cockpit';
+    const now = Date.now();
+    const sessionDetail = {
+      id: SESSION_ID, windowId: `@${SESSION_ID}`, windowName: 'Cockpit regression',
+      workDir: 'D:\\src\\aegis', byteOffset: 0, monitorOffset: 0,
+      status: 'idle', createdAt: now - 120_000, lastActivity: now - 30_000,
+      stallThresholdMs: 300_000, permissionMode: 'bypassPermissions',
+      ownerKeyId: `${SESSION_ID}-owner`,
+    };
+    const sessionHealth = { sessionId: SESSION_ID, alive: true, status: 'idle', lastActivity: now - 30_000, details: null, windowExists: true, claudeRunning: true, paneCommand: 'claude' };
+    const sessionMessages = { messages: [
+      { role: 'user', contentType: 'text', text: 'Review the README.', timestamp: new Date(now - 60_000).toISOString() },
+      { role: 'assistant', contentType: 'text', text: 'Here is the review…', timestamp: new Date(now - 50_000).toISOString() },
+      { role: 'assistant', contentType: 'tool_use', text: '', toolName: 'Read', timestamp: new Date(now - 45_000).toISOString() },
+    ], status: 'idle', statusText: null, interactiveContent: null };
+    const sessionMetrics = { durationSec: 124, messages: 3, toolCalls: 1, approvals: 0, autoApprovals: 0, statusChanges: [], tokenUsage: { inputTokens: 116800, outputTokens: 1700, cacheCreationTokens: 0, cacheReadTokens: 129700, estimatedCostUsd: 0.414 } };
+    const sessionLatency = { sessionId: SESSION_ID, realtime: null, aggregated: null };
 
-  await page.route(`**/v1/sessions/${SESSION_ID}`, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        id: SESSION_ID,
-        windowId: `@${SESSION_ID}`,
-        windowName: 'Cockpit regression',
-        workDir: 'D:\\src\\aegis',
-        byteOffset: 0,
-        monitorOffset: 0,
-        status: 'idle',
-        createdAt: Date.now() - 120_000,
-        lastActivity: Date.now() - 30_000,
-        stallThresholdMs: 300_000,
-        permissionMode: 'bypassPermissions',
-      }),
-    }),
-  );
+    const origFetch = window.fetch;
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : (input as URL).href;
+      if (url.endsWith(`/v1/sessions/${SESSION_ID}`)) {
+        return new Response(JSON.stringify(sessionDetail), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.endsWith(`/v1/sessions/${SESSION_ID}/health`)) {
+        return new Response(JSON.stringify(sessionHealth), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.endsWith(`/v1/sessions/${SESSION_ID}/messages`)) {
+        return new Response(JSON.stringify(sessionMessages), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.endsWith(`/v1/sessions/${SESSION_ID}/metrics`)) {
+        return new Response(JSON.stringify(sessionMetrics), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.endsWith(`/v1/sessions/${SESSION_ID}/latency`)) {
+        return new Response(JSON.stringify(sessionLatency), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return origFetch(input, init);
+    };
+  });
+
+  await mockDashboardFixtures(page);
 
   await page.route(`**/v1/sessions/${SESSION_ID}/health`, (route) =>
     route.fulfill({
@@ -139,13 +161,14 @@ test.describe('Session Cockpit — regression pins', () => {
   test('Metrics tab renders the condensed KPI banner (issue 04.1)', async ({ page }) => {
     await page.getByRole('tab', { name: /^Metrics$/ }).click();
 
-    // Six banner labels.
+    // Six banner labels (Duration / Messages / Tool calls / Approvals / Auto / Model).
+    // Model — issue 04.9: per-model accent colors replace the "Status" label.
     await expect(page.getByText('Duration', { exact: true })).toBeVisible();
     await expect(page.getByText('Messages', { exact: true })).toBeVisible();
     await expect(page.getByText('Tool calls', { exact: true })).toBeVisible();
     await expect(page.getByText('Approvals', { exact: true })).toBeVisible();
     await expect(page.getByText('Auto', { exact: true })).toBeVisible();
-    await expect(page.getByText('Status', { exact: true })).toBeVisible();
+    await expect(page.getByText('Model', { exact: true })).toBeVisible();
 
     // Old 6-card label must not render.
     await expect(page.getByText('Auto-approvals', { exact: true })).toHaveCount(0);

--- a/dashboard/src/components/session/TranscriptView.tsx
+++ b/dashboard/src/components/session/TranscriptView.tsx
@@ -201,7 +201,29 @@ export function TranscriptView({ sessionId }: TranscriptViewProps) {
               aria-hidden="true"
             />
             <div className="text-sm">No messages yet</div>
-            <div className="text-xs opacity-60 font-mono">⌘↵ to send · /help for commands · /cost to check spend</div>
+            <div className="text-xs opacity-60 font-mono">⌘↵ to send · /model · /bash</div>
+            <div className="flex flex-wrap justify-center gap-2 mt-1">
+              {['/model', '/bash', '/help', '/cost', '/status'].map((cmd) => (
+                <button
+                  key={cmd}
+                  type="button"
+                  onClick={() => {
+                    window.dispatchEvent(new CustomEvent('coach:fill-input', { detail: cmd }));
+                    // Attempt to fill the desktop/mobile input directly as fallback
+                    const input = document.querySelector<HTMLInputElement>('#session-message-input-desktop, #session-message-input-mobile');
+                    if (input) {
+                      const nativeSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+                      nativeSetter?.call(input, cmd);
+                      input.dispatchEvent(new Event('input', { bubbles: true }));
+                      input.focus();
+                    }
+                  }}
+                  className="px-2 py-1 text-xs font-mono rounded bg-[var(--color-void-lighter)] text-[var(--color-text-muted)] hover:bg-[var(--color-void-light)] hover:text-[var(--color-text-primary)] transition-colors"
+                >
+                  {cmd}
+                </button>
+              ))}
+            </div>
           </div>
         )}
         {filteredMessages.length > 0 && (

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -619,6 +619,18 @@ export default function SessionHistoryPage() {
                         icon={<SearchX className="h-8 w-8" />}
                         title="No session history records found"
                         description="Try adjusting your filters or date range."
+                        action={
+                          <button
+                            className="mt-4 px-4 py-2 text-sm rounded-lg bg-zinc-700 hover:bg-zinc-600 transition-colors"
+                            onClick={() => {
+                              setFilterSearch('');
+                              setFilterStatus('all');
+                              setFilterDateRange('7d');
+                            }}
+                          >
+                            Clear all filters
+                          </button>
+                        }
                       />
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

Phase 2 dashboard polish — three targeted fixes:

### 1. Grid orphan fix (MetricCards.tsx)
Already committed — 'Avg Channel Latency' card span corrected from `col-span-1 lg:col-span-2` → `col-span-2 lg:col-span-4`, eliminating the orphan on its own row.

### 2. Empty state CTA (SessionHistoryPage.tsx)
Added 'Clear all filters' button to the empty state in session history when filters return no results.

### 3. Coach chips (TranscriptView.tsx)
Added auto-fill chip buttons (`/model`, `/bash`, `/help`, `/cost`, `/status`) to the 'No messages yet' empty state. Clicking dispatches a `coach:fill-input` custom event and directly fills the message input as fallback.

### 4. E2E fixture + test fixes (session-cockpit.spec.ts, dashboard-fixtures.ts)
- Added `sess-cockpit` to `mockDashboardFixtures` (session list, health, metrics, messages, latency)
- Fixed 'Status' → 'Model' label expectation per issue 04.9 spec (per-model accent colors replace Status)
- Switched to `addInitScript` fetch mock for reliability

## Verification

- `npm test -- --run` → 638 passed, 2 skipped ✅
- `npm run build` → built in 1.18s ✅

## Tagged for review
@argus — PR ready for review.