### PR TITLE
feat(dashboard): add MetricsPage with summary stat cards

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -14,6 +14,7 @@ import { FirstRunTour, isTourCompleted } from './components/tour/FirstRunTour';
 import { OnboardingScreen } from './components/brand/OnboardingScreen';
 
 const AuditPage = lazy(() => import('./pages/AuditPage'));
+const MetricsPage = lazy(() => import('./pages/MetricsPage'));
 const AuthKeysPage = lazy(() => import('./pages/AuthKeysPage'));
 const CostPage = lazy(() => import('./pages/CostPage'));
 const LoginPage = lazy(() => import('./pages/LoginPage'));
@@ -157,6 +158,14 @@ export default function App() {
               element={
                 <Suspense fallback={<LoadingFallback />}>
                   <AuditPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/metrics"
+              element={
+                <Suspense fallback={<LoadingFallback />}>
+                  <MetricsPage />
                 </Suspense>
               }
             />

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -440,7 +440,7 @@ describe('Layout sidebar', () => {
     // Count nav links (6 main + Settings in footer = 7 total NavLinks, but we check nav)
     const nav = document.querySelector('nav[aria-label="Main navigation"]');
     const links = nav?.querySelectorAll('a');
-    expect(links?.length).toBe(6);
+    expect(links?.length).toBe(7);
   });
 
   it('Settings nav link is rendered in sidebar footer', () => {

--- a/dashboard/src/__tests__/MetricsPage.test.tsx
+++ b/dashboard/src/__tests__/MetricsPage.test.tsx
@@ -3,7 +3,6 @@
  */
 
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
-import { fireEvent } from '@testing-library/react';
 import { render, screen, waitFor } from '@testing-library/react';
 import MetricsPage from '../pages/MetricsPage';
 import { useAuthStore } from '../store/useAuthStore';

--- a/dashboard/src/__tests__/MetricsPage.test.tsx
+++ b/dashboard/src/__tests__/MetricsPage.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * __tests__/MetricsPage.test.tsx — Issue #2087
+ */
+
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import MetricsPage from '../pages/MetricsPage';
+import { useAuthStore } from '../store/useAuthStore';
+
+const mockMetrics = {
+  uptime: 3600,
+  sessions: {
+    total_created: 142,
+    currently_active: 3,
+    completed: 130,
+    failed: 12,
+    avg_duration_sec: 384,
+    avg_messages_per_session: 24,
+  },
+  auto_approvals: 312,
+  webhooks_sent: 89,
+  webhooks_failed: 2,
+  screenshots_taken: 45,
+  pipelines_created: 7,
+  batches_created: 3,
+  prompt_delivery: {
+    sent: 1000,
+    delivered: 980,
+    failed: 20,
+    success_rate: 0.98,
+  },
+  latency: {
+    hook_latency_ms: { p50: 120, p95: 450, p99: 800 },
+    state_change_detection_ms: { p50: 5, p95: 20, p99: 50 },
+    permission_response_ms: { p50: 30, p95: 120, p99: 200 },
+    channel_delivery_ms: { p50: 80, p95: 300, p99: 600 },
+  },
+};
+
+describe('MetricsPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    useAuthStore.setState({ token: 'test-token' });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders loading skeletons initially', () => {
+    render(<MetricsPage />);
+    expect(document.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('renders summary stat cards when data loads', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockMetrics),
+    } as Response);
+
+    render(<MetricsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Sessions Created')).toBeTruthy();
+    });
+    expect(screen.getByText('142')).toBeTruthy();
+    expect(screen.getByText('Avg Duration')).toBeTruthy();
+    expect(screen.getByText('Completion Rate')).toBeTruthy();
+    expect(screen.getByText('Prompt Delivery')).toBeTruthy();
+  });
+
+  it('shows correct completion rate', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockMetrics),
+    } as Response);
+
+    render(<MetricsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('92%')).toBeTruthy(); // 130/142 ≈ 92%
+    });
+  });
+
+  it('shows average duration in minutes', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockMetrics),
+    } as Response);
+
+    render(<MetricsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('6.4')).toBeTruthy(); // 384/60 = 6.4 min
+    });
+  });
+
+  it('shows error state with retry button', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as Response);
+
+    render(<MetricsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load metrics/)).toBeTruthy();
+    });
+    const btn = screen.getByRole('button', { name: /Retry/i });
+    expect(btn).toBeTruthy();
+
+    // Mock a successful retry
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockMetrics),
+    } as Response);
+    // Retry tested via existence check above
+    expect(btn).toBeTruthy();
+  });
+
+  it('shows coming soon notice for time-series features', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockMetrics),
+    } as Response);
+
+    render(<MetricsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Time-series.*By-key Breakdown/i)).toBeTruthy();
+    });
+  });
+
+  it('renders all secondary stat cards', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockMetrics),
+    } as Response);
+
+    render(<MetricsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('312')).toBeTruthy(); // auto_approvals
+      expect(screen.getByText('89')).toBeTruthy(); // webhooks_sent
+      expect(screen.getByText('2 failed')).toBeTruthy(); // webhooks_failed
+      expect(screen.getByText('45')).toBeTruthy(); // screenshots
+      expect(screen.getByText('7')).toBeTruthy(); // pipelines
+      expect(screen.getByText('3')).toBeTruthy(); // batches
+      expect(screen.getByText('20')).toBeTruthy(); // prompts failed
+    });
+  });
+});

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -22,6 +22,7 @@ import {
   Menu,
   RefreshCw,
   Shield,
+  TrendingUp,
   Cog,
   Terminal,
 } from 'lucide-react';
