### PR TITLE
feat: API versioning policy + deprecation headers + /v2/ migration doc (#1956)

### DIFF
--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,122 @@
+# API Versioning Policy
+
+> Issue #1956 — Formal versioning and deprecation for the Aegis REST API.
+
+## Overview
+
+Aegis uses **URL-path versioning** (`/v1/`, `/v2/`) with HTTP headers to signal
+deprecation and sunset timelines. This document defines what triggers a major
+version, the support window for deprecated endpoints, and the header semantics
+consumers must handle.
+
+## Current version
+
+| Prefix | Status | Since |
+|--------|--------|-------|
+| `/v1/` | Active | v1.0.0 |
+| Legacy (`/health`, `/sessions`, etc.) | Deprecated | Sunset 2027-01-01 |
+| `/v2/` | Planned (stub only) | — |
+
+## Versioning rules
+
+### What triggers a major version bump
+
+A new major API version (`/v2/`, `/v3/`, etc.) is introduced only when a
+breaking change is required. Breaking changes include:
+
+- Removing an endpoint.
+- Removing or renaming a required request field or response field.
+- Changing a field's type incompatibly.
+- Changing authentication semantics.
+- Changing error response shapes.
+
+The following are **not** breaking changes and ship within the current version:
+
+- Adding new endpoints.
+- Adding new optional request fields.
+- Adding new response fields (clients must ignore unknown fields).
+- Adding new enum values (clients must handle unknown values).
+- Changing the order of fields in a JSON response.
+
+### Support window
+
+- Each major version is supported for **at least 12 months** after its
+  successor is released.
+- During the support window, deprecated endpoints receive bug fixes but no new
+  features.
+- After the support window ends, deprecated endpoints may return `410 Gone`.
+
+## Deprecation headers
+
+All deprecated endpoints emit the following HTTP headers on every response:
+
+| Header | Format | Example | Description |
+|--------|--------|---------|-------------|
+| `Deprecation` | `true` | `true` | RFC 8594 — signals the endpoint is deprecated |
+| `Sunset` | HTTP-date | `Thu, 01 Jan 2027 00:00:00 GMT` | RFC 8594 — date after which the endpoint may be removed |
+| `X-API-Deprecated` | Free text | `Use /v1/health instead` | Human-readable migration hint (non-standard) |
+
+All `/v1/` responses also include:
+
+| Header | Format | Example |
+|--------|--------|---------|
+| `X-Aegis-API-Version` | Integer | `1` |
+
+### Consumer responsibilities
+
+API consumers **must**:
+
+1. Check for `Deprecation: true` on every response.
+2. Read the `Sunset` header to plan migration before the deadline.
+3. Follow `X-API-Deprecated` for the replacement endpoint.
+4. Ignore unknown response fields (forward-compatible).
+
+## Legacy (unversioned) routes
+
+Before versioning was introduced, Aegis registered some endpoints at both
+`/v1/...` and an unversioned alias (e.g. `/health`, `/sessions`). These
+aliases are now **deprecated** and emit deprecation headers. They will be
+removed on **2027-01-01**.
+
+Consumers must migrate to the `/v1/` equivalents:
+
+| Deprecated path | Replacement |
+|-----------------|-------------|
+| `GET /health` | `GET /v1/health` |
+| `GET /sessions` | `GET /v1/sessions` |
+| `POST /sessions` | `POST /v1/sessions` |
+| `GET /sessions/{id}` | `GET /v1/sessions/{id}` |
+| `DELETE /sessions/{id}` | `DELETE /v1/sessions/{id}` |
+
+(All routes registered via `registerWithLegacy()` are affected.)
+
+## Migration to v2
+
+When v2 is planned, the following steps will occur:
+
+1. **Announcement** — `docs/api-v2-migration.md` is published with a full
+   changelog and migration guide.
+2. **v2 stub** — `GET /v2/` returns metadata (already exists).
+3. **Parallel operation** — v1 and v2 endpoints coexist for at least 12 months.
+4. **v1 deprecation** — v1 endpoints emit `Deprecation` and `Sunset` headers.
+5. **v1 removal** — After the sunset date, v1 endpoints return `410 Gone`.
+
+### v2 migration template
+
+A migration doc should include:
+
+```markdown
+# Migrating from API v1 to v2
+
+## Overview
+<!-- Summary of what changed and why -->
+
+## Breaking changes
+<!-- Table of removed/renamed endpoints and fields -->
+
+## Step-by-step migration
+<!-- Per-endpoint instructions -->
+
+## Deprecation timeline
+<!-- Dates for announcement, deprecation headers, removal -->
+```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,6 +12,11 @@ info:
     Pass `Authorization: Bearer <your-token>` header, or set `AEGIS_AUTH_TOKEN` env var.
 
     **Session lifecycle:** `working` → `idle` → `permission_prompt` → `asking` → `stalled`
+
+    **API versioning:** All `/v1/` responses include `X-Aegis-API-Version: 1`.
+    Legacy unversioned paths (e.g. `/health`, `/sessions`) emit `Deprecation: true`,
+    `Sunset`, and `X-API-Deprecated` headers. See `docs/api-versioning.md` for the
+    full versioning policy.
 servers:
   - url: http://localhost:9100
     description: Local Aegis server
@@ -41,12 +46,30 @@ paths:
   /health:
     get:
       operationId: getHealthAlias
-      summary: Server health check (alias)
+      summary: Server health check (alias, deprecated)
+      deprecated: true
       security: []
       tags: [Health]
       responses:
         '200':
           description: Server is healthy
+          headers:
+            Deprecation:
+              description: 'Indicates this endpoint is deprecated (RFC 8594)'
+              schema:
+                type: string
+                example: 'true'
+            Sunset:
+              description: 'Date after which this endpoint may be removed'
+              schema:
+                type: string
+                format: date-time
+                example: 'Thu, 01 Jan 2027 00:00:00 GMT'
+            X-API-Deprecated:
+              description: 'Human-readable replacement path'
+              schema:
+                type: string
+                example: 'Use /v1/health instead'
           content:
             application/json:
               schema:
@@ -1677,11 +1700,29 @@ paths:
   /sessions:
     get:
       operationId: listSessionsAlias
-      summary: List all sessions (alias, no /v1 prefix)
+      summary: List all sessions (alias, deprecated)
+      deprecated: true
       tags: [Sessions]
       responses:
         '200':
           description: List of sessions
+          headers:
+            Deprecation:
+              description: 'Indicates this endpoint is deprecated (RFC 8594)'
+              schema:
+                type: string
+                example: 'true'
+            Sunset:
+              description: 'Date after which this endpoint may be removed'
+              schema:
+                type: string
+                format: date-time
+                example: 'Thu, 01 Jan 2027 00:00:00 GMT'
+            X-API-Deprecated:
+              description: 'Human-readable replacement path'
+              schema:
+                type: string
+                example: 'Use /v1/sessions instead'
           content:
             application/json:
               schema:
@@ -1690,6 +1731,42 @@ paths:
                   $ref: '#/components/schemas/SessionInfo'
         '401':
           $ref: '#/components/responses/Unauthorized'
+
+  # ─── API v2 (stub) ──────────────────────────────────────────────────────────
+
+  /v2/:
+    get:
+      operationId: getV2Status
+      summary: API v2 migration info (stub)
+      description: |
+        Returns versioning metadata for the planned v2 API.
+        No v2 endpoints are implemented yet — this endpoint exists so consumers
+        can probe for v2 availability programmatically.
+      security: []
+      tags: [Versioning]
+      responses:
+        '200':
+          description: v2 migration info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: integer
+                    example: 2
+                  status:
+                    type: string
+                    example: planned
+                  message:
+                    type: string
+                    example: 'API v2 is not yet available. Continue using /v1/ endpoints.'
+                  migration_guide:
+                    type: string
+                    example: '/v1/openapi.json'
+                  v1_base:
+                    type: string
+                    example: '/v1/'
 
 # ─── Components ────────────────────────────────────────────────────────────────
 

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -286,6 +286,10 @@ type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
  * Register a route at both `/v1/...` and its legacy alias (without prefix)
  * in a single call. Reduces duplicate route registrations.
  *
+ * Legacy alias routes emit `Deprecation` and `Sunset` headers per the
+ * API versioning policy (Issue #1956). Consumers must migrate to `/v1/`
+ * paths before the sunset date.
+ *
  * Accepts the same argument forms as Fastify's shorthand methods:
  *   registerWithLegacy(app, 'get', '/v1/path', handler)
  *   registerWithLegacy(app, 'post', '/v1/path', { config: {...}, handler })
@@ -301,7 +305,59 @@ export function registerWithLegacy(
   const legacyPath = v1Path.replace(/^\/v1/, '');
   const register = app[method].bind(app) as (path: string, opts: unknown) => void;
   register(v1Path, handlerOrOpts);
-  register(legacyPath, handlerOrOpts);
+
+  // Issue #1956: Wrap legacy handler to add Deprecation + Sunset headers.
+  // The Sunset date is set to 2027-01-01 — consumers must migrate before then.
+  const SUNSET_DATE = 'Thu, 01 Jan 2027 00:00:00 GMT';
+  if (legacyPath !== v1Path) {
+    const wrappedOpts = wrapWithDeprecationHeaders(handlerOrOpts, v1Path, SUNSET_DATE);
+    register(legacyPath, wrappedOpts);
+  }
+}
+
+/**
+ * Issue #1956: Wrap a handler or route options to inject Deprecation + Sunset
+ * headers on legacy (unversioned) API paths.
+ */
+function wrapWithDeprecationHeaders(
+  handlerOrOpts: unknown,
+  v1Replacement: string,
+  sunsetDate: string,
+): unknown {
+  // Fastify route options object with a handler function
+  if (typeof handlerOrOpts === 'object' && handlerOrOpts !== null && 'handler' in handlerOrOpts) {
+    const opts = handlerOrOpts as Record<string, unknown>;
+    const originalHandler = opts.handler as (req: FastifyRequest, reply: FastifyReply) => Promise<unknown> | unknown;
+    return {
+      ...opts,
+      handler: async (req: FastifyRequest, reply: FastifyReply) => {
+        addDeprecationHeaders(reply, v1Replacement, sunsetDate);
+        return originalHandler(req, reply);
+      },
+    };
+  }
+
+  // Plain handler function
+  if (typeof handlerOrOpts === 'function') {
+    const originalHandler = handlerOrOpts as (req: FastifyRequest, reply: FastifyReply) => Promise<unknown> | unknown;
+    return async (req: FastifyRequest, reply: FastifyReply) => {
+      addDeprecationHeaders(reply, v1Replacement, sunsetDate);
+      return originalHandler(req, reply);
+    };
+  }
+
+  // Fallback: return as-is (shouldn't happen in practice)
+  return handlerOrOpts;
+}
+
+/**
+ * Add RFC 8594 Deprecation and Sunset headers to the response.
+ * Also adds X-API-Deprecated with the replacement path for easy migration.
+ */
+function addDeprecationHeaders(reply: FastifyReply, v1Replacement: string, sunsetDate: string): void {
+  reply.header('Deprecation', 'true');
+  reply.header('Sunset', sunsetDate);
+  reply.header('X-API-Deprecated', `Use ${v1Replacement} instead`);
 }
 
 type RouteHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<unknown> | unknown;

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -184,4 +184,15 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
       return { channel: ch.name, healthy: true, lastSuccess: null, lastError: null, pendingCount: 0 };
     });
   });
