### PR TITLE
fix(dashboard): migrate HeatmapGrid rgba() literals to design tokens

### DIFF
--- a/dashboard/src/components/analytics/HeatmapGrid.tsx
+++ b/dashboard/src/components/analytics/HeatmapGrid.tsx
@@ -31,27 +31,20 @@ interface HeatmapGridProps {
   className?: string;
 }
 
+import { tokens } from '../../design/tokens.js';
+
 const COLOR_SCALES = {
   cyan: {
     empty: 'var(--color-void-light)',
-    level1: 'rgba(6, 182, 212, 0.2)',
-    level2: 'rgba(6, 182, 212, 0.4)',
-    level3: 'rgba(6, 182, 212, 0.65)',
-    level4: 'rgba(6, 182, 212, 0.9)',
+    ...tokens.chartOpacity.cyan,
   },
   purple: {
     empty: 'var(--color-void-light)',
-    level1: 'rgba(139, 92, 246, 0.2)',
-    level2: 'rgba(139, 92, 246, 0.4)',
-    level3: 'rgba(139, 92, 246, 0.65)',
-    level4: 'rgba(139, 92, 246, 0.9)',
+    ...tokens.chartOpacity.purple,
   },
   green: {
     empty: 'var(--color-void-light)',
-    level1: 'rgba(34, 197, 94, 0.2)',
-    level2: 'rgba(34, 197, 94, 0.4)',
-    level3: 'rgba(34, 197, 94, 0.65)',
-    level4: 'rgba(34, 197, 94, 0.9)',
+    ...tokens.chartOpacity.green,
   },
 } as const;
 

--- a/dashboard/src/design/tokens.ts
+++ b/dashboard/src/design/tokens.ts
@@ -44,8 +44,32 @@ export const tokens = {
 
     // Charts & metrics
     metricsPurple: '#8b5cf6',
+    metricsCyan: '#06b6d4',
+    metricsGreen: '#22c55e',
     successBg: '#064e3b',
     errorBg: '#4c1d1f',
+  },
+
+  /** Opacity variants for chart heatmap cells (rgba equivalents). */
+  chartOpacity: {
+    cyan: {
+      level1: 'rgba(6, 182, 212, 0.2)',
+      level2: 'rgba(6, 182, 212, 0.4)',
+      level3: 'rgba(6, 182, 212, 0.65)',
+      level4: 'rgba(6, 182, 212, 0.9)',
+    },
+    purple: {
+      level1: 'rgba(139, 92, 246, 0.2)',
+      level2: 'rgba(139, 92, 246, 0.4)',
+      level3: 'rgba(139, 92, 246, 0.65)',
+      level4: 'rgba(139, 92, 246, 0.9)',
+    },
+    green: {
+      level1: 'rgba(34, 197, 94, 0.2)',
+      level2: 'rgba(34, 197, 94, 0.4)',
+      level3: 'rgba(34, 197, 94, 0.65)',
+      level4: 'rgba(34, 197, 94, 0.9)',
+    },
   },
 
   /**


### PR DESCRIPTION
## Summary
- Replace 12 raw rgba() literals in HeatmapGrid with design tokens
- Add chartOpacity palette to tokens.ts (cyan/purple/green intensity scales)
- Fixes tokens-gate violations preventing `npm run gate` from passing

## Test Plan
- [x] `npm run dashboard:tokens:gate` passes (99 files scanned, 0 violations)
- [x] `npx tsc --noEmit` passes

Closes #2267