### PR TITLE
feat(dashboard): add useFocusTrap hook and integrate into all modal/dialog components

### DIFF
--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -30,8 +31,7 @@ const VARIANT_STYLES = {
   },
 } as const;
 
-const FOCUSABLE_SELECTOR =
-  'input, textarea, select, button, [tabindex]:not([tabindex="-1"])';
+
 
 export function ConfirmDialog({
   open,
@@ -44,7 +44,7 @@ export function ConfirmDialog({
   onCancel,
 }: ConfirmDialogProps) {
   const confirmRef = useRef<HTMLButtonElement>(null);
-  const modalRef = useRef<HTMLDivElement>(null);
+  const trapRef = useFocusTrap(open, { autoFocus: false });
   const titleId = 'confirm-dialog-title';
 
   // Auto-focus the confirm button when opened
@@ -67,35 +67,7 @@ export function ConfirmDialog({
     return () => window.removeEventListener('keydown', handler);
   }, [open, onCancel]);
 
-  // Focus trap
-  useEffect(() => {
-    if (!open) return;
-    const modal = modalRef.current;
-    if (!modal) return;
 
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const focusable = Array.from(
-        modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-    modal.addEventListener('keydown', handler);
-    return () => modal.removeEventListener('keydown', handler);
-  }, [open]);
 
   if (!open) return null;
 
@@ -111,7 +83,7 @@ export function ConfirmDialog({
 
       {/* Dialog */}
       <div
-        ref={modalRef}
+        ref={trapRef}
         role="alertdialog"
         aria-modal="true"
         aria-labelledby={titleId}

--- a/dashboard/src/components/CreatePipelineModal.tsx
+++ b/dashboard/src/components/CreatePipelineModal.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useNavigate } from 'react-router-dom';
 import { X, Loader2, Plus, Trash2 } from 'lucide-react';
 import { createPipeline } from '../api/client';
@@ -26,8 +27,8 @@ function makeStep(): StepRow {
 
 export default function CreatePipelineModal({ open, onClose }: CreatePipelineModalProps) {
   const navigate = useNavigate();
-  const modalRef = useRef<HTMLDivElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
+  const trapRef = useFocusTrap(open);
 
   const [pipelineName, setPipelineName] = useState('');
   const [steps, setSteps] = useState<StepRow[]>([makeStep(), makeStep()]);
@@ -56,35 +57,9 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
     return () => window.removeEventListener('keydown', handler);
   }, [open, handleClose]);
 
-  // Focus trap
-  useEffect(() => {
-    if (!open) return;
-    const modal = modalRef.current;
-    if (!modal) return;
-    const FOCUSABLE = 'input, textarea, select, button, [tabindex]:not([tabindex="-1"])';
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const focusable = Array.from(modal.querySelectorAll<HTMLElement>(FOCUSABLE));
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) { e.preventDefault(); last.focus(); }
-      } else {
-        if (document.activeElement === last) { e.preventDefault(); first.focus(); }
-      }
-    };
-    modal.addEventListener('keydown', handler);
-    return () => modal.removeEventListener('keydown', handler);
-  }, [open]);
 
-  // Focus first input
-  useEffect(() => {
-    if (open) {
-      const t = setTimeout(() => nameRef.current?.focus(), 50);
-      return () => clearTimeout(t);
-    }
-  }, [open]);
+
+
 
   function addStep(): void {
     if (steps.length >= 10) return;
@@ -143,7 +118,7 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
 
-      <div ref={modalRef} role="dialog" aria-modal="true" aria-label="Create new pipeline" className="relative w-full max-w-2xl mx-4 bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg shadow-2xl max-h-[90vh] overflow-y-auto">
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Create new pipeline" className="relative w-full max-w-2xl mx-4 bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg shadow-2xl max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-4 sm:px-5 py-4 border-b border-[var(--color-void-lighter)]">
           <h2 className="text-sm font-semibold text-gray-100">New Pipeline</h2>

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useNavigate } from 'react-router-dom';
 import { X, Loader2, Plus, Trash2 } from 'lucide-react';
 import { createSession, batchCreateSessions, getTemplates } from '../api/client';
@@ -23,13 +24,13 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
   const navigate = useNavigate();
   const workDirRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const trapRef = useFocusTrap(open);
 
   const handleClose = useCallback((): void => {
     resetForm();
     onClose();
   }, [onClose]);
 
-  const modalRef = useRef<HTMLDivElement>(null);
 
   // Close on Escape key â€” abort in-flight request
   useEffect(() => {
@@ -44,44 +45,9 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
     return () => window.removeEventListener('keydown', handler);
   }, [open, handleClose]);
 
-  // Focus trap â€” Tab/Shift+Tab cycles within the modal (#246)
-  useEffect(() => {
-    if (!open) return;
-    const modal = modalRef.current;
-    if (!modal) return;
 
-    const FOCUSABLE_SELECTOR = 'input, textarea, select, button, [tabindex]:not([tabindex="-1"])';
 
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const focusable = Array.from(modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-    modal.addEventListener('keydown', handler);
-    return () => modal.removeEventListener('keydown', handler);
-  }, [open]);
 
-  // Focus first input when modal opens
-  useEffect(() => {
-    if (open) {
-      // Small delay to ensure the modal is rendered
-      const t = setTimeout(() => workDirRef.current?.focus(), 50);
-      return () => clearTimeout(t);
-    }
-  }, [open]);
 
   // Load templates
   const [templates, setTemplates] = useState<SessionTemplate[]>([]);
@@ -226,7 +192,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
       />
 
       {/* Modal */}
-      <div ref={modalRef} role="dialog" aria-modal="true" aria-label="Create new session" className={`relative w-full ${mode === 'batch' ? 'max-w-2xl' : 'max-w-md'} mx-4 bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg shadow-2xl max-h-[90vh] overflow-y-auto`}>
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Create new session" className={`relative w-full ${mode === 'batch' ? 'max-w-2xl' : 'max-w-md'} mx-4 bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg shadow-2xl max-h-[90vh] overflow-y-auto`}>
         {/* Header */}
         <div className="flex items-center justify-between px-4 sm:px-5 py-4 border-b border-[var(--color-void-lighter)]">
           <div className="flex items-center gap-4">

--- a/dashboard/src/components/NewSessionDrawer.tsx
+++ b/dashboard/src/components/NewSessionDrawer.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, Plus, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -35,6 +36,7 @@ export function NewSessionDrawer() {
   const [templates, setTemplates] = useState<SessionTemplate[]>([]);
 
   const firstInputRef = useRef<HTMLInputElement>(null);
+  const trapRef = useFocusTrap(newSessionOpen, { autoFocus: false });
   const submitButtonRef = useRef<HTMLButtonElement>(null);
 
   // Load templates when drawer opens
@@ -125,6 +127,7 @@ export function NewSessionDrawer() {
             role="dialog"
             aria-modal="true"
             aria-label="New Session"
+            ref={trapRef as React.Ref<HTMLDivElement>}
             initial={{ x: '100%' }}
             animate={{ x: 0 }}
             exit={{ x: '100%' }}

--- a/dashboard/src/components/SaveTemplateModal.tsx
+++ b/dashboard/src/components/SaveTemplateModal.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { X, Loader2 } from 'lucide-react';
 import { createTemplate } from '../api/client';
 import { useToastStore } from '../store/useToastStore';
@@ -15,7 +16,7 @@ interface SaveTemplateModalProps {
 
 export default function SaveTemplateModal({ open, onClose, sessionId }: SaveTemplateModalProps) {
   const abortRef = useRef<AbortController | null>(null);
-  const modalRef = useRef<HTMLDivElement>(null);
+  const trapRef = useFocusTrap(open);
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -44,35 +45,7 @@ export default function SaveTemplateModal({ open, onClose, sessionId }: SaveTemp
     return () => window.removeEventListener('keydown', handler);
   }, [open, handleClose]);
 
-  // Focus trap
-  useEffect(() => {
-    if (!open) return;
-    const modal = modalRef.current;
-    if (!modal) return;
 
-    const FOCUSABLE_SELECTOR = 'input, textarea, button, [tabindex]:not([tabindex="-1"])';
-
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const focusable = Array.from(modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-    modal.addEventListener('keydown', handler);
-    return () => modal.removeEventListener('keydown', handler);
-  }, [open]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -119,7 +92,7 @@ export default function SaveTemplateModal({ open, onClose, sessionId }: SaveTemp
 
       {/* Modal */}
       <div
-        ref={modalRef}
+        ref={trapRef}
         role="dialog"
         aria-modal="true"
         aria-label="Save session as template"

--- a/dashboard/src/components/TemplateModal.tsx
+++ b/dashboard/src/components/TemplateModal.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { X, Loader2 } from 'lucide-react';
 import { createTemplate, updateTemplate } from '../api/client';
 import type { SessionTemplate } from '../types';
@@ -28,8 +29,8 @@ interface TemplateModalProps {
 
 export default function TemplateModal({ open, onClose, template, onSaved }: TemplateModalProps) {
   const abortRef = useRef<AbortController | null>(null);
-  const modalRef = useRef<HTMLDivElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
+  const trapRef = useFocusTrap(open);
 
   const isEditing = template != null;
 
@@ -65,12 +66,7 @@ export default function TemplateModal({ open, onClose, template, onSaved }: Temp
     setLoading(false);
   }, [open, template]);
 
-  // Auto-focus name input
-  useEffect(() => {
-    if (!open) return;
-    const timer = setTimeout(() => nameInputRef.current?.focus(), 50);
-    return () => clearTimeout(timer);
-  }, [open]);
+
 
   const handleClose = useCallback((): void => {
     abortRef.current?.abort();
@@ -92,35 +88,7 @@ export default function TemplateModal({ open, onClose, template, onSaved }: Temp
     return () => window.removeEventListener('keydown', handler);
   }, [open, handleClose]);
 
-  // Focus trap
-  useEffect(() => {
-    if (!open) return;
-    const modal = modalRef.current;
-    if (!modal) return;
 
-    const FOCUSABLE_SELECTOR = 'input, textarea, select, button, [tabindex]:not([tabindex="-1"])';
-
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const focusable = Array.from(modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-    modal.addEventListener('keydown', handler);
-    return () => modal.removeEventListener('keydown', handler);
-  }, [open]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -185,7 +153,7 @@ export default function TemplateModal({ open, onClose, template, onSaved }: Temp
 
       {/* Modal */}
       <div
-        ref={modalRef}
+        ref={trapRef}
         role="dialog"
         aria-modal="true"
         aria-label={isEditing ? 'Edit template' : 'Create template'}

--- a/dashboard/src/components/shared/CommandPalette.tsx
+++ b/dashboard/src/components/shared/CommandPalette.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Search,
@@ -85,6 +86,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const trapRef = useFocusTrap(open);
   const navigate = useViewTransitionNavigate();
   const sessions = useStore((s) => s.sessions);
   const openNewSession = useDrawerStore((s) => s.openNewSession);
@@ -163,7 +165,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
       const item = flatFiltered[activeIndex];
       if (item) handleSelect(item);
     } else if (e.key === 'Tab') {
-      onClose();
+      e.preventDefault();
     }
   };
 
@@ -199,6 +201,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
             role="dialog"
             aria-modal="true"
             aria-label="Command palette"
+            ref={trapRef as React.Ref<HTMLDivElement>}
             className="fixed left-1/2 top-[20vh] z-[201] w-full max-w-xl -translate-x-1/2"
           >
             <div className="card-glass overflow-hidden shadow-palette">

--- a/dashboard/src/hooks/useFocusTrap.ts
+++ b/dashboard/src/hooks/useFocusTrap.ts
@@ -1,0 +1,107 @@
+/**
+ * hooks/useFocusTrap.ts — Focus trap hook for modal/dialog accessibility.
+ *
+ * Traps Tab/Shift+Tab within a container element. Restores focus to the
+ * previously-focused element on unmount. Meets WCAG 2.1 focus management
+ * requirements for modal dialogs.
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(', ');
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute('aria-hidden') && el.offsetParent !== null,
+  );
+}
+
+function isFocusable(el: HTMLElement): boolean {
+  return el.matches(FOCUSABLE_SELECTOR) && !el.hasAttribute('aria-hidden') && el.offsetParent !== null;
+}
+
+export function useFocusTrap(
+  isActive: boolean,
+  options: {
+    /** Restore focus to this element on deactivate (default: previously focused element) */
+    restoreFocusRef?: React.RefObject<HTMLElement | null>;
+    /** Auto-focus the first focusable element on activate */
+    autoFocus?: boolean;
+  } = {},
+) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !containerRef.current) return;
+
+      const focusable = getFocusableElements(containerRef.current);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey) {
+        // Shift+Tab: wrap from first to last
+        if (active === first || !containerRef.current.contains(active as Node)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab: wrap from last to first
+        if (active === last || !containerRef.current.contains(active as Node)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    // Save currently focused element
+    previouslyFocusedRef.current = document.activeElement as HTMLElement;
+
+    // Auto-focus first focusable element
+    if (options.autoFocus !== false && containerRef.current) {
+      const focusable = getFocusableElements(containerRef.current);
+      if (focusable.length > 0) {
+        // Use requestAnimationFrame to ensure DOM is painted
+        requestAnimationFrame(() => {
+          focusable[0].focus();
+        });
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+
+      // Restore focus
+      const restoreTarget = options.restoreFocusRef?.current ?? previouslyFocusedRef.current;
+      if (restoreTarget && isFocusable(restoreTarget)) {
+        requestAnimationFrame(() => {
+          restoreTarget.focus();
+        });
+      }
+    };
+  }, [isActive, handleKeyDown, options.autoFocus, options.restoreFocusRef]);
+
+  return containerRef;
+}


### PR DESCRIPTION
## Summary

Extract duplicated focus trap logic into a reusable `useFocusTrap` hook and integrate it into all modal/dialog/drawer components for WCAG 2.1 compliance.

## Changes

- **New:** `useFocusTrap` hook — traps Tab/Shift+Tab, auto-focuses first element, restores focus on close
- **Refactored:** 5 modals (CreateSession, CreatePipeline, Template, SaveTemplate, ConfirmDialog) — replaced ~166 lines of duplicated focus trap code with hook calls
- **Fixed:** NewSessionDrawer — was missing focus trap entirely
- **Fixed:** CommandPalette — Tab key was closing the palette instead of trapping focus

## Verification

- `npx tsc --noEmit` — zero errors
- `npm test --run` — 76 test files, 692 tests pass
- `npm run build` — clean production build
- Net: 133 insertions, 166 deletions (33 lines saved)

## Acceptance criteria (from #1946)

- [x] Focus traps in modals; focus restore on close
- [ ] ARIA labels/roles on all interactive controls (next PR)
- [ ] axe-core clean on all routes in CI (next PR)
- [ ] WCAG AA contrast verified in dark theme (next PR)

Closes part of #1946