### PR TITLE
fix(ci): guard DISCORD_WEBHOOK curl against empty secret

### DIFF
--- a/.github/workflows/ci-failure-alert.yml
+++ b/.github/workflows/ci-failure-alert.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord notification
+        if: secrets.DISCORD_WEBHOOK != ''
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
           PAYLOAD=$(cat << 'EOF'
           {
@@ -19,5 +22,5 @@ jobs:
           }
           EOF
           )
-          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.DISCORD_WEBHOOK }}"
+          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 


### PR DESCRIPTION
## Summary

Fix same root cause as #2229: the `ci-failure-alert.yml` workflow fails when `DISCORD_WEBHOOK` secret is empty or not configured.

## Changes

- Added `if: secrets.DISCORD_WEBHOOK != ''` guard on the notification step
- Use env variable pattern (same as fixed `discord-notify.yml`)

## Testing

- YAML-only change, follows same pattern applied in #2229

Closes #2290