@@ -58,6 +59,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: 'OPERATIONS',
     items: [
       { to: '/audit', label: 'Audit', icon: Shield },
+      { to: '/metrics', label: 'Metrics', icon: TrendingUp },
       { to: '/cost', label: 'Cost', icon: DollarSign },
     ],
   },

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -1,0 +1,239 @@
+/**
+ * pages/MetricsPage.tsx — Metrics aggregation dashboard.
+ *
+ * Issue #2087: displays team-level usage metrics from GET /v1/metrics.
+ * Time-series chart and by-key breakdown require GET /v1/metrics/aggregate
+ * (backend, separate issue). This page shows summary cards + current metrics
+ * immediately, with those sections flagged as "coming soon".
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Activity,
+  CheckCircle,
+  Clock,
+  TrendingUp,
+  XCircle,
+  Zap,
+} from 'lucide-react';
+import { useAuthStore } from '../store/useAuthStore';
+import type { GlobalMetrics } from '../types';
+
+function StatCard({
+  label,
+  value,
+  subValue,
+  icon: Icon,
+  accent,
+}: {
+  label: string;
+  value: string | number;
+  subValue?: string;
+  icon: React.ElementType;
+  accent?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            {label}
+          </p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-[var(--color-text-primary)]">
+            {value}
+          </p>
+          {subValue && (
+            <p className="mt-1 text-xs text-[var(--color-text-muted)]">{subValue}</p>
+          )}
+        </div>
+        <div
+          className={`rounded-lg p-2.5 ${accent ?? 'bg-[var(--color-accent-cyan)]/10'}`}
+        >
+          <Icon className={`h-5 w-5 ${accent ? '' : 'text-[var(--color-accent-cyan)]'}`}
+            style={accent ? { color: accent } : undefined} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function percentOf(part: number, total: number): string {
+  if (total === 0) return '0%';
+  return `${Math.round((part / total) * 100)}%`;
+}
+
+export default function MetricsPage() {
+  const token = useAuthStore((s) => s.token);
+  const [metrics, setMetrics] = useState<GlobalMetrics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchMetrics = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/v1/metrics', {
+        headers: { Authorization: `Bearer ${token}` },
+        signal,
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const data: GlobalMetrics = await res.json();
+      setMetrics(data);
+    } catch (err) {
+      if ((err as DOMException).name === 'AbortError') return;
+      setError((err as Error).message ?? 'Failed to load metrics');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    abortRef.current = new AbortController();
+    void fetchMetrics(abortRef.current.signal);
+    return () => abortRef.current?.abort();
+  }, [fetchMetrics]);
+
+  const sessionsTotal = metrics?.sessions.total_created ?? 0;
+  const sessionsCompleted = metrics?.sessions.completed ?? 0;
+  const sessionsFailed = metrics?.sessions.failed ?? 0;
+  const completionRate = percentOf(sessionsCompleted, sessionsTotal);
+
+  const promptsTotal = (metrics?.prompt_delivery.sent ?? 0);
+  const promptsDelivered = (metrics?.prompt_delivery.delivered ?? 0);
+  const promptSuccessRate = metrics?.prompt_delivery.success_rate;
+
+  const avgDuration = metrics?.sessions.avg_duration_sec ?? 0;
+  const avgDurationMin = avgDuration > 0 ? (avgDuration / 60).toFixed(1) : '—';
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold text-[var(--color-text-primary)]">Metrics</h2>
+        <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+          Team-level usage and performance overview.
+        </p>
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-rose-500/30 bg-rose-950/20 p-8 text-center">
+          <p className="font-medium text-rose-400">Failed to load metrics</p>
+          <p className="mt-1 text-xs text-[var(--color-text-muted)]">{error}</p>
+          <button
+            onClick={() => { void fetchMetrics(); }}
+            className="mt-4 rounded border border-rose-500/30 bg-rose-500/10 px-4 py-2 text-xs font-medium text-rose-400 transition-colors hover:bg-rose-500/20"
+          >
+            Retry
+          </button>
+        </div>
+      ) : loading ? (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
+              <div className="h-4 w-20 animate-pulse rounded bg-[var(--color-border)]" />
+              <div className="mt-2 h-8 w-16 animate-pulse rounded bg-[var(--color-border)]" />
+            </div>
+          ))}
+        </div>
+      ) : metrics ? (
+        <>
+          {/* Summary cards */}
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            <StatCard
+              label="Sessions Created"
+              value={sessionsTotal.toLocaleString()}
+              subValue={`${metrics.sessions.currently_active} active now`}
+              icon={Activity}
+            />
+            <StatCard
+              label="Avg Duration"
+              value={avgDurationMin}
+              subValue="minutes per session"
+              icon={Clock}
+            />
+            <StatCard
+              label="Completion Rate"
+              value={completionRate}
+              subValue={`${sessionsCompleted} done · ${sessionsFailed} failed`}
+              icon={CheckCircle}
+              accent="var(--color-accent-emerald)"
+            />
+            <StatCard
+              label="Prompt Delivery"
+              value={promptSuccessRate != null ? `${Math.round(promptSuccessRate * 100)}%` : '—'}
+              subValue={`${promptsDelivered} / ${promptsTotal} delivered`}
+              icon={TrendingUp}
+              accent="var(--color-accent-amber)"
+            />
+          </div>
+
+          {/* Secondary stats */}
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+            <StatCard
+              label="Auto-approvals"
+              value={metrics.auto_approvals.toLocaleString()}
+              icon={Zap}
+              accent="var(--color-accent-violet)"
+            />
+            <StatCard
+              label="Webhooks Sent"
+              value={metrics.webhooks_sent.toLocaleString()}
+              subValue={metrics.webhooks_failed > 0 ? `${metrics.webhooks_failed} failed` : undefined}
+              icon={Zap}
+              accent={metrics.webhooks_failed > 0 ? 'var(--color-accent-amber)' : undefined}
+            />
+            <StatCard
+              label="Screenshots"
+              value={metrics.screenshots_taken.toLocaleString()}
+              icon={Activity}
+            />
+          </div>
+
+          {/* Pipeline & batch stats */}
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            <StatCard
+              label="Pipelines Created"
+              value={metrics.pipelines_created.toLocaleString()}
+              icon={TrendingUp}
+            />
+            <StatCard
+              label="Batches Created"
+              value={metrics.batches_created.toLocaleString()}
+              icon={TrendingUp}
+            />
+            <StatCard
+              label="Prompts Failed"
+              value={metrics.prompt_delivery.failed.toLocaleString()}
+              icon={metrics.prompt_delivery.failed > 0 ? XCircle : CheckCircle}
+              accent={metrics.prompt_delivery.failed > 0 ? 'var(--color-accent-rose)' : 'var(--color-accent-emerald)'}
+            />
+            <StatCard
+              label="Up time"
+              value={`${Math.round(metrics.uptime / 60)}m`}
+              subValue="server uptime"
+              icon={Clock}
+            />
+          </div>
+
+          {/* Coming soon sections */}
+          <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--color-surface)] p-8 text-center">
+            <div className="mb-6 flex items-center justify-center gap-3">
+              <TrendingUp className="h-5 w-5 text-[var(--color-text-muted)]" />
+              <h3 className="text-sm font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+                Time-series &amp; By-key Breakdown
+              </h3>
+            </div>
+            <p className="text-sm text-[var(--color-text-muted)]">
+              Sessions over time, token cost by API key, and anomaly detection require{' '}
+              <code className="rounded bg-[var(--color-void)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-accent-cyan)]">
+                GET /v1/metrics/aggregate
+              </code>{' '}
+              (backend implementation).
+            </p>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new Metrics page at /metrics — first iteration of issue #2087.

## What it does

11 stat cards covering data from GET /v1/metrics:
- Sessions Created (+ active count)
- Avg Duration (in minutes)
- Completion Rate (done/failed breakdown)
- Prompt Delivery (% + sent/delivered counts)
- Auto-approvals, Webhooks, Screenshots
- Pipelines, Batches, Prompts Failed, Uptime

## What it does NOT yet

Time-series chart and by-key breakdown require GET /v1/metrics/aggregate (backend, separate issue). A "Coming Soon" notice is shown for those sections.

## Changes
- dashboard/src/pages/MetricsPage.tsx — new page
- dashboard/src/App.tsx — route added
- dashboard/src/components/Layout.tsx — sidebar link
- dashboard/src/__tests__/MetricsPage.test.tsx — 7 tests

## Verification
- Build: clean
- MetricsPage tests: 7 passed

Issue: #2087
