### PR TITLE
fix: restore SECURITY.md full policy content

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,36 @@
-# security
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.5.x-alpha (current) | :white_check_mark: |
+| Older alpha builds | :x: |
+| Legacy non-alpha lines | :x: |
+
+> Aegis currently ships in the alpha channel only. Legacy version lines are retired and no longer receive security fixes.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Aegis, please report it responsibly:
+
+1. **Preferred**: Open a [GitHub Security Advisory](https://github.com/OneStepAt4time/aegis/security). This keeps the report private until a fix is released.
+2. **Fallback**: Use the [Security Vulnerability issue template](https://github.com/OneStepAt4time/aegis/issues/new?template=security.yml). Maintainers will move it to a private advisory if needed.
+3. Include a description of the vulnerability, steps to reproduce, and potential impact.
+4. We will acknowledge receipt within 48 hours and provide a timeline for the fix.
+
+## Security Measures
+
+Aegis implements the following security controls:
+
+- **Authentication**: API key-based auth with optional master token
+- **Session ownership**: All action routes enforce ownership — non-owning API keys cannot send/interrupt/kill sessions unless admin or master token
+- **Input validation**: Path traversal prevention, env var name validation, Zod schema validation on all routes
+- **Env var denylist**: CreateSession rejects dangerous env vars (AI provider keys, credentials, shell vars) and prefix-blocked vars (npm_config_, SSH_, GIT_ etc.)
+- **SSRF protection**: URL scheme and private IP range validation
+- **Command injection prevention**: Port validation, safe exec patterns
+- **Transport security**: Recommended behind HTTPS reverse proxy
+
+## Security Updates
+
+Security patches are released through the active alpha line. We recommend upgrading to the latest published alpha immediately.


### PR DESCRIPTION
## Summary

SECURITY.md was reduced to `# security` — a Copilot artifact that stripped the entire security policy from the repository.

## What was lost

The `# security` placeholder removed:
- **Supported Versions** table (0.5.x-alpha only)
- **Vulnerability Reporting** process (GH Security Advisory + issue template fallback)
- **Security Measures** documentation covering:
  - API key auth with master token
  - Session ownership enforcement
  - Input validation (path traversal, env var validation, Zod schemas)
  - Env var denylist (AI provider keys, shell vars, prefix-blocked vars)
  - SSRF protection
  - Command injection prevention
  - Transport security guidance
- **Security Updates** policy

## Fix

Restored the full original SECURITY.md content from PR #2017 diff (authored by Emanuele).

## Security relevance

Users and security researchers rely on SECURITY.md to understand:
1. What versions receive patches
2. How to report vulnerabilities responsibly
3. What security controls are already in place

A gutted SECURITY.md actively harms the security posture by discouraging responsible disclosure and hiding the security model.

## Verification

- `git diff` confirms 36 lines restored
- No code changes — documentation only
- `npm run gate` should pass (no production files touched)

## Tagged for review

@argus — security docs restoration. 36-line change to a single markdown file.