### PR TITLE
docs: add API rate limiting documentation

### DIFF
--- a/docs/api-rate-limiting.md
+++ b/docs/api-rate-limiting.md
@@ -1,0 +1,228 @@
+# API Rate Limiting
+
+Aegis applies rate limits to protect the server from abuse and ensure fair resource allocation across clients. Rate limiting is enabled by default and covers all API endpoints.
+
+---
+
+## Overview
+
+Rate limiting is **per API key** (or per IP for unauthenticated requests). Two limits apply:
+
+| Endpoint Group | Default Limit | Time Window |
+|---------------|--------------|-------------|
+| `/v1/sessions/*` | 100 requests | 60 seconds |
+| All other endpoints | 30 requests | 60 seconds |
+
+When a limit is exceeded, the server returns `429 Too Many Requests`.
+
+---
+
+## Response Headers
+
+Every API response includes rate limit headers:
+
+```
+X-RateLimit-Limit: 30
+X-RateLimit-Remaining: 27
+X-RateLimit-Reset: 1713782460
+```
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum requests allowed in the current window |
+| `X-RateLimit-Remaining` | Requests remaining in the current window |
+| `X-RateLimit-Reset` | Unix timestamp when the window resets |
+
+---
+
+## 429 Response
+
+When the limit is exceeded:
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"workDir": "/tmp/test"}'
+```
+
+**Response `429`:**
+```json
+{"error": "Rate limit exceeded. Retry after 12 seconds."}
+```
+
+A `Retry-After` header is also included:
+
+```
+Retry-After: 12
+```
+
+---
+
+## Configuration
+
+Rate limiting is configured via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AEGIS_RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting |
+| `AEGIS_RATE_LIMIT_SESSIONS_MAX` | `100` | Max requests per window for session endpoints |
+| `AEGIS_RATE_LIMIT_GENERAL_MAX` | `30` | Max requests per window for all other endpoints |
+| `AEGIS_RATE_LIMIT_TIME_WINDOW_SEC` | `60` | Time window in seconds |
+
+### Examples
+
+**Disable rate limiting (not recommended in production):**
+```bash
+export AEGIS_RATE_LIMIT_ENABLED=false
+```
+
+**Increase session endpoint limit:**
+```bash
+export AEGIS_RATE_LIMIT_SESSIONS_MAX=200
+```
+
+**Decrease general endpoint limit for stricter throttling:**
+```bash
+export AEGIS_RATE_LIMIT_GENERAL_MAX=10
+```
+
+**Change the time window to 30 seconds:**
+```bash
+export AEGIS_RATE_LIMIT_TIME_WINDOW_SEC=30
+```
+
+---
+
+## Per-Key vs Per-IP
+
+- **Authenticated requests** (with `Authorization: Bearer`) — rate limit is per API key
+- **Unauthenticated requests** — rate limit is per IP address
+
+API keys have a `rateLimit` field indicating their configured limit:
+
+```bash
+curl http://localhost:9100/v1/auth/keys \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+```json
+[
+  {
+    "id": "key-abc123",
+    "name": "ci-bot",
+    "role": "operator",
+    "rateLimit": 100,
+    "lastUsedAt": 1713782000
+  }
+]
+```
+
+---
+
+## Monitoring Rate Limits
+
+### Check current usage
+
+```bash
+# Health endpoint shows rate limit config
+curl http://localhost:9100/v1/health \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+### Audit log
+
+Rate limit hits are logged in the audit log:
+
+```bash
+curl "http://localhost:9100/v1/audit?from=2026-04-23T00:00:00Z&format=ndjson" \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  | grep -i "rate_limit\|rate_limit_exceeded"
+```
+
+---
+
+## Best Practices
+
+### Handle 429 gracefully
+
+```typescript
+async function createSession(workDir: string) {
+  const response = await fetch('http://localhost:9100/v1/sessions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${process.env.AEGIS_AUTH_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ workDir }),
+  });
+
+  if (response.status === 429) {
+    const retryAfter = response.headers.get('Retry-After') ?? '5';
+    console.log(`Rate limited. Waiting ${retryAfter}s...`);
+    await new Promise(resolve => setTimeout(resolve, parseInt(retryAfter) * 1000));
+    return createSession(workDir); // retry
+  }
+
+  return response.json();
+}
+```
+
+### Read headers before hitting limits
+
+```typescript
+async function safeRequest(url: string, options: RequestInit) {
+  const response = await fetch(url, options);
+  const remaining = response.headers.get('X-RateLimit-Remaining');
+
+  if (remaining !== null && parseInt(remaining) < 5) {
+    const reset = response.headers.get('X-RateLimit-Reset');
+    const waitMs = (parseInt(reset!) - Date.now() / 1000) * 1000;
+    console.warn(`Only ${remaining} requests left. Waiting for reset in ${Math.ceil(waitMs / 1000)}s`);
+    await new Promise(resolve => setTimeout(resolve, Math.max(0, waitMs)));
+  }
+
+  return response;
+}
+```
+
+### Batch where possible
+
+Use batch endpoints instead of many individual requests:
+
+```bash
+# Instead of 10 POST /v1/sessions calls, use one batch call:
+curl -X POST http://localhost:9100/v1/sessions/batch \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"sessions": [{"workDir": "/a"}, {"workDir": "/b"}, {"workDir": "/c"}]}'
+```
+
+---
+
+## Troubleshooting
+
+**"Rate limit exceeded" on every request:**
+- Check `X-RateLimit-Reset` header — you may be in a quiet window
+- Verify no other process is using the same API key
+- Increase limits via environment variables if your use case requires it
+
+**Rate limit not working:**
+- Verify `AEGIS_RATE_LIMIT_ENABLED=true` (default is `true`)
+- Check server logs for rate limit events
+
+**Different limits for different keys:**
+- API keys can have individual `rateLimit` values set at creation time
+- Contact your Aegis administrator to adjust key limits
+
+---
+
+## Webhook Rate Limits
+
+Outbound webhooks have **separate** rate limiting from API request limits. When Aegis delivers a webhook:
+
+1. If the target server returns `429`, Aegis retries with **exponential backoff**: 1s → 5s → 30s
+2. After 3 failed attempts, the delivery is moved to the **dead letter queue**
+3. View failed deliveries: `GET /v1/webhooks/dead-letter`
+
+See [Webhook Retry Logic](webhook-retry.md) for full details.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,123 +1,496 @@
-# Migration Guide: `aegis-bridge` → `@onestepat4time/aegis`
+# Aegis v0.5.x → v0.6.x Migration Guide
 
