### PR TITLE
feat: add rate-limit analytics endpoint (#2248)

### DIFF
--- a/.github/workflows/ci-failure-alert.yml
+++ b/.github/workflows/ci-failure-alert.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord notification
+        if: secrets.DISCORD_WEBHOOK != ''
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
           PAYLOAD=$(cat << 'EOF'
           {
@@ -19,5 +22,5 @@ jobs:
           }
           EOF
           )
-          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.DISCORD_WEBHOOK }}"
+          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 

--- a/dashboard/src/components/analytics/HeatmapGrid.tsx
+++ b/dashboard/src/components/analytics/HeatmapGrid.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useMemo, useState, useCallback } from 'react';
+import { tokens } from '../../design/tokens.js';
 
 export interface HeatmapDataPoint {
   date: string; // YYYY-MM-DD
@@ -32,27 +33,9 @@ interface HeatmapGridProps {
 }
 
 const COLOR_SCALES = {
-  cyan: {
-    empty: 'var(--color-void-light)',
-    level1: 'rgba(6, 182, 212, 0.2)',
-    level2: 'rgba(6, 182, 212, 0.4)',
-    level3: 'rgba(6, 182, 212, 0.65)',
-    level4: 'rgba(6, 182, 212, 0.9)',
-  },
-  purple: {
-    empty: 'var(--color-void-light)',
-    level1: 'rgba(139, 92, 246, 0.2)',
-    level2: 'rgba(139, 92, 246, 0.4)',
-    level3: 'rgba(139, 92, 246, 0.65)',
-    level4: 'rgba(139, 92, 246, 0.9)',
-  },
-  green: {
-    empty: 'var(--color-void-light)',
-    level1: 'rgba(34, 197, 94, 0.2)',
-    level2: 'rgba(34, 197, 94, 0.4)',
-    level3: 'rgba(34, 197, 94, 0.65)',
-    level4: 'rgba(34, 197, 94, 0.9)',
-  },
+  cyan: tokens.glamour.heatmap.cyan,
+  purple: tokens.glamour.heatmap.purple,
+  green: tokens.glamour.heatmap.green,
 } as const;
 
 type ColorScale = typeof COLOR_SCALES[keyof typeof COLOR_SCALES];

--- a/dashboard/src/design/tokens.ts
+++ b/dashboard/src/design/tokens.ts
@@ -170,6 +170,35 @@ export const tokens = {
     paletteStaggerMs: 30,
     /** Max live events shown in the side-rail. */
     sideRailMaxEvents: 50,
+
+    /**
+     * Heatmap colour scales (GitHub-style contribution grid).
+     * Pre-computed rgba() strings so the SVG fill attribute can use them directly.
+     * Each scale is anchored on a CSS var, so light/dark overrides propagate.
+     */
+    heatmap: {
+      cyan: {
+        empty: 'var(--color-void-light)',
+        level1: 'rgba(var(--color-accent-cyan-rgb), 0.2)',
+        level2: 'rgba(var(--color-accent-cyan-rgb), 0.4)',
+        level3: 'rgba(var(--color-accent-cyan-rgb), 0.65)',
+        level4: 'rgba(var(--color-accent-cyan-rgb), 0.9)',
+      },
+      purple: {
+        empty: 'var(--color-void-light)',
+        level1: 'rgba(var(--color-accent-purple-rgb), 0.2)',
+        level2: 'rgba(var(--color-accent-purple-rgb), 0.4)',
+        level3: 'rgba(var(--color-accent-purple-rgb), 0.65)',
+        level4: 'rgba(var(--color-accent-purple-rgb), 0.9)',
+      },
+      green: {
+        empty: 'var(--color-void-light)',
+        level1: 'rgba(var(--color-success-rgb), 0.2)',
+        level2: 'rgba(var(--color-success-rgb), 0.4)',
+        level3: 'rgba(var(--color-success-rgb), 0.65)',
+        level4: 'rgba(var(--color-success-rgb), 0.9)',
+      },
+    },
   },
 } as const;
 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -73,7 +73,9 @@
   --color-accent: #3b82f6; /* Modern Blue */
   --color-accent-dim: #3b82f620;
   --color-accent-cyan: #06b6d4;
