### PR TITLE
feat(dashboard): template duplicate, NewSessionPage selector, and Vitest tests (#2109)

### DIFF
--- a/dashboard/src/__tests__/TemplatesPage.test.tsx
+++ b/dashboard/src/__tests__/TemplatesPage.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * TemplatesPage.test.tsx — Tests for session templates management page.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { act } from 'react';
+import TemplatesPage from '../pages/TemplatesPage';
+import * as client from '../api/client';
+import type { SessionTemplate } from '../types';
+
+// Mock the API client
+vi.mock('../api/client', () => ({
+  getTemplates: vi.fn(),
+  createSession: vi.fn(),
+  createTemplate: vi.fn(),
+  deleteTemplate: vi.fn(),
+}));
+
+// Mock useToastStore
+vi.mock('../store/useToastStore', () => ({
+  useToastStore: (sel: (s: { addToast: ReturnType<typeof vi.fn> }) => unknown) =>
+    sel({ addToast: vi.fn() }),
+}));
+
+const mockTemplates: SessionTemplate[] = [
+  {
+    id: 'tmpl-1',
+    name: 'React Scaffold',
+    description: 'Standard React project setup',
+    workDir: '/home/user/projects/react-app',
+    prompt: 'Create a new React app with TypeScript',
+    claudeCommand: 'claude --model opus',
+    permissionMode: 'bypassPermissions',
+    autoApprove: false,
+    createdAt: Date.now() - 86400000,
+    updatedAt: Date.now() - 86400000,
+  },
+  {
+    id: 'tmpl-2',
+    name: 'Bug Fix',
+    description: 'Fix a bug in existing code',
+    workDir: '/home/user/projects/myapp',
+    createdAt: Date.now() - 3600000,
+    updatedAt: Date.now() - 3600000,
+  },
+];
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <TemplatesPage />
+    </BrowserRouter>,
+  );
+}
+
+describe('TemplatesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(client.getTemplates).mockResolvedValue(mockTemplates);
+  });
+
+  it('renders templates list', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('React Scaffold')).toBeDefined();
+    });
+    expect(screen.getByText('Bug Fix')).toBeDefined();
+  });
+
+  it('shows empty state when no templates', async () => {
+    vi.mocked(client.getTemplates).mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No templates yet')).toBeDefined();
+    });
+  });
+
+  it('shows error state on fetch failure', async () => {
+    vi.mocked(client.getTemplates).mockRejectedValue(new Error('Network error'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to load templates')).toBeDefined();
+    });
+  });
+
+  it('deletes a template after confirmation', async () => {
+    vi.mocked(client.deleteTemplate).mockResolvedValue({ ok: true });
+
+    renderPage();
+
+    // Wait for templates to load
+    await waitFor(() => {
+      expect(screen.getByText('React Scaffold')).toBeDefined();
+    });
+
+    // There should be at least 2 "Delete" buttons (one per template card)
+    // The first template's Delete button should trigger the confirm dialog
+    const allDeleteBtns = screen.getAllByText('Delete');
+    expect(allDeleteBtns.length).toBeGreaterThanOrEqual(2);
+
+    // Click the first Delete button
+    await act(async () => {
+      fireEvent.click(allDeleteBtns[0]);
+    });
+
+    // The confirm dialog should render - check for the dialog heading
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Delete Template' })).toBeDefined();
+    }, { timeout: 3000 });
+
+    // Verify deleteTemplate was NOT called yet (confirmation needed)
+    expect(client.deleteTemplate).not.toHaveBeenCalled();
+  });
+
+  it('opens create template modal', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('React Scaffold')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText('Create Template'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Create Template' })).toBeDefined();
+    });
+  });
+
+  it('duplicates a template', async () => {
+    vi.mocked(client.createTemplate).mockResolvedValue({
+      ...mockTemplates[0],
+      id: 'tmpl-3',
+      name: 'React Scaffold (copy)',
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('React Scaffold')).toBeDefined();
+    });
+
+    const duplicateButtons = screen.getAllByText('Duplicate');
+    fireEvent.click(duplicateButtons[0]);
+
+    await waitFor(() => {
+      expect(client.createTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'React Scaffold (copy)',
+          workDir: '/home/user/projects/react-app',
+        }),
+      );
+    });
+  });
+
+  it('displays template metadata', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('React Scaffold')).toBeDefined();
+    });
+
+    // Shows permission mode badge
+    expect(screen.getByText('bypassPermissions')).toBeDefined();
+    // Shows work directory
+    expect(screen.getByText('/home/user/projects/react-app')).toBeDefined();
+  });
+});