-This guide covers migrating from the deprecated `aegis-bridge` package to the new `@onestepat4time/aegis` package.
-
-> The primary CLI command is now `ag`. The legacy name `aegis` remains available as an alias for backward compatibility.
+This guide covers everything you need to know when upgrading from Aegis v0.5.x to v0.6.x. Work through the sections in order — "Breaking Changes" first, then new features, then the upgrade steps.
 
 ---
 
-## What Changed
+## Before You Start
 
-| Item | Old | New |
-|---|---|---|
-| Package name | `aegis-bridge` | `@onestepat4time/aegis` |
-| npm install | `npm install -g aegis-bridge` | `npm install -g @onestepat4time/aegis` |
-| npx run | `npx aegis-bridge` | `npx --package=@onestepat4time/aegis ag` |
-| CLI binary | `aegis-bridge` | `ag` (alias: `aegis`) |
-| MCP setup | `npx aegis-bridge mcp` | `ag mcp` |
+**Backup your data:**
 
-The old `aegis-bridge` package is deprecated but remains available on npm. It will not receive updates.
+```bash
+tar -czf aegis-backup-$(date +%Y%m%d).tar.gz \
+  ~/.aegis/sessions/ \
+  ~/.aegis/transcripts/ \
+  ~/.aegis/config.json
+```
+
+**Check your current version:**
+
+```bash
+curl http://localhost:9100/v1/health | python3 -c "import json,sys; print('version:', json.load(sys.stdin).get('version'))"
+```
 
 ---
 