+  --color-accent-cyan-rgb: 6, 182, 212;
   --color-accent-purple: #8b5cf6;
+  --color-accent-purple-rgb: 139, 92, 246;
   /* Accent tuned for light-mode contrast (blue-600 ≥ 4.5:1 on #f8fafc). */
   --color-accent-on-light: #2563eb;
 
@@ -91,7 +93,9 @@
 
   /* Status Colors */
   --color-danger: #ef4444;
+  --color-danger-rgb: 239, 68, 68;
   --color-success: #22c55e;
+  --color-success-rgb: 34, 197, 94;
   --color-warning: #f59e0b;
   --color-info: #3b82f6;
 

--- a/src/__tests__/analytics-rate-limits-2248.test.ts
+++ b/src/__tests__/analytics-rate-limits-2248.test.ts
@@ -1,0 +1,379 @@
+/**
+ * analytics-rate-limits-2248.test.ts — Tests for GET /v1/analytics/rate-limits endpoint.
+ *
+ * Issue #2248: Rate-limit / quota usage API with session forecast.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyRequest } from 'fastify';
+import { registerAnalyticsRoutes } from '../routes/analytics.js';
+import type { RouteContext } from '../routes/context.js';
+import type { MetricsCache } from '../services/metrics-cache.js';
+import type { AuthManager } from '../auth.js';
+import type { QuotaManager } from '../services/auth/QuotaManager.js';
+import type { ApiKeyPermission } from '../api-contracts.js';
+import type { ApiKey } from '../services/auth/types.js';
+import type { QuotaUsage } from '../services/auth/QuotaManager.js';
+
+// ── Mock factories ──────────────────────────────────────────────────
+
+function makeKey(overrides: Partial<ApiKey> = {}): ApiKey {
+  return {
+    id: overrides.id ?? 'key-1',
+    name: overrides.name ?? 'Test Key',
+    hash: 'hash',
+    createdAt: Date.now(),
+    lastUsedAt: Date.now(),
+    rateLimit: 60,
+    expiresAt: null,
+    role: 'operator',
+    permissions: ['create', 'send'],
+    ...overrides,
+  };
+}
+
+function buildMockMetricsCache(): MetricsCache {
+  return {
+    getMetrics: () => ({
+      sessionVolume: [],
+      tokenUsageByModel: [],
+      costTrends: [],
+      topApiKeys: [],
+      durationTrends: [],
+      errorRates: { totalSessions: 0, errorRate: 0 },
+      generatedAt: new Date().toISOString(),
+    }),
+  } as unknown as MetricsCache;
+}
+
+function buildMockAuth(keys: ApiKey[] = []): AuthManager {
+  return {
+    validate: () => ({ valid: true, keyId: 'master', role: 'admin' }),
+    listKeys: () => keys,
+    authEnabled: false,
+  } as unknown as AuthManager;
+}
+
+function buildMockQuotaManager(keyUsageMap: Map<string, QuotaUsage> = new Map()): QuotaManager {
+  return {
+    getUsage: (key: ApiKey, activeSessionCount: number) => {
+      const cached = keyUsageMap.get(key.id);
+      if (cached) return cached;
+      return {
+        activeSessions: activeSessionCount,
+        maxSessions: key.quotas?.maxConcurrentSessions ?? null,
+        tokensInWindow: 0,
+        maxTokens: key.quotas?.maxTokensPerWindow ?? null,
+        spendInWindow: 0,
+        maxSpendUsd: key.quotas?.maxSpendPerWindow ?? null,
+        windowMs: key.quotas?.quotaWindowMs ?? 3_600_000,
+      };
+    },
+  } as unknown as QuotaManager;
+}
+
+function buildMockSessions(ownerKeyIdCounts: Map<string, number> = new Map()) {
+  const sessions: Array<{ ownerKeyId: string }> = [];
+  for (const [keyId, count] of ownerKeyIdCounts) {
+    for (let i = 0; i < count; i++) {
+      sessions.push({ ownerKeyId: keyId });
+    }
+  }
+  return { listSessions: () => sessions };
+}
+
+function createApp(keys: ApiKey[], keyUsageMap: Map<string, QuotaUsage>, ownerKeyIdCounts: Map<string, number>) {
+  const app = Fastify({ logger: false });
+  app.decorateRequest('authKeyId', null as unknown as string);
+  app.decorateRequest('matchedPermission', null as unknown as ApiKeyPermission);
+  app.decorateRequest('tenantId', '_system' as unknown as string);
+
+  app.addHook('onRequest', async (req: FastifyRequest) => {
+    const header = req.headers.authorization;
+    const token = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
+    if (token) req.authKeyId = token;
+  });
+
+  const ctx = {
+    metricsCache: buildMockMetricsCache(),
+    auth: buildMockAuth(keys),
+    quotas: buildMockQuotaManager(keyUsageMap),
+    sessions: buildMockSessions(ownerKeyIdCounts),
+  } as unknown as RouteContext;
+
+  registerAnalyticsRoutes(app, ctx);
+  return app;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('GET /v1/analytics/rate-limits (Issue #2248)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    const keys = [
+      makeKey({
+        id: 'key-1',
+        name: 'Production Key',
+        quotas: { maxConcurrentSessions: 5, maxTokensPerWindow: 100_000, maxSpendPerWindow: 10, quotaWindowMs: 3_600_000 },
+      }),
+      makeKey({
+        id: 'key-2',
+        name: 'Dev Key',
+        quotas: { maxConcurrentSessions: 2, maxTokensPerWindow: null, maxSpendPerWindow: null, quotaWindowMs: 3_600_000 },
+      }),
+    ];
+
+    const usageMap = new Map<string, QuotaUsage>([
+      ['key-1', {
+        activeSessions: 3,
+        maxSessions: 5,
+        tokensInWindow: 40_000,
+        maxTokens: 100_000,
+        spendInWindow: 2.50,
+        maxSpend: 10,
+        windowMs: 3_600_000,
+      }],
+      ['key-2', {
+        activeSessions: 2,
+        maxSessions: 2,
+        tokensInWindow: 15_000,
+        maxTokens: null,
+        spendInWindow: 0.80,
+        maxSpend: null,
+        windowMs: 3_600_000,
+      }],
+    ]);
+
+    const ownerCounts = new Map<string, number>([
+      ['key-1', 3],
+      ['key-2', 2],
+    ]);
+
+    app = createApp(keys, usageMap, ownerCounts);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 200 with correct structure', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body).toHaveProperty('global');
+    expect(body).toHaveProperty('perKey');
+    expect(body).toHaveProperty('forecast');
+    expect(body).toHaveProperty('generatedAt');
+  });
+
+  it('returns global rate-limit config', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    const body = res.json();
+    expect(body.global.max).toBe(600);
+    expect(body.global.timeWindowMs).toBe(60_000);
+  });
+
+  it('returns per-key quota usage', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    const body = res.json();
+    expect(body.perKey).toHaveLength(2);
+
+    const prod = body.perKey.find((k: { keyId: string }) => k.keyId === 'key-1');
+    expect(prod).toBeDefined();
+    expect(prod.keyName).toBe('Production Key');
+    expect(prod.activeSessions).toBe(3);
+    expect(prod.maxSessions).toBe(5);
+    expect(prod.tokensInWindow).toBe(40_000);
+    expect(prod.maxTokens).toBe(100_000);
+    expect(prod.spendInWindowUsd).toBe(2.50);
+    expect(prod.maxSpendUsd).toBe(10);
+    expect(prod.windowMs).toBe(3_600_000);
+
+    const dev = body.perKey.find((k: { keyId: string }) => k.keyId === 'key-2');
+    expect(dev).toBeDefined();
+    expect(dev.activeSessions).toBe(2);
+    expect(dev.maxSessions).toBe(2);
+    expect(dev.maxTokens).toBeNull();
+    expect(dev.maxSpendUsd).toBeNull();
+  });
+
+  it('computes session forecast with bottleneck detection', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    const body = res.json();
+    expect(body.forecast).toBeDefined();
+    // key-2 has 2/2 concurrent sessions — bottleneck is concurrent_sessions, remaining = 0
+    expect(body.forecast.estimatedSessionsRemaining).toBe(0);
+    expect(body.forecast.bottleneck).toBe('concurrent_sessions');
+  });
+
+  it('includes generatedAt timestamp', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    const body = res.json();
+    expect(typeof body.generatedAt).toBe('string');
+    expect(new Date(body.generatedAt).getTime()).not.toBeNaN();
+  });
+
+  it('handles empty keys gracefully', async () => {
+    const emptyApp = createApp([], new Map(), new Map());
+    await emptyApp.ready();
+
+    const res = await emptyApp.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.perKey).toHaveLength(0);
+    expect(body.forecast.estimatedSessionsRemaining).toBeNull();
+    expect(body.forecast.bottleneck).toBeNull();
+
+    await emptyApp.close();
+  });
+
+  it('requires authentication', async () => {
+    const noAuthApp = Fastify({ logger: false });
+    const authEnabled = {
+      authEnabled: true,
+      validate: () => ({ valid: false, reason: 'no_auth' }),
+      listKeys: () => [],
+    } as unknown as AuthManager;
+
+    noAuthApp.decorateRequest('authKeyId', null as unknown as string);
+    noAuthApp.decorateRequest('matchedPermission', null as unknown as ApiKeyPermission);
+    noAuthApp.decorateRequest('tenantId', '_system' as unknown as string);
+
+    noAuthApp.addHook('onRequest', async (req: FastifyRequest) => {
+      const header = req.headers.authorization;
+      const token = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
+      if (token) req.authKeyId = token;
+    });
+
+    const ctx = {
+      metricsCache: buildMockMetricsCache(),
+      auth: authEnabled,
+      quotas: buildMockQuotaManager(),
+      sessions: buildMockSessions(),
+    } as unknown as RouteContext;
+
+    registerAnalyticsRoutes(noAuthApp, ctx);
+    await noAuthApp.ready();
+
+    const res = await noAuthApp.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+    });
+
+    expect(res.statusCode).toBe(401);
+
+    await noAuthApp.close();
+  });
+
+  it('forecast detects tokens bottleneck when tighter than concurrent', async () => {
+    const keys = [
+      makeKey({
+        id: 'key-tokens',
+        name: 'Token Heavy',
+        quotas: { maxConcurrentSessions: 100, maxTokensPerWindow: 50_000, maxSpendPerWindow: null, quotaWindowMs: 3_600_000 },
+      }),
+    ];
+
+    const usageMap = new Map<string, QuotaUsage>([
+      ['key-tokens', {
+        activeSessions: 10,
+        maxSessions: 100,
+        tokensInWindow: 45_000,   // only 5k left → 1 more session at 4500 avg
+        maxTokens: 50_000,
+        spendInWindow: 0,
+        maxSpend: null,
+        windowMs: 3_600_000,
+      }],
+    ]);
+
+    const ownerCounts = new Map<string, number>([['key-tokens', 10]]);
+    const tokensApp = createApp(keys, usageMap, ownerCounts);
+    await tokensApp.ready();
+
+    const res = await tokensApp.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    const body = res.json();
+    // 5000 remaining tokens / 4500 avg per session = 1 session
+    expect(body.forecast.bottleneck).toBe('tokens_per_window');
+    expect(body.forecast.estimatedSessionsRemaining).toBe(1);
+
+    await tokensApp.close();
+  });
+
+  it('forecast detects spend bottleneck when tighter than others', async () => {
+    const keys = [
+      makeKey({
+        id: 'key-spend',
+        name: 'Spend Heavy',
+        quotas: { maxConcurrentSessions: 100, maxTokensPerWindow: 1_000_000, maxSpendPerWindow: 5, quotaWindowMs: 3_600_000 },
+      }),
+    ];
+
+    const usageMap = new Map<string, QuotaUsage>([
+      ['key-spend', {
+        activeSessions: 10,
+        maxSessions: 100,
+        tokensInWindow: 100_000,
+        maxTokens: 1_000_000,
+        spendInWindow: 4.50,   // only $0.50 left at $0.45/session avg = 1 session
+        maxSpend: 5,
+        windowMs: 3_600_000,
+      }],
+    ]);
+
+    const ownerCounts = new Map<string, number>([['key-spend', 10]]);
+    const spendApp = createApp(keys, usageMap, ownerCounts);
+    await spendApp.ready();
+
+    const res = await spendApp.inject({
+      method: 'GET',
+      url: '/v1/analytics/rate-limits',
+      headers: { Authorization: 'Bearer master' },
+    });
+
+    const body = res.json();
+    // $0.50 remaining / $0.45 avg = 1 session
+    expect(body.forecast.bottleneck).toBe('spend_per_window');
+    expect(body.forecast.estimatedSessionsRemaining).toBe(1);
+
+    await spendApp.close();
+  });
+});

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -415,6 +415,41 @@ export interface AnalyticsSummary {
   generatedAt: string;
 }
 
+/** Issue #2248: Per-key rate-limit / quota usage snapshot. */
+export interface RateLimitKeyUsage {
+  keyId: string;
+  keyName: string;
+  activeSessions: number;
+  maxSessions: number | null;
+  tokensInWindow: number;
+  maxTokens: number | null;
+  spendInWindowUsd: number;
+  maxSpendUsd: number | null;
+  windowMs: number;
+}
+
+/** Issue #2248: Session forecast based on remaining quota headroom. */
+export interface RateLimitForecast {
+  /** Estimated additional sessions that fit within the smallest remaining quota. */
+  estimatedSessionsRemaining: number | null;
+  /** Which quota dimension is the bottleneck, if any. */
+  bottleneck: 'concurrent_sessions' | 'tokens_per_window' | 'spend_per_window' | null;
+}
+
+/** Issue #2248: Global rate-limit config from the Fastify rate-limit plugin. */
+export interface GlobalRateLimits {
+  max: number;
+  timeWindowMs: number;
+}
+
+/** Issue #2248: Response for GET /v1/analytics/rate-limits. */
+export interface RateLimitAnalyticsResponse {
+  global: GlobalRateLimits;
+  perKey: RateLimitKeyUsage[];
+  forecast: RateLimitForecast;
+  generatedAt: string;
+}
+
 /** Issue #2087: Aggregate metrics response types */
 export interface AggregateMetricsTimePoint {
   timestamp: string;

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -137,7 +137,7 @@ export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext)
       });
 
       // Compute forecast: find the tightest bottleneck across all keys
