### PR TITLE
feat(dashboard): add ProjectCardGrid and HeatmapGrid for analytics (#2249)

### DIFF
--- a/dashboard/src/__tests__/HeatmapGrid.test.tsx
+++ b/dashboard/src/__tests__/HeatmapGrid.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * __tests__/HeatmapGrid.test.tsx
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HeatmapGrid, type HeatmapDataPoint } from '../components/analytics/HeatmapGrid';
+
+/** Generate daily data for the last N days. */
+function generateDailyData(days: number, maxVal: number = 100): HeatmapDataPoint[] {
+  const data: HeatmapDataPoint[] = [];
+  const now = new Date();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toISOString().split('T')[0] ?? '';
+    data.push({
+      date: dateStr,
+      value: Math.round(Math.random() * maxVal),
+    });
+  }
+  return data;
+}
+
+describe('HeatmapGrid', () => {
+  it('renders an SVG with the correct role', () => {
+    const data = generateDailyData(30);
+    render(<HeatmapGrid data={data} metricLabel="Sessions" />);
+    const svg = screen.getByRole('img', { name: /Sessions heatmap/ });
+    expect(svg).toBeTruthy();
+  });
+
+  it('renders grid cells for every day in the range', () => {
+    const data = generateDailyData(7);
+    render(<HeatmapGrid data={data} weeks={1} />);
+    // 1 week × 7 days = 7 cells
+    const cells = screen.getAllByRole('gridcell');
+    expect(cells).toHaveLength(7);
+  });
+
+  it('renders cells for 53 weeks by default', () => {
+    const data = generateDailyData(10);
+    render(<HeatmapGrid data={data} />);
+    const cells = screen.getAllByRole('gridcell');
+    expect(cells.length).toBe(53 * 7);
+  });
+
+  it('applies aria-labels with date and value to cells', () => {
+    const data: HeatmapDataPoint[] = [
+      { date: '2026-04-28', value: 42 },
+    ];
+    render(<HeatmapGrid data={data} weeks={1} metricLabel="tokens" />);
+    const cell = screen.getByRole('gridcell', { name: /2026-04-28: 42 tokens/ });
+    expect(cell).toBeTruthy();
+  });
+
+  it('uses color intensity based on value relative to max', () => {
+    const data: HeatmapDataPoint[] = [
+      { date: '2026-04-28', value: 0 },   // level 0
+      { date: '2026-04-27', value: 10 },  // level 1 (10/100 = 0.1)
+      { date: '2026-04-26', value: 50 },  // level 2 (50/100 = 0.5)
+      { date: '2026-04-25', value: 75 },  // level 3 (75/100 = 0.75)
+      { date: '2026-04-24', value: 100 }, // level 4 (100/100 = 1.0)
+    ];
+    const { container } = render(<HeatmapGrid data={data} weeks={1} />);
+    const rects = container.querySelectorAll('rect[role="gridcell"]');
+
+    // Verify different fill values — level 0 should differ from level 4
+    const fills = Array.from(rects).map((r) => r.getAttribute('fill'));
+    const uniqueFills = new Set(fills);
+    expect(uniqueFills.size).toBeGreaterThan(1);
+  });
+
+  it('supports different color scales', () => {
+    const data = generateDailyData(14);
+    const { container: cyanContainer } = render(
+      <HeatmapGrid data={data} weeks={2} color="cyan" />,
+    );
+    const { container: purpleContainer } = render(
+      <HeatmapGrid data={data} weeks={2} color="purple" />,
+    );
+
+    const cyanCells = cyanContainer.querySelectorAll('rect[role="gridcell"]');
+    const purpleCells = purpleContainer.querySelectorAll('rect[role="gridcell"]');
+
+    // Both should render the same number of cells
+    expect(cyanCells.length).toBe(purpleCells.length);
+
+    // Colors should differ for at least some non-zero cells
+    const cyanFills = Array.from(cyanCells).map((r) => r.getAttribute('fill'));
+    const purpleFills = Array.from(purpleCells).map((r) => r.getAttribute('fill'));
+
+    // At least one cell with a value should have different fills between cyan and purple
+    const hasDifference = cyanFills.some(
+      (f, i) => f !== purpleFills[i] && f !== 'var(--color-void-light)',
+    );
+    expect(hasDifference).toBe(true);
+  });
+
+  it('formats tooltip values using formatValue prop', () => {
+    const data: HeatmapDataPoint[] = [
+      { date: '2026-04-28', value: 1234 },
+    ];
+    render(
+      <HeatmapGrid
+        data={data}
+        weeks={1}
+        metricLabel="tokens"
+        formatValue={(v) => `${(v / 1000).toFixed(1)}K`}
+      />,
+    );
+    const cell = screen.getByRole('gridcell', { name: /2026-04-28: 1.2K tokens/ });
+    expect(cell).toBeTruthy();
+  });
+
+  it('renders legend with Less/More labels', () => {
+    const data = generateDailyData(7);
+    const { container } = render(<HeatmapGrid data={data} weeks={1} />);
+    expect(screen.getByText('Less')).toBeTruthy();
+    expect(screen.getByText('More')).toBeTruthy();
+
+    // Legend should have 5 color swatches
+    const swatches = container.querySelectorAll('.rounded-sm');
+    expect(swatches).toHaveLength(5);
+  });
+
+  it('renders month labels for transitions', () => {
+    // Generate data spanning 2 months
+    const data: HeatmapDataPoint[] = [];
+    for (let i = 0; i < 60; i++) {
+      const d = new Date();
+      d.setDate(d.getDate() - i);
+      data.push({ date: d.toISOString().split('T')[0] ?? '', value: 10 });
+    }
+    render(<HeatmapGrid data={data} weeks={9} />);
+    // Should have at least 1 month label
+    const textElements = document.querySelectorAll('svg text');
+    const monthTexts = Array.from(textElements).filter(
+      (t) => t.textContent && ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'].includes(t.textContent),
+    );
+    expect(monthTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows tooltip on cell hover', () => {
+    const data: HeatmapDataPoint[] = [
+      { date: '2026-04-28', value: 99 },
+      { date: '2026-04-27', value: 0 },
+    ];
+    render(<HeatmapGrid data={data} weeks={1} />);
+
+    const cell = screen.getByRole('gridcell', { name: /2026-04-28/ });
+    fireEvent.mouseEnter(cell);
+
+    // Tooltip should appear as SVG text
+    const svg = screen.getByRole('img');
+    const tooltipGroup = svg.querySelector('g[pointer-events="none"]');
+    expect(tooltipGroup).toBeTruthy();
+  });
+
+  it('hides tooltip on cell leave', () => {
+    const data: HeatmapDataPoint[] = [
+      { date: '2026-04-28', value: 50 },
+    ];
+    render(<HeatmapGrid data={data} weeks={1} />);
+
+    const cell = screen.getByRole('gridcell', { name: /2026-04-28/ });
+    fireEvent.mouseEnter(cell);
+    fireEvent.mouseLeave(cell);
+
+    // Tooltip group should be gone
+    const svg = screen.getByRole('img');
+    const tooltipGroup = svg.querySelector('g[pointer-events="none"]');
+    expect(tooltipGroup).toBeNull();
+  });
+
+  it('renders empty cells with zero value as level 0', () => {
+    const data: HeatmapDataPoint[] = [
+      { date: '2026-04-28', value: 0 },
+    ];
+    const { container } = render(<HeatmapGrid data={data} weeks={1} />);
+    const cell = container.querySelector('rect[role="gridcell"]');
+    expect(cell?.getAttribute('fill')).toBe('var(--color-void-light)');
+  });
+
+  it('accepts className prop', () => {
+    const data = generateDailyData(7);
+    const { container } = render(
+      <HeatmapGrid data={data} weeks={1} className="extra-spacing" />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain('extra-spacing');
+  });
+});

--- a/dashboard/src/__tests__/ProjectCardGrid.test.tsx
+++ b/dashboard/src/__tests__/ProjectCardGrid.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * __tests__/ProjectCardGrid.test.tsx
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectCardGrid, type ProjectSummary } from '../components/analytics/ProjectCardGrid';
+
+// Mock react-router-dom navigate
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const SAMPLE_PROJECTS: ProjectSummary[] = [
+  {
+    name: 'aegis',
+    workDir: '/home/user/projects/aegis',
+    sessions: 42,
+    totalCostUsd: 15.5,
+    totalTokens: 1_200_000,
+    costTrend: [1, 2, 3, 4, 5, 4, 3],
+  },
+  {
+    name: 'my-app',
+    workDir: '/home/user/projects/my-app',
+    sessions: 12,
+    totalCostUsd: 3.2,
+    totalTokens: 350_000,
+    costTrend: [0.5, 1, 0.8, 0.9, 1.2, 1.1, 0.7],
+  },
+  {
+    name: 'empty-project',
+    workDir: '/home/user/projects/empty',
+    sessions: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    costTrend: [],
+  },
+];
+
+function renderGrid(projects: ProjectSummary[] = SAMPLE_PROJECTS) {
+  return render(
+    <MemoryRouter>
+      <ProjectCardGrid projects={projects} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ProjectCardGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a card for each project', () => {
+    renderGrid();
+    const cards = screen.getAllByRole('listitem');
+    expect(cards).toHaveLength(3);
+  });
+
+  it('renders the grid container with aria-label', () => {
+    renderGrid();
+    expect(screen.getByRole('list', { name: 'Project cards' })).toBeTruthy();
+  });
+
+  it('displays project names', () => {
+    renderGrid();
+    expect(screen.getByText('aegis')).toBeTruthy();
+    expect(screen.getByText('my-app')).toBeTruthy();
+    expect(screen.getByText('empty-project')).toBeTruthy();
+  });
+
+  it('shows session counts', () => {
+    renderGrid();
+    expect(screen.getByText('42')).toBeTruthy();
+    expect(screen.getByText('12')).toBeTruthy();
+    // '0' appears in the empty-project's sessions pill
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('navigates to project detail on click', () => {
+    renderGrid();
+    fireEvent.click(screen.getByRole('listitem', { name: /aegis/ }));
+    expect(mockNavigate).toHaveBeenCalledWith('/analytics/aegis');
+  });
+
+  it('encodes project names with special characters', () => {
+    const projects: ProjectSummary[] = [
+      {
+        name: 'my project',
+        workDir: '/home/user/my project',
+        sessions: 1,
+        totalCostUsd: 0,
+        totalTokens: 0,
+        costTrend: [],
+      },
+    ];
+    render(
+      <MemoryRouter>
+        <ProjectCardGrid projects={projects} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('listitem'));
+    expect(mockNavigate).toHaveBeenCalledWith('/analytics/my%20project');
+  });
+
+  it('renders sparkline for projects with cost trend data', () => {
+    renderGrid();
+    // SparkLine SVG elements with aria-labels
+    const sparklines = screen.getAllByRole('img').filter(
+      (el) => el.getAttribute('aria-label')?.includes('Cost trend'),
+    );
+    expect(sparklines).toHaveLength(2); // aegis and my-app have trend data
+  });
+
+  it('does not render sparkline for projects without trend data', () => {
+    renderGrid();
+    const emptyCard = screen.getByRole('listitem', { name: /empty-project/ });
+    // empty-project has no costTrend, so no SparkLine SVG inside
+    // (FolderKanban icon SVG has aria-hidden, SparkLine has role="img")
+    const sparkSvg = emptyCard.querySelector('svg[role="img"]');
+    expect(sparkSvg).toBeNull();
+  });
+
+  it('shows empty state when no projects provided', () => {
+    renderGrid([]);
+    expect(screen.getByText('No project data available')).toBeTruthy();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ProjectCardGrid projects={SAMPLE_PROJECTS} className="custom-class" />
+      </MemoryRouter>,
+    );
+    const grid = container.querySelector('[role="list"]');
+    expect(grid?.className).toContain('custom-class');
+  });
+});

