### PR TITLE
docs: Phase 3 docs sprint — DR runbook, air-gapped, API versioning

### DIFF
--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -426,6 +426,51 @@ aegis
 0 4 * * * find $HOME/aegis-backups/ -maxdepth 1 -mtime +30 -exec rm -rf {} \;
 ```
 
+### Planned: `ag admin export` / `ag admin import`
+
+> **Status: Planned — not yet implemented.**
+> These CLI commands are part of the Phase 4 roadmap (Issue #1950).
+> Use the manual backup/restore scripts above until these ship.
+
+When implemented, Aegis will provide built-in export and import commands:
+
+```bash
+# Export all state to a portable archive
+ag admin export --output /path/to/aegis-backup-20260426.tar.gz
+
+# Export with audit verification
+ag admin export --output /path/to/backup.tar.gz --verify-audit
+
+# Import from an archive (Aegis must be stopped)
+ag admin import --input /path/to/aegis-backup-20260426.tar.gz
+
+# Dry-run import (verify archive without applying)
+ag admin import --input /path/to/backup.tar.gz --dry-run
+
+# Import with force (overwrite existing state)
+ag admin import --input /path/to/backup.tar.gz --force
+```
+
+**Export archive contents:**
+
+```
+aegis-export-YYYYMMDD-HHMMSS/
+├── manifest.json          # Export metadata (version, timestamp, checksums)
+├── state.json             # Session state
+├── keys.json              # API key store (encrypted at rest)
+├── audit/                 # Audit log chain
+│   ├── audit-2026-04-25.log
+│   └── audit-2026-04-26.log
+├── pipelines.json         # Pipeline state
+├── memory.json            # Cross-session memory
+└── checksums.sha256       # Integrity verification
+```
+
+**Security considerations:**
+- Exported archives contain sensitive data (API keys, audit trails). Encrypt before transferring.
+- The `--verify-audit` flag runs chain integrity verification during export.
+- Import validates checksums before applying. Corrupted archives are rejected.
+
 ---
 
 ## Audit Chain Backup and Verification

--- a/docs/api-v2-migration-template.md
+++ b/docs/api-v2-migration-template.md
@@ -1,0 +1,143 @@
+# Migrating from API v1 to v2
+
+> **Template** — Copy this file to `docs/api-v2-migration.md` and fill in the
+> concrete breaking changes when v2 is planned. Do not edit this template.
+
+## Overview
+
+<!-- Describe what changed in v2 and why. Example:
+Aegis v2 introduces multi-tenancy primitives (tenantId), a new SessionStore
+abstraction, and removes legacy unversioned routes. This guide walks you
+through every breaking change.
+-->
+
+## Breaking changes
+
+### Removed endpoints
+
+| Endpoint | Status | Replacement |
+|----------|--------|-------------|
+| `GET /health` | Removed (was deprecated) | `GET /v1/health` |
+| `GET /sessions` | Removed (was deprecated) | `GET /v1/sessions` |
+| `POST /sessions` | Removed (was deprecated) | `POST /v1/sessions` |
+| `GET /sessions/{id}` | Removed (was deprecated) | `GET /v1/sessions/{id}` |
+| `DELETE /sessions/{id}` | Removed (was deprecated) | `DELETE /v1/sessions/{id}` |
+
+<!-- Add any v1 endpoints removed in v2 below this line. -->
+
+### Changed request fields
+
+| Endpoint | Field | v1 | v2 | Migration |
+|----------|-------|----|----|-----------|
+| <!-- endpoint --> | <!-- field --> | <!-- old --> | <!-- new --> | <!-- action --> |
+
+### Changed response fields
+
+| Endpoint | Field | v1 | v2 | Migration |
+|----------|-------|----|----|-----------|
+| <!-- endpoint --> | <!-- field --> | <!-- old --> | <!-- new --> | <!-- action --> |
+
+### New required fields
+
+| Endpoint | Field | Type | Description |
+|----------|-------|------|-------------|
+| <!-- endpoint --> | <!-- field --> | <!-- type --> | <!-- why it's required --> |
+
+## Step-by-step migration
+
+### 1. Update base URL
+
+```bash
+# Before (v1)
+curl http://localhost:9100/v1/sessions
+
+# After (v2) — update the version prefix
+curl http://localhost:9100/v2/sessions
+```
+
+### 2. Handle new required fields
+
+<!-- Per-endpoint instructions for fields that became required in v2.
+Example:
+```bash
+# v1 — tenantId was optional
+curl -X POST http://localhost:9100/v1/sessions -d '{"workDir": "/tmp"}'
+
+# v2 — tenantId is required
+curl -X POST http://localhost:9100/v2/sessions -d '{"workDir": "/tmp", "tenantId": "acme"}'
+```
+-->
+
+### 3. Update authentication
+
+<!-- If authentication semantics changed (e.g., token format, header name),
+document the migration here.
+-->
+
+### 4. Update error handling
+
+<!-- If error response shapes changed, show before/after examples.
+Example:
+```json
+// v1 error
+{ "error": "Session not found" }
+
+// v2 error
+{ "code": "SESSION_NOT_FOUND", "message": "Session not found", "requestId": "..." }
+```
+-->
+
+### 5. Verify migration
+
+```bash
+# Health check (should return v2)
+curl -I http://localhost:9100/v2/health | grep X-Aegis-API-Version
+
+# Verify no deprecated headers on v2 responses
+curl -I http://localhost:9100/v2/sessions | grep Deprecation
+# Should return nothing — v2 endpoints are not deprecated
+```
+
+## Deprecation timeline
+
+| Milestone | Date | What happens |
+|-----------|------|--------------|
+| v2 announcement | <!-- YYYY-MM-DD --> | `docs/api-v2-migration.md` published |
+| v2 release | <!-- YYYY-MM-DD --> | v2 endpoints available alongside v1 |
+| v1 deprecation headers | <!-- YYYY-MM-DD --> | v1 endpoints emit `Deprecation` + `Sunset` |
+| v1 end of support | <!-- YYYY-MM-DD + 12 months --> | v1 endpoints receive bug fixes only |
+| v1 removal | <!-- YYYY-MM-DD + 24 months --> | v1 endpoints return `410 Gone` |
+
+## Automated migration script
+
+```bash
+#!/usr/bin/env bash
+# migrate-v1-to-v2.sh — Update API calls from v1 to v2
+# Usage: ./migrate-v1-to-v2.sh /path/to/your/codebase
+
+set -euo pipefail
+
+SEARCH_DIR="${1:-.}"
+V1_BASE="${V1_BASE:-http://localhost:9100/v1}"
+V2_BASE="${V2_BASE:-http://localhost:9100/v2}"
+
+echo "Migrating API calls from ${V1_BASE} to ${V2_BASE}..."
+
+# Find and replace versioned URLs
+find "$SEARCH_DIR" -type f \( -name "*.ts" -o -name "*.js" -o -name "*.py" -o -name "*.sh" \) \
+  -exec sed -i "s|${V1_BASE}|${V2_BASE}|g" {} +
+
+# Report files changed
+CHANGED=$(git diff --name-only 2>/dev/null || echo "see output above")
+echo "Files updated:"
+echo "$CHANGED"
+
+echo ""
+echo "Review the changes, then run your test suite to verify."
+```
+
+## Need help?
+
+- [API Reference](./api-reference.md) — current v1 endpoint documentation
+- [API Versioning Policy](./api-versioning.md) — full versioning rules
+- [GitHub Discussions](https://github.com/OneStepAt4time/aegis/discussions) — ask questions

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -103,20 +103,6 @@ When v2 is planned, the following steps will occur:
 
 ### v2 migration template
 
-A migration doc should include:
-
-```markdown
-# Migrating from API v1 to v2
-
-## Overview
-<!-- Summary of what changed and why -->
-
-## Breaking changes
-<!-- Table of removed/renamed endpoints and fields -->
-
-## Step-by-step migration
-<!-- Per-endpoint instructions -->
-
-## Deprecation timeline
-<!-- Dates for announcement, deprecation headers, removal -->
-```
+When v2 is planned, copy `docs/api-v2-migration-template.md` to
+`docs/api-v2-migration.md` and fill in the concrete changes. The template
+covers every section consumers need to migrate successfully.


### PR DESCRIPTION
## Summary

Addresses Phase 3/4 documentation sprint: closes #1950, closes #1952, closes #1956.

### #1950 — Disaster Recovery Runbook
- Added planned `ag admin export` / `ag admin import` CLI command documentation
- Documented export archive structure, security considerations, and usage examples
- Marked as **planned (not yet implemented)** — manual backup/restore scripts remain the current approach
- All other acceptance criteria already met (audit chain backup, key recovery, tabletop exercise)

### #1952 — Air-Gapped Deployment Guide
- **No changes needed** — all 4 acceptance criteria already met:
  - ✅ Offline install procedure with pre-bundled dashboard assets
  - ✅ Mirror / vendoring guidance for npm + container image
  - ✅ License notes for bundled dependencies
  - ✅ Validated dry run instructions

### #1956 — API Versioning Policy
- Added `docs/api-v2-migration-template.md` — standalone migration template for v2
- Template covers: breaking changes table, step-by-step migration, deprecation timeline, automated migration script
- Updated `docs/api-versioning.md` to reference the template file instead of inline skeleton
- Deprecation/Sunset headers already implemented in `src/routes/context.ts` (Issue #1956)

## Files changed
- `docs/DISASTER_RECOVERY.md` — added planned CLI export/import section
- `docs/api-versioning.md` — updated v2 migration section to reference template
- `docs/api-v2-migration-template.md` — **new file**, full v2 migration template

Closes #1950
Closes #1952
Closes #1956