-      const forecast = computeForecast(perKey, allSessions.length);
+      const forecast = computeForecast(perKey);
 
       const response: RateLimitAnalyticsResponse = {
         global: { ...GLOBAL_RATE_LIMIT },
@@ -158,7 +158,7 @@ export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext)
  * quota dimension is exhausted.  Returns null when no quotas are set
  * (unlimited capacity).
  */
-function computeForecast(perKey: RateLimitKeyUsage[], totalActive: number): RateLimitForecast {
+function computeForecast(perKey: RateLimitKeyUsage[]): RateLimitForecast {
   if (perKey.length === 0) return { estimatedSessionsRemaining: null, bottleneck: null };
 
   let minRemaining: number | null = null;
@@ -199,6 +199,5 @@ function computeForecast(perKey: RateLimitKeyUsage[], totalActive: number): Rate
     }
   }
 
-  void totalActive;
   return { estimatedSessionsRemaining: minRemaining, bottleneck };
 }

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -1,18 +1,28 @@
 /**
- * routes/analytics.ts — Analytics aggregation endpoints (Issue #1970, #2246, #2247).
+ * routes/analytics.ts — Analytics aggregation endpoints (Issue #1970, #2246, #2247, #2248).
  *
- * GET /v1/analytics/summary — aggregated session, token, cost,
+ * GET /v1/analytics/summary     — aggregated session, token, cost,
  *   duration, and error-rate data from the MetricsCache (Issue #2250).
- * GET /v1/analytics/costs  — cost breakdown with per-model and daily trends (Issue #2246).
- * GET /v1/analytics/tokens — token usage with per-model distribution (Issue #2247).
+ * GET /v1/analytics/costs       — cost breakdown with per-model and daily trends (Issue #2246).
+ * GET /v1/analytics/tokens      — token usage with per-model distribution (Issue #2247).
+ * GET /v1/analytics/rate-limits — rate-limit / quota usage with session forecast (Issue #2248).
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { RouteContext } from './context.js';
 import { requireRole, registerWithLegacy } from './context.js';
+import type {
+  RateLimitKeyUsage,
+  RateLimitForecast,
+  RateLimitAnalyticsResponse,
+} from '../api-contracts.js';
+import type { ApiKey } from '../services/auth/types.js';
+
+/** Fastify rate-limit plugin global config, exposed at startup. */
+const GLOBAL_RATE_LIMIT = { max: 600, timeWindowMs: 60_000 };
 
 export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext): void {
-  const { metricsCache, auth } = ctx;
+  const { metricsCache, auth, quotas, sessions } = ctx;
 
   // ── Summary endpoint (delegates to MetricsCache) ────────────
   registerWithLegacy(app, 'get', '/v1/analytics/summary', {
@@ -98,4 +108,97 @@ export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext)
       };
     },
   });
