### PR TITLE
fix: ag CLI produces no output on fresh install + misleading doctor messages (#2094)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -362,19 +362,10 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
   return 0;
 }
 
-const isMainModule = (() => {
-  try {
-    return fileURLToPath(import.meta.url) === process.argv[1];
-  } catch {
-    return false;
-  }
-})();
-
-if (isMainModule) {
-  void runCli().then((code) => {
-    process.exitCode = code;
-  }).catch((error) => {
-    console.error('Failed to start Aegis:', error);
-    process.exitCode = 1;
-  });
-}
+// Fixed: always run CLI when this file is executed directly (Issue #2094)
+void runCli().then((code) => {
+  process.exitCode = code;
+}).catch((error) => {
+  console.error('Failed to start Aegis:', error);
+  process.exitCode = 1;
+});

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -602,7 +602,7 @@ export async function runDoctorChecks(
       : 'authenticated'
     : claudeVersionResult.ok
       ? claudeAuthMetadata?.loggedIn === false
-        ? 'not authenticated'
+        ? 'not logged into claude.ai (Claude Code works without auth)'
         : summarizeCommandFailure(claudeAuthResult)
       : 'Claude CLI is not installed';
   if (hasAnthropicToken || hasAnthropicBaseUrl) {


### PR DESCRIPTION
Fixes #2094 — two related CLI issues.\n\n## Changes\n\n### 1. Silent exit when ag installed globally (root cause fixed)\n**File:** \n**Bug:**  check compared  (real file path) against  (npm symlink path). When npm installs globally, these never match →  → CLI exits silently with no output.\n**Fix:** Removed the  guard entirely. The file IS the CLI entry point, so it should always execute.\n\n### 2. Misleading ag doctor message (fix)\n**File:** \n**Before:** \n**After:** \n\n## Test\n\n```bash\nnode dist/cli.js --help   # was: nothing. now: help output ✅\nnode dist/cli.js doctor   # shows improved message ✅\n```\n\nNote: The "Audit chain invalid" failure is a pre-existing separate issue (audit log file is truncated/corrupted). Not included in this fix.