### PR TITLE
fix(dashboard): resolve flaky AuditPage pagination test

### DIFF
--- a/dashboard/src/__tests__/AuditPage.test.tsx
+++ b/dashboard/src/__tests__/AuditPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AuditPage from '../pages/AuditPage';
 
@@ -120,7 +120,7 @@ describe('AuditPage', () => {
       expect(screen.getByLabelText('To')).toBeDefined();
       expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDefined();
       expect(screen.getByRole('button', { name: 'Export NDJSON' })).toBeDefined();
-      expect(screen.getByText('admin-key')).toBeDefined();
+      expect(screen.getAllByText('admin-key')[0]).toBeDefined();
       expect(screen.getByText('session.create')).toBeDefined();
     });
   });
@@ -218,7 +218,7 @@ describe('AuditPage', () => {
       expect(screen.getByText('Page 1 of 2')).toBeDefined();
     });
 
-    fireEvent.click(screen.getByLabelText('Next page'));
+    await act(async () => { fireEvent.click(screen.getByLabelText('Next page')); });
 
     await waitFor(() => {
       expect(mockFetchAuditLogs).toHaveBeenLastCalledWith(expect.objectContaining({


### PR DESCRIPTION
## Summary
Fixes two issues in `dashboard/src/__tests__/AuditPage.test.tsx`:

1. **`getAllByText('admin-key')[0]`** — The "renders filters" test used `getByText('admin-key')` which fails when multiple rows contain the same actor key. The test data creates records with `admin-key` appearing multiple times. Using `getAllByText` and taking the first match is more precise.

2. **`act()` wrapper for pagination click** — The "uses cursor pagination metadata for the next page" test wraps the Next page button click in `act(async () => { ... })` to ensure React state updates (setPage → useEffect → fetch) are flushed before the assertion runs. This addresses the timing sensitivity of the original `fireEvent.click` which could race with async state updates.

## Verification
- `npm run build` ✓
- Dashboard tests run via `cd dashboard && npx vitest run`

## Notes
- These fixes are defensive improvements to test robustness
- The develop CI dashboard test suite runs via a separate `cd dashboard && npx vitest run` step (excluded from root vitest config which excludes `dashboard/**`)
