### PR TITLE
feat(dashboard): add Audit trail tab to SessionDetailPage

### DIFF
--- a/dashboard/src/components/session/AuditTrailPanel.tsx
+++ b/dashboard/src/components/session/AuditTrailPanel.tsx
@@ -1,0 +1,138 @@
+/**
+ * components/session/AuditTrailPanel.tsx
+ * Displays permission prompts, approvals, and rejections for a session.
+ * Fetched via GET /v1/audit?sessionId=:id
+ */
+
+import { Shield, CheckCircle, XCircle, AlertTriangle, Clock } from 'lucide-react';
+import type { AuditRecord } from '../../types';
+
+interface AuditTrailPanelProps {
+  records: AuditRecord[];
+  loading: boolean;
+  error: string | null;
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return '';
+  }
+}
+
+function actionIcon(action: string): typeof CheckCircle {
+  const a = action.toLowerCase();
+  if (a.includes('approve') || a.includes('permission_granted')) return CheckCircle;
+  if (a.includes('reject') || a.includes('deny') || a.includes('permission_denied')) return XCircle;
+  if (a.includes('prompt') || a.includes('request')) return AlertTriangle;
+  return Shield;
+}
+
+function actionColor(action: string): string {
+  const a = action.toLowerCase();
+  if (a.includes('approve') || a.includes('permission_granted'))
+    return 'text-green-400';
+  if (a.includes('reject') || a.includes('deny') || a.includes('permission_denied'))
+    return 'text-red-400';
+  if (a.includes('prompt') || a.includes('request'))
+    return 'text-amber-400';
+  return 'text-slate-400';
+}
+
+function actionBg(action: string): string {
+  const a = action.toLowerCase();
+  if (a.includes('approve') || a.includes('permission_granted'))
+    return 'bg-green-950/30 border-green-900/30';
+  if (a.includes('reject') || a.includes('deny') || a.includes('permission_denied'))
+    return 'bg-red-950/30 border-red-900/30';
+  if (a.includes('prompt') || a.includes('request'))
+    return 'bg-amber-950/30 border-amber-900/30';
+  return 'bg-[var(--color-surface-strong)] border-[var(--color-border)]';
+}
+
+export function AuditTrailPanel({ records, loading, error }: AuditTrailPanelProps) {
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-20 rounded-lg bg-[var(--color-surface-strong)] animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-900/30 bg-red-950/20 p-4 text-red-400 text-sm">
+        Failed to load audit trail: {error}
+      </div>
+    );
+  }
+
+  if (records.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+        <Shield className="h-10 w-10 text-[var(--color-text-muted)]" />
+        <p className="text-sm text-[var(--color-text-muted)]">No audit events for this session</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2" role="list" aria-label="Audit trail">
+      {records.map((record, i) => {
+        const Icon = actionIcon(record.action);
+        const color = actionColor(record.action);
+        const bg = actionBg(record.action);
+
+        return (
+          <div
+            key={`${record.hash}-${i}`}
+            role="listitem"
+            className={`flex items-start gap-3 rounded-lg border p-3 ${bg}`}
+          >
+            <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${color}`} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className={`text-sm font-medium ${color}`}>
+                  {record.action}
+                </span>
+                <span className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] shrink-0">
+                  <Clock className="h-3 w-3" />
+                  {formatDate(record.ts)} {formatTime(record.ts)}
+                </span>
+              </div>
+              {record.detail && (
+                <p className="mt-1 text-xs text-[var(--color-text-muted)] break-all">
+                  {record.detail}
+                </p>
+              )}
+              {record.actor && (
+                <p className="mt-0.5 text-xs text-[var(--color-text-muted)]">
+                  by {record.actor}
+                </p>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
+import type { AuditRecord } from '../types';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Send,
 } from 'lucide-react';
 import {
+  fetchAuditLogs,
   sendMessage,
   sendCommand,
   sendBash,
@@ -22,6 +24,7 @@ import { SessionHeader } from '../components/session/SessionHeader';
 import { StreamTab } from '../components/session/StreamTab';
 import { SessionMetricsPanel } from '../components/session/SessionMetricsPanel';
 import { LatencyPanel } from '../components/metrics/LatencyPanel';
+import { AuditTrailPanel } from '../components/session/AuditTrailPanel';
 import { ApprovalBanner } from '../components/session/ApprovalBanner';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PendingQuestionCard } from '../components/session/PendingQuestionCard';
@@ -34,11 +37,12 @@ interface ScreenshotState {
   capturedAt: number;
 }
 
-type TabId = 'stream' | 'metrics';
+type TabId = 'stream' | 'metrics' | 'audit';
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'stream', label: 'Stream' },
   { id: 'metrics', label: 'Metrics' },
+  { id: 'audit', label: 'Audit' },
 ];
 
 const COMMON_SLASH_COMMANDS = ['/clear', '/compact', '/cost', '/config'] as const;
@@ -75,6 +79,10 @@ export default function SessionDetailPage() {
   const fullBleedRef = useRef(false);
   fullBleedRef.current = fullBleed;
   const [mobileFooterHeight, setMobileFooterHeight] = useState(0);
+  // Audit trail state
+  const [auditRecords, setAuditRecords] = useState<AuditRecord[]>([]);
+  const [auditLoading, setAuditLoading] = useState(false);
+  const [auditError, setAuditError] = useState<string | null>(null);
   const desktopMsgInputRef = useRef<HTMLInputElement>(null);
   const mobileMsgInputRef = useRef<HTMLInputElement>(null);
   const mobileFooterRef = useRef<HTMLDivElement>(null);
@@ -152,6 +160,30 @@ export default function SessionDetailPage() {
 
     return () => observer.disconnect();
   }, []);
+
+  // Fetch audit trail when audit tab is active
+  useEffect(() => {
+    if (activeTab !== 'audit' || !id) return;
+
+    let cancelled = false;
+    setAuditLoading(true);
+    setAuditError(null);
+
+    fetchAuditLogs({ sessionId: id, limit: 100, reverse: true })
+      .then((data) => {
+        if (cancelled) return;
+        setAuditRecords(data.records);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setAuditError(err.message ?? 'Failed to load audit trail');
+      })
+      .finally(() => {
+        if (!cancelled) setAuditLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [activeTab, id]);
 
   if (loading) {
     return (
@@ -643,6 +675,23 @@ export default function SessionDetailPage() {
                   <div className="mt-4">
                     <LatencyPanel latency={latency} loading={latencyLoading} />
                   </div>
+                </motion.div>
+              )}
+
+              {activeTab === 'audit' && (
+                <motion.div
+                  key="panel-audit"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  transition={{ duration: 0.2 }}
+                  id="panel-audit"
+                  role="tabpanel"
+                  aria-labelledby="tab-audit"
+                  tabIndex={0}
+                  className="overflow-auto p-3 sm:p-4"
+                >
+                  <AuditTrailPanel records={auditRecords} loading={auditLoading} error={auditError} />
                 </motion.div>
               )}
             </AnimatePresence>


### PR DESCRIPTION
## Summary

Adds an **Audit tab** to the SessionDetailPage that displays permission prompts, approvals, and rejections for a session.

### Changes
- **SessionDetailPage**: Added 'audit' tab alongside 'stream' and 'metrics'
- **AuditTrailPanel**: New component showing color-coded audit events:
  - 🟢 **Green** — permission granted / approved
  - 🔴 **Red** — permission denied / rejected  
  - 🟡 **Amber** — permission prompt / request
- Fetches via 

### Files Changed
```
dashboard/src/pages/SessionDetailPage.tsx       (+51 lines — tab + state + fetch)
dashboard/src/components/session/AuditTrailPanel.tsx  (+138 lines — new component)
```

### Testing
- `npx tsc --noEmit` ✅
- `npm test -- --run` — 633 passed (same pre-existing failures as develop)