### PR TITLE
fix: tighten .gitignore — prevent settings files and test artifacts from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ state.json
 Thumbs.db
 .vscode/
 .claude/settings.local.json.aegis-backup
+.claude/settings.local*
+.claude/settings.local copy.json
+.claude/*.local*
 *.aegis-backup
 # Test result data
 results.tsv
@@ -72,3 +75,8 @@ scripts/dashboard-icons-audit.current.txt
 # Local memory / vibe files and release tarballs
 memory/
 *.tgz
+
+# Test artifacts (leaked in 996feb8)
+/.test-scratch/
+playwright-report/
+test-results/


### PR DESCRIPTION
Prevents future secret leaks by hardening .gitignore patterns.\n\n### Changes\n- **.claude/settings.local\*** — catches any file starting with  (copy, backup, etc.)\n- **/.test-scratch/** — test scratch directories\n- **playwright-report/** — Playwright test reports\n- **test-results/** — Vitest test result artifacts\n\n### Background\nCommit  accidentally committed  and multiple test artifact directories, exposing an API key in git history. This PR hardens .gitignore to prevent recurrence.