### PR TITLE
feat(dashboard): add Transcript tab to SessionDetailPage with syntax highlighting

### DIFF
--- a/dashboard/src/__tests__/TranscriptViewer.test.tsx
+++ b/dashboard/src/__tests__/TranscriptViewer.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 import { TranscriptViewer } from '../components/session/TranscriptViewer';
+import type { ParsedEntry } from '../types';
 
 const mockGetSessionMessages = vi.fn();
 const mockSubscribeSSE = vi.fn();
@@ -15,6 +16,32 @@ vi.mock('../store/useStore', () => ({
   useStore: (selector: (state: { token: string | null }) => unknown) => selector({ token: 'test-token' }),
 }));
 
+// Mock @tanstack/react-virtual for jsdom (no layout)
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (opts: { count: number }) => ({
+    getTotalSize: () => opts.count * 80,
+    getVirtualItems: () =>
+      Array.from({ length: opts.count }, (_, i) => ({
+        key: `msg-${i}`,
+        index: i,
+        start: i * 80,
+        size: 80,
+      })),
+    scrollToIndex: vi.fn(),
+    measureElement: vi.fn(),
+  }),
+}));
+
+function makeMessages(count: number, overrides: Partial<ParsedEntry> = {}): ParsedEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    role: 'assistant' as const,
+    contentType: 'text' as const,
+    text: `Message ${i + 1}`,
+    timestamp: `2026-04-24T10:00:${String(i).padStart(2, '0')}Z`,
+    ...overrides,
+  }));
+}
+
 describe('TranscriptViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,14 +54,261 @@ describe('TranscriptViewer', () => {
     mockSubscribeSSE.mockReturnValue(() => {});
   });
 