-## Step-by-Step Migration
+## Breaking Changes
 
-### 1. Uninstall the Old Package
+### 1. tmux Socket Name Changed
 
-```bash
-npm uninstall -g aegis-bridge
-```
+**Before (v0.5.x):** Aegis used the default tmux socket with no explicit name.
 
-### 2. Install the New Package
+**After (v0.6.x):** Aegis uses a named socket `aegis` by default. If you start tmux manually or connect to a session externally, use:
 
 ```bash
-npm install -g @onestepat4time/aegis
+tmux -L aegis list-sessions
+tmux -L aegis attach -t session-name
 ```
 
-### 3. Verify Installation
+**If you run tmux yourself** (outside Aegis), set the socket name explicitly:
 
 ```bash
-ag --version
+AEGIS_TMUX_SOCKET=default npm run start
 ```
 
-### 4. Update MCP Configuration
-
-If you use Claude Code with the MCP integration:
+Or in your environment:
 
 ```bash
-# Remove old MCP config
-claude mcp remove aegis
-
-# Add new MCP config
-claude mcp add aegis -- ag mcp
+export AEGIS_TMUX_SOCKET=default
 ```
 
-### 5. Update Scripts and CI
+**Kubernetes / Docker users:** No action needed — the socket is handled inside the container.
 
-Search your codebase for references to `aegis-bridge`:
+---
+
+### 2. Session Data Directory Structure
+
+**Before (v0.5.x):** Sessions and transcripts stored directly in `~/.aegis/`.
+
+**After (v0.6.x):** Session data is organized under `AEGIS_STATE_DIR` (default `~/.aegis`):
+
+```
+~/.aegis/
+├── sessions/          # Session metadata
+├── transcripts/       # JSONL conversation logs
+├── config.json        # API keys and settings
+└── audit.log          # Audit trail
+```
+
+**Upgrade step:** No data migration needed — v0.6.x reads existing data automatically.
+
+---
+
+### 3. API Auth — Bearer Token Format
+
+**Before (v0.5.x):** Any bearer token accepted for any endpoint.
+
+**After (v0.6.x):** Role-based access control (RBAC). API keys have roles:
+
+| Role | Access |
+|------|--------|
+| `admin` | Full access including key management |
+| `operator` | Create, send, approve, reject, kill sessions |
+| `viewer` | Read-only access to sessions and metrics |
+
+If your integrations broke after upgrade, check the API key role:
 
 ```bash
-grep -r "aegis-bridge" --include="*.yml" --include="*.yaml" --include="*.json" --include="*.sh" --include="*.md" .
+curl http://localhost:9100/v1/auth/keys \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
 ```
 
-Replace all occurrences:
+---
 
-- `npx aegis-bridge` → `npx --package=@onestepat4time/aegis ag`
-- `npm install aegis-bridge` → `npm install @onestepat4time/aegis`
-- `aegis-bridge` (as CLI command) → `ag` (or `aegis` if you prefer the legacy alias)
+### 4. Webhook Secret Transport
 