+
+  // ── Rate-limit / quota usage endpoint (Issue #2248) ──────────
+  registerWithLegacy(app, 'get', '/v1/analytics/rate-limits', {
+    config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
+    handler: async (req: FastifyRequest, reply: FastifyReply) => {
+      if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
+
+      const keys = auth.listKeys();
+      const allSessions = sessions.listSessions();
+
+      // Build per-key usage snapshots
+      // listKeys() omits 'hash' but QuotaManager.getUsage only reads id + quotas
+      const perKey: RateLimitKeyUsage[] = keys.map((key) => {
+        const owned = allSessions.filter((s) => s.ownerKeyId === key.id);
+        const usage = quotas.getUsage(key as unknown as ApiKey, owned.length);
+        return {
+          keyId: key.id,
+          keyName: key.name,
+          activeSessions: usage.activeSessions,
+          maxSessions: usage.maxSessions,
+          tokensInWindow: usage.tokensInWindow,
+          maxTokens: usage.maxTokens,
+          spendInWindowUsd: usage.spendInWindow,
+          maxSpendUsd: usage.maxSpend,
+          windowMs: usage.windowMs,
+        };
+      });
+
+      // Compute forecast: find the tightest bottleneck across all keys
+      const forecast = computeForecast(perKey, allSessions.length);
+
+      const response: RateLimitAnalyticsResponse = {
+        global: { ...GLOBAL_RATE_LIMIT },
+        perKey,
+        forecast,
+        generatedAt: new Date().toISOString(),
+      };
+
+      return response;
+    },
+  });
+}
+
+// ── Forecast helper ──────────────────────────────────────────────
+
+/**
+ * Estimate how many more sessions can be created before the first
+ * quota dimension is exhausted.  Returns null when no quotas are set
+ * (unlimited capacity).
+ */
+function computeForecast(perKey: RateLimitKeyUsage[], totalActive: number): RateLimitForecast {
+  if (perKey.length === 0) return { estimatedSessionsRemaining: null, bottleneck: null };
+
+  let minRemaining: number | null = null;
+  let bottleneck: RateLimitForecast['bottleneck'] = null;
+
+  for (const key of perKey) {
+    // Concurrent sessions dimension
+    if (key.maxSessions !== null) {
+      const remaining = key.maxSessions - key.activeSessions;
+      if (minRemaining === null || remaining < minRemaining) {
+        minRemaining = remaining;
+        bottleneck = 'concurrent_sessions';
+      }
+    }
+
+    // Tokens dimension — estimate from average tokens/session
+    if (key.maxTokens !== null && key.tokensInWindow > 0 && key.activeSessions > 0) {
+      const avgTokensPerSession = key.tokensInWindow / key.activeSessions;
+      if (avgTokensPerSession > 0) {
+        const remaining = Math.floor((key.maxTokens - key.tokensInWindow) / avgTokensPerSession);
+        if (minRemaining === null || remaining < minRemaining) {
+          minRemaining = remaining;
+          bottleneck = 'tokens_per_window';
+        }
+      }
+    }
+
+    // Spend dimension — estimate from average spend/session
+    if (key.maxSpendUsd !== null && key.spendInWindowUsd > 0 && key.activeSessions > 0) {
+      const avgSpendPerSession = key.spendInWindowUsd / key.activeSessions;
+      if (avgSpendPerSession > 0) {
+        const remaining = Math.floor((key.maxSpendUsd - key.spendInWindowUsd) / avgSpendPerSession);
+        if (minRemaining === null || remaining < minRemaining) {
+          minRemaining = remaining;
+          bottleneck = 'spend_per_window';
+        }
+      }
+    }
+  }
+
+  void totalActive;
+  return { estimatedSessionsRemaining: minRemaining, bottleneck };
 }

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -882,6 +882,42 @@ export function registerOpenApiSpec(): void {
     },
   });
 
