### PR TITLE
fix(dashboard): resolve 12 baseline CI test failures

### DIFF
--- a/dashboard/src/__tests__/AuditPage.test.tsx
+++ b/dashboard/src/__tests__/AuditPage.test.tsx
@@ -153,7 +153,7 @@ describe('AuditPage', () => {
     renderPage();
 
     await waitFor(() => {
-      expect(mockFetchAuditLogs).toHaveBeenCalledTimes(1);
+      expect(screen.getAllByText('admin-key')[0]).toBeDefined();
     });
 
     fireEvent.change(screen.getByLabelText('Actor'), { target: { value: 'admin-key ' } });
@@ -181,7 +181,7 @@ describe('AuditPage', () => {
     renderPage();
 
     await waitFor(() => {
-      expect(mockFetchAuditLogs).toHaveBeenCalledTimes(1);
+      expect(screen.getAllByText('admin-key')[0]).toBeDefined();
     });
 
     fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-04-17T11:00' } });
@@ -189,20 +189,20 @@ describe('AuditPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
     expect(screen.getByText('From must be earlier than or equal to To.')).toBeDefined();
-    expect(mockFetchAuditLogs).toHaveBeenCalledTimes(1);
+    // StrictMode double-renders cause 2 initial fetches; validation should not trigger more
+    expect(mockFetchAuditLogs).toHaveBeenCalledTimes(2);
   });
 
   it('uses cursor pagination metadata for the next page', async () => {
-    mockFetchAuditLogs
-      .mockResolvedValueOnce(createAuditPageResponse({
+    const page1Response = createAuditPageResponse({
         total: 30,
         pagination: {
           limit: 25,
           hasMore: true,
           nextCursor: 'cursor-page-2',
         },
-      }))
-      .mockResolvedValueOnce(createAuditPageResponse({
+      });
+      const page2Response = createAuditPageResponse({
         records: [mockRecords[2]],
         total: 30,
         pagination: {
@@ -210,7 +210,11 @@ describe('AuditPage', () => {
           hasMore: false,
           nextCursor: null,
         },
-      }));
+      });
+    mockFetchAuditLogs
+      .mockResolvedValueOnce(page1Response)
+      .mockResolvedValueOnce(page1Response)   // StrictMode double-mount
+      .mockResolvedValueOnce(page2Response);
 
     renderPage();
 

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -409,7 +409,7 @@ describe('Layout sidebar', () => {
     expect(overviewLink).toBeDefined();
   });
 
-  it('nav has exactly 7 items in 3 labelled groups', () => {
+  it('nav has exactly 8 items in 3 labelled groups', () => {
     mockSubscribeGlobalSSE.mockReturnValue(() => {});
     useSidebarStore.setState({ isCollapsed: false });
 
@@ -440,7 +440,7 @@ describe('Layout sidebar', () => {
     // Count nav links (7 main + Settings in footer = 8 total NavLinks, but we check nav)
     const nav = document.querySelector('nav[aria-label="Main navigation"]');
     const links = nav?.querySelectorAll('a');
-    expect(links?.length).toBe(8);
+    expect(links?.length).toBe(9);
   });
 
   it('Settings nav link is rendered in sidebar footer', () => {

--- a/dashboard/src/__tests__/MetricsPage.test.tsx
+++ b/dashboard/src/__tests__/MetricsPage.test.tsx
@@ -1,5 +1,6 @@
 /**
  * __tests__/MetricsPage.test.tsx — Issue #2087
+ * Tests for the aggregated metrics dashboard page.
  */
 
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
@@ -7,140 +8,137 @@ import { render, screen, waitFor } from '@testing-library/react';
 import MetricsPage from '../pages/MetricsPage';
 import { useAuthStore } from '../store/useAuthStore';
 
+const mockGetMetricsAggregate = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getMetricsAggregate: (...args: unknown[]) => mockGetMetricsAggregate(...args),
+}));
+
 const mockMetrics = {
-  uptime: 3600,
-  sessions: {
-    total_created: 142,
-    currently_active: 3,
-    completed: 130,
-    failed: 12,
-    avg_duration_sec: 384,
-    avg_messages_per_session: 24,
+  summary: {
+    totalSessions: 142,
+    avgDurationSeconds: 384,
+    totalTokenCostUsd: 247.53,
+    totalMessages: 3408,
+    totalToolCalls: 1856,
+    permissionsApproved: 312,
+    permissionApprovalRate: 92,
+    stalls: 5,
   },
-  auto_approvals: 312,
-  webhooks_sent: 89,
-  webhooks_failed: 2,
-  screenshots_taken: 45,
-  pipelines_created: 7,
-  batches_created: 3,
-  prompt_delivery: {
-    sent: 1000,
-    delivered: 980,
-    failed: 20,
-    success_rate: 0.98,
-  },
-  latency: {
-    hook_latency_ms: { p50: 120, p95: 450, p99: 800 },
-    state_change_detection_ms: { p50: 5, p95: 20, p99: 50 },
-    permission_response_ms: { p50: 30, p95: 120, p99: 200 },
-    channel_delivery_ms: { p50: 80, p95: 300, p99: 600 },
-  },
+  timeSeries: [
+    { timestamp: '2026-04-19T00:00:00Z', sessions: 20, messages: 480, toolCalls: 260, tokenCostUsd: 34.5 },
+    { timestamp: '2026-04-20T00:00:00Z', sessions: 22, messages: 528, toolCalls: 286, tokenCostUsd: 37.8 },
+  ],
+  byKey: [
+    { keyId: 'k1', keyName: 'claude-main', sessions: 100, messages: 2400, toolCalls: 1300, tokenCostUsd: 175.0 },
+    { keyId: 'k2', keyName: 'claude-review', sessions: 42, messages: 1008, toolCalls: 556, tokenCostUsd: 72.53 },
+  ],
+  anomalies: [
+    { sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', tokenCostUsd: 45.0, reason: 'Token cost 3x above p95' },
+  ],
+};
+
+const mockMetricsNoAnomalies = {
+  ...mockMetrics,
+  anomalies: [],
 };
 
 describe('MetricsPage', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn());
+    vi.clearAllMocks();
     useAuthStore.setState({ token: 'test-token' });
   });
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('renders loading skeletons initially', () => {
+  it('renders loading state with placeholders', () => {
+    mockGetMetricsAggregate.mockReturnValue(new Promise(() => {})); // never resolves
     render(<MetricsPage />);
-    expect(document.querySelector('.animate-pulse')).toBeTruthy();
+    // Component shows '—' placeholders when data is null
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3);
   });
 
   it('renders summary stat cards when data loads', async () => {
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMetrics),
-    } as Response);
-
+    mockGetMetricsAggregate.mockResolvedValue(mockMetricsNoAnomalies);
     render(<MetricsPage />);
     await waitFor(() => {
-      expect(screen.getByText('Sessions Created')).toBeTruthy();
+      expect(screen.getByText('Total Sessions')).toBeTruthy();
     });
     expect(screen.getByText('142')).toBeTruthy();
     expect(screen.getByText('Avg Duration')).toBeTruthy();
-    expect(screen.getByText('Completion Rate')).toBeTruthy();
-    expect(screen.getByText('Prompt Delivery')).toBeTruthy();
+    expect(screen.getByText('Total Cost')).toBeTruthy();
+    expect(screen.getByText('Approval Rate')).toBeTruthy();
   });
 
-  it('shows correct completion rate', async () => {
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMetrics),
-    } as Response);
-
+  it('shows correct approval rate', async () => {
+    mockGetMetricsAggregate.mockResolvedValue(mockMetricsNoAnomalies);
     render(<MetricsPage />);
     await waitFor(() => {
-      expect(screen.getByText('92%')).toBeTruthy(); // 130/142 ≈ 92%
+      expect(screen.getByText('92%')).toBeTruthy();
     });
   });
 
   it('shows average duration in minutes', async () => {
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMetrics),
-    } as Response);
-
+    mockGetMetricsAggregate.mockResolvedValue(mockMetricsNoAnomalies);
     render(<MetricsPage />);
+    // 384s → Math.round(384/60) = 6 → formatDuration returns "6m"
     await waitFor(() => {
-      expect(screen.getByText('6.4')).toBeTruthy(); // 384/60 = 6.4 min
+      expect(screen.getByText('6m')).toBeTruthy();
     });
   });
 
-  it('shows error state with retry button', async () => {
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-    } as Response);
-
+  it('shows error state', async () => {
+    mockGetMetricsAggregate.mockRejectedValue(new Error('Server error'));
     render(<MetricsPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Failed to load metrics/)).toBeTruthy();
+      // Component renders err.message for Error instances
+      expect(screen.getByText('Server error')).toBeTruthy();
     });
-    const btn = screen.getByRole('button', { name: /Retry/i });
-    expect(btn).toBeTruthy();
-
-    // Mock a successful retry
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMetrics),
-    } as Response);
-    // Retry tested via existence check above
-    expect(btn).toBeTruthy();
   });
 
   it('shows coming soon notice for time-series features', async () => {
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMetrics),
-    } as Response);
-
+    mockGetMetricsAggregate.mockResolvedValue(mockMetricsNoAnomalies);
     render(<MetricsPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Time-series.*By-key Breakdown/i)).toBeTruthy();
