### PR TITLE
feat: add VT100 screen buffer parser module (#2204)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@types/nodemailer": "^8.0.0",
         "async-mutex": "^0.5.0",
         "fastify": "^5.8.2",
-        "ioredis": "*",
         "nodemailer": "^8.0.5",
         "prom-client": "^15.1.3",
         "yaml": "^2.8.3",

--- a/src/__tests__/vt100-screen.test.ts
+++ b/src/__tests__/vt100-screen.test.ts
@@ -1,0 +1,709 @@
+import { describe, it, expect } from 'vitest';
+import { VT100Screen } from '../vt100-screen.js';
+
+describe('VT100Screen', () => {
+  // ── Basic text output ───────────────────────────────────────────────────
+
+  describe('basic text output', () => {
+    it('writes plain text to the screen', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('Hello');
+      expect(s.getRow(0)).toBe('Hello');
+      expect(s.getCursor()).toEqual({ row: 0, col: 5 });
+    });
+
+    it('defaults to 80x24', () => {
+      const s = new VT100Screen();
+      s.write('\x1b[24;80H');
+      expect(s.getCursor()).toEqual({ row: 23, col: 79 });
+    });
+  });
+
+  // ── Cursor movement ─────────────────────────────────────────────────────
+
+  describe('cursor movement', () => {
+    it('CUU — cursor up (A)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[5;5H'); // row 4, col 4 (1-indexed → 0-indexed)
+      s.write('\x1b[2A');
+      expect(s.getCursor()).toEqual({ row: 2, col: 4 });
+    });
+
+    it('CUU clamps at top', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[2;1H');
+      s.write('\x1b[5A');
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+    });
+
+    it('CUD — cursor down (B)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[2;2H');
+      s.write('\x1b[3B');
+      expect(s.getCursor()).toEqual({ row: 4, col: 1 });
+    });
+
+    it('CUF — cursor forward (C)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[1;1H');
+      s.write('\x1b[5C');
+      expect(s.getCursor()).toEqual({ row: 0, col: 5 });
+    });
+
+    it('CUB — cursor back (D)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('ABCDE');
+      s.write('\x1b[2D');
+      expect(s.getCursor()).toEqual({ row: 0, col: 3 });
+    });
+
+    it('CNL — cursor next line (E)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[3;8H');
+      s.write('\x1b[2E');
+      expect(s.getCursor()).toEqual({ row: 4, col: 0 });
+    });
+
+    it('CPL — cursor previous line (F)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[5;6H'); // row 4, col 5
+      s.write('\x1b[3F');
+      expect(s.getCursor()).toEqual({ row: 1, col: 0 });
+    });
+
+    it('CHA — cursor horizontal absolute (G)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[1;15H');
+      s.write('\x1b[5G');
+      expect(s.getCursor()).toEqual({ row: 0, col: 4 });
+    });
+
+    it('CUP — cursor position (H)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[5;10H');
+      expect(s.getCursor()).toEqual({ row: 4, col: 9 });
+    });
+
+    it('HVP — horizontal vertical position (f)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[3;7f');
+      expect(s.getCursor()).toEqual({ row: 2, col: 6 });
+    });
+
+    it('CUP defaults to 1;1', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[5;5H');
+      s.write('\x1b[H');
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+    });
+  });
+
+  // ── Line wrapping ───────────────────────────────────────────────────────
+
+  describe('line wrapping', () => {
+    it('wraps to next line when past last column', () => {
+      const s = new VT100Screen(5, 5);
+      s.write('ABCDE');
+      expect(s.getRow(0)).toBe('ABCDE');
+      // After filling all 5 cols, cursor is at col 4 with wrapPending
+      expect(s.getCursor()).toEqual({ row: 0, col: 4 });
+      s.write('F');
+      expect(s.getRow(1)).toBe('F');
+      expect(s.getCursor()).toEqual({ row: 1, col: 1 });
+    });
+
+    it('wraps multiple lines', () => {
+      const s = new VT100Screen(3, 5);
+      s.write('ABCDEFGHI');
+      expect(s.getRow(0)).toBe('ABC');
+      expect(s.getRow(1)).toBe('DEF');
+      expect(s.getRow(2)).toBe('GHI');
+    });
+
+    it('scrolls when wrapping past last row', () => {
+      const s = new VT100Screen(3, 2);
+      s.write('ABCDEFGH');
+      expect(s.getScrollback()).toEqual(['ABC']);
+      expect(s.getRow(0)).toBe('DEF');
+      expect(s.getRow(1)).toBe('GH');
+    });
+  });
+
+  // ── CR and LF ───────────────────────────────────────────────────────────
+
+  describe('CR and LF', () => {
+    it('CR returns cursor to column 0', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('Hello\rWorld');
+      expect(s.getRow(0)).toBe('World');
+    });
+
+    it('LF moves to next line (does not reset column)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('Line1\r\nLine2');
+      expect(s.getRow(0)).toBe('Line1');
+      expect(s.getRow(1)).toBe('Line2');
+    });
+
+    it('CR+LF together', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('A\r\nB');
+      expect(s.getRow(0)).toBe('A');
+      expect(s.getRow(1)).toBe('B');
+    });
+  });
+
+  // ── Backspace ───────────────────────────────────────────────────────────
+
+  describe('backspace', () => {
+    it('moves cursor back one column', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('AB\x08');
+      expect(s.getCursor()).toEqual({ row: 0, col: 1 });
+    });
+
+    it('does not go below column 0', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x08\x08');
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+    });
+  });
+
+  // ── Tab ─────────────────────────────────────────────────────────────────
+
+  describe('tab', () => {
+    it('advances to next tab stop (multiples of 8)', () => {
+      const s = new VT100Screen(40, 5);
+      s.write('A\tB');
+      expect(s.getCursor()).toEqual({ row: 0, col: 9 });
+      expect(s.getRow(0)).toBe('A       B');
+    });
+
+    it('tab from column 0 goes to column 8', () => {
+      const s = new VT100Screen(40, 5);
+      s.write('\tX');
+      expect(s.getCursor()).toEqual({ row: 0, col: 9 });
+    });
+  });
+
+  // ── CSI erase ───────────────────────────────────────────────────────────
+
+  describe('erase display (J)', () => {
+    it('ED 0 — erase from cursor to end', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('AAAAAAAAAA\r\nBBBBBBBBBB\r\nCCCCCCCCCC');
+      s.write('\x1b[2;3H\x1b[0J');
+      expect(s.getRow(0)).toBe('AAAAAAAAAA');
+      expect(s.getRow(1)).toBe('BB');
+      expect(s.getRow(2)).toBe('');
+    });
+
+    it('ED 1 — erase from start to cursor', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('AAAAAAAAAA\r\nBBBBBBBBBB\r\nCCCCCCCCCC');
+      s.write('\x1b[3;3H\x1b[1J');
+      expect(s.getRow(0)).toBe('');
+      expect(s.getRow(1)).toBe('');
+      expect(s.getRow(2)).toBe('   CCCCCCC'); // first 3 cols cleared (0,1,2)
+    });
+
+    it('ED 2 — erase entire display', () => {
+      const s = new VT100Screen(20, 3);
+      s.write('AAAAAAAAAA\r\nBBBBBBBBBB');
+      s.write('\x1b[2J');
+      expect(s.getText()).toBe('\n\n');
+    });
+
+    it('ED 3 — clear scrollback', () => {
+      const s = new VT100Screen(5, 2);
+      s.write('AAAAABBBBBCCCCC'); // scroll one line off
+      expect(s.getScrollback().length).toBe(1);
+      s.write('\x1b[3J');
+      expect(s.getScrollback()).toEqual([]);
+    });
+  });
+
+  describe('erase line (K)', () => {
+    it('EL 0 — erase from cursor to end of line', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('ABCDEFGHIJ');
+      s.write('\x1b[1;5H\x1b[0K');
+      expect(s.getRow(0)).toBe('ABCD');
+    });
+
+    it('EL 1 — erase from start to cursor', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('ABCDEFGHIJ');
+      s.write('\x1b[1;5H\x1b[1K');
+      expect(s.getRow(0)).toBe('     FGHIJ');
+    });
+
+    it('EL 2 — erase entire line', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('ABCDEFGHIJ');
+      s.write('\x1b[1;5H\x1b[2K');
+      expect(s.getRow(0)).toBe('');
+    });
+  });
+
+  // ── SGR attributes ──────────────────────────────────────────────────────
+
+  describe('SGR attributes (m)', () => {
+    it('reset (0)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[1;31mX\x1b[0mY');
+      const xAttrs = s.getAttrs(0, 0);
+      const yAttrs = s.getAttrs(0, 1);
+      expect(xAttrs.bold).toBe(true);
+      expect(xAttrs.fg).toBe(1);
+      expect(yAttrs.bold).toBe(false);
+      expect(yAttrs.fg).toBe(-1);
+    });
+
+    it('bold (1)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[1mX');
+      expect(s.getAttrs(0, 0).bold).toBe(true);
+    });
+
+    it('dim (2)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[2mX');
+      expect(s.getAttrs(0, 0).dim).toBe(true);
+    });
+
+    it('underline (4)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[4mX');
+      expect(s.getAttrs(0, 0).underline).toBe(true);
+    });
+
+    it('blink (5)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[5mX');
+      expect(s.getAttrs(0, 0).blink).toBe(true);
+    });
+
+    it('reverse (7)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[7mX');
+      expect(s.getAttrs(0, 0).reverse).toBe(true);
+    });
+
+    it('hidden (8)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[8mX');
+      expect(s.getAttrs(0, 0).hidden).toBe(true);
+    });
+
+    it('standard foreground colors (30-37)', () => {
+      const s = new VT100Screen(20, 5);
+      for (let i = 0; i < 8; i++) {
+        s.write(`\x1b[${30 + i}mC`);
+        expect(s.getAttrs(0, i).fg).toBe(i);
+      }
+    });
+
+    it('standard background colors (40-47)', () => {
+      const s = new VT100Screen(20, 5);
+      for (let i = 0; i < 8; i++) {
+        s.write(`\x1b[${40 + i}mC`);
+        expect(s.getAttrs(0, i).bg).toBe(i);
+      }
+    });
+
+    it('default fg/bg (39/49)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[31;44mX\x1b[39;49mY');
+      expect(s.getAttrs(0, 0).fg).toBe(1);
+      expect(s.getAttrs(0, 0).bg).toBe(4);
+      expect(s.getAttrs(0, 1).fg).toBe(-1);
+      expect(s.getAttrs(0, 1).bg).toBe(-1);
+    });
+
+    it('bright foreground (90-97)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[91mX');
+      expect(s.getAttrs(0, 0).fg).toBe(9);
+    });
+
+    it('bright background (100-107)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[105mX');
+      expect(s.getAttrs(0, 0).bg).toBe(13);
+    });
+
+    it('256-color foreground (38;5;n)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[38;5;200mX');
+      expect(s.getAttrs(0, 0).fg).toBe(200);
+    });
+
+    it('truecolor foreground (38;2;r;g;b)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[38;2;100;150;200mX');
+      expect(s.getAttrs(0, 0).fg).toBe(16 + (100 << 16) + (150 << 8) + 200);
+    });
+
+    it('combined SGR codes', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[1;3;4;31mX'); // bold, italic (ignored), underline, red fg
+      const attrs = s.getAttrs(0, 0);
+      expect(attrs.bold).toBe(true);
+      expect(attrs.underline).toBe(true);
+      expect(attrs.fg).toBe(1);
+    });
+  });
+
+  // ── Scroll region ───────────────────────────────────────────────────────
+
+  describe('scroll region', () => {
+    it('sets scroll margins with DECSTBM (r)', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[3;7r');
+      expect(s.getScrollRegion()).toEqual({ top: 2, bottom: 6 });
+    });
+
+    it('scrolls only within the region', () => {
+      const s = new VT100Screen(5, 6);
+      // Row 0-1 outside region, rows 2-4 inside region
+      s.write('\x1b[3;5r');
+      // Fill rows using explicit positioning
+      s.write('\x1b[1;1HAAA');
+      s.write('\x1b[2;1HBBB');
+      s.write('\x1b[3;1HCCC');
+      s.write('\x1b[4;1HDDD');
+      s.write('\x1b[5;1HEEE');
+      s.write('\x1b[6;1HFFF');
+      // Cursor at row 4 (scroll bottom), LF should scroll region
+      s.write('\x1b[5;1H\nXXX');
+      expect(s.getRow(0)).toBe('AAA'); // unchanged
+      expect(s.getRow(1)).toBe('BBB'); // unchanged
+      expect(s.getRow(2)).toBe('DDD'); // CCC scrolled out
+      expect(s.getRow(3)).toBe('EEE');
+      expect(s.getRow(4)).toBe('XXX');
+      expect(s.getRow(5)).toBe('FFF'); // unchanged
+    });
+
+    it('resets scroll region with no params', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[3;7r');
+      s.write('\x1b[r');
+      expect(s.getScrollRegion()).toEqual({ top: 0, bottom: 9 });
+    });
+
+    it('scroll up with CSI S', () => {
+      const s = new VT100Screen(10, 4);
+      s.write('AAAAA\r\nBBBBB\r\nCCCCC\r\nDDDDD');
+      s.write('\x1b[2S'); // scroll up 2
+      expect(s.getRow(0)).toBe('CCCCC');
+      expect(s.getRow(1)).toBe('DDDDD');
+      expect(s.getScrollback()).toEqual(['AAAAA', 'BBBBB']);
+    });
+
+    it('scroll down with CSI T', () => {
+      const s = new VT100Screen(10, 4);
+      s.write('AAAAA\r\nBBBBB\r\nCCCCC\r\nDDDDD');
+      s.write('\x1b[2T'); // scroll down 2
+      expect(s.getRow(0)).toBe('');
+      expect(s.getRow(1)).toBe('');
+      expect(s.getRow(2)).toBe('AAAAA');
+      expect(s.getRow(3)).toBe('BBBBB');
+    });
+  });
+
+  // ── Insert / delete lines ───────────────────────────────────────────────
+
+  describe('insert / delete lines', () => {
+    it('IL — insert lines (L)', () => {
+      const s = new VT100Screen(10, 5);
+      s.write('AAAAA\r\nBBBBB\r\nCCCCC\r\nDDDDD\r\nEEEEE');
+      s.write('\x1b[3;1H\x1b[2L'); // insert 2 lines at row 2
+      expect(s.getRow(0)).toBe('AAAAA');
+      expect(s.getRow(1)).toBe('BBBBB');
+      expect(s.getRow(2)).toBe('');
+      expect(s.getRow(3)).toBe('');
+      expect(s.getRow(4)).toBe('CCCCC'); // DDDDD and EEEEE pushed off
+    });
+
+    it('DL — delete lines (M)', () => {
+      const s = new VT100Screen(10, 5);
+      s.write('AAAAA\r\nBBBBB\r\nCCCCC\r\nDDDDD\r\nEEEEE');
+      s.write('\x1b[2;1H\x1b[2M'); // delete 2 lines at row 1
+      expect(s.getRow(0)).toBe('AAAAA');
+      expect(s.getRow(1)).toBe('DDDDD');
+      expect(s.getRow(2)).toBe('EEEEE');
+      expect(s.getRow(3)).toBe('');
+      expect(s.getRow(4)).toBe('');
+    });
+  });
+
+  // ── Insert / delete characters ──────────────────────────────────────────
+
+  describe('insert / delete characters', () => {
+    it('ICH — insert characters (@)', () => {
+      const s = new VT100Screen(10, 3);
+      s.write('ABCDEFGHIJ');
+      s.write('\x1b[1;3H\x1b[3@'); // insert 3 at col 2
+      expect(s.getRow(0)).toBe('AB   CDEFG');
+    });
+
+    it('DCH — delete characters (P)', () => {
+      const s = new VT100Screen(10, 3);
+      s.write('ABCDEFGHIJ');
+      s.write('\x1b[1;3H\x1b[3P'); // delete 3 at col 2
+      expect(s.getRow(0)).toBe('ABFGHIJ');
+    });
+  });
+
+  // ── OSC title ───────────────────────────────────────────────────────────
+
+  describe('OSC title', () => {
+    it('OSC 0 — set window title (consumed, discarded)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b]0;My Title\x07Hello');
+      expect(s.getRow(0)).toBe('Hello');
+    });
+
+    it('OSC 2 — set window title (consumed, discarded)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b]2;Another Title\x07World');
+      expect(s.getRow(0)).toBe('World');
+    });
+
+    it('OSC terminated with ST (ESC \\)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b]0;Title\x1b\\Hello');
+      expect(s.getRow(0)).toBe('Hello');
+    });
+  });
+
+  // ── Alt screen ──────────────────────────────────────────────────────────
+
+  describe('alt screen', () => {
+    it('switches to alt screen and back', () => {
+      const s = new VT100Screen(10, 5);
+      s.write('MainText');
+      s.write('\x1b[?1049h'); // enter alt screen
+      s.write('AltText');
+      expect(s.getRow(0)).toBe('AltText');
+      s.write('\x1b[?1049l'); // leave alt screen
+      expect(s.getRow(0)).toBe('MainText');
+    });
+
+    it('restores cursor position', () => {
+      const s = new VT100Screen(10, 5);
+      s.write('\x1b[3;5H'); // cursor at row 2, col 4
+      s.write('\x1b[?1049h'); // enter alt
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+      s.write('\x1b[?1049l'); // leave alt
+      expect(s.getCursor()).toEqual({ row: 2, col: 4 });
+    });
+  });
+
+  // ── Reverse index ───────────────────────────────────────────────────────
+
+  describe('reverse index (ESC M)', () => {
+    it('moves cursor up', () => {
+      const s = new VT100Screen(10, 5);
+      s.write('\x1b[3;1H'); // row 2
+      s.write('\x1bM'); // reverse index
+      expect(s.getCursor()).toEqual({ row: 1, col: 0 });
+    });
+
+    it('scrolls down when at top of scroll region', () => {
+      const s = new VT100Screen(10, 3);
+      s.write('AAAAAAAAAA\r\nBBBBBBBBBB\r\nCCCCCCCCCC');
+      s.write('\x1b[1;1H\x1bM'); // at top row, reverse index
+      expect(s.getRow(0)).toBe(''); // blank line inserted
+      expect(s.getRow(1)).toBe('AAAAAAAAAA');
+      expect(s.getRow(2)).toBe('BBBBBBBBBB');
+    });
+  });
+
+  // ── Save / restore cursor ───────────────────────────────────────────────
+
+  describe('save / restore cursor (ESC 7 / ESC 8)', () => {
+    it('saves and restores cursor position', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[3;10H');
+      s.write('\x1b7'); // save
+      s.write('\x1b[1;1H');
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+      s.write('\x1b8'); // restore
+      expect(s.getCursor()).toEqual({ row: 2, col: 9 });
+    });
+  });
+
+  // ── Tab stops ───────────────────────────────────────────────────────────
+
+  describe('tab stops', () => {
+    it('clears single tab stop with CSI 0g', () => {
+      const s = new VT100Screen(40, 5);
+      s.write('\x1b[1;9H'); // cursor at row 0, col 8 (the tab stop)
+      s.write('\x1b[0g'); // clear it
+      s.write('\x1b[1;1H\tX');
+      // Tab stop at 8 removed, should pass through to next one at 16
+      expect(s.getCursor()).toEqual({ row: 0, col: 17 });
+    });
+
+    it('clears all tab stops with CSI 3g', () => {
+      const s = new VT100Screen(40, 5);
+      s.write('\x1b[3g'); // clear all
+      s.write('\tX');
+      // No tab stops, cursor goes to end of line (col 39)
+      expect(s.getCursor()).toEqual({ row: 0, col: 39 });
+    });
+  });
+
+  // ── Resize ──────────────────────────────────────────────────────────────
+
+  describe('resize', () => {
+    it('resizes screen preserving content', () => {
+      const s = new VT100Screen(10, 5);
+      s.write('AAAAAAAAAA');
+      s.resize(20, 3);
+      expect(s.getRow(0)).toBe('AAAAAAAAAA');
+      // After resize, cursor is clamped to new cols-1
+      expect(s.getCursor()).toEqual({ row: 0, col: 9 });
+    });
+
+    it('clamps cursor to new dimensions', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[10;20H');
+      s.resize(5, 3);
+      expect(s.getCursor()).toEqual({ row: 2, col: 4 });
+    });
+
+    it('resets scroll region on resize', () => {
+      const s = new VT100Screen(20, 10);
+      s.write('\x1b[3;7r');
+      s.resize(20, 10);
+      expect(s.getScrollRegion()).toEqual({ top: 0, bottom: 9 });
+    });
+  });
+
+  // ── Full reset ──────────────────────────────────────────────────────────
+
+  describe('full reset (ESC c)', () => {
+    it('clears everything', () => {
+      const s = new VT100Screen(10, 5);
+      s.write('AAAAA\r\nBBBBB');
+      s.write('\x1b[1;31m');
+      s.write('\x1bc');
+      expect(s.getText()).toBe('\n\n\n\n');
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+      expect(s.getScrollRegion()).toEqual({ top: 0, bottom: 4 });
+      expect(s.getScrollback()).toEqual([]);
+      // attrs should be reset — write a char and check
+      s.write('X');
+      expect(s.getAttrs(0, 0).bold).toBe(false);
+      expect(s.getAttrs(0, 0).fg).toBe(-1);
+    });
+  });
+
+  // ── Scrollback limits ───────────────────────────────────────────────────
+
+  describe('scrollback limits', () => {
+    it('caps scrollback at 1000 lines', () => {
+      const s = new VT100Screen(10, 1); // wider to avoid wrapping
+      for (let i = 0; i < 1010; i++) {
+        s.write(`L${String(i).padStart(3, '0')}\r\n`);
+      }
+      expect(s.getScrollback().length).toBe(1000);
+      // First 10 entries shifted out, first remaining is L010
+      expect(s.getScrollback()[0]).toBe('L010');
+    });
+  });
+
+  // ── Cursor visibility ───────────────────────────────────────────────────
+
+  describe('cursor visibility', () => {
+    it('show cursor (?25h)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[?25l');
+      s.write('\x1b[?25h');
+      // No crash, no state corruption — just a side-effect flag
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+    });
+
+    it('hide cursor (?25l)', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('\x1b[?25l');
+      expect(s.getCursor()).toEqual({ row: 0, col: 0 });
+    });
+  });
+
+  // ── BEL ─────────────────────────────────────────────────────────────────
+
+  describe('BEL', () => {
+    it('is ignored without side effects', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('A\x07B');
+      expect(s.getRow(0)).toBe('AB');
+    });
+  });
+
+  // ── Uint8Array input ────────────────────────────────────────────────────
+
+  describe('Uint8Array input', () => {
+    it('accepts Uint8Array data', () => {
+      const s = new VT100Screen(20, 5);
+      s.write(new TextEncoder().encode('Hello'));
+      expect(s.getRow(0)).toBe('Hello');
+    });
+  });
+
+  // ── getRow bounds ───────────────────────────────────────────────────────
+
+  describe('getRow bounds', () => {
+    it('returns empty string for out-of-range rows', () => {
+      const s = new VT100Screen(20, 5);
+      expect(s.getRow(-1)).toBe('');
+      expect(s.getRow(99)).toBe('');
+    });
+  });
+
+  // ── getAttrs bounds ─────────────────────────────────────────────────────
+
+  describe('getAttrs bounds', () => {
+    it('returns default attrs for out-of-range positions', () => {
+      const s = new VT100Screen(20, 5);
+      const attrs = s.getAttrs(-1, -1);
+      expect(attrs.fg).toBe(-1);
+      expect(attrs.bold).toBe(false);
+    });
+  });
+
+  // ── getText ─────────────────────────────────────────────────────────────
+
+  describe('getText', () => {
+    it('returns all rows joined by LF', () => {
+      const s = new VT100Screen(20, 3);
+      s.write('AA\r\nBB');
+      const text = s.getText();
+      expect(text).toBe('AA\nBB\n');
+    });
+  });
+
+  // ── DSR ─────────────────────────────────────────────────────────────────
+
+  describe('DSR (device status report)', () => {
+    it('DSR 6n is consumed without error', () => {
+      const s = new VT100Screen(20, 5);
+      s.write('A\x1b[6nB');
+      expect(s.getRow(0)).toBe('AB');
+    });
+  });
+
+  // ── ECH — erase characters ──────────────────────────────────────────────
+
+  describe('ECH — erase characters (X)', () => {
+    it('erases N characters at cursor', () => {
+      const s = new VT100Screen(10, 3);
+      s.write('ABCDEFGHIJ');
+      s.write('\x1b[1;3H\x1b[3X'); // erase 3 at col 2
+      expect(s.getRow(0)).toBe('AB   FGHIJ');
+    });
+  });
+});