--- a/dashboard/src/components/analytics/HeatmapGrid.tsx
+++ b/dashboard/src/components/analytics/HeatmapGrid.tsx
@@ -1,0 +1,299 @@
+/**
+ * components/analytics/HeatmapGrid.tsx — GitHub-style contribution heatmap.
+ *
+ * Renders a grid of colored cells where:
+ * - Each cell = one day
+ * - Rows = days of week (Mon–Sun)
+ * - Columns = weeks
+ * - Color intensity maps to the metric value
+ *
+ * Pure SVG implementation (no chart library dependency).
+ * Follows the SparkLine.tsx pattern for theming via CSS custom properties.
+ */
+
+import { useMemo, useState, useCallback } from 'react';
+
+export interface HeatmapDataPoint {
+  date: string; // YYYY-MM-DD
+  value: number;
+}
+
+interface HeatmapGridProps {
+  data: HeatmapDataPoint[];
+  /** Number of weeks to display. Defaults to 53 (~1 year). */
+  weeks?: number;
+  /** Color accent for cells. Defaults to cyan. */
+  color?: 'cyan' | 'purple' | 'green';
+  /** Label shown in legend / aria. */
+  metricLabel?: string;
+  /** Format function for tooltip values. */
+  formatValue?: (value: number) => string;
+  className?: string;
+}
+
+const COLOR_SCALES = {
+  cyan: {
+    empty: 'var(--color-void-light)',
+    level1: 'rgba(6, 182, 212, 0.2)',
+    level2: 'rgba(6, 182, 212, 0.4)',
+    level3: 'rgba(6, 182, 212, 0.65)',
+    level4: 'rgba(6, 182, 212, 0.9)',
+  },
+  purple: {
+    empty: 'var(--color-void-light)',
+    level1: 'rgba(139, 92, 246, 0.2)',
+    level2: 'rgba(139, 92, 246, 0.4)',
+    level3: 'rgba(139, 92, 246, 0.65)',
+    level4: 'rgba(139, 92, 246, 0.9)',
+  },
+  green: {
+    empty: 'var(--color-void-light)',
+    level1: 'rgba(34, 197, 94, 0.2)',
+    level2: 'rgba(34, 197, 94, 0.4)',
+    level3: 'rgba(34, 197, 94, 0.65)',
+    level4: 'rgba(34, 197, 94, 0.9)',
+  },
+} as const;
+
+type ColorScale = typeof COLOR_SCALES[keyof typeof COLOR_SCALES];
+type IntensityLevel = 0 | 1 | 2 | 3 | 4;
+
+const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const;
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const;
+
+const CELL_SIZE = 12;
+const CELL_GAP = 2;
+const CELL_RADIUS = 2;
+const LABEL_WIDTH = 32;
+const MONTH_LABEL_HEIGHT = 18;
+
+function getIntensityLevel(value: number, max: number): IntensityLevel {
+  if (value === 0 || max === 0) return 0;
+  const ratio = value / max;
+  if (ratio <= 0.25) return 1;
+  if (ratio <= 0.5) return 2;
+  if (ratio <= 0.75) return 3;
+  return 4;
+}
+
+function getLevelColor(level: IntensityLevel, scale: ColorScale): string {
+  switch (level) {
+    case 0: return scale.empty;
+    case 1: return scale.level1;
+    case 2: return scale.level2;
+    case 3: return scale.level3;
+    case 4: return scale.level4;
+  }
+}
+
+interface GridCell {
+  date: string;
+  row: number;
+  col: number;
+  value: number;
+  level: IntensityLevel;
+}
+
+interface MonthMarker {
+  label: string;
+  col: number;
+}
+
+interface TooltipState {
+  date: string;
+  value: number;
+  x: number;
+  y: number;
+}
+
+export function HeatmapGrid({
+  data,
+  weeks = 53,
+  color = 'cyan',
+  metricLabel = 'Activity',
+  formatValue = (v) => String(v),
+  className = '',
+}: HeatmapGridProps) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const scale = COLOR_SCALES[color];
+
+  // Build date → value lookup
+  const valueMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const dp of data) {
+      map.set(dp.date, dp.value);
+    }
+    return map;
+  }, [data]);
+
+  const maxValue = useMemo(() => Math.max(1, ...data.map((d) => d.value)), [data]);
+
+  // Generate grid cells starting from Monday, `weeks` weeks back from today
+  const { cells, monthMarkers } = useMemo(() => {
+    const today = new Date();
+    // Find the most recent Sunday (end of current week)
+    const dayOfWeek = today.getDay(); // 0=Sun
+    const endOfWeek = new Date(today);
+    endOfWeek.setDate(today.getDate() + ((7 - dayOfWeek) % 7));
+
+    // Start from `weeks` weeks before, aligned to Monday
+    const start = new Date(endOfWeek);
+    start.setDate(endOfWeek.getDate() - (weeks * 7 - 1));
+    const startDay = start.getDay();
+    const mondayOffset = startDay === 0 ? -6 : 1 - startDay;
+    start.setDate(start.getDate() + mondayOffset);
+
+    const result: GridCell[] = [];
+    const markers: MonthMarker[] = [];
+    let lastMonth = -1;
+
+    for (let week = 0; week < weeks; week++) {
+      for (let day = 0; day < 7; day++) {
+        const d = new Date(start);
+        d.setDate(start.getDate() + week * 7 + day);
+
+        const dateStr = d.toISOString().split('T')[0] ?? '';
+        const value = valueMap.get(dateStr) ?? 0;
+        const level = getIntensityLevel(value, maxValue);
+
+        result.push({ date: dateStr, row: day, col: week, value, level });
+
+        const month = d.getMonth();
+        if (day === 0 && month !== lastMonth) {
+          markers.push({ label: MONTH_LABELS[month], col: week });
+          lastMonth = month;
+        }
+      }
+    }
+
+    return { cells: result, monthMarkers: markers };
+  }, [weeks, valueMap, maxValue]);
+
+  const handleCellEnter = useCallback(
+    (cell: GridCell) => {
+      setTooltip({
+        date: cell.date,
+        value: cell.value,
+        x: LABEL_WIDTH + cell.col * (CELL_SIZE + CELL_GAP),
+        y: MONTH_LABEL_HEIGHT + cell.row * (CELL_SIZE + CELL_GAP),
+      });
+    },
+    [],
+  );
+
+  const handleCellLeave = useCallback(() => setTooltip(null), []);
+
+  const svgWidth = LABEL_WIDTH + weeks * (CELL_SIZE + CELL_GAP);
+  const svgHeight = MONTH_LABEL_HEIGHT + 7 * (CELL_SIZE + CELL_GAP);
+
+  return (
+    <div className={className}>
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        role="img"
+        aria-label={`${metricLabel} heatmap: ${cells.length} days`}
+      >
+        {/* Month labels */}
+        {monthMarkers.map((m, i) => (
+          <text
+            key={`${m.label}-${i}`}
+            x={LABEL_WIDTH + m.col * (CELL_SIZE + CELL_GAP)}
+            y={12}
+            fill="var(--color-text-muted)"
+            fontSize={10}
+            fontFamily="ui-monospace, monospace"
+          >
+            {m.label}
+          </text>
+        ))}
+
+        {/* Day labels */}
+        {DAY_LABELS.map((label, i) =>
+          label ? (
+            <text
+              key={label}
+              x={0}
+              y={
+                MONTH_LABEL_HEIGHT +
+                i * (CELL_SIZE + CELL_GAP) +
+                CELL_SIZE / 2 +
+                3
+              }
+              fill="var(--color-text-muted)"
+              fontSize={9}
+              fontFamily="ui-monospace, monospace"
+            >
+              {label}
+            </text>
+          ) : null,
+        )}
+
+        {/* Cells */}
+        {cells.map((cell) => (
+          <rect
+            key={cell.date}
+            x={LABEL_WIDTH + cell.col * (CELL_SIZE + CELL_GAP)}
+            y={MONTH_LABEL_HEIGHT + cell.row * (CELL_SIZE + CELL_GAP)}
+            width={CELL_SIZE}
+            height={CELL_SIZE}
+            rx={CELL_RADIUS}
+            fill={getLevelColor(cell.level, scale)}
+            stroke="var(--color-void-lighter)"
+            strokeWidth={0.5}
+            onMouseEnter={() => handleCellEnter(cell)}
+            onMouseLeave={handleCellLeave}
+            role="gridcell"
+            aria-label={`${cell.date}: ${formatValue(cell.value)} ${metricLabel}`}
+          >
+            <title>{`${cell.date}: ${formatValue(cell.value)}`}</title>
+          </rect>
+        ))}
+
+        {/* Tooltip overlay */}
+        {tooltip && (
+          <g pointerEvents="none">
+            <rect
+              x={tooltip.x - 56}
+              y={tooltip.y - 32}
+              width={112}
+              height={24}
+              rx={4}
+              fill="var(--color-surface-strong)"
+              stroke="var(--color-border)"
+              strokeWidth={1}
+            />
+            <text
+              x={tooltip.x}
+              y={tooltip.y - 16}
+              textAnchor="middle"
+              fill="var(--color-text-primary)"
+              fontSize={10}
+              fontFamily="ui-monospace, monospace"
+            >
+              {tooltip.date}: {formatValue(tooltip.value)}
+            </text>
+          </g>
+        )}
+      </svg>
+
+      {/* Legend */}
+      <div className="mt-2 flex items-center justify-end gap-1.5 text-[10px] text-[var(--color-text-muted)]">
+        <span>Less</span>
+        {([0, 1, 2, 3, 4] as const).map((level) => (
+          <div
+            key={level}
+            className="rounded-sm border border-[var(--color-void-lighter)]"
+            style={{
+              width: CELL_SIZE,
+              height: CELL_SIZE,
+              backgroundColor: getLevelColor(level, scale),
+            }}
+          />
+        ))}
+        <span>More</span>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/analytics/ProjectCardGrid.tsx
+++ b/dashboard/src/components/analytics/ProjectCardGrid.tsx
@@ -1,0 +1,133 @@
+/**
+ * components/analytics/ProjectCardGrid.tsx — Per-project summary cards with sparklines.
+ *
+ * Renders a responsive grid of project cards, each showing:
+ * - Project name (derived from workDir)
+ * - Total cost, token usage, session count
+ * - Inline SVG sparkline for cost trend
+ *
+ * Click-through navigates to the per-project detail route.
+ */
+
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FolderKanban, DollarSign, Cpu, Activity } from 'lucide-react';
+import { formatCurrency, formatCompact } from '../../utils/formatNumber';
+import { SparkLine } from '../overview/SparkLine';
+
+export interface ProjectSummary {
+  name: string;
+  workDir: string;
+  sessions: number;
+  totalCostUsd: number;
+  totalTokens: number;
+  costTrend: number[];
+}
+
+interface ProjectCardGridProps {
+  projects: ProjectSummary[];
+  className?: string;
+}
+
+export function ProjectCardGrid({ projects, className = '' }: ProjectCardGridProps) {
+  if (projects.length === 0) {
+    return (
+      <div className="flex h-[200px] items-center justify-center text-sm text-[var(--color-text-muted)]">
+        No project data available
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 ${className}`}
+      role="list"
+      aria-label="Project cards"
+    >
+      {projects.map((project) => (
+        <ProjectCard key={project.workDir} project={project} />
+      ))}
+    </div>
+  );
+}
+
+function ProjectCard({ project }: { project: ProjectSummary }) {
+  const navigate = useNavigate();
+
+  const handleClick = useCallback(() => {
+    navigate(`/analytics/${encodeURIComponent(project.name)}`);
+  }, [navigate, project.name]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="group w-full rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4 text-left transition-all hover:border-[var(--color-accent-cyan)]/40 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+      role="listitem"
+      aria-label={`${project.name}: ${project.sessions} sessions, ${formatCurrency(project.totalCostUsd)} cost`}
+    >
+      {/* Header */}
+      <div className="mb-3 flex items-center gap-2">
+        <FolderKanban className="h-4 w-4 shrink-0 text-[var(--color-accent-cyan)]" />
+        <span className="truncate text-sm font-medium text-[var(--color-text-primary)]">
+          {project.name}
+        </span>
+      </div>
+
+      {/* Metrics row */}
+      <div className="mb-3 grid grid-cols-3 gap-3">
+        <MetricPill
+          icon={<DollarSign className="h-3 w-3" />}
+          value={formatCurrency(project.totalCostUsd)}
+          label="cost"
+        />
+        <MetricPill
+          icon={<Cpu className="h-3 w-3" />}
+          value={formatCompact(project.totalTokens)}
+          label="tokens"
+        />
+        <MetricPill
+          icon={<Activity className="h-3 w-3" />}
+          value={String(project.sessions)}
+          label="sessions"
+        />
+      </div>
+
+      {/* Sparkline */}
+      {project.costTrend.length >= 2 && (
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] text-[var(--color-text-muted)]">Cost trend</span>
+          <SparkLine
+            data={project.costTrend}
+            width={100}
+            height={20}
+            color="var(--color-accent-cyan)"
+            ariaLabel={`Cost trend for ${project.name}`}
+          />
+        </div>
+      )}
+    </button>
+  );
+}
+
+function MetricPill({
+  icon,
+  value,
+  label,
+}: {
+  icon: React.ReactNode;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-0.5 rounded-md bg-[var(--color-surface)] px-2 py-1.5">
+      <div className="flex items-center gap-1 text-[var(--color-text-muted)]">
+        {icon}
+        <span className="text-[10px]">{label}</span>
+      </div>
+      <span className="font-mono text-xs font-medium text-[var(--color-text-primary)]">
+        {value}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #2249 (partial — TimeFilterBar already shipped in #2271)

## What changed

Two new analytics dashboard components:

### ProjectCardGrid + ProjectCard
- Responsive CSS grid (1/2/3 cols) of per-project summary cards
- Each card shows: project name, cost, tokens, sessions, SVG sparkline cost trend
- Click-through navigation to \`/analytics/:project\`
- Reuses existing \`SparkLine\` component from overview

### HeatmapGrid
- GitHub-style contribution heatmap in pure SVG (zero chart library deps)
- 7 rows (Mon–Sun) × N columns (weeks, default 53)
- 5-level color intensity with 3 color scales (cyan, purple, green)
- SVG hover tooltips showing date + value
- Month/day labels, Less/More legend
- All colors via CSS custom properties (themed)

### Tests
- **23 new Vitest tests** (10 ProjectCardGrid + 13 HeatmapGrid)
- Covers: rendering, data display, responsive layout, a11y attributes, color scales, tooltips, empty state
- **Full suite: 747 tests passing, 0 failures**

### Quality gate
- \`npx tsc --noEmit\` ✅ clean
- \`npm run build\` ✅ clean
- \`npm test\` ✅ 747 passed

### Zero new dependencies
- Uses existing \`lucide-react\`, \`react-router-dom\`, \`SparkLine\`, \`formatCurrency/formatCompact\`
- Pure SVG heatmap (no recharts/d3/etc)

### Aegis version
Server: running at localhost:9100