### PR TITLE
docs: update SDK documentation for Phase 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ src/
 
 ## TypeScript Client SDK
 
-Official `@onestepat4time/aegis-client` package for TypeScript/JavaScript applications.
+Official `@onestepat4time/aegis-client` package — generated from the OpenAPI 3.1 specification.
 
 ```bash
 npm install @onestepat4time/aegis-client
@@ -463,7 +463,7 @@ npm install @onestepat4time/aegis-client
 ```typescript
 import { AegisClient } from '@onestepat4time/aegis-client';
 
-const client = new AegisClient('http://localhost:18792', process.env.AEGIS_AUTH_TOKEN);
+const client = new AegisClient('http://localhost:9100', process.env.AEGIS_AUTH_TOKEN);
 
 // List sessions
 const sessions = await client.listSessions();
@@ -479,29 +479,52 @@ await client.approvePermission(id);
 ```
 
 **What's included:**
-- Full TypeScript types for all 30+ API endpoints
-- Sessions, health, metrics, pipelines, memory, audit log
-- Works in Node.js and browser
-- `X-Aegis-API-Version: 1` header on all requests
-- Configurable request timeouts
+- Generated from OpenAPI spec — all 53 REST endpoints with full TypeScript types
+- Backward-compatible class API + function-based API for new code
+- Sessions, health, metrics, pipelines, templates, memory, audit log
+- Works in Node.js and browser (fetch-based, zero external HTTP deps)
 
 See [`packages/client/`](packages/client/) for the full SDK source.
 
+## Python Client SDK
+
+Official `aegis-python-client` package with Pydantic v2 models generated from the OpenAPI spec.
+
+```bash
+pip install aegis-python-client
+```
+
+```python
+from aegis_python_client import AegisClient
+
+client = AegisClient(base_url="http://localhost:9100", auth_token="your-token")
+sessions = client.list_sessions()
+client.send_message(session_id, "Hello, Claude!")
+```
+
+**What's included:**
+- 53 public methods covering all REST endpoints
+- 33 Pydantic v2 models for type-safe request/response handling
+- Zero external HTTP dependencies (stdlib `urllib` only)
+
+See [`packages/python-client/`](packages/python-client/) for the full SDK source.
 
 
 ## Documentation
 
 - **[Getting Started](docs/getting-started.md)** — Zero to first session in 5 minutes
-- **[External Deployment Guide](EXTERNAL_DEPLOYMENT_GUIDE.md)** — Step-by-step for external teams
-- **[Phase 2 Exit Checklist](PHASE2_EXIT_CHECKLIST.md)** — Phase 2 completion validation
-- **[API Reference](docs/api-reference.md)** — Complete REST API documentation
+- **[API Reference](docs/api-reference.md)** — Complete REST API documentation (53 endpoints)
 - **[MCP Tools](docs/mcp-tools.md)** — 24 MCP tools and 3 prompts
-- **[Notifications](docs/integrations/notifications.md)** — Telegram, Slack, Email, webhooks
 - **[Advanced Features](docs/advanced.md)** — Pipelines, Memory Bridge, templates
 - **[Enterprise Deployment](docs/enterprise.md)** — Auth, rate limiting, security, production
 - **[Enterprise Technical Review](docs/enterprise/index.md)** — Deep architecture, security, observability, and roadmap analysis
-- **[Migration Guide](docs/migration-guide.md)** — Upgrading from `aegis-bridge`
 - **[Architecture](docs/architecture.md)** — Module overview and design
+- **[Migration Guide](docs/migration-guide.md)** — Upgrading from `aegis-bridge`
+- **[Notifications](docs/integrations/notifications.md)** — Telegram, Slack, Email, webhooks
+- **[Deployment Guide](docs/deployment.md)** — Secure access away from localhost
+- **[Remote Access](docs/remote-access.md)** — External access configuration
+- **[BYO LLM](docs/byo-llm.md)** — OpenAI-compatible provider setup (GLM, OpenRouter, LM Studio, Ollama)
+- **[Troubleshooting](docs/troubleshooting.md)** — Common issues and fixes
 - **[TypeDoc API](https://onestepat4time.github.io/aegis/)** — Auto-generated TypeScript reference
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,11 +102,20 @@ src/
 └── worktree-lookup.ts        # Git worktree discovery
 
 packages/
-└── client/                    # Official TypeScript client SDK (published to npm)
-    └── src/
-        ├── AegisClient.ts     # HTTP API client class
-        ├── types.ts           # All API contract types (SessionInfo, UIState, etc.)
-        └── index.ts           # Public package exports
+├── client/                    # Official TypeScript SDK (OpenAPI-generated, published to npm)
+│   └── src/
+│       ├── AegisClient.ts     # Backward-compatible wrapper class (v0.3.x API)
+│       ├── index.ts           # Public exports (class + SDK functions + types)
+│       └── generated/         # Auto-generated from openapi.yaml (do not edit)
+│           ├── sdk.gen.ts     # 53 endpoint functions
+│           ├── types.gen.ts   # Request/response types
+│           ├── client.gen.ts  # HTTP client setup
+│           └── core/          # Auth, serialization, SSE utilities
+└── python-client/             # Official Python SDK (OpenAPI-generated)
+    └── src/aegis_python_client/
+        ├── client.py           # AegisClient class (53 methods, urllib-based)
+        ├── models.py           # Pydantic v2 models (33 types)
+        └── __init__.py         # Package exports
 
 dashboard/                     # React dashboard (served by Fastify static)
 ├── src/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -238,6 +238,42 @@ memoryBridge:
 
 For the full configuration reference, see [Enterprise Deployment](./enterprise.md#configuration-reference).
 
+## Using the SDKs
+
+Aegis provides official client SDKs for TypeScript and Python, both generated from the OpenAPI 3.1 specification.
+
+### TypeScript SDK
+
+```bash
+npm install @onestepat4time/aegis-client
+```
+
+```typescript
+import { AegisClient } from '@onestepat4time/aegis-client';
+
+const client = new AegisClient('http://localhost:9100', process.env.AEGIS_AUTH_TOKEN);
+const sessions = await client.listSessions();
+await client.sendMessage(sessions[0].id, 'Continue the task');
+```
+
+See [`packages/client/`](../packages/client/) for source and the full README.
+
+### Python SDK
+
+```bash
+pip install aegis-python-client
+```
+
+```python
+from aegis_python_client import AegisClient
+
+client = AegisClient(base_url="http://localhost:9100", auth_token="your-token")
+sessions = client.list_sessions()
+client.send_message(sessions["sessions"][0]["id"], "Continue the task")
+```
+
+See [`packages/python-client/`](../packages/python-client/) for source and the full README.
+
 ## Next Steps
 
 - **[MCP Tools Reference](./mcp-tools.md)** — Full documentation for all 24 MCP tools


### PR DESCRIPTION
## Summary

Update README, getting-started guide, and architecture docs to reflect the Phase 3 SDK deliverables (TypeScript + Python).

## Changes

- **README.md**: Add Python SDK section, update TypeScript SDK section (53 endpoints, OpenAPI-generated, port 9100), clean up navigation links
- **docs/getting-started.md**: Add 'Using the SDKs' section with TypeScript and Python quick-start examples
- **docs/architecture.md**: Update `packages/` tree to show generated SDK structure (TS: `generated/` dir with 16 files, Python: `aegis_python_client/`)

## Verification

- [x] All code examples use port 9100 (not legacy 18792)
- [x] All SDK references match actual package structure
- [x] No broken links or stale references