### PR TITLE
feat: workdir namespacing per tenant (#1945)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -314,3 +314,61 @@ traces in your observability backend.
 
 See [Troubleshooting Guide](./troubleshooting.md) for common deployment issues.
 
+## Tenant Workdir Namespacing
+
+When multi-tenancy is enabled, you can restrict each tenant's sessions to a
+specific directory root. This prevents cross-tenant path access.
+
+### Configuration
+
+Add a `tenantWorkdirs` map to your config file (YAML or JSON):
+
+**YAML** (`.aegis/config.yaml`):
+
+```yaml
+tenantWorkdirs:
+  tenant-a:
+    root: /tenants/tenant-a
+    allowedPaths:
+      - projects
+      - workspace
+  tenant-b:
+    root: /tenants/tenant-b
+```
+
+**JSON** (`aegis.config.json`):
+
+```json
+{
+  "tenantWorkdirs": {
+    "tenant-a": {
+      "root": "/tenants/tenant-a",
+      "allowedPaths": ["projects", "workspace"]
+    },
+    "tenant-b": {
+      "root": "/tenants/tenant-b"
+    }
+  }
+}
+```
+
+### How it works
+
+- **`root`** (required): The directory root for the tenant. All session `workDir`
+  values must be at or under this path.
+- **`allowedPaths`** (optional): Further restrict to specific subdirectories
+  within the root. Paths are relative to `root`.
+
+### Behavior
+
+| Scenario | Result |
+|----------|--------|
+| Master token (no tenant) | Bypasses all workdir restrictions |
+| Tenant with no config | Unrestricted (backward compatible) |
+| Path under tenant root | Allowed |
+| Path outside tenant root | Rejected with 403 + audit log |
+| Path in unallowed subdirectory | Rejected with 403 + audit log |
+
+Cross-tenant violations are logged to the audit trail with action
+`session.action.denied` and the tenant ID.
+

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -220,6 +220,7 @@ async function buildTestServer(): Promise<{
     stateStore: 'file',
     postgresUrl: '',
     defaultTenantId: 'default',
+    tenantWorkdirs: {},
   };
 
   const auth = new AuthManager('/tmp/aegis-test-keys.json', AUTH_TOKEN);

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -100,6 +100,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     stateStore: 'file',
     postgresUrl: '',
     defaultTenantId: 'default',
+    tenantWorkdirs: {},
   } satisfies Config;
 
   const sessions = new SessionManager(

--- a/src/__tests__/tenant-workdir-1945.test.ts
+++ b/src/__tests__/tenant-workdir-1945.test.ts
@@ -1,0 +1,148 @@
+/**
+ * tenant-workdir-1945.test.ts — Tests for Issue #1945: tenant workdir namespacing.
+ *
+ * Covers:
+ *  - Master token (no tenantId) bypasses all restrictions
+ *  - Tenant with configured root: path under root is allowed
+ *  - Cross-tenant path rejection (path outside root)
+ *  - Path traversal attempts (..) are rejected
+ *  - Tenant without config falls back to unrestricted
+ *  - allowedPaths restricts subdirectories within root
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateWorkdirPath } from '../tenant-workdir.js';
+
+describe('Tenant workdir validation (Issue #1945)', () => {
+  describe('master token bypass', () => {
+    it('allows any path when tenantId is undefined', () => {
+      const result = validateWorkdirPath(undefined, '/any/random/path', {
+        tenantWorkdirs: {},
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.resolvedPath).toBe('/any/random/path');
+    });
+
+    it('allows any path when tenantId is undefined even with tenant config present', () => {
+      const result = validateWorkdirPath(undefined, '/etc/passwd', {
+        tenantWorkdirs: {
+          tenantA: { root: '/tenants/a' },
+        },
+      });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('tenant without config', () => {
+    it('allows any path for tenant with no workdir config (backward compat)', () => {
+      const result = validateWorkdirPath('unknown-tenant', '/any/path', {
+        tenantWorkdirs: {},
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows any path for tenant with no workdir config when other tenants have config', () => {
+      const result = validateWorkdirPath('tenantB', '/any/path', {
+        tenantWorkdirs: {
+          tenantA: { root: '/tenants/a' },
+        },
+      });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('tenant with configured root', () => {
+    const config = {
+      tenantWorkdirs: {
+        tenantA: { root: '/tenants/a' },
+        tenantB: { root: '/tenants/b' },
+      },
+    };
+
+    it('allows path exactly at tenant root', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/a', config);
+      expect(result.allowed).toBe(true);
+      expect(result.resolvedPath).toBe('/tenants/a');
+    });
+
+    it('allows path under tenant root', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/a/projects/my-app', config);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('rejects path in another tenant root', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/b/projects', config);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('outside tenant');
+      expect(result.reason).toContain('tenantA');
+    });
+
+    it('rejects path completely outside any tenant root', () => {
+      const result = validateWorkdirPath('tenantA', '/etc/secrets', config);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('outside tenant');
+    });
+
+    it('rejects path traversal attempt with ..', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/a/../../../etc/secrets', config);
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe('allowedPaths restriction', () => {
+    const config = {
+      tenantWorkdirs: {
+        tenantA: {
+          root: '/tenants/a',
+          allowedPaths: ['projects', 'workspace'],
+        },
+      },
+    };
+
+    it('allows path within an allowed subdirectory', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/a/projects/my-app', config);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows path within workspace subdirectory', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/a/workspace/repo', config);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('rejects path under root but not in any allowedPaths', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/a/forbidden-dir', config);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('not in tenant');
+    });
+
+    it('rejects path at root itself when allowedPaths is set', () => {
+      const result = validateWorkdirPath('tenantA', '/tenants/a', config);
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe('path normalization', () => {
+    const config = {
+      tenantWorkdirs: {
+        tenantA: { root: '/tenants/a' },
+      },
+    };
+
+    it('normalizes relative paths to absolute', () => {
+      const result = validateWorkdirPath('tenantA', 'relative/path', config);
+      // resolve('relative/path') becomes process.cwd() + '/relative/path'
+      // This should be rejected since cwd is likely not under /tenants/a
+      expect(result.allowed).toBe(false);
+    });
+
+    it('handles trailing slashes in root', () => {
+      const trailingConfig = {
+        tenantWorkdirs: {
+          tenantA: { root: '/tenants/a/' },
+        },
+      };
+      const result = validateWorkdirPath('tenantA', '/tenants/a/projects', trailingConfig);
+      expect(result.allowed).toBe(true);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,6 +138,10 @@ export interface Config {
   dashboardEnabled?: boolean;
   /** Issue #1944: Default tenant ID for keys/sessions without explicit tenant. Default: 'default'. Env: AEGIS_DEFAULT_TENANT_ID */
   defaultTenantId: string;
+  /** Issue #1945: Per-tenant workdir roots. Each tenant's sessions are scoped to their root.
+   *  Map of tenantId → { root: string, allowedPaths?: string[] }.
+   *  Empty = no tenant workdir restrictions (backward compatible). */
+  tenantWorkdirs: Record<string, { root: string; allowedPaths?: string[] }>;
   /** Issue #2097: API rate limiting configuration. */
   rateLimit: {
     /** Enable/disable rate limiting (default: true). */
@@ -207,6 +211,7 @@ const defaults: Config = {
   shutdownHardMs: 20_000,
   dashboardEnabled: true,
   defaultTenantId: 'default',
+  tenantWorkdirs: {},
   stateStore: 'file',
   postgresUrl: '',
   rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { compareSemver, extractCCVersion, MIN_CC_VERSION, buildEnvSchema } from '../validation.js';
+import { validateWorkdirPath } from '../tenant-workdir.js';
 import { cleanupTerminatedSessionState } from '../session-cleanup.js';
 import {
   type RouteContext,
@@ -339,6 +340,14 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
 
     const safeWorkDir = await validateWorkDir(workDir);
     if (typeof safeWorkDir === 'object') return reply.status(400).send({ error: safeWorkDir.error, code: safeWorkDir.code });
+
+    // Issue #1945: Tenant workdir namespace validation
+    const tenantWorkdirResult = validateWorkdirPath(req.tenantId, safeWorkDir, ctx.config);
+    if (!tenantWorkdirResult.allowed) {
+      const auditLogger = getAuditLogger();
+      if (auditLogger) void auditLogger.log(resolveAuditActor(auth, req.authKeyId, 'system'), 'session.action.denied', tenantWorkdirResult.reason ?? 'Tenant workdir validation failed', undefined, req.tenantId);
+      return reply.status(403).send({ error: tenantWorkdirResult.reason ?? 'workDir is outside tenant root', code: 'TENANT_WORKDIR_DENIED' });
+    }
 
     // Issue #607: Check for an existing idle session with the same workDir
     const existing = await sessions.findIdleSessionByWorkDir(safeWorkDir);

--- a/src/session.ts
+++ b/src/session.ts
@@ -19,6 +19,7 @@ import { SessionDiscovery } from './session-discovery.js';
 import type { Config } from './config.js';
 import { computeStallThreshold } from './config.js';
 import { getConfiguredBaseUrl } from './base-url.js';
+import { validateWorkdirPath } from './tenant-workdir.js';
 import { neutralizeBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
 import { persistedStateSchema, type PermissionPolicy, type PermissionProfile, ENV_NAME_RE, ENV_DENYLIST, ENV_DANGEROUS_PREFIXES, stripCrLf, hasControlChars, ENV_VALUE_MAX_BYTES, sanitizeWindowName } from './validation.js';
 import type { z } from 'zod';
@@ -822,6 +823,12 @@ export class SessionManager {
     opts: Parameters<SessionManager['createSession']>[0],
     parentSpan: Span,
   ): Promise<SessionInfo> {
+    // Issue #1945: Validate workdir path against tenant workdir namespace
+    const workdirValidation = validateWorkdirPath(opts.tenantId, opts.workDir, this.config);
+    if (!workdirValidation.allowed) {
+      throw new Error(workdirValidation.reason ?? 'workDir is outside tenant root');
+    }
+
     const windowName = opts.name ? sanitizeWindowName(opts.name) : `cc-${id.slice(0, 8)}`;
 
     // Merge defaultSessionEnv (from config) with per-session env (per-session wins)

--- a/src/tenant-workdir.ts
+++ b/src/tenant-workdir.ts
@@ -1,0 +1,83 @@
+/**
+ * tenant-workdir.ts — Tenant-scoped workdir path validation.
+ *
+ * Issue #1945: Each tenant's sessions are scoped to a tenant-specific
+ * workdir root. Cross-tenant path attempts fail closed with an audited
+ * rejection.
+ *
+ * Master tokens (tenantId === undefined) bypass all restrictions.
+ * Tenants without a configured root fall back to unrestricted (backward compat).
+ */
+
+import { resolve, relative } from 'node:path';
+import type { Config } from './config.js';
+
+export interface WorkdirValidationResult {
+  allowed: boolean;
+  resolvedPath: string;
+  reason?: string;
+}
+
+/**
+ * Validate that a requested workdir path is within the tenant's allowed root.
+ *
+ * @param tenantId - The tenant ID from the API key (undefined = master token)
+ * @param requestedPath - The workDir requested for the session
+ * @param config - Aegis config (contains tenantWorkdirs map)
+ * @returns Validation result with resolved path and optional rejection reason
+ */
+export function validateWorkdirPath(
+  tenantId: string | undefined,
+  requestedPath: string,
+  config: Pick<Config, 'tenantWorkdirs'>,
+): WorkdirValidationResult {
+  const resolvedPath = resolve(requestedPath);
+
+  // Master tokens (no tenantId) bypass all workdir restrictions
+  if (tenantId === undefined) {
+    return { allowed: true, resolvedPath };
+  }
+
+  // Look up tenant workdir configuration
+  const tenantWorkdirs = config.tenantWorkdirs ?? {};
+  const tenantConfig = tenantWorkdirs[tenantId];
+
+  // No config for this tenant = unrestricted (backward compatible)
+  if (!tenantConfig) {
+    return { allowed: true, resolvedPath };
+  }
+
+  // Resolve the tenant root for consistent comparison
+  const tenantRoot = resolve(tenantConfig.root);
+
+  // Check if the resolved path is under the tenant root
+  const relativePath = relative(tenantRoot, resolvedPath);
+
+  // If relative path starts with '..', the path escapes the tenant root
+  if (relativePath.startsWith('..') || relativePath.startsWith('/')) {
+    return {
+      allowed: false,
+      resolvedPath,
+      reason: `workDir "${resolvedPath}" is outside tenant "${tenantId}" root "${tenantRoot}"`,
+    };
+  }
+
+  // If allowedPaths is configured, additionally check against the allowlist
+  if (tenantConfig.allowedPaths && tenantConfig.allowedPaths.length > 0) {
+    const allowed = tenantConfig.allowedPaths.some((allowedPath) => {
+      const resolvedAllowed = resolve(tenantRoot, allowedPath);
+      const rel = relative(resolvedAllowed, resolvedPath);
+      return !rel.startsWith('..') && !rel.startsWith('/');
+    });
+
+    if (!allowed) {
+      return {
+        allowed: false,
+        resolvedPath,
+        reason: `workDir "${resolvedPath}" is not in tenant "${tenantId}" allowed paths`,
+      };
+    }
+  }
+
+  return { allowed: true, resolvedPath };
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -804,6 +804,10 @@ export const configFileSchema = z.object({
   shutdownHardMs: z.number().int().positive().optional(),
   dashboardEnabled: z.boolean().optional(),
   defaultTenantId: z.string().optional(),
+  tenantWorkdirs: z.record(z.string(), z.object({
+    root: z.string(),
+    allowedPaths: z.array(z.string()).optional(),
+  })).optional(),
   stateStore: z.enum(['file', 'redis', 'postgres']).optional(),
   postgresUrl: z.string().optional(),
   rateLimit: z.object({


### PR DESCRIPTION
## Summary

- Adds `tenantWorkdirs` config map to restrict each tenant's sessions to a configured directory root
- Creates `validateWorkdirPath()` in `src/tenant-workdir.ts` for tenant-scoped path validation
- Applies validation at session creation in both `session.ts` and `routes/sessions.ts`
- Master tokens bypass all restrictions; tenants without config are unrestricted (backward compatible)
- Cross-tenant violations fail closed with 403 + audit log (`session.action.denied`)
- 15 unit tests covering bypass, cross-tenant rejection, path traversal, allowedPaths
- Documents configuration in `docs/deployment.md`

## Aegis version
**Developed with:** v0.6.0-preview

## Test plan
- [x] `npx tsc --noEmit` passes (zero new errors; 6 pre-existing rate-limit/ioredis errors)
- [x] `npm test` passes (zero new failures; pre-existing failures on develop)
- [x] 15 new unit tests in `src/__tests__/tenant-workdir-1945.test.ts`
- [x] Existing multitenancy tests (`multitenancy-1944.test.ts`, `multi-tenancy-1944.test.ts`) pass
- [ ] Manual: configure `tenantWorkdirs` and verify cross-tenant rejection via API

Closes #1945

Generated by Hephaestus (Aegis dev agent)