### PR TITLE
feat(cli): add login, logout, whoami commands (3/3) #1943

### DIFF
--- a/src/__tests__/device-flow-cli.test.ts
+++ b/src/__tests__/device-flow-cli.test.ts
@@ -1,0 +1,333 @@
+/**
+ * device-flow-cli.test.ts — Unit tests for ag login / ag logout / ag whoami commands.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Writable } from 'node:stream';
+
+import { handleLogin } from '../commands/login.js';
+import { handleLogout } from '../commands/logout.js';
+import { handleWhoami } from '../commands/whoami.js';
+import { setStoredAuth, deleteAuthStore, type StoredAuth } from '../services/auth/token-store.js';
+
+// Helper to capture stdout/stderr output
+function createMockIO() {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const stdout = new Writable({ write: (chunk, _enc, cb) => { stdoutChunks.push(chunk.toString()); cb(); } });
+  const stderr = new Writable({ write: (chunk, _enc, cb) => { stderrChunks.push(chunk.toString()); cb(); } });
+  return {
+    stdin: process.stdin,
+    stdout,
+    stderr,
+    getStdout: () => stdoutChunks.join(''),
+    getStderr: () => stderrChunks.join(''),
+  };
+}
+
+// Create a valid base64url-encoded JWT-like id_token for testing
+function createTestIdToken(sub: string, email: string, role: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub, email, name: 'Test User', aegis_role: role })).toString('base64url');
+  const signature = Buffer.from('test-signature').toString('base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+const sampleAuth: StoredAuth = {
+  idp: 'https://idp.example.com',
+  identity: { sub: 'user-123', email: 'alice@example.com', name: 'Alice Engineer' },
+  tokens: {
+    access: 'access-token',
+    refresh: 'refresh-token',
+    id_token: createTestIdToken('user-123', 'alice@example.com', 'admin'),
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    scope: 'openid profile email',
+  },
+  role: 'admin',
+  obtained_at: '2026-04-30T10:00:00Z',
+};
+
+let testDir: string;
+const originalEnv = process.env;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'aegis-test-cli-'));
+  process.env = { ...originalEnv };
+  process.env.AEGIS_AUTH_DIR = testDir;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  rmSync(testDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('ag login', () => {
+  it('exits with code 2 when OIDC is not configured', async () => {
+    delete process.env.AEGIS_OIDC_ISSUER;
+    delete process.env.AEGIS_OIDC_CLIENT_ID;
+
+    const io = createMockIO();
+    const code = await handleLogin([], io);
+    expect(code).toBe(2);
+    expect(io.getStderr()).toContain('OIDC is not configured');
+  });
+
+  it('exits with code 2 for invalid issuer URL', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'not-a-url';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const io = createMockIO();
+    const code = await handleLogin([], io);
+    expect(code).toBe(2);
+    expect(io.getStderr()).toContain('not a valid URL');
+  });
+
+  it('exits with code 1 when IdP discovery fails', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin([], io, mockFetch as unknown as typeof fetch);
+    expect(code).toBe(1);
+    expect(io.getStderr()).toContain('discovery failed');
+  });
+
+  it('exits with code 1 when IdP does not support device flow', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        issuer: 'https://idp.example.com',
+        token_endpoint: 'https://idp.example.com/token',
+        // no device_authorization_endpoint
+      }),
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin([], io, mockFetch as unknown as typeof fetch);
+    expect(code).toBe(1);
+    expect(io.getStderr()).toContain('does not support');
+  });
+
+  it('completes full device flow successfully', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async (url: string, _opts?: RequestInit) => {
+      callCount++;
+      const urlStr = url.toString();
+
+      // Discovery
+      if (urlStr.includes('.well-known')) {
+        return {
+          ok: true,
+          json: async () => ({
+            issuer: 'https://idp.example.com',
+            token_endpoint: 'https://idp.example.com/token',
+            device_authorization_endpoint: 'https://idp.example.com/device/code',
+          }),
+        };
+      }
+
+      // Device authorization
+      if (urlStr.includes('/device/code')) {
+        return {
+          ok: true,
+          json: async () => ({
+            device_code: 'device-123',
+            user_code: 'ABCD-EFGH',
+            verification_uri: 'https://idp.example.com/device',
+            expires_in: 900,
+            interval: 1,
+          }),
+        };
+      }
+
+      // Token endpoint — success on first poll
+      if (urlStr.includes('/token')) {
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'access-abc',
+            refresh_token: 'refresh-def',
+            id_token: createTestIdToken('user-123', 'alice@example.com', 'admin'),
+            expires_in: 3600,
+            token_type: 'Bearer',
+          }),
+        };
+      }
+
+      return { ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) };
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin([], io, mockFetch as unknown as typeof fetch);
+
+    expect(code).toBe(0);
+    expect(io.getStdout()).toContain('Logged in as alice@example.com (admin)');
+    expect(callCount).toBeGreaterThanOrEqual(3); // discovery + device auth + token
+  });
+
+  it('supports --json output', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('.well-known')) {
+        return { ok: true, json: async () => ({ issuer: 'https://idp.example.com', token_endpoint: 'https://idp.example.com/token', device_authorization_endpoint: 'https://idp.example.com/device/code' }) };
+      }
+      if (urlStr.includes('/device/code')) {
+        return { ok: true, json: async () => ({ device_code: 'dc', user_code: 'UC', verification_uri: 'https://idp.example.com/device', expires_in: 900, interval: 1 }) };
+      }
+      if (urlStr.includes('/token')) {
+        return { ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt', id_token: createTestIdToken('u1', 'a@b.com', 'viewer'), expires_in: 3600 }) };
+      }
+      return { ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) };
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin(['--json'], io, mockFetch as unknown as typeof fetch);
+    expect(code).toBe(0);
+
+    const output = JSON.parse(io.getStdout());
+    expect(output.identity.email).toBe('a@b.com');
+    expect(output.role).toBe('viewer');
+  });
+});
+
+describe('ag logout', () => {
+  it('shows not logged in when store is empty', async () => {
+    await deleteAuthStore(testDir);
+
+    const io = createMockIO();
+    const code = await handleLogout([], io);
+    expect(code).toBe(1);
+    expect(io.getStdout()).toContain('Not logged in');
+  });
+
+  it('logs out from a single server', async () => {
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+
+    const io = createMockIO();
+    const code = await handleLogout([], io);
+    expect(code).toBe(0);
+    expect(io.getStdout()).toContain('Logged out');
+    expect(io.getStdout()).toContain('alice@example.com');
+  });
+
+  it('--all deletes entire store', async () => {
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+    await setStoredAuth('http://staging:9100', { ...sampleAuth, identity: { sub: 'u2', email: 'bob@test.com' } }, testDir);
+
+    const io = createMockIO();
+    const code = await handleLogout(['--all'], io);
+    expect(code).toBe(0);
+    expect(io.getStdout()).toContain('all servers');
+  });
+
+  it('attempts token revocation at IdP', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+
+    let revoked = false;
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('.well-known')) {
+        return { ok: true, json: async () => ({ issuer: 'https://idp.example.com', token_endpoint: 'https://idp.example.com/token', revocation_endpoint: 'https://idp.example.com/revoke' }) };
+      }
+      if (urlStr.includes('/revoke')) {
+        revoked = true;
+        return { ok: true, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const io = createMockIO();
+    const code = await handleLogout([], io, mockFetch as unknown as typeof fetch);
+    expect(code).toBe(0);
+    expect(revoked).toBe(true);
+  });
+});
+
+describe('ag whoami', () => {
+  it('shows not logged in when store is empty', async () => {
+    await deleteAuthStore(testDir);
+
+    const io = createMockIO();
+    const code = await handleWhoami([], io);
+    expect(code).toBe(1);
+    expect(io.getStdout()).toContain('Not logged in');
+  });
+
+  it('shows identity for logged-in user', async () => {
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+
+    const io = createMockIO();
+    const code = await handleWhoami([], io);
+    expect(code).toBe(0);
+    expect(io.getStdout()).toContain('alice@example.com');
+    expect(io.getStdout()).toContain('admin');
+  });
+
+  it('shows token expiry time', async () => {
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+
+    const io = createMockIO();
+    const code = await handleWhoami([], io);
+    expect(code).toBe(0);
+    expect(io.getStdout()).toContain('expires in');
+  });
+
+  it('supports --json output', async () => {
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+
+    const io = createMockIO();
+    const code = await handleWhoami(['--json'], io);
+    expect(code).toBe(0);
+
+    const output = JSON.parse(io.getStdout());
+    expect(output.identity.email).toBe('alice@example.com');
+    expect(output.role).toBe('admin');
+    expect(output.server).toBe('http://localhost:9100');
+  });
+
+  it('shows all servers when multiple exist', async () => {
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+    await setStoredAuth('http://staging:9100', {
+      ...sampleAuth,
+      identity: { sub: 'user-456', email: 'bob@example.com' },
+      role: 'viewer',
+    }, testDir);
+
+    const io = createMockIO();
+    const code = await handleWhoami([], io);
+    expect(code).toBe(0);
+    expect(io.getStdout()).toContain('alice@example.com');
+    expect(io.getStdout()).toContain('bob@example.com');
+  });
+
+  it('returns 1 for non-existent server with --server flag', async () => {
+    await setStoredAuth('http://localhost:9100', sampleAuth, testDir);
+
+    const io = createMockIO();
+    const code = await handleWhoami(['--server', 'http://unknown:9100'], io);
+    expect(code).toBe(1);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,9 @@ import { deriveBaseUrl, getConfiguredBaseUrl } from './base-url.js';
 import { loadConfig } from './config.js';
 import { runDoctorCommand } from './doctor.js';
 import { handleInit, findStarterTemplateFiles, handleStarterTemplateDoctor } from './commands/init.js';
+import { handleLogin } from './commands/login.js';
+import { handleLogout } from './commands/logout.js';
+import { handleWhoami } from './commands/whoami.js';
 import { getErrorMessage, parseIntSafe } from './validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -242,6 +245,12 @@ function printHelp(io: CliIO): void {
     ag mcp --port 3000     Custom Aegis API port
     claude mcp add aegis -- ag mcp
 
+  Auth (OAuth2 device flow):
+    ag login               Authenticate via your IdP (requires OIDC config)
+    ag logout              Revoke tokens and clear credentials
+    ag logout --all        Clear credentials for all servers
+    ag whoami              Show current identity and token status
+
   Environment variables:
     AEGIS_BASE_URL                 Preferred API base URL for hooks + CLI
     AEGIS_PORT                     Server port (default: 9100)
@@ -254,6 +263,8 @@ function printHelp(io: CliIO): void {
     AEGIS_TG_GROUP                 Telegram group chat ID
     AEGIS_TG_ALLOWED_USERS         Allowed Telegram user IDs (comma-separated)
     AEGIS_WEBHOOKS                 Webhook URLs (comma-separated)
+    AEGIS_OIDC_ISSUER              OIDC issuer URL (for ag login)
+    AEGIS_OIDC_CLIENT_ID           OIDC client ID (for ag login)
 
   API:
     POST /v1/sessions             Create a session
@@ -303,6 +314,18 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
 
   if (argv[0] === 'create') {
     return handleCreate(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'login') {
+    return handleLogin(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'logout') {
+    return handleLogout(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'whoami') {
+    return handleWhoami(argv.slice(1), io);
   }
 
   if (argv.length === 1 && !argv[0].startsWith('-')) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,361 @@
+/**
+ * commands/login.ts — `ag login` CLI command.
+ *
+ * Implements the OAuth2 device authorization grant (RFC 8628) for the CLI.
+ * The CLI talks directly to the IdP — no Aegis server required.
+ */
+
+
+import {
+  parseOidcConfig,
+  discoverOidcEndpoints,
+  mergeDiscovery,
+  type OidcConfig,
+} from '../services/auth/oidc-config.js';
+import {
+  readAuthStore,
+  setStoredAuth,
+  type StoredAuth,
+} from '../services/auth/token-store.js';
+
+interface CliIO {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
+  stream.write(`${text}\n`);
+}
+
+// ── RFC 8628 Device Flow ────────────────────────────────────────────
+
+interface DeviceAuthResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+interface TokenResponse {
+  access_token: string;
+  token_type?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  id_token?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+/** Request device authorization from the IdP. */
+async function requestDeviceAuthorization(
+  config: OidcConfig,
+  fetchFn: typeof fetch = fetch,
+): Promise<DeviceAuthResponse> {
+  if (!config.deviceAuthorizationEndpoint) {
+    throw new Error('IdP does not support device authorization flow. No device_authorization_endpoint found in discovery document.');
+  }
+
+  const body = new URLSearchParams({
+    client_id: config.clientId,
+    scope: config.scopes,
+  });
+
+  const response = await fetchFn(config.deviceAuthorizationEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  const data = await response.json() as DeviceAuthResponse;
+
+  if (!response.ok) {
+    const errData = data as unknown as { error?: string; error_description?: string };
+    throw new Error(`Device authorization failed: ${errData.error || response.statusText}${errData.error_description ? ` — ${errData.error_description}` : ''}`);
+  }
+
+  return data;
+}
+
+/** Poll the IdP token endpoint until the user completes browser auth. */
+async function pollForToken(
+  config: OidcConfig,
+  deviceCode: string,
+  interval: number,
+  expiresInSeconds: number,
+  fetchFn: typeof fetch = fetch,
+): Promise<TokenResponse> {
+  const maxElapsed = Math.min(expiresInSeconds, 900) * 1000;
+  const startTime = Date.now();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const elapsed = Date.now() - startTime;
+    if (elapsed >= maxElapsed) {
+      throw new Error('Device code expired. Run ag login again.');
+    }
+
+    // Wait before polling
+    await new Promise(resolve => setTimeout(resolve, interval * 1000));
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth2:grant-type:device_code',
+      device_code: deviceCode,
+      client_id: config.clientId,
+    });
+
+    const response = await fetchFn(config.tokenEndpoint!, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    const data = await response.json() as TokenResponse;
+
+    if (!data.error) {
+      return data;
+    }
+
+    switch (data.error) {
+      case 'authorization_pending':
+        // Normal — user hasn't completed auth yet. Keep polling.
+        break;
+      case 'slow_down':
+        // RFC 8628 §3.5: Increase interval by 5s
+        interval += 5;
+        break;
+      case 'expired_token':
+        throw new Error('Device code expired. Run ag login again.');
+      case 'access_denied':
+        throw new Error('Authorization denied by user.');
+      default:
+        throw new Error(`Token error: ${data.error}${data.error_description ? ` — ${data.error_description}` : ''}`);
+    }
+  }
+}
+
+/** Parse id_token JWT payload (without verification — verification happens server-side). */
+function parseIdTokenPayload(idToken: string): { sub: string; email?: string; name?: string; [key: string]: unknown } {
+  const parts = idToken.split('.');
+  if (parts.length !== 3) throw new Error('Invalid id_token format');
+  const payload = Buffer.from(parts[1]!, 'base64url').toString('utf-8');
+  return JSON.parse(payload) as { sub: string; email?: string; name?: string; [key: string]: unknown };
+}
+
+/** Extract role from id_token claims using the configured role claim. */
+function extractRole(claims: Record<string, unknown>, roleClaim: string): string {
+  const value = claims[roleClaim];
+  if (typeof value === 'string' && ['admin', 'operator', 'viewer'].includes(value)) {
+    return value;
+  }
+  return 'viewer';
+}
+
+/** Derive the server origin from a base URL string. */
+function deriveServerOrigin(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    return url.origin;
+  } catch {
+    return baseUrl;
+  }
+}
+
+// ── Command Handler ─────────────────────────────────────────────────
+
+export async function handleLogin(args: string[], io: CliIO, fetchFn: typeof fetch = fetch): Promise<number> {
+  // Parse flags
+  let serverUrl = '';
+  let noOpen = false;
+  let jsonOutput = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--server' && args[i + 1]) {
+      serverUrl = args[++i]!;
+    } else if (args[i] === '--no-open') {
+      noOpen = true;
+    } else if (args[i] === '--json') {
+      jsonOutput = true;
+    }
+  }
+
+  // 1. Read OIDC config
+  let config: OidcConfig;
+  try {
+    const parsed = parseOidcConfig();
+    if (!parsed) {
+      if (jsonOutput) {
+        writeLine(io.stdout, JSON.stringify({ error: 'OIDC not configured', code: 'CONFIG_ERROR' }));
+      } else {
+        writeLine(io.stderr, '  OIDC is not configured.');
+        writeLine(io.stderr, '  Set AEGIS_OIDC_ISSUER and AEGIS_OIDC_CLIENT_ID environment variables.');
+      }
+      return 2;
+    }
+    config = parsed;
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'CONFIG_ERROR' }));
+    } else {
+      writeLine(io.stderr, `  Configuration error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 2;
+  }
+
+  // 2. Discover IdP endpoints
+  if (!jsonOutput) {
+    writeLine(io.stdout, `  Authenticating via ${config.issuer}...`);
+  }
+
+  try {
+    const discovery = await discoverOidcEndpoints(config.issuer, fetchFn);
+    config = mergeDiscovery(config, discovery);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'DISCOVERY_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  OIDC discovery failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  if (!config.deviceAuthorizationEndpoint) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'IdP does not support device authorization flow', code: 'UNSUPPORTED_FLOW' }));
+    } else {
+      writeLine(io.stderr, '  Your IdP does not support the device authorization flow.');
+      writeLine(io.stderr, '  Use API keys instead (AEGIS_AUTH_TOKEN).');
+    }
+    return 1;
+  }
+
+  // 3. Request device authorization
+  let deviceAuth: DeviceAuthResponse;
+  try {
+    deviceAuth = await requestDeviceAuthorization(config, fetchFn);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'DEVICE_AUTH_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  Device authorization failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  // 4. Display verification URI and user code
+  const verificationUrl = deviceAuth.verification_uri_complete || deviceAuth.verification_uri;
+  const userCode = deviceAuth.user_code;
+
+  if (!jsonOutput) {
+    writeLine(io.stdout);
+    writeLine(io.stdout, '  To authenticate, visit:');
+    writeLine(io.stdout, `    ${verificationUrl}`);
+    writeLine(io.stdout);
+    writeLine(io.stdout, `  Enter code:  ${userCode}`);
+    writeLine(io.stdout);
+    writeLine(io.stdout, '  Waiting for authorization...');
+
+    // Try to open browser (best-effort, silently ignore failure)
+    if (!noOpen && deviceAuth.verification_uri_complete) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error — 'open' is an optional dependency
+        const { default: open } = await import('open');
+        await open(deviceAuth.verification_uri_complete);
+      } catch {
+        // open package not available or browser launch failed — user can copy URL manually
+      }
+    }
+  }
+
+  // 5. Poll for token
+  let tokenResponse: TokenResponse;
+  try {
+    const pollInterval = deviceAuth.interval ?? 5;
+    tokenResponse = await pollForToken(config, deviceAuth.device_code, pollInterval, deviceAuth.expires_in, fetchFn);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'TOKEN_POLL_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  // 6. Validate id_token and extract identity
+  if (!tokenResponse.id_token || !tokenResponse.access_token) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'Token response missing id_token or access_token', code: 'INVALID_TOKEN_RESPONSE' }));
+    } else {
+      writeLine(io.stderr, '  Token response is missing required fields.');
+    }
+    return 1;
+  }
+
+  let claims: Record<string, unknown>;
+  try {
+    claims = parseIdTokenPayload(tokenResponse.id_token);
+  } catch {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'Failed to parse id_token', code: 'INVALID_ID_TOKEN' }));
+    } else {
+      writeLine(io.stderr, '  Received an invalid id_token from the IdP.');
+    }
+    return 1;
+  }
+
+  const role = extractRole(claims, config.roleClaim);
+  const identity = {
+    sub: claims.sub as string,
+    email: claims.email as string | undefined,
+    name: claims.name as string | undefined,
+  };
+
+  // 7. Store tokens
+  const serverOrigin = serverUrl ? deriveServerOrigin(serverUrl) : 'cli-local';
+  const expiresIn = tokenResponse.expires_in ?? 3600;
+  const storedAuth: StoredAuth = {
+    idp: config.issuer,
+    identity,
+    tokens: {
+      access: tokenResponse.access_token,
+      refresh: tokenResponse.refresh_token ?? '',
+      id_token: tokenResponse.id_token,
+      expires_at: Math.floor(Date.now() / 1000) + expiresIn,
+      scope: tokenResponse.scope ?? config.scopes,
+    },
+    role,
+    obtained_at: new Date().toISOString(),
+  };
+
+  try {
+    await setStoredAuth(serverOrigin, storedAuth, config.authDir || undefined);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: `Failed to store tokens: ${e instanceof Error ? e.message : String(e)}`, code: 'STORAGE_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  Failed to store tokens: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  // 8. Print confirmation
+  const displayIdentity = identity.email || identity.name || identity.sub;
+  if (jsonOutput) {
+    writeLine(io.stdout, JSON.stringify({
+      identity,
+      role,
+      server: serverOrigin,
+      expires_in: expiresIn,
+    }));
+  } else {
+    writeLine(io.stdout, `  Logged in as ${displayIdentity} (${role})`);
+  }
+
+  return 0;
+}

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,163 @@
+/**
+ * commands/logout.ts — `ag logout` CLI command.
+ *
+ * Revokes tokens at the IdP (best-effort) and removes stored auth.
+ */
+
+import {
+  readAuthStore,
+  removeStoredAuth,
+  deleteAuthStore,
+  resolveAuthFilePath,
+  type StoredAuth,
+} from '../services/auth/token-store.js';
+import { parseOidcConfig, discoverOidcEndpoints, mergeDiscovery, type OidcConfig } from '../services/auth/oidc-config.js';
+
+interface CliIO {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
+  stream.write(`${text}\n`);
+}
+
+/** Attempt token revocation at the IdP (best-effort, does not block logout). */
+async function attemptRevocation(auth: StoredAuth, config: OidcConfig, fetchFn: typeof fetch): Promise<boolean> {
+  if (!config.revocationEndpoint) {
+    return false;
+  }
+
+  try {
+    // Revoke refresh token and access token
+    for (const token of [auth.tokens.refresh, auth.tokens.access]) {
+      if (!token) continue;
+      const body = new URLSearchParams({
+        token,
+        client_id: config.clientId,
+        token_type_hint: token === auth.tokens.refresh ? 'refresh_token' : 'access_token',
+      });
+      await fetchFn(config.revocationEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+        signal: AbortSignal.timeout(5_000),
+      });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function handleLogout(args: string[], io: CliIO, fetchFn: typeof fetch = fetch): Promise<number> {
+  let serverUrl = '';
+  let logoutAll = false;
+  let jsonOutput = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--server' && args[i + 1]) {
+      serverUrl = args[++i]!;
+    } else if (args[i] === '--all') {
+      logoutAll = true;
+    } else if (args[i] === '--json') {
+      jsonOutput = true;
+    }
+  }
+
+  // --all: delete the entire auth store
+  if (logoutAll) {
+    const deleted = await deleteAuthStore();
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ deleted }));
+    } else {
+      if (deleted) {
+        writeLine(io.stdout, '  Logged out from all servers.');
+      } else {
+        writeLine(io.stdout, '  No stored credentials found.');
+      }
+    }
+    return 0;
+  }
+
+  // Derive server origin
+  let serverOrigin: string;
+  if (serverUrl) {
+    try {
+      serverOrigin = new URL(serverUrl).origin;
+    } catch {
+      serverOrigin = serverUrl;
+    }
+  } else {
+    // Default to first stored entry
+    const store = await readAuthStore();
+    const entries = Object.entries(store);
+    if (entries.length === 0) {
+      if (jsonOutput) {
+        writeLine(io.stdout, JSON.stringify({ error: 'Not logged in', code: 'NOT_LOGGED_IN' }));
+      } else {
+        writeLine(io.stdout, '  Not logged in.');
+      }
+      return 1;
+    }
+    if (entries.length === 1) {
+      serverOrigin = entries[0]![0];
+    } else {
+      // Multiple servers — list them
+      if (jsonOutput) {
+        writeLine(io.stdout, JSON.stringify({ error: 'Multiple servers found. Use --server or --all.', servers: entries.map(([k]) => k) }));
+      } else {
+        writeLine(io.stderr, '  Multiple servers found. Specify one with --server <url> or use --all.');
+        for (const [origin, auth] of entries) {
+          const identity = auth.identity.email || auth.identity.sub;
+          writeLine(io.stderr, `    ${origin}  (${identity})`);
+        }
+      }
+      return 1;
+    }
+  }
+
+  // Read stored auth for this server
+  const store = await readAuthStore();
+  const auth = store[serverOrigin];
+  if (!auth) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'Not logged in to this server', server: serverOrigin }));
+    } else {
+      writeLine(io.stdout, `  Not logged in to ${serverOrigin}.`);
+    }
+    return 1;
+  }
+
+  // Attempt revocation at IdP
+  let config = parseOidcConfig();
+  let revoked = false;
+  if (config) {
+    // Discover revocation endpoint if not already known
+    if (!config.revocationEndpoint) {
+      try {
+        const discovery = await discoverOidcEndpoints(config.issuer, fetchFn);
+        config = mergeDiscovery(config, discovery);
+      } catch {
+        // Discovery failed — skip revocation
+      }
+    }
+    revoked = await attemptRevocation(auth, config, fetchFn);
+  }
+
+  // Remove stored auth
+  await removeStoredAuth(serverOrigin);
+
+  const identity = auth.identity.email || auth.identity.name || auth.identity.sub;
+  if (jsonOutput) {
+    writeLine(io.stdout, JSON.stringify({ loggedOut: true, identity, server: serverOrigin, revoked }));
+  } else {
+    writeLine(io.stdout, `  Logged out (${identity}).`);
+    if (!revoked && config) {
+      writeLine(io.stdout, '  Note: IdP does not support token revocation. Tokens may remain valid until expiry.');
+    }
+  }
+
+  return 0;
+}

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,0 +1,198 @@
+/**
+ * commands/whoami.ts — `ag whoami` CLI command.
+ *
+ * Reads stored tokens, refreshes if expired, prints identity and role.
+ */
+
+import {
+  readAuthStore,
+  setStoredAuth,
+  type StoredAuth,
+} from '../services/auth/token-store.js';
+import { parseOidcConfig, discoverOidcEndpoints, mergeDiscovery, type OidcConfig } from '../services/auth/oidc-config.js';
+
+interface CliIO {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
+  stream.write(`${text}\n`);
+}
+
+/** Attempt to refresh an expired access token. */
+async function refreshToken(
+  auth: StoredAuth,
+  config: OidcConfig,
+  fetchFn: typeof fetch,
+): Promise<StoredAuth> {
+  if (!auth.tokens.refresh) {
+    throw new Error('No refresh token available. Run ag login again.');
+  }
+
+  // Ensure we have the token endpoint
+  let cfg = config;
+  if (!cfg.tokenEndpoint) {
+    const discovery = await discoverOidcEndpoints(cfg.issuer, fetchFn);
+    cfg = mergeDiscovery(cfg, discovery);
+  }
+
+  if (!cfg.tokenEndpoint) {
+    throw new Error('Cannot discover token endpoint for refresh.');
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: auth.tokens.refresh,
+    client_id: cfg.clientId,
+  });
+
+  const response = await fetchFn(cfg.tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  const data = await response.json() as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    id_token?: string;
+    scope?: string;
+    error?: string;
+    error_description?: string;
+  };
+
+  if (data.error || !response.ok) {
+    throw new Error(data.error_description || data.error || 'Token refresh failed');
+  }
+
+  // Update stored auth with new tokens
+  const expiresIn = data.expires_in ?? 3600;
+  const updated: StoredAuth = {
+    ...auth,
+    tokens: {
+      access: data.access_token ?? auth.tokens.access,
+      refresh: data.refresh_token ?? auth.tokens.refresh,
+      id_token: data.id_token ?? auth.tokens.id_token,
+      expires_at: Math.floor(Date.now() / 1000) + expiresIn,
+      scope: data.scope ?? auth.tokens.scope,
+    },
+  };
+
+  return updated;
+}
+
+/** Format remaining time in human-readable form. */
+function formatExpiresIn(expiresAt: number): string {
+  const remaining = expiresAt - Math.floor(Date.now() / 1000);
+  if (remaining <= 0) return 'expired';
+  if (remaining < 60) return `${remaining}s`;
+  if (remaining < 3600) return `${Math.floor(remaining / 60)}m`;
+  return `${Math.floor(remaining / 3600)}h ${Math.floor((remaining % 3600) / 60)}m`;
+}
+
+export async function handleWhoami(args: string[], io: CliIO, fetchFn: typeof fetch = fetch): Promise<number> {
+  let serverUrl = '';
+  let jsonOutput = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--server' && args[i + 1]) {
+      serverUrl = args[++i]!;
+    } else if (args[i] === '--json') {
+      jsonOutput = true;
+    }
+  }
+
+  const store = await readAuthStore();
+  const entries = Object.entries(store);
+
+  if (entries.length === 0) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'Not logged in', code: 'NOT_LOGGED_IN' }));
+    } else {
+      writeLine(io.stdout, '  Not logged in. Run ag login first.');
+    }
+    return 1;
+  }
+
+  // Determine which server to show
+  let serverOrigin: string;
+  if (serverUrl) {
+    try {
+      serverOrigin = new URL(serverUrl).origin;
+    } catch {
+      serverOrigin = serverUrl;
+    }
+  } else if (entries.length === 1) {
+    serverOrigin = entries[0]![0];
+  } else {
+    // Multiple servers — show all
+    if (jsonOutput) {
+      const result: Record<string, unknown> = {};
+      for (const [origin, auth] of entries) {
+        const identity = auth.identity.email || auth.identity.sub;
+        result[origin] = { identity, role: auth.role, expires: formatExpiresIn(auth.tokens.expires_at) };
+      }
+      writeLine(io.stdout, JSON.stringify(result));
+    } else {
+      for (const [origin, auth] of entries) {
+        const identity = auth.identity.email || auth.identity.sub;
+        writeLine(io.stdout, `  ${identity}  ${auth.role}  (expires in ${formatExpiresIn(auth.tokens.expires_at)})  [${origin}]`);
+      }
+    }
+    return 0;
+  }
+
+  const auth = store[serverOrigin];
+  if (!auth) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'Not logged in to this server', server: serverOrigin }));
+    } else {
+      writeLine(io.stdout, `  Not logged in to ${serverOrigin}.`);
+    }
+    return 1;
+  }
+
+  // Check if token is expired — try refresh
+  const now = Math.floor(Date.now() / 1000);
+  let currentAuth = auth;
+  if (auth.tokens.expires_at <= now && auth.tokens.refresh) {
+    const config = parseOidcConfig();
+    if (config) {
+      try {
+        currentAuth = await refreshToken(auth, config, fetchFn);
+        // Persist refreshed tokens
+        await setStoredAuth(serverOrigin, currentAuth);
+      } catch {
+        // Refresh failed — remove stale entry and report
+        if (jsonOutput) {
+          writeLine(io.stdout, JSON.stringify({ error: 'Token expired and refresh failed. Run ag login again.', code: 'REFRESH_FAILED' }));
+        } else {
+          writeLine(io.stderr, '  Token expired and refresh failed. Run ag login again.');
+        }
+        return 1;
+      }
+    }
+  }
+
+  const identity = currentAuth.identity.email || currentAuth.identity.name || currentAuth.identity.sub;
+  const expires = formatExpiresIn(currentAuth.tokens.expires_at);
+
+  if (jsonOutput) {
+    writeLine(io.stdout, JSON.stringify({
+      identity: currentAuth.identity,
+      role: currentAuth.role,
+      server: serverOrigin,
+      idp: currentAuth.idp,
+      expires_at: currentAuth.tokens.expires_at,
+      expires_in: expires,
+    }));
+  } else {
+    writeLine(io.stdout, `  ${identity}  ${currentAuth.role}  (token expires in ${expires})`);
+  }
+
+  return 0;
+}

--- a/src/services/auth/oidc-config.ts
+++ b/src/services/auth/oidc-config.ts
@@ -1,0 +1,112 @@
+/**
+ * oidc-config.ts — OIDC configuration parsing for device flow and dashboard SSO.
+ *
+ * Reads AEGIS_OIDC_* env vars, validates them, and exports a typed config object.
+ * Shared between CLI device flow (#1943) and dashboard SSO (#1942).
+ */
+
+/** Validated OIDC configuration. */
+export interface OidcConfig {
+  /** IdP issuer URL (e.g. https://login.microsoftonline.com/tenant-id/v2.0). */
+  issuer: string;
+  /** OAuth2 client ID registered with the IdP (public client for device flow). */
+  clientId: string;
+  /** Expected audience for tokens (defaults to clientId). */
+  audience: string;
+  /** Space-separated scopes (defaults to "openid profile email"). */
+  scopes: string;
+  /** Claim name for role mapping (default: "aegis_role"). */
+  roleClaim: string;
+  /** Directory for auth.json (defaults to ~/.aegis/). */
+  authDir: string;
+  /** Device authorization endpoint (discovered from .well-known, optional). */
+  deviceAuthorizationEndpoint?: string;
+  /** Token endpoint (discovered from .well-known, optional). */
+  tokenEndpoint?: string;
+  /** Revocation endpoint (discovered from .well-known, optional). */
+  revocationEndpoint?: string;
+  /** JWKS URI (discovered from .well-known, optional). */
+  jwksUri?: string;
+}
+
+/** Parse AEGIS_OIDC_* environment variables into a validated config object.
+ *  Returns null if required fields are missing (OIDC not configured). */
+export function parseOidcConfig(env: Record<string, string | undefined> = process.env): OidcConfig | null {
+  const issuer = env.AEGIS_OIDC_ISSUER?.trim();
+  const clientId = env.AEGIS_OIDC_CLIENT_ID?.trim();
+
+  if (!issuer || !clientId) return null;
+
+  // Basic URL validation
+  try {
+    const url = new URL(issuer);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      throw new Error('Invalid protocol');
+    }
+  } catch {
+    throw new Error(`AEGIS_OIDC_ISSUER is not a valid URL: ${issuer}`);
+  }
+
+  return {
+    issuer,
+    clientId,
+    audience: env.AEGIS_OIDC_AUDIENCE?.trim() || clientId,
+    scopes: env.AEGIS_OIDC_SCOPES?.trim() || 'openid profile email',
+    roleClaim: env.AEGIS_OIDC_ROLE_CLAIM?.trim() || 'aegis_role',
+    authDir: env.AEGIS_AUTH_DIR?.trim() || '',
+  };
+}
+
+/** OIDC discovery document structure (subset of fields we need). */
+export interface OidcDiscovery {
+  issuer: string;
+  token_endpoint: string;
+  device_authorization_endpoint?: string;
+  revocation_endpoint?: string;
+  jwks_uri?: string;
+  token_endpoint_auth_methods_supported?: string[];
+  response_types_supported?: string[];
+}
+
+/** Fetch and parse the OIDC discovery document from the IdP.
+ *  Caches the result in the returned config object. */
+export async function discoverOidcEndpoints(
+  issuer: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<OidcDiscovery> {
+  const url = `${issuer.replace(/\/$/, '')}/.well-known/openid-configuration`;
+  const response = await fetchFn(url, {
+    signal: AbortSignal.timeout(10_000),
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`OIDC discovery failed: ${response.status} ${response.statusText} (${url})`);
+  }
+
+  const doc = await response.json() as OidcDiscovery;
+
+  // Validate issuer matches configured value (RFC 8414 §3.1, ADR-0026)
+  const normalizedIssuer = issuer.replace(/\/$/, '');
+  if (doc.issuer !== normalizedIssuer && doc.issuer !== `${normalizedIssuer}/`) {
+    throw new Error(`OIDC issuer mismatch: configured ${issuer} but discovery returned ${doc.issuer}`);
+  }
+
+  // Validate required fields
+  if (!doc.token_endpoint) {
+    throw new Error('OIDC discovery document missing required field: token_endpoint');
+  }
+
+  return doc;
+}
+
+/** Merge discovered endpoints into an OidcConfig. */
+export function mergeDiscovery(config: OidcConfig, discovery: OidcDiscovery): OidcConfig {
+  return {
+    ...config,
+    deviceAuthorizationEndpoint: discovery.device_authorization_endpoint,
+    tokenEndpoint: discovery.token_endpoint,
+    revocationEndpoint: discovery.revocation_endpoint,
+    jwksUri: discovery.jwks_uri,
+  };
+}

--- a/src/services/auth/token-store.ts
+++ b/src/services/auth/token-store.ts
@@ -1,0 +1,135 @@
+/**
+ * token-store.ts — Read/write ~/.aegis/auth.json for OAuth2 device flow tokens.
+ *
+ * Token storage keyed by server origin so multi-server is supported from day one.
+ * Uses atomic writes (write to .tmp, then rename) and enforces 0o600 permissions.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readFile, writeFile, rename, mkdir, unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { secureFilePermissions } from '../../file-utils.js';
+
+/** Stored identity extracted from id_token at login time. */
+export interface StoredIdentity {
+  sub: string;
+  email?: string;
+  name?: string;
+}
+
+/** Stored token set for one server. */
+export interface StoredTokens {
+  access: string;
+  refresh: string;
+  id_token: string;
+  expires_at: number; // Unix epoch seconds
+  scope: string;
+}
+
+/** Full entry stored per server origin. */
+export interface StoredAuth {
+  idp: string;
+  identity: StoredIdentity;
+  tokens: StoredTokens;
+  role: string;
+  obtained_at: string; // ISO 8601
+}
+
+/** Top-level auth.json structure — keyed by server origin URL. */
+export type AuthStore = Record<string, StoredAuth>;
+
+/** Resolve the auth directory path.
+ *  Priority: explicit parameter > AEGIS_AUTH_DIR env var > ~/.aegis/ */
+function resolveAuthDir(authDir?: string): string {
+  return authDir || process.env.AEGIS_AUTH_DIR || join(homedir(), '.aegis');
+}
+
+/** Resolve the auth.json file path. */
+export function resolveAuthFilePath(authDir?: string): string {
+  return join(resolveAuthDir(authDir), 'auth.json');
+}
+
+/** Read the auth store from disk. Returns empty object if file doesn't exist. */
+export async function readAuthStore(authDir?: string): Promise<AuthStore> {
+  const filePath = resolveAuthFilePath(authDir);
+  if (!existsSync(filePath)) return {};
+
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as AuthStore;
+  } catch {
+    return {};
+  }
+}
+
+/** Write the auth store to disk with atomic write and 0o600 permissions. */
+export async function writeAuthStore(store: AuthStore, authDir?: string): Promise<void> {
+  const dir = resolveAuthDir(authDir);
+  const filePath = join(dir, 'auth.json');
+  const tmpPath = `${filePath}.tmp`;
+
+  await mkdir(dir, { recursive: true });
+
+  const content = JSON.stringify(store, null, 2) + '\n';
+  await writeFile(tmpPath, content, { mode: 0o600 });
+  await rename(tmpPath, filePath);
+  await secureFilePermissions(filePath);
+}
+
+/** Get stored auth for a specific server origin. */
+export async function getStoredAuth(
+  serverOrigin: string,
+  authDir?: string,
+): Promise<StoredAuth | null> {
+  const store = await readAuthStore(authDir);
+  return store[serverOrigin] ?? null;
+}
+
+/** Store auth for a specific server origin (atomic write). */
+export async function setStoredAuth(
+  serverOrigin: string,
+  auth: StoredAuth,
+  authDir?: string,
+): Promise<void> {
+  const store = await readAuthStore(authDir);
+  store[serverOrigin] = auth;
+  await writeAuthStore(store, authDir);
+}
+
+/** Remove stored auth for a specific server origin. */
+export async function removeStoredAuth(
+  serverOrigin: string,
+  authDir?: string,
+): Promise<boolean> {
+  const store = await readAuthStore(authDir);
+  if (!store[serverOrigin]) return false;
+  delete store[serverOrigin];
+
+  // If store is empty, delete the file entirely
+  if (Object.keys(store).length === 0) {
+    const filePath = resolveAuthFilePath(authDir);
+    try {
+      await unlink(filePath);
+    } catch {
+      // File may already be gone — ignore
+    }
+    return true;
+  }
+
+  await writeAuthStore(store, authDir);
+  return true;
+}
+
+/** Delete the entire auth.json file (ag logout --all). */
+export async function deleteAuthStore(authDir?: string): Promise<boolean> {
+  const filePath = resolveAuthFilePath(authDir);
+  if (!existsSync(filePath)) return false;
+
+  try {
+    await unlink(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Part 3 of 3 for OAuth2 device authorization grant (#1943). CLI commands for device flow authentication.

**Files:** 7 changed, +1325 lines

| File | Change |
|------|--------|
| `src/commands/login.ts` | **New** — ag login (device flow initiation + polling) |
| `src/commands/logout.ts` | **New** — ag logout (token revocation) |
| `src/commands/whoami.ts` | **New** — ag whoami (identity display) |
| `src/cli.ts` | Wire login/logout/whoami into dispatch + help text |
| `src/services/auth/oidc-config.ts` | Includes shared services |
| `src/services/auth/token-store.ts` | Includes shared services |
| `src/__tests__/device-flow-cli.test.ts` | **New** — 16 tests |

## Cleanup

- Removed dead imports (homedir, writeFileSync per Argus review)

## Verification

```
tsc --noEmit:  ✓ 0 errors
npm run build: ✓ Success
npm test:      ✓ 16 tests passed, 0 failures
```

## Depends on

- #2311 (shared OIDC services) — merge first
- #2312 (device auth endpoints) — merge second

## Series

1. [#2311](#) — shared OIDC services + token store
2. [#2312](#) — device auth server endpoints
3. **This PR** — CLI commands (login/logout/whoami)