### PR TITLE
feat(dashboard): responsive mobile layout fixes for 375px viewport (#2168)

### DIFF
--- a/dashboard/src/__tests__/HomeStatusPanel.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/HomeStatusPanel.mobile-responsive.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * HomeStatusPanel.mobile-responsive.test.tsx — Tests for 375px responsive fixes.
+ *
+ * Verifies that StatusCard uses responsive icon sizes, gaps, and text sizing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HomeStatusPanel from '../components/overview/HomeStatusPanel';
+import { useStore } from '../store/useStore';
+
+const mockGetHealth = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getHealth: (...args: unknown[]) => mockGetHealth(...args),
+}));
+
+function makeHealth(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    status: 'ok',
+    version: '0.5.3-alpha',
+    platform: 'win32',
+    uptime: 120,
+    sessions: { active: 1, total: 3 },
+    tmux: { healthy: true, error: null },
+    claude: { available: true, healthy: true, version: '2.1.90', minimumVersion: '2.1.80', error: null },
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('HomeStatusPanel mobile responsive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    useStore.setState({ activities: [], sseConnected: false, sseError: null });
+    mockGetHealth.mockResolvedValue(makeHealth());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('status card icon circle uses responsive sizing (h-8 w-8 sm:h-10 sm:w-10)', async () => {
+    render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    const iconCircle = card.querySelector('div.rounded-full');
+
+    expect(iconCircle).not.toBeNull();
+    expect(iconCircle!.classList.contains('h-8')).toBe(true);
+    expect(iconCircle!.classList.contains('w-8')).toBe(true);
+    expect(iconCircle!.classList.contains('sm:h-10')).toBe(true);
+    expect(iconCircle!.classList.contains('sm:w-10')).toBe(true);
+  });
+
+  it('status card value uses responsive font sizing (text-lg sm:text-xl)', async () => {
+    render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    // The "Ready" value element
+    const valueEl = card.querySelector('.font-mono.font-bold');
+    expect(valueEl).not.toBeNull();
+    expect(valueEl!.classList.contains('text-lg')).toBe(true);
+    expect(valueEl!.classList.contains('sm:text-xl')).toBe(true);
+  });
+
+  it('status card icon row uses responsive gap (gap-3 sm:gap-4)', async () => {
+    render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    // The row containing icon + label + value
+    const row = card.querySelector('.flex.items-center');
+    expect(row).not.toBeNull();
+    expect(row!.classList.contains('gap-3')).toBe(true);
+    expect(row!.classList.contains('sm:gap-4')).toBe(true);
+  });
+
+  it('degraded status card shows action button with responsive margin', async () => {
+    mockGetHealth.mockResolvedValue(makeHealth({
+      tmux: { healthy: false, error: 'tmux not running' },
+    }));
+
+    render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    const card = screen.getByRole('article', { name: 'Tmux status: Degraded' });
+    const actionBtn = card.querySelector('button');
+    expect(actionBtn).not.toBeNull();
+    expect(actionBtn!.classList.contains('ml-11')).toBe(true);
+    expect(actionBtn!.classList.contains('sm:ml-14')).toBe(true);
+  });
+});

