### PR TITLE
fix(dashboard): resolve session cards overlapping in Overview page

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -1011,7 +1011,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
         </div>
       ) : (
         <>
-          <div className="space-y-3 md:hidden">
+          <div className="flex flex-col gap-3 md:hidden">
             <div className="flex items-center justify-between rounded-md border border-void-lighter bg-[var(--color-surface)] px-4 py-3 text-sm text-gray-400">
               <label className="flex items-center gap-2">
                 <input


### PR DESCRIPTION
## Summary
Replace `space-y-3` with `flex flex-col gap-3` on the mobile session card container in the Overview page.

## Root Cause
`space-y-3` uses `margin-top` which interacts with the `animate-bento-reveal` transform (`translateY(20px) scale(0.98)`) during staggered animation delays (0-250ms across 6 children). This causes visual overlap where text from multiple rows renders in the same area during and after the entrance animation.

`flex gap` does not interact with CSS transforms the same way, eliminating the overlap.

## Changes
- `dashboard/src/components/overview/SessionTable.tsx` line 1014: `space-y-3` → `flex flex-col gap-3`

## Verification
- ✅ TypeScript: zero errors
- ✅ Build: clean
- ✅ Tests: 78 files / 724 passed / 2 skipped / 0 failures

Closes #2251