-  it('renders an empty state when transcript replay has no messages', async () => {
+  // ── Loading state ──────────────────────────────────────────────────
+
+  it('shows loading state while fetching', () => {
+    mockGetSessionMessages.mockReturnValue(new Promise(() => {}));
+    render(<TranscriptViewer sessionId="session-1" />);
+    expect(screen.getByText(/loading transcript/i)).toBeDefined();
+  });
+
+  // ── Empty state ────────────────────────────────────────────────────
+
+  it('renders empty state when no messages', async () => {
     render(<TranscriptViewer sessionId="session-1" />);
 
     await waitFor(() => {
       expect(screen.getByText('No messages yet')).toBeDefined();
     });
 
-    expect(screen.queryByText('Loading transcript…')).toBeNull();
+    expect(screen.queryByText(/loading transcript/i)).toBeNull();
     expect(mockGetSessionMessages).toHaveBeenCalledWith('session-1');
+  });
+
+  // ── Error state ────────────────────────────────────────────────────
+
+  it('shows error state when fetch fails', async () => {
+    mockGetSessionMessages.mockRejectedValue(new Error('Network error'));
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/network error/i)).toBeDefined();
+    });
+  });
+
+  // ── Message rendering ──────────────────────────────────────────────
+
+  it('renders user messages', async () => {
+    mockGetSessionMessages.mockResolvedValue({
+      messages: [
+        { role: 'user', contentType: 'text', text: 'Hello, Claude!', timestamp: '2026-04-24T10:00:00Z' },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello, Claude!')).toBeDefined();
+    });
+  });
+
+  it('renders assistant messages with code blocks', async () => {
+    mockGetSessionMessages.mockResolvedValue({
+      messages: [
+        {
+          role: 'assistant',
+          contentType: 'text',
+          text: 'Here is code:\n```ts\nconst x = 1;\n```',
+          timestamp: '2026-04-24T10:00:01Z',
+        },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    const { container } = render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      // CodeBlock renders language label and highlighted code via dangerouslySetInnerHTML.
+      // Syntax highlighter wraps keywords in spans, so check for parts.
+      expect(container.querySelector('code')).toBeDefined();
+      expect(container.querySelector('pre')).toBeDefined();
+      // The language label "ts" is rendered in the code block header
+      expect(container.textContent).toContain('ts');
+    });
+  });
+
+  it('renders tool_use entries', async () => {
+    mockGetSessionMessages.mockResolvedValue({
+      messages: [
+        {
+          role: 'assistant',
+          contentType: 'tool_use',
+          text: '{"command": "ls -la"}',
+          toolName: 'Bash',
+          toolUseId: 'tool-1',
+          timestamp: '2026-04-24T10:00:02Z',
+        },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bash')).toBeDefined();
+      expect(screen.getByText('tool_use')).toBeDefined();
+    });
+  });
+
+  it('renders tool_result entries', async () => {
+    mockGetSessionMessages.mockResolvedValue({
+      messages: [
+        {
+          role: 'assistant',
+          contentType: 'tool_result',
+          text: 'file1.txt\nfile2.txt',
+          toolName: 'Bash',
+          toolUseId: 'tool-1',
+          timestamp: '2026-04-24T10:00:03Z',
+        },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('OK Result')).toBeDefined();
+    });
+  });
+
+  // ── SSE subscription ───────────────────────────────────────────────
+
+  it('subscribes to SSE on mount with session ID and token', async () => {
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(mockSubscribeSSE).toHaveBeenCalledWith(
+        'session-1',
+        expect.any(Function),
+        'test-token',
+      );
+    });
+  });
+
+  it('unsubscribes from SSE on unmount', async () => {
+    const unsubscribe = vi.fn();
+    mockSubscribeSSE.mockReturnValue(unsubscribe);
+
+    const { unmount } = render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(mockSubscribeSSE).toHaveBeenCalled();
+    });
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  // ── Filtering ──────────────────────────────────────────────────────
+
+  it('shows filter buttons', async () => {
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('thinking')).toBeDefined();
+      expect(screen.getByText('Tools')).toBeDefined();
+      expect(screen.getByText('Results')).toBeDefined();
+    });
+  });
+
+  it('shows filtered count in the filter bar', async () => {
+    mockGetSessionMessages.mockResolvedValue({
+      messages: [
+        { role: 'user', contentType: 'text', text: 'Hi', timestamp: '2026-04-24T10:00:00Z' },
+        { role: 'assistant', contentType: 'thinking', text: 'hmm', timestamp: '2026-04-24T10:00:01Z' },
+        { role: 'assistant', contentType: 'text', text: 'Done', timestamp: '2026-04-24T10:00:02Z' },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    // thinking filter is off by default, so 2/3 visible
+    await waitFor(() => {
+      expect(screen.getByText('2 / 3')).toBeDefined();
+    });
+  });
+
+  it('toggles thinking filter when clicked', async () => {
+    mockGetSessionMessages.mockResolvedValue({
+      messages: [
+        { role: 'user', contentType: 'text', text: 'Hi', timestamp: '2026-04-24T10:00:00Z' },
+        { role: 'assistant', contentType: 'thinking', text: 'hmm', timestamp: '2026-04-24T10:00:01Z' },
+        { role: 'assistant', contentType: 'text', text: 'Done', timestamp: '2026-04-24T10:00:02Z' },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('2 / 3')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText('thinking'));
+
+    await waitFor(() => {
+      expect(screen.getByText('3 / 3')).toBeDefined();
+    });
+  });
+
+  it('hides tool_use when Tools filter is toggled off', async () => {
+    mockGetSessionMessages.mockResolvedValue({
+      messages: [
+        { role: 'user', contentType: 'text', text: 'Hi', timestamp: '2026-04-24T10:00:00Z' },
+        { role: 'assistant', contentType: 'tool_use', text: 'ls', toolName: 'Bash', timestamp: '2026-04-24T10:00:01Z' },
+      ],
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    // Both visible initially (user + tool_use)
+    await waitFor(() => {
+      expect(screen.getByText('2 / 2')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText('Tools'));
+
+    await waitFor(() => {
+      expect(screen.getByText('1 / 2')).toBeDefined();
+    });
+  });
+
+  // ── Message cap ────────────────────────────────────────────────────
+
+  it('caps messages at 1000', async () => {
+    const messages = makeMessages(1050);
+
+    mockGetSessionMessages.mockResolvedValue({
+      messages,
+      status: 'idle',
+      statusText: null,
+      interactiveContent: null,
+    });
+
+    render(<TranscriptViewer sessionId="session-1" />);
+
+    // Should show 1000 messages (the last 1000 of the 1050)
+    await waitFor(() => {
+      expect(screen.getByText('1000 / 1000')).toBeDefined();
+    });
   });
 });

--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -1,18 +1,18 @@
-﻿import { useState } from 'react';
+import { useState } from 'react';
 import type { ParsedEntry } from '../../types';
 import { RenderWithCodeBlocks } from '../shared/CodeBlock';
 
 const TOOL_ICONS: Record<string, string> = {
-  Read: 'ðŸ“–',
-  Edit: 'âœï¸',
-  Write: 'ðŸ“',
-  Bash: 'ðŸ’»',
-  Search: 'ðŸ”',
+  Read: '\u{1F4D6}',
+  Edit: '\u270F\uFE0F',
+  Write: '\u{1F4DD}',
+  Bash: '\u{1F4BB}',
+  Search: '\u{1F50D}',
 };
 
 function getToolIcon(toolName?: string): string {
-  if (!toolName) return 'â“';
-  return TOOL_ICONS[toolName] ?? 'â“';
+  if (!toolName) return '\u2753';
+  return TOOL_ICONS[toolName] ?? '\u2753';
 }
 
 function formatTimestamp(ts?: string): string {
@@ -25,7 +25,12 @@ function formatTimestamp(ts?: string): string {
   }
 }
 
-// â”€â”€â”€ Text Message â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+/** Check if text contains markdown fenced code blocks. */
+function hasCodeBlocks(text: string): boolean {
+  return /```\w*\n?[\s\S]*?```/.test(text);
+}
+
+// ── Text Message ─────────────────────────────────────────────────────
 function TextMessage({ entry }: { entry: ParsedEntry }) {
   const isUser = entry.role === 'user';
 
@@ -49,7 +54,7 @@ function TextMessage({ entry }: { entry: ParsedEntry }) {
   );
 }
 
-// â”€â”€â”€ Thinking Block â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Thinking Block ───────────────────────────────────────────────────
 function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
   const [open, setOpen] = useState(false);
 
@@ -64,9 +69,9 @@ function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
             className="inline-block transition-transform duration-200"
             style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}
           >
-            â–¶
+            \u25B6
           </span>
-          <span className="italic">Thinkingâ€¦</span>
+          <span className="italic">Thinking\u2026</span>
         </button>
         {open && (
           <div className="bg-[var(--color-void-deepest)] border border-[var(--color-void-lighter)] rounded-lg px-4 py-3 mt-1 text-sm text-[#555] italic leading-relaxed whitespace-pre-wrap break-words max-h-64 overflow-y-auto">
@@ -78,10 +83,11 @@ function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
   );
 }
 
-// â”€â”€â”€ Tool Use Card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Tool Use Card ────────────────────────────────────────────────────
 function ToolUseCard({ entry }: { entry: ParsedEntry }) {
-  const rawPreview = entry.text;
-  const preview = rawPreview.length > 100 ? rawPreview.slice(0, 100) + 'â€¦' : rawPreview;
+  const [expanded, setExpanded] = useState(false);
+  const rawText = entry.text;
+  const containsCodeBlocks = hasCodeBlocks(rawText);
 
   return (
     <div className="flex justify-start mb-3">
@@ -93,19 +99,36 @@ function ToolUseCard({ entry }: { entry: ParsedEntry }) {
           </span>
           <span className="text-[10px] text-[#555] ml-auto">tool_use</span>
         </div>
-        <div className="px-3 py-2 text-xs text-[#888] font-mono whitespace-pre-wrap break-all max-h-32 overflow-y-auto">
-          {preview}
-        </div>
+        {containsCodeBlocks ? (
+          <div className={`px-3 py-2 overflow-y-auto ${expanded ? 'max-h-[600px]' : 'max-h-32'}`}>
+            <RenderWithCodeBlocks text={rawText} />
+          </div>
+        ) : (
+          <div className={`px-3 py-2 text-xs text-[#888] font-mono whitespace-pre-wrap break-all overflow-y-auto ${expanded ? 'max-h-[600px]' : 'max-h-32'}`}>
+            {expanded ? rawText : (rawText.length > 100 ? rawText.slice(0, 100) + '\u2026' : rawText)}
+          </div>
+        )}
+        {rawText.length > 100 && (
+          <button
+            onClick={() => setExpanded(e => !e)}
+            className="w-full text-[10px] text-[#555] hover:text-[#888] py-1 border-t border-[var(--color-void-lighter)] transition-colors"
+          >
+            {expanded ? 'Collapse' : 'Expand'}
+          </button>
+        )}
       </div>
     </div>
   );
 }
 
-// â”€â”€â”€ Tool Result Card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Tool Result Card ─────────────────────────────────────────────────
 function ToolResultCard({ entry }: { entry: ParsedEntry }) {
+  const [expanded, setExpanded] = useState(false);
   const isError =
     /^\s*error(?:\s*[:\-]|\s*$)/i.test(entry.text)
     || /^\s*(?:failed|exception)(?:\s*[:\-]|\s*$)/i.test(entry.text);
+  const rawText = entry.text || '(empty)';
+  const containsCodeBlocks = hasCodeBlocks(rawText);
 
   return (
     <div className="flex justify-start mb-3">
@@ -122,9 +145,23 @@ function ToolResultCard({ entry }: { entry: ParsedEntry }) {
             <span className="text-[10px] text-[#555] font-mono">{entry.toolName}</span>
           )}
         </div>
-        <div className="px-3 py-2 text-xs text-[#666] font-mono whitespace-pre-wrap break-all max-h-32 overflow-y-auto">
-          {entry.text || '(empty)'}
-        </div>
+        {containsCodeBlocks ? (
+          <div className={`px-3 py-2 overflow-y-auto ${expanded ? 'max-h-[600px]' : 'max-h-32'}`}>
+            <RenderWithCodeBlocks text={rawText} />
+          </div>
+        ) : (
+          <div className={`px-3 py-2 text-xs text-[#666] font-mono whitespace-pre-wrap break-all overflow-y-auto ${expanded ? 'max-h-[600px]' : 'max-h-32'}`}>
+            {expanded ? rawText : (rawText.length > 100 ? rawText.slice(0, 100) + '\u2026' : rawText)}
+          </div>
+        )}
+        {rawText.length > 100 && (
+          <button
+            onClick={() => setExpanded(e => !e)}
+            className="w-full text-[10px] text-[#555] hover:text-[#888] py-1 border-t border-[var(--color-void-lighter)] transition-colors"
+          >
+            {expanded ? 'Collapse' : 'Expand'}
+          </button>
+        )}
       </div>
     </div>
   );
@@ -141,7 +178,7 @@ function PermissionRequestMessage({ entry }: { entry: ParsedEntry }) {
   );
 }
 
-// â”€â”€â”€ MessageBubble (main export) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── MessageBubble (main export) ──────────────────────────────────────
 export function MessageBubble({ entry }: { entry: ParsedEntry }) {
   if (entry.contentType === 'permission_request') {
     return <PermissionRequestMessage entry={entry} />;
@@ -164,4 +201,3 @@ export function MessageBubble({ entry }: { entry: ParsedEntry }) {
       return <TextMessage entry={entry} />;
   }
 }
-

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -25,6 +25,7 @@ import { StreamTab } from '../components/session/StreamTab';
 import { SessionMetricsPanel } from '../components/session/SessionMetricsPanel';
 import { LatencyPanel } from '../components/metrics/LatencyPanel';
 import { AuditTrailPanel } from '../components/session/AuditTrailPanel';
+import { TranscriptViewer } from '../components/session/TranscriptViewer';
 import { ApprovalBanner } from '../components/session/ApprovalBanner';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PendingQuestionCard } from '../components/session/PendingQuestionCard';
@@ -37,12 +38,13 @@ interface ScreenshotState {
   capturedAt: number;
 }
 
-type TabId = 'stream' | 'metrics' | 'audit';
+type TabId = 'stream' | 'metrics' | 'audit' | 'transcript';
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'stream', label: 'Stream' },
   { id: 'metrics', label: 'Metrics' },
   { id: 'audit', label: 'Audit' },
+  { id: 'transcript', label: 'Transcript' },
 ];
 
 const COMMON_SLASH_COMMANDS = ['/clear', '/compact', '/cost', '/config'] as const;
@@ -692,6 +694,23 @@ export default function SessionDetailPage() {
                   className="overflow-auto p-3 sm:p-4"
                 >
                   <AuditTrailPanel records={auditRecords} loading={auditLoading} error={auditError} />
+                </motion.div>
+              )}
+
+              {activeTab === 'transcript' && (
+                <motion.div
+                  key="panel-transcript"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  transition={{ duration: 0.2 }}
+                  id="panel-transcript"
+                  role="tabpanel"
+                  aria-labelledby="tab-transcript"
+                  tabIndex={0}
+                  className={fullBleed ? 'h-full min-h-[200px]' : 'h-[calc(100vh-300px)] min-h-[200px] sm:h-[calc(100vh-420px)] sm:min-h-[300px]'}
+                >
+                  <TranscriptViewer sessionId={s.id} />
                 </motion.div>
               )}
             </AnimatePresence>


### PR DESCRIPTION
## Summary
Adds a **Transcript tab** to  that displays the full chronological message history of a session using the existing  component.

### Changes
- **SessionDetailPage.tsx**: Added  tab with  panel (motion-animated tab switch, WCAG tab/panel ARIA attributes)
- **MessageBubble.tsx**: Enhanced  and  with:
  - Expand/collapse for long content (toggle button, 100-char truncation)
  - Code block detection via  with syntax highlighting
  - Consistent visual styling across tool result types
- **TranscriptViewer.test.tsx**: Expanded from 1 to 14 tests covering:
  - Loading and error states
  - Empty state
  - Message rendering (user, assistant, tool_use, tool_result)
  - SSE subscription/unsubscription
  - Filter toggling (show/hide thinking)
  - 1000-message cap

### Verification
```
Build: passes ✓
Tests: 14/14 TranscriptViewer tests pass ✓
```

Note: 4 pre-existing MetricsPage test failures exist in the dashboard test suite (unrelated to this change — they fail on develop CI as well).</body>