### PR TITLE
docs: add API key rotation, quotas, metering hooks, and webhook signature docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -339,6 +339,85 @@ curl http://localhost:9100/v1/pipelines \
 
 ---
 
+## Metering & Billing Hooks
+
+Aegis tracks per-session and per-API-key usage for billing and metering. The MeteringService records token deltas and session lifecycle events, exposing REST endpoints for usage queries.
+
+### Usage Endpoints
+
+#### Get key usage breakdown
+
+```bash
+curl "http://localhost:9100/v1/metering/keys/key-abc123/usage?window=day" \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+Returns token counts, estimated cost, and session count for a key over a time window.
+
+#### List all key usages
+
+```bash
+curl "http://localhost:9100/v1/metering/usage?window=day&limit=50" \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+Returns paginated usage records across all keys.
+
+#### Get session usage
+
+```bash
+curl "http://localhost:9100/v1/metering/sessions/sess-abc123/usage" \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+Returns token delta and cost estimate for a specific session.
+
+### Rate Tiers
+
+Usage is calculated against configurable rate tiers. Contact your admin to set up tier pricing for your organization.
+
+---
+
+## Webhook Signature Verification
+
+Aegis signs outbound webhooks with HMAC-SHA256 including a timestamp to prevent replay attacks.
+
+### Signature Header Format
+
+Outbound webhooks include:
+- `X-Aegis-Signature: t=<unix_timestamp>,v1=<hex_signature>` (new format)
+- Legacy `sha256=<hex_signature>` still accepted for backward compatibility
+
+### Verification (Node.js)
+
+```typescript
+import { signPayload, verifySignature } from '@onestepat4time/aegis/webhook';
+
+// Verify an incoming webhook
+const isValid = verifySignature(payload, headers['x-aegis-signature'], secret);
+if (!isValid) {
+  throw new Error('Invalid signature');
+}
+
+// Create a signed payload (for testing)
+const { timestamp, signature } = signPayload(payload, secret);
+```
+
+### Parameters
+
+| Function | Parameter | Type | Description |
+|---|---|---|---|
+| `signPayload` | payload | string | Raw request body |
+| `signPayload` | secret | string | Webhook signing secret |
+| `verifySignature` | payload | string | Raw request body |
+| `verifySignature` | header | string | Full `X-Aegis-Signature` header value |
+| `verifySignature` | secret | string | Webhook signing secret |
+| `verifySignature` | tolerance? | number | Max age in seconds (default: 300) |
+
+**Security:** `verifySignature` uses constant-time comparison, rejects timestamps outside the tolerance window, and handles both new and legacy signature formats.
+
+---
+
 ## Diagnostics
 
 Aegis exposes a bounded diagnostics endpoint for debugging the server itself. This endpoint returns internal events (no user prompts or session content — PII-free).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -781,7 +781,32 @@ curl -X POST http://localhost:9100/v1/auth/keys/key-abc123/rotate \
   -d '{"ttlDays": 365}'
 ```
 
-Rotates an API key. Admin-only. Optionally set TTL in days. Returns the updated key metadata.
+Rotates a specific API key. Admin-only. Optionally set TTL in days. Returns the updated key metadata.
+
+### Rotate API Key (Zero-Downtime)
+
+```bash
+curl -X POST http://localhost:9100/v1/auth/keys/rotate \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-key-name",
+    "gracePeriodSeconds": 3600,
+    "role": "admin"
+  }'
+```
+
+Creates a new API key while keeping the old key valid during a configurable grace period (default: 1 hour, max: 24 hours). Both keys authenticate during the overlap window, enabling zero-downtime key rotation. The old key is automatically invalidated after the grace period expires.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | Friendly name for the new key |
+| `gracePeriodSeconds` | number | No | Seconds to keep old key valid (default: 3600, max: 86400) |
+| `role` | string | No | Role for the new key: `admin`, `operator`, `observer` |
+
+**Response:** Returns the new key object with `key` (secret), `name`, `keyId`, `role`, `createdAt`, and `expiresAt`.
+
+**Audit:** A `key.rotate` entry is logged with key name, ID, and grace period duration.
 
 ### Create SSE Token
 
@@ -790,6 +815,55 @@ curl -X POST http://localhost:9100/v1/auth/sse-token
 ```
 
 Returns a short-lived token for SSE event stream authentication.
+
+### Get Key Quotas
+
+```bash
+curl http://localhost:9100/v1/auth/keys/key-abc123/quotas \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+Returns the current quota configuration and usage for an API key.
+
+**Response:**
+```json
+{
+  "maxConcurrentSessions": 5,
+  "maxTokensPerWindow": 1000000,
+  "maxSpendPerWindow": 10.00,
+  "windowUnit": "day",
+  "used": {
+    "concurrentSessions": 2,
+    "tokens": 342000,
+    "spend": 3.42
+  }
+}
+```
+
+### Update Key Quotas
+
+```bash
+curl -X PUT http://localhost:9100/v1/auth/keys/key-abc123/quotas \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "maxConcurrentSessions": 10,
+    "maxTokensPerWindow": 5000000,
+    "maxSpendPerWindow": 50.00,
+    "windowUnit": "day"
+  }'
+```
+
+Updates quota limits for an API key. Admin-only. Returns the updated quota configuration.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `maxConcurrentSessions` | number | No | Max concurrent sessions (0 = unlimited) |
+| `maxTokensPerWindow` | number | No | Max tokens per window (0 = unlimited) |
+| `maxSpendPerWindow` | number | No | Max USD spend per window (0 = unlimited) |
+| `windowUnit` | string | No | Window granularity: `minute`, `hour`, `day` |
+
+**Audit:** A `key.quotas.update` entry is logged on changes. `session.quota.rejected` is logged when a quota is exceeded.
 
 ---
 


### PR DESCRIPTION
## Summary\n\nAdd user-facing documentation for features merged in recent PRs:\n\n1. **API Key Rotation with Grace Period** (#2111) —  for zero-downtime key rotation\n2. **Per-Tenant Quotas** (#2121) —  for managing per-key resource limits\n3. **Billing/Metering Hooks** (#2122) — Usage tracking endpoints for per-session and per-key metering\n4. **Webhook Signature Verification SDK** (#2120) — HMAC-SHA256 signing with replay protection\n\n## Changes\n\n### docs/api-reference.md\n- Add "Rotate API Key (Zero-Downtime)" section for \n- Add "Get Key Quotas" and "Update Key Quotas" sections for quota management\n- Update existing "Rotate API Key" description to clarify it rotates a specific key\n\n### docs/advanced.md\n- Add "Metering & Billing Hooks" section with usage endpoints\n- Add "Webhook Signature Verification" section with Node.js SDK docs\n\n## Files Changed\n- docs/advanced.md: +79 lines\n- docs/api-reference.md: +76 lines, -1 line\n\n---\nTagged <@1490089830472880218> for review.