+
+  // Issue #1956: /v2/ migration stub — returns versioning info until real v2 routes exist
+  app.get('/v2/', async (_req: FastifyRequest, reply: FastifyReply) => {
+    return reply.header('X-Aegis-API-Version', '2').send({
+      version: 2,
+      status: 'planned',
+      message: 'API v2 is not yet available. Continue using /v1/ endpoints.',
+      migration_guide: '/v1/openapi.json',
+      v1_base: '/v1/',
+    });
+  });
 }

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -1021,6 +1021,25 @@ export function registerOpenApiSpec(): void {
     parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
     responses: { '200': okJsonResponse(z.any()), '404': notFoundResponse },
   });
+
+  // ── Versioning (Issue #1956) ───────────────────────────────────
+
+  registerOpenApiPath({
+    method: 'get',
+    path: '/v2/',
+    summary: 'API v2 migration info (stub)',
+    description: 'Returns versioning metadata for the planned v2 API. No v2 endpoints exist yet.',
+    tags: ['Versioning'],
+    responses: {
+      '200': okJsonResponse(z.object({
+        version: z.number(),
+        status: z.string(),
+        message: z.string(),
+        migration_guide: z.string(),
+        v1_base: z.string(),
+      })),
+    },
+  });
 }
 
 // ── Route handler ──────────────────────────────────────────────────


### PR DESCRIPTION
API versioning policy doc, deprecation headers on v1 routes, /v2/ migration stub. 288 insertions, 5 files.