### PR TITLE
feat: per-tenant quotas for sessions, tokens, and USD spend (#1953)

### DIFF
--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -245,6 +245,7 @@ async function buildTestServer(): Promise<{
     config.pipelineStageTimeoutMs,
   );
 
+  const { QuotaManager } = await import('../services/auth/QuotaManager.js');
   const routeCtx: RouteContext = {
     sessions: mockSessions as never,
     tmux: {
@@ -260,6 +261,7 @@ async function buildTestServer(): Promise<{
       windowExists: vi.fn(async () => true),
     } as never,
     auth,
+    quotas: new QuotaManager(),
     config,
     metrics,
     monitor,

--- a/src/__tests__/per-action-rbac-1922.test.ts
+++ b/src/__tests__/per-action-rbac-1922.test.ts
@@ -80,6 +80,7 @@ function makeContext(granted: Partial<Record<PermissionName, boolean>> = {}) {
       if (keyId === null || keyId === undefined) return fallbackActor;
       return keyId === 'master' ? 'master' : `actor:${keyId}`;
     }),
+    getKey: vi.fn(() => null), // Issue #1953: return null = no quotas
   };
   const sessions = {
     getSession: vi.fn(() => ownedSession),
@@ -111,6 +112,10 @@ function makeContext(granted: Partial<Record<PermissionName, boolean>> = {}) {
       resizePane: vi.fn(async () => {}),
     },
     auth,
+    quotas: {
+      checkSessionQuota: vi.fn(() => ({ allowed: true })),
+      checkSendQuota: vi.fn(() => ({ allowed: true })),
+    },
     config: {
       enforceSessionOwnership: true,
       envDenylist: [],

--- a/src/__tests__/quota-manager-1953.test.ts
+++ b/src/__tests__/quota-manager-1953.test.ts
@@ -1,0 +1,335 @@
+/**
+ * quota-manager-1953.test.ts — Tests for Issue #1953: Per-tenant quotas.
+ *
+ * Tests QuotaManager enforcement, AuthManager quota CRUD,
+ * and route-level integration.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { QuotaManager } from '../services/auth/QuotaManager.js';
+import { AuthManager } from '../services/auth/AuthManager.js';
+import type { ApiKey, QuotaConfig } from '../services/auth/types.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rm } from 'node:fs/promises';
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function makeKey(id: string, quotas?: QuotaConfig): ApiKey {
+  return {
+    id,
+    name: `test-${id}`,
+    hash: 'fake-hash',
+    createdAt: Date.now(),
+    lastUsedAt: 0,
+    rateLimit: 100,
+    expiresAt: null,
+    role: 'operator',
+    permissions: ['create', 'send'],
+    quotas,
+  };
+}
+
+describe('QuotaManager (Issue #1953)', () => {
+  let qm: QuotaManager;
+
+  beforeEach(() => {
+    qm = new QuotaManager();
+  });
+
+  describe('No quotas set', () => {
+    it('allows session creation when key has no quotas', () => {
+      const key = makeKey('k1');
+      const result = qm.checkSessionQuota(key, 0);
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('allows null key (no auth)', () => {
+      const result = qm.checkSessionQuota(null, 0);
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('Concurrent sessions quota', () => {
+    it('allows when under the limit', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: 5,
+        maxTokensPerWindow: null,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      const result = qm.checkSessionQuota(key, 4);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('rejects when at the limit', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: 3,
+        maxTokensPerWindow: null,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      const result = qm.checkSessionQuota(key, 3);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('concurrent_sessions');
+      expect(result.message).toContain('3 active sessions');
+      expect(result.message).toContain('max 3');
+    });
+
+    it('rejects when over the limit', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: 2,
+        maxTokensPerWindow: null,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      const result = qm.checkSessionQuota(key, 5);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('concurrent_sessions');
+    });
+
+    it('usage snapshot reflects correct session count', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: 10,
+        maxTokensPerWindow: null,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      const result = qm.checkSessionQuota(key, 7);
+      expect(result.usage.activeSessions).toBe(7);
+      expect(result.usage.maxSessions).toBe(10);
+    });
+  });
+
+  describe('Token quota per window', () => {
+    it('allows when under token limit', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: 1000,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      qm.recordUsage('k1', 500, 0);
+      const result = qm.checkSessionQuota(key, 0);
+      expect(result.allowed).toBe(true);
+      expect(result.usage.tokensInWindow).toBe(500);
+    });
+
+    it('rejects when token limit reached', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: 1000,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      qm.recordUsage('k1', 1000, 0);
+      const result = qm.checkSessionQuota(key, 0);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('tokens_per_window');
+      expect(result.message).toContain('1000 tokens');
+    });
+
+    it('rejects send when over token limit', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: 500,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      qm.recordUsage('k1', 600, 0);
+      const result = qm.checkSendQuota(key, 1);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('tokens_per_window');
+    });
+  });
+
+  describe('Spend quota per window', () => {
+    it('allows when under spend limit', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: null,
+        maxSpendPerWindow: 10,
+        quotaWindowMs: 3_600_000,
+      });
+      qm.recordUsage('k1', 0, 5.50);
+      const result = qm.checkSessionQuota(key, 0);
+      expect(result.allowed).toBe(true);
+      expect(result.usage.spendInWindow).toBeCloseTo(5.50, 4);
+    });
+
+    it('rejects when spend limit reached', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: null,
+        maxSpendPerWindow: 5,
+        quotaWindowMs: 3_600_000,
+      });
+      qm.recordUsage('k1', 0, 5.10);
+      const result = qm.checkSessionQuota(key, 0);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('spend_per_window');
+      expect(result.message).toContain('$5.1000');
+    });
+  });
+
+  describe('Rolling window expiry', () => {
+    it('expires old entries on sweep', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: 100,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 1_000, // 1 second window
+      });
+
+      // Record usage, then wait for it to expire
+      qm.recordUsage('k1', 100, 0);
+      const result1 = qm.checkSessionQuota(key, 0);
+      expect(result1.allowed).toBe(false);
+
+      // Manually push timestamps into the past
+      const entries = (qm as any).usageLog.get('k1') as Array<{ timestamp: number; tokens: number; costUsd: number }>;
+      entries[0].timestamp = Date.now() - 2_000; // 2s ago, past the 1s window
+
+      qm.sweep(1_000);
+
+      const result2 = qm.checkSessionQuota(key, 0);
+      expect(result2.allowed).toBe(true);
+      expect(result2.usage.tokensInWindow).toBe(0);
+    });
+  });
+
+  describe('clearKey', () => {
+    it('removes all usage data for a key', () => {
+      qm.recordUsage('k1', 100, 0.5);
+      qm.clearKey('k1');
+      // After clearing, a key with quotas should be allowed
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: 50,
+        maxSpendPerWindow: null,
+        quotaWindowMs: 3_600_000,
+      });
+      const result = qm.checkSessionQuota(key, 0);
+      expect(result.allowed).toBe(true);
+      expect(result.usage.tokensInWindow).toBe(0);
+    });
+  });
+
+  describe('getUsage', () => {
+    it('returns complete usage snapshot', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: 5,
+        maxTokensPerWindow: 10_000,
+        maxSpendPerWindow: 50,
+        quotaWindowMs: 3_600_000,
+      });
+      qm.recordUsage('k1', 2000, 3.50);
+      const usage = qm.getUsage(key, 3);
+      expect(usage.activeSessions).toBe(3);
+      expect(usage.maxSessions).toBe(5);
+      expect(usage.tokensInWindow).toBe(2000);
+      expect(usage.maxTokens).toBe(10_000);
+      expect(usage.spendInWindow).toBeCloseTo(3.50, 4);
+      expect(usage.maxSpend).toBe(50);
+      expect(usage.windowMs).toBe(3_600_000);
+    });
+  });
+
+  describe('Multiple usage entries accumulate', () => {
+    it('sums multiple records in the same window', () => {
+      const key = makeKey('k1', {
+        maxConcurrentSessions: null,
+        maxTokensPerWindow: 1000,
+        maxSpendPerWindow: 10,
+        quotaWindowMs: 3_600_000,
+      });
+      qm.recordUsage('k1', 300, 1);
+      qm.recordUsage('k1', 400, 2);
+      qm.recordUsage('k1', 200, 0.5);
+      const usage = qm.getUsage(key, 0);
+      expect(usage.tokensInWindow).toBe(900);
+      expect(usage.spendInWindow).toBeCloseTo(3.50, 4);
+    });
+  });
+});
+
+describe('AuthManager quota CRUD (Issue #1953)', () => {
+  let auth: AuthManager;
+  let tmpFile: string;
+
+  beforeEach(async () => {
+    tmpFile = join(tmpdir(), `aegis-quotas-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+    auth = new AuthManager(tmpFile, 'test-master');
+    await auth.load();
+  });
+
+  it('creates key without quotas', async () => {
+    const { id } = await auth.createKey('no-quotas');
+    const key = auth.getKey(id);
+    expect(key).not.toBeNull();
+    expect(key!.quotas).toBeUndefined();
+  });
+
+  it('getKey returns null for unknown id', () => {
+    expect(auth.getKey('nonexistent')).toBeNull();
+  });
+
+  it('setQuotas persists quotas on a key', async () => {
+    const { id } = await auth.createKey('quota-key');
+    const quotas: QuotaConfig = {
+      maxConcurrentSessions: 5,
+      maxTokensPerWindow: 50_000,
+      maxSpendPerWindow: 100,
+      quotaWindowMs: 3_600_000,
+    };
+    const updated = await auth.setQuotas(id, quotas);
+    expect(updated).not.toBeNull();
+    expect(updated!.quotas).toEqual(quotas);
+
+    // Verify persistence
+    const key = auth.getKey(id);
+    expect(key!.quotas).toEqual(quotas);
+  });
+
+  it('setQuotas returns null for unknown key', async () => {
+    const result = await auth.setQuotas('nonexistent', {
+      maxConcurrentSessions: 1,
+      maxTokensPerWindow: null,
+      maxSpendPerWindow: null,
+      quotaWindowMs: 3_600_000,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('quotas survive reload from disk', async () => {
+    const { id } = await auth.createKey('persist-key');
+    const quotas: QuotaConfig = {
+      maxConcurrentSessions: 3,
+      maxTokensPerWindow: 10_000,
+      maxSpendPerWindow: 25,
+      quotaWindowMs: 1_800_000,
+    };
+    await auth.setQuotas(id, quotas);
+
+    // Create a new AuthManager and load from the same file
+    const auth2 = new AuthManager(tmpFile, 'test-master');
+    await auth2.load();
+    const key = auth2.getKey(id);
+    expect(key!.quotas).toEqual(quotas);
+  });
+
+  it('listKeys includes quotas', async () => {
+    const { id } = await auth.createKey('listed-key');
+    await auth.setQuotas(id, {
+      maxConcurrentSessions: 10,
+      maxTokensPerWindow: null,
+      maxSpendPerWindow: null,
+      quotaWindowMs: 3_600_000,
+    });
+    const keys = auth.listKeys();
+    const found = keys.find(k => k.id === id);
+    expect(found).toBeDefined();
+    expect(found!.quotas?.maxConcurrentSessions).toBe(10);
+  });
+});

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -17,7 +17,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 
 import { SessionManager } from '../session.js';
-import { AuthManager, type ApiKeyPermission } from '../services/auth/index.js';
+import { AuthManager, QuotaManager, type ApiKeyPermission } from '../services/auth/index.js';
 import { MetricsCollector } from '../metrics.js';
 import { SessionMonitor } from '../monitor.js';
 import { SessionEventBus } from '../events.js';
@@ -132,6 +132,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     sessions,
     tmux: mockTmux as unknown as import('../tmux.js').TmuxManager,
     auth,
+    quotas: new QuotaManager(),
     config,
     metrics,
     monitor,

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -40,8 +40,10 @@ export interface AuditRecord {
 export type AuditAction =
   | 'key.create'
   | 'key.revoke'
+  | 'key.quotas.update'
   | 'session.create'
   | 'session.kill'
+  | 'session.quota.rejected'
   | 'session.env.rejected'
   | 'session.action.allowed'
   | 'session.action.denied'

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,5 +1,5 @@
 /**
- * routes/auth.ts — Auth verify, API key CRUD, SSE token.
+ * routes/auth.ts — Auth verify, API key CRUD, SSE token, quota management.
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
@@ -7,8 +7,15 @@ import { z } from 'zod';
 import { authKeySchema } from '../validation.js';
 import { type RouteContext, requireRole, registerWithLegacy, withValidation } from './context.js';
 
+const setQuotasSchema = z.object({
+  maxConcurrentSessions: z.number().int().positive().nullable().optional(),
+  maxTokensPerWindow: z.number().int().positive().nullable().optional(),
+  maxSpendPerWindow: z.number().positive().nullable().optional(),
+  quotaWindowMs: z.number().int().positive().optional(),
+}).strict();
+
 export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): void {
-  const { auth } = ctx;
+  const { auth, quotas, sessions } = ctx;
 
   const verifyTokenSchema = z.object({
     token: z.string().min(1),
@@ -66,6 +73,43 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
     const rotated = await auth.rotateKey(keyId, data.ttlDays);
     if (!rotated) return reply.status(404).send({ error: 'Key not found' });
     return reply.status(200).send(rotated);
+  }));
+
+  // Issue #1953: Get quota config and usage for a key
+  registerWithLegacy(app, 'get', '/v1/auth/keys/:id/quotas', async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+    if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
+    if (!requireRole(auth, req, reply, 'admin')) return;
+    const key = auth.getKey(req.params.id);
+    if (!key) return reply.status(404).send({ error: 'Key not found' });
+    const ownedSessions = sessions.listSessions().filter(s => s.ownerKeyId === key.id);
+    return {
+      quotas: key.quotas ?? null,
+      usage: quotas.getUsage(key, ownedSessions.length),
+    };
+  });
+
+  // Issue #1953: Set quotas for a key
+  registerWithLegacy(app, 'put', '/v1/auth/keys/:id/quotas', withValidation(setQuotasSchema, async (req: FastifyRequest, reply: FastifyReply, data) => {
+    if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
+    if (!requireRole(auth, req, reply, 'admin')) return;
+    const keyId = (req.params as { id: string }).id;
+    const existing = auth.getKey(keyId);
+    if (!existing) return reply.status(404).send({ error: 'Key not found' });
+
+    const currentQuotas = existing.quotas ?? {
+      maxConcurrentSessions: null,
+      maxTokensPerWindow: null,
+      maxSpendPerWindow: null,
+      quotaWindowMs: 3_600_000,
+    };
+    const newQuotas = {
+      maxConcurrentSessions: data.maxConcurrentSessions ?? currentQuotas.maxConcurrentSessions,
+      maxTokensPerWindow: data.maxTokensPerWindow ?? currentQuotas.maxTokensPerWindow,
+      maxSpendPerWindow: data.maxSpendPerWindow ?? currentQuotas.maxSpendPerWindow,
+      quotaWindowMs: data.quotaWindowMs ?? currentQuotas.quotaWindowMs,
+    };
+    const updated = await auth.setQuotas(keyId, newQuotas);
+    return reply.status(200).send(updated);
   }));
 
   // #297: SSE token endpoint

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -16,6 +16,7 @@ import type { z } from 'zod';
 import type { SessionManager, SessionInfo } from '../session.js';
 import type { TmuxManager } from '../tmux.js';
 import type { AuthManager, ApiKeyPermission, ApiKeyRole } from '../services/auth/index.js';
+import type { QuotaManager } from '../services/auth/QuotaManager.js';
 import type { Config } from '../config.js';
 import type { MetricsCollector } from '../metrics.js';
 import type { SessionMonitor } from '../monitor.js';
@@ -39,6 +40,7 @@ export interface RouteContext {
   sessions: SessionManager;
   tmux: TmuxManager;
   auth: AuthManager;
+  quotas: QuotaManager;
   config: Config;
   metrics: MetricsCollector;
   monitor: SessionMonitor;

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -20,7 +20,7 @@ import {
 
 export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteContext): void {
   const {
-    sessions, tmux, auth, config, metrics, monitor, eventBus, channels,
+    sessions, tmux, auth, quotas, config, metrics, monitor, eventBus, channels,
     toolRegistry, getAuditLogger, validateWorkDir,
   } = ctx;
 
@@ -31,6 +31,22 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
     const { text } = parsed.data;
     const sessionId = session.id;
+
+    // Issue #1953: Per-key token/spend quota enforcement at send time.
+    const keyId = req.authKeyId;
+    const apiKey = keyId && keyId !== 'master' ? auth.getKey(keyId) : null;
+    if (apiKey) {
+      const ownedSessions = sessions.listSessions().filter(s => s.ownerKeyId === keyId);
+      const quotaResult = quotas.checkSendQuota(apiKey, ownedSessions.length);
+      if (!quotaResult.allowed) {
+        return reply.status(429).send({
+          error: 'QUOTA_EXCEEDED',
+          message: quotaResult.message,
+          quota: quotaResult.reason,
+          usage: quotaResult.usage,
+        });
+      }
+    }
     try {
       const result = await sessions.sendMessage(sessionId, text);
       // Issue #1809: Re-fetch stall info AFTER delivery to avoid false-positive.

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -62,7 +62,7 @@ const sessionHistoryQuerySchema = z.object({
 });
 export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): void {
   const {
-    sessions, auth, metrics, monitor, eventBus, channels,
+    sessions, auth, quotas, metrics, monitor, eventBus, channels,
     memoryBridge, toolRegistry, getAuditLogger, validateWorkDir,
   } = ctx;
 
@@ -286,6 +286,24 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     if (!requirePermission(auth, req, reply, 'create')) return;
     const { workDir, name, prompt, prd, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId, memoryKeys } = data;
     if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
+
+    // Issue #1953: Per-key quota enforcement at session creation.
+    const keyId = req.authKeyId;
+    const apiKey = keyId && keyId !== 'master' ? auth.getKey(keyId) : null;
+    if (apiKey) {
+      const ownedSessions = sessions.listSessions().filter(s => s.ownerKeyId === keyId);
+      const quotaResult = quotas.checkSessionQuota(apiKey, ownedSessions.length);
+      if (!quotaResult.allowed) {
+        const auditLogger = getAuditLogger();
+        if (auditLogger) void auditLogger.log(resolveAuditActor(auth, keyId, 'system'), 'session.quota.rejected', quotaResult.message ?? 'Quota exceeded', undefined);
+        return reply.status(429).send({
+          error: 'QUOTA_EXCEEDED',
+          message: quotaResult.message,
+          quota: quotaResult.reason,
+          usage: quotaResult.usage,
+        });
+      }
+    }
 
     // Issue #564: Validate installed Claude Code version
     try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ import { PipelineManager } from './pipeline.js';
 import { ToolRegistry } from './tool-registry.js';
 import {
   AuthManager,
+  QuotaManager,
   RateLimiter,
   classifyBearerTokenForRoute,
   type ApiKeyPermission,
@@ -708,6 +709,9 @@ async function main(): Promise<void> {
   auth = new AuthManager(path.join(config.stateDir, 'keys.json'), config.authToken);
   auth.setHost(config.host);  // #1080: needed for auth bypass security check
 
+  // Issue #1953: Per-key quota manager
+  const quotaManager = new QuotaManager();
+
   // #1419: Initialize audit logger and wire into auth
   auditLogger = new AuditLogger(path.join(config.stateDir, 'audit'));
   await auditLogger.init();
@@ -841,7 +845,7 @@ async function main(): Promise<void> {
   const serverState = { draining: false };
 
   const routeCtx: RouteContext = {
-    sessions, tmux, auth, config, metrics, monitor, eventBus, channels,
+    sessions, tmux, auth, quotas: quotaManager, config, metrics, monitor, eventBus, channels,
     jsonlWatcher, pipelines, toolRegistry, getAuditLogger: () => auditLogger,
     alertManager, swarmMonitor, sseLimiter, memoryBridge, requestKeyMap,
     validateWorkDir: validateWorkDirWithConfig,
@@ -871,6 +875,8 @@ async function main(): Promise<void> {
   const authFailPruneInterval = setInterval(pruneAuthFailLimits, 60_000);
   // #398: Sweep stale API key rate limit buckets every 5 minutes
   const authSweepInterval = setInterval(() => auth.sweepStaleRateLimits(), 5 * 60_000);
+  // Issue #1953: Sweep stale quota usage entries every 5 minutes
+  const quotaSweepInterval = setInterval(() => quotaManager.sweep(), 5 * 60_000);
   let pidFilePath = '';
 
   // Issue #361: Graceful shutdown handler
@@ -932,6 +938,7 @@ async function main(): Promise<void> {
       clearInterval(ipPruneInterval);
       clearInterval(authFailPruneInterval);
       clearInterval(authSweepInterval);
+      clearInterval(quotaSweepInterval);
       rateLimiter.dispose();
 
       // 3. Close file watchers, pipelines, and reaper

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -45,7 +45,15 @@ const SSE_TOKEN_MAX_PER_KEY = 5;
 /** #583: Minimum interval between batch creation requests per key (5 seconds). */
 const BATCH_COOLDOWN_MS = 5_000;
 
-type PersistedApiKey = Omit<ApiKey, 'permissions'> & { permissions?: string[] };
+type PersistedApiKey = Omit<ApiKey, 'permissions' | 'quotas'> & {
+  permissions?: string[];
+  quotas?: {
+    maxConcurrentSessions?: number | null;
+    maxTokensPerWindow?: number | null;
+    maxSpendPerWindow?: number | null;
+    quotaWindowMs?: number;
+  };
+};
 
 /** Route-level auth policy for bearer tokens. */
 export function classifyBearerTokenForRoute(
@@ -138,14 +146,35 @@ export class AuthManager {
     const normalizedPermissions = key.permissions === undefined
       ? permissionsForRole(key.role)
       : normalizePermissions(providedPermissions ?? []);
-    const changed = key.permissions === undefined
+    let changed = key.permissions === undefined
       || (key.permissions?.length ?? 0) !== normalizedPermissions.length
       || !AuthManager.permissionsEqual(providedPermissions ?? [], normalizedPermissions);
+
+    // Issue #1953: Normalize quotas — convert undefined fields to null for strict typing.
+    let quotas: import('./types.js').QuotaConfig | undefined;
+    if (key.quotas) {
+      quotas = {
+        maxConcurrentSessions: key.quotas.maxConcurrentSessions ?? null,
+        maxTokensPerWindow: key.quotas.maxTokensPerWindow ?? null,
+        maxSpendPerWindow: key.quotas.maxSpendPerWindow ?? null,
+        quotaWindowMs: key.quotas.quotaWindowMs ?? 3_600_000,
+      };
+      // Detect if any normalization happened
+      if (
+        key.quotas.maxConcurrentSessions === undefined
+        || key.quotas.maxTokensPerWindow === undefined
+        || key.quotas.maxSpendPerWindow === undefined
+        || key.quotas.quotaWindowMs === undefined
+      ) {
+        changed = true;
+      }
+    }
 
     return {
       key: {
         ...key,
         permissions: normalizedPermissions,
+        quotas,
       },
       changed,
     };
@@ -222,6 +251,26 @@ export class AuthManager {
       ...rest,
       permissions: [...permissions],
     }));
+  }
+
+  /** Issue #1953: Get an API key by ID (for quota lookups). Returns null if not found. */
+  getKey(id: string): ApiKey | null {
+    return this.store.keys.find(k => k.id === id) ?? null;
+  }
+
+  /** Issue #1953: Set quotas on an API key. Returns the updated key (without hash) or null. */
+  async setQuotas(id: string, quotas: import('./types.js').QuotaConfig): Promise<Omit<ApiKey, 'hash'> | null> {
+    const key = this.store.keys.find(k => k.id === id);
+    if (!key) return null;
+    key.quotas = { ...quotas };
+    await this.save();
+
+    if (this.audit) {
+      void this.audit.log('system', 'key.quotas.update', `Quotas updated for key ${key.name} (${id}): sessions=${quotas.maxConcurrentSessions}, tokens=${quotas.maxTokensPerWindow}, spend=${quotas.maxSpendPerWindow}`, undefined);
+    }
+
+    const { hash: _, ...rest } = key;
+    return { ...rest, permissions: [...key.permissions] };
   }
 
   /** Revoke a key by ID. */

--- a/src/services/auth/QuotaManager.ts
+++ b/src/services/auth/QuotaManager.ts
@@ -1,0 +1,191 @@
+/**
+ * QuotaManager.ts — Per-key resource quota tracking and enforcement.
+ *
+ * Issue #1953: Prevents one API key from starving others by enforcing:
+ *   - Max concurrent sessions
+ *   - Max tokens per rolling window
+ *   - Max USD spend per rolling window
+ *
+ * Usage is tracked in-memory with a rolling window. The manager is
+ * queried at session-create and send-time to enforce limits.
+ */
+
+import type { ApiKey, QuotaConfig } from './types.js';
+
+/** Default rolling window: 1 hour. */
+const DEFAULT_WINDOW_MS = 3_600_000;
+
+/** A single usage record within the rolling window. */
+interface UsageEntry {
+  timestamp: number;
+  tokens: number;
+  costUsd: number;
+}
+
+export interface QuotaCheckResult {
+  allowed: boolean;
+  /** Which quota was exceeded, if any. */
+  reason?: 'concurrent_sessions' | 'tokens_per_window' | 'spend_per_window';
+  /** Human-readable message. */
+  message?: string;
+  /** Current usage snapshot for the key. */
+  usage: QuotaUsage;
+}
+
+export interface QuotaUsage {
+  activeSessions: number;
+  maxSessions: number | null;
+  tokensInWindow: number;
+  maxTokens: number | null;
+  spendInWindow: number;
+  maxSpend: number | null;
+  windowMs: number;
+}
+
+export class QuotaManager {
+  /** Per-key usage entries, ordered by timestamp. */
+  private usageLog = new Map<string, UsageEntry[]>();
+
+  /**
+   * Check if an API key is allowed to create a new session.
+   * Counts active sessions owned by the key.
+   *
+   * @param key - The API key (may have no quotas set).
+   * @param activeSessionCount - Number of sessions currently owned by this key.
+   */
+  checkSessionQuota(key: ApiKey | null, activeSessionCount: number): QuotaCheckResult {
+    if (!key?.quotas) return this.unlimitedResult(activeSessionCount);
+
+    const q = key.quotas;
+    const maxSessions = q.maxConcurrentSessions;
+
+    if (maxSessions !== null && activeSessionCount >= maxSessions) {
+      return {
+        allowed: false,
+        reason: 'concurrent_sessions',
+        message: `Quota exceeded: key "${key.name}" has ${activeSessionCount} active sessions (max ${maxSessions})`,
+        usage: this.buildUsage(key, activeSessionCount),
+      };
+    }
+
+    // Also check token and spend quotas (even for session creation,
+    // to fail fast before launching a tmux window).
+    const tokenCheck = this.checkWindowUsage(key, 0);
+    if (!tokenCheck.allowed) return tokenCheck;
+
+    return {
+      allowed: true,
+      usage: this.buildUsage(key, activeSessionCount),
+    };
+  }
+
+  /**
+   * Check if an API key is allowed to send a message (tokens/spend quota).
+   *
+   * @param key - The API key.
+   * @param activeSessionCount - Number of active sessions for this key.
+   */
+  checkSendQuota(key: ApiKey | null, activeSessionCount: number): QuotaCheckResult {
+    if (!key?.quotas) return this.unlimitedResult(activeSessionCount);
+    return this.checkWindowUsage(key, activeSessionCount);
+  }
+
+  /**
+   * Record token usage and cost for a key.
+   */
+  recordUsage(keyId: string, tokens: number, costUsd: number): void {
+    if (tokens === 0 && costUsd === 0) return;
+    const log = this.usageLog.get(keyId) ?? [];
+    log.push({ timestamp: Date.now(), tokens, costUsd });
+    this.usageLog.set(keyId, log);
+  }
+
+  /**
+   * Get current quota usage for a key.
+   */
+  getUsage(key: ApiKey, activeSessionCount: number): QuotaUsage {
+    return this.buildUsage(key, activeSessionCount);
+  }
+
+  /**
+   * Clean up usage entries older than the window for all keys.
+   * Should be called periodically (e.g., every 5 minutes).
+   */
+  sweep(windowMs: number = DEFAULT_WINDOW_MS): void {
+    const cutoff = Date.now() - windowMs;
+    for (const [keyId, entries] of this.usageLog) {
+      const filtered = entries.filter(e => e.timestamp > cutoff);
+      if (filtered.length === 0) {
+        this.usageLog.delete(keyId);
+      } else if (filtered.length !== entries.length) {
+        this.usageLog.set(keyId, filtered);
+      }
+    }
+  }
+
+  /** Remove all usage data for a key (e.g., after revocation). */
+  clearKey(keyId: string): void {
+    this.usageLog.delete(keyId);
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────
+
+  private checkWindowUsage(key: ApiKey, activeSessionCount: number): QuotaCheckResult {
+    const q = key.quotas!;
+    const windowMs = q.quotaWindowMs || DEFAULT_WINDOW_MS;
+    const usage = this.buildUsage(key, activeSessionCount);
+
+    if (q.maxTokensPerWindow !== null && usage.tokensInWindow >= q.maxTokensPerWindow) {
+      return {
+        allowed: false,
+        reason: 'tokens_per_window',
+        message: `Quota exceeded: key "${key.name}" used ${usage.tokensInWindow} tokens in window (max ${q.maxTokensPerWindow})`,
+        usage,
+      };
+    }
+
+    if (q.maxSpendPerWindow !== null && usage.spendInWindow >= q.maxSpendPerWindow) {
+      return {
+        allowed: false,
+        reason: 'spend_per_window',
+        message: `Quota exceeded: key "${key.name}" spent $${usage.spendInWindow.toFixed(4)} in window (max $${q.maxSpendPerWindow})`,
+        usage,
+      };
+    }
+
+    return { allowed: true, usage };
+  }
+
+  private buildUsage(key: ApiKey, activeSessionCount: number): QuotaUsage {
+    const q = key.quotas;
+    const windowMs = q?.quotaWindowMs || DEFAULT_WINDOW_MS;
+    const cutoff = Date.now() - windowMs;
+    const entries = this.usageLog.get(key.id) ?? [];
+    const recent = entries.filter(e => e.timestamp > cutoff);
+
+    return {
+      activeSessions: activeSessionCount,
+      maxSessions: q?.maxConcurrentSessions ?? null,
+      tokensInWindow: recent.reduce((sum, e) => sum + e.tokens, 0),
+      maxTokens: q?.maxTokensPerWindow ?? null,
+      spendInWindow: recent.reduce((sum, e) => sum + e.costUsd, 0),
+      maxSpend: q?.maxSpendPerWindow ?? null,
+      windowMs,
+    };
+  }
+
+  private unlimitedResult(activeSessionCount: number): QuotaCheckResult {
+    return {
+      allowed: true,
+      usage: {
+        activeSessions: activeSessionCount,
+        maxSessions: null,
+        tokensInWindow: 0,
+        maxTokens: null,
+        spendInWindow: 0,
+        maxSpend: null,
+        windowMs: DEFAULT_WINDOW_MS,
+      },
+    };
+  }
+}

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -1,4 +1,6 @@
 export { AuthManager, classifyBearerTokenForRoute } from './AuthManager.js';
+export { QuotaManager } from './QuotaManager.js';
+export type { QuotaCheckResult, QuotaUsage } from './QuotaManager.js';
 export { RateLimiter } from './RateLimiter.js';
 export {
   API_KEY_PERMISSION_VALUES,
@@ -7,4 +9,4 @@ export {
   permissionsForRole,
 } from './permissions.js';
 export type { ApiKeyPermission } from './permissions.js';
-export type { ApiKey, ApiKeyRole, ApiKeyStore, AuthRejectReason } from './types.js';
+export type { ApiKey, ApiKeyRole, ApiKeyStore, AuthRejectReason, QuotaConfig } from './types.js';

--- a/src/services/auth/types.ts
+++ b/src/services/auth/types.ts
@@ -2,6 +2,17 @@ import type { ApiKeyPermission } from './permissions.js';
 
 export type ApiKeyRole = 'admin' | 'operator' | 'viewer';
 
+export interface QuotaConfig {
+  /** Max concurrent sessions for this key (null = unlimited). */
+  maxConcurrentSessions: number | null;
+  /** Max tokens (input + output) per rolling window (null = unlimited). */
+  maxTokensPerWindow: number | null;
+  /** Max estimated USD spend per rolling window (null = unlimited). */
+  maxSpendPerWindow: number | null;
+  /** Rolling window duration in milliseconds (default 1 hour). */
+  quotaWindowMs: number;
+}
+
 export interface ApiKey {
   id: string;
   name: string;
@@ -12,6 +23,8 @@ export interface ApiKey {
   expiresAt: number | null;
   role: ApiKeyRole;
   permissions: ApiKeyPermission[];
+  /** Per-key resource quotas (Issue #1953). Omitted when no quotas set. */
+  quotas?: QuotaConfig;
 }
 
 export interface ApiKeyStore {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -359,6 +359,12 @@ export const authStoreSchema = z.object({
     expiresAt: z.number().nullable().optional().default(null),
     role: z.enum(['admin', 'operator', 'viewer']).optional().default('viewer'),
     permissions: z.array(z.string()).optional(),
+    quotas: z.object({
+      maxConcurrentSessions: z.number().nullable().optional(),
+      maxTokensPerWindow: z.number().nullable().optional(),
+      maxSpendPerWindow: z.number().nullable().optional(),
+      quotaWindowMs: z.number().optional(),
+    }).optional(),
   })),
 });
 


### PR DESCRIPTION
Per-API-key quotas: max sessions, max tokens, max USD spend. Enforcement middleware, quota exceeded errors, admin endpoint to manage quotas. 702 insertions, 15 files.