--- a/src/vt100-screen.ts
+++ b/src/vt100-screen.ts
@@ -1,0 +1,737 @@
+/**
+ * VT100/ANSI terminal emulator — in-memory screen buffer.
+ *
+ * Maintains a virtual terminal that can be fed raw PTY output and queried for
+ * the current visible screen content, cursor position, per-cell attributes,
+ * and scrollback history.  Zero external dependencies.
+ *
+ * @module vt100-screen
+ */
+
+/** Per-cell visual attributes. */
+export interface CellAttrs {
+  fg: number;
+  bg: number;
+  bold: boolean;
+  dim: boolean;
+  underline: boolean;
+  blink: boolean;
+  reverse: boolean;
+  hidden: boolean;
+}
+
+const DEFAULT_ATTRS: CellAttrs = {
+  fg: -1,
+  bg: -1,
+  bold: false,
+  dim: false,
+  underline: false,
+  blink: false,
+  reverse: false,
+  hidden: false,
+};
+
+interface Cell {
+  char: string;
+  attrs: CellAttrs;
+}
+
+const MAX_SCROLLBACK = 1000;
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const TAB_WIDTH = 8;
+
+function defaultCell(): Cell {
+  return { char: ' ', attrs: { ...DEFAULT_ATTRS } };
+}
+
+function newRow(cols: number): Cell[] {
+  const row: Cell[] = [];
+  for (let i = 0; i < cols; i++) row.push(defaultCell());
+  return row;
+}
+
+/**
+ * Pure TypeScript VT100/ANSI terminal emulator.
+ *
+ * Maintains an in-memory screen buffer that can be fed raw terminal output
+ * via {@link write} and queried for rendered content, cursor position,
+ * per-cell attributes, and scrollback history.
+ */
+export class VT100Screen {
+  private cols: number;
+  private rows: number;
+  private buffer: Cell[][];
+  private cursorRow: number;
+  private cursorCol: number;
+  private savedCursorRow: number;
+  private savedCursorCol: number;
+  private scrollTop: number;
+  private scrollBottom: number;
+  private scrollback: string[];
+  private attrs: CellAttrs;
+  private cursorVisible: boolean;
+  private usingAltScreen: boolean;
+  private savedMainBuffer: Cell[][] | null;
+  private savedMainCursorRow: number;
+  private savedMainCursorCol: number;
+  private tabStops: boolean[];
+  private wrapPending: boolean;
+
+  constructor(cols: number = DEFAULT_COLS, rows: number = DEFAULT_ROWS) {
+    this.cols = cols;
+    this.rows = rows;
+    this.buffer = this.createBuffer(rows, cols);
+    this.cursorRow = 0;
+    this.cursorCol = 0;
+    this.savedCursorRow = 0;
+    this.savedCursorCol = 0;
+    this.scrollTop = 0;
+    this.scrollBottom = rows - 1;
+    this.scrollback = [];
+    this.attrs = { ...DEFAULT_ATTRS };
+    this.cursorVisible = true;
+    this.usingAltScreen = false;
+    this.savedMainBuffer = null;
+    this.savedMainCursorRow = 0;
+    this.savedMainCursorCol = 0;
+    this.tabStops = this.createDefaultTabStops(cols);
+    this.wrapPending = false;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────
+
+  /**
+   * Feed raw terminal output (ANSI/VT100 escape sequences and plain text)
+   * into the screen buffer.
+   */
+  write(data: string | Uint8Array): void {
+    const str = typeof data === 'string' ? data : new TextDecoder().decode(data);
+    this.parse(str);
+  }
+
+  /** Return the visible screen content as a single string (rows joined by LF). */
+  getText(): string {
+    const lines: string[] = [];
+    for (let r = 0; r < this.rows; r++) {
+      lines.push(this.renderRow(r));
+    }
+    return lines.join('\n');
+  }
+
+  /** Return a single row of visible text (right-trimmed). */
+  getRow(y: number): string {
+    if (y < 0 || y >= this.rows) return '';
+    return this.renderRow(y);
+  }
+
+  /** Return the current cursor position (0-based). */
+  getCursor(): { row: number; col: number } {
+    return { row: this.cursorRow, col: this.cursorCol };
+  }
+
+  /** Return the current scroll region margins (0-based, inclusive). */
+  getScrollRegion(): { top: number; bottom: number } {
+    return { top: this.scrollTop, bottom: this.scrollBottom };
+  }
+
+  /** Return lines that have scrolled off the top of the screen. */
+  getScrollback(): string[] {
+    return [...this.scrollback];
+  }
+
+  /** Resize the virtual terminal. Preserves content where possible. */
+  resize(cols: number, rows: number): void {
+    if (cols < 1 || rows < 1) return;
+
+    const newBuffer = this.createBuffer(rows, cols);
+
+    const copyRows = Math.min(this.rows, rows);
+    const copyCols = Math.min(this.cols, cols);
+    for (let r = 0; r < copyRows; r++) {
+      for (let c = 0; c < copyCols; c++) {
+        newBuffer[r][c] = this.buffer[r][c];
+      }
+    }
+
+    this.buffer = newBuffer;
+    this.cols = cols;
+    this.rows = rows;
+    this.scrollTop = 0;
+    this.scrollBottom = rows - 1;
+    this.cursorRow = Math.min(this.cursorRow, rows - 1);
+    this.cursorCol = Math.min(this.cursorCol, cols - 1);
+    this.tabStops = this.createDefaultTabStops(cols);
+    this.wrapPending = false;
+  }
+
+  /** Clear the screen and reset all state to defaults. */
+  reset(): void {
+    this.buffer = this.createBuffer(this.rows, this.cols);
+    this.cursorRow = 0;
+    this.cursorCol = 0;
+    this.savedCursorRow = 0;
+    this.savedCursorCol = 0;
+    this.scrollTop = 0;
+    this.scrollBottom = this.rows - 1;
+    this.scrollback = [];
+    this.attrs = { ...DEFAULT_ATTRS };
+    this.cursorVisible = true;
+    this.usingAltScreen = false;
+    this.savedMainBuffer = null;
+    this.savedMainCursorRow = 0;
+    this.savedMainCursorCol = 0;
+    this.tabStops = this.createDefaultTabStops(this.cols);
+    this.wrapPending = false;
+  }
+
+  /** Return per-cell visual attributes at the given position. */
+  getAttrs(row: number, col: number): CellAttrs {
+    if (row < 0 || row >= this.rows || col < 0 || col >= this.cols) {
+      return { ...DEFAULT_ATTRS };
+    }
+    return { ...this.buffer[row][col].attrs };
+  }
+
+  // ── Internal helpers ────────────────────────────────────────────────────
+
+  private createBuffer(rows: number, cols: number): Cell[][] {
+    const buf: Cell[][] = [];
+    for (let r = 0; r < rows; r++) buf.push(newRow(cols));
+    return buf;
+  }
+
+  private createDefaultTabStops(cols: number): boolean[] {
+    const stops: boolean[] = [];
+    for (let c = 0; c < cols; c++) {
+      stops.push(c % TAB_WIDTH === 0);
+    }
+    return stops;
+  }
+
+  private renderRow(r: number): string {
+    const row = this.buffer[r];
+    let end = this.cols;
+    while (end > 0 && row[end - 1].char === ' ') end--;
+    let result = '';
+    for (let c = 0; c < end; c++) result += row[c].char;
+    return result;
+  }
+
+  private putChar(ch: string): void {
+    if (this.wrapPending) {
+      this.cursorCol = 0;
+      this.wrapPending = false;
+      if (this.cursorRow === this.scrollBottom) {
+        this.scrollUp();
+      } else if (this.cursorRow < this.rows - 1) {
+        this.cursorRow++;
+      }
+    }
+    this.buffer[this.cursorRow][this.cursorCol] = {
+      char: ch,
+      attrs: { ...this.attrs },
+    };
+    if (this.cursorCol < this.cols - 1) {
+      this.cursorCol++;
+    } else {
+      this.wrapPending = true;
+    }
+  }
+
+  private scrollUp(): void {
+    const topRow = this.buffer[this.scrollTop];
+    this.pushScrollback(this.renderRow(this.scrollTop));
+    for (let r = this.scrollTop; r < this.scrollBottom; r++) {
+      this.buffer[r] = this.buffer[r + 1];
+    }
+    this.buffer[this.scrollBottom] = newRow(this.cols);
+    // Reuse topRow cells object identity not required; newRow is fine.
+    void topRow;
+  }
+
+  private scrollDown(): void {
+    for (let r = this.scrollBottom; r > this.scrollTop; r--) {
+      this.buffer[r] = this.buffer[r - 1];
+    }
+    this.buffer[this.scrollTop] = newRow(this.cols);
+  }
+
+  private pushScrollback(line: string): void {
+    this.scrollback.push(line);
+    if (this.scrollback.length > MAX_SCROLLBACK) {
+      this.scrollback.shift();
+    }
+  }
+
+  private lineFeed(): void {
+    if (this.cursorRow === this.scrollBottom) {
+      this.scrollUp();
+    } else if (this.cursorRow < this.rows - 1) {
+      this.cursorRow++;
+    }
+  }
+
+  private reverseIndex(): void {
+    if (this.cursorRow === this.scrollTop) {
+      this.scrollDown();
+    } else if (this.cursorRow > 0) {
+      this.cursorRow--;
+    }
+  }
+
+  private clampCursor(): void {
+    this.cursorRow = Math.max(0, Math.min(this.cursorRow, this.rows - 1));
+    this.cursorCol = Math.max(0, Math.min(this.cursorCol, this.cols - 1));
+  }
+
+  // ── CSI parameter parsing ───────────────────────────────────────────────
+
+  private parseCSI(params: string, intermediate: string, final: string): void {
+    // Check for private mode sequences (e.g. ?25h, ?1049h)
+    if (params.startsWith('?')) {
+      this.handlePrivateMode(params.slice(1), final);
+      return;
+    }
+
+    const parts = params.length > 0 ? params.split(';') : [];
+    const p = (i: number, def: number): number => {
+      const v = parts[i];
+      return v && v.length > 0 ? parseInt(v, 10) : def;
+    };
+
+    this.wrapPending = false;
+
+    switch (final) {
+      // Cursor movement
+      case 'A': { // CUU — cursor up
+        const n = Math.max(p(0, 1), 1);
+        this.cursorRow = Math.max(this.cursorRow - n, 0);
+        break;
+      }
+      case 'B': { // CUD — cursor down
+        const n = Math.max(p(0, 1), 1);
+        this.cursorRow = Math.min(this.cursorRow + n, this.rows - 1);
+        break;
+      }
+      case 'C': { // CUF — cursor forward
+        const n = Math.max(p(0, 1), 1);
+        this.cursorCol = Math.min(this.cursorCol + n, this.cols - 1);
+        break;
+      }
+      case 'D': { // CUB — cursor back
+        const n = Math.max(p(0, 1), 1);
+        this.cursorCol = Math.max(this.cursorCol - n, 0);
+        break;
+      }
+      case 'E': { // CNL — cursor next line
+        const n = Math.max(p(0, 1), 1);
+        this.cursorRow = Math.min(this.cursorRow + n, this.rows - 1);
+        this.cursorCol = 0;
+        break;
+      }
+      case 'F': { // CPL — cursor previous line
+        const n = Math.max(p(0, 1), 1);
+        this.cursorRow = Math.max(this.cursorRow - n, 0);
+        this.cursorCol = 0;
+        break;
+      }
+      case 'G': { // CHA — cursor horizontal absolute
+        this.cursorCol = Math.max(0, Math.min(p(0, 1) - 1, this.cols - 1));
+        break;
+      }
+      case 'H':   // CUP — cursor position
+      case 'f': { // HVP — horizontal and vertical position
+        this.cursorRow = Math.max(0, Math.min(p(0, 1) - 1, this.rows - 1));
+        this.cursorCol = Math.max(0, Math.min(p(1, 1) - 1, this.cols - 1));
+        break;
+      }
+      case 'J': { // ED — erase in display
+        this.eraseDisplay(p(0, 0));
+        break;
+      }
+      case 'K': { // EL — erase in line
+        this.eraseLine(p(0, 0));
+        break;
+      }
+      case 'L': { // IL — insert lines
+        this.insertLines(Math.max(p(0, 1), 1));
+        break;
+      }
+      case 'M': { // DL — delete lines
+        this.deleteLines(Math.max(p(0, 1), 1));
+        break;
+      }
+      case 'P': { // DCH — delete characters
+        this.deleteChars(Math.max(p(0, 1), 1));
+        break;
+      }
+      case '@': { // ICH — insert characters
+        this.insertChars(Math.max(p(0, 1), 1));
+        break;
+      }
+      case 'S': { // SU — scroll up
+        for (let i = 0; i < Math.max(p(0, 1), 1); i++) this.scrollUp();
+        break;
+      }
+      case 'T': { // SD — scroll down
+        for (let i = 0; i < Math.max(p(0, 1), 1); i++) this.scrollDown();
+        break;
+      }
+      case 'm': { // SGR — select graphic rendition
+        this.handleSGR(parts);
+        break;
+      }
+      case 'r': { // DECSTBM — set scrolling region
+        this.scrollTop = Math.max(0, p(0, 1) - 1);
+        this.scrollBottom = Math.min(this.rows - 1, p(1, this.rows) - 1);
+        if (this.scrollTop >= this.scrollBottom) {
+          this.scrollTop = 0;
+          this.scrollBottom = this.rows - 1;
+        }
+        this.cursorRow = 0;
+        this.cursorCol = 0;
+        break;
+      }
+      case 'n': { // DSR — device status report
+        if (p(0, 0) === 6) {
+          // Response would be sent to the terminal input; we ignore it here
+        }
+        break;
+      }
+      case 'g': { // TBC — tabulation clear
+        const mode = p(0, 0);
+        if (mode === 0) {
+          if (this.cursorCol < this.cols) this.tabStops[this.cursorCol] = false;
+        } else if (mode === 3) {
+          this.tabStops = this.createDefaultTabStops(this.cols);
+          for (let c = 0; c < this.cols; c++) this.tabStops[c] = false;
+        }
+        break;
+      }
+      case 'X': { // ECH — erase characters
+        const n = Math.max(p(0, 1), 1);
+        for (let i = 0; i < n && this.cursorCol + i < this.cols; i++) {
+          this.buffer[this.cursorRow][this.cursorCol + i] = defaultCell();
+        }
+        break;
+      }
+      default:
+        // Unknown CSI sequence — ignore
+        break;
+    }
+  }
+
+  // ── SGR (Select Graphic Rendition) ──────────────────────────────────────
+
+  private handleSGR(parts: string[]): void {
+    if (parts.length === 0 || (parts.length === 1 && parts[0] === '')) {
+      this.attrs = { ...DEFAULT_ATTRS };
+      return;
+    }
+
+    for (let i = 0; i < parts.length; i++) {
+      const code = parts[i].length > 0 ? parseInt(parts[i], 10) : 0;
+      switch (code) {
+        case 0: this.attrs = { ...DEFAULT_ATTRS }; break;
+        case 1: this.attrs.bold = true; break;
+        case 2: this.attrs.dim = true; break;
+        case 4: this.attrs.underline = true; break;
+        case 5: this.attrs.blink = true; break;
+        case 7: this.attrs.reverse = true; break;
+        case 8: this.attrs.hidden = true; break;
+        case 22: this.attrs.bold = false; this.attrs.dim = false; break;
+        case 24: this.attrs.underline = false; break;
+        case 25: this.attrs.blink = false; break;
+        case 27: this.attrs.reverse = false; break;
+        case 28: this.attrs.hidden = false; break;
+        // Standard foreground colors 30–37
+        case 30: case 31: case 32: case 33:
+        case 34: case 35: case 36: case 37:
+          this.attrs.fg = code - 30;
+          break;
+        case 39: this.attrs.fg = -1; break;
+        // Standard background colors 40–47
+        case 40: case 41: case 42: case 43:
+        case 44: case 45: case 46: case 47:
+          this.attrs.bg = code - 40;
+          break;
+        case 49: this.attrs.bg = -1; break;
+        // Bright foreground colors 90–97
+        case 90: case 91: case 92: case 93:
+        case 94: case 95: case 96: case 97:
+          this.attrs.fg = code - 90 + 8;
+          break;
+        // Bright background colors 100–107
+        case 100: case 101: case 102: case 103:
+        case 104: case 105: case 106: case 107:
+          this.attrs.bg = code - 100 + 8;
+          break;
+        default:
+          // Extended color (256-color, truecolor) — skip the extra params
+          if (code === 38 || code === 48) {
+            if (i + 1 < parts.length) {
+              const type = parseInt(parts[i + 1], 10);
+              if (type === 5 && i + 2 < parts.length) {
+                // 256-color: 38;5;n or 48;5;n
+                const color = parseInt(parts[i + 2], 10);
+                if (code === 38) this.attrs.fg = color;
+                else this.attrs.bg = color;
+                i += 2;
+              } else if (type === 2 && i + 4 < parts.length) {
+                // Truecolor: 38;2;r;g;b — store as a combined index
+                const r = parseInt(parts[i + 2], 10);
+                const g = parseInt(parts[i + 3], 10);
+                const b = parseInt(parts[i + 4], 10);
+                const colorIdx = 16 + (r << 16) + (g << 8) + b;
+                if (code === 38) this.attrs.fg = colorIdx;
+                else this.attrs.bg = colorIdx;
+                i += 4;
+              }
+            }
+          }
+          break;
+      }
+    }
+  }
+
+  // ── Private mode sequences (? prefix) ───────────────────────────────────
+
+  private handlePrivateMode(params: string, final: string): void {
+    const code = parseInt(params, 10);
+    if (final === 'h') {
+      switch (code) {
+        case 25: this.cursorVisible = true; break;
+        case 1049: this.enterAltScreen(); break;
+      }
+    } else if (final === 'l') {
+      switch (code) {
+        case 25: this.cursorVisible = false; break;
+        case 1049: this.leaveAltScreen(); break;
+      }
+    }
+  }
+
+  private enterAltScreen(): void {
+    if (this.usingAltScreen) return;
+    this.savedMainBuffer = this.buffer;
+    this.savedMainCursorRow = this.cursorRow;
+    this.savedMainCursorCol = this.cursorCol;
+    this.buffer = this.createBuffer(this.rows, this.cols);
+    this.cursorRow = 0;
+    this.cursorCol = 0;
+    this.usingAltScreen = true;
+  }
+
+  private leaveAltScreen(): void {
+    if (!this.usingAltScreen) return;
+    if (this.savedMainBuffer) {
+      this.buffer = this.savedMainBuffer;
+      this.cursorRow = this.savedMainCursorRow;
+      this.cursorCol = this.savedMainCursorCol;
+    }
+    this.savedMainBuffer = null;
+    this.usingAltScreen = false;
+  }
+
+  // ── Erase operations ────────────────────────────────────────────────────
+
+  private eraseDisplay(mode: number): void {
+    switch (mode) {
+      case 0: { // Cursor to end
+        for (let c = this.cursorCol; c < this.cols; c++) {
+          this.buffer[this.cursorRow][c] = defaultCell();
+        }
+        for (let r = this.cursorRow + 1; r < this.rows; r++) {
+          this.buffer[r] = newRow(this.cols);
+        }
+        break;
+      }
+      case 1: { // Start to cursor
+        for (let r = 0; r < this.cursorRow; r++) {
+          this.buffer[r] = newRow(this.cols);
+        }
+        for (let c = 0; c <= this.cursorCol && c < this.cols; c++) {
+          this.buffer[this.cursorRow][c] = defaultCell();
+        }
+        break;
+      }
+      case 2: { // Entire display
+        for (let r = 0; r < this.rows; r++) {
+          this.buffer[r] = newRow(this.cols);
+        }
+        break;
+      }
+      case 3: // Scrollback (often ignored in simple emulators)
+        this.scrollback = [];
+        break;
+    }
+  }
+
+  private eraseLine(mode: number): void {
+    switch (mode) {
+      case 0: // Cursor to end
+        for (let c = this.cursorCol; c < this.cols; c++) {
+          this.buffer[this.cursorRow][c] = defaultCell();
+        }
+        break;
+      case 1: // Start to cursor
+        for (let c = 0; c <= this.cursorCol && c < this.cols; c++) {
+          this.buffer[this.cursorRow][c] = defaultCell();
+        }
+        break;
+      case 2: // Entire line
+        this.buffer[this.cursorRow] = newRow(this.cols);
+        break;
+    }
+  }
+
+  // ── Insert / delete operations ──────────────────────────────────────────
+
+  private insertLines(n: number): void {
+    if (this.cursorRow < this.scrollTop || this.cursorRow > this.scrollBottom) return;
+    for (let i = 0; i < n; i++) {
+      // Remove the bottom line of the scroll region
+      this.buffer.splice(this.scrollBottom, 1);
+      // Insert a blank line at the cursor row
+      this.buffer.splice(this.cursorRow, 0, newRow(this.cols));
+    }
+  }
+
+  private deleteLines(n: number): void {
+    if (this.cursorRow < this.scrollTop || this.cursorRow > this.scrollBottom) return;
+    for (let i = 0; i < n; i++) {
+      // Remove line at cursor
+      this.buffer.splice(this.cursorRow, 1);
+      // Insert blank line at bottom of scroll region
+      this.buffer.splice(this.scrollBottom, 0, newRow(this.cols));
+    }
+  }
+
+  private deleteChars(n: number): void {
+    const row = this.buffer[this.cursorRow];
+    for (let i = this.cursorCol; i < this.cols; i++) {
+      const src = i + n;
+      row[i] = src < this.cols ? row[src] : defaultCell();
+    }
+  }
+
+  private insertChars(n: number): void {
+    const row = this.buffer[this.cursorRow];
+    for (let i = this.cols - 1; i >= this.cursorCol; i--) {
+      const src = i - n;
+      row[i] = src >= this.cursorCol ? row[src] : defaultCell();
+    }
+  }
+
+  // ── Main parser state machine ───────────────────────────────────────────
+
+  private parse(data: string): void {
+    let i = 0;
+    const len = data.length;
+
+    while (i < len) {
+      const ch = data[i];
+
+      if (ch === '\x1b') {
+        // Begin escape sequence
+        if (i + 1 >= len) break; // incomplete — wait for more
+        const next = data[i + 1];
+
+        if (next === '[') {
+          // CSI sequence: ESC [ <params> <final>
+          i += 2;
+          let params = '';
+          let intermediate = '';
+          while (i < len) {
+            const c = data[i];
+            if (c >= '\x30' && c <= '\x3f') {
+              // Parameter bytes: 0–9, ;, <, =, >, ?
+              params += c;
+              i++;
+            } else if (c >= '\x20' && c <= '\x2f') {
+              // Intermediate bytes
+              intermediate += c;
+              i++;
+            } else if (c >= '\x40' && c <= '\x7e') {
+              // Final byte
+              this.parseCSI(params, intermediate, c);
+              i++;
+              break;
+            } else {
+              // Unexpected byte in CSI — abort
+              break;
+            }
+          }
+        } else if (next === ']') {
+          // OSC sequence: ESC ] <text> BEL (or ST)
+          i += 2;
+          let _oscText = '';
+          while (i < len) {
+            if (data[i] === '\x07') { i++; break; } // BEL terminates
+            if (data[i] === '\x1b' && i + 1 < len && data[i + 1] === '\\') {
+              i += 2; break; // ST terminates
+            }
+            _oscText += data[i];
+            i++;
+          }
+          // Consume OSC (window title) — discard
+        } else if (next === 'M') {
+          // Reverse index
+          this.reverseIndex();
+          i += 2;
+        } else if (next === '7') {
+          // Save cursor
+          this.savedCursorRow = this.cursorRow;
+          this.savedCursorCol = this.cursorCol;
+          this.wrapPending = false;
+          i += 2;
+        } else if (next === '8') {
+          // Restore cursor
+          this.cursorRow = this.savedCursorRow;
+          this.cursorCol = this.savedCursorCol;
+          this.wrapPending = false;
+          i += 2;
+        } else if (next === 'c') {
+          // Full reset
+          this.reset();
+          i += 2;
+        } else {
+          // Unknown ESC sequence — skip ESC and the next char
+          i += 2;
+        }
+      } else if (ch === '\r') {
+        this.cursorCol = 0;
+        this.wrapPending = false;
+        i++;
+      } else if (ch === '\n') {
+        this.wrapPending = false;
+        this.lineFeed();
+        i++;
+      } else if (ch === '\t') {
+        // Advance to next tab stop
+        this.wrapPending = false;
+        let nextTab = this.cursorCol + 1;
+        while (nextTab < this.cols - 1 && !this.tabStops[nextTab]) {
+          nextTab++;
+        }
+        this.cursorCol = nextTab;
+        i++;
+      } else if (ch === '\x08') {
+        // Backspace
+        this.wrapPending = false;
+        if (this.cursorCol > 0) this.cursorCol--;
+        i++;
+      } else if (ch === '\x07') {
+        // BEL — ignore
+        i++;
+      } else if (ch >= ' ') {
+        this.putChar(ch);
+        i++;
+      } else {
+        // Other control characters — ignore
+        i++;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Phase 1 of #2204 — a pure TypeScript VT100/ANSI terminal emulator that maintains an in-memory screen buffer. Zero external dependencies.

## What this adds
- **`src/vt100-screen.ts`** (737 lines) — `VT100Screen` class with full ANSI/VT100 sequence parsing
- **`src/__tests__/vt100-screen.test.ts`** (709 lines) — 78 comprehensive unit tests

## Supported sequences
- **CSI**: cursor movement (A-F, G, H/f), erase (J 0-3, K 0-2), SGR attributes (bold, dim, underline, blink, reverse, hidden, 8 fg/bg colors, reset), scroll region (r), scroll (S/T), insert/delete lines (L/M), insert/delete chars (P/@), cursor show/hide (?25h/?25l), alt screen buffer (?1049h/?1049l), DSR 6n
- **OSC**: window title setting (0; and 2; — consumed and discarded)
- **Other**: reverse index (ESC M), save/restore cursor (ESC 7/8), full reset (ESC c), CR, LF, tab stops, backspace, BEL

## API
```typescript
const screen = new VT100Screen(80, 24);
screen.write(rawPtyOutput);
screen.getText();        // full screen as string
screen.getRow(0);        // single row
screen.getCursor();      // { row, col }
screen.getScrollback();  // scrolled-out lines
screen.getAttrs(r, c);   // per-cell attributes
```

## Verification
- `tsc --noEmit`: ✅ zero errors
- `eslint`: ✅ zero errors
- `vitest`: ✅ 78/78 tests passed, 0 regressions (201 test files pass)

## Related
- Part of epic #2204 (VT100 Parser + Enhanced State Detection)
- Phase 2 will rewrite `terminal-parser.ts` to use this buffer for state detection