### PR TITLE
fix(dashboard): replace raw hex colors with CSS var design tokens in analytics charts

### DIFF
--- a/dashboard/src/__tests__/RateLimitChart.test.tsx
+++ b/dashboard/src/__tests__/RateLimitChart.test.tsx
@@ -22,21 +22,21 @@ const makeKey = (overrides: Partial<RateLimitKeyUsage> = {}): RateLimitKeyUsage 
 
 describe('barColor', () => {
   it('returns cyan below 66%', () => {
-    expect(barColor(0)).toBe('#06b6d4');
-    expect(barColor(0.5)).toBe('#06b6d4');
-    expect(barColor(0.65)).toBe('#06b6d4');
+    expect(barColor(0)).toBe('var(--color-accent-cyan)');
+    expect(barColor(0.5)).toBe('var(--color-accent-cyan)');
+    expect(barColor(0.65)).toBe('var(--color-accent-cyan)');
   });
 
   it('returns amber between 66% and 90%', () => {
-    expect(barColor(0.66)).toBe('#f59e0b');
-    expect(barColor(0.75)).toBe('#f59e0b');
-    expect(barColor(0.89)).toBe('#f59e0b');
+    expect(barColor(0.66)).toBe('var(--color-warning)');
+    expect(barColor(0.75)).toBe('var(--color-warning)');
+    expect(barColor(0.89)).toBe('var(--color-warning)');
   });
 
   it('returns red at 90% and above', () => {
-    expect(barColor(0.9)).toBe('#ef4444');
-    expect(barColor(1.0)).toBe('#ef4444');
-    expect(barColor(1.5)).toBe('#ef4444');
+    expect(barColor(0.9)).toBe('var(--color-danger)');
+    expect(barColor(1.0)).toBe('var(--color-danger)');
+    expect(barColor(1.5)).toBe('var(--color-danger)');
   });
 });
 

--- a/dashboard/src/components/analytics/RateLimitChart.tsx
+++ b/dashboard/src/components/analytics/RateLimitChart.tsx
@@ -1,5 +1,5 @@
 /**
- * components/analytics/RateLimitChart.tsx — Per-key quota usage bars (Issue #2283).
+ * components/analytics/RateLimitChart.tsx — Per-key quota usage bars (Issue #2283). // token-ok
  *
  * Bar chart showing sessions, tokens, and spend usage per API key
  * with color-coded thresholds: <66% cyan, 66-90% amber, >90% red.
@@ -17,10 +17,10 @@ import {
 } from 'recharts';
 import type { RateLimitKeyUsage } from '../../types';
 
-/** Color thresholds matching the plan spec. */
-const COLOR_CYAN = '#06b6d4';
-const COLOR_AMBER = '#f59e0b';
-const COLOR_RED = '#ef4444';
+/** Color thresholds matching the plan spec — CSS vars so they work with recharts Cell fill. */
+const COLOR_CYAN = 'var(--color-accent-cyan)';
+const COLOR_AMBER = 'var(--color-warning)';
+const COLOR_RED = 'var(--color-danger)';
 
 export function barColor(ratio: number): string {
   if (ratio >= 0.9) return COLOR_RED;

--- a/dashboard/src/components/analytics/RateLimitForecastCard.tsx
+++ b/dashboard/src/components/analytics/RateLimitForecastCard.tsx
@@ -1,5 +1,5 @@
 /**
- * components/analytics/RateLimitForecastCard.tsx — Bottleneck forecast (Issue #2283).
+ * components/analytics/RateLimitForecastCard.tsx — Bottleneck forecast (Issue #2283). // token-ok
  *
  * Shows predicted session capacity and bottleneck type with severity
  * indicators: green (>10 or unlimited), amber (1-10), red (0).


### PR DESCRIPTION
## Summary
- Replace hardcoded hex color constants (`#06b6d4`, `#f59e0b`, `#ef4444`) in `RateLimitChart.tsx` with CSS custom property references so they respect dark/light theme
- Add `// token-ok` escapes on JSDoc comment lines that contain issue reference numbers like `#2283` (the gate scanner flags `#2283` as a hex color)

## Test Plan
- [x] `npm run gate` passes (tokens-gate + all other checks)
- [x] All 3693 tests pass
- [x] Dashboard builds successfully

## Blocked by
None

Closes #2283