### PR TITLE
feat: observability bundles — Grafana, Datadog, OTLP, alerting (#1951)

### DIFF
--- a/docs/ALERTING.md
+++ b/docs/ALERTING.md
@@ -1,0 +1,239 @@
+# Alerting Recommendations
+
+Recommended alert rules for Aegis deployments. These complement the built-in
+AlertManager (see [alerting.md](./alerting.md)) with metrics-based alerts for
+Prometheus, Datadog, or any observability platform scraping the `/metrics`
+endpoint.
+
+---
+
+## Alert Summary
+
+| # | Alert | Severity | Metric | Threshold |
+|---|-------|----------|--------|-----------|
+| 1 | HighSessionCount | warning | `aegis_sessions_active` | > 50 |
+| 2 | CriticalSessionCount | critical | `aegis_sessions_active` | > 100 |
+| 3 | SessionFailureRateSpike | critical | `aegis_sessions_failed_total / aegis_sessions_created_total` | > 20% over 15m |
+| 4 | SessionFailureRateWarning | warning | same | > 10% over 15m |
+| 5 | WebhookDeliveryFailures | warning | `aegis_webhooks_failed_total` | > 10 in 10m |
+| 6 | PromptDeliveryFailures | warning | `aegis_prompts_failed_total` | > 5 in 10m |
+| 7 | PermissionLatencyHigh | warning | `aegis_permission_response_latency_ms` p99 | > 5s |
+| 8 | PermissionLatencyCritical | critical | same | > 10s |
+| 9 | DailyCostThreshold | warning | `/v1/usage` cost | > $50/day |
+| 10 | DailyCostCritical | critical | same | > $100/day |
+| 11 | HealthDegraded | critical | `/v1/health` status | status ≠ "ok" |
+
+---
+
+## Prometheus Alert Rules
+
+Save to your Alertmanager rules file (e.g., `aegis-alerts.yml`):
+
+```yaml
+groups:
+  - name: aegis.sessions
+    rules:
+      - alert: AegisHighSessionCount
+        expr: aegis_sessions_active > 50
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Aegis has {{ $value }} active sessions"
+          runbook: "Check for runaway sessions. Consider scaling or enabling session limits."
+
+      - alert: AegisCriticalSessionCount
+        expr: aegis_sessions_active > 100
+        for: 2m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "Aegis session count is critical: {{ $value }}"
+          runbook: "Immediate action needed. Kill stale sessions or scale the deployment."
+
+      - alert: AegisSessionFailureRateSpike
+        expr: >
+          rate(aegis_sessions_failed_total[15m])
+            / on()
+          rate(aegis_sessions_created_total[15m])
+            > 0.2
+        for: 5m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "Aegis session failure rate is {{ $value | humanizePercentage }}"
+          runbook: "Check Claude CLI health (`/v1/health`), tmux status, and recent deployments."
+
+      - alert: AegisSessionFailureRateWarning
+        expr: >
+          rate(aegis_sessions_failed_total[15m])
+            / on()
+          rate(aegis_sessions_created_total[15m])
+            > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Aegis session failure rate is elevated: {{ $value | humanizePercentage }}"
+
+  - name: aegis.webhooks
+    rules:
+      - alert: AegisWebhookDeliveryFailures
+        expr: increase(aegis_webhooks_failed_total[10m]) > 10
+        for: 2m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "{{ $value }} webhook delivery failures in 10 minutes"
+          runbook: "Check webhook endpoint health and network connectivity."
+
+  - name: aegis.prompts
+    rules:
+      - alert: AegisPromptDeliveryFailures
+        expr: increase(aegis_prompts_failed_total[10m]) > 5
+        for: 2m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "{{ $value }} prompt delivery failures in 10 minutes"
+          runbook: "Check channel health via /v1/channels/health."
+
+  - name: aegis.latency
+    rules:
+      - alert: AegisPermissionLatencyHigh
+        expr: >
+          histogram_quantile(0.99, rate(aegis_permission_response_latency_ms_bucket[15m]))
+            > 5000
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Aegis permission response p99 latency is {{ $value }}ms"
+          runbook: "Sessions may be stalling. Check approval workflow responsiveness."
+
+      - alert: AegisPermissionLatencyCritical
+        expr: >
+          histogram_quantile(0.99, rate(aegis_permission_response_latency_ms_bucket[15m]))
+            > 10000
+        for: 3m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "Aegis permission response p99 latency is critical: {{ $value }}ms"
+          runbook: "Sessions are likely timing out. Check approval handlers immediately."
+```
+
+---
+
+## Cost Alerts
+
+Aegis tracks cost via the `/v1/usage` API rather than Prometheus counters. Use
+one of these approaches:
+
+### Option A: Cron + curl
+
+```bash
+#!/bin/bash
+# Run daily via cron. Posts to a webhook if cost exceeds threshold.
+FROM=$(date -d 'yesterday' +%Y-%m-%d)
+TO=$(date +%Y-%m-%d)
+TOKEN="${AEGIS_AUTH_TOKEN}"
+THRESHOLD=100
+
+COST=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9100/v1/usage?from=${FROM}&to=${TO}" \
+  | jq -r '.totalCostUsd')
+
+if (( $(echo "$COST > $THRESHOLD" | bc -l) )); then
+  curl -sf -X POST "${ALERT_WEBHOOK}" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\": \"Aegis daily cost alert: \$${COST} (threshold: \$${THRESHOLD})\"}"
+fi
+```
+
+### Option B: Datadog monitor
+
+Import from `examples/datadog/aegis-monitors.json` or create manually using the
+cost metric bridge described in [OBSERVABILITY.md](./OBSERVABILITY.md).
+
+---
+
+## Health Check Alerting
+
+### HTTP-based
+
+```bash
+# Simple health check with alert on non-OK status
+STATUS=$(curl -sf http://localhost:9100/v1/health | jq -r '.status')
+if [ "$STATUS" != "ok" ]; then
+  echo "Aegis health is: $STATUS" >&2
+  # Trigger alert
+fi
+```
+
+### Prometheus blackbox exporter
+
+```yaml
+# blackbox.yml
+modules:
+  http_aegis_health:
+    prober: http
+    timeout: 5s
+    http:
+      valid_status_codes: [200]
+      fail_if_body_not_matches_regexp:
+        - '"status":"ok"'
+```
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: aegis_health
+    metrics_path: /probe
+    params:
+      module: [http_aegis_health]
+    static_configs:
+      - targets:
+          - http://localhost:9100/v1/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+```
+
+---
+
+## Alerting Best Practices
+
+1. **Start with session failures and health checks.** These are the highest-signal
+   alerts for Aegis.
+
+2. **Tune thresholds to your deployment.** The defaults above assume a
+   small-to-medium deployment (10–100 concurrent sessions). Adjust based on
+   your baseline.
+
+3. **Use the built-in AlertManager for webhook delivery.** Aegis can push
+   alerts directly to Slack, PagerDuty, etc. via `AEGIS_ALERT_WEBHOOKS`.
+   Metrics-based alerts are complementary.
+
+4. **Set cooldown periods.** Aegis's built-in alerts use a 10-minute cooldown
+   by default (`AEGIS_ALERT_COOLDOWN_MS`). Apply similar cooldowns in your
+   observability platform to prevent alert fatigue.
+
+5. **Correlate with traces.** When a latency alert fires, use the OTLP traces
+   (see [OBSERVABILITY.md](./OBSERVABILITY.md)) to identify which session or
+   tmux operation is slow.
+
+6. **Monitor cost daily.** Token costs can accumulate quickly with high session
+   counts. Set up daily cost checks using the `/v1/usage` API.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,362 @@
+# Observability Guide
+
+Aegis exposes metrics, traces, and events that integrate with standard
+observability stacks. This guide covers Prometheus, Grafana, Datadog, and
+OpenTelemetry (OTLP).
+
+---
+
+## Overview
+
+| Signal | Endpoint | Format | Auth |
+|--------|----------|--------|------|
+| Metrics | `GET /metrics` | Prometheus text exposition | `metricsToken` or `authToken` |
+| Health | `GET /v1/health` | JSON | None (basic) / Bearer (detailed) |
+| Events | `GET /v1/events` | SSE stream | Bearer |
+| Traces | OTLP HTTP | Protobuf over HTTP | None (collector-side) |
+| Alert stats | `GET /v1/alerts/stats` | JSON | Bearer (admin/operator/viewer) |
+| Usage | `GET /v1/usage` | JSON | Bearer (admin/operator) |
+
+---
+
+## Prometheus Metrics
+
+Aegis exposes a `/metrics` endpoint in standard Prometheus exposition format.
+Scrape it from your Prometheus server:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: aegis
+    scrape_interval: 15s
+    scheme: http
+    basic_auth:
+      username: metrics
+      password: ${AEGIS_METRICS_TOKEN}
+    static_configs:
+      - targets: ['localhost:9100']
+```
+
+### Available Metrics
+
+**Counters:**
+
+| Metric | Description |
+|--------|-------------|
+| `aegis_sessions_created_total` | Total sessions created |
+| `aegis_sessions_completed_total` | Total sessions completed |
+| `aegis_sessions_failed_total` | Total sessions that failed |
+| `aegis_messages_total` | Total messages received |
+| `aegis_tool_calls_total` | Total tool calls |
+| `aegis_auto_approvals_total` | Total auto-approved permissions |
+| `aegis_webhooks_sent_total` | Total webhooks sent |
+| `aegis_webhooks_failed_total` | Total webhooks that failed |
+| `aegis_screenshots_total` | Total screenshots taken |
+| `aegis_pipelines_created_total` | Total pipelines created |
+| `aegis_batches_created_total` | Total batch sessions created |
+| `aegis_prompts_sent_total` | Total prompts sent |
+| `aegis_prompts_delivered_total` | Total prompts delivered |
+| `aegis_prompts_failed_total` | Total prompts that failed |
+
+**Gauges:**
+
+| Metric | Description |
+|--------|-------------|
+| `aegis_sessions_active` | Currently active sessions |
+
+**Histograms** (buckets: 0.5ms to 10s):
+
+| Metric | Description |
+|--------|-------------|
+| `aegis_hook_latency_ms` | Hook processing latency |
+| `aegis_state_change_detection_latency_ms` | State change detection latency |
+| `aegis_permission_response_latency_ms` | Permission response latency |
+| `aegis_channel_delivery_latency_ms` | Channel delivery latency |
+
+**Default Node.js metrics** (memory, CPU, event loop lag) are also exposed via
+`prom-client`'s `collectDefaultMetrics`.
+
+### Metrics Token
+
+Set `AEGIS_METRICS_TOKEN` to require authentication on `/metrics`. If unset,
+the primary `AEGIS_AUTH_TOKEN` is used.
+
+---
+
+## Grafana Integration
+
+### Prerequisites
+
+- Prometheus scraping Aegis `/metrics` (see above)
+- Grafana connected to that Prometheus data source
+
+### Quick Start
+
+1. Import the bundled dashboards from `examples/grafana/`:
+
+```bash
+# Each JSON file is a Grafana dashboard export.
+# Import via: Dashboards → Import → Upload JSON file
+```
+
+| Dashboard | File | Panels |
+|-----------|------|--------|
+| Session Metrics | `aegis-sessions.json` | Active sessions, creation/completion rate, failure rate, avg duration |
+| Cost & Usage | `aegis-costs.json` | Token usage by model, estimated cost, cost over time |
+| Error Rates | `aegis-errors.json` | Session failure rate, webhook failures, prompt delivery failures |
+
+### Example PromQL Queries
+
+```promql
+# Active sessions
+aegis_sessions_active
+
+# Session creation rate (per minute)
+rate(aegis_sessions_created_total[5m]) * 60
+
+# Session failure ratio
+rate(aegis_sessions_failed_total[5m])
+  / on() rate(aegis_sessions_created_total[5m])
+
+# P99 permission response latency
+histogram_quantile(0.99, rate(aegis_permission_response_latency_ms_bucket[5m]))
+
+# Webhook success rate
+rate(aegis_webhooks_sent_total[5m])
+  - rate(aegis_webhooks_failed_total[5m])
+```
+
+---
+
+## Datadog Integration
+
+### Option A: Agent-based (Prometheus autodiscovery)
+
+Datadog Agent can scrape Prometheus endpoints natively:
+
+```yaml
+# datadog-agent/conf.d/prometheus.d/conf.yaml
+init_config:
+
+instances:
+  - prometheus_url: http://localhost:9100/metrics
+    namespace: aegis
+    metrics:
+      - aegis_sessions_*:
+          name: aegis.sessions
+      - aegis_messages_total:
+          name: aegis.messages
+      - aegis_tool_calls_total:
+          name: aegis.tool_calls
+      - aegis_webhooks_*:
+          name: aegis.webhooks
+      - aegis_prompts_*:
+          name: aegis.prompts
+      - aegis_*_latency_ms:
+          name: aegis.latency
+    headers:
+      Authorization: "Bearer ${AEGIS_METRICS_TOKEN}"
+```
+
+### Option B: StatsD/DogStatsD custom metrics
+
+Use the Datadog Agent's StatsD listener with a small bridge script:
+
+```bash
+# Pipe Prometheus text output to datadog-metrics bridge
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:9100/metrics \
+  | datadog-prometheus-bridge
+```
+
+### Dashboard and Monitors
+
+Import the bundled configurations from `examples/datadog/`:
+
+| File | Description |
+|------|-------------|
+| `aegis-dashboard.json` | Dashboard with session, cost, and error panels |
+| `aegis-monitors.json` | Monitor definitions for session count, error rate, cost threshold |
+
+---
+
+## OpenTelemetry (OTLP) Tracing
+
+Aegis emits distributed traces via OTLP HTTP when tracing is enabled.
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AEGIS_OTEL_ENABLED` | `false` | Enable tracing |
+| `AEGIS_OTEL_SERVICE_NAME` | `aegis` | Service name in traces |
+| `AEGIS_OTEL_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP collector endpoint |
+| `AEGIS_OTEL_SAMPLE_RATE` | `1.0` | Sampling ratio (0.0–1.0) |
+
+### Span Taxonomy
+
+| Span | Kind | Key Attributes |
+|------|------|----------------|
+| `session.create` | INTERNAL | `aegis.session.id`, `workDir` |
+| `session.send` | INTERNAL | `aegis.session.id` |
+| `session.kill` | INTERNAL | `aegis.session.id` |
+| `tmux.send-keys` | INTERNAL | `aegis.tmux.window_id` |
+| `tmux.capture-pane` | INTERNAL | `aegis.tmux.window_id` |
+| `tmux.create-window` | INTERNAL | `aegis.tmux.window_id`, `workDir` |
+| `monitor.poll` | INTERNAL | — |
+| `monitor.stall_check` | INTERNAL | `stall_type` |
+| HTTP spans | SERVER | Auto-instrumented |
+
+### Collector Configurations
+
+Example OTLP collector configurations for common backends are in
+`examples/otlp/`:
+
+| File | Backend |
+|------|---------|
+| `collector-grafana.yaml` | Grafana Tempo via OTLP |
+| `collector-jaeger.yaml` | Jaeger via OTLP |
+| `collector-honeycomb.yaml` | Honeycomb via OTLP |
+
+### Quick Start: Grafana Tempo
+
+```bash
+# 1. Start the collector
+docker run -d --name otel-collector \
+  -p 4318:4318 \
+  -v ./examples/otlp/collector-grafana.yaml:/etc/otelcol/config.yaml \
+  otel/opentelemetry-collector
+
+# 2. Enable tracing in Aegis
+AEGIS_OTEL_ENABLED=true \
+AEGIS_OTEL_OTLP_ENDPOINT=http://localhost:4318 \
+AEGIS_AUTH_TOKEN=my-secret \
+ag
+```
+
+### Quick Start: Jaeger
+
+```bash
+# 1. Start Jaeger all-in-one
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/jaeger:latest
+
+# 2. Enable tracing in Aegis
+AEGIS_OTEL_ENABLED=true \
+AEGIS_OTEL_OTLP_ENDPOINT=http://localhost:4318 \
+AEGIS_AUTH_TOKEN=my-secret \
+ag
+```
+
+---
+
+## Alerting
+
+See [ALERTING.md](./ALERTING.md) for recommended alert rules for session count,
+error rates, and cost thresholds.
+
+Aegis includes a built-in AlertManager that fires webhook notifications when
+failure thresholds are exceeded. See [alerting.md](./alerting.md) for the
+built-in alerting configuration.
+
+---
+
+## Health Checks
+
+### Load Balancer (unauthenticated)
+
+```bash
+curl http://localhost:9100/v1/health
+```
+
+Returns:
+
+```json
+{ "status": "ok", "timestamp": "...", "sessions": { "active": 3 } }
+```
+
+Status values: `ok` | `degraded` | `draining`.
+
+### Detailed (authenticated)
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://localhost:9100/v1/health
+```
+
+Adds `version`, `platform`, `uptime`, `tmux` health, and `claude` CLI health.
+
+### Alert Stats
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://localhost:9100/v1/alerts/stats
+```
+
+Returns alert delivery counts and per-type failure tracking.
+
+---
+
+## Usage / Billing Integration
+
+Aegis tracks per-session and per-key token usage with cost estimation:
+
+```bash
+# Total usage summary
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9100/v1/usage?from=2026-04-01&to=2026-04-30"
+
+# Per-key breakdown
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:9100/v1/usage/by-key
+
+# Per-session usage
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:9100/v1/usage/sessions/abc-123
+```
+
+### Rate Tiers (default pricing per million tokens)
+
+| Model | Input | Output | Cache Write | Cache Read |
+|-------|-------|--------|-------------|------------|
+| haiku | $0.80 | $4.00 | $1.00 | $0.08 |
+| sonnet | $3.00 | $15.00 | $3.75 | $0.30 |
+| opus | $15.00 | $75.00 | $18.75 | $1.50 |
+
+---
+
+## SSE Event Streams
+
+For real-time observability, consume the SSE streams:
+
+```bash
+# All sessions
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://localhost:9100/v1/events
+
+# Specific session
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://localhost:9100/v1/sessions/{id}/events
+```
+
+Global event types: `session_created`, `session_status_change`,
+`session_message`, `session_approval`, `session_ended`, `session_stall`,
+`session_dead`, `session_subagent_start`, `session_subagent_stop`,
+`shutdown`.
+
+---
+
+## End-to-End Stack Example
+
+```
+Aegis (:9100)
+  │
+  ├─ /metrics ──────► Prometheus ──────► Grafana dashboards
+  │                                        + alert rules
+  │
+  ├─ OTLP (:4318) ──► OTel Collector ──► Grafana Tempo / Jaeger
+  │                                        (traces in Grafana)
+  │
+  ├─ /v1/events ────► SSE consumer ────► Custom dashboards / paging
+  │
+  └─ /v1/usage ─────► Billing system / cost dashboards
+```

--- a/examples/datadog/aegis-dashboard.json
+++ b/examples/datadog/aegis-dashboard.json
@@ -1,0 +1,159 @@
+{
+  "title": "Aegis — Session & Cost Overview",
+  "description": "Aegis control plane monitoring: sessions, costs, errors, latency",
+  "widgets": [
+    {
+      "id": 1,
+      "definition": {
+        "title": "Active Sessions",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:aegis.sessions.active{*}",
+            "aggregator": "last"
+          }
+        ],
+        "conditional_formats": [
+          { "comparator": ">", "value": 50, "palette": "yellow_on_white" },
+          { "comparator": ">", "value": 100, "palette": "red_on_white" }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "definition": {
+        "title": "Session Creation Rate",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "per_minute(sum:aegis.sessions.created.total{*}.as_count())",
+            "display_type": "line",
+            "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+          }
+        ],
+        "yaxis": { "label": "sessions/min", "scale": "linear" }
+      }
+    },
+    {
+      "id": 3,
+      "definition": {
+        "title": "Session Completion vs Failure",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "per_minute(sum:aegis.sessions.completed.total{*}.as_count())",
+            "display_type": "line",
+            "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
+          },
+          {
+            "q": "per_minute(sum:aegis.sessions.failed.total{*}.as_count())",
+            "display_type": "line",
+            "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
+          }
+        ],
+        "markers": [
+          { "type": "error", "label": "Error threshold", "value": "y = 5" }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "definition": {
+        "title": "Messages & Tool Calls",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "per_minute(sum:aegis.messages.total{*}.as_count())",
+            "display_type": "bars",
+            "style": { "palette": "dog_classic" }
+          },
+          {
+            "q": "per_minute(sum:aegis.tool_calls.total{*}.as_count())",
+            "display_type": "line",
+            "style": { "palette": "cool" }
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "definition": {
+        "title": "Webhook Success Rate",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(
+              per_minute(sum:aegis.webhooks.sent.total{*}.as_count())
+              - per_minute(sum:aegis.webhooks.failed.total{*}.as_count())
+            ) / per_minute(sum:aegis.webhooks.sent.total{*}.as_count()) * 100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": "<", "value": 90, "palette": "red_on_white" },
+              { "comparator": "<", "value": 95, "palette": "yellow_on_white" }
+            ]
+          }
+        ],
+        "custom_unit": "%"
+      }
+    },
+    {
+      "id": 6,
+      "definition": {
+        "title": "Permission Response Latency (p99)",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:aegis.latency.permission_response_latency_ms{quantile:0.99}.rollup(max, 300)",
+            "display_type": "line",
+            "style": { "palette": "warm", "line_type": "dashed", "line_width": "thick" }
+          }
+        ],
+        "yaxis": { "label": "ms", "scale": "linear" },
+        "markers": [
+          { "type": "error", "label": "SLO: 5000ms", "value": "y = 5000" }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "definition": {
+        "title": "Hook Processing Latency (p50, p90, p99)",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:aegis.latency.hook_latency_ms{quantile:0.5}.rollup(avg, 300)",
+            "display_type": "line",
+            "style": { "palette": "cool", "line_type": "solid" }
+          },
+          {
+            "q": "avg:aegis.latency.hook_latency_ms{quantile:0.9}.rollup(avg, 300)",
+            "display_type": "line",
+            "style": { "palette": "cool", "line_type": "dashed" }
+          },
+          {
+            "q": "avg:aegis.latency.hook_latency_ms{quantile:0.99}.rollup(avg, 300)",
+            "display_type": "line",
+            "style": { "palette": "warm", "line_type": "solid" }
+          }
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "definition": {
+        "title": "Prompt Delivery Failures",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "per_minute(sum:aegis.prompts.failed.total{*}.as_count())",
+            "display_type": "bars",
+            "style": { "palette": "warm" }
+          }
+        ]
+      }
+    }
+  ],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "tags": ["aegis", "observability"]
+}

--- a/examples/datadog/aegis-monitors.json
+++ b/examples/datadog/aegis-monitors.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "Datadog monitor definitions for Aegis. Import via the Datadog API or UI.",
+  "monitors": [
+    {
+      "name": "Aegis — High Session Count",
+      "type": "metric alert",
+      "query": "avg(last_10m):avg:aegis.sessions.active{*} > 80",
+      "message": "**Too many active Aegis sessions.**\n\nCurrent: {{value}} active sessions.\nThreshold: 80.\n\nCheck for runaway sessions or increase capacity.\n\n@slack-aegis-alerts @pagerduty-aegis",
+      "tags": ["aegis", "capacity", "alert"],
+      "options": {
+        "thresholds": {
+          "critical": 80,
+          "warning": 50
+        },
+        "notify_no_data": true,
+        "no_data_timeframe": 30,
+        "evaluation_delay": 120,
+        "renotify_interval": 600,
+        "timeout_h": 0
+      },
+      "priority": 2
+    },
+    {
+      "name": "Aegis — Session Failure Rate Spike",
+      "type": "metric alert",
+      "query": "avg(last_15m):(sum:aegis.sessions.failed.total{*}.as_count() / sum:aegis.sessions.created.total{*}.as_count()) > 0.2",
+      "message": "**Aegis session failure rate is too high.**\n\nCurrent: {{value | humanizePercentage}}\nThreshold: 20%\n\nCheck Claude Code health, tmux status, and recent deployments.\n\n@slack-aegis-alerts @pagerduty-aegis",
+      "tags": ["aegis", "errors", "alert"],
+      "options": {
+        "thresholds": {
+          "critical": 0.2,
+          "warning": 0.1
+        },
+        "notify_no_data": false,
+        "evaluation_delay": 120,
+        "renotify_interval": 600
+      },
+      "priority": 1
+    },
+    {
+      "name": "Aegis — Webhook Delivery Failures",
+      "type": "metric alert",
+      "query": "sum(last_10m):sum:aegis.webhooks.failed.total{*}.as_count() > 10",
+      "message": "**Webhook delivery failures detected.**\n\n{{value}} webhook failures in the last 10 minutes.\nThreshold: 10.\n\nCheck webhook endpoint health and network connectivity.\n\n@slack-aegis-alerts",
+      "tags": ["aegis", "webhooks", "alert"],
+      "options": {
+        "thresholds": {
+          "critical": 10,
+          "warning": 5
+        },
+        "notify_no_data": false,
+        "evaluation_delay": 60,
+        "renotify_interval": 900
+      },
+      "priority": 3
+    },
+    {
+      "name": "Aegis — Permission Response Latency",
+      "type": "metric alert",
+      "query": "p99(last_15m):avg:aegis.latency.permission_response_latency_ms{*} > 10000",
+      "message": "**Permission responses are too slow.**\n\np99 latency: {{value}} ms.\nThreshold: 10,000 ms.\n\nSessions may be stalling waiting for approvals.\n\n@slack-aegis-alerts",
+      "tags": ["aegis", "latency", "alert"],
+      "options": {
+        "thresholds": {
+          "critical": 10000,
+          "warning": 5000
+        },
+        "notify_no_data": false,
+        "evaluation_delay": 120,
+        "renotify_interval": 1800
+      },
+      "priority": 3
+    },
+    {
+      "name": "Aegis — Cost Threshold",
+      "type": "metric alert",
+      "query": "sum(last_1d):sum:aegis.cost.estimated_usd{*} > 100",
+      "message": "**Daily estimated cost exceeded threshold.**\n\nCurrent: ${{value}}\nThreshold: $100/day.\n\nReview active sessions and token usage via `/v1/usage`.\n\n@slack-aegis-alerts",
+      "tags": ["aegis", "cost", "alert"],
+      "options": {
+        "thresholds": {
+          "critical": 100,
+          "warning": 50
+        },
+        "notify_no_data": false,
+        "evaluation_delay": 300,
+        "renotify_interval": 3600
+      },
+      "priority": 3,
+      "_comment": "Requires a cost metric bridge from /v1/usage to Datadog. See docs/OBSERVABILITY.md."
+    },
+    {
+      "name": "Aegis — Health Check Degraded",
+      "type": "service check",
+      "query": "\"aegis.health\".over('.*').last(3).count_by_status()",
+      "message": "**Aegis health check is not OK.**\n\nCheck tmux health, Claude CLI availability, and server resources.\n\n@slack-aegis-alerts @pagerduty-aegis",
+      "tags": ["aegis", "health", "alert"],
+      "options": {
+        "thresholds": {
+          "critical": 3,
+          "warning": 2,
+          "ok": 1
+        },
+        "notify_no_data": true,
+        "no_data_timeframe": 10,
+        "renotify_interval": 600
+      },
+      "priority": 1
+    }
+  ]
+}

--- a/examples/grafana/aegis-costs.json
+++ b/examples/grafana/aegis-costs.json
@@ -1,0 +1,148 @@
+{
+  "annotations": { "list": [] },
+  "description": "Aegis cost and token usage tracking",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "title": "Estimated Cost (USD)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "aegis_sessions_active",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "description": "Use /v1/usage API for actual cost data. This panel is a placeholder for cost metrics exported via a Prometheus bridge.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "currencyUSD",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 200 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Session Throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 18, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_created_total[1h])",
+          "legendFormat": "created/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_sessions_completed_total[1h])",
+          "legendFormat": "completed/sec",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(aegis_sessions_failed_total[1h])",
+          "legendFormat": "failed/sec",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Pipelines & Batches",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_pipelines_created_total[5m]) * 60",
+          "legendFormat": "pipelines/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_batches_created_total[5m]) * 60",
+          "legendFormat": "batches/min",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Prompt Delivery",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_prompts_sent_total[5m]) * 60",
+          "legendFormat": "sent/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_prompts_delivered_total[5m]) * 60",
+          "legendFormat": "delivered/min",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(aegis_prompts_failed_total[5m]) * 60",
+          "legendFormat": "failed/min",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Cost Over Time (Usage API)",
+      "type": "text",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 14 },
+      "options": {
+        "mode": "markdown",
+        "content": "## Token Cost Tracking\n\nAegis tracks per-session and per-key token usage with cost estimation via the `/v1/usage` API.\n\n**Default rate tiers (per million tokens):**\n\n| Model | Input | Output | Cache Write | Cache Read |\n|-------|-------|--------|-------------|------------|\n| haiku | $0.80 | $4.00 | $1.00 | $0.08 |\n| sonnet | $3.00 | $15.00 | $3.75 | $0.30 |\n| opus | $15.00 | $75.00 | $18.75 | $1.50 |\n\nTo visualize cost data in Grafana, use the [JSON API data source](https://grafana.com/grafana/plugins/marcusolsson-json-datasource/) to query:\n\n- `GET /v1/usage?from=2026-04-01&to=2026-04-30` — total summary\n- `GET /v1/usage/by-key` — per-key breakdown\n- `GET /v1/usage/sessions/{id}` — per-session detail"
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["aegis", "costs"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timezone": "",
+  "title": "Aegis — Cost & Usage",
+  "uid": "aegis-costs",
+  "version": 1
+}

--- a/examples/grafana/aegis-errors.json
+++ b/examples/grafana/aegis-errors.json
@@ -1,0 +1,235 @@
+{
+  "annotations": { "list": [] },
+  "description": "Aegis error rates — session failures, webhook errors, prompt delivery failures",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "title": "Session Failure Rate",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_failed_total[5m]) / on() rate(aegis_sessions_created_total[5m])",
+          "legendFormat": "failure rate",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Session Failures (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 9, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_failed_total[5m]) * 60",
+          "legendFormat": "failures/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20
+          }
+        }
+      }
+    },
+    {
+      "title": "Webhook Failure Rate",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 15, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_webhooks_failed_total[5m]) / on() rate(aegis_webhooks_sent_total[5m])",
+          "legendFormat": "webhook failure rate",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.15 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Webhooks: Sent vs Failed",
+      "type": "timeseries",
+      "gridPos": { "h": 3, "x": 0, "w": 24, "y": 8 },
+      "targets": [
+        {
+          "expr": "rate(aegis_webhooks_sent_total[5m]) * 60",
+          "legendFormat": "sent/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_webhooks_failed_total[5m]) * 60",
+          "legendFormat": "failed/min",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Prompt Delivery Failures",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 11 },
+      "targets": [
+        {
+          "expr": "rate(aegis_prompts_sent_total[5m]) * 60",
+          "legendFormat": "sent/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_prompts_delivered_total[5m]) * 60",
+          "legendFormat": "delivered/min",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(aegis_prompts_failed_total[5m]) * 60",
+          "legendFormat": "failed/min",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Channel Delivery Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 11 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_channel_delivery_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, rate(aegis_channel_delivery_latency_ms_bucket[5m]))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_channel_delivery_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "State Change Detection Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_state_change_detection_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_state_change_detection_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Alert Stats",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
+      "description": "Use /v1/alerts/stats API for alert delivery counts. Poll and display with the JSON API plugin.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "targets": []
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["aegis", "errors"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "",
+  "title": "Aegis — Error Rates",
+  "uid": "aegis-errors",
+  "version": 1
+}

--- a/examples/grafana/aegis-sessions.json
+++ b/examples/grafana/aegis-sessions.json
@@ -1,0 +1,252 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Aegis session metrics — active sessions, creation/completion rates, failures, duration",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Active Sessions",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "aegis_sessions_active",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "none"
+        }
+      }
+    },
+    {
+      "title": "Sessions Created (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_created_total[5m]) * 60",
+          "legendFormat": "created/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Sessions Completed (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_completed_total[5m]) * 60",
+          "legendFormat": "completed/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Session Failure Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_failed_total[5m]) / on() rate(aegis_sessions_created_total[5m])",
+          "legendFormat": "failure ratio",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Messages & Tool Calls (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_messages_total[5m]) * 60",
+          "legendFormat": "messages/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_tool_calls_total[5m]) * 60",
+          "legendFormat": "tool_calls/min",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Auto Approvals (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_auto_approvals_total[5m]) * 60",
+          "legendFormat": "auto_approvals/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Permission Response Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_permission_response_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, rate(aegis_permission_response_latency_ms_bucket[5m]))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_permission_response_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Hook Processing Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_hook_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, rate(aegis_hook_latency_ms_bucket[5m]))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_hook_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["aegis", "sessions"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Aegis — Session Metrics",
+  "uid": "aegis-sessions",
+  "version": 1
+}

--- a/examples/otlp/collector-grafana.yaml
+++ b/examples/otlp/collector-grafana.yaml
@@ -1,0 +1,36 @@
+# OTLP Collector config — Grafana Tempo backend
+#
+# Usage:
+#   docker run -d --name otel-collector \
+#     -p 4318:4318 \
+#     -v $(pwd)/collector-grafana.yaml:/etc/otelcol/config.yaml \
+#     otel/opentelemetry-collector
+#
+# Aegis env:
+#   AEGIS_OTEL_ENABLED=true
+#   AEGIS_OTEL_OTLP_ENDPOINT=http://localhost:4318
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+    send_batch_max_size: 1024
+
+exporters:
+  otlphttp:
+    endpoint: http://tempo:4318  # Grafana Tempo OTLP endpoint
+    # For Tempo running locally:
+    # endpoint: http://host.docker.internal:4318
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]

--- a/examples/otlp/collector-honeycomb.yaml
+++ b/examples/otlp/collector-honeycomb.yaml
@@ -1,0 +1,42 @@
+# OTLP Collector config — Honeycomb backend
+#
+# Usage:
+#   docker run -d --name otel-collector \
+#     -p 4318:4318 \
+#     -v $(pwd)/collector-honeycomb.yaml:/etc/otelcol/config.yaml \
+#     otel/opentelemetry-collector
+#
+# Aegis env:
+#   AEGIS_OTEL_ENABLED=true
+#   AEGIS_OTEL_OTLP_ENDPOINT=http://localhost:4318
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+  # Add Aegis-specific resource attributes
+  resource:
+    attributes:
+      - key: service.namespace
+        value: aegis
+        action: upsert
+
+exporters:
+  otlphttp:
+    endpoint: https://api.honeycomb.io
+    headers:
+      "x-honeycomb-team": "${HONEYCOMB_API_KEY}"
+      "x-honeycomb-dataset": "aegis-traces"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resource, batch]
+      exporters: [otlphttp]

--- a/examples/otlp/collector-jaeger.yaml
+++ b/examples/otlp/collector-jaeger.yaml
@@ -1,0 +1,41 @@
+# OTLP Collector config — Jaeger backend
+#
+# Usage:
+#   docker run -d --name otel-collector \
+#     -p 4318:4318 \
+#     -v $(pwd)/collector-jaeger.yaml:/etc/otelcol/config.yaml \
+#     otel/opentelemetry-collector
+#
+# Jaeger all-in-one must be running:
+#   docker run -d --name jaeger \
+#     -p 16686:16686 \
+#     -p 4317:4317 \
+#     jaegertracing/jaeger:latest
+#
+# Aegis env:
+#   AEGIS_OTEL_ENABLED=true
+#   AEGIS_OTEL_OTLP_ENDPOINT=http://localhost:4318
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+
+exporters:
+  otlphttp:
+    endpoint: http://jaeger:4318  # Jaeger OTLP HTTP endpoint
+    # For Jaeger running locally:
+    # endpoint: http://host.docker.internal:4318
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]


### PR DESCRIPTION
Observability integration guide with sample Grafana dashboards, Datadog configs, OTLP exporter, and alerting recommendations. 1625 insertions, 10 files.