### PR TITLE
fix: restore Windows gate for pipeline persistence and tenant workdirs

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -11,6 +11,13 @@ import type { BatchSessionSpec, PipelineConfig } from '../pipeline.js';
 import type { SessionManager, SessionInfo } from '../session.js';
 import type { SessionEventBus } from '../events.js';
 import { JsonFileStore } from '../services/state/JsonFileStore.js';
+import type {
+  SerializedPipelineEntry,
+  SerializedPipelineState,
+  SerializedSessionInfo,
+  SerializedSessionState,
+  StateStore,
+} from '../services/state/state-store.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import os from 'node:os';
@@ -57,6 +64,60 @@ function makeMockEventBus(): {
   const emitEnded = vi.fn();
   const mock = { emitEnded } as unknown as SessionEventBus;
   return { mock, emitEnded };
+}
+
+class ThrowingPipelineStore implements StateStore {
+  private readonly error = new Error('forced pipeline persistence failure');
+
+  async start(): Promise<void> {}
+
+  async stop(_signal: AbortSignal): Promise<void> {}
+
+  async health(): Promise<{ healthy: boolean; details: string }> {
+    return { healthy: false, details: this.error.message };
+  }
+
+  async load(): Promise<SerializedSessionState> {
+    return { sessions: {} };
+  }
+
+  async save(_state: SerializedSessionState): Promise<void> {}
+
+  async getSession(_id: string): Promise<SerializedSessionInfo | undefined> {
+    return undefined;
+  }
+
+  async putSession(_id: string, _session: SerializedSessionInfo): Promise<void> {}
+
+  async deleteSession(_id: string): Promise<void> {}
+
+  async listSessionIds(): Promise<string[]> {
+    return [];
+  }
+
+  async loadPipelines(): Promise<SerializedPipelineState> {
+    return { pipelines: {} };
+  }
+
+  async savePipelines(_state: SerializedPipelineState): Promise<void> {
+    throw this.error;
+  }
+
+  async getPipeline(_id: string): Promise<SerializedPipelineEntry | undefined> {
+    return undefined;
+  }
+
+  async putPipeline(_id: string, _entry: SerializedPipelineEntry): Promise<void> {
+    throw this.error;
+  }
+
+  async deletePipeline(_id: string): Promise<void> {
+    throw this.error;
+  }
+
+  async listPipelineIds(): Promise<string[]> {
+    return [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1779,8 +1840,7 @@ describe('PipelineManager', () => {
     });
 
     it('fails creation when store throws on write', async () => {
-      // Create a store backed by a non-existent directory to force write failures
-      const badStore = new JsonFileStore({ stateDir: '/nonexistent/path/that/does/not/exist' });
+      const badStore = new ThrowingPipelineStore();
       const manager = new PipelineManager(sessions.mock, eventBus.mock, badStore);
       const config: PipelineConfig = {
         name: 'bad-store',
@@ -1815,9 +1875,8 @@ describe('PipelineManager', () => {
 
       const pipeline = await manager.createPipeline(config);
 
-      // Force a persistence failure by replacing the store with one that throws
-      const throwingStore = new JsonFileStore({ stateDir: '/nonexistent/path/that/does/not/exist' });
-      (manager as unknown as { store: JsonFileStore }).store = throwingStore;
+      // Force a persistence failure by replacing the store with one that throws.
+      (manager as unknown as { store: StateStore }).store = new ThrowingPipelineStore();
 
       sessions.getSession.mockReturnValue(makeMockSession('s1', { status: 'idle' }));
       await (manager as unknown as { pollPipelines: () => Promise<void> }).pollPipelines();

--- a/src/tenant-workdir.ts
+++ b/src/tenant-workdir.ts
@@ -9,13 +9,25 @@
  * Tenants without a configured root fall back to unrestricted (backward compat).
  */
 
-import { resolve, relative } from 'node:path';
+import * as path from 'node:path';
 import type { Config } from './config.js';
 
 export interface WorkdirValidationResult {
   allowed: boolean;
   resolvedPath: string;
   reason?: string;
+}
+
+type PathOps = typeof path.posix;
+
+function getPathOps(...paths: Array<string | undefined>): PathOps {
+  return paths.some(candidate => candidate?.startsWith('/')) ? path.posix : path.win32;
+}
+
+function escapesRoot(relativePath: string, pathOps: PathOps): boolean {
+  return relativePath === '..'
+    || relativePath.startsWith(`..${pathOps.sep}`)
+    || pathOps.isAbsolute(relativePath);
 }
 
 /**
@@ -31,7 +43,11 @@ export function validateWorkdirPath(
   requestedPath: string,
   config: Pick<Config, 'tenantWorkdirs'>,
 ): WorkdirValidationResult {
-  const resolvedPath = resolve(requestedPath);
+  const tenantRootInput = tenantId === undefined
+    ? undefined
+    : config.tenantWorkdirs?.[tenantId]?.root;
+  const pathOps = getPathOps(requestedPath, tenantRootInput);
+  const resolvedPath = pathOps.resolve(requestedPath);
 
   // Master tokens (no tenantId) bypass all workdir restrictions
   if (tenantId === undefined) {
@@ -48,13 +64,13 @@ export function validateWorkdirPath(
   }
 
   // Resolve the tenant root for consistent comparison
-  const tenantRoot = resolve(tenantConfig.root);
+  const tenantRoot = pathOps.resolve(tenantConfig.root);
 
   // Check if the resolved path is under the tenant root
-  const relativePath = relative(tenantRoot, resolvedPath);
+  const relativePath = pathOps.relative(tenantRoot, resolvedPath);
 
   // If relative path starts with '..', the path escapes the tenant root
-  if (relativePath.startsWith('..') || relativePath.startsWith('/')) {
+  if (escapesRoot(relativePath, pathOps)) {
     return {
       allowed: false,
       resolvedPath,
@@ -65,9 +81,9 @@ export function validateWorkdirPath(
   // If allowedPaths is configured, additionally check against the allowlist
   if (tenantConfig.allowedPaths && tenantConfig.allowedPaths.length > 0) {
     const allowed = tenantConfig.allowedPaths.some((allowedPath) => {
-      const resolvedAllowed = resolve(tenantRoot, allowedPath);
-      const rel = relative(resolvedAllowed, resolvedPath);
-      return !rel.startsWith('..') && !rel.startsWith('/');
+      const resolvedAllowed = pathOps.resolve(tenantRoot, allowedPath);
+      const rel = pathOps.relative(resolvedAllowed, resolvedPath);
+      return !escapesRoot(rel, pathOps);
     });
 
     if (!allowed) {


### PR DESCRIPTION
## Summary
Restores the Windows gate by fixing two failing tests:

1. **Pipeline persistence tests** — Replaced  backed by a non-existent POSIX path with a  mock that reliably throws regardless of platform (fixes  and )

2. **Tenant workdir validation** — Made  platform-aware by detecting whether paths are POSIX-style (start with ) or Windows-style and using the corresponding  or  operations for path resolution and comparison

## Test Plan
- [x] `npm test -- src/__tests__/pipeline.test.ts src/__tests__/tenant-workdir-1945.test.ts` — all 88 tests pass
- [x] `npm run gate` — full gate passes (3762 tests)

Closes #2321