--- a/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Layout.mobile-responsive.test.tsx — Tests for 375px viewport responsive fixes.
+ *
+ * Verifies that the footer, header, and main content use mobile-friendly classes:
+ * - Footer hides ⌘K button, shows compact version, hides full version on mobile
+ * - Header hides PREVIEW badge, "Check updates" button on mobile
+ * - Main content uses reduced padding on small screens
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const mockSubscribeGlobalSSE = vi.fn();
+const mockGetHealth = vi.fn();
+const mockCheckForUpdates = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getHealth: (...args: unknown[]) => mockGetHealth(...args),
+  checkForUpdates: (...args: unknown[]) => mockCheckForUpdates(...args),
+  subscribeGlobalSSE: (...args: unknown[]) => mockSubscribeGlobalSSE(...args),
+}));
+
+vi.mock('../components/ToastContainer', () => ({
+  default: () => <div data-testid="toast-container" />,
+}));
+
+import Layout from '../components/Layout';
+import { useSidebarStore } from '../store/useSidebarStore';
+
+const SIDEBAR_STORAGE_KEY = 'aegis-sidebar-collapsed';
+
+function renderLayout(): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="/" element={<div>Test Content</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function setupDefaults() {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+  });
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  mockGetHealth.mockResolvedValue({
+    status: 'ok',
+    version: '2.13.1',
+    uptime: 120,
+    sessions: { active: 1, total: 1 },
+    timestamp: new Date().toISOString(),
+  });
+  mockCheckForUpdates.mockResolvedValue({
+    currentVersion: '2.13.1',
+    latestVersion: '2.13.1',
+    updateAvailable: false,
+    releaseUrl: 'https://www.npmjs.com/package/@onestepat4time/aegis',
+  });
+  mockSubscribeGlobalSSE.mockReturnValue(() => {});
+  localStorage.removeItem('aegis:update-check:v1');
+  localStorage.removeItem(SIDEBAR_STORAGE_KEY);
+  localStorage.removeItem('aegis-dashboard-theme');
+  useSidebarStore.setState({ isCollapsed: false, isMobileOpen: false });
+}
+
+describe('Layout mobile responsive', () => {
+  beforeEach(() => {
+    setupDefaults();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    localStorage.removeItem(SIDEBAR_STORAGE_KEY);
+    localStorage.removeItem('aegis-dashboard-theme');
+  });
+
+  describe('footer', () => {
+    it('hides command palette button on mobile (hidden md:flex)', () => {
+      renderLayout();
+
+      const footer = document.querySelector('footer');
+      expect(footer).not.toBeNull();
+
+      // The ⌘K Command palette button should have hidden md:flex classes
+      const cmdButtons = footer!.querySelectorAll('button');
+      const paletteButton = Array.from(cmdButtons).find(
+        (btn) => btn.textContent?.includes('Command palette'),
+      );
+      expect(paletteButton).toBeDefined();
+      expect(paletteButton!.classList.contains('hidden')).toBe(true);
+      expect(paletteButton!.classList.contains('md:flex')).toBe(true);
+    });
+
+    it('hides full version string on mobile, shows compact version', async () => {
+      renderLayout();
+
+      const version = await screen.findByText('v2.13.1');
+      expect(version).toBeDefined();
+      // Compact version should have sm:hidden (hidden on sm+)
+      expect(version.classList.contains('sm:hidden')).toBe(true);
+    });
+
+    it('full version label is hidden on mobile (hidden sm:block)', async () => {
+      renderLayout();
+
+      const fullVersion = await screen.findByText('aegis v2.13.1');
+      expect(fullVersion).toBeDefined();
+      expect(fullVersion.classList.contains('hidden')).toBe(true);
+      expect(fullVersion.classList.contains('sm:block')).toBe(true);
+    });
+
+    it('uses reduced horizontal padding on mobile (px-3)', () => {
+      renderLayout();
+
+      const footer = document.querySelector('footer');
+      expect(footer).not.toBeNull();
+      expect(footer!.classList.contains('px-3')).toBe(true);
+      expect(footer!.classList.contains('sm:px-6')).toBe(true);
+    });
+
+    it('SSE indicator container has min-w-0 and truncate for overflow safety', () => {
+      renderLayout();
+
+      const footer = document.querySelector('footer');
+      const sseDiv = footer!.querySelector('div');
+      expect(sseDiv?.classList.contains('min-w-0')).toBe(true);
+    });
+  });
+
+  describe('header', () => {
+    it('hides PREVIEW badge on small screens (hidden sm:inline-flex)', () => {
+      renderLayout();
+
+      const preview = screen.queryByText('PREVIEW');
+      expect(preview).toBeDefined();
+      expect(preview!.classList.contains('hidden')).toBe(true);
+      expect(preview!.classList.contains('sm:inline-flex')).toBe(true);
+    });
+
+    it('hides Check updates button on mobile (hidden sm:inline-flex)', () => {
+      renderLayout();
+
+      const checkBtn = screen.queryByRole('button', { name: /Check updates/i });
+      expect(checkBtn).toBeDefined();
+      expect(checkBtn!.classList.contains('hidden')).toBe(true);
+      expect(checkBtn!.classList.contains('sm:inline-flex')).toBe(true);
+    });
+
+    it('hides version label text on mobile inside header badge', () => {
+      renderLayout();
+
+      const header = document.querySelector('header');
+      // The "Version X.Y.Z" span should be hidden sm:inline
+      const versionSpans = header!.querySelectorAll('span');
+      const versionLabel = Array.from(versionSpans).find(
+        (span) => span.textContent?.startsWith('Version'),
+      );
+      expect(versionLabel).toBeDefined();
+      expect(versionLabel!.classList.contains('hidden')).toBe(true);
+      expect(versionLabel!.classList.contains('sm:inline')).toBe(true);
+    });
+
+    it('theme toggle button is always visible (no hidden class)', () => {
+      renderLayout();
+
+      const themeBtn = screen.getByRole('button', { name: /Switch to/i });
+      expect(themeBtn).toBeDefined();
+      expect(themeBtn.classList.contains('hidden')).toBe(false);
+    });
+
+    it('New Session button is always visible', () => {
+      renderLayout();
+
+      const newSessionBtn = screen.getByRole('button', { name: /New Session/i });
+      expect(newSessionBtn).toBeDefined();
+      expect(newSessionBtn.classList.contains('hidden')).toBe(false);
+    });
+  });
+
+  describe('main content area', () => {
+    it('uses responsive padding (p-3 sm:p-6 md:p-10)', () => {
+      renderLayout();
+
+      const main = screen.getByRole('main');
+      expect(main.classList.contains('p-3')).toBe(true);
+      expect(main.classList.contains('sm:p-6')).toBe(true);
+      expect(main.classList.contains('md:p-10')).toBe(true);
+    });
+  });
+});