+  // ── Analytics: Rate-limit / quota usage (Issue #2248) ──────────
+
+  registerOpenApiPath({
+    method: 'get',
+    path: '/v1/analytics/rate-limits',
+    summary: 'Rate-limit and quota usage',
+    description: 'Current rate-limit / quota usage per API key with session forecast based on remaining headroom.',
+    tags: ['Analytics'],
+    responses: {
+      '200': okJsonResponse(z.object({
+        global: z.object({
+          max: z.number(),
+          timeWindowMs: z.number(),
+        }),
+        perKey: z.array(z.object({
+          keyId: z.string(),
+          keyName: z.string(),
+          activeSessions: z.number(),
+          maxSessions: z.number().nullable(),
+          tokensInWindow: z.number(),
+          maxTokens: z.number().nullable(),
+          spendInWindowUsd: z.number(),
+          maxSpendUsd: z.number().nullable(),
+          windowMs: z.number(),
+        })),
+        forecast: z.object({
+          estimatedSessionsRemaining: z.number().nullable(),
+          bottleneck: z.enum(['concurrent_sessions', 'tokens_per_window', 'spend_per_window']).nullable(),
+        }),
+        generatedAt: z.string(),
+      })),
+      '401': unauthorizedResponse,
+      '403': forbiddenResponse,
+    },
+  });
+
   registerOpenApiPath({
     method: 'get',
     path: '/v1/audit',


### PR DESCRIPTION
## Summary

- **`GET /v1/analytics/rate-limits`** — new analytics endpoint for rate-limit / quota monitoring
- Per-key quota usage snapshots (sessions, tokens, spend) from `QuotaManager`
- Session forecast: estimates remaining capacity with bottleneck detection (concurrent sessions, tokens/window, spend/window)
- Global rate-limit config exposure (Fastify plugin settings)
- OpenAPI 3.1 spec documented
- Auth-gated: admin, operator, viewer roles
- 9 unit tests covering response shape, forecast logic, auth gating, and edge cases

## Aegis version
**Developed with:** v0.6.0-preview

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] All tests pass
- [x] `npm run security-check` passes

Closes #2248

Supersedes PR #2278