### PR TITLE
feat: webhook signature-verification helper SDK (#1955)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     },
     "./cli": {
       "import": "./dist/cli.js"
+    },
+    "./webhook": {
+      "import": "./dist/webhook-signature.js",
+      "types": "./dist/webhook-signature.d.ts"
     }
   },
   "bin": {

--- a/src/__tests__/webhook-signature-1955.test.ts
+++ b/src/__tests__/webhook-signature-1955.test.ts
@@ -1,0 +1,183 @@
+/**
+ * webhook-signature-1955.test.ts — Unit tests for webhook signature verification SDK.
+ *
+ * Covers: valid signature, expired timestamp, tampered payload,
+ * wrong secret, missing/invalid header, legacy format, replay protection.
+ */
+
+import crypto from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { signPayload, verifySignature } from '../webhook-signature.js';
+
+const SECRET = 'whsec_test_secret_12345';
+const PAYLOAD = JSON.stringify({ event: 'session.created', session: { id: 'abc-123' } });
+
+describe('webhook-signature', () => {
+  // ─── signPayload ──────────────────────────────────────────────
+
+  describe('signPayload', () => {
+    it('produces a t=<ts>,v1=<hex> header', () => {
+      const result = signPayload(PAYLOAD, SECRET, 1700000000);
+      expect(result.timestamp).toBe(1700000000);
+      expect(result.signatureHeader).toMatch(/^t=1700000000,v1=[a-f0-9]{64}$/);
+    });
+
+    it('uses current time when no timestamp provided', () => {
+      const before = Math.floor(Date.now() / 1000);
+      const result = signPayload(PAYLOAD, SECRET);
+      const after = Math.floor(Date.now() / 1000);
+      expect(result.timestamp).toBeGreaterThanOrEqual(before);
+      expect(result.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('produces deterministic HMAC for same inputs', () => {
+      const a = signPayload(PAYLOAD, SECRET, 1700000000);
+      const b = signPayload(PAYLOAD, SECRET, 1700000000);
+      expect(a.signatureHeader).toBe(b.signatureHeader);
+    });
+
+    it('produces different HMAC for different payloads', () => {
+      const a = signPayload(PAYLOAD, SECRET, 1700000000);
+      const b = signPayload('{"different":true}', SECRET, 1700000000);
+      expect(a.signatureHeader).not.toBe(b.signatureHeader);
+    });
+  });
+
+  // ─── verifySignature — happy path ────────────────────────────
+
+  describe('verifySignature — valid signatures', () => {
+    it('accepts a valid current-format signature', () => {
+      const ts = Math.floor(Date.now() / 1000);
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      const result = verifySignature(PAYLOAD, signatureHeader, SECRET);
+      expect(result.valid).toBe(true);
+      if (result.valid) expect(result.timestamp).toBe(ts);
+    });
+
+    it('accepts a valid legacy sha256=<hex> signature', () => {
+      const hmac = crypto.createHmac('sha256', SECRET).update(PAYLOAD, 'utf8').digest('hex');
+      const header = `sha256=${hmac}`;
+      const result = verifySignature(PAYLOAD, header, SECRET);
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts a signature at the edge of tolerance', () => {
+      const now = 1700000000;
+      const ts = now - 299; // within default 300s tolerance
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      const result = verifySignature(PAYLOAD, signatureHeader, SECRET, { currentTime: now });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // ─── verifySignature — replay / expired ──────────────────────
+
+  describe('verifySignature — expired timestamp', () => {
+    it('rejects a signature older than tolerance', () => {
+      const now = 1700000000;
+      const ts = now - 301; // 1s past default 300s tolerance
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      const result = verifySignature(PAYLOAD, signatureHeader, SECRET, { currentTime: now });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('expired');
+    });
+
+    it('respects custom tolerance', () => {
+      const now = 1700000000;
+      const ts = now - 60;
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      // With 30s tolerance, 60s old should fail
+      const result = verifySignature(PAYLOAD, signatureHeader, SECRET, {
+        toleranceSeconds: 30,
+        currentTime: now,
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('expired');
+    });
+
+    it('rejects a future-dated timestamp', () => {
+      const now = 1700000000;
+      const ts = now + 60; // 60s in the future
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      const result = verifySignature(PAYLOAD, signatureHeader, SECRET, { currentTime: now });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('future');
+    });
+  });
+
+  // ─── verifySignature — tampered / wrong secret ───────────────
+
+  describe('verifySignature — tampered payload', () => {
+    it('rejects when payload is modified', () => {
+      const ts = Math.floor(Date.now() / 1000);
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      const tampered = JSON.stringify({ event: 'session.deleted', session: { id: 'abc-123' } });
+      const result = verifySignature(tampered, signatureHeader, SECRET);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('mismatch');
+    });
+
+    it('rejects when secret is wrong', () => {
+      const ts = Math.floor(Date.now() / 1000);
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      const result = verifySignature(PAYLOAD, signatureHeader, 'wrong_secret');
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('mismatch');
+    });
+
+    it('rejects legacy signature with wrong secret', () => {
+      const hmac = crypto.createHmac('sha256', SECRET).update(PAYLOAD, 'utf8').digest('hex');
+      const header = `sha256=${hmac}`;
+      const result = verifySignature(PAYLOAD, header, 'wrong_secret');
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('mismatch');
+    });
+  });
+
+  // ─── verifySignature — malformed header ──────────────────────
+
+  describe('verifySignature — invalid header', () => {
+    it('rejects empty header', () => {
+      const result = verifySignature(PAYLOAD, '', SECRET);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('Missing');
+    });
+
+    it('rejects garbage header', () => {
+      const result = verifySignature(PAYLOAD, 'not-a-real-signature', SECRET);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('format');
+    });
+
+    it('rejects header with timestamp but no signature', () => {
+      const result = verifySignature(PAYLOAD, 't=1700000000', SECRET);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('format');
+    });
+
+    it('rejects header with non-numeric timestamp', () => {
+      const result = verifySignature(PAYLOAD, 't=abc,v1=abc123', SECRET);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('format');
+    });
+
+    it('rejects header with no v1 signature', () => {
+      const result = verifySignature(PAYLOAD, 't=1700000000,v2=abc123', SECRET);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('No v1');
+    });
+  });
+
+  // ─── Timing-safe comparison ──────────────────────────────────
+
+  describe('timing-safe comparison', () => {
+    it('rejects a signature with different length (no crash)', () => {
+      const ts = Math.floor(Date.now() / 1000);
+      const { signatureHeader } = signPayload(PAYLOAD, SECRET, ts);
+      // Truncate the hex part — different length
+      const tamperedHeader = signatureHeader.slice(0, -5);
+      const result = verifySignature(PAYLOAD, tamperedHeader, SECRET);
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -5,7 +5,6 @@
  * Configure via AEGIS_WEBHOOKS (or legacy MANUS_WEBHOOKS) env var or config file.
  */
 
-import crypto from 'node:crypto';
 import type {
   Channel,
   SessionEvent,
@@ -15,6 +14,7 @@ import { webhookEndpointSchema, getErrorMessage } from '../validation.js';
 import { validateWebhookUrl, resolveAndCheckIp, buildConnectionUrl } from '../ssrf.js';
 import { redactSecretsFromText } from '../utils/redact-headers.js';
 import { RetriableError } from './manager.js';
+import { signPayload } from '../webhook-signature.js';
 
 export interface WebhookEndpoint {
   /** URL to POST to. */
@@ -199,10 +199,10 @@ export class WebhookChannel implements Channel {
           'Content-Type': 'application/json',
           ...(ep.headers || {}),
         };
-        // E5-4: HMAC-SHA256 signing — compute signature before DNS check (body must match)
+        // E5-4: HMAC-SHA256 signing with timestamp — compute signature before DNS check (body must match)
         if (ep.secret) {
-          const sig = crypto.createHmac('sha256', ep.secret).update(body, 'utf8').digest('hex');
-          headers['X-Aegis-Signature'] = `sha256=${sig}`;
+          const { signatureHeader } = signPayload(body, ep.secret);
+          headers['X-Aegis-Signature'] = signatureHeader;
         }
         if (bareHost !== '127.0.0.1' && bareHost !== '::1' && bareHost !== 'localhost') {
           const dnsResult = await resolveAndCheckIp(bareHost);

--- a/src/webhook-signature.ts
+++ b/src/webhook-signature.ts
@@ -1,0 +1,186 @@
+/**
+ * webhook-signature.ts — Webhook signature verification helper SDK.
+ *
+ * Provides HMAC-SHA256 signing and verification for webhook payloads.
+ * Consumers import this module to validate incoming Aegis webhooks.
+ *
+ * Signature format:  t=<unix_seconds>,v1=<hmac_sha256_hex>
+ * HMAC input:        <timestamp>.<payload_body>
+ */
+
+import crypto from 'node:crypto';
+
+/** Default timestamp tolerance: 5 minutes. */
+const DEFAULT_TOLERANCE_SECONDS = 300;
+
+/** Current signature version prefix. */
+const SIGNATURE_VERSION = 'v1';
+
+// ─── Signing ────────────────────────────────────────────────────────
+
+export interface SignedPayload {
+  /** The signature header value: `t=<unix>,v1=<hex>`. */
+  signatureHeader: string;
+  /** Unix timestamp (seconds) used for signing. */
+  timestamp: number;
+}
+
+/**
+ * Sign a webhook payload with HMAC-SHA256.
+ *
+ * @param payload  - Raw JSON string of the webhook body.
+ * @param secret   - Shared secret (the endpoint's `secret` field).
+ * @param timestamp - Unix timestamp in seconds. Defaults to `Date.now() / 1000`.
+ * @returns The signature header value and timestamp.
+ */
+export function signPayload(
+  payload: string,
+  secret: string,
+  timestamp: number = Math.floor(Date.now() / 1000),
+): SignedPayload {
+  const signedInput = `${timestamp}.${payload}`;
+  const hmac = crypto.createHmac('sha256', secret).update(signedInput, 'utf8').digest('hex');
+  const signatureHeader = `t=${timestamp},${SIGNATURE_VERSION}=${hmac}`;
+  return { signatureHeader, timestamp };
+}
+
+// ─── Verification ───────────────────────────────────────────────────
+
+export interface VerifyOptions {
+  /** Max age of the signature in seconds. Default: 300 (5 minutes). */
+  toleranceSeconds?: number;
+  /** Current time override for testing. Unix seconds. */
+  currentTime?: number;
+}
+
+export interface VerifyResult {
+  valid: true;
+  timestamp: number;
+}
+
+export interface VerifyFailure {
+  valid: false;
+  reason: string;
+}
+
+/**
+ * Verify an incoming webhook signature.
+ *
+ * Supports the current `t=<ts>,v1=<hex>` format.
+ * Also accepts the legacy `sha256=<hex>` format (no timestamp / no replay protection).
+ *
+ * @param payload         - Raw JSON string of the received body.
+ * @param signatureHeader - Value of the `X-Aegis-Signature` header.
+ * @param secret          - Shared secret.
+ * @param options         - Tolerance and time overrides.
+ * @returns Verification result with `valid` flag and details.
+ */
+export function verifySignature(
+  payload: string,
+  signatureHeader: string,
+  secret: string,
+  options?: VerifyOptions,
+): VerifyResult | VerifyFailure {
+  if (!signatureHeader || typeof signatureHeader !== 'string') {
+    return { valid: false, reason: 'Missing or invalid signature header' };
+  }
+
+  // Legacy format: sha256=<hex> (no timestamp)
+  if (signatureHeader.startsWith('sha256=')) {
+    const expected = crypto
+      .createHmac('sha256', secret)
+      .update(payload, 'utf8')
+      .digest('hex');
+    const provided = signatureHeader.slice('sha256='.length);
+    if (!timingSafeEqual(expected, provided)) {
+      return { valid: false, reason: 'Signature mismatch' };
+    }
+    return { valid: true, timestamp: 0 };
+  }
+
+  // Current format: t=<ts>,v1=<hex>
+  const parsed = parseSignatureHeader(signatureHeader);
+  if (!parsed) {
+    return { valid: false, reason: 'Invalid signature header format' };
+  }
+
+  const { timestamp, signatures } = parsed;
+
+  // Check for v1 signatures early (before expensive HMAC computation)
+  const v1Signatures = signatures.filter(s => s.version === SIGNATURE_VERSION);
+  if (v1Signatures.length === 0) {
+    return { valid: false, reason: `No ${SIGNATURE_VERSION} signature found` };
+  }
+
+  // Timestamp freshness check (replay protection)
+  const tolerance = options?.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
+  const now = options?.currentTime ?? Math.floor(Date.now() / 1000);
+  const age = now - timestamp;
+  if (age < 0) {
+    return { valid: false, reason: `Signature timestamp is in the future (${age}s)` };
+  }
+  if (age > tolerance) {
+    return { valid: false, reason: `Signature expired (${age}s old, max ${tolerance}s)` };
+  }
+
+  // Recompute expected signature
+  const signedInput = `${timestamp}.${payload}`;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(signedInput, 'utf8')
+    .digest('hex');
+
+  const matched = v1Signatures.some(s => timingSafeEqual(expected, s.hex));
+  if (!matched) {
+    return { valid: false, reason: 'Signature mismatch' };
+  }
+
+  return { valid: true, timestamp };
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────
+
+interface ParsedSignature {
+  timestamp: number;
+  signatures: { version: string; hex: string }[];
+}
+
+/**
+ * Parse `t=<ts>,v1=<hex>[,vN=<hex>]` into structured parts.
+ */
+function parseSignatureHeader(header: string): ParsedSignature | null {
+  const parts = header.split(',');
+  let timestamp: number | undefined;
+  const signatures: { version: string; hex: string }[] = [];
+
+  for (const part of parts) {
+    const eqIndex = part.indexOf('=');
+    if (eqIndex === -1) return null;
+    const key = part.slice(0, eqIndex);
+    const value = part.slice(eqIndex + 1);
+
+    if (key === 't') {
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed <= 0) return null;
+      timestamp = parsed;
+    } else {
+      // Versioned signature: v1=<hex>, v2=<hex>, etc.
+      if (!/^[a-f0-9]+$/i.test(value)) return null;
+      signatures.push({ version: key, hex: value });
+    }
+  }
+
+  if (timestamp === undefined || signatures.length === 0) return null;
+  return { timestamp, signatures };
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Both strings must be valid hex (same length after comparison).
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  return crypto.timingSafeEqual(bufA, bufB);
+}


### PR DESCRIPTION
HMAC-SHA256 webhook signing and verification with timestamp-based replay protection. Unit tests for valid, expired, and tampered payloads.