### PR TITLE
docs: fix MCP tool count from 25 to 24

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -160,7 +160,7 @@ HASH2=$(curl -s http://127.0.0.1:9100/v1/sessions/$SID/read | jq -r '.messages |
 
 ## MCP Tool Reference
 
-When MCP is configured, 25 tools are available natively:
+When MCP is configured, 24 tools are available natively:
 
 ### Session Lifecycle
 | Tool | Description |

--- a/skill/references/api-quick-ref.md
+++ b/skill/references/api-quick-ref.md
@@ -129,7 +129,7 @@ See [workflow-examples.md](./workflow-examples.md) for complete scripts for:
 - PR review loop
 - Batch pipeline loop
 
-## MCP Tool Mapping (25 tools)
+## MCP Tool Mapping (24 tools)
 
 | MCP Tool | REST Equivalent |
 |----------|----------------|


### PR DESCRIPTION
## Summary

Fixes stale tool count references in internal skill documentation.

- skill/SKILL.md: 25 → 24 tools
- skill/references/api-quick-ref.md: 25 → 24 tools

## Verification

Counted actual server.tool() registrations in src/mcp/tools/*.ts:
- session-tools.ts: 12
- monitoring-tools.ts: 6
- pipeline-tools.ts: 3
- management-tools.ts: 3
- Total: 24

README.md and docs/mcp-tools.md already correctly reference 24.

## Type

docs-only, no code changes.