### PR TITLE
feat: Helm chart v1 for Kubernetes deployments (#2083)

### DIFF
--- a/charts/aegis/.helmignore
+++ b/charts/aegis/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.gitignore
+.github/
+.idea/
+*.swp
+*.tmp
+*.bak

--- a/charts/aegis/Chart.yaml
+++ b/charts/aegis/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: aegis
+description: Deploy Aegis — the control plane for Claude Code — on Kubernetes.
+type: application
+# Chart version follows SemVer 2. Bump on each chart change.
+version: 0.6.0-preview
+# appVersion tracks the Aegis container image tag (sourced from package.json).
+appVersion: "0.6.0-preview"
+home: https://github.com/OneStepAt4time/aegis
+sources:
+  - https://github.com/OneStepAt4time/aegis
+keywords:
+  - aegis
+  - claude-code
+  - mcp
+  - tmux
+  - ai
+maintainers:
+  - name: OneStepAt4time
+    url: https://github.com/OneStepAt4time

--- a/charts/aegis/README.md
+++ b/charts/aegis/README.md
@@ -1,0 +1,144 @@
+# Aegis Helm Chart
+
+Deploys [Aegis](https://github.com/OneStepAt4time/aegis) — the control plane for Claude Code — on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.8+
+
+## Install
+
+```bash
+helm repo add aegis https://onestepat4time.github.io/aegis
+helm install aegis aegis/aegis \
+  --namespace aegis \
+  --create-namespace \
+  --set auth.token="your-secret-token"
+```
+
+Or from a local checkout:
+
+```bash
+helm install aegis ./charts/aegis \
+  --namespace aegis \
+  --create-namespace \
+  --set auth.token="your-secret-token"
+```
+
+## Upgrade
+
+```bash
+helm upgrade aegis ./charts/aegis \
+  --namespace aegis \
+  --reuse-values \
+  --set image.tag="0.7.0"
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `replicaCount` | int | `1` | Number of replicas (must be 1 — local state) |
+| `image.repository` | string | `ghcr.io/onestepat4time/aegis` | Container image repository |
+| `image.tag` | string | `""` (uses `appVersion`) | Container image tag |
+| `image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
+| `aegis.host` | string | `"0.0.0.0"` | Bind address (`AEGIS_HOST`) |
+| `aegis.port` | int | `9100` | HTTP port (`AEGIS_PORT`) |
+| `aegis.tmuxSession` | string | `"aegis"` | tmux session prefix (`AEGIS_TMUX_SESSION`) |
+| `aegis.stateDir` | string | `/var/lib/aegis` | State dir mounted from PVC (`AEGIS_STATE_DIR`) |
+| `aegis.extraEnv` | list | `[]` | Additional env vars (`{name, value}` or `{name, valueFrom}`) |
+| `aegis.extraEnvFrom` | list | `[]` | Additional `envFrom` entries |
+| `auth.token` | string | `""` | Inline API token stored in a generated Secret |
+| `auth.existingSecret` | string | `""` | Existing Secret name (overrides `auth.token`) |
+| `auth.existingSecretKey` | string | `AEGIS_AUTH_TOKEN` | Key inside the Secret |
+| `serviceAccount.create` | bool | `true` | Create a dedicated ServiceAccount |
+| `serviceAccount.name` | string | `""` | Override ServiceAccount name |
+| `serviceAccount.annotations` | object | `{}` | ServiceAccount annotations |
+| `service.type` | string | `ClusterIP` | Service type |
+| `service.port` | int | `9100` | Service port |
+| `service.portName` | string | `"http"` | Named port |
+| `ingress.enabled` | bool | `false` | Create an Ingress resource |
+| `ingress.className` | string | `"nginx"` | Ingress class name |
+| `ingress.annotations` | object | `{}` | Ingress annotations |
+| `ingress.hosts` | list | `[aegis.local]` | Host/path rules |
+| `ingress.tls` | list | `[]` | TLS configuration |
+| `persistence.enabled` | bool | `true` | Enable persistent storage |
+| `persistence.size` | string | `1Gi` | PVC storage size |
+| `persistence.storageClass` | string | `""` | StorageClass (cluster default if empty) |
+| `persistence.accessModes` | list | `["ReadWriteOnce"]` | PVC access modes |
+| `persistence.existingClaim` | string | `""` | Use an existing PVC |
+| `configMap.enabled` | bool | `false` | Create a ConfigMap for env vars |
+| `configMap.data` | object | `{}` | ConfigMap key-value pairs |
+| `probes.path` | string | `/v1/health` | Health check HTTP path |
+| `probes.liveness.*` | object | see values | Liveness probe tuning |
+| `probes.readiness.*` | object | see values | Readiness probe tuning |
+| `resources` | object | `{}` | Pod resource requests/limits |
+| `autoscaling.enabled` | bool | `false` | Create an HPA (not yet supported >1 replica) |
+| `autoscaling.minReplicas` | int | `1` | HPA minimum replicas |
+| `autoscaling.maxReplicas` | int | `3` | HPA maximum replicas |
+| `autoscaling.targetCPUUtilizationPercentage` | int | `80` | HPA CPU target |
+| `nodeSelector` | object | `{}` | Node selector labels |
+| `tolerations` | list | `[]` | Pod tolerations |
+| `affinity` | object | `{}` | Pod affinity rules |
+| `extraVolumes` | list | `[]` | Additional pod volumes |
+| `extraVolumeMounts` | list | `[]` | Additional container volume mounts |
+| `terminationGracePeriodSeconds` | int | `30` | Pod termination grace period |
+
+## Examples
+
+### Minimal install with auth
+
+```bash
+helm install aegis ./charts/aegis \
+  --set auth.token="s3cret" \
+  --set persistence.size=5Gi
+```
+
+### With nginx Ingress and TLS
+
+```bash
+helm install aegis ./charts/aegis \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set 'ingress.hosts[0].host=aegis.example.com' \
+  --set 'ingress.tls[0].secretName=aegis-tls' \
+  --set 'ingress.tls[0].hosts[0]=aegis.example.com' \
+  --set ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt-prod
+```
+
+### Using an existing Secret for auth
+
+```bash
+helm install aegis ./charts/aegis \
+  --set auth.existingSecret=my-aegis-secret \
+  --set auth.existingSecretKey=AUTH_TOKEN
+```
+
+### Injecting Claude auth via extraVolumes
+
+```bash
+helm install aegis ./charts/aegis \
+  --set 'extraVolumes[0].name=claude-auth' \
+  --set 'extraVolumes[0].secret.secretName=claude-auth-secret' \
+  --set 'extraVolumeMounts[0].name=claude-auth' \
+  --set 'extraVolumeMounts[0].mountPath=/home/aegis/.claude'
+```
+
+### Resource limits
+
+```bash
+helm install aegis ./charts/aegis \
+  --set 'resources.requests.cpu=250m' \
+  --set 'resources.requests.memory=256Mi' \
+  --set 'resources.limits.cpu=1' \
+  --set 'resources.limits.memory=512Mi'
+```
+
+## Architecture notes
+
+- Aegis runs as a **StatefulSet** because session state is stored on local disk.
+- The chart enforces `replicaCount: 1` via a validation helper. Scaling beyond
+  1 replica requires external state storage (planned for a future phase).
+- A headless Service provides stable network identity for the StatefulSet.
+- The HPA template is included for forward-compatibility but is disabled by default.

--- a/charts/aegis/templates/NOTES.txt
+++ b/charts/aegis/templates/NOTES.txt
@@ -1,0 +1,23 @@
+1. Aegis has been deployed as a StatefulSet named {{ include "aegis.fullname" . }}.
+
+2. The Kubernetes Service is available at:
+   http://{{ include "aegis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+3. Health checks are wired to:
+   {{ .Values.probes.path }}
+
+4. {{- if or .Values.auth.token .Values.auth.existingSecret }}
+   Retrieve the auth token from:
+   Secret {{ include "aegis.authSecretName" . }} key {{ .Values.auth.existingSecretKey }}
+   {{- else }}
+   No auth token configured — set auth.token or auth.existingSecret.
+   {{- end }}
+
+5. {{- if .Values.ingress.enabled }}
+   Ingress is active at:
+   {{- range .Values.ingress.hosts }}
+   https://{{ .host }}
+   {{- end }}
+   {{- else }}
+   Ingress is disabled. Enable with ingress.enabled=true.
+   {{- end }}

--- a/charts/aegis/templates/_helpers.tpl
+++ b/charts/aegis/templates/_helpers.tpl
@@ -1,0 +1,108 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aegis.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "aegis.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "aegis.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label value.
+*/}}
+{{- define "aegis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{/*
+Common selector labels.
+*/}}
+{{- define "aegis.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aegis.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "aegis.labels" -}}
+helm.sh/chart: {{ include "aegis.chart" . }}
+{{ include "aegis.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "aegis.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "aegis.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Headless Service name (for StatefulSet network identity).
+*/}}
+{{- define "aegis.headlessServiceName" -}}
+{{- printf "%s-headless" (include "aegis.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Container image reference.
+*/}}
+{{- define "aegis.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+State volume name.
+*/}}
+{{- define "aegis.stateVolumeName" -}}data{{- end -}}
+
+{{/*
+Auth Secret name.
+*/}}
+{{- define "aegis.authSecretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "aegis.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ConfigMap name.
+*/}}
+{{- define "aegis.configMapName" -}}
+{{- printf "%s-config" (include "aegis.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Validation: enforce single-replica and sane persistence config.
+*/}}
+{{- define "aegis.validate" -}}
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "Aegis currently supports replicaCount=1 only because session state is local to the pod." -}}
+{{- end -}}
+{{- if and (not .Values.persistence.enabled) .Values.persistence.existingClaim -}}
+{{- fail "persistence.existingClaim requires persistence.enabled=true." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/aegis/templates/configmap.yaml
+++ b/charts/aegis/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.configMap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aegis.configMapName" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.configMap.data | nindent 2 }}
+{{- end }}

--- a/charts/aegis/templates/headless-service.yaml
+++ b/charts/aegis/templates/headless-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aegis.headlessServiceName" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.headlessService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.portName }}
+      protocol: TCP
+  selector:
+    {{- include "aegis.selectorLabels" . | nindent 4 }}

--- a/charts/aegis/templates/hpa.yaml
+++ b/charts/aegis/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "aegis.fullname" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "aegis.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/aegis/templates/ingress.yaml
+++ b/charts/aegis/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "aegis.fullname" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "aegis.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/aegis/templates/pvc.yaml
+++ b/charts/aegis/templates/pvc.yaml
@@ -1,0 +1,5 @@
+{{- if and .Values.persistence.enabled .Values.persistence.existingClaim (not .Values.persistence.existingClaim) }}
+{{/* PVC is only rendered standalone when NOT using existingClaim and NOT inside a StatefulSet.
+     For StatefulSet the volumeClaimTemplate handles provisioning, so this file is a no-op.
+     Kept for Deployments or standalone use. */}}
+{{- end }}

--- a/charts/aegis/templates/secret.yaml
+++ b/charts/aegis/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (not .Values.auth.existingSecret) .Values.auth.token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "aegis.authSecretName" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.existingSecretKey }}: {{ .Values.auth.token | quote }}
+{{- end }}

--- a/charts/aegis/templates/service.yaml
+++ b/charts/aegis/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aegis.fullname" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.portName }}
+      protocol: TCP
+  selector:
+    {{- include "aegis.selectorLabels" . | nindent 4 }}

--- a/charts/aegis/templates/serviceaccount.yaml
+++ b/charts/aegis/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aegis.serviceAccountName" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/aegis/templates/statefulset.yaml
+++ b/charts/aegis/templates/statefulset.yaml
@@ -1,0 +1,179 @@
+{{- include "aegis.validate" . -}}
+{{- $usesGeneratedClaim := and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- $mountPath := .Values.aegis.stateDir }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "aegis.fullname" . }}
+  labels:
+    {{- include "aegis.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "aegis.headlessServiceName" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "aegis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "aegis.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or (and (not .Values.auth.existingSecret) .Values.auth.token) .Values.podAnnotations .Values.configMap.enabled }}
+      annotations:
+        {{- if and (not .Values.auth.existingSecret) .Values.auth.token }}
+        checksum/auth-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.configMap.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "aegis.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: aegis
+          image: {{ include "aegis.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.aegis.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.aegis.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: {{ .Values.service.portName }}
+              containerPort: {{ .Values.aegis.port }}
+              protocol: TCP
+          env:
+            - name: AEGIS_HOST
+              value: {{ .Values.aegis.host | quote }}
+            - name: AEGIS_PORT
+              value: {{ printf "%v" .Values.aegis.port | quote }}
+            - name: AEGIS_STATE_DIR
+              value: {{ $mountPath | quote }}
+            - name: AEGIS_TMUX_SESSION
+              value: {{ .Values.aegis.tmuxSession | quote }}
+            {{- if or .Values.auth.token .Values.auth.existingSecret }}
+            - name: AEGIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aegis.authSecretName" . }}
+                  key: {{ .Values.auth.existingSecretKey }}
+            {{- end }}
+            {{- with .Values.aegis.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.aegis.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.configMap.enabled }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "aegis.configMapName" . }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.path | quote }}
+              port: {{ .Values.service.portName }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.liveness.successThreshold }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.path | quote }}
+              port: {{ .Values.service.portName }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          volumeMounts:
+            - name: {{ include "aegis.stateVolumeName" . }}
+              mountPath: {{ $mountPath | quote }}
+              {{- with .Values.persistence.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if or (not $usesGeneratedClaim) .Values.extraVolumes }}
+      volumes:
+        {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+        - name: {{ include "aegis.stateVolumeName" . }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+        {{- else if not .Values.persistence.enabled }}
+        - name: {{ include "aegis.stateVolumeName" . }}
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if $usesGeneratedClaim }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "aegis.stateVolumeName" . }}
+        labels:
+          {{- include "aegis.selectorLabels" . | nindent 10 }}
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        volumeMode: {{ .Values.persistence.volumeMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/charts/aegis/values.yaml
+++ b/charts/aegis/values.yaml
@@ -1,0 +1,209 @@
+# -- Override the chart name used for resource names.
+nameOverride: ""
+
+# -- Override the fully qualified app name.
+fullnameOverride: ""
+
+# -- Number of Aegis replicas. Keep at 1 — Aegis stores session state locally.
+replicaCount: 1
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+
+image:
+  # -- Container image repository.
+  repository: ghcr.io/onestepat4time/aegis
+  # -- Container image tag. When empty, the chart appVersion is used.
+  tag: ""
+  # -- Container image pull policy.
+  pullPolicy: IfNotPresent
+
+aegis:
+  # -- Bind host passed to AEGIS_HOST.
+  host: "0.0.0.0"
+  # -- HTTP port passed to AEGIS_PORT.
+  port: 9100
+  # -- tmux session prefix passed to AEGIS_TMUX_SESSION.
+  tmuxSession: aegis
+  # -- State directory mounted from PVC and passed to AEGIS_STATE_DIR.
+  stateDir: /var/lib/aegis
+  # -- Override container entrypoint. Leave empty to use the image default.
+  command: []
+  # -- Override container arguments. Leave empty to use the image default.
+  args: []
+  # -- Additional environment variables (list of {name, value} or {name, valueFrom} objects).
+  extraEnv: []
+  # -- Additional envFrom entries appended to the container.
+  extraEnvFrom: []
+
+auth:
+  # -- Inline API token stored in a generated Secret and exposed as AEGIS_AUTH_TOKEN.
+  token: ""
+  # -- Existing Secret name containing the API token. Takes precedence over auth.token.
+  existingSecret: ""
+  # -- Key inside the Secret that holds the API token.
+  existingSecretKey: AEGIS_AUTH_TOKEN
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount for the pod.
+  create: true
+  # -- Annotations applied to the ServiceAccount.
+  annotations: {}
+  # -- ServiceAccount name. When create=false, uses this or "default".
+  name: ""
+  # -- Mount a Kubernetes service account token into the pod.
+  automountServiceAccountToken: false
+
+# -- Extra annotations for the pod template.
+podAnnotations: {}
+
+# -- Extra labels for the pod template.
+podLabels: {}
+
+# -- Pod-level security context.
+podSecurityContext: {}
+#  fsGroup: 1000
+#  runAsNonRoot: true
+
+# -- Container-level security context.
+securityContext: {}
+#  readOnlyRootFilesystem: true
+#  runAsUser: 1000
+#  capabilities:
+#    drop:
+#      - ALL
+
+service:
+  # -- Annotations applied to the Service.
+  annotations: {}
+  # -- Service type.
+  type: ClusterIP
+  # -- Port exposed by the Service.
+  port: 9100
+  # -- Named port used by Service and probes.
+  portName: http
+
+headlessService:
+  # -- Annotations applied to the StatefulSet governing Service.
+  annotations: {}
+
+ingress:
+  # -- Create an Ingress resource.
+  enabled: false
+  # -- Ingress class name (e.g. "nginx").
+  className: "nginx"
+  # -- Annotations applied to the Ingress.
+  annotations: {}
+  #  cert-manager.io/cluster-issuer: letsencrypt-prod
+  # -- Host and path rules.
+  hosts:
+    - host: aegis.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration.
+  tls: []
+  #  - secretName: aegis-tls
+  #    hosts:
+  #      - aegis.example.com
+
+persistence:
+  # -- Enable persistent storage for session state and audit logs.
+  enabled: true
+  # -- Use an existing PVC instead of a volumeClaimTemplate.
+  existingClaim: ""
+  # -- Annotations on the generated PVC / volumeClaimTemplate.
+  annotations: {}
+  # -- Access modes for the PVC.
+  accessModes:
+    - ReadWriteOnce
+  # -- Requested storage size.
+  size: 1Gi
+  # -- StorageClass name. Empty = cluster default.
+  storageClass: ""
+  # -- Volume mode.
+  volumeMode: Filesystem
+  # -- Optional subPath to mount from the PV.
+  subPath: ""
+
+# -- Configuration values rendered as a ConfigMap and mounted as env vars.
+# Each key is uppercased and prefixed with AEGIS_ automatically when loaded
+# via extraEnvFrom. For direct env control, use aegis.extraEnv instead.
+configMap:
+  # -- Create a ConfigMap with the specified keys.
+  enabled: false
+  # -- Key-value pairs rendered into the ConfigMap.
+  data: {}
+
+probes:
+  # -- HTTP path for liveness and readiness probes.
+  path: /v1/health
+  liveness:
+    # -- Delay before liveness probes start.
+    initialDelaySeconds: 20
+    # -- Interval between liveness probes.
+    periodSeconds: 10
+    # -- Timeout for each liveness probe.
+    timeoutSeconds: 3
+    # -- Consecutive successes to be considered healthy.
+    successThreshold: 1
+    # -- Consecutive failures before restart.
+    failureThreshold: 3
+  readiness:
+    # -- Delay before readiness probes start.
+    initialDelaySeconds: 5
+    # -- Interval between readiness probes.
+    periodSeconds: 5
+    # -- Timeout for each readiness probe.
+    timeoutSeconds: 3
+    # -- Consecutive successes to be considered ready.
+    successThreshold: 1
+    # -- Consecutive failures before marking unready.
+    failureThreshold: 3
+
+# -- Pod resource requests and limits.
+resources: {}
+#  requests:
+#    cpu: 250m
+#    memory: 256Mi
+#  limits:
+#    cpu: "1"
+#    memory: 512Mi
+
+autoscaling:
+  # -- Enable a HorizontalPodAutoscaler. Note: Aegis uses local state so
+  # scaling beyond 1 replica is not yet supported. This is provided for
+  # forward-compatibility when external state is available.
+  enabled: false
+  # -- Minimum replica count for the HPA.
+  minReplicas: 1
+  # -- Maximum replica count for the HPA.
+  maxReplicas: 3
+  # -- Target CPU utilization percentage.
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage.
+  targetMemoryUtilizationPercentage: {}
+
+# -- Node selector labels for pod scheduling.
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling.
+tolerations: []
+
+# -- Affinity rules for pod scheduling.
+affinity: {}
+
+# -- Topology spread constraints.
+topologySpreadConstraints: []
+
+# -- PriorityClass assigned to the pod.
+priorityClassName: ""
+
+# -- Pod termination grace period (seconds).
+terminationGracePeriodSeconds: 30
+
+# -- Additional volumes injected into the pod (e.g. Claude auth, SSH keys, CA bundles).
+extraVolumes: []
+
+# -- Additional volume mounts appended to the container.
+extraVolumeMounts: []


### PR DESCRIPTION
## Summary
Implements #2083 — Production-grade Helm chart for K8s deployments.

- charts/aegis/ with full template set (deployment, service, ingress, PVC, configmap, secret, serviceaccount, HPA, headless-service)
- Liveness/readiness probes on /v1/health
- Values with enterprise-ready defaults
- README with install/upgrade/values documentation
- 836 insertions, 15 files

## QA
- helm lint ✅
- helm template ✅