--- a/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const mockSubscribeGlobalSSE = vi.fn();

--- a/dashboard/src/__tests__/MetricCards.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/MetricCards.mobile-responsive.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * MetricCards.mobile-responsive.test.tsx — Tests for 375px responsive fixes.
+ *
+ * Verifies that the Delivery Rate section stacks vertically on mobile
+ * and uses responsive RingGauge size and padding.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MetricCards from '../components/overview/MetricCards';
+import { useStore } from '../store/useStore';
+
+const mockGetMetrics = vi.fn();
+const mockGetHealth = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getMetrics: (...args: unknown[]) => mockGetMetrics(...args),
+  getHealth: (...args: unknown[]) => mockGetHealth(...args),
+}));
+
+describe('MetricCards mobile responsive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    useStore.setState({ metrics: null, activities: [], sseConnected: false, sseError: null });
+
+    mockGetMetrics.mockResolvedValue({
+      uptime: 3600,
+      sessions: { total_created: 10, currently_active: 3, completed: 6, failed: 1, avg_duration_sec: 42, avg_messages_per_session: 5 },
+      auto_approvals: 0,
+      webhooks_sent: 0,
+      webhooks_failed: 0,
+      screenshots_taken: 0,
+      pipelines_created: 0,
+      batches_created: 0,
+      prompt_delivery: { sent: 100, delivered: 95, failed: 5, success_rate: 95 },
+      latency: {
+        hook_latency_ms: { min: 2, max: 6, avg: 4, count: 2 },
+        state_change_detection_ms: { min: 2, max: 6, avg: 4, count: 2 },
+        permission_response_ms: { min: 20, max: 40, avg: 30, count: 2 },
+        channel_delivery_ms: { min: 3, max: 7, avg: 5, count: 2 },
+      },
+    });
+
+    mockGetHealth.mockResolvedValue({
+      status: 'ok',
+      version: 'test',
+      uptime: 1,
+      sessions: { active: 1, total: 2 },
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('Delivery Rate card uses flex-col on mobile and sm:flex-row on larger screens', async () => {
+    render(<MemoryRouter><MetricCards /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    // Find the card containing "Delivery Rate"
+    const heading = screen.getByText('Delivery Rate');
+    const card = heading.closest('.card-glass');
+    expect(card).not.toBeNull();
+
+    // The flex container holding RingGauge + text details
+    const flexContainer = card!.querySelector('.flex.flex-col');
+    expect(flexContainer).not.toBeNull();
+    expect(flexContainer!.classList.contains('sm:flex-row')).toBe(true);
+  });
+
+  it('Delivery Rate card uses responsive padding (p-4 sm:p-5)', async () => {
+    render(<MemoryRouter><MetricCards /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    const heading = screen.getByText('Delivery Rate');
+    const card = heading.closest('.card-glass');
+    expect(card).not.toBeNull();
+    expect(card!.classList.contains('p-4')).toBe(true);
+    expect(card!.classList.contains('sm:p-5')).toBe(true);
+  });
+
+  it('Delivery Rate text content is centered on mobile, left-aligned on sm+', async () => {
+    render(<MemoryRouter><MetricCards /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    const heading = screen.getByText('Delivery Rate');
+    const card = heading.closest('.card-glass');
+    // The text details div
+    const textDiv = card!.querySelector('.flex-1.space-y-3');
+    expect(textDiv).not.toBeNull();
+    expect(textDiv!.classList.contains('text-center')).toBe(true);
+    expect(textDiv!.classList.contains('sm:text-left')).toBe(true);
+  });
+
+  it('RingGauge renders inside the delivery rate card', async () => {
+    render(<MemoryRouter><MetricCards /></MemoryRouter>);
+
+    await act(async () => { await vi.runAllTicks(); });
+
+    const heading = screen.getByText('Delivery Rate');
+    const card = heading.closest('.card-glass');
+    // RingGauge renders an SVG element
+    const svg = card!.querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
+});

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -362,7 +362,7 @@ export default function Layout() {
                   end={to === '/'}
                   onClick={handleNavClick}
                   className={({ isActive }) =>
-                    `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all ${
+                    `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
                       isActive
                         ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-cyan dark:bg-cyan/10 dark:text-cyan glow-nav-active'
                         : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 border-l-2 border-transparent dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200'
@@ -385,7 +385,7 @@ export default function Layout() {
             to="/settings"
             onClick={handleNavClick}
             className={({ isActive }) =>
-              `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all ${
+              `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
                 isActive
                   ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-cyan dark:bg-cyan/10 dark:text-cyan glow-nav-active'
                   : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 border-l-2 border-transparent dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200'

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -446,8 +446,9 @@ export default function Layout() {
               </div>
             </div>
 
-            <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
-              <span className="rounded-md border border-transparent bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-blue-800 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-500/10 dark:text-blue-400 dark:ring-0">
+            <div className="flex items-center justify-end gap-1.5 sm:gap-3">
+              {/* PREVIEW badge — hidden on very small screens */}
+              <span className="hidden sm:inline-flex rounded-md border border-transparent bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-blue-800 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-500/10 dark:text-blue-400 dark:ring-0">
                 PREVIEW
               </span>
 
@@ -462,7 +463,7 @@ export default function Layout() {
                 <Plus className="h-4 w-4" />
               </button>
 
-              {/* Cmd+K Palette trigger */}
+              {/* Cmd+K Palette trigger — hidden on mobile */}
               <button
                 type="button"
                 onClick={() => setPaletteOpen(true)}
@@ -473,24 +474,26 @@ export default function Layout() {
                 <kbd className="ml-1 font-mono text-[10px] text-slate-600 border border-white/10 rounded px-1">⌘K</kbd>
               </button>
 
-              <div className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 dark:border-void-lighter dark:bg-void dark:text-gray-300">
-                <span className="truncate">Version {aegisVersion}</span>
+              {/* Version + theme toggle */}
+              <div className="inline-flex items-center gap-1 sm:gap-2 rounded-md border border-slate-200 bg-white px-1.5 py-1 sm:px-2 text-xs text-slate-700 dark:border-void-lighter dark:bg-void dark:text-gray-300">
                 <button
                   type="button"
                   onClick={toggleTheme}
-                  className="rounded p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-zinc-400 dark:hover:bg-void-lighter dark:hover:text-zinc-200"
+                  className="rounded p-1 sm:p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-zinc-400 dark:hover:bg-void-lighter dark:hover:text-zinc-200"
                   aria-label={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                   title={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                 >
                   {resolvedTheme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
                 </button>
+                <span className="hidden sm:inline truncate">Version {aegisVersion}</span>
               </div>
 
+              {/* Check updates — hidden on mobile */}
               <button
                 type="button"
                 onClick={handleCheckUpdates}
                 disabled={updateCheckLoading || aegisVersion === '...'}
-                className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-100 dark:border-void-lighter dark:text-gray-300 dark:hover:bg-void-lighter disabled:cursor-not-allowed disabled:opacity-50"
+                className="hidden sm:inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-100 dark:border-void-lighter dark:text-gray-300 dark:hover:bg-void-lighter disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RefreshCw className={`h-3 w-3 ${updateCheckLoading ? 'animate-spin' : ''}`} />
                 {updateCheckLoading ? 'Checking…' : 'Check updates'}
@@ -514,7 +517,7 @@ export default function Layout() {
               )}
 
               {updateCheckError && (
-                <div className="text-xs text-amber-500" title={updateCheckError}>
+                <div className="hidden sm:block text-xs text-amber-500" title={updateCheckError}>
                   Update check failed
                 </div>
               )}
@@ -525,7 +528,7 @@ export default function Layout() {
 
         {/* Content + LiveAuditStream side rail */}
         <div className="flex flex-1 overflow-hidden">
-          <main id="main-content" className="flex-1 overflow-auto overscroll-contain p-6 sm:p-10 transition-all duration-500 animate-slide-in">
+          <main id="main-content" className="flex-1 overflow-auto overscroll-contain p-3 sm:p-6 md:p-10 transition-all duration-500 animate-slide-in">
             <ErrorBoundary>
               <Outlet />
             </ErrorBoundary>
@@ -534,37 +537,40 @@ export default function Layout() {
         </div>
 
         {/* ── Status Footer ────────────────────────────────────── */}
-        <footer className="shrink-0 border-t border-white/5 bg-transparent backdrop-blur-md px-6 py-2 flex items-center justify-between">
+        <footer className="shrink-0 border-t border-white/5 bg-transparent backdrop-blur-md px-3 py-2 sm:px-6 flex items-center justify-between gap-2">
           {/* Left: SSE connectivity */}
-          <div className="flex items-center gap-2" title={sseError ?? undefined}>
+          <div className="flex items-center gap-1.5 sm:gap-2 min-w-0" title={sseError ?? undefined}>
             {sseError ? (
               <>
-                <AlertTriangle className="h-3 w-3 text-amber-500" />
-                <span className="text-[11px] text-amber-500">{sseIndicatorLabel}</span>
+                <AlertTriangle className="h-3 w-3 text-amber-500 shrink-0" />
+                <span className="text-[11px] text-amber-500 truncate">{sseIndicatorLabel}</span>
               </>
             ) : (
               <>
                 <span
-                  className={`status-dot ${sseConnected ? 'status-dot--idle' : ''}`}
+                  className={`status-dot shrink-0 ${sseConnected ? 'status-dot--idle' : ''}`}
                   style={sseConnected ? undefined : { backgroundColor: '#666' }}
                 />
-                <span className="text-[11px] text-slate-500">{sseIndicatorLabel}</span>
+                <span className="text-[11px] text-slate-500 truncate">{sseIndicatorLabel}</span>
               </>
             )}
           </div>
 
-          {/* Center: version */}
-          <span className="text-[11px] text-slate-600 font-mono">aegis v{aegisVersion}</span>
+          {/* Center: version — hidden on very small screens */}
+          <span className="hidden sm:block text-[11px] text-slate-600 font-mono">aegis v{aegisVersion}</span>
 
-          {/* Right: keyboard hint */}
+          {/* Right: keyboard hint — desktop only */}
           <button
             type="button"
             onClick={() => setPaletteOpen(true)}
-            className="flex items-center gap-1.5 text-[11px] text-slate-600 hover:text-slate-400 transition-colors"
+            className="hidden md:flex items-center gap-1.5 text-[11px] text-slate-600 hover:text-slate-400 transition-colors"
           >
             <kbd className="font-mono text-[10px] border border-white/10 bg-white/5 rounded px-1">⌘K</kbd>
             Command palette
           </button>
+
+          {/* Mobile: compact version on the right */}
+          <span className="sm:hidden text-[11px] text-slate-600 font-mono truncate">v{aegisVersion}</span>
         </footer>
       </div>
       {/* Toast notifications */}

--- a/dashboard/src/components/overview/HomeStatusPanel.tsx
+++ b/dashboard/src/components/overview/HomeStatusPanel.tsx
@@ -70,15 +70,15 @@ function StatusCard({ label, value, detail, tone, icon, actionButton }: StatusCa
       )}
 
       <div className="flex flex-col gap-2 relative z-10">
-        <div className="flex items-center gap-4">
-          <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/5 shadow-inner ${toneStyles[tone].icon}`}>
+        <div className="flex items-center gap-3 sm:gap-4">
+          <div className={`flex h-8 w-8 sm:h-10 sm:w-10 shrink-0 items-center justify-center rounded-full bg-white/5 shadow-inner ${toneStyles[tone].icon}`}>
             {icon}
           </div>
           <div className="flex-1 min-w-0">
             <h4 className="text-xs font-semibold uppercase tracking-wider text-slate-400">{label}</h4>
             <p className="mt-0.5 text-xs text-slate-500 truncate">{detail}</p>
           </div>
-          <div className={`font-mono text-xl font-bold tracking-tight shrink-0 pl-4 ${toneStyles[tone].value}`}>
+          <div className={`font-mono text-lg sm:text-xl font-bold tracking-tight shrink-0 sm:pl-4 ${toneStyles[tone].value}`}>
             {value}
           </div>
         </div>
@@ -87,7 +87,7 @@ function StatusCard({ label, value, detail, tone, icon, actionButton }: StatusCa
           <button
             type="button"
             onClick={actionButton.onClick}
-            className={`ml-14 inline-flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest transition-colors ${
+            className={`ml-11 sm:ml-14 inline-flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest transition-colors ${
               tone === 'red' ? 'text-red-400 hover:text-red-300' : 'text-amber-400 hover:text-amber-300'
             }`}
           >

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -167,19 +167,19 @@ export default function MetricCards() {
 
 
       {/* ── Prompt Delivery ──────────────────────────────── */}
-      <div className="col-span-2 lg:col-span-4 card-glass card-glass-interactive animate-bento-reveal p-5 flex flex-col">
+      <div className="col-span-2 lg:col-span-4 card-glass card-glass-interactive animate-bento-reveal p-4 sm:p-5 flex flex-col">
         <div className="mb-1 flex items-center gap-2 text-sm text-slate-400 font-medium">
           <Zap className="h-4 w-4" />
           Delivery Rate
         </div>
-        <div className="flex items-center gap-6 flex-1">
+        <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 flex-1">
           <RingGauge
             value={deliveryRate_ !== null ? Math.round(deliveryRate_) : 0}
-            size={110}
+            size={90}
             label="Success"
             primaryColor={deliveryColor === 'green' ? 'var(--color-success)' : deliveryColor === 'red' ? 'var(--color-error)' : 'var(--color-warning)'}
           />
-          <div className="flex-1 space-y-3">
+          <div className="flex-1 space-y-3 text-center sm:text-left">
             <div>
               <p className="text-2xl font-mono font-bold text-white">
                 {deliveryRate_ !== null ? `${deliveryRate_.toFixed(1)}%` : '—'}

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -151,6 +151,7 @@ export default function PipelineDetailPage() {
             No steps yet
           </div>
         ) : (
+          <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead>
               <tr className="border-b border-void-lighter text-gray-600">
@@ -191,6 +192,7 @@ export default function PipelineDetailPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Responsive mobile layout fixes for the Aegis dashboard at 375px viewport width.

### Changes (via Aegis CC session)

**Layout.tsx:**
- Footer: hide command-K button on mobile, compact version string, reduced padding
- Header: hide PREVIEW badge and Check updates on mobile, theme toggle always visible
- Main content: responsive padding p-3 sm:p-6 md:p-10

**HomeStatusPanel.tsx:**
- StatusCard icon sizing: h-8 w-8 on mobile, h-10 w-10 on desktop
- Value text: text-lg on mobile, text-xl on desktop
- Row gap and action button margin adjusted

**MetricCards.tsx:**
- Delivery Rate: flex-col on mobile, flex-row on desktop
- Reduced padding and centered text on mobile

### Tests (3 files, 19 tests)
- Layout.mobile-responsive.test.tsx (12 tests)
- HomeStatusPanel.mobile-responsive.test.tsx (4 tests)
- MetricCards.mobile-responsive.test.tsx (4 tests)

### Quality Gate
- TypeScript: clean
- Build: succeeds
- New tests: 19/19 pass
- Pre-existing failures: Layout.test.tsx (nav count 8 vs 9), AuditPage, MetricsPage (not caused by this PR)

Closes #2168