### PR TITLE
chore: formally activate Phase 3 — Team and Early-Enterprise

### DIFF
--- a/.claude/epics/phase-3-team-early-enterprise/epic.md
+++ b/.claude/epics/phase-3-team-early-enterprise/epic.md
@@ -1,9 +1,11 @@
 # EPIC: Phase 3 — Team & Early-Enterprise
 
 **Phase:** 3
-**Status:** ⏸ **NOT ACTIVE — do not open GitHub issues yet**
-**Activation trigger:** Phase 2 closed AND at least one external team has
-requested at least one of: SSO, multi-tenancy, or Postgres persistence.
+**Status:** ✅ **ACTIVE** (activated 2026-04-27)
+**Activation trigger:** Phase 2 closed ✅ AND at least one external team has
+requested at least one of: SSO, multi-tenancy, or Postgres persistence ✅
+**Activation record:** Ema requested Postgres persistence (shipped #2201) and
+SSO for team use. Phase 2 exit checklist satisfied.
 **Wall-clock target:** 3–6 months part-time after activation, demand-driven
 **Parent roadmap:** [ROADMAP.md](../../../ROADMAP.md)
 **Positioning:** [ADR-0023](../../../docs/adr/0023-positioning-claude-code-control-plane.md)
@@ -24,20 +26,20 @@ isolation, and generate a TypeScript or Python SDK from the OpenAPI contract.
 Demand-driven. Every item below must be justified by at least one real user
 request before work begins; speculative work is deferred to Phase 4.
 
-| # | Item | Gap ref |
-|---|---|---|
-| 3.1 | Pluggable `SessionStore` interface + `PostgresStore` | P0-5 |
-| 3.2 | Pipeline state persistence on the same interface | P0-5 |
-| 3.3 | OpenTelemetry end-to-end: HTTP → service → tmux → channels | P1-3 / ADR-0017 |
-| 3.4 | Generated TypeScript SDK from OpenAPI | P2-5 |
-| 3.5 | Generated Python SDK from OpenAPI | P2-5 |
-| 3.6 | SSO / OIDC for dashboard (Entra ID, Google, Okta, Keycloak, Authentik) | P1-2 |
-| 3.7 | OAuth2 device flow for CLI (`ag login`) | P1-2 |
-| 3.8 | Multi-tenancy primitives: `tenantId` on keys / sessions / audit | P1-1 |
-| 3.9 | Workdir namespacing per tenant | P1-1 |
-| 3.10 | Dashboard list virtualization (transcripts, session history) | P1-7 |
-| 3.11 | Dashboard full a11y pass (focus traps, ARIA, contrast) | P1-7 |
-| 3.12 | i18n scaffolding (EN + IT to start) | — |
+| # | Item | Gap ref | Status |
+|---|---|---|---|
+| 3.1 | Pluggable `SessionStore` interface + `PostgresStore` | P0-5 | ✅ Shipped (#2201) |
+| 3.2 | Pipeline state persistence on the same interface | P0-5 | 🔲 Ready |
+| 3.3 | OpenTelemetry end-to-end: HTTP → service → tmux → channels | P1-3 / ADR-0017 | 🔲 Ready |
+| 3.4 | Generated TypeScript SDK from OpenAPI | P2-5 | 🔲 Ready |
+| 3.5 | Generated Python SDK from OpenAPI | P2-5 | 🔲 Ready |
+| 3.6 | SSO / OIDC for dashboard (Entra ID, Google, Okta, Keycloak, Authentik) | P1-2 | 🔲 Ready |
+| 3.7 | OAuth2 device flow for CLI (`ag login`) | P1-2 | 🔲 Ready |
+| 3.8 | Multi-tenancy primitives: `tenantId` on keys / sessions / audit | P1-1 | 🔲 Ready |
+| 3.9 | Workdir namespacing per tenant | P1-1 | 🔲 Ready |
+| 3.10 | Dashboard list virtualization (transcripts, session history) | P1-7 | 🔲 Ready |
+| 3.11 | Dashboard full a11y pass (focus traps, ARIA, contrast) | P1-7 | 🔄 In progress (#2230) |
+| 3.12 | i18n scaffolding (EN + IT to start) | — | 🔲 Ready |
 
 ## Architectural decisions to formalise during Phase 3
 
@@ -57,13 +59,13 @@ Each of these needs its own ADR before implementation:
 
 ## Activation checklist
 
-- [ ] Phase 2 exit checklist satisfied.
-- [ ] At least one external user request for an SSO, multi-tenancy, or
+- [x] Phase 2 exit checklist satisfied.
+- [x] At least one external user request for an SSO, multi-tenancy, or
   Postgres feature is on record (GitHub issue or documented conversation).
-- [ ] Update this file: status → **ACTIVE**, activation date set.
-- [ ] Open tracking issue **"EPIC: Phase 3 — Team & Early-Enterprise"**.
-- [ ] Open sub-issues referencing this epic.
-- [ ] ROADMAP.md updated.
+- [x] Update this file: status → **ACTIVE**, activation date set.
+- [x] Open tracking issue **"EPIC: Phase 3 — Team & Early-Enterprise"** (#1918).
+- [x] Open sub-issues referencing this epic.
+- [x] ROADMAP.md updated.
 
 ## Exit checklist
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,11 +74,11 @@ deployment guide: [EXTERNAL_DEPLOYMENT_GUIDE.md](./EXTERNAL_DEPLOYMENT_GUIDE.md)
 
 ---
 
-## Phase 3 — Team & Early-Enterprise (3–6 months, demand-driven)
+## Phase 3 — Team & Early-Enterprise (3–6 months, demand-driven) 🟢 ACTIVE (activated 2026-04-27)
 
 **Goal:** first external team of 10 + can run Aegis in production.
 
-- [ ] Pluggable `SessionStore` with Postgres implementation (P0-5)
+- [x] Pluggable `SessionStore` with Postgres implementation (P0-5) ✅ #2201
 - [ ] OpenTelemetry wired end-to-end ([ADR-0017](docs/adr/0017-opentelemetry-tracing.md), P1-3)
 - [ ] SDKs for TypeScript and Python generated from OpenAPI (P2-5)
 - [ ] SSO / OIDC (Entra ID, Google, Okta, Keycloak, Authentik) (P1-2)


### PR DESCRIPTION
## Summary

Formal activation of Phase 3 per the process defined in .claude/rules/positioning.md.

## Activation trigger (both satisfied)

- **Phase 2 exit checklist satisfied** — all Phase 2 items shipped and promoted to main (#2216)
- **External demand on record** — Ema requested Postgres persistence (shipped as #2201) and SSO for team use

## Changes

- .claude/epics/phase-3-team-early-enterprise/epic.md: status NOT ACTIVE → ACTIVE, activation date set, scope table updated with Status column
- ROADMAP.md: Phase 3 header marked ACTIVE (2026-04-27), SessionStore item marked shipped (#2201)

## Process compliance per positioning.md

1. Remove status:not-active from phase epic + sub-issues ✅
2. Flip phase status in .claude/epics/phase-3-team-early-enterprise/epic.md ✅
3. Update ROADMAP.md phase markers ✅

## Issue labels (updated separately)

- Removed status:not-active from all Phase 3 issues (#1918, #1938-#1947)
- Added in-progress to active assignments (#1944, #1938, #1942, #1946, #1947, #1940, #1941)