### PR TITLE
fix(dashboard): mobile responsive test fixes and overflow-x-auto

### DIFF
--- a/dashboard/src/__tests__/AuditPage.test.tsx
+++ b/dashboard/src/__tests__/AuditPage.test.tsx
@@ -226,7 +226,7 @@ describe('AuditPage', () => {
         limit: 25,
       }));
       expect(screen.getByText('Page 2 of 2')).toBeDefined();
-    });
+    }, { timeout: 5000 });
   });
 
   it('exports CSV and renders chain-integrity metadata from the response', async () => {

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -409,7 +409,7 @@ describe('Layout sidebar', () => {
     expect(overviewLink).toBeDefined();
   });
 
-  it('nav has exactly 7 items in 3 labelled groups', () => {
+  it('nav has exactly 9 items in 3 labelled groups', () => {
     mockSubscribeGlobalSSE.mockReturnValue(() => {});
     useSidebarStore.setState({ isCollapsed: false });
 
@@ -437,10 +437,10 @@ describe('Layout sidebar', () => {
     expect(screen.queryByText('New Session')).toBeNull();
     expect(screen.queryByText('Audit Trail')).toBeNull();
 
-    // Count nav links (7 main + Settings in footer = 8 total NavLinks, but we check nav)
+    // Count nav links (WORKSPACE 4 + OPERATIONS 4 + ADMIN 1 = 9 total)
     const nav = document.querySelector('nav[aria-label="Main navigation"]');
     const links = nav?.querySelectorAll('a');
-    expect(links?.length).toBe(8);
+    expect(links?.length).toBe(9);
   });
 
   it('Settings nav link is rendered in sidebar footer', () => {

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -362,7 +362,7 @@ export default function Layout() {
                   end={to === '/'}
                   onClick={handleNavClick}
                   className={({ isActive }) =>
-                    `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all ${
+                    `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
                       isActive
                         ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-cyan dark:bg-cyan/10 dark:text-cyan glow-nav-active'
                         : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 border-l-2 border-transparent dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200'
@@ -385,7 +385,7 @@ export default function Layout() {
             to="/settings"
             onClick={handleNavClick}
             className={({ isActive }) =>
-              `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all ${
+              `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
                 isActive
                   ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-cyan dark:bg-cyan/10 dark:text-cyan glow-nav-active'
                   : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 border-l-2 border-transparent dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200'

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -151,6 +151,7 @@ export default function PipelineDetailPage() {
             No steps yet
           </div>
         ) : (
+          <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead>
               <tr className="border-b border-void-lighter text-gray-600">
@@ -191,6 +192,7 @@ export default function PipelineDetailPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
Fixes for closed PRs #2150 and #2145 test failures.

## Changes
- **Layout.test.tsx**: expect 9 nav items (was 8 after Analytics added)
- **PipelineDetailPage.tsx**: wrap stages table with overflow-x-auto for mobile horizontal scroll
- **Layout.tsx**: add min-h-[44px] touch target for WCAG a11y
- **AuditPage.test.tsx**: increase pagination waitFor timeout to 5000ms for CI stability

## Root cause
- #2150: Analytics nav item added makes 9 items (test expected 8)
- #2145: AuditPage pagination test timing out on CI (1000ms not enough)

Closes #2150
Closes #2145