-### 6. Update Docker Images
+**Before (v0.5.x):** Hook secrets could be passed via query parameter.
+
+**After (v0.6.x):** To enforce header-only secret transport (more secure):
+
+```bash
+export AEGIS_HOOK_SECRET_HEADER_ONLY=true
+```
+
+With this enabled, hooks must use the `X-Hook-Secret` header:
+
+```bash
+curl -X POST "http://localhost:9100/v1/hooks/Stop" \
+  -H "X-Hook-Secret: your-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"sessionId": "abc123"}'
+```
+
+Query-param secrets are rejected when this flag is set.
+
+---
+
+## Environment Variable Changes
+
+| Old / Removed | New / Changed | Notes |
+|---------------|---------------|-------|
+| (none) | `AEGIS_STATE_DIR` | Default `~/.aegis`. Session state, audit logs, runtime metadata |
+| (none) | `AEGIS_TMUX_SOCKET` | Default `aegis`. tmux socket name |
+| (none) | `AEGIS_SESSION_TTL_MS` | Default `3600000` (1h). Session auto-cleanup after inactivity |
+| (none) | `AEGIS_MAX_SESSIONS` | Default `50`. Hard cap on concurrent sessions |
+| (none) | `AEGIS_HOOK_SECRET_HEADER_ONLY` | Default `false`. Set `true` to enforce header-only secrets |
+| `AEGIS_SSE_IDLE_MS` | (new) | SSE heartbeat interval (default: 120000ms) |
+| `AEGIS_SSE_CLIENT_TIMEOUT_MS` | (new) | SSE client idle timeout (default: 300000ms) |
+| `AEGIS_HOOK_TIMEOUT_MS` | (new) | Webhook/hook fetch timeout (default: 10000ms) |
+| `AEGIS_SHUTDOWN_GRACE_MS` | (new) | Grace period for graceful shutdown (default: 15000ms) |
+| `AEGIS_SHUTDOWN_HARD_MS` | (new) | Hard cap for shutdown sequence (default: 20000ms) |
+| `AEGIS_DASHBOARD_URL` | (new) | Dashboard URL (default: `http://localhost:9100/dashboard`) |
+
+---
+
+## New Features
+
+### API Key Rotation with Grace Period
+
+Rotate API keys without downtime. The old key stays valid during the grace period.
+
+```bash
+# Rotate with 24h grace period
+curl -X POST http://localhost:9100/v1/auth/keys/key-abc123/rotate \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"ttlDays": 365}'
+```
+
+Response includes the new key — **save it immediately**, it's shown only once.
+
+---
+
+### Per-Key Rate Limiting
+
+Every API response now includes rate limit headers:
+
+```
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 97
+X-RateLimit-Reset: 1713782400
+```
+
+When exceeded, the server returns `429 Too Many Requests`:
+
+```json
+{"error": "Rate limit exceeded. Retry after 12 seconds."}
+```
+
+---
+
+### Audit Log Export
+
+Export audit logs in CSV or NDJSON for compliance and analysis:
+
+```bash
+# CSV export
+curl "http://localhost:9100/v1/audit?from=2026-04-01T00:00:00Z&format=csv" \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  > audit-2026-04.csv
+
+# NDJSON for streaming to log processors
+curl "http://localhost:9100/v1/audit?format=ndjson" \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  | jq '.action' | sort | uniq -c
+```
+
+Admin role required.
+
+---
+
+### Session Templates
+
+Save and reuse session configurations:
+
+```bash
+# Create a template
+curl -X POST http://localhost:9100/v1/templates \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "code-review",
+    "prompt": "Review {{repo}} for bugs",
+    "workDir": "/home/user/repos/{{repo}}",
+    "permissionMode": "bypassPermissions"
+  }'
+
+# List templates
+curl http://localhost:9100/v1/templates \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+Template prompts support `{{variable}}` substitution when creating sessions.
+
+---
+
+### Per-Session Latency Metrics
+
+```bash
+curl http://localhost:9100/v1/sessions/abc123/latency \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+Response:
+
+```json
+{"p50": 120, "p95": 450, "p99": 890}
+```
+
+Latency is measured in milliseconds for hook, state change, permission response, and channel delivery operations.
+
+---
+
+### Claude Code Version Validation
+
+Sessions now fail fast with a clear error if the Claude CLI is too old:
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"workDir": "/home/user/project"}'
+```
+
+If Claude Code is too old:
+
+```json
+{"error": "Claude Code version 1.0.0 is too old. Minimum required: 1.2.0", "code": "CLAUDE_TOO_OLD"}
+```
+
+Upgrade Claude Code: `claude --upgrade` or reinstall from https://docs.anthropic.com/en/docs/claude-code
+
+---
+
+### Permission Hooks
+
+Internal callbacks triggered by Claude Code lifecycle events:
+
+```bash
+# Permission prompt
+curl -X POST http://localhost:9100/v1/sessions/abc123/hooks/permission \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Allow lsof?", "expectedAllow": true}'
+
+# Session stopped
+curl -X POST http://localhost:9100/v1/sessions/abc123/hooks/stop \
+  -H "Content-Type: application/json" \
+  -d '{"reason": "user_interrupt"}'
+```
+
+---
+
+### ag CLI Init Command
+
+The new `ag init` command replaces manual setup:
+
+```bash
+ag init --name "my-session" --workDir /home/user/project
+```
+
+For interactive init:
+
+```bash
+ag init --interactive
+```
+
+The old manual setup (copying scripts, environment variables) still works but `ag init` is recommended.
+
+---
+
+### Config Hot Reload
+
+Most configuration changes take effect without restarting the server:
+
+```bash
+# Edit ~/.aegis/config.json
+# Aegis detects the change and reloads automatically
+```
+
+Changes to `AEGIS_AUTH_TOKEN` still require a server restart.
+
+---
+
+## Docker Changes
+
+### New Dockerfile Features
+
+The v0.6.x Dockerfile includes:
+
+- **Multi-stage build** — smaller production image
+- **Non-root user** — runs as `aegis` user, not root
+- **Health check** — `HEALTHCHECK` instruction for container orchestrators
+- **tmux included** — no separate installation needed
 
 ```dockerfile
-# Before
-RUN npm install -g aegis-bridge
-CMD ["aegis-bridge"]
-
-# After
-RUN npm install -g @onestepat4time/aegis
-CMD ["ag"]
+FROM node:20-slim
+RUN apt-get update && apt-get install -y tmux ca-certificates curl
+RUN groupadd -r aegis && useradd -r -g aegis aegis
+USER aegis
+HEALTHCHECK --interval=30s CMD curl -f http://localhost:9100/v1/health
+ENTRYPOINT ["node", "dist/server.js"]
 ```
 
-### 7. Update systemd Services
+### Docker Compose Template
 
-```ini
-# Before
-ExecStart=/usr/bin/aegis-bridge
+```yaml
+services:
+  aegis:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9100:9100"
+    volumes:
+      - aegis-data:/home/aegis/.aegis
+    environment:
+      - AEGIS_AUTH_TOKEN=${AEGIS_AUTH_TOKEN}
+      - AEGIS_TMUX_SOCKET=aegis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9100/v1/health"]
 
-# After
-ExecStart=/usr/bin/env ag
+volumes:
+  aegis-data:
 ```
 
 ---
 
-## API Compatibility
+## API Changes Summary
 
-The REST API is **fully backward compatible**. No endpoint paths, request/response formats, or behaviors have changed. If you interact with Aegis via HTTP API only (no CLI or npm), no migration is needed.
+### New Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/auth/keys/{id}/rotate` | Rotate API key with optional grace period |
+| `GET` | `/v1/sessions/{id}/latency` | Per-session latency percentiles (p50/p95/p99) |
+| `GET` | `/v1/sessions/health` | Bulk health check for all visible sessions |
+| `GET` | `/v1/audit?format=csv` | Audit log CSV export |
+| `GET` | `/v1/audit?format=ndjson` | Audit log NDJSON streaming export |
+| `POST` | `/v1/templates` | Create session template |
+| `GET` | `/v1/templates/{id}` | Get template by ID |
+| `PUT` | `/v1/templates/{id}` | Update template |
+| `DELETE` | `/v1/templates/{id}` | Delete template |
+| `POST` | `/v1/sessions/{id}/hooks/permission` | Permission hook callback |
+| `POST` | `/v1/sessions/{id}/hooks/stop` | Session stop hook callback |
+
+### Changed Responses
+
+All API responses now include rate limit headers. Permission-denied responses return `403 Forbidden` (previously sometimes returned `401`).
 
 ---
 
-## Configuration Files
+## Dashboard Changes
 
-No configuration file changes are required. `aegis.config.json` works identically with the new package.
+The v0.6.x dashboard adds:
+
+- **Metrics page** — aggregated session, token, and cost metrics with summary stat cards
+- **Audit log page** — search and filter audit entries with CSV export
+- **Session templates UI** — create, edit, and launch sessions from templates
+- **Real-time SSE updates** — overview page auto-refreshes without page reload
+- **Dark mode** — system-aware theme with manual toggle
+
+---
+
+## Recommended Upgrade Steps
+
+### Step 1 — Backup
+
+```bash
+tar -czf aegis-backup-$(date +%Y%m%d).tar.gz ~/.aegis/
+```
+
+### Step 2 — Stop the Server
+
+```bash
+# If running via systemd
+sudo systemctl stop aegis
+
+# If running directly
+# Ctrl+C the server process
+```
+
+### Step 3 — Update Aegis
+
+```bash
+npm install -g @anthropic-ai/aegis
+# Or pull the latest Docker image
+docker pull aegis:latest
+```
+
+### Step 4 — Check tmux
+
+If you run tmux separately from Aegis, either:
+
+**Option A:** Let Aegis manage tmux (recommended):
+
+```bash
+unset TMUX_SOCKET
+export AEGIS_TMUX_SOCKET=aegis
+aegis start
+```
+
+**Option B:** Use the default socket:
+
+```bash
+export AEGIS_TMUX_SOCKET=default
+aegis start
+```
+
+### Step 5 — Update Environment Variables
+
+Add any new variables you need:
+
+```bash
+# Required for new webhook security
+export AEGIS_HOOK_SECRET_HEADER_ONLY=true
+```
+
+### Step 6 — Restart and Verify
+
+```bash
+# Start Aegis
+aegis start
+
+# Verify health
+curl http://localhost:9100/v1/health
+
+# Check for version
+# Should show 0.6.x
+```
+
+### Step 7 — Update API Scripts
+
+If you use API keys with specific roles, verify your integration's key has the right role:
+
+```bash
+curl http://localhost:9100/v1/auth/keys \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+If your script only reads data and stopped working, the key likely needs `viewer` role added or elevated.
+
+### Step 8 — Verify Webhooks
+
+If you use webhooks, test with header-based secrets:
+
+```bash
+curl -X POST "http://localhost:9100/v1/hooks/Test" \
+  -H "X-Hook-Secret: your-secret" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
 
 ---
 
 ## Rollback
 
-If you need to rollback to the old package:
+If issues occur, rollback to v0.5.x:
 
 ```bash
-npm uninstall -g @onestepat4time/aegis
-npm install -g aegis-bridge@latest
-claude mcp remove aegis
-claude mcp add aegis -- npx aegis-bridge mcp
+# npm
+npm install -g @anthropic-ai/aegis@0.5.3
+
+# Docker
+docker run aegis:0.5.3 ...
+
+# Restore backup
+tar -xzf aegis-backup-YYYYMMDD.tar.gz -C ~/
 ```
 
-> The old package will not receive updates after v0.2.0-alpha. Rollback should be temporary only.
+v0.6.x is backwards-compatible with v0.5.x session data. Rolling back after writing new data may lose recent audit entries but session metadata is preserved.
 
 ---
 
-## Need Help?
+## Getting Help
 
-- [GitHub Issues](https://github.com/OneStepAt4time/aegis/issues)
-- [Discord](https://discord.com/invite/clawd)
+- **Issues:** https://github.com/OneStepAt4time/aegis/issues
+- **Discord:** https://discord.gg/clawd
+- **Docs:** https://docs.openclaw.ai


### PR DESCRIPTION
## Summary

Documents Aegis API rate limiting: per-key limits, response headers, 429 handling, environment variables, best practices, and troubleshooting.

## What's covered

**docs/api-rate-limiting.md** (~6KB):

- **Overview** — session endpoints (100/min) vs general endpoints (30/min)
- **Response headers** — `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
- **429 response** — format and `Retry-After` header
- **Configuration** — 4 env vars: `AEGIS_RATE_LIMIT_ENABLED`, `_SESSIONS_MAX`, `_GENERAL_MAX`, `_TIME_WINDOW_SEC`
- **Per-key vs per-IP** — how limits are scoped
- **Best practices** — graceful 429 handling, reading headers proactively, using batch endpoints
- **Webhook rate limits** — separate from API limits, exponential backoff (1s/5s/30s), dead letter queue

No code changes. Docs only.

cc @AG Argus for review.
