### PR TITLE
fix(doctor): show ANTHROPIC_AUTH_TOKEN as authenticated in ag doctor (fixes #2094)

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -591,26 +591,36 @@ export async function runDoctorChecks(
     });
   }
 
+  // Issue #2094: ANTHROPIC_AUTH_TOKEN means CC works without web login
+  const hasAnthropicToken = Boolean(process.env.ANTHROPIC_AUTH_TOKEN);
+  const hasAnthropicBaseUrl = Boolean(process.env.ANTHROPIC_BASE_URL);
   const claudeAuthMetadata = parseClaudeAuthMetadata(claudeAuthResult.stdout);
+  let claudeAuthStatus: DoctorCheckStatus = claudeAuthResult.ok ? 'ok' : 'fail';
+  let claudeAuthMessage = claudeAuthResult.ok
+    ? claudeAuthMetadata?.authMethod
+      ? `authenticated via ${claudeAuthMetadata.authMethod}`
+      : 'authenticated'
+    : claudeVersionResult.ok
+      ? claudeAuthMetadata?.loggedIn === false
+        ? 'not authenticated'
+        : summarizeCommandFailure(claudeAuthResult)
+      : 'Claude CLI is not installed';
+  if (hasAnthropicToken || hasAnthropicBaseUrl) {
+    claudeAuthStatus = 'ok';
+    claudeAuthMessage = hasAnthropicToken ? 'authenticated via ANTHROPIC_AUTH_TOKEN' : 'authenticated via ANTHROPIC_BASE_URL';
+  }
   checks.push({
     key: 'claude-auth',
     label: 'Claude auth',
-    status: claudeAuthResult.ok ? 'ok' : 'fail',
-    message: claudeAuthResult.ok
-      ? claudeAuthMetadata?.authMethod
-        ? `authenticated via ${claudeAuthMetadata.authMethod}`
-        : 'authenticated'
-      : claudeVersionResult.ok
-        ? claudeAuthMetadata?.loggedIn === false
-          ? 'not authenticated'
-          : summarizeCommandFailure(claudeAuthResult)
-        : 'Claude CLI is not installed',
+    status: claudeAuthStatus,
+    message: claudeAuthMessage,
     details: {
       exitCode: claudeAuthResult.exitCode,
       loggedIn: claudeAuthMetadata?.loggedIn,
       authMethod: claudeAuthMetadata?.authMethod,
       apiProvider: claudeAuthMetadata?.apiProvider,
       subscriptionType: claudeAuthMetadata?.subscriptionType,
+      authenticatedViaToken: hasAnthropicToken || hasAnthropicBaseUrl,
     },
   });
 


### PR DESCRIPTION
## Summary

Fixes false positive in `ag doctor` — when `ANTHROPIC_AUTH_TOKEN` is set, Claude Code works via token auth without web login. Doctor now correctly reports:

```
✅ Claude auth  authenticated via ANTHROPIC_AUTH_TOKEN
```

Instead of the misleading:
```
❌ Claude auth  not authenticated
```

## Changes

- `src/doctor.ts`: Check for `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` in environment before evaluating `claude auth` check
- If token env vars are set, report status as `ok` with descriptive message  
- Added `authenticatedViaToken` field to check details for transparency

## Testing

```
$ ANTHROPIC_AUTH_TOKEN=xxx ANTHROPIC_BASE_URL=https://api.z.ai node dist/cli.js doctor
✅ Claude auth  authenticated via ANTHROPIC_AUTH_TOKEN
```

**Note on "ag produces no output":** CLI works correctly when built. Tested with `node dist/cli.js` — banner and server startup work. The "no output" symptom may be environment-specific (port conflict, missing dist/).

**Note on "Audit chain invalid":** This is a GENUINE failure from old audit rotation (audit-2026-04-11.log line 1). The hash chain is broken from a rotation event. This is a separate issue from #2094's scope.

## Verification

Gate: 3260 tests ✅

## Fixes
#2094