### PR TITLE
feat(cli): add ag login command (3a/3) #1943

### DIFF
--- a/src/__tests__/device-flow-cli.test.ts
+++ b/src/__tests__/device-flow-cli.test.ts
@@ -1,0 +1,210 @@
+/**
+ * device-flow-cli.test.ts — Unit tests for ag login / ag logout / ag whoami commands.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Writable } from 'node:stream';
+
+import { handleLogin } from '../commands/login.js';
+import { setStoredAuth, deleteAuthStore, type StoredAuth } from '../services/auth/token-store.js';
+
+// Helper to capture stdout/stderr output
+function createMockIO() {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const stdout = new Writable({ write: (chunk, _enc, cb) => { stdoutChunks.push(chunk.toString()); cb(); } });
+  const stderr = new Writable({ write: (chunk, _enc, cb) => { stderrChunks.push(chunk.toString()); cb(); } });
+  return {
+    stdin: process.stdin,
+    stdout,
+    stderr,
+    getStdout: () => stdoutChunks.join(''),
+    getStderr: () => stderrChunks.join(''),
+  };
+}
+
+// Create a valid base64url-encoded JWT-like id_token for testing
+function createTestIdToken(sub: string, email: string, role: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub, email, name: 'Test User', aegis_role: role })).toString('base64url');
+  const signature = Buffer.from('test-signature').toString('base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+const sampleAuth: StoredAuth = {
+  idp: 'https://idp.example.com',
+  identity: { sub: 'user-123', email: 'alice@example.com', name: 'Alice Engineer' },
+  tokens: {
+    access: 'access-token',
+    refresh: 'refresh-token',
+    id_token: createTestIdToken('user-123', 'alice@example.com', 'admin'),
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    scope: 'openid profile email',
+  },
+  role: 'admin',
+  obtained_at: '2026-04-30T10:00:00Z',
+};
+
+let testDir: string;
+const originalEnv = process.env;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'aegis-test-cli-'));
+  process.env = { ...originalEnv };
+  process.env.AEGIS_AUTH_DIR = testDir;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  rmSync(testDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('ag login', () => {
+  it('exits with code 2 when OIDC is not configured', async () => {
+    delete process.env.AEGIS_OIDC_ISSUER;
+    delete process.env.AEGIS_OIDC_CLIENT_ID;
+
+    const io = createMockIO();
+    const code = await handleLogin([], io);
+    expect(code).toBe(2);
+    expect(io.getStderr()).toContain('OIDC is not configured');
+  });
+
+  it('exits with code 2 for invalid issuer URL', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'not-a-url';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const io = createMockIO();
+    const code = await handleLogin([], io);
+    expect(code).toBe(2);
+    expect(io.getStderr()).toContain('not a valid URL');
+  });
+
+  it('exits with code 1 when IdP discovery fails', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin([], io, mockFetch as unknown as typeof fetch);
+    expect(code).toBe(1);
+    expect(io.getStderr()).toContain('discovery failed');
+  });
+
+  it('exits with code 1 when IdP does not support device flow', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        issuer: 'https://idp.example.com',
+        token_endpoint: 'https://idp.example.com/token',
+        // no device_authorization_endpoint
+      }),
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin([], io, mockFetch as unknown as typeof fetch);
+    expect(code).toBe(1);
+    expect(io.getStderr()).toContain('does not support');
+  });
+
+  it('completes full device flow successfully', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async (url: string, _opts?: RequestInit) => {
+      callCount++;
+      const urlStr = url.toString();
+
+      // Discovery
+      if (urlStr.includes('.well-known')) {
+        return {
+          ok: true,
+          json: async () => ({
+            issuer: 'https://idp.example.com',
+            token_endpoint: 'https://idp.example.com/token',
+            device_authorization_endpoint: 'https://idp.example.com/device/code',
+          }),
+        };
+      }
+
+      // Device authorization
+      if (urlStr.includes('/device/code')) {
+        return {
+          ok: true,
+          json: async () => ({
+            device_code: 'device-123',
+            user_code: 'ABCD-EFGH',
+            verification_uri: 'https://idp.example.com/device',
+            expires_in: 900,
+            interval: 1,
+          }),
+        };
+      }
+
+      // Token endpoint — success on first poll
+      if (urlStr.includes('/token')) {
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'access-abc',
+            refresh_token: 'refresh-def',
+            id_token: createTestIdToken('user-123', 'alice@example.com', 'admin'),
+            expires_in: 3600,
+            token_type: 'Bearer',
+          }),
+        };
+      }
+
+      return { ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) };
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin([], io, mockFetch as unknown as typeof fetch);
+
+    expect(code).toBe(0);
+    expect(io.getStdout()).toContain('Logged in as alice@example.com (admin)');
+    expect(callCount).toBeGreaterThanOrEqual(3); // discovery + device auth + token
+  });
+
+  it('supports --json output', async () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'test-client';
+
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('.well-known')) {
+        return { ok: true, json: async () => ({ issuer: 'https://idp.example.com', token_endpoint: 'https://idp.example.com/token', device_authorization_endpoint: 'https://idp.example.com/device/code' }) };
+      }
+      if (urlStr.includes('/device/code')) {
+        return { ok: true, json: async () => ({ device_code: 'dc', user_code: 'UC', verification_uri: 'https://idp.example.com/device', expires_in: 900, interval: 1 }) };
+      }
+      if (urlStr.includes('/token')) {
+        return { ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt', id_token: createTestIdToken('u1', 'a@b.com', 'viewer'), expires_in: 3600 }) };
+      }
+      return { ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) };
+    });
+
+    const io = createMockIO();
+    const code = await handleLogin(['--json'], io, mockFetch as unknown as typeof fetch);
+    expect(code).toBe(0);
+
+    const output = JSON.parse(io.getStdout());
+    expect(output.identity.email).toBe('a@b.com');
+    expect(output.role).toBe('viewer');
+  });
+});
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { deriveBaseUrl, getConfiguredBaseUrl } from './base-url.js';
 import { loadConfig } from './config.js';
 import { runDoctorCommand } from './doctor.js';
 import { handleInit, findStarterTemplateFiles, handleStarterTemplateDoctor } from './commands/init.js';
+import { handleLogin } from './commands/login.js';
 import { getErrorMessage, parseIntSafe } from './validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -242,6 +243,9 @@ function printHelp(io: CliIO): void {
     ag mcp --port 3000     Custom Aegis API port
     claude mcp add aegis -- ag mcp
 
+  Auth (OAuth2 device flow):
+    ag login               Authenticate via your IdP (requires OIDC config)
+
   Environment variables:
     AEGIS_BASE_URL                 Preferred API base URL for hooks + CLI
     AEGIS_PORT                     Server port (default: 9100)
@@ -254,6 +258,8 @@ function printHelp(io: CliIO): void {
     AEGIS_TG_GROUP                 Telegram group chat ID
     AEGIS_TG_ALLOWED_USERS         Allowed Telegram user IDs (comma-separated)
     AEGIS_WEBHOOKS                 Webhook URLs (comma-separated)
+    AEGIS_OIDC_ISSUER              OIDC issuer URL (for ag login)
+    AEGIS_OIDC_CLIENT_ID           OIDC client ID (for ag login)
 
   API:
     POST /v1/sessions             Create a session
@@ -303,6 +309,10 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
 
   if (argv[0] === 'create') {
     return handleCreate(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'login') {
+    return handleLogin(argv.slice(1), io);
   }
 
   if (argv.length === 1 && !argv[0].startsWith('-')) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,361 @@
+/**
+ * commands/login.ts — `ag login` CLI command.
+ *
+ * Implements the OAuth2 device authorization grant (RFC 8628) for the CLI.
+ * The CLI talks directly to the IdP — no Aegis server required.
+ */
+
+
+import {
+  parseOidcConfig,
+  discoverOidcEndpoints,
+  mergeDiscovery,
+  type OidcConfig,
+} from '../services/auth/oidc-config.js';
+import {
+  readAuthStore,
+  setStoredAuth,
+  type StoredAuth,
+} from '../services/auth/token-store.js';
+
+interface CliIO {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
+  stream.write(`${text}\n`);
+}
+
+// ── RFC 8628 Device Flow ────────────────────────────────────────────
+
+interface DeviceAuthResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+interface TokenResponse {
+  access_token: string;
+  token_type?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  id_token?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+/** Request device authorization from the IdP. */
+async function requestDeviceAuthorization(
+  config: OidcConfig,
+  fetchFn: typeof fetch = fetch,
+): Promise<DeviceAuthResponse> {
+  if (!config.deviceAuthorizationEndpoint) {
+    throw new Error('IdP does not support device authorization flow. No device_authorization_endpoint found in discovery document.');
+  }
+
+  const body = new URLSearchParams({
+    client_id: config.clientId,
+    scope: config.scopes,
+  });
+
+  const response = await fetchFn(config.deviceAuthorizationEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  const data = await response.json() as DeviceAuthResponse;
+
+  if (!response.ok) {
+    const errData = data as unknown as { error?: string; error_description?: string };
+    throw new Error(`Device authorization failed: ${errData.error || response.statusText}${errData.error_description ? ` — ${errData.error_description}` : ''}`);
+  }
+
+  return data;
+}
+
+/** Poll the IdP token endpoint until the user completes browser auth. */
+async function pollForToken(
+  config: OidcConfig,
+  deviceCode: string,
+  interval: number,
+  expiresInSeconds: number,
+  fetchFn: typeof fetch = fetch,
+): Promise<TokenResponse> {
+  const maxElapsed = Math.min(expiresInSeconds, 900) * 1000;
+  const startTime = Date.now();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const elapsed = Date.now() - startTime;
+    if (elapsed >= maxElapsed) {
+      throw new Error('Device code expired. Run ag login again.');
+    }
+
+    // Wait before polling
+    await new Promise(resolve => setTimeout(resolve, interval * 1000));
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth2:grant-type:device_code',
+      device_code: deviceCode,
+      client_id: config.clientId,
+    });
+
+    const response = await fetchFn(config.tokenEndpoint!, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    const data = await response.json() as TokenResponse;
+
+    if (!data.error) {
+      return data;
+    }
+
+    switch (data.error) {
+      case 'authorization_pending':
+        // Normal — user hasn't completed auth yet. Keep polling.
+        break;
+      case 'slow_down':
+        // RFC 8628 §3.5: Increase interval by 5s
+        interval += 5;
+        break;
+      case 'expired_token':
+        throw new Error('Device code expired. Run ag login again.');
+      case 'access_denied':
+        throw new Error('Authorization denied by user.');
+      default:
+        throw new Error(`Token error: ${data.error}${data.error_description ? ` — ${data.error_description}` : ''}`);
+    }
+  }
+}
+
+/** Parse id_token JWT payload (without verification — verification happens server-side). */
+function parseIdTokenPayload(idToken: string): { sub: string; email?: string; name?: string; [key: string]: unknown } {
+  const parts = idToken.split('.');
+  if (parts.length !== 3) throw new Error('Invalid id_token format');
+  const payload = Buffer.from(parts[1]!, 'base64url').toString('utf-8');
+  return JSON.parse(payload) as { sub: string; email?: string; name?: string; [key: string]: unknown };
+}
+
+/** Extract role from id_token claims using the configured role claim. */
+function extractRole(claims: Record<string, unknown>, roleClaim: string): string {
+  const value = claims[roleClaim];
+  if (typeof value === 'string' && ['admin', 'operator', 'viewer'].includes(value)) {
+    return value;
+  }
+  return 'viewer';
+}
+
+/** Derive the server origin from a base URL string. */
+function deriveServerOrigin(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    return url.origin;
+  } catch {
+    return baseUrl;
+  }
+}
+
+// ── Command Handler ─────────────────────────────────────────────────
+
+export async function handleLogin(args: string[], io: CliIO, fetchFn: typeof fetch = fetch): Promise<number> {
+  // Parse flags
+  let serverUrl = '';
+  let noOpen = false;
+  let jsonOutput = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--server' && args[i + 1]) {
+      serverUrl = args[++i]!;
+    } else if (args[i] === '--no-open') {
+      noOpen = true;
+    } else if (args[i] === '--json') {
+      jsonOutput = true;
+    }
+  }
+
+  // 1. Read OIDC config
+  let config: OidcConfig;
+  try {
+    const parsed = parseOidcConfig();
+    if (!parsed) {
+      if (jsonOutput) {
+        writeLine(io.stdout, JSON.stringify({ error: 'OIDC not configured', code: 'CONFIG_ERROR' }));
+      } else {
+        writeLine(io.stderr, '  OIDC is not configured.');
+        writeLine(io.stderr, '  Set AEGIS_OIDC_ISSUER and AEGIS_OIDC_CLIENT_ID environment variables.');
+      }
+      return 2;
+    }
+    config = parsed;
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'CONFIG_ERROR' }));
+    } else {
+      writeLine(io.stderr, `  Configuration error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 2;
+  }
+
+  // 2. Discover IdP endpoints
+  if (!jsonOutput) {
+    writeLine(io.stdout, `  Authenticating via ${config.issuer}...`);
+  }
+
+  try {
+    const discovery = await discoverOidcEndpoints(config.issuer, fetchFn);
+    config = mergeDiscovery(config, discovery);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'DISCOVERY_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  OIDC discovery failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  if (!config.deviceAuthorizationEndpoint) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'IdP does not support device authorization flow', code: 'UNSUPPORTED_FLOW' }));
+    } else {
+      writeLine(io.stderr, '  Your IdP does not support the device authorization flow.');
+      writeLine(io.stderr, '  Use API keys instead (AEGIS_AUTH_TOKEN).');
+    }
+    return 1;
+  }
+
+  // 3. Request device authorization
+  let deviceAuth: DeviceAuthResponse;
+  try {
+    deviceAuth = await requestDeviceAuthorization(config, fetchFn);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'DEVICE_AUTH_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  Device authorization failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  // 4. Display verification URI and user code
+  const verificationUrl = deviceAuth.verification_uri_complete || deviceAuth.verification_uri;
+  const userCode = deviceAuth.user_code;
+
+  if (!jsonOutput) {
+    writeLine(io.stdout);
+    writeLine(io.stdout, '  To authenticate, visit:');
+    writeLine(io.stdout, `    ${verificationUrl}`);
+    writeLine(io.stdout);
+    writeLine(io.stdout, `  Enter code:  ${userCode}`);
+    writeLine(io.stdout);
+    writeLine(io.stdout, '  Waiting for authorization...');
+
+    // Try to open browser (best-effort, silently ignore failure)
+    if (!noOpen && deviceAuth.verification_uri_complete) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error — 'open' is an optional dependency
+        const { default: open } = await import('open');
+        await open(deviceAuth.verification_uri_complete);
+      } catch {
+        // open package not available or browser launch failed — user can copy URL manually
+      }
+    }
+  }
+
+  // 5. Poll for token
+  let tokenResponse: TokenResponse;
+  try {
+    const pollInterval = deviceAuth.interval ?? 5;
+    tokenResponse = await pollForToken(config, deviceAuth.device_code, pollInterval, deviceAuth.expires_in, fetchFn);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: e instanceof Error ? e.message : String(e), code: 'TOKEN_POLL_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  // 6. Validate id_token and extract identity
+  if (!tokenResponse.id_token || !tokenResponse.access_token) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'Token response missing id_token or access_token', code: 'INVALID_TOKEN_RESPONSE' }));
+    } else {
+      writeLine(io.stderr, '  Token response is missing required fields.');
+    }
+    return 1;
+  }
+
+  let claims: Record<string, unknown>;
+  try {
+    claims = parseIdTokenPayload(tokenResponse.id_token);
+  } catch {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: 'Failed to parse id_token', code: 'INVALID_ID_TOKEN' }));
+    } else {
+      writeLine(io.stderr, '  Received an invalid id_token from the IdP.');
+    }
+    return 1;
+  }
+
+  const role = extractRole(claims, config.roleClaim);
+  const identity = {
+    sub: claims.sub as string,
+    email: claims.email as string | undefined,
+    name: claims.name as string | undefined,
+  };
+
+  // 7. Store tokens
+  const serverOrigin = serverUrl ? deriveServerOrigin(serverUrl) : 'cli-local';
+  const expiresIn = tokenResponse.expires_in ?? 3600;
+  const storedAuth: StoredAuth = {
+    idp: config.issuer,
+    identity,
+    tokens: {
+      access: tokenResponse.access_token,
+      refresh: tokenResponse.refresh_token ?? '',
+      id_token: tokenResponse.id_token,
+      expires_at: Math.floor(Date.now() / 1000) + expiresIn,
+      scope: tokenResponse.scope ?? config.scopes,
+    },
+    role,
+    obtained_at: new Date().toISOString(),
+  };
+
+  try {
+    await setStoredAuth(serverOrigin, storedAuth, config.authDir || undefined);
+  } catch (e: unknown) {
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: `Failed to store tokens: ${e instanceof Error ? e.message : String(e)}`, code: 'STORAGE_FAILED' }));
+    } else {
+      writeLine(io.stderr, `  Failed to store tokens: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return 1;
+  }
+
+  // 8. Print confirmation
+  const displayIdentity = identity.email || identity.name || identity.sub;
+  if (jsonOutput) {
+    writeLine(io.stdout, JSON.stringify({
+      identity,
+      role,
+      server: serverOrigin,
+      expires_in: expiresIn,
+    }));
+  } else {
+    writeLine(io.stdout, `  Logged in as ${displayIdentity} (${role})`);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Part 3a of 4 for OAuth2 device authorization grant (#1943). CLI login command.

**Base:** `feat/1943-oidc-services` (merge #2311 first)
**Files:** 3 changed, +581 lines

| File | Change |
|------|--------|
| `src/commands/login.ts` | **New** — ag login (device flow initiation + polling) |
| `src/cli.ts` | Wire login into dispatch + help text (+10 lines) |
| `src/__tests__/device-flow-cli.test.ts` | **New** — 6 tests (login only) |

## Notes
- login.ts is 361 lines — the device flow requires polling loop, error handling, display formatting, and JSON output. Further splitting (e.g., extracting polling into a utility) would be a refactoring follow-up.
- Dead imports (homedir, writeFileSync) removed per Argus review.

## Verification
```
tsc --noEmit:  ✓ 0 errors
npm run build: ✓ Success
npm test:      ✓ 6 tests passed, 0 failures
```

## Depends on
- #2311 (shared OIDC services) — merge first