### PR TITLE
feat(dashboard): adapt terminal components to PTY stream protocol

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -421,6 +421,11 @@ const WsStatusMessageSchema = z.object({
   status: z.string(),
 });
 
+const WsStreamMessageSchema = z.object({
+  type: z.literal('stream'),
+  data: z.string(),
+});
+
 const WsErrorMessageSchema = z.object({
   type: z.literal('error'),
   message: z.string(),
@@ -429,6 +434,7 @@ const WsErrorMessageSchema = z.object({
 export const WsInboundMessageSchema = z.discriminatedUnion('type', [
   WsPaneMessageSchema,
   WsStatusMessageSchema,
+  WsStreamMessageSchema,
   WsErrorMessageSchema,
 ]);
 

--- a/dashboard/src/components/session/LiveTerminal.tsx
+++ b/dashboard/src/components/session/LiveTerminal.tsx
@@ -93,18 +93,17 @@ export function LiveTerminal({ sessionId, status }: LiveTerminalProps) {
 
         switch (msg.type) {
           case 'pane': {
-            // Backend sends full pane snapshots â€” write only the delta
-            // to avoid resetting the xterm buffer and losing scrollback.
-            const prev = prevContentRef.current;
-            const next = msg.content;
-            if (prev && next.startsWith(prev)) {
-              term.write(next.slice(prev.length));
-            } else {
-              // Content diverged â€” full redraw needed
-              term.reset();
-              term.write(next);
-            }
-            prevContentRef.current = next;
+            // One-shot catchup on connect - full replace, no diffing.
+            term.reset();
+            term.write(msg.content);
+            prevContentRef.current = msg.content;
+            setErrorMsg(null);
+            break;
+          }
+
+          case 'stream': {
+            // Incremental PTY output - write directly, always a delta.
+            term.write(msg.data);
             setErrorMsg(null);
             break;
           }

--- a/dashboard/src/components/session/TerminalPassthrough.tsx
+++ b/dashboard/src/components/session/TerminalPassthrough.tsx
@@ -296,21 +296,15 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
 
         switch (msg.type) {
           case 'pane': {
-            // Issue 003a: strip shell bootstrap, hook-settings paths, the
-            // Claude CLI ASCII logo and raw status-footer lines BEFORE the
-            // diff against prevPaneContentRef. Sanitation is deterministic
-            // and idempotent, so applying it once to each snapshot keeps
-            // the delta-write optimisation valid. Opt-out via `?raw=1`.
+            // One-shot catchup on connect - sanitize and full replace, no diffing.
             const sanitized = sanitizeTerminalStream(msg.content, sanitationCtx.platform, {
               preserveRaw: sanitationCtx.preserveRaw,
             });
-            
+
             // Issue 003b: Parse status footer from raw pane content (before sanitation strips it)
-            // Look for status lines near the bottom of the pane capture
             const rawLines = msg.content.split('\n');
-            const bottomLines = rawLines.slice(-10); // check last 10 lines
+            const bottomLines = rawLines.slice(-10);
             for (const line of bottomLines) {
-              // Match Claude CLI status footer patterns
               if (/[·•]\s*[A-Z][a-zA-Z]+ing/i.test(line) || /esc\s+to\s+interrupt/i.test(line) || /\bv?\d+\.\d+\.\d+\b/.test(line)) {
                 const parsed = parseStatusFooter(line);
                 if (parsed && Object.keys(parsed).length > 0) {
@@ -320,35 +314,28 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
                 }
               }
             }
-            
-            // Write delta pane content to xterm
-            const prev = prevPaneContentRef.current;
-            const next = sanitized;
-            if (prev && next.startsWith(prev)) {
-              term.write(next.slice(prev.length));
-            } else {
-              // Content diverged — need to re-render everything
-              // Save current pane content and re-render the full view
-              prevPaneContentRef.current = next;
-              // Trigger re-render with current filter state
-              const term = xtermRef.current;
-              if (term) {
-                term.reset();
 
-                // Issue 01.1: see same comment above — no ASCII box banners.
-                if (filteredMessagesRef.current.length > 0) {
-                  for (const entry of filteredMessagesRef.current) {
-                    term.writeln(formatTranscriptEntry(entry));
-                  }
-                  term.writeln('');
-                }
-
-                term.write(next);
-                // Update rendered count after full re-render
-                prevRenderedCountRef.current = filteredMessagesRef.current.length;
+            // Full replace - reset terminal, re-render transcript, write pane content.
+            prevPaneContentRef.current = sanitized;
+            term.reset();
+            if (filteredMessagesRef.current.length > 0) {
+              for (const entry of filteredMessagesRef.current) {
+                term.writeln(formatTranscriptEntry(entry));
               }
+              term.writeln('');
             }
-            prevPaneContentRef.current = next;
+            term.write(sanitized);
+            prevRenderedCountRef.current = filteredMessagesRef.current.length;
+            setErrorMsg(null);
+            break;
+          }
+
+          case 'stream': {
+            // Incremental PTY output - sanitize and write directly.
+            const sanitized = sanitizeTerminalStream(msg.data, sanitationCtx.platform, {
+              preserveRaw: sanitationCtx.preserveRaw,
+            });
+            term.write(sanitized);
             setErrorMsg(null);
             break;
           }

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -181,12 +181,17 @@ export interface WsStatusMessage {
   status: string;
 }
 
+export interface WsStreamMessage {
+  type: 'stream';
+  data: string;
+}
+
 export interface WsErrorMessage {
   type: 'error';
   message: string;
 }
 
-export type WsInboundMessage = WsPaneMessage | WsStatusMessage | WsErrorMessage;
+export type WsInboundMessage = WsPaneMessage | WsStatusMessage | WsStreamMessage | WsErrorMessage;
 
 export interface WsInputMessage {
   type: 'input';


### PR DESCRIPTION
## Summary

Adapts `LiveTerminal` and `TerminalPassthrough` to consume the new WebSocket PTY streaming protocol introduced in #2209. The backend now sends `{ type: "stream", data }` for incremental PTY output and `{ type: "pane", content }` as one-shot catchup on connect.

## Changes

| File | Change |
|------|--------|
| `dashboard/src/types/index.ts` | Add `WsStreamMessage { type: "stream"; data: string }` to `WsInboundMessage` union |
| `dashboard/src/api/schemas.ts` | Add `WsStreamMessageSchema` to `WsInboundMessageSchema` discriminated union |
| `dashboard/src/components/session/LiveTerminal.tsx` | Handle `stream` as incremental write; `pane` as one-shot full replace |
| `dashboard/src/components/session/TerminalPassthrough.tsx` | Same stream handler with sanitization; `pane` as full replace with transcript re-render |

## Behavioral Change

**Before:** Backend sent `{ type: "pane" }` every 500ms → dashboard diffed against previous snapshot → wrote delta.

**After:** Backend sends `{ type: "pane" }` once (catchup) → dashboard does full replace. Then `{ type: "stream" }` fires continuously → dashboard writes directly to xterm (always incremental, no diffing needed).

## Quality Gate

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 76/76 test files, 692/692 tests passed
- [x] Only `dashboard/` files modified
- [x] No new dependencies

## Aegis version

**Developed with:** v0.6.0-preview

Closes #2210