--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -4,7 +4,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Loader2, Plus, ArrowLeft, Star, Clock, X } from 'lucide-react';
+import { FileText, Loader2, Plus, ArrowLeft, Star, Clock, X } from 'lucide-react';
 import { createSession, getTemplates } from '../api/client';
 import type { SessionTemplate } from '../types';
 import { useToastStore } from '../store/useToastStore';
@@ -76,6 +76,14 @@ export default function NewSessionPage() {
       setLoading(false);
     }
   }, [workDir, name, claudeCommand, prompt, permissionMode, addToast, navigate, addRecentDir]);
+
+  function applyTemplate(template: SessionTemplate): void {
+    setName(template.name);
+    setWorkDir(template.workDir);
+    setPrompt(template.prompt ?? '');
+    setClaudeCommand(template.claudeCommand ?? '');
+    setPermissionMode(template.permissionMode ?? 'default');
+  }
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -254,12 +262,28 @@ export default function NewSessionPage() {
           </select>
         </div>
 
-        {/* Templates hint */}
+        {/* Template Selector */}
         {templates.length > 0 && (
           <div>
-            <p className="text-xs text-gray-500 mb-2">
-              {templates.length} template{templates.length !== 1 ? 's' : ''} available — use the Overview page to create from template
+            <p className="text-sm font-medium text-gray-300 mb-2 flex items-center gap-1.5">
+              <FileText className="h-4 w-4" />
+              Start from a template
             </p>
+            <div className="flex flex-wrap gap-2">
+              {templates.map((template) => (
+                <button
+                  key={template.id}
+                  type="button"
+                  onClick={() => applyTemplate(template)}
+                  className="flex items-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
+                  aria-label={`Apply template ${template.name}`}
+                >
+                  <FileText className="h-3.5 w-3.5" />
+                  <span className="truncate max-w-[180px]">{template.name}</span>
+                </button>
+              ))}
+            </div>
+            <p className="mt-1 text-xs text-gray-500">Click a template to pre-fill the form fields above.</p>
           </div>
         )}
 

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  Copy,
   FileText,
   Loader2,
   Pencil,
@@ -18,6 +19,7 @@ import {
 } from 'lucide-react';
 import {
   createSession,
+  createTemplate,
   deleteTemplate,
   getTemplates,
 } from '../api/client';
@@ -128,6 +130,27 @@ export default function TemplatesPage() {
       addToast('error', 'Failed to create session', err instanceof Error ? err.message : undefined);
     } finally {
       setUsingId(null);
+    }
+  }
+
+  async function handleDuplicate(template: SessionTemplate): Promise<void> {
+    try {
+      await createTemplate({
+        name: `${template.name} (copy)`,
+        description: template.description,
+        workDir: template.workDir,
+        prompt: template.prompt,
+        claudeCommand: template.claudeCommand,
+        permissionMode: template.permissionMode,
+        env: template.env,
+        stallThresholdMs: template.stallThresholdMs,
+        autoApprove: template.autoApprove,
+        memoryKeys: template.memoryKeys,
+      });
+      addToast('success', 'Template duplicated', `"${template.name}" duplicated`);
+      void fetchTemplates(true);
+    } catch (err) {
+      addToast('error', 'Failed to duplicate template', err instanceof Error ? err.message : undefined);
     }
   }
 
@@ -255,6 +278,15 @@ export default function TemplatesPage() {
                   >
                     <Pencil className="h-3.5 w-3.5" />
                     Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleDuplicate(template)}
+                    className="flex min-h-[40px] items-center justify-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
+                    title="Duplicate template"
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                    Duplicate
                   </button>
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

Completes remaining acceptance criteria for #2109 (Session Templates management UI).

### Changes

**TemplatesPage:**
- Add **Duplicate** button — copies all template fields with '(copy)' suffix via createTemplate API

**NewSessionPage:**
- Replace static hint text with **clickable template selector cards**
- Clicking a template pre-fills name, workDir, prompt, claudeCommand, and permissionMode

**TemplatesPage.test.tsx (new):**
- 7 test cases: renders list, empty state, error state, delete confirmation, create modal, duplicate, metadata display

### Acceptance Criteria Status

- [x] TemplatesPage at /dashboard/templates with list/create/edit/delete (pre-existing)
- [x] Template editor modal (pre-existing)
- [x] **Duplicate template** (new)
- [x] **NewSessionPage shows template selector** (new — replaces hint)
- [x] **Vitest tests** (new — 7/7 pass)
- [ ] SessionDetailPage template badge — blocked on backend (needs templateId in SessionInfo, Hep territory)

### Quality Gate

- TypeScript: clean
- Build: succeeds
- Tests: 7/7 pass

Part of #2109