### PR TITLE
fix(gates): enable worktree execution by resolving repo root from cwd

### DIFF
--- a/scripts/clickable-gate.cjs
+++ b/scripts/clickable-gate.cjs
@@ -12,8 +12,23 @@
 const fs = require('fs');
 const path = require('path');
 
-const ALLOWLIST_PATH = path.join(__dirname, 'clickable-gate.allowlist.txt');
-const SCAN_DIR = path.join(__dirname, '..', 'dashboard', 'src');
+// Resolve repo root by finding .git directory upward from cwd.
+// This allows the script to scan a worktree instead of the main repo
+// when executed from within a worktree directory.
+function findRepoRoot(cwd) {
+  let dir = path.resolve(cwd);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(__dirname, '..');
+}
+
+const REPO_ROOT = findRepoRoot(process.cwd());
+const ALLOWLIST_PATH = path.join(REPO_ROOT, 'scripts', 'clickable-gate.allowlist.txt');
+const SCAN_DIR = path.join(REPO_ROOT, 'dashboard', 'src');
 
 function loadAllowlist() {
   if (!fs.existsSync(ALLOWLIST_PATH)) return new Set();
@@ -124,7 +139,7 @@ function main() {
 
   for (const file of files) {
     // Normalize to relative path using forward slashes for allowlist comparison
-    const rel = path.relative(path.join(__dirname, '..'), file).replace(/\\/g, '/');
+    const rel = path.relative(REPO_ROOT, file).replace(/\\/g, '/');
     if (allowlist.has(rel)) continue;
 
     const violations = checkFile(file);

--- a/scripts/dashboard-tokens-gate.cjs
+++ b/scripts/dashboard-tokens-gate.cjs
@@ -26,7 +26,21 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const REPO_ROOT = path.resolve(__dirname, '..');
+// Resolve repo root by finding .git directory upward from cwd.
+// This allows the script to scan a worktree instead of the main repo
+// when executed from within a worktree directory.
+function findRepoRoot(cwd) {
+  let dir = path.resolve(cwd);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return path.resolve(__dirname, '..'); // fallback to script location
+}
+
+const REPO_ROOT = findRepoRoot(process.cwd());
 const SCAN_ROOTS = [
   path.join(REPO_ROOT, 'dashboard', 'src', 'components'),
   path.join(REPO_ROOT, 'dashboard', 'src', 'pages'),


### PR DESCRIPTION
## Summary

Both `dashboard-tokens-gate.cjs` and `clickable-gate.cjs` previously resolved `REPO_ROOT` as `__dirname/..` (relative to the script file location). When the agent runs gates from a git worktree (e.g. `.claude/worktrees/fix-NNN/`), the scanner would incorrectly point at the main repo's `dashboard/src/` tree instead of the worktree's.

The fix adds a `findRepoRoot()` helper that walks upward from `process.cwd()` looking for a `.git` directory, falling back to `__dirname/..` for scripts run outside a repo context. All path computations (SCAN_DIR, ALLOWLIST_FILE, etc.) now use the resolved REPO_ROOT, so both scripts work correctly whether invoked from the repo root or from within a worktree.

## Test Plan

- [x] `npm run gate` passes on the worktree branch
- [x] Both `dashboard-tokens-gate.cjs` and `clickable-gate.cjs` pass when invoked from the worktree directory
- [x] All 3644 tests pass

Closes #2263