+      expect(screen.getByText('Sessions & Cost Over Time')).toBeTruthy();
     });
+    expect(screen.getByText('Token Cost Trend')).toBeTruthy();
+    expect(screen.getByText('Breakdown by API Key')).toBeTruthy();
   });
 
   it('renders all secondary stat cards', async () => {
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMetrics),
-    } as Response);
-
+    mockGetMetricsAggregate.mockResolvedValue(mockMetricsNoAnomalies);
     render(<MetricsPage />);
     await waitFor(() => {
-      expect(screen.getByText('312')).toBeTruthy(); // auto_approvals
-      expect(screen.getByText('89')).toBeTruthy(); // webhooks_sent
-      expect(screen.getByText('2 failed')).toBeTruthy(); // webhooks_failed
-      expect(screen.getByText('45')).toBeTruthy(); // screenshots
-      expect(screen.getByText('7')).toBeTruthy(); // pipelines
-      expect(screen.getByText('3')).toBeTruthy(); // batches
-      expect(screen.getByText('20')).toBeTruthy(); // prompts failed
+      expect(screen.getByText('142')).toBeTruthy();
+    });
+    // Verify the summary card shows the total cost formatted
+    expect(screen.getByText(/\$247/)).toBeTruthy();
+  });
+
+  it('renders anomaly alerts when anomalies exist', async () => {
+    mockGetMetricsAggregate.mockResolvedValue(mockMetrics);
+    render(<MetricsPage />);
+    // Wait for data to load first
+    await waitFor(() => {
+      expect(screen.getByText('Total Sessions')).toBeTruthy();
+    });
+    // Then check for anomaly section
+    expect(screen.getByText(/Anomalous Sessions/)).toBeTruthy();
+    expect(screen.getByText(/Token cost 3x above p95/)).toBeTruthy();
+  });
+
+  it('renders empty state when no sessions', async () => {
+    mockGetMetricsAggregate.mockResolvedValue({
+      ...mockMetricsNoAnomalies,
+      summary: { ...mockMetricsNoAnomalies.summary, totalSessions: 0 },
+      timeSeries: [],
+      byKey: [],
+    });
+    render(<MetricsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/No session data found/)).toBeTruthy();
     });
   });
 });

--- a/dashboard/src/__tests__/NewSessionPage.test.tsx
+++ b/dashboard/src/__tests__/NewSessionPage.test.tsx
@@ -42,7 +42,7 @@ async function renderPage(): Promise<void> {
     </MemoryRouter>,
   );
   await waitFor(() => {
-    expect(mockGetTemplates).toHaveBeenCalledTimes(1);
+    expect(mockGetTemplates).toHaveBeenCalled();
   });
 }
 
@@ -245,13 +245,16 @@ describe('NewSessionPage', () => {
   // ── Templates hint ──────────────────────────────────────────────
 
   it('shows template count when templates are available', async () => {
-    mockGetTemplates.mockResolvedValueOnce([
+    mockGetTemplates.mockResolvedValue([
       { id: 't1', name: 'Template 1' },
       { id: 't2', name: 'Template 2' },
     ] as unknown[]);
 
     await renderPage();
 
-    expect(await screen.findByText(/2 templates available/)).toBeDefined();
+    // NewSessionPage renders template buttons, not a count text
+    expect(await screen.findByText('Start from a template')).toBeDefined();
+    expect(screen.getByLabelText('Apply template Template 1')).toBeTruthy();
+    expect(screen.getByLabelText('Apply template Template 2')).toBeTruthy();
   });
 });

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -223,7 +223,7 @@ export default function MetricsPage() {
       </div>
 
       {/* Anomaly alerts */}
-      {data && data.anomalies.length > 0 && (
+      {data && data.anomalies?.length > 0 && (
         <section className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
           <div className="flex items-start gap-3">
             <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-500 mt-0.5" />


### PR DESCRIPTION
## Summary

Fixes 12 dashboard-test failures on `develop` that are blocking all open PRs (including #2171, #2169, #2164).

## Changes

### Bug fix
- **MetricsPage.tsx**: Added optional chaining on `data.anomalies?.length` — was crashing with `TypeError: Cannot read properties of undefined` when API response lacked `anomalies` field

### Test fixes
- **MetricsPage.test.tsx**: Complete rewrite to match new `AggregateMetricsResponse` API format (component was rewritten but tests still mocked old `fetch` with legacy format)
- **AuditPage.test.tsx**: Fixed 3 tests broken by React 18 StrictMode double-renders (mock call counts, pagination mock exhaustion)
- **Layout.test.tsx**: Updated nav item count 8→9 (Templates nav item added by #2149)
- **NewSessionPage.test.tsx**: Fixed StrictMode mock assertion and updated template count assertion

## Verification
- `npx tsc --noEmit`: ✅ zero errors
- `npm test`: ✅ 73 files, 674 tests passed, 0 failures

## Impact
Unblocks CI on all open dashboard PRs.