### PR TITLE
feat(dashboard): add TimeFilterBar component for analytics (#2249)

### DIFF
--- a/dashboard/src/__tests__/TimeFilterBar.test.tsx
+++ b/dashboard/src/__tests__/TimeFilterBar.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * __tests__/components/analytics/TimeFilterBar.test.tsx
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TimeFilterBar, { type TimeRange } from '../components/analytics/TimeFilterBar';
+
+describe('TimeFilterBar', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock URL API
+    delete (window as unknown as Record<string, unknown>).location;
+    (window as any).location = {
+      pathname: '/analytics',
+      search: '',
+      href: '/analytics',
+      replaceState: vi.fn(),
+    } as unknown as Location;
+  });
+
+  function renderBar(value: TimeRange = { from: null, to: null }) {
+    return render(<TimeFilterBar value={value} onChange={onChange} />);
+  }
+
+  it('renders all 6 preset buttons', () => {
+    renderBar();
+    expect(screen.getByRole('toolbar', { name: 'Time range filter' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '1h' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '12h' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Today' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Last week' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Last month' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'All' })).toBeTruthy();
+  });
+
+  it('calls onChange with null range when "All" is clicked', () => {
+    renderBar();
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(onChange).toHaveBeenCalledWith({ from: null, to: null });
+  });
+
+  it('calls onChange with ISO date range when "1h" is clicked', () => {
+    renderBar();
+    fireEvent.click(screen.getByRole('button', { name: '1h' }));
+    const call = onChange.mock.calls[0][0] as TimeRange;
+    expect(call.from).toBeTruthy();
+    expect(call.to).toBeTruthy();
+    const fromTime = new Date(call.from!).getTime();
+    const toTime = new Date(call.to!).getTime();
+    const diffMinutes = (toTime - fromTime) / (1000 * 60);
+    expect(diffMinutes).toBeGreaterThanOrEqual(55);
+    expect(diffMinutes).toBeLessThanOrEqual(65);
+  });
+
+  it('sets aria-pressed on active button', () => {
+    renderBar();
+    expect(screen.getByRole('button', { name: 'All' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: '1h' }).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('updates aria-pressed when a different preset is clicked', () => {
+    renderBar();
+    fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+    expect(screen.getByRole('button', { name: 'Today' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'All' }).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('syncs from URL params on mount', () => {
+    window.location.search = '?from=2026-04-01T00:00:00.000Z&to=2026-04-28T00:00:00.000Z';
+    renderBar();
+    expect(onChange).toHaveBeenCalledWith({
+      from: '2026-04-01T00:00:00.000Z',
+      to: '2026-04-28T00:00:00.000Z',
+    });
+  });
+
+  it('sets from and to in onChange when a preset is clicked', () => {
+    renderBar();
+    fireEvent.click(screen.getByRole('button', { name: 'Last week' }));
+    const call = onChange.mock.calls[0][0] as TimeRange;
+    expect(call.from).toBeTruthy();
+    expect(call.to).toBeTruthy();
+  });
+
+  it('accepts className prop', () => {
+    const { container } = render(
+      <TimeFilterBar value={{ from: null, to: null }} onChange={onChange} className="extra-class" />,
+    );
+    expect(container.firstChild).toBeTruthy();
+    expect((container.firstChild as HTMLElement).className).toContain('extra-class');
+  });
+
+  it('computes "Today" preset starting at midnight', () => {
+    renderBar();
+    fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+    const call = onChange.mock.calls[0][0] as TimeRange;
+    const fromDate = new Date(call.from!);
+    expect(fromDate.getHours()).toBe(0);
+    expect(fromDate.getMinutes()).toBe(0);
+  });
+
+  it('computes "Last month" preset approximately 30 days back', () => {
+    renderBar();
+    fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
+    const call = onChange.mock.calls[0][0] as TimeRange;
+    const fromTime = new Date(call.from!).getTime();
+    const toTime = new Date(call.to!).getTime();
+    const diffDays = (toTime - fromTime) / (1000 * 60 * 60 * 24);
+    expect(diffDays).toBeGreaterThanOrEqual(28);
+    expect(diffDays).toBeLessThanOrEqual(32);
+  });
+});

--- a/dashboard/src/components/analytics/TimeFilterBar.tsx
+++ b/dashboard/src/components/analytics/TimeFilterBar.tsx
@@ -1,0 +1,119 @@
+/**
+ * components/analytics/TimeFilterBar.tsx — Time range filter for analytics pages.
+ *
+ * Preset buttons compute `from`/`to` ISO strings.
+ * State syncs to URL search params for shareable views.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Clock, CalendarDays, CalendarRange, Infinity } from 'lucide-react';
+
+export interface TimeRange {
+  from: string | null;
+  to: string | null;
+}
+
+interface TimeFilterBarProps {
+  value: TimeRange;
+  onChange: (range: TimeRange) => void;
+  className?: string;
+}
+
+const PRESETS = [
+  { label: '1h', icon: Clock, compute: () => ({ from: hoursAgo(1), to: now() }) },
+  { label: '12h', icon: Clock, compute: () => ({ from: hoursAgo(12), to: now() }) },
+  { label: 'Today', icon: CalendarDays, compute: () => ({ from: startOfDay(), to: now() }) },
+  { label: 'Last week', icon: CalendarRange, compute: () => ({ from: daysAgo(7), to: now() }) },
+  { label: 'Last month', icon: CalendarRange, compute: () => ({ from: daysAgo(30), to: now() }) },
+  { label: 'All', icon: Infinity, compute: () => ({ from: null, to: null }) },
+] as const;
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function hoursAgo(h: number): string {
+  return new Date(Date.now() - h * 60 * 60 * 1000).toISOString();
+}
+
+function daysAgo(d: number): string {
+  return new Date(Date.now() - d * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function startOfDay(): string {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
+export default function TimeFilterBar({ value, onChange, className = '' }: TimeFilterBarProps) {
+  const [activePreset, setActivePreset] = useState<string | null>(() => {
+    if (!value.from && !value.to) return 'All';
+    const from = value.from ? new Date(value.from).getTime() : 0;
+    const diff = Date.now() - from;
+    if (diff <= 1.5 * 60 * 60 * 1000) return '1h';
+    if (diff <= 13 * 60 * 60 * 1000) return '12h';
+    if (diff <= 25 * 60 * 60 * 1000) return 'Today';
+    if (diff <= 8 * 24 * 60 * 60 * 1000) return 'Last week';
+    if (diff <= 32 * 24 * 60 * 60 * 1000) return 'Last month';
+    return null;
+  });
+
+  // Sync from URL params on mount
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const from = params.get('from');
+    const to = params.get('to');
+    if (from || to) {
+      onChange({ from, to });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync to URL params
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (value.from) params.set('from', value.from);
+    else params.delete('from');
+    if (value.to) params.set('to', value.to);
+    else params.delete('to');
+    const qs = params.toString();
+    const newUrl = `${window.location.pathname}${qs ? `?${qs}` : ''}`;
+    window.history.replaceState(null, '', newUrl);
+  }, [value.from, value.to]);
+
+  const handlePreset = useCallback(
+    (label: string, compute: () => TimeRange) => {
+      const range = compute();
+      setActivePreset(label);
+      onChange(range);
+    },
+    [onChange],
+  );
+
+  const presets = useMemo(() => PRESETS, []);
+
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-2 ${className}`}
+      role="toolbar"
+      aria-label="Time range filter"
+    >
+      {presets.map(({ label, icon: Icon }) => (
+        <button
+          key={label}
+          type="button"
+          onClick={() => handlePreset(label, presets.find((p) => p.label === label)!.compute)}
+          className={`inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] ${
+            activePreset === label
+              ? 'border-[var(--color-accent-cyan)] bg-[var(--color-accent-cyan)]/10 text-[var(--color-accent-cyan)]'
+              : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-secondary)] hover:border-[var(--color-accent-cyan)]/40 hover:text-[var(--color-text-primary)]'
+          }`}
+          aria-pressed={activePreset === label}
+        >
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
First component of the analytics dashboard (#2249). TimeFilterBar provides preset time range buttons (1h, 12h, Today, Last week, Last month, All) that compute ISO date ranges and sync to URL search params for shareable views.

## Changes
- `dashboard/src/components/analytics/TimeFilterBar.tsx` — new component (132 lines)
- `dashboard/src/__tests__/TimeFilterBar.test.tsx` — 10 Vitest tests

## Features
- 6 preset buttons with icons from lucide-react
- Computes `from`/`to` ISO strings from selected preset
- Reads URL params on mount for shareable views
- Writes URL params on change via `history.replaceState`
- Active preset auto-detection on mount
- CSS custom properties for all colors (no hardcoded hex)
- `aria-pressed` on active button, `role="toolbar"` on container
- Responsive flex-wrap layout

## Verification
- ✅ TypeScript: zero source errors
- ✅ Build: clean
- ✅ Tests: 10/10 passed
- ✅ No new dependencies

Part of #2249 (analytics dashboard cards, heatmaps, time filters)