### PR TITLE
feat(dashboard): Mac keyboard shortcut support (Cmd+K, Cmd+N, Cmd+/)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -69,7 +69,8 @@ export default function App() {
 
   useKeyboardShortcuts({
     onShortcut: (shortcut) => {
-      if (shortcut.key === '?' || (shortcut.key === 'k' && shortcut.modifier === 'ctrl')) {
+      // Toggle help: ? (shift+/) or Cmd+/ (meta+/)
+      if (shortcut.key === '?' || (shortcut.key === '/' && shortcut.modifier === 'meta')) {
         setShowHelp((prev) => !prev);
       }
     },

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -111,7 +111,7 @@ export default function Layout() {
   const [updateCheckError, setUpdateCheckError] = useState<string | null>(null);
   const [updateResult, setUpdateResult] = useState<UpdateCheckResult | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
-
+  
   function readCachedUpdate(version: string): UpdateCheckResult | null {
     try {
       const raw = localStorage.getItem(UPDATE_CHECK_CACHE_KEY);
@@ -309,6 +309,7 @@ export default function Layout() {
   }
 
   const sidebarWidth = isCollapsed ? 'w-16' : 'w-56';
+
 
   return (
     <div className="flex h-screen overflow-hidden bg-void">

--- a/dashboard/src/hooks/useKeyboardShortcuts.ts
+++ b/dashboard/src/hooks/useKeyboardShortcuts.ts
@@ -6,13 +6,19 @@ interface Shortcut {
   key: string;
   description: string;
   modifier?: Modifier;
+  /** Accept BOTH ctrl and meta (Cmd on Mac) for the same shortcut */
+  allowMacCompat?: boolean;
   sequence?: string[];
   scope?: string;
 }
 
 export const SHORTCUTS: Shortcut[] = [
   { key: '?', modifier: 'shift', description: 'Show keyboard shortcuts' },
-  { key: 'k', modifier: 'ctrl', description: 'Focus search' },
+  { key: '/', modifier: 'meta', description: 'Show keyboard shortcuts (Mac)' },
+  { key: 'k', modifier: 'ctrl', description: 'Focus search', allowMacCompat: true },
+  { key: 'k', modifier: 'meta', description: 'Focus search (Mac)' },
+  { key: 'n', modifier: 'ctrl', description: 'New session', allowMacCompat: true },
+  { key: 'n', modifier: 'meta', description: 'New session (Mac)' },
   { key: 'g o', sequence: ['g', 'o'], description: 'Go to Overview' },
   { key: 'g s', sequence: ['g', 's'], description: 'Go to Sessions' },
   { key: 'g p', sequence: ['g', 'p'], description: 'Go to Pipelines' },
@@ -47,16 +53,24 @@ export function useKeyboardShortcuts({
       for (const shortcut of SHORTCUTS) {
         if (shortcut.sequence) continue;
 
-        const keyMatch = e.key.toLowerCase() === shortcut.key.toLowerCase() ||
+        const keyMatch =
+          e.key.toLowerCase() === shortcut.key.toLowerCase() ||
           (shortcut.key === 'Escape' && e.key === 'Escape');
-        const modMatch =
+
+        // Normal modifier check
+        const normalModMatch =
           !shortcut.modifier ||
           (shortcut.modifier === 'ctrl' && e.ctrlKey) ||
           (shortcut.modifier === 'shift' && e.shiftKey) ||
           (shortcut.modifier === 'alt' && e.altKey) ||
           (shortcut.modifier === 'meta' && e.metaKey);
 
-        if (keyMatch && modMatch) {
+        // Mac compatibility: if shortcut allows Mac compat, accept both ctrl and meta
+        const macModMatch = shortcut.allowMacCompat
+          ? normalModMatch || (e.metaKey && shortcut.modifier === 'ctrl')
+          : normalModMatch;
+
+        if (keyMatch && macModMatch) {
           e.preventDefault();
           onShortcut?.(shortcut);
           return;

--- a/dashboard/src/store/useDrawerStore.ts
+++ b/dashboard/src/store/useDrawerStore.ts
@@ -1,5 +1,5 @@
 /**
- * store/useDrawerStore.ts — Global drawer state for the New Session drawer.
+ * store/useDrawerStore.ts — Global drawer and palette state.
  */
 
 import { create } from 'zustand';
@@ -8,10 +8,16 @@ interface DrawerState {
   newSessionOpen: boolean;
   openNewSession: () => void;
   closeNewSession: () => void;
+  paletteOpen: boolean;
+  openPalette: () => void;
+  closePalette: () => void;
 }
 
 export const useDrawerStore = create<DrawerState>((set) => ({
   newSessionOpen: false,
   openNewSession: () => set({ newSessionOpen: true }),
   closeNewSession: () => set({ newSessionOpen: false }),
+  paletteOpen: false,
+  openPalette: () => set({ paletteOpen: true }),
+  closePalette: () => set({ paletteOpen: false }),
 }));


### PR DESCRIPTION
## Summary

Adds Mac keyboard shortcut compatibility for the Aegis dashboard:

### Changes
- **Cmd+K / Ctrl+K**: Opens command palette (existing behavior, already worked)
- **Cmd+N / Ctrl+N**: Opens new session drawer (existing behavior, already worked)
- **Cmd+/ (Mac) / ? (Shift+/)**: Shows keyboard shortcuts help dialog

### Technical Details
- `useKeyboardShortcuts.ts`: Added `allowMacCompat` for k/n shortcuts, added Cmd+/ shortcut
- `useDrawerStore.ts`: Added `paletteOpen` state management for future extensibility
- `App.tsx`: Handle Cmd+/ to show keyboard shortcuts help dialog

### Files Changed
```
dashboard/src/App.tsx
dashboard/src/components/Layout.tsx
dashboard/src/hooks/useKeyboardShortcuts.ts
dashboard/src/store/useDrawerStore.ts
```

Note: Layout.tsx already had Cmd+K/Cmd+N handlers via useEffect. These changes enhance the hook to also fire for Meta key (Mac Cmd) and add Cmd+/ support.