### PR TITLE
docs: April 2026 feature sprint — SessionStore, PTY streaming, VT100, slash command discovery

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -42,6 +42,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `POST` | `/v1/sessions/{id}/approve` | Bearer | Approve permission request |
 | `POST` | `/v1/sessions/{id}/reject` | Bearer | Reject permission request |
 | `POST` | `/v1/sessions/{id}/answer` | Bearer | Answer a pending question |
+| `POST` | `/v1/sessions/{id}/discover-commands` | Bearer | Discover available slash commands |
 
 ## Session Data
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -434,6 +434,29 @@ Sends a slash command to the Claude Code session (e.g., `/clear`, `/commit`, `/r
 
 **Response:** `200 OK` with session update.
 
+### Discover Slash Commands
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions/abc123/discover-commands \
+  -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
+```
+
+Interacts with Claude Code's autocomplete panel to discover available slash commands. Opens the `/` autocomplete, scrolls through all entries, extracts command names and descriptions, then closes the panel.
+
+**Response:** `200 OK`
+
+```json
+{
+  "commands": [
+    { "name": "help", "description": "Show help" },
+    { "name": "compact", "description": "Compact conversation context" },
+    { "name": "clear", "description": "Clear conversation history" }
+  ]
+}
+```
+
+> **Note:** This endpoint sends keystrokes to the session's tmux pane (Ctrl+U, `/`, Escape). The session must be in an interactive state (not mid-execution). The discovery takes 5–10 seconds depending on the number of available commands.
+
 ### Execute Bash Command
 
 ```bash
@@ -1291,6 +1314,55 @@ curl http://localhost:9100/v1/alerts/stats \
 ```
 
 Returns alert counts. Available to `admin`, `operator`, and `viewer` roles.
+
+---
+
+## WebSocket Terminal Streaming
+
+Aegis streams live terminal output to connected dashboard clients over WebSocket. This replaces the previous 500ms polling approach with real-time delivery via tmux `pipe-pane`.
+
+**Endpoint:** `WS /v1/sessions/:id/terminal`
+
+### Connection
+
+```js
+const ws = new WebSocket('ws://localhost:9100/v1/sessions/abc123/terminal', {
+  headers: { Authorization: 'Bearer your-token' }
+});
+```
+
+### Authentication
+
+- **Browser clients:** Send `{ type: "auth", token: "..." }` as the first message (within 5 seconds or the connection is dropped).
+- **Non-browser clients:** `Authorization: Bearer <token>` header is accepted.
+- Per-connection rate limiting: 10 messages/second.
+
+### Message Protocol
+
+#### Server → Client
+
+| Type | Fields | Description |
+|---|---|---|
+| `pane` | `content` | Full pane catchup (sent on connect) |
+| `stream` | `data` | Incremental PTY output chunk |
+| `status` | `status` | Current UI state (`idle`, `working`, etc.) |
+| `error` | `message` | Error notification |
+
+#### Client → Server
+
+| Type | Fields | Description |
+|---|---|---|
+| `auth` | `token` | Authentication handshake (first message) |
+| `input` | `text` | Send keystrokes to the session |
+| `resize` | `cols`, `rows` | Resize the terminal |
+
+### Architecture
+
+``
+tmux pane → pipe-pane → cat > FIFO → Node.js ReadStream → WebSocket
+```
+
+Each session has one shared `PtyStream` instance (not per-connection). Late-joining subscribers receive a ~64KB catchup buffer of recent output. Status detection polls every 3 seconds.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,8 @@ src/
 ├── session-cleanup.ts        # Idle session reaping and resource cleanup
 ├── tmux.ts                   # tmux operations — windows, panes, send-keys
 ├── terminal-parser.ts        # Detect Claude Code UI state from terminal output
+├── vt100-screen.ts            # Pure TS VT100/ANSI terminal emulator (screen buffer)
+├── pty-stream.ts              # Real-time PTY output streaming via tmux pipe-pane + FIFO
 ├── channels/                  # Notification channels (event fan-out)
 │   ├── manager.ts            # Event fan-out to all active channels
 │   ├── telegram.ts           # Telegram bot — bidirectional (approve/reject from chat)
@@ -48,7 +50,7 @@ src/
 ├── events.ts                 # SSE event types (session + global)
 ├── sse-writer.ts             # SSE response streaming
 ├── sse-limiter.ts            # SSE rate limiting per client
-├── ws-terminal.ts            # WebSocket terminal relay
+├── ws-terminal.ts            # WebSocket terminal relay (PTY streaming + catchup)
 │
 ├── permission-guard.ts       # Permission request interception and routing
 ├── services/
@@ -57,6 +59,13 @@ src/
 │   │   ├── RateLimiter.ts    # Route-level IP and auth-failure rate limiting
 │   │   ├── types.ts          # Auth manager and API key types
 │   │   └── index.ts          # Auth service exports
+│   ├── state/
+│   │   ├── state-store.ts    # Pluggable session state store interface
+│   │   ├── JsonFileStore.ts  # Default: file-backed state persistence
+│   │   ├── RedisStateStore.ts # Redis-backed state for horizontal scaling
+│   │   ├── PostgresStore.ts  # PostgreSQL-backed state with connection pooling
+│   │   ├── store-factory.ts  # Factory: creates StateStore from config
+│   │   └── index.ts          # State store module re-exports
 │   └── permission/
 │       ├── evaluator.ts      # Permission profile evaluation logic
 │       ├── types.ts          # Permission evaluator input/output types
@@ -228,6 +237,8 @@ See: PRs #1779 (search/filter), #1782 (keyboard shortcuts), #1791 (CSV export), 
 | `session-cleanup.ts` | Reaps idle sessions and frees resources |
 | `tmux.ts` | Low-level tmux operations: create windows, send-keys, capture output |
 | `terminal-parser.ts` | Detects Claude Code's UI state (working, idle, permission prompt, etc.) from terminal text |
+| `vt100-screen.ts` | Pure TypeScript VT100/ANSI terminal emulator — in-memory screen buffer for clean state detection |
+| `pty-stream.ts` | Real-time PTY output streaming via tmux `pipe-pane` + FIFO (replaces 500ms polling) |
 | `transcript.ts` | Parses Claude Code's JSONL output into structured entries with token usage |
 | `jsonl-watcher.ts` | Watches JSONL files for new entries in real time |
 
@@ -272,7 +283,27 @@ those arguments as untrusted command surfaces, not benign display strings.
 | `pipeline.ts` | Batch session creation and multi-stage orchestration (sequential or parallel stages) |
 | `swarm-monitor.ts` | Coordinates parallel session swarms with status aggregation |
 
-### 5. Templates
+### 5. Session State Persistence
+
+Aegis supports pluggable session state backends via the `StateStore` interface (#1937). The default file-based store is suitable for single-node deployments; Redis and PostgreSQL backends enable horizontal scaling.
+
+| Module | Purpose |
+|---|---|
+| `services/state/state-store.ts` | Abstract interface: `load()`, `save()`, `getSession()`, `putSession()`, `deleteSession()`, `listSessionIds()` |
+| `services/state/JsonFileStore.ts` | Default file-backed implementation — reads/writes `state.json` |
+| `services/state/RedisStateStore.ts` | Redis-backed implementation for multi-node horizontal scaling |
+| `services/state/PostgresStore.ts` | PostgreSQL implementation with connection pooling, JSONB storage, and transactional saves |
+| `services/state/store-factory.ts` | Factory function: creates the correct `StateStore` based on `AEGIS_SESSION_STORE` env var |
+
+Backend selection via environment:
+
+| `AEGIS_SESSION_STORE` | Backend | Required env vars |
+|---|---|---|
+| `file` (default) | Local filesystem | `AEGIS_STATE_DIR` |
+| `redis` | Redis | `AEGIS_REDIS_URL` |
+| `postgres` | PostgreSQL | `AEGIS_POSTGRES_URL` |
+
+### 6. Templates
 
 | Module | Purpose |
 |---|---|
@@ -280,7 +311,7 @@ those arguments as untrusted command surfaces, not benign display strings.
 | `continuation-pointer.ts` | Checkpoints and resumes sessions from saved state |
 | `question-manager.ts` | Manages pending user questions with TTL and lifecycle |
 
-### 6. Monitoring & Events
+### 7. Monitoring & Events
 
 | Module | Purpose |
 |---|---|
@@ -288,9 +319,9 @@ those arguments as untrusted command surfaces, not benign display strings.
 | `events.ts` | Defines SSE event types for session and global events |
 | `sse-writer.ts` | Streams SSE events to HTTP clients |
 | `sse-limiter.ts` | Rate-limits SSE connections per client |
-| `ws-terminal.ts` | Relays terminal output over WebSocket |
+| `ws-terminal.ts` | Relays terminal output over WebSocket using real-time PTY streaming |
 
-### 7. Permissions
+### 8. Permissions
 
 | Module | Purpose |
 |---|---|
@@ -299,7 +330,7 @@ those arguments as untrusted command surfaces, not benign display strings.
 | `permission-request-manager.ts` | Queues and tracks pending permission requests |
 | `permission-routes.ts` | REST endpoints: approve, reject, list pending permissions |
 
-### 8. Memory & Metrics
+### 9. Memory & Metrics
 
 | Module | Purpose |
 |---|---|
@@ -308,7 +339,7 @@ those arguments as untrusted command surfaces, not benign display strings.
 | `metrics.ts` | Token usage tracking, cost estimation, and session statistics |
 | `screenshot.ts` | Captures URL screenshots via Playwright |
 
-### 9. Hooks
+### 10. Hooks
 
 | Module | Purpose |
 |---|---|
@@ -316,7 +347,7 @@ those arguments as untrusted command surfaces, not benign display strings.
 | `hook.ts` | Builds hook commands for pre/post session lifecycle events |
 | `hook-settings.ts` | Parses and validates hook configuration |
 
-### 10. Shared Utilities
+### 11. Shared Utilities
 
 | Module | Purpose |
 |---|---|
@@ -354,11 +385,12 @@ server.ts (Fastify, port 9100)
   ├─ session.ts (session operations)
   │     │
   │     ├─ tmux.ts (tmux window management)
-  │     ├─ terminal-parser.ts (UI state detection)
+  │     ├─ terminal-parser.ts (UI state detection via VT100Screen)
+  │     ├─ pty-stream.ts (real-time PTY output streaming)
   │     ├─ transcript.ts (JSONL parsing)
   │     └─ permission-guard.ts (approval flow)
   │
-  ├─ pipeline.ts (batch orchestration)
+  ├─ services/state/ (pluggable session persistence)
   │     └─ swarm-monitor.ts (parallel coordination)
   │
   ├─ monitor.ts (state tracking + events)
@@ -378,6 +410,7 @@ Issue #1622 introduces explicit service registration and dependency-driven start
 
 ```text
 tmuxManager
+stateStore
   └─ sessionManager
       ├─ channelManager
       └─ sessionMonitor
@@ -387,7 +420,8 @@ authManager
 | Service | Depends on | Startup action | Shutdown action |
 |---|---|---|---|
 | `tmuxManager` | — | `tmux.ensureSession()` | no-op |
-| `sessionManager` | `tmuxManager` | `sessions.load()` | `sessions.save()` |
+| `sessionManager` | `tmuxManager`, `stateStore` | `sessions.load()` | `sessions.save()` |
+| `stateStore` | — | `store.start()` | `store.stop()` |
 | `authManager` | — | `auth.load()` | no-op |
 | `channelManager` | `sessionManager` | `channels.init(handleInbound)` | `channels.destroy()` |
 | `sessionMonitor` | `tmuxManager`, `sessionManager`, `channelManager` | `monitor.start()` | `monitor.stop()` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -218,6 +218,13 @@ Aegis is configured via environment variables:
 | `AEGIS_AUTH_TOKEN` | _(empty)_ | Bearer token (empty = no auth) |
 | `AEGIS_STATE_DIR` | `~/.aegis` | State directory |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity |
+| `AEGIS_SESSION_STORE` | `file` | Session state backend: `file`, `redis`, or `postgres` |
+| `AEGIS_POSTGRES_URL` | _(empty)_ | PostgreSQL connection URL (required when `AEGIS_SESSION_STORE=postgres`) |
+| `AEGIS_PG_TABLE` | `aegis_sessions` | PostgreSQL table name for session state |
+| `AEGIS_PG_SCHEMA` | `public` | PostgreSQL schema name |
+| `AEGIS_PG_POOL_MAX` | `5` | PostgreSQL connection pool max size |
+| `AEGIS_REDIS_URL` | `redis://localhost:6379` | Redis URL (used when `AEGIS_SESSION_STORE=redis`) |
+| `AEGIS_REDIS_KEY_PREFIX` | `aegis` | Redis key prefix |
 
 Or use a config file (`.aegis/config.yaml` is the preferred bootstrap path, and `aegis.config.json` remains supported):
 


### PR DESCRIPTION
## Summary

Documents all features shipped in the April 2026 sprint:

- **#2201** — Pluggable SessionStore (file/Redis/PostgreSQL backends)
- **#2208** — Slash command discovery API endpoint
- **#2209** — WebSocket PTY streaming via tmux pipe-pane
- **#2211** — VT100 screen buffer parser module
- **#2212** — Dashboard PTY stream adaptation
- **#2213** — VT100-enhanced state detection

## Changes

### docs/architecture.md
- Add `vt100-screen.ts`, `pty-stream.ts`, `services/state/` to module tree
- New **Section 5: Session State Persistence** — covers StateStore interface, all 3 backends, env var selection
- Update request flow diagram and service dependency graph
- Renumber sections 5→6 through 10→11

### docs/api-reference.md
- Add **Discover Slash Commands** endpoint (`POST /v1/sessions/:id/discover-commands`) with example response
- Add new **WebSocket Terminal Streaming** section — endpoint, auth, message protocol, architecture diagram

### docs/api-quick-ref.md
- Add `POST /v1/sessions/{id}/discover-commands` to Session Actions table

### docs/getting-started.md
- Add 7 new environment variables for SessionStore configuration (PostgreSQL, Redis, pool settings)

## Verification
- [x] Code examples use placeholder values (no real credentials)
- [x] API endpoints match source code route definitions
- [x] Env var names match `config.ts` + source code defaults
- [x] Architecture module paths match actual `src/` structure