### PR TITLE
feat: add dashboard OIDC SSO

### DIFF
--- a/dashboard/e2e/helpers/auth.ts
+++ b/dashboard/e2e/helpers/auth.ts
@@ -2,6 +2,14 @@ import type { Page } from '@playwright/test';
 
 const TEST_TOKEN = 'e2e-test-token';
 
+export async function mockOidcUnavailable(page: Page): Promise<void> {
+  await page.route('**/auth/session', async (route) => {
+    await route.fulfill({
+      status: 204,
+    });
+  });
+}
+
 /**
  * Authenticate the dashboard through the current memory-only token flow.
  * The helper replays login on every full document load so tests can safely
@@ -9,6 +17,8 @@ const TEST_TOKEN = 'e2e-test-token';
  * Required before navigating to protected pages in smoke tests.
  */
 export async function authenticate(page: Page): Promise<void> {
+  await mockOidcUnavailable(page);
+
   // Suppress OnboardingScreen and FirstRunTour so protected pages render immediately
   await page.addInitScript(() => {
     localStorage.setItem('aegis:onboarded', 'true');

--- a/dashboard/e2e/login.spec.ts
+++ b/dashboard/e2e/login.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { mockOidcUnavailable } from './helpers/auth';
 
 const DASHBOARD_BASE_URL = 'http://localhost:5200/dashboard';
 
 test.describe('Login Page', () => {
   test.beforeEach(async ({ page }) => {
+    await mockOidcUnavailable(page);
     await page.addInitScript(() => {
       localStorage.setItem('aegis:onboarded', 'true');
       localStorage.setItem('aegis:tour:completed', '1');

--- a/dashboard/src/__tests__/App.auth-routing.test.tsx
+++ b/dashboard/src/__tests__/App.auth-routing.test.tsx
@@ -20,6 +20,9 @@ describe('App auth routing', () => {
     localStorage.setItem('aegis:onboarded', 'true');
     useAuthStore.setState({
       token: null,
+      authMode: null,
+      identity: null,
+      oidcAvailable: false,
       isAuthenticated: false,
       isVerifying: false,
       lastVerifiedAt: null,
@@ -45,5 +48,34 @@ describe('App auth routing', () => {
     );
 
     expect(await screen.findByText('Login Page')).toBeDefined();
+  });
+
+  it('allows OIDC-authenticated dashboard access without an API token', async () => {
+    useAuthStore.setState({
+      token: null,
+      authMode: 'oidc',
+      identity: {
+        authenticated: true,
+        userId: 'user-123',
+        email: 'dev@example.com',
+        tenantId: 'default',
+        role: 'viewer',
+        createdAt: 1,
+        expiresAt: 2,
+      },
+      oidcAvailable: true,
+      isAuthenticated: true,
+      isVerifying: false,
+      lastVerifiedAt: null,
+      init: vi.fn(async () => {}),
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Layout Outlet')).toBeDefined();
   });
 });

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -27,9 +27,22 @@ vi.mock('../components/ToastContainer', () => ({
 // Lazy import so mocks are in place
 import Layout from '../components/Layout';
 import { useSidebarStore } from '../store/useSidebarStore';
+import { useAuthStore } from '../store/useAuthStore';
 
 const UPDATE_CHECK_CACHE_KEY = 'aegis:update-check:v1';
 const SIDEBAR_STORAGE_KEY = 'aegis-sidebar-collapsed';
+
+function resetAuthStoreForLayoutTest(): void {
+  useAuthStore.setState({
+    token: null,
+    authMode: null,
+    identity: null,
+    oidcAvailable: false,
+    isAuthenticated: false,
+    isVerifying: false,
+    lastVerifiedAt: null,
+  });
+}
 
 function renderLayout(): RenderResult {
   return render(
@@ -71,6 +84,7 @@ describe('Layout SSE error handling (#587)', () => {
     localStorage.removeItem(SIDEBAR_STORAGE_KEY);
     localStorage.removeItem('aegis-dashboard-theme');
     useSidebarStore.setState({ isCollapsed: false, isMobileOpen: false });
+    resetAuthStoreForLayoutTest();
   });
 
   afterEach(() => {
@@ -331,6 +345,7 @@ describe('Layout sidebar', () => {
     localStorage.removeItem(SIDEBAR_STORAGE_KEY);
     localStorage.removeItem('aegis-dashboard-theme');
     useSidebarStore.setState({ isCollapsed: false, isMobileOpen: false });
+    resetAuthStoreForLayoutTest();
   });
 
   afterEach(() => {
@@ -450,5 +465,32 @@ describe('Layout sidebar', () => {
     renderLayout();
 
     expect(screen.getByText('Settings')).toBeDefined();
+  });
+
+  it('shows OIDC identity metadata in the sidebar footer without an API token', () => {
+    mockSubscribeGlobalSSE.mockReturnValue(() => {});
+    useSidebarStore.setState({ isCollapsed: false });
+    useAuthStore.setState({
+      token: null,
+      authMode: 'oidc',
+      identity: {
+        authenticated: true,
+        userId: 'user-123',
+        email: 'dev@example.com',
+        tenantId: 'default',
+        role: 'viewer',
+        createdAt: 1,
+        expiresAt: 2,
+      },
+      oidcAvailable: true,
+      isAuthenticated: true,
+      isVerifying: false,
+    });
+
+    renderLayout();
+
+    expect(screen.getByLabelText('Signed in user')).toBeDefined();
+    expect(screen.getByText('dev@example.com')).toBeDefined();
+    expect(screen.getByText('viewer - default')).toBeDefined();
   });
 });

--- a/dashboard/src/__tests__/LoginPage.test.tsx
+++ b/dashboard/src/__tests__/LoginPage.test.tsx
@@ -10,11 +10,28 @@ import { I18nProvider } from '../i18n/context';
 
 const mockLogin = vi.fn();
 const mockInit = vi.fn(async () => {});
+const mockLoginWithOidc = vi.fn();
+
+interface MockAuthState {
+  login: typeof mockLogin;
+  loginWithOidc: typeof mockLoginWithOidc;
+  init: typeof mockInit;
+  isAuthenticated: boolean;
+  isVerifying: boolean;
+  oidcAvailable: boolean | null;
+}
+
+let mockAuthState: MockAuthState = {
+  login: mockLogin,
+  loginWithOidc: mockLoginWithOidc,
+  init: mockInit,
+  isAuthenticated: false,
+  isVerifying: false,
+  oidcAvailable: false,
+};
 
 vi.mock('../store/useAuthStore', () => ({
-  useAuthStore: (
-    selector: (state: { login: typeof mockLogin; init: typeof mockInit; isAuthenticated: boolean }) => unknown,
-  ) => selector({ login: mockLogin, init: mockInit, isAuthenticated: false }),
+  useAuthStore: (selector: (state: MockAuthState) => unknown) => selector(mockAuthState),
 }));
 
 function renderPage(): void {
@@ -30,6 +47,15 @@ function renderPage(): void {
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    mockAuthState = {
+      login: mockLogin,
+      loginWithOidc: mockLoginWithOidc,
+      init: mockInit,
+      isAuthenticated: false,
+      isVerifying: false,
+      oidcAvailable: false,
+    };
     mockInit.mockResolvedValue(undefined);
   });
 
@@ -95,5 +121,35 @@ describe('LoginPage', () => {
     renderPage();
 
     expect((screen.getByRole('button', { name: 'Sign in' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows OIDC sign-in when dashboard OIDC is available', () => {
+    mockAuthState = { ...mockAuthState, oidcAvailable: true };
+
+    renderPage();
+
+    expect(screen.getByText('Sign in with your identity provider to continue')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Sign in with SSO' })).toBeDefined();
+    expect(screen.queryByLabelText('API token')).toBeNull();
+  });
+
+  it('uses OIDC sign-in without storing or submitting token secrets', () => {
+    mockAuthState = { ...mockAuthState, oidcAvailable: true };
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with SSO' }));
+
+    expect(mockLoginWithOidc).toHaveBeenCalledTimes(1);
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('shows a checking state while auth mode is still unknown', () => {
+    mockAuthState = { ...mockAuthState, isVerifying: true, oidcAvailable: null };
+
+    renderPage();
+
+    expect(screen.getByLabelText('Checking authentication')).toBeDefined();
+    expect(screen.queryByLabelText('API token')).toBeNull();
   });
 });

--- a/dashboard/src/__tests__/ProtectedRoute.test.tsx
+++ b/dashboard/src/__tests__/ProtectedRoute.test.tsx
@@ -8,6 +8,9 @@ describe('ProtectedRoute', () => {
   beforeEach(() => {
     useAuthStore.setState({
       token: null,
+      authMode: null,
+      identity: null,
+      oidcAvailable: false,
       isAuthenticated: false,
       isVerifying: false,
       lastVerifiedAt: null,
@@ -33,6 +36,9 @@ describe('ProtectedRoute', () => {
   it('renders protected content for authenticated users', () => {
     useAuthStore.setState({
       token: 'token-123',
+      authMode: 'token',
+      identity: null,
+      oidcAvailable: false,
       isAuthenticated: true,
       isVerifying: false,
       lastVerifiedAt: Date.now(),
@@ -53,9 +59,46 @@ describe('ProtectedRoute', () => {
     expect(screen.getByText('Protected Content')).toBeDefined();
   });
 
+  it('renders protected content for authenticated OIDC sessions without API token', () => {
+    useAuthStore.setState({
+      token: null,
+      authMode: 'oidc',
+      identity: {
+        authenticated: true,
+        userId: 'user-123',
+        email: 'dev@example.com',
+        tenantId: 'default',
+        role: 'viewer',
+        createdAt: 1,
+        expiresAt: 2,
+      },
+      oidcAvailable: true,
+      isAuthenticated: true,
+      isVerifying: false,
+      lastVerifiedAt: null,
+      init: vi.fn(async () => {}),
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/login" element={<div>Login Screen</div>} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/" element={<div>Protected Content</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Protected Content')).toBeDefined();
+  });
+
   it('shows loading state while verifying', () => {
     useAuthStore.setState({
       token: 'token-123',
+      authMode: 'token',
+      identity: null,
+      oidcAvailable: false,
       isAuthenticated: false,
       isVerifying: true,
       lastVerifiedAt: null,

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -297,6 +297,106 @@ describe('checkForUpdates', () => {
   });
 });
 
+describe('dashboard OIDC session client (#1942)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('treats /auth/session 404 as OIDC unavailable', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { getDashboardSession } = await import('../api/client');
+
+    await expect(getDashboardSession()).resolves.toEqual({ oidcAvailable: false, authenticated: false });
+    expect(fetchMock).toHaveBeenCalledWith('/auth/session', expect.objectContaining({
+      method: 'GET',
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    }));
+  });
+
+  it('treats /auth/session 401 as OIDC available but unauthenticated', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ authenticated: false }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { getDashboardSession } = await import('../api/client');
+
+    await expect(getDashboardSession()).resolves.toEqual({ oidcAvailable: true, authenticated: false });
+  });
+
+  it('returns only dashboard identity fields for authenticated OIDC sessions', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      authenticated: true,
+      userId: 'user-123',
+      email: 'dev@example.com',
+      name: 'Dev User',
+      tenantId: 'default',
+      role: 'viewer',
+      createdAt: 1,
+      expiresAt: 2,
+      idToken: 'secret-id-token',
+      accessToken: 'secret-access-token',
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { getDashboardSession } = await import('../api/client');
+
+    const result = await getDashboardSession();
+
+    expect(result).toEqual({
+      oidcAvailable: true,
+      authenticated: true,
+      identity: {
+        authenticated: true,
+        userId: 'user-123',
+        email: 'dev@example.com',
+        name: 'Dev User',
+        tenantId: 'default',
+        role: 'viewer',
+        createdAt: 1,
+        expiresAt: 2,
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('secret');
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('posts OIDC logout with cookies and no bearer token', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const { logoutDashboardSession } = await import('../api/client');
+
+    await expect(logoutDashboardSession()).resolves.toBe('logged-out');
+    expect(fetchMock).toHaveBeenCalledWith('/auth/logout', expect.objectContaining({
+      method: 'POST',
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    }));
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(requestInit.headers).toEqual(expect.not.objectContaining({ Authorization: expect.anything() }));
+  });
+});
+
 describe('SSE bearer token fallback (#408)', () => {
   // #408: Verify that when SSE token creation fails, the code NEVER falls back
   // to using the long-lived bearer token in the SSE URL query parameter.

--- a/dashboard/src/__tests__/useAuthStore.test.ts
+++ b/dashboard/src/__tests__/useAuthStore.test.ts
@@ -3,15 +3,22 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { DashboardSessionIdentity } from '../api/client';
 
 const mockVerifyToken = vi.fn();
 const mockSetUnauthorizedHandler = vi.fn();
 const mockSetTokenAccessor = vi.fn();
+const mockGetDashboardSession = vi.fn();
+const mockLogoutDashboardSession = vi.fn();
+const mockGetOidcLoginUrl = vi.fn();
 
 vi.mock('../api/client', () => ({
   verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
   setUnauthorizedHandler: (...args: unknown[]) => mockSetUnauthorizedHandler(...args),
   setTokenAccessor: (...args: unknown[]) => mockSetTokenAccessor(...args),
+  getDashboardSession: (...args: unknown[]) => mockGetDashboardSession(...args),
+  logoutDashboardSession: (...args: unknown[]) => mockLogoutDashboardSession(...args),
+  getOidcLoginUrl: (...args: unknown[]) => mockGetOidcLoginUrl(...args),
 }));
 
 // Lazy import so mock is in place
@@ -21,9 +28,15 @@ import { useStore } from '../store/useStore';
 describe('useAuthStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetDashboardSession.mockResolvedValue({ oidcAvailable: false, authenticated: false });
+    mockLogoutDashboardSession.mockResolvedValue('logged-out');
+    mockGetOidcLoginUrl.mockReturnValue('/auth/login');
     localStorage.removeItem('aegis_token');
     useAuthStore.setState({
       token: null,
+      authMode: null,
+      identity: null,
+      oidcAvailable: null,
       isAuthenticated: false,
       isVerifying: false,
       lastVerifiedAt: null,
@@ -46,6 +59,8 @@ describe('useAuthStore', () => {
 
       expect(success).toBe(true);
       expect(useAuthStore.getState().token).toBe('my-token');
+      expect(useAuthStore.getState().authMode).toBe('token');
+      expect(useAuthStore.getState().identity).toBeNull();
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
       expect(useStore.getState().token).toBe('my-token');
       expect(localStorage.getItem('aegis_token')).toBeNull();
@@ -75,19 +90,51 @@ describe('useAuthStore', () => {
   });
 
   describe('logout', () => {
-    it('clears token and resets auth state', () => {
+    it('clears token and resets auth state', async () => {
       localStorage.setItem('aegis_token', 'stored-token');
       useAuthStore.setState({
         token: 'stored-token',
+        authMode: 'token',
+        identity: null,
         isAuthenticated: true,
       });
 
-      useAuthStore.getState().logout();
+      await useAuthStore.getState().logout();
 
       expect(useAuthStore.getState().token).toBeNull();
+      expect(useAuthStore.getState().authMode).toBeNull();
+      expect(useAuthStore.getState().identity).toBeNull();
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
       expect(useStore.getState().token).toBeNull();
       expect(localStorage.getItem('aegis_token')).toBeNull();
+      expect(mockLogoutDashboardSession).not.toHaveBeenCalled();
+    });
+
+    it('posts OIDC logout for OIDC sessions and clears local state', async () => {
+      useAuthStore.setState({
+        token: null,
+        authMode: 'oidc',
+        identity: {
+          authenticated: true,
+          userId: 'user-123',
+          email: 'dev@example.com',
+          tenantId: 'default',
+          role: 'viewer',
+          createdAt: 1,
+          expiresAt: 2,
+        },
+        oidcAvailable: true,
+        isAuthenticated: true,
+      });
+
+      await useAuthStore.getState().logout();
+
+      expect(mockLogoutDashboardSession).toHaveBeenCalledTimes(1);
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(useAuthStore.getState().authMode).toBeNull();
+      expect(useAuthStore.getState().identity).toBeNull();
+      expect(useAuthStore.getState().isAuthenticated).toBe(false);
+      expect(useStore.getState().token).toBeNull();
     });
   });
 
@@ -104,11 +151,53 @@ describe('useAuthStore', () => {
       expect(mockVerifyToken).not.toHaveBeenCalled();
       expect(mockSetUnauthorizedHandler).toHaveBeenCalledTimes(1);
       expect(mockSetTokenAccessor).toHaveBeenCalledTimes(1);
+      expect(mockGetDashboardSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores an authenticated dashboard OIDC session without storing API tokens', async () => {
+      const identity: DashboardSessionIdentity = {
+        authenticated: true,
+        userId: 'user-123',
+        email: 'dev@example.com',
+        tenantId: 'default',
+        role: 'viewer',
+        createdAt: 1,
+        expiresAt: 2,
+      };
+      mockGetDashboardSession.mockResolvedValueOnce({
+        oidcAvailable: true,
+        authenticated: true,
+        identity,
+      });
+
+      await useAuthStore.getState().init();
+
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(useAuthStore.getState().authMode).toBe('oidc');
+      expect(useAuthStore.getState().identity).toEqual(identity);
+      expect(useAuthStore.getState().oidcAvailable).toBe(true);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useStore.getState().token).toBeNull();
+      expect(localStorage.getItem('aegis_token')).toBeNull();
+      expect(mockVerifyToken).not.toHaveBeenCalled();
+    });
+
+    it('marks OIDC available when /auth/session returns unauthenticated', async () => {
+      mockGetDashboardSession.mockResolvedValueOnce({ oidcAvailable: true, authenticated: false });
+
+      await useAuthStore.getState().init();
+
+      expect(useAuthStore.getState().oidcAvailable).toBe(true);
+      expect(useAuthStore.getState().isAuthenticated).toBe(false);
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(mockVerifyToken).not.toHaveBeenCalled();
     });
 
     it('preserves an authenticated in-memory token across route changes', async () => {
       useAuthStore.setState({
         token: 'live-token',
+        authMode: 'token',
+        identity: null,
         isAuthenticated: true,
         isVerifying: false,
         lastVerifiedAt: Date.now(),
@@ -117,6 +206,7 @@ describe('useAuthStore', () => {
       await useAuthStore.getState().init();
 
       expect(useAuthStore.getState().token).toBe('live-token');
+      expect(useAuthStore.getState().authMode).toBe('token');
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
       expect(useStore.getState().token).toBe('live-token');
       expect(mockVerifyToken).not.toHaveBeenCalled();
@@ -132,6 +222,8 @@ describe('useAuthStore', () => {
     it('revalidates an in-memory token when auth state is incomplete', async () => {
       useAuthStore.setState({
         token: 'some-token',
+        authMode: null,
+        identity: null,
         isAuthenticated: false,
         isVerifying: false,
         lastVerifiedAt: null,
@@ -142,12 +234,15 @@ describe('useAuthStore', () => {
 
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
       expect(useAuthStore.getState().token).toBe('some-token');
+      expect(useAuthStore.getState().authMode).toBe('token');
       expect(useStore.getState().token).toBe('some-token');
     });
 
     it('keeps the in-memory token on non-401 verify errors during init', async () => {
       useAuthStore.setState({
         token: 'some-token',
+        authMode: null,
+        identity: null,
         isAuthenticated: false,
         isVerifying: false,
         lastVerifiedAt: null,
@@ -159,6 +254,7 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().isVerifying).toBe(false);
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
       expect(useAuthStore.getState().token).toBe('some-token');
+      expect(useAuthStore.getState().authMode).toBe('token');
       expect(useStore.getState().token).toBe('some-token');
     });
   });

--- a/dashboard/src/__tests__/users-redirect.test.tsx
+++ b/dashboard/src/__tests__/users-redirect.test.tsx
@@ -38,6 +38,9 @@ describe('/users client-side redirect', () => {
     localStorage.setItem('aegis:onboarded', 'true');
     useAuthStore.setState({
       token: 'test-token',
+      authMode: 'token',
+      identity: null,
+      oidcAvailable: false,
       isAuthenticated: true,
       isVerifying: false,
       lastVerifiedAt: Date.now(),

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -27,6 +27,7 @@ import type {
   UIState,
   ApiError,
   AuthKeySummary,
+  ApiKeyRole,
   VerifyTokenResponse,
   CreatedAuthKey,
   AnalyticsSummary,
@@ -56,6 +57,7 @@ import {
   AllSessionsHealthSchema,
 } from './schemas';
 const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
+const OIDC_LOGIN_PATH = '/auth/login';
 const SESSION_STATUS_VALUES: UIState[] = [
   'idle',
   'working',
@@ -95,6 +97,10 @@ function headersToObject(h: HeadersInit | undefined): Record<string, string> {
     return obj;
   }
   return h as Record<string, string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 // ── Runtime validation (defensive, non-blocking) ─────────────────
@@ -666,6 +672,115 @@ export function verifyToken(token: string): Promise<VerifyTokenResponse> {
     method: 'POST',
     body: JSON.stringify({ token }),
   });
+}
+
+// ── Dashboard OIDC Session ─────────────────────────────────────
+
+export interface DashboardSessionIdentity {
+  authenticated: true;
+  userId: string;
+  email?: string;
+  name?: string;
+  tenantId: string;
+  role: ApiKeyRole;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export type DashboardSessionResult =
+  | { oidcAvailable: false; authenticated: false }
+  | { oidcAvailable: true; authenticated: false }
+  | { oidcAvailable: true; authenticated: true; identity: DashboardSessionIdentity };
+
+export type DashboardLogoutResult = 'logged-out' | 'unavailable';
+
+function isApiKeyRole(value: unknown): value is ApiKeyRole {
+  return value === 'admin' || value === 'operator' || value === 'viewer';
+}
+
+function isDashboardSessionIdentity(value: unknown): value is DashboardSessionIdentity {
+  if (!isRecord(value)) return false;
+  const email = value.email;
+  const name = value.name;
+  return value.authenticated === true
+    && typeof value.userId === 'string'
+    && (email === undefined || typeof email === 'string')
+    && (name === undefined || typeof name === 'string')
+    && typeof value.tenantId === 'string'
+    && isApiKeyRole(value.role)
+    && typeof value.createdAt === 'number'
+    && typeof value.expiresAt === 'number';
+}
+
+async function readJsonOrNull(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+export function getOidcLoginUrl(): string {
+  return `${BASE_URL}${OIDC_LOGIN_PATH}`;
+}
+
+export async function getDashboardSession(): Promise<DashboardSessionResult> {
+  const response = await fetch(`${BASE_URL}/auth/session`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (response.status === 404) {
+    return { oidcAvailable: false, authenticated: false };
+  }
+  if (response.status === 401) {
+    return { oidcAvailable: true, authenticated: false };
+  }
+  if (!response.ok) {
+    const body = await readJsonOrNull(response);
+    const message = isRecord(body) && typeof body.error === 'string'
+      ? body.error
+      : `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+
+  const body = await readJsonOrNull(response);
+  if (!isDashboardSessionIdentity(body)) {
+    throw new Error('Invalid dashboard session response');
+  }
+  const identity: DashboardSessionIdentity = {
+    authenticated: true,
+    userId: body.userId,
+    ...(body.email ? { email: body.email } : {}),
+    ...(body.name ? { name: body.name } : {}),
+    tenantId: body.tenantId,
+    role: body.role,
+    createdAt: body.createdAt,
+    expiresAt: body.expiresAt,
+  };
+  return { oidcAvailable: true, authenticated: true, identity };
+}
+
+export async function logoutDashboardSession(): Promise<DashboardLogoutResult> {
+  const response = await fetch(`${BASE_URL}/auth/logout`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (response.status === 404) {
+    return 'unavailable';
+  }
+  if (response.ok) {
+    return 'logged-out';
+  }
+
+  const body = await readJsonOrNull(response);
+  const message = isRecord(body) && typeof body.error === 'string'
+    ? body.error
+    : `HTTP ${response.status}`;
+  throw new Error(message);
 }
 
 // ── Auth Keys ──────────────────────────────────────────────────

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -97,6 +97,7 @@ export default function Layout() {
   const addActivity = useStore((s) => s.addActivity);
   const token = useStore((s) => s.token);
   const logout = useAuthStore((s) => s.logout);
+  const identity = useAuthStore((s) => s.identity);
 
   const isCollapsed = useSidebarStore((s) => s.isCollapsed);
   const isMobileOpen = useSidebarStore((s) => s.isMobileOpen);
@@ -308,7 +309,13 @@ export default function Layout() {
     }
   }
 
+  function handleLogout(): void {
+    void logout();
+  }
+
   const sidebarWidth = isCollapsed ? 'w-16' : 'w-56';
+  const identityLabel = identity?.email ?? identity?.name ?? identity?.userId;
+  const identityDetailLabel = identity ? `${identity.role} - ${identity.tenantId}` : null;
 
 
   return (
@@ -380,6 +387,15 @@ export default function Layout() {
 
         {/* Bottom section: Settings + toggle + logout */}
         <div className="border-t border-white/5 px-3 py-4 flex flex-col gap-2">
+          {identityLabel && identityDetailLabel && !isCollapsed && (
+            <div className="px-3 py-2" aria-label="Signed in user">
+              <p className="truncate text-xs font-medium text-slate-700 dark:text-gray-200">{identityLabel}</p>
+              <p className="truncate text-[11px] text-slate-500 dark:text-gray-500">
+                {identityDetailLabel}
+              </p>
+            </div>
+          )}
+
           {/* Settings link */}
           <NavLink
             to="/settings"
@@ -416,7 +432,7 @@ export default function Layout() {
           {/* Logout */}
           <button
             type="button"
-            onClick={logout}
+            onClick={handleLogout}
             className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
             title={isCollapsed ? 'Sign out' : undefined}
           >

--- a/dashboard/src/components/ProtectedRoute.tsx
+++ b/dashboard/src/components/ProtectedRoute.tsx
@@ -11,7 +11,6 @@ function LoadingFallback() {
 }
 
 export default function ProtectedRoute() {
-  const token = useAuthStore((s) => s.token);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isVerifying = useAuthStore((s) => s.isVerifying);
   const init = useAuthStore((s) => s.init);
@@ -25,7 +24,7 @@ export default function ProtectedRoute() {
     return <LoadingFallback />;
   }
 
-  if (!token || !isAuthenticated) {
+  if (!isAuthenticated) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -4,15 +4,18 @@
 
 import { type FormEvent, useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { Shield, Eye, EyeOff } from 'lucide-react';
+import { Shield, Eye, EyeOff, LogIn } from 'lucide-react';
 import { useAuthStore } from '../store/useAuthStore.js';
 import { useT } from '../i18n/context';
 
 export default function LoginPage() {
   const t = useT();
   const login = useAuthStore((s) => s.login);
+  const loginWithOidc = useAuthStore((s) => s.loginWithOidc);
   const init = useAuthStore((s) => s.init);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isVerifying = useAuthStore((s) => s.isVerifying);
+  const oidcAvailable = useAuthStore((s) => s.oidcAvailable);
   const [token, setToken] = useState('');
   const [showToken, setShowToken] = useState(false);
   const [error, setError] = useState('');
@@ -26,6 +29,12 @@ export default function LoginPage() {
   useEffect(() => {
     void init();
   }, [init]);
+
+  useEffect(() => {
+    if (oidcAvailable) {
+      setToken('');
+    }
+  }, [oidcAvailable]);
 
   if (isAuthenticated) {
     return <Navigate to={from} replace />;
@@ -47,53 +56,76 @@ export default function LoginPage() {
     // On success, the auth store sets isAuthenticated and ProtectedRoute redirects
   }
 
+  function handleOidcLogin(): void {
+    setError('');
+    loginWithOidc();
+  }
+
+  const checkingAuthMode = oidcAvailable === null && isVerifying;
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[var(--color-void)]]">
+    <div className="flex min-h-screen items-center justify-center bg-[var(--color-void)]">
       <div className="w-full max-w-sm rounded-xl border border-zinc-800 bg-zinc-900 p-8">
         {/* Logo / Title */}
         <div className="mb-8 flex flex-col items-center gap-2">
           <Shield className="h-10 w-10 text-blue-500" />
           <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Aegis</h1>
-          <p className="text-sm text-gray-400">Enter your API token to continue</p>
+          <p className="text-sm text-gray-400">
+            {oidcAvailable ? 'Sign in with your identity provider to continue' : 'Enter your API token to continue'}
+          </p>
         </div>
 
-        {/* Form */}
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <div className="relative">
-            <label htmlFor="token" className="sr-only">API token</label>
-            <input
-              id="token"
-              name="token"
-              type={showToken ? 'text' : 'password'}
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              placeholder="API token"
-              autoFocus
-              autoComplete="current-password"
-              className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 pr-10 text-sm text-gray-200 placeholder-gray-500 focus:border-blue-500 focus:outline-none touch-action-manipulation"
-            />
-            <button
-              type="button"
-              onClick={() => setShowToken(!showToken)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
-              aria-label={showToken ? 'Hide token' : 'Show token'}
-            >
-              {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-            </button>
+        {checkingAuthMode ? (
+          <div className="flex justify-center py-2" aria-label="Checking authentication">
+            <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-500" />
           </div>
-
-          {error && (
-            <p className="text-sm text-red-400">{error}</p>
-          )}
-
+        ) : oidcAvailable ? (
           <button
-            type="submit"
-            disabled={loading || !token.trim()}
-            className="rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            type="button"
+            onClick={handleOidcLogin}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500"
           >
-            {loading ? t('login.verifying') : t('login.signInButton')}
+            <LogIn className="h-4 w-4" />
+            <span>Sign in with SSO</span>
           </button>
-        </form>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="relative">
+              <label htmlFor="token" className="sr-only">API token</label>
+              <input
+                id="token"
+                name="token"
+                type={showToken ? 'text' : 'password'}
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="API token"
+                autoFocus
+                autoComplete="current-password"
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 pr-10 text-sm text-gray-200 placeholder-gray-500 focus:border-blue-500 focus:outline-none touch-action-manipulation"
+              />
+              <button
+                type="button"
+                onClick={() => setShowToken(!showToken)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+                aria-label={showToken ? 'Hide token' : 'Show token'}
+              >
+                {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-400">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading || !token.trim()}
+              className="rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? t('login.verifying') : t('login.signInButton')}
+            </button>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/dashboard/src/store/useAuthStore.ts
+++ b/dashboard/src/store/useAuthStore.ts
@@ -6,16 +6,30 @@
  */
 
 import { create } from 'zustand';
-import { setTokenAccessor, setUnauthorizedHandler, verifyToken } from '../api/client.js';
+import {
+  getDashboardSession,
+  getOidcLoginUrl,
+  logoutDashboardSession,
+  setTokenAccessor,
+  setUnauthorizedHandler,
+  verifyToken,
+  type DashboardSessionIdentity,
+} from '../api/client.js';
 import { useStore } from './useStore.js';
+
+type AuthMode = 'token' | 'oidc' | null;
 
 interface AuthState {
   token: string | null;
+  authMode: AuthMode;
+  identity: DashboardSessionIdentity | null;
+  oidcAvailable: boolean | null;
   isAuthenticated: boolean;
   isVerifying: boolean;
   lastVerifiedAt: number | null;
   login: (token: string) => Promise<boolean>;
-  logout: () => void;
+  loginWithOidc: () => void;
+  logout: () => Promise<void>;
   init: () => Promise<void>;
   revalidate: (force?: boolean) => Promise<boolean>;
 }
@@ -43,16 +57,50 @@ function syncAuthToken(token: string | null): void {
   useStore.getState().clearToken();
 }
 
-function clearAuthState(set: (partial: Partial<AuthState>) => void): void {
+function clearAuthState(
+  set: (partial: Partial<AuthState>) => void,
+  options: { oidcAvailable?: boolean | null } = {},
+): void {
   purgeLegacyToken();
   syncAuthToken(null);
-  set({ token: null, isAuthenticated: false, isVerifying: false, lastVerifiedAt: null });
+  const partial: Partial<AuthState> = {
+    token: null,
+    authMode: null,
+    identity: null,
+    isAuthenticated: false,
+    isVerifying: false,
+    lastVerifiedAt: null,
+  };
+  if ('oidcAvailable' in options) {
+    partial.oidcAvailable = options.oidcAvailable;
+  }
+  set(partial);
+}
+
+function setOidcAuthState(
+  set: (partial: Partial<AuthState>) => void,
+  identity: DashboardSessionIdentity,
+): void {
+  purgeLegacyToken();
+  syncAuthToken(null);
+  set({
+    token: null,
+    authMode: 'oidc',
+    identity,
+    oidcAvailable: true,
+    isAuthenticated: true,
+    isVerifying: false,
+    lastVerifiedAt: null,
+  });
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
   token: null,
+  authMode: null,
+  identity: null,
+  oidcAvailable: null,
   isAuthenticated: false,
-  isVerifying: false,
+  isVerifying: true,
   lastVerifiedAt: null,
 
   login: async (token: string): Promise<boolean> => {
@@ -62,39 +110,80 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const result = await verifyToken(token);
       if (result.valid) {
         syncAuthToken(token);
-        set({ token, isAuthenticated: true, isVerifying: false, lastVerifiedAt: Date.now() });
+        set({
+          token,
+          authMode: 'token',
+          identity: null,
+          isAuthenticated: true,
+          isVerifying: false,
+          lastVerifiedAt: Date.now(),
+        });
         return true;
       }
-      clearAuthState(set);
+      clearAuthState(set, { oidcAvailable: get().oidcAvailable });
       return false;
     } catch {
-      clearAuthState(set);
+      clearAuthState(set, { oidcAvailable: get().oidcAvailable });
       return false;
     }
   },
 
-  logout: () => {
-    clearAuthState(set);
+  loginWithOidc: () => {
+    window.location.assign(getOidcLoginUrl());
+  },
+
+  logout: async () => {
+    const state = get();
+    const wasOidcSession = state.authMode === 'oidc';
+    clearAuthState(set, { oidcAvailable: state.oidcAvailable });
+    if (!wasOidcSession) return;
+
+    try {
+      const result = await logoutDashboardSession();
+      if (result === 'unavailable') {
+        set({ oidcAvailable: false });
+      }
+    } catch {
+      // Local auth state is already cleared. The next /auth/session probe will
+      // reconcile any stale server-side cookie without storing a client secret.
+    }
   },
 
   init: async () => {
     purgeLegacyToken();
 
     setUnauthorizedHandler(() => {
-      clearAuthState(set);
+      if (get().authMode === 'oidc') {
+        return;
+      }
+      clearAuthState(set, { oidcAvailable: get().oidcAvailable });
     });
     setTokenAccessor(() => get().token);
 
+    set({ isVerifying: true });
+
+    try {
+      const session = await getDashboardSession();
+      if (session.authenticated) {
+        setOidcAuthState(set, session.identity);
+        return;
+      }
+      set({ oidcAvailable: session.oidcAvailable });
+    } catch {
+      set({ oidcAvailable: false });
+    }
+
     const state = get();
     if (!state.token) {
-      // No persisted token to restore — user must re-authenticate on reload.
-      clearAuthState(set);
+      // No persisted token to restore. When OIDC is configured, the login page
+      // will show the provider sign-in action; otherwise it falls back to API token login.
+      clearAuthState(set, { oidcAvailable: state.oidcAvailable });
       return;
     }
 
     syncAuthToken(state.token);
 
-    if (state.isAuthenticated) {
+    if (state.isAuthenticated && state.authMode === 'token') {
       set({ isVerifying: false });
       return;
     }
@@ -106,7 +195,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     const state = get();
     const token = state.token;
     if (!token) {
-      clearAuthState(set);
+      if (state.authMode === 'oidc' && state.isAuthenticated) {
+        return true;
+      }
+      clearAuthState(set, { oidcAvailable: state.oidcAvailable });
       return false;
     }
 
@@ -126,19 +218,26 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         const result = await verifyToken(token);
         if (result.valid) {
           syncAuthToken(token);
-          set({ token, isAuthenticated: true, isVerifying: false, lastVerifiedAt: Date.now() });
+          set({
+            token,
+            authMode: 'token',
+            identity: null,
+            isAuthenticated: true,
+            isVerifying: false,
+            lastVerifiedAt: Date.now(),
+          });
           return true;
         }
-        clearAuthState(set);
+        clearAuthState(set, { oidcAvailable: get().oidcAvailable });
         return false;
       } catch (error) {
         if (error instanceof Error && error.message === 'Unauthorized') {
-          clearAuthState(set);
+          clearAuthState(set, { oidcAvailable: get().oidcAvailable });
           return false;
         }
         // Network/server errors: keep existing token and avoid hard logout.
         syncAuthToken(token);
-        set({ token, isAuthenticated: true, isVerifying: false });
+        set({ token, authMode: 'token', identity: null, isAuthenticated: true, isVerifying: false });
         return true;
       } finally {
         inFlightValidation = null;

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
         changeOrigin: true,
         ws: true,
       },
+      '/auth': {
+        target: 'http://127.0.0.1:19200',
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "async-mutex": "^0.5.0",
         "fastify": "^5.8.2",
         "nodemailer": "^8.0.5",
+        "openid-client": "^6.8.4",
         "prom-client": "^15.1.3",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
@@ -7828,6 +7829,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7898,6 +7908,19 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "async-mutex": "^0.5.0",
     "fastify": "^5.8.2",
     "nodemailer": "^8.0.5",
+    "openid-client": "^6.8.4",
     "prom-client": "^15.1.3",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"

--- a/src/__tests__/dashboard-session-auth.test.ts
+++ b/src/__tests__/dashboard-session-auth.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { ApiKeyPermission, ApiKeyRole } from '../services/auth/index.js';
+import {
+  AuthManager,
+  DASHBOARD_SESSION_COOKIE,
+  DashboardSessionStore,
+  getDashboardSessionAuthContext,
+  type DashboardSession,
+} from '../services/auth/index.js';
+import { authenticateDashboardSessionCookie } from '../dashboard-session-auth.js';
+import { isGlobalEventVisibleToRequest } from '../routes/events.js';
+import { requirePermission, requireRole, withOwnership } from '../routes/context.js';
+import type { SessionInfo, SessionManager } from '../session.js';
+
+function decorateAuthRequest(app: FastifyInstance): void {
+  app.decorateRequest('authKeyId', null as unknown as string);
+  app.decorateRequest('matchedPermission', null as unknown as ApiKeyPermission);
+  app.decorateRequest('authRole', null as unknown as ApiKeyRole);
+  app.decorateRequest('authPermissions', null as unknown as ApiKeyPermission[]);
+  app.decorateRequest('authActor', null as unknown as string);
+  app.decorateRequest('tenantId', undefined as unknown as string);
+}
+
+function createDashboardSession(role: ApiKeyRole, sessionId: string): DashboardSession {
+  const store = new DashboardSessionStore(() => 1_000, () => sessionId);
+  return store.create({
+    userId: `user-${role}`,
+    tenantId: 'default',
+    role,
+    claims: { sub: `user-${role}` },
+  });
+}
+
+function makeSession(id: string, ownerKeyId: string, tenantId = 'default'): SessionInfo {
+  return {
+    id,
+    windowId: `window-${id}`,
+    windowName: id,
+    workDir: '/tmp/default/project',
+    status: 'idle',
+    createdAt: 1,
+    lastActivity: 1,
+    ownerKeyId,
+    tenantId,
+  } as SessionInfo;
+}
+
+async function createApp(
+  dashboardSession: DashboardSession,
+  sessionMap: Map<string, SessionInfo> = new Map(),
+): Promise<{ app: FastifyInstance; auth: AuthManager }> {
+  const app = Fastify({ logger: false });
+  decorateAuthRequest(app);
+  const auth = new AuthManager('/tmp/aegis-test-keys.json', '', 'default');
+  auth.setHost('0.0.0.0');
+
+  app.addHook('onRequest', async (req, reply) => {
+    const path = req.url.split('?')[0] ?? '';
+    const hasBearer = req.headers.authorization?.startsWith('Bearer ');
+    if (!hasBearer && path.startsWith('/v1/')) {
+      const context = authenticateDashboardSessionCookie(req, {
+        getSession: (sessionId: string | undefined) => sessionId === dashboardSession.sessionId ? dashboardSession : null,
+      });
+      if (!context) {
+        return reply.status(401).send({ error: 'Unauthorized - Bearer token required' });
+      }
+    }
+  });
+
+  app.get('/v1/protected-create', async (req, reply) => {
+    if (!requirePermission(auth, req, reply, 'create')) return;
+    return {
+      keyId: req.authKeyId,
+      role: req.authRole,
+      tenantId: req.tenantId,
+      matchedPermission: req.matchedPermission,
+    };
+  });
+
+  app.get('/v1/admin-only', async (req, reply) => {
+    if (!requireRole(auth, req, reply, 'admin')) return;
+    return { ok: true, role: req.authRole };
+  });
+
+  app.get('/v1/events', async (req) => ({ ok: true, keyId: req.authKeyId }));
+
+  const sessions = {
+    getSession: (id: string) => sessionMap.get(id) ?? null,
+  } as SessionManager;
+
+  app.get('/v1/owned/:id', withOwnership(sessions, async (_req, _reply, session) => ({ ok: true, sessionId: session.id })));
+
+  await app.ready();
+  return { app, auth };
+}
+
+function cookieHeader(sessionId: string): string {
+  return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(sessionId)}`;
+}
+
+describe('dashboard session cookie request auth', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  it('authenticates same-origin /v1 and SSE requests without exposing a bearer API key', async () => {
+    const dashboardSession = createDashboardSession('viewer', 'dashboard-session-viewer');
+    const created = await createApp(dashboardSession);
+    app = created.app;
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/v1/protected-create',
+      headers: { cookie: cookieHeader(dashboardSession.sessionId) },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { keyId: string; role: ApiKeyRole; tenantId: string; matchedPermission: ApiKeyPermission };
+    expect(body).toMatchObject({ role: 'viewer', tenantId: 'default', matchedPermission: 'create' });
+    expect(body.keyId).toMatch(/^dashboard:default:[a-f0-9]{32}$/);
+    expect(created.auth.validate(body.keyId).valid).toBe(false);
+
+    const adminOnly = await app.inject({
+      method: 'GET',
+      url: '/v1/admin-only',
+      headers: { cookie: cookieHeader(dashboardSession.sessionId) },
+    });
+    expect(adminOnly.statusCode).toBe(403);
+
+    const sseLike = await app.inject({
+      method: 'GET',
+      url: '/v1/events',
+      headers: { cookie: cookieHeader(dashboardSession.sessionId) },
+    });
+    expect(sseLike.statusCode).toBe(200);
+    expect(sseLike.json()).toMatchObject({ keyId: body.keyId });
+  });
+
+  it('authorizes sessions owned by the same dashboard user and denies other owners', async () => {
+    const dashboardSession = createDashboardSession('viewer', 'dashboard-session-owner');
+    const context = getDashboardSessionAuthContext(dashboardSession);
+    const sessionMap = new Map<string, SessionInfo>([
+      ['owned', makeSession('owned', context.keyId)],
+      ['other', makeSession('other', 'api-key-other')],
+    ]);
+    const created = await createApp(dashboardSession, sessionMap);
+    app = created.app;
+
+    const owned = await app.inject({
+      method: 'GET',
+      url: '/v1/owned/owned',
+      headers: { cookie: cookieHeader(dashboardSession.sessionId) },
+    });
+    expect(owned.statusCode).toBe(200);
+
+    const other = await app.inject({
+      method: 'GET',
+      url: '/v1/owned/other',
+      headers: { cookie: cookieHeader(dashboardSession.sessionId) },
+    });
+    expect(other.statusCode).toBe(403);
+  });
+
+  it('lets dashboard admin role bypass ownership within its tenant only', async () => {
+    const dashboardSession = createDashboardSession('admin', 'dashboard-session-admin');
+    const sessionMap = new Map<string, SessionInfo>([
+      ['other-owner', makeSession('other-owner', 'api-key-other')],
+      ['other-tenant', makeSession('other-tenant', 'api-key-other', 'other-tenant')],
+    ]);
+    const created = await createApp(dashboardSession, sessionMap);
+    app = created.app;
+
+    const sameTenant = await app.inject({
+      method: 'GET',
+      url: '/v1/owned/other-owner',
+      headers: { cookie: cookieHeader(dashboardSession.sessionId) },
+    });
+    expect(sameTenant.statusCode).toBe(200);
+
+    const otherTenant = await app.inject({
+      method: 'GET',
+      url: '/v1/owned/other-tenant',
+      headers: { cookie: cookieHeader(dashboardSession.sessionId) },
+    });
+    expect(otherTenant.statusCode).toBe(403);
+  });
+
+  it('filters global SSE events for tenant-scoped dashboard sessions', () => {
+    const dashboardSession = createDashboardSession('viewer', 'dashboard-session-events');
+    const context = getDashboardSessionAuthContext(dashboardSession);
+    const sessionMap = new Map<string, SessionInfo>([
+      ['same-tenant', makeSession('same-tenant', context.keyId)],
+      ['other-tenant', makeSession('other-tenant', 'api-key-other', 'other-tenant')],
+    ]);
+    const sessions = {
+      getSession: (id: string) => sessionMap.get(id) ?? null,
+    } as Pick<SessionManager, 'getSession'>;
+
+    expect(isGlobalEventVisibleToRequest({
+      event: 'session_message',
+      sessionId: 'same-tenant',
+      timestamp: '2026-04-30T00:00:00.000Z',
+      data: { text: 'visible' },
+    }, sessions, context.tenantId, true)).toBe(true);
+
+    expect(isGlobalEventVisibleToRequest({
+      event: 'session_message',
+      sessionId: 'other-tenant',
+      timestamp: '2026-04-30T00:00:00.000Z',
+      data: { text: 'hidden' },
+    }, sessions, context.tenantId, true)).toBe(false);
+
+    expect(isGlobalEventVisibleToRequest({
+      event: 'session_message',
+      sessionId: 'missing',
+      timestamp: '2026-04-30T00:00:00.000Z',
+      data: { text: 'hidden' },
+    }, sessions, context.tenantId, true)).toBe(false);
+
+    expect(isGlobalEventVisibleToRequest({
+      event: 'shutdown',
+      sessionId: '',
+      timestamp: '2026-04-30T00:00:00.000Z',
+      data: {},
+    }, sessions, context.tenantId, true)).toBe(true);
+  });
+});

--- a/src/__tests__/dashboard-session-auth.test.ts
+++ b/src/__tests__/dashboard-session-auth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
+import fastifyRateLimit from '@fastify/rate-limit';
 import type { ApiKeyPermission, ApiKeyRole } from '../services/auth/index.js';
 import {
   AuthManager,
@@ -51,6 +52,12 @@ async function createApp(
   sessionMap: Map<string, SessionInfo> = new Map(),
 ): Promise<{ app: FastifyInstance; auth: AuthManager }> {
   const app = Fastify({ logger: false });
+  await app.register(fastifyRateLimit, {
+    global: true,
+    keyGenerator: (req) => req.ip ?? 'unknown',
+    max: 600,
+    timeWindow: '1 minute',
+  });
   decorateAuthRequest(app);
   const auth = new AuthManager('/tmp/aegis-test-keys.json', '', 'default');
   auth.setHost('0.0.0.0');

--- a/src/__tests__/dashboard-session-auth.test.ts
+++ b/src/__tests__/dashboard-session-auth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify';
 import fastifyRateLimit from '@fastify/rate-limit';
 import type { ApiKeyPermission, ApiKeyRole } from '../services/auth/index.js';
 import {
@@ -13,6 +13,8 @@ import { authenticateDashboardSessionCookie } from '../dashboard-session-auth.js
 import { isGlobalEventVisibleToRequest } from '../routes/events.js';
 import { requirePermission, requireRole, withOwnership } from '../routes/context.js';
 import type { SessionInfo, SessionManager } from '../session.js';
+
+const TEST_RATE_LIMIT = { max: 600, timeWindow: '1 minute' } as const;
 
 function decorateAuthRequest(app: FastifyInstance): void {
   app.decorateRequest('authKeyId', null as unknown as string);
@@ -62,11 +64,9 @@ async function createApp(
   const auth = new AuthManager('/tmp/aegis-test-keys.json', '', 'default');
   auth.setHost('0.0.0.0');
 
-  // lgtm[js/missing-rate-limiting] This test app registers global Fastify rate limiting before the auth hook.
-  app.addHook('onRequest', async (req, reply) => {
-    const path = req.url.split('?')[0] ?? '';
+  const authenticateDashboardRequest = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
     const hasBearer = req.headers.authorization?.startsWith('Bearer ');
-    if (!hasBearer && path.startsWith('/v1/')) {
+    if (!hasBearer) {
       const context = authenticateDashboardSessionCookie(req, {
         getSession: (sessionId: string | undefined) => sessionId === dashboardSession.sessionId ? dashboardSession : null,
       });
@@ -74,9 +74,9 @@ async function createApp(
         return reply.status(401).send({ error: 'Unauthorized - Bearer token required' });
       }
     }
-  });
+  };
 
-  app.get('/v1/protected-create', async (req, reply) => {
+  app.get('/v1/protected-create', { config: { rateLimit: TEST_RATE_LIMIT }, preHandler: authenticateDashboardRequest }, async (req, reply) => {
     if (!requirePermission(auth, req, reply, 'create')) return;
     return {
       keyId: req.authKeyId,
@@ -86,18 +86,25 @@ async function createApp(
     };
   });
 
-  app.get('/v1/admin-only', async (req, reply) => {
+  app.get('/v1/admin-only', { config: { rateLimit: TEST_RATE_LIMIT }, preHandler: authenticateDashboardRequest }, async (req, reply) => {
     if (!requireRole(auth, req, reply, 'admin')) return;
     return { ok: true, role: req.authRole };
   });
 
-  app.get('/v1/events', async (req) => ({ ok: true, keyId: req.authKeyId }));
+  app.get('/v1/events', { config: { rateLimit: TEST_RATE_LIMIT }, preHandler: authenticateDashboardRequest }, async (req) => ({
+    ok: true,
+    keyId: req.authKeyId,
+  }));
 
   const sessions = {
     getSession: (id: string) => sessionMap.get(id) ?? null,
   } as SessionManager;
 
-  app.get('/v1/owned/:id', withOwnership(sessions, async (_req, _reply, session) => ({ ok: true, sessionId: session.id })));
+  app.get(
+    '/v1/owned/:id',
+    { config: { rateLimit: TEST_RATE_LIMIT }, preHandler: authenticateDashboardRequest },
+    withOwnership(sessions, async (_req, _reply, session) => ({ ok: true, sessionId: session.id })),
+  );
 
   await app.ready();
   return { app, auth };

--- a/src/__tests__/dashboard-session-auth.test.ts
+++ b/src/__tests__/dashboard-session-auth.test.ts
@@ -62,6 +62,7 @@ async function createApp(
   const auth = new AuthManager('/tmp/aegis-test-keys.json', '', 'default');
   auth.setHost('0.0.0.0');
 
+  // lgtm[js/missing-rate-limiting] This test app registers global Fastify rate limiting before the auth hook.
   app.addHook('onRequest', async (req, reply) => {
     const path = req.url.split('?')[0] ?? '';
     const hasBearer = req.headers.authorization?.startsWith('Bearer ');

--- a/src/__tests__/env-denylist-1392.test.ts
+++ b/src/__tests__/env-denylist-1392.test.ts
@@ -312,6 +312,7 @@ describe('Env var denylist — live Zod schema (Issues #1392 + #1908)', () => {
       expect(ENV_DENYLIST).toContain('DYLD_INSERT_LIBRARIES');
       expect(ENV_DENYLIST).toContain('LD_LIBRARY_PATH');
       expect(ENV_DENYLIST).toContain('ANTHROPIC_API_KEY');
+      expect(ENV_DENYLIST).toContain('AEGIS_OIDC_CLIENT_SECRET');
       expect(ENV_DENYLIST).toContain('COMSPEC');
       expect(ENV_DENYLIST).toContain('DYLD_FRAMEWORK_PATH');
     });

--- a/src/__tests__/oidc-auth-routes.test.ts
+++ b/src/__tests__/oidc-auth-routes.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import fastifyRateLimit from '@fastify/rate-limit';
+import type { AuthorizationCodeGrantChecks } from 'openid-client';
+import type { Config } from '../config.js';
+import { registerOidcAuthRoutes } from '../routes/oidc-auth.js';
+import {
+  DASHBOARD_SESSION_COOKIE,
+  DashboardOIDCManager,
+  OIDC_STATE_COOKIE,
+  type OidcAuthorizationRequest,
+  type OidcProvider,
+  type OidcTokenValidationResult,
+} from '../services/auth/OIDCManager.js';
+import type { DashboardOidcConfig } from '../services/auth/oidc-config.js';
+
+class RouteFakeProvider implements OidcProvider {
+  lastAuthorizationRequest: OidcAuthorizationRequest | null = null;
+  exchangeError: Error | null = null;
+
+  async discover(): Promise<void> {}
+
+  buildAuthorizationUrl(request: OidcAuthorizationRequest): URL {
+    this.lastAuthorizationRequest = request;
+    const url = new URL('https://idp.example.com/authorize');
+    url.searchParams.set('state', request.state);
+    url.searchParams.set('nonce', request.nonce);
+    url.searchParams.set('code_challenge', request.codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+    return url;
+  }
+
+  async exchangeAuthorizationCode(
+    _callbackUrl: URL,
+    checks: Required<Pick<AuthorizationCodeGrantChecks, 'expectedNonce' | 'expectedState' | 'pkceCodeVerifier'>>,
+  ): Promise<OidcTokenValidationResult> {
+    if (this.exchangeError) throw this.exchangeError;
+    return {
+      idToken: 'id-token',
+      claims: {
+        iss: 'https://idp.example.com',
+        aud: 'aegis-dashboard',
+        exp: 2_000,
+        nbf: 900,
+        nonce: checks.expectedNonce,
+        sub: 'user-1',
+        email: 'ada@example.com',
+        'aegis:tenant': 'default',
+        aegis_role: 'admin',
+      },
+    };
+  }
+
+  buildEndSessionUrl(idToken: string, postLogoutRedirectUri: string): URL | null {
+    const url = new URL('https://idp.example.com/logout');
+    url.searchParams.set('id_token_hint', idToken);
+    url.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+    return url;
+  }
+}
+
+function makeConfig(): Config {
+  return {
+    baseUrl: 'https://aegis.example.com',
+    port: 9100,
+    host: '127.0.0.1',
+    authToken: '',
+    clientAuthToken: '',
+    tmuxSession: 'aegis',
+    stateDir: '/tmp/aegis',
+    claudeProjectsDir: '/tmp/claude',
+    maxSessionAgeMs: 1,
+    reaperIntervalMs: 1,
+    continuationPointerTtlMs: 1,
+    tgBotToken: '',
+    tgGroupId: '',
+    tgAllowedUsers: [],
+    tgTopicTtlMs: 1,
+    tgTopicAutoDelete: true,
+    tgTopicTTLHours: 0,
+    webhooks: [],
+    defaultSessionEnv: {},
+    defaultPermissionMode: 'default',
+    stallThresholdMs: 1,
+    sseMaxConnections: 100,
+    sseMaxPerIp: 10,
+    allowedWorkDirs: [],
+    hookSecretHeaderOnly: false,
+    memoryBridge: { enabled: false },
+    worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+    verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
+    metricsToken: '',
+    pipelineStageTimeoutMs: 0,
+    alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 1 },
+    envDenylist: [],
+    envAdminAllowlist: [],
+    enforceSessionOwnership: true,
+    sseIdleMs: 1,
+    sseClientTimeoutMs: 1,
+    hookTimeoutMs: 1,
+    shutdownGraceMs: 1,
+    keyRotationGraceSeconds: 1,
+    shutdownHardMs: 1,
+    stateStore: 'file',
+    postgresUrl: '',
+    dashboardEnabled: true,
+    defaultTenantId: 'default',
+    tenantWorkdirs: { default: { root: '/tmp/default' } },
+    rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
+  };
+}
+
+function makeOidcConfig(): DashboardOidcConfig {
+  return {
+    issuer: 'https://idp.example.com',
+    clientId: 'aegis-dashboard',
+    clientSecret: 'secret',
+    audience: 'aegis-dashboard',
+    scopes: 'openid profile email',
+    roleClaim: 'aegis_role',
+    authDir: '',
+    redirectPath: '/auth/callback',
+  };
+}
+
+async function createApp(withOidc = true): Promise<{ app: FastifyInstance; manager: DashboardOIDCManager | null; provider: RouteFakeProvider }> {
+  const app = Fastify({ logger: false });
+  await app.register(fastifyRateLimit, { global: false, keyGenerator: (req) => req.ip ?? 'unknown' });
+  const provider = new RouteFakeProvider();
+  const manager = withOidc
+    ? new DashboardOIDCManager({ config: makeConfig(), oidcConfig: makeOidcConfig(), provider, now: () => 1_000_000 })
+    : null;
+  if (manager) await manager.initialize();
+  registerOidcAuthRoutes(app, { dashboardOidc: manager });
+  await app.ready();
+  return { app, manager, provider };
+}
+
+function findCookie(setCookie: string[] | undefined, name: string): string | undefined {
+  return setCookie?.find((cookie) => cookie.startsWith(`${name}=`));
+}
+
+function setCookieHeaders(header: string | string[] | undefined): string[] {
+  if (Array.isArray(header)) return header;
+  if (typeof header === 'string') return [header];
+  return [];
+}
+
+describe('OIDC auth routes', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = null;
+  });
+
+  it('returns 404 when OIDC is disabled', async () => {
+    const created = await createApp(false);
+    app = created.app;
+
+    const response = await app.inject({ method: 'GET', url: '/auth/login' });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('login redirects to IdP and sets an HttpOnly SameSite=Lax state cookie', async () => {
+    const created = await createApp();
+    app = created.app;
+
+    const response = await app.inject({ method: 'GET', url: '/auth/login?login_hint=ada%40example.com' });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toContain('https://idp.example.com/authorize');
+    expect(response.headers.location).toContain('code_challenge_method=S256');
+    const stateCookie = findCookie(setCookieHeaders(response.headers['set-cookie']), OIDC_STATE_COOKIE);
+    expect(stateCookie).toContain('HttpOnly');
+    expect(stateCookie).toContain('Secure');
+    expect(stateCookie).toContain('SameSite=Lax');
+    expect(created.provider.lastAuthorizationRequest?.loginHint).toBe('ada@example.com');
+  });
+
+  it('callback rejects state mismatch generically and clears state cookie', async () => {
+    const created = await createApp();
+    app = created.app;
+    const login = await app.inject({ method: 'GET', url: '/auth/login' });
+    const state = new URL(String(login.headers.location)).searchParams.get('state');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/auth/callback?code=abc&state=${state}`,
+      headers: { cookie: `${OIDC_STATE_COOKIE}=wrong` },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toContain('Authentication failed');
+    expect(response.body).not.toContain('state mismatch');
+    const cleared = findCookie(setCookieHeaders(response.headers['set-cookie']), OIDC_STATE_COOKIE);
+    expect(cleared).toContain('Max-Age=0');
+    expect(cleared).toContain('SameSite=Lax');
+  });
+
+  it('callback creates secure dashboard session cookie and /auth/session exposes identity', async () => {
+    const created = await createApp();
+    app = created.app;
+    const login = await app.inject({ method: 'GET', url: '/auth/login' });
+    const loginUrl = new URL(String(login.headers.location));
+    const state = loginUrl.searchParams.get('state');
+
+    const callback = await app.inject({
+      method: 'GET',
+      url: `/auth/callback?code=abc&state=${state}`,
+      headers: { cookie: `${OIDC_STATE_COOKIE}=${state}` },
+    });
+
+    expect(callback.statusCode).toBe(302);
+    expect(callback.headers.location).toBe('/dashboard/');
+    const sessionCookie = findCookie(setCookieHeaders(callback.headers['set-cookie']), DASHBOARD_SESSION_COOKIE);
+    expect(sessionCookie).toContain('HttpOnly');
+    expect(sessionCookie).toContain('Secure');
+    expect(sessionCookie).toContain('SameSite=Strict');
+    expect(sessionCookie).toContain('Max-Age=3600');
+
+    const sessionValue = callback.cookies.find((cookie) => cookie.name === DASHBOARD_SESSION_COOKIE)?.value;
+    const session = await app.inject({ method: 'GET', url: '/auth/session', headers: { cookie: `${DASHBOARD_SESSION_COOKIE}=${sessionValue}` } });
+    expect(session.statusCode).toBe(200);
+    expect(session.json()).toMatchObject({ authenticated: true, userId: 'user-1', tenantId: 'default', role: 'admin' });
+    expect(session.json()).not.toHaveProperty('sessionId');
+  });
+
+  it('callback returns a generic error without leaking provider details', async () => {
+    const created = await createApp();
+    app = created.app;
+    created.provider.exchangeError = new Error('IdP rejected client secret super-sensitive-secret');
+    const login = await app.inject({ method: 'GET', url: '/auth/login' });
+    const state = new URL(String(login.headers.location)).searchParams.get('state');
+
+    const callback = await app.inject({
+      method: 'GET',
+      url: `/auth/callback?code=abc&state=${state}`,
+      headers: { cookie: `${OIDC_STATE_COOKIE}=${state}` },
+    });
+
+    expect(callback.statusCode).toBe(502);
+    expect(callback.body).toContain('Authentication failed');
+    expect(callback.body).not.toContain('super-sensitive-secret');
+    expect(callback.body).not.toContain('IdP rejected');
+  });
+
+  it('logout deletes the server-side session and clears the cookie', async () => {
+    const created = await createApp();
+    app = created.app;
+    const login = await app.inject({ method: 'GET', url: '/auth/login' });
+    const state = new URL(String(login.headers.location)).searchParams.get('state');
+    const callback = await app.inject({
+      method: 'GET',
+      url: `/auth/callback?code=abc&state=${state}`,
+      headers: { cookie: `${OIDC_STATE_COOKIE}=${state}` },
+    });
+    const sessionValue = callback.cookies.find((cookie) => cookie.name === DASHBOARD_SESSION_COOKIE)?.value;
+
+    const logout = await app.inject({ method: 'POST', url: '/auth/logout', headers: { cookie: `${DASHBOARD_SESSION_COOKIE}=${sessionValue}` } });
+
+    expect(logout.statusCode).toBe(204);
+    expect(created.manager?.getSession(sessionValue)).toBeNull();
+    const cleared = findCookie(setCookieHeaders(logout.headers['set-cookie']), DASHBOARD_SESSION_COOKIE);
+    expect(cleared).toContain('Max-Age=0');
+  });
+
+  it('logout can redirect browser flows to the discovered IdP end-session endpoint', async () => {
+    const created = await createApp();
+    app = created.app;
+    const login = await app.inject({ method: 'GET', url: '/auth/login' });
+    const state = new URL(String(login.headers.location)).searchParams.get('state');
+    const callback = await app.inject({
+      method: 'GET',
+      url: `/auth/callback?code=abc&state=${state}`,
+      headers: { cookie: `${OIDC_STATE_COOKIE}=${state}` },
+    });
+    const sessionValue = callback.cookies.find((cookie) => cookie.name === DASHBOARD_SESSION_COOKIE)?.value;
+
+    const logout = await app.inject({
+      method: 'POST',
+      url: '/auth/logout',
+      headers: { cookie: `${DASHBOARD_SESSION_COOKIE}=${sessionValue}`, accept: 'text/html' },
+    });
+
+    expect(logout.statusCode).toBe(303);
+    expect(logout.headers.location).toContain('https://idp.example.com/logout');
+    expect(logout.headers.location).toContain('post_logout_redirect_uri=https%3A%2F%2Faegis.example.com%2Fdashboard%2F');
+  });
+
+  it('rate limits login and callback routes', async () => {
+    const created = await createApp();
+    app = created.app;
+
+    for (let index = 0; index < 30; index += 1) {
+      const response = await app.inject({ method: 'GET', url: '/auth/login' });
+      expect(response.statusCode).toBe(302);
+    }
+    const throttledLogin = await app.inject({ method: 'GET', url: '/auth/login' });
+    expect(throttledLogin.statusCode).toBe(429);
+
+    const second = await createApp();
+    await app.close();
+    app = second.app;
+    for (let index = 0; index < 20; index += 1) {
+      const response = await app.inject({ method: 'GET', url: '/auth/callback' });
+      expect(response.statusCode).toBe(400);
+    }
+    const throttledCallback = await app.inject({ method: 'GET', url: '/auth/callback' });
+    expect(throttledCallback.statusCode).toBe(429);
+  });
+});

--- a/src/__tests__/oidc-config.test.ts
+++ b/src/__tests__/oidc-config.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { parseOidcConfig, discoverOidcEndpoints, mergeDiscovery, type OidcDiscovery } from '../services/auth/oidc-config.js';
+import {
+  parseOidcConfig,
+  parseDashboardOidcConfig,
+  discoverOidcEndpoints,
+  mergeDiscovery,
+  type OidcDiscovery,
+} from '../services/auth/oidc-config.js';
 
 describe('parseOidcConfig', () => {
   const originalEnv = process.env;
@@ -84,6 +90,72 @@ describe('parseOidcConfig', () => {
 
     const config = parseOidcConfig();
     expect(config!.issuer).toBe('http://localhost:8080/realms/test');
+  });
+});
+
+describe('parseDashboardOidcConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns null when no OIDC env vars are configured', () => {
+    delete process.env.AEGIS_OIDC_ISSUER;
+    delete process.env.AEGIS_OIDC_CLIENT_ID;
+    delete process.env.AEGIS_OIDC_CLIENT_SECRET;
+    delete process.env.AEGIS_OIDC_REDIRECT_PATH;
+    expect(parseDashboardOidcConfig()).toBeNull();
+  });
+
+  it('returns null for shared device-flow OIDC config without dashboard client secret', () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'aegis-dashboard';
+    delete process.env.AEGIS_OIDC_CLIENT_SECRET;
+    delete process.env.AEGIS_OIDC_REDIRECT_PATH;
+
+    expect(parseDashboardOidcConfig()).toBeNull();
+  });
+
+  it('requires client secret when dashboard-specific OIDC config is present', () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'aegis-dashboard';
+    process.env.AEGIS_OIDC_REDIRECT_PATH = '/auth/callback';
+    delete process.env.AEGIS_OIDC_CLIENT_SECRET;
+
+    expect(() => parseDashboardOidcConfig()).toThrow('AEGIS_OIDC_CLIENT_SECRET is required');
+  });
+
+  it('fails closed when dashboard client secret is configured without shared issuer/client ID', () => {
+    delete process.env.AEGIS_OIDC_ISSUER;
+    delete process.env.AEGIS_OIDC_CLIENT_ID;
+    process.env.AEGIS_OIDC_CLIENT_SECRET = 'secret';
+
+    expect(() => parseDashboardOidcConfig()).toThrow('AEGIS_OIDC_ISSUER and AEGIS_OIDC_CLIENT_ID are required');
+  });
+
+  it('parses dashboard OIDC config without exposing the secret in errors', () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'aegis-dashboard';
+    process.env.AEGIS_OIDC_CLIENT_SECRET = 'super-sensitive-secret';
+    process.env.AEGIS_OIDC_REDIRECT_PATH = '/auth/callback';
+
+    const config = parseDashboardOidcConfig();
+    expect(config?.clientSecret).toBe('super-sensitive-secret');
+    expect(config?.redirectPath).toBe('/auth/callback');
+  });
+
+  it('rejects redirect paths that are not absolute paths', () => {
+    process.env.AEGIS_OIDC_ISSUER = 'https://idp.example.com';
+    process.env.AEGIS_OIDC_CLIENT_ID = 'aegis-dashboard';
+    process.env.AEGIS_OIDC_CLIENT_SECRET = 'secret';
+    process.env.AEGIS_OIDC_REDIRECT_PATH = 'auth/callback';
+
+    expect(() => parseDashboardOidcConfig()).toThrow('AEGIS_OIDC_REDIRECT_PATH must start with /');
   });
 });
 

--- a/src/__tests__/oidc-dashboard-manager.test.ts
+++ b/src/__tests__/oidc-dashboard-manager.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest';
+import type { AuthorizationCodeGrantChecks } from 'openid-client';
+import type { Config } from '../config.js';
+import {
+  DASHBOARD_SESSION_TTL_MS,
+  DashboardOIDCManager,
+  DashboardSessionStore,
+  OidcAuthError,
+  generatePkcePair,
+  getDashboardSessionAuthContext,
+  mapOidcClaimsToIdentity,
+  validateOidcClaims,
+  type OidcAuthorizationRequest,
+  type OidcProvider,
+  type OidcTokenValidationResult,
+} from '../services/auth/OIDCManager.js';
+import type { DashboardOidcConfig } from '../services/auth/oidc-config.js';
+
+class FakeProvider implements OidcProvider {
+  discoveries = 0;
+  authorizationRequest: OidcAuthorizationRequest | null = null;
+  grantChecks: AuthorizationCodeGrantChecks | null = null;
+  tokenResult: OidcTokenValidationResult = {
+    idToken: 'id-token',
+    claims: {
+      iss: 'https://idp.example.com',
+      aud: 'aegis-dashboard',
+      exp: 2_000,
+      nbf: 900,
+      nonce: '',
+      sub: 'user-1',
+      email: 'ada@example.com',
+      'aegis:tenant': 'default',
+      aegis_role: 'operator',
+    },
+  };
+
+  async discover(): Promise<void> {
+    this.discoveries += 1;
+  }
+
+  buildAuthorizationUrl(request: OidcAuthorizationRequest): URL {
+    this.authorizationRequest = request;
+    const url = new URL('https://idp.example.com/authorize');
+    url.searchParams.set('state', request.state);
+    url.searchParams.set('nonce', request.nonce);
+    url.searchParams.set('code_challenge', request.codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+    url.searchParams.set('redirect_uri', request.redirectUri);
+    url.searchParams.set('scope', request.scope);
+    return url;
+  }
+
+  async exchangeAuthorizationCode(
+    _callbackUrl: URL,
+    checks: Required<Pick<AuthorizationCodeGrantChecks, 'expectedNonce' | 'expectedState' | 'pkceCodeVerifier'>>,
+  ): Promise<OidcTokenValidationResult> {
+    this.grantChecks = checks;
+    return {
+      ...this.tokenResult,
+      claims: { ...this.tokenResult.claims, nonce: checks.expectedNonce },
+    };
+  }
+
+  buildEndSessionUrl(idToken: string, postLogoutRedirectUri: string): URL | null {
+    const url = new URL('https://idp.example.com/logout');
+    url.searchParams.set('id_token_hint', idToken);
+    url.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+    return url;
+  }
+}
+
+function makeConfig(): Config {
+  return {
+    baseUrl: 'https://aegis.example.com',
+    port: 9100,
+    host: '127.0.0.1',
+    authToken: '',
+    clientAuthToken: '',
+    tmuxSession: 'aegis',
+    stateDir: '/tmp/aegis',
+    claudeProjectsDir: '/tmp/claude',
+    maxSessionAgeMs: 1,
+    reaperIntervalMs: 1,
+    continuationPointerTtlMs: 1,
+    tgBotToken: '',
+    tgGroupId: '',
+    tgAllowedUsers: [],
+    tgTopicTtlMs: 1,
+    tgTopicAutoDelete: true,
+    tgTopicTTLHours: 0,
+    webhooks: [],
+    defaultSessionEnv: {},
+    defaultPermissionMode: 'default',
+    stallThresholdMs: 1,
+    sseMaxConnections: 100,
+    sseMaxPerIp: 10,
+    allowedWorkDirs: [],
+    hookSecretHeaderOnly: false,
+    memoryBridge: { enabled: false },
+    worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+    verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
+    metricsToken: '',
+    pipelineStageTimeoutMs: 0,
+    alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 1 },
+    envDenylist: [],
+    envAdminAllowlist: [],
+    enforceSessionOwnership: true,
+    sseIdleMs: 1,
+    sseClientTimeoutMs: 1,
+    hookTimeoutMs: 1,
+    shutdownGraceMs: 1,
+    keyRotationGraceSeconds: 1,
+    shutdownHardMs: 1,
+    stateStore: 'file',
+    postgresUrl: '',
+    dashboardEnabled: true,
+    defaultTenantId: 'default',
+    tenantWorkdirs: {
+      default: { root: '/tmp/default' },
+      'example.com': { root: '/tmp/example' },
+      entraTenant: { root: '/tmp/entra' },
+    },
+    rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
+  };
+}
+
+function makeOidcConfig(): DashboardOidcConfig {
+  return {
+    issuer: 'https://idp.example.com',
+    clientId: 'aegis-dashboard',
+    clientSecret: 'secret',
+    audience: 'aegis-dashboard',
+    scopes: 'openid profile email',
+    roleClaim: 'aegis_role',
+    authDir: '',
+    redirectPath: '/auth/callback',
+  };
+}
+
+describe('generatePkcePair', () => {
+  it('generates RFC 7636 sized verifier and S256 challenge', () => {
+    const pkce = generatePkcePair();
+    expect(pkce.codeVerifier).toHaveLength(43);
+    expect(pkce.codeChallenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(pkce.codeChallenge).not.toBe(pkce.codeVerifier);
+  });
+});
+
+describe('validateOidcClaims', () => {
+  const validClaims = {
+    iss: 'https://idp.example.com',
+    aud: ['aegis-dashboard'],
+    exp: 2_000,
+    nbf: 900,
+    nonce: 'nonce-1',
+    sub: 'user-1',
+  };
+
+  it('accepts claims only when issuer, audience, exp, nbf, nonce, and sub pass', () => {
+    expect(() => validateOidcClaims({
+      claims: validClaims,
+      issuer: 'https://idp.example.com',
+      clientId: 'aegis-dashboard',
+      nonce: 'nonce-1',
+      nowSeconds: 1_000,
+    })).not.toThrow();
+  });
+
+  it('accepts claims without the optional nbf claim', () => {
+    const { nbf: _nbf, ...claimsWithoutNbf } = validClaims;
+    expect(() => validateOidcClaims({
+      claims: claimsWithoutNbf,
+      issuer: 'https://idp.example.com',
+      clientId: 'aegis-dashboard',
+      nonce: 'nonce-1',
+      nowSeconds: 1_000,
+    })).not.toThrow();
+  });
+
+  it('rejects each required validation failure', () => {
+    const base = { issuer: 'https://idp.example.com', clientId: 'aegis-dashboard', nonce: 'nonce-1', nowSeconds: 1_000 };
+    expect(() => validateOidcClaims({ ...base, claims: { ...validClaims, iss: 'https://evil.example.com' } })).toThrow(OidcAuthError);
+    expect(() => validateOidcClaims({ ...base, claims: { ...validClaims, aud: 'other-client' } })).toThrow(OidcAuthError);
+    expect(() => validateOidcClaims({ ...base, claims: { ...validClaims, exp: 999 } })).toThrow(OidcAuthError);
+    expect(() => validateOidcClaims({ ...base, claims: { ...validClaims, nbf: 1_001 } })).toThrow(OidcAuthError);
+    expect(() => validateOidcClaims({ ...base, claims: { ...validClaims, nonce: 'wrong' } })).toThrow(OidcAuthError);
+    expect(() => validateOidcClaims({ ...base, claims: { ...validClaims, sub: '' } })).toThrow(OidcAuthError);
+  });
+});
+
+describe('mapOidcClaimsToIdentity', () => {
+  it('maps tenant by priority and defaults unknown roles to viewer', () => {
+    const identity = mapOidcClaimsToIdentity({
+      sub: 'user-1',
+      email: 'ada@example.com',
+      name: 'Ada',
+      hd: 'example.com',
+      'aegis:tenant': 'default',
+      aegis_role: 'owner',
+    }, {
+      roleClaim: 'aegis_role',
+      defaultTenantId: 'default',
+      tenantWorkdirs: makeConfig().tenantWorkdirs,
+    });
+
+    expect(identity?.tenantId).toBe('default');
+    expect(identity?.role).toBe('viewer');
+    expect(identity?.email).toBe('ada@example.com');
+  });
+
+  it('falls back to email domain when provisioned', () => {
+    const identity = mapOidcClaimsToIdentity({
+      sub: 'user-1',
+      email: 'ada@example.com',
+    }, {
+      roleClaim: 'aegis_role',
+      defaultTenantId: 'default',
+      tenantWorkdirs: makeConfig().tenantWorkdirs,
+    });
+
+    expect(identity?.tenantId).toBe('example.com');
+  });
+
+  it('denies unmapped tenants and reserved system tenant', () => {
+    const options = {
+      roleClaim: 'aegis_role',
+      defaultTenantId: 'default',
+      tenantWorkdirs: makeConfig().tenantWorkdirs,
+    };
+    expect(mapOidcClaimsToIdentity({ sub: 'user-1', email: 'ada@unknown.com' }, options)).toBeNull();
+    expect(mapOidcClaimsToIdentity({ sub: 'user-1', 'aegis:tenant': '_system' }, options)).toBeNull();
+  });
+});
+
+describe('DashboardSessionStore', () => {
+  it('stores opaque server-side sessions with expiration and max per user', () => {
+    let now = 1_000;
+    let counter = 0;
+    const store = new DashboardSessionStore(() => now, () => `session-${counter += 1}`);
+    const identity = {
+      userId: 'user-1',
+      tenantId: 'default',
+      role: 'viewer' as const,
+      claims: { sub: 'user-1' },
+    };
+
+    for (let index = 0; index < 6; index += 1) {
+      store.create(identity);
+    }
+
+    expect(store.count()).toBe(5);
+    expect(store.get('session-1')).toBeNull();
+    expect(store.get('session-6')?.expiresAt).toBe(1_000 + DASHBOARD_SESSION_TTL_MS);
+    now += DASHBOARD_SESSION_TTL_MS + 1;
+    expect(store.get('session-6')).toBeNull();
+  });
+});
+
+describe('getDashboardSessionAuthContext', () => {
+  it('builds a synthetic non-bearer actor with role-default permissions', () => {
+    const context = getDashboardSessionAuthContext({
+      sessionId: 'opaque-session-id',
+      userId: 'user-1',
+      email: 'ada@example.com',
+      tenantId: 'default',
+      role: 'viewer',
+      claims: { sub: 'user-1' },
+      createdAt: 1,
+      expiresAt: 2,
+    });
+
+    expect(context.keyId).toMatch(/^dashboard:default:[a-f0-9]{32}$/);
+    expect(context.actor).toBe(context.keyId);
+    expect(context.keyId).not.toContain('opaque-session-id');
+    expect(context.keyId).not.toContain('ada@example.com');
+    expect(context.tenantId).toBe('default');
+    expect(context.role).toBe('viewer');
+    expect(context.permissions).toEqual(['create', 'audit']);
+  });
+});
+
+describe('DashboardOIDCManager', () => {
+  it('creates authorization requests with mandatory PKCE, state, and nonce', async () => {
+    const provider = new FakeProvider();
+    const manager = new DashboardOIDCManager({ config: makeConfig(), oidcConfig: makeOidcConfig(), provider, now: () => 1_000_000 });
+    await manager.initialize();
+
+    const login = await manager.beginLogin({ loginHint: 'ada@example.com' });
+
+    expect(login.redirectUrl.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(login.redirectUrl.searchParams.get('code_challenge')).toBeTruthy();
+    expect(login.redirectUrl.searchParams.get('state')).toBe(login.state);
+    expect(login.redirectUrl.searchParams.get('nonce')).toBeTruthy();
+    expect(provider.authorizationRequest?.loginHint).toBe('ada@example.com');
+  });
+
+  it('exchanges authorization code once and creates a tenant-aware dashboard session', async () => {
+    const provider = new FakeProvider();
+    const manager = new DashboardOIDCManager({ config: makeConfig(), oidcConfig: makeOidcConfig(), provider, now: () => 1_000_000 });
+    await manager.initialize();
+    const login = await manager.beginLogin();
+    const callbackUrl = new URL(`https://aegis.example.com/auth/callback?code=abc&state=${login.state}`);
+
+    const session = await manager.completeCallback(callbackUrl, login.state);
+
+    expect(provider.grantChecks?.expectedState).toBe(login.state);
+    expect(provider.grantChecks?.pkceCodeVerifier).toHaveLength(43);
+    expect(session.sessionId).toBeTruthy();
+    expect(session.tenantId).toBe('default');
+    expect(session.role).toBe('operator');
+    await expect(manager.completeCallback(callbackUrl, login.state)).rejects.toThrow(OidcAuthError);
+  });
+});

--- a/src/dashboard-session-auth.ts
+++ b/src/dashboard-session-auth.ts
@@ -1,0 +1,58 @@
+import type { FastifyRequest } from 'fastify';
+import type { ApiKeyPermission, ApiKeyRole } from './services/auth/index.js';
+import {
+  DASHBOARD_SESSION_COOKIE,
+  getDashboardSessionAuthContext,
+  type DashboardOIDCManager,
+  type DashboardRequestAuthContext,
+} from './services/auth/index.js';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    authRole?: ApiKeyRole | null;
+    authPermissions?: ApiKeyPermission[] | null;
+    authActor?: string | null;
+  }
+}
+
+function parseCookies(header: string | undefined): Map<string, string> {
+  const cookies = new Map<string, string>();
+  if (!header) return cookies;
+  for (const part of header.split(';')) {
+    const [rawName, ...rawValue] = part.trim().split('=');
+    if (!rawName || rawValue.length === 0) continue;
+    cookies.set(rawName, decodeURIComponent(rawValue.join('=')));
+  }
+  return cookies;
+}
+
+export function resolveDashboardSessionAuthContext(
+  cookieHeader: string | undefined,
+  manager: Pick<DashboardOIDCManager, 'getSession'> | null | undefined,
+): DashboardRequestAuthContext | null {
+  if (!manager) return null;
+  const sessionId = parseCookies(cookieHeader).get(DASHBOARD_SESSION_COOKIE);
+  const session = manager.getSession(sessionId);
+  return session ? getDashboardSessionAuthContext(session) : null;
+}
+
+export function applyDashboardSessionAuthContext(
+  req: FastifyRequest,
+  context: DashboardRequestAuthContext,
+): void {
+  req.authKeyId = context.keyId;
+  req.authRole = context.role;
+  req.authPermissions = [...context.permissions];
+  req.authActor = context.actor;
+  req.tenantId = context.tenantId;
+}
+
+export function authenticateDashboardSessionCookie(
+  req: FastifyRequest,
+  manager: Pick<DashboardOIDCManager, 'getSession'> | null | undefined,
+): DashboardRequestAuthContext | null {
+  const context = resolveDashboardSessionAuthContext(req.headers.cookie, manager);
+  if (!context) return null;
+  applyDashboardSessionAuthContext(req, context);
+  return context;
+}

--- a/src/permission-routes.ts
+++ b/src/permission-routes.ts
@@ -3,7 +3,7 @@ import type { SessionManager } from './session.js';
 import type { MetricsCollector } from './metrics.js';
 import type { AuditLogger } from './audit.js';
 import type { ApiKeyRole } from './auth.js';
-import type { Config } from './config.js';
+import { SYSTEM_TENANT, type Config } from './config.js';
 
 type PermissionAction = 'approve' | 'reject';
 type IdParams = { Params: { id: string } };
@@ -11,8 +11,8 @@ type IdRequest = FastifyRequest<IdParams>;
 
 type PermissionSessions = Pick<SessionManager, 'approve' | 'reject' | 'getLatencyMetrics' | 'getSession'>;
 type PermissionMetrics = Pick<MetricsCollector, 'recordPermissionResponse'>;
-type ResolveRole = (keyId: string | null | undefined) => ApiKeyRole;
-type HasPermission = (keyId: string | null | undefined, permission: PermissionAction) => boolean;
+type ResolveRole = (keyId: string | null | undefined, req: FastifyRequest) => ApiKeyRole;
+type HasPermission = (keyId: string | null | undefined, permission: PermissionAction, req: FastifyRequest) => boolean;
 
 function createPermissionHandler(
   action: PermissionAction,
@@ -26,7 +26,7 @@ function createPermissionHandler(
 ): (req: IdRequest, reply: FastifyReply) => Promise<unknown> {
   return async (req: IdRequest, reply: FastifyReply): Promise<unknown> => {
     req.matchedPermission = action;
-    if (hasPermission && !hasPermission(req.authKeyId ?? null, action)) {
+    if (hasPermission && !hasPermission(req.authKeyId ?? null, action, req)) {
       return reply.status(403).send({ error: `Forbidden: missing ${action} permission` });
     }
 
@@ -36,12 +36,19 @@ function createPermissionHandler(
     const session = sessions.getSession(req.params.id);
     if (!session) return reply.status(404).send({ error: 'Session not found' });
     const keyId = req.authKeyId;
+    const callerTenantId = req.tenantId;
+
+    if (callerTenantId && callerTenantId !== SYSTEM_TENANT && session.tenantId !== callerTenantId) {
+      const effectiveAudit = getAuditLogger ? getAuditLogger() : audit;
+      if (effectiveAudit) void effectiveAudit.log(keyId ?? 'system', 'session.action.denied', `Cross-tenant ${matchedPermission} denied on session ${session.id} (tenant: ${session.tenantId})`, session.id, callerTenantId);
+      return reply.status(403).send({ error: 'SESSION_FORBIDDEN', message: 'Session belongs to another tenant' });
+    }
 
     // Feature flag check (#1910): skip enhanced ownership when disabled
     const enforce = config?.enforceSessionOwnership ?? true;
 
     if (enforce && keyId !== 'master' && keyId !== null && keyId !== undefined && session.ownerKeyId) {
-      const role = resolveRole ? resolveRole(keyId) : 'viewer';
+      const role = resolveRole ? resolveRole(keyId, req) : 'viewer';
       if (role === 'admin') {
         // Admin bypass — emit allowed audit
         const effectiveAudit = getAuditLogger ? getAuditLogger() : audit;

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -33,6 +33,7 @@ import type { SSEConnectionLimiter } from '../sse-limiter.js';
 import type { MemoryBridge } from '../memory-bridge.js';
 import type { MeteringService } from '../metering.js';
 import type { MetricsCache } from '../services/metrics-cache.js';
+import type { DashboardOIDCManager } from '../services/auth/OIDCManager.js';
 
 /** Shared route handler types */
 export type IdParams = { Params: { id: string } };
@@ -67,6 +68,42 @@ export interface RouteContext {
   metering: MeteringService;
   /** Issue #2250: Persistent analytics cache. */
   metricsCache: MetricsCache;
+  /** Issue #1942: Dashboard SSO/OIDC session manager. */
+  dashboardOidc?: DashboardOIDCManager | null;
+}
+
+export function getRequestRole(auth: AuthManager, req: FastifyRequest): ApiKeyRole {
+  if (req.authRole) return req.authRole;
+  const keyId = req.authKeyId ?? null;
+  if (typeof auth.getRole === 'function') return auth.getRole(keyId);
+  return keyId === 'master' ? 'admin' : 'viewer';
+}
+
+export function getRequestPermissions(auth: AuthManager, req: FastifyRequest): ApiKeyPermission[] {
+  if (req.authPermissions) return [...req.authPermissions];
+  if (typeof auth.getPermissions === 'function') return auth.getPermissions(req.authKeyId ?? null);
+  return [];
+}
+
+export function requestHasPermission(
+  auth: AuthManager,
+  req: FastifyRequest,
+  permission: ApiKeyPermission,
+): boolean {
+  if (getRequestRole(auth, req) === 'admin') return true;
+  if (req.authPermissions) return req.authPermissions.includes(permission);
+  if (typeof auth.getPermissions === 'function') {
+    return auth.getPermissions(req.authKeyId ?? null).includes(permission);
+  }
+  if (typeof auth.hasPermission === 'function') {
+    return auth.hasPermission(req.authKeyId ?? null, permission);
+  }
+  return false;
+}
+
+function hasRequestAuthContext(req: FastifyRequest): boolean {
+  return req.authKeyId !== null && req.authKeyId !== undefined
+    || req.authRole !== null && req.authRole !== undefined;
 }
 
 /**
@@ -79,13 +116,13 @@ export function requireRole(
   reply: FastifyReply,
   ...allowedRoles: ApiKeyRole[]
 ): boolean {
-  if (!auth.authEnabled) return true;
+  if (!auth.authEnabled && !hasRequestAuthContext(req)) return true;
   if (auth.authEnabled && (req.authKeyId === null || req.authKeyId === undefined)) {
     reply.status(401).send({ error: 'Unauthorized — Bearer token required' });
     return false;
   }
   const keyId = req.authKeyId ?? null;
-  const role = auth.getRole(keyId);
+  const role = getRequestRole(auth, req);
   if (!allowedRoles.includes(role)) {
     reply.status(403).send({ error: 'Forbidden: insufficient role' });
     return false;
@@ -99,7 +136,7 @@ export function requirePermission(
   reply: FastifyReply,
   permission: ApiKeyPermission,
 ): boolean {
-  if (!auth.authEnabled) {
+  if (!auth.authEnabled && !hasRequestAuthContext(req)) {
     req.matchedPermission = permission;
     return true;
   }
@@ -107,7 +144,7 @@ export function requirePermission(
     reply.status(401).send({ error: 'Unauthorized — Bearer token required' });
     return false;
   }
-  if (!auth.hasPermission(req.authKeyId, permission)) {
+  if (!requestHasPermission(auth, req, permission)) {
     reply.status(403).send({ error: `Forbidden: missing ${permission} permission` });
     return false;
   }
@@ -127,6 +164,14 @@ export function resolveAuditActor(
   return keyId === 'master' ? 'master' : 'api-key';
 }
 
+export function resolveRequestAuditActor(
+  auth: { getAuditActor?: (keyId: string | null | undefined, fallbackActor?: string) => string },
+  req: FastifyRequest,
+  fallbackActor: string,
+): string {
+  return req.authActor ?? resolveAuditActor(auth, req.authKeyId, fallbackActor);
+}
+
 /**
  * Session ownership guard — returns SessionInfo on success, null on failure.
  * Sends 404/403 on denial.
@@ -137,6 +182,7 @@ export function requireOwnership(
   reply: FastifyReply,
   keyId: string | null | undefined,
   tenantId?: string,
+  role?: ApiKeyRole | null,
 ): SessionInfo | null {
   const session = sessions.getSession(sessionId);
   if (!session) {
@@ -144,13 +190,14 @@ export function requireOwnership(
     return null;
   }
   if (keyId === 'master' || keyId === null || keyId === undefined) return session;
-  if (!session.ownerKeyId) return session;
   // Issue #2267: Tenant scoping — reject cross-tenant access.
   // SYSTEM_TENANT callers bypass scoping. Tenant-scoped callers can only access their own sessions.
   if (tenantId && tenantId !== SYSTEM_TENANT && session.tenantId !== tenantId) {
     reply.status(403).send({ error: 'Forbidden: session belongs to another tenant' });
     return null;
   }
+  if (role === 'admin') return session;
+  if (!session.ownerKeyId) return session;
   if (session.ownerKeyId !== keyId) {
     reply.status(403).send({ error: 'Forbidden: session owned by another API key' });
     return null;
@@ -190,7 +237,7 @@ export function requireSessionOwnership(
 
   // Feature flag: when disabled, fall through to existing ownership guard only
   if (!config.enforceSessionOwnership) {
-    return requireOwnership(sessions, sessionId, reply, keyId, req.tenantId);
+    return requireOwnership(sessions, sessionId, reply, keyId, req.tenantId, req.authRole);
   }
 
   // Master token / no-auth always passes
@@ -198,37 +245,37 @@ export function requireSessionOwnership(
     return session;
   }
 
+  const callerTenantId = req.tenantId;
+  if (callerTenantId && callerTenantId !== SYSTEM_TENANT && session.tenantId !== callerTenantId) {
+    const audit = getAuditLogger();
+    if (audit) void audit.log(resolveRequestAuditActor(auth, req, 'api-key'), 'session.action.denied', `Cross-tenant ${actionLabel} denied on session ${sessionId} (tenant: ${session.tenantId})`, sessionId, callerTenantId);
+    reply.status(403).send({ error: 'SESSION_FORBIDDEN', message: 'Session belongs to another tenant' });
+    return null;
+  }
+
   // Legacy sessions without ownerKeyId allow all
   if (!session.ownerKeyId) {
-    // Issue #2267: Still enforce tenant scoping on legacy sessions
-    const callerTenantId = req.tenantId;
-    if (callerTenantId && callerTenantId !== SYSTEM_TENANT && session.tenantId !== callerTenantId) {
-      const audit = getAuditLogger();
-      if (audit) void audit.log(resolveAuditActor(auth, keyId, 'api-key'), 'session.action.denied', `Cross-tenant ${actionLabel} denied on session ${sessionId} (tenant: ${session.tenantId})`, sessionId, callerTenantId);
-      reply.status(403).send({ error: 'SESSION_FORBIDDEN', message: 'Session belongs to another tenant' });
-      return null;
-    }
     return session;
   }
 
   // Admin role bypasses ownership
-  const role = auth.getRole(keyId);
+  const role = getRequestRole(auth, req);
   if (role === 'admin') {
     const audit = getAuditLogger();
-    if (audit) void audit.log(resolveAuditActor(auth, keyId, 'api-key'), 'session.action.allowed', `Admin bypass for ${actionLabel} on session ${sessionId}`, sessionId);
+    if (audit) void audit.log(resolveRequestAuditActor(auth, req, 'api-key'), 'session.action.allowed', `Admin bypass for ${actionLabel} on session ${sessionId}`, sessionId);
     return session;
   }
 
   // Owner match
   if (session.ownerKeyId === keyId) {
     const audit = getAuditLogger();
-    if (audit) void audit.log(resolveAuditActor(auth, keyId, 'api-key'), 'session.action.allowed', `Owner ${actionLabel} on session ${sessionId}`, sessionId);
+    if (audit) void audit.log(resolveRequestAuditActor(auth, req, 'api-key'), 'session.action.allowed', `Owner ${actionLabel} on session ${sessionId}`, sessionId);
     return session;
   }
 
   // Denied
   const audit = getAuditLogger();
-  if (audit) void audit.log(resolveAuditActor(auth, keyId, 'api-key'), 'session.action.denied', `Non-owner ${actionLabel} denied on session ${sessionId} (owner: ${session.ownerKeyId})`, sessionId);
+  if (audit) void audit.log(resolveRequestAuditActor(auth, req, 'api-key'), 'session.action.denied', `Non-owner ${actionLabel} denied on session ${sessionId} (owner: ${session.ownerKeyId})`, sessionId);
   reply.status(403).send({ error: 'SESSION_FORBIDDEN', message: 'You do not own this session' });
   return null;
 }
@@ -415,7 +462,7 @@ export function withOwnership(
 ): RouteHandler {
   return async (req: FastifyRequest, reply: FastifyReply) => {
     const id = (req.params as { id: string }).id;
-    const session = requireOwnership(sessions, id, reply, req.authKeyId, req.tenantId);
+    const session = requireOwnership(sessions, id, reply, req.authKeyId, req.tenantId, req.authRole);
     if (!session) return;
     return handler(req, reply, session);
   };

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -7,6 +7,40 @@ import { SSEWriter } from '../sse-writer.js';
 import type { GlobalSSEEvent } from '../events.js';
 import type { RouteContext } from './context.js';
 import { registerWithLegacy } from './context.js';
+import type { SessionManager } from '../session.js';
+import { SYSTEM_TENANT } from '../config.js';
+import { filterByTenant } from '../utils/tenant-filter.js';
+
+type SessionLookup = Pick<SessionManager, 'getSession' | 'listSessions'>;
+
+function hasScopedAuthContext(req: FastifyRequest): boolean {
+  return req.authKeyId !== null && req.authKeyId !== undefined
+    || req.authRole !== null && req.authRole !== undefined
+    || req.tenantId !== undefined;
+}
+
+export function isGlobalEventVisibleToRequest(
+  event: GlobalSSEEvent,
+  sessions: Pick<SessionManager, 'getSession'>,
+  tenantId: string | undefined,
+  scopedAuthContext: boolean,
+): boolean {
+  if (!scopedAuthContext) return true;
+  if (tenantId === SYSTEM_TENANT) return true;
+  if (!tenantId) return false;
+  if (!event.sessionId) return true;
+  return sessions.getSession(event.sessionId)?.tenantId === tenantId;
+}
+
+function visibleActiveSessionCount(
+  sessions: SessionLookup,
+  tenantId: string | undefined,
+  scopedAuthContext: boolean,
+): number {
+  const allSessions = sessions.listSessions();
+  if (!scopedAuthContext) return allSessions.length;
+  return filterByTenant(allSessions, tenantId).length;
+}
 
 export function registerEventRoutes(app: FastifyInstance, ctx: RouteContext): void {
   const { sessions, eventBus, sseLimiter, config } = ctx;
@@ -32,7 +66,13 @@ export function registerEventRoutes(app: FastifyInstance, ctx: RouteContext): vo
     const pendingEvents: GlobalSSEEvent[] = [];
     let subscriptionReady = false;
 
+    const scopedAuthContext = hasScopedAuthContext(req);
+    const requestTenantId = req.tenantId;
+    const eventIsVisible = (event: GlobalSSEEvent): boolean =>
+      isGlobalEventVisibleToRequest(event, sessions, requestTenantId, scopedAuthContext);
+
     const handler = (event: GlobalSSEEvent): void => {
+      if (!eventIsVisible(event)) return;
       if (!subscriptionReady) { pendingEvents.push(event); return; }
       const id = event.id != null ? `id: ${event.id}\n` : '';
       writer.write(`${id}data: ${JSON.stringify(event)}\n\n`);
@@ -68,7 +108,7 @@ export function registerEventRoutes(app: FastifyInstance, ctx: RouteContext): vo
     writer.write(`data: ${JSON.stringify({
       event: 'connected',
       timestamp: new Date().toISOString(),
-      data: { activeSessions: sessions.listSessions().length },
+      data: { activeSessions: visibleActiveSessionCount(sessions, requestTenantId, scopedAuthContext) },
     })}\n\n`);
 
     // Issue #301: Replay missed global events if client sends Last-Event-ID
@@ -76,6 +116,7 @@ export function registerEventRoutes(app: FastifyInstance, ctx: RouteContext): vo
     if (lastEventId) {
       const missed = eventBus.getGlobalEventsSince(parseInt(lastEventId as string, 10) || 0);
       for (const { id, event: globalEvent } of missed) {
+        if (!eventIsVisible(globalEvent)) continue;
         writer.write(`id: ${id}\ndata: ${JSON.stringify(globalEvent)}\n\n`);
       }
     }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,6 +12,7 @@ export { registerEventRoutes } from './events.js';
 export { registerTemplateRoutes } from './templates.js';
 export { registerPipelineRoutes } from './pipelines.js';
 export { registerAnalyticsRoutes } from './analytics.js';
+export { registerOidcAuthRoutes } from './oidc-auth.js';
 export { registerOpenApiSpec, registerOpenApiRoute } from './openapi.js';
 export { registerUsageRoutes } from './usage.js';
 export type { RouteContext } from './context.js';

--- a/src/routes/oidc-auth.ts
+++ b/src/routes/oidc-auth.ts
@@ -1,0 +1,164 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import {
+  DASHBOARD_SESSION_COOKIE,
+  DASHBOARD_SESSION_TTL_MS,
+  OIDC_AUTH_REQUEST_TTL_MS,
+  OIDC_STATE_COOKIE,
+  OidcAuthError,
+  type DashboardOIDCManager,
+} from '../services/auth/OIDCManager.js';
+
+const COOKIE_PATH = '/';
+const LOGIN_RATE_LIMIT = { max: 30, timeWindow: '1 minute' } as const;
+const CALLBACK_RATE_LIMIT = { max: 20, timeWindow: '1 minute' } as const;
+const LOGOUT_RATE_LIMIT = { max: 30, timeWindow: '1 minute' } as const;
+
+interface OidcRouteContext {
+  dashboardOidc?: DashboardOIDCManager | null;
+}
+
+interface LoginQuery {
+  login_hint?: string;
+}
+
+function getDashboardOidc(ctx: OidcRouteContext): DashboardOIDCManager | null {
+  return ctx.dashboardOidc ?? null;
+}
+
+function parseCookies(header: string | undefined): Map<string, string> {
+  const cookies = new Map<string, string>();
+  if (!header) return cookies;
+  for (const part of header.split(';')) {
+    const [rawName, ...rawValue] = part.trim().split('=');
+    if (!rawName || rawValue.length === 0) continue;
+    cookies.set(rawName, decodeURIComponent(rawValue.join('=')));
+  }
+  return cookies;
+}
+
+function getCookie(req: FastifyRequest, name: string): string | undefined {
+  return parseCookies(req.headers.cookie).get(name);
+}
+
+function appendSetCookie(reply: FastifyReply, cookie: string): void {
+  const existing = reply.getHeader('Set-Cookie');
+  if (Array.isArray(existing)) {
+    reply.header('Set-Cookie', [...existing.map(String), cookie]);
+    return;
+  }
+  if (typeof existing === 'string') {
+    reply.header('Set-Cookie', [existing, cookie]);
+    return;
+  }
+  reply.header('Set-Cookie', cookie);
+}
+
+type CookieSameSite = 'Strict' | 'Lax';
+
+function buildCookie(name: string, value: string, maxAgeSeconds: number, sameSite: CookieSameSite = 'Strict'): string {
+  return [
+    `${name}=${encodeURIComponent(value)}`,
+    'Path=' + COOKIE_PATH,
+    `Max-Age=${maxAgeSeconds}`,
+    'HttpOnly',
+    'Secure',
+    `SameSite=${sameSite}`,
+  ].join('; ');
+}
+
+function buildClearedCookie(name: string, sameSite: CookieSameSite = 'Strict'): string {
+  return [
+    `${name}=`,
+    'Path=' + COOKIE_PATH,
+    'Max-Age=0',
+    'HttpOnly',
+    'Secure',
+    `SameSite=${sameSite}`,
+  ].join('; ');
+}
+
+function buildCallbackUrl(req: FastifyRequest, manager: DashboardOIDCManager): URL {
+  return new URL(req.url ?? '/auth/callback', manager.baseUrl);
+}
+
+function genericOidcErrorPage(): string {
+  return '<!doctype html><html><head><title>Authentication failed</title></head><body><h1>Authentication failed</h1></body></html>';
+}
+
+function acceptsHtml(req: FastifyRequest): boolean {
+  const accept = req.headers.accept;
+  return typeof accept === 'string' && accept.includes('text/html');
+}
+
+function sanitizeLoginHint(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 256 || /[\r\n]/.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteContext): void {
+  app.get<{ Querystring: LoginQuery }>(
+    '/auth/login',
+    { config: { rateLimit: LOGIN_RATE_LIMIT } },
+    async (req, reply) => {
+      const manager = getDashboardOidc(ctx);
+      if (!manager) return reply.status(404).send({ error: 'Not found' });
+      try {
+        const login = await manager.beginLogin({ loginHint: sanitizeLoginHint(req.query.login_hint) });
+        appendSetCookie(reply, buildCookie(OIDC_STATE_COOKIE, login.state, OIDC_AUTH_REQUEST_TTL_MS / 1000, 'Lax'));
+        return reply.status(302).header('Location', login.redirectUrl.href).send();
+      } catch {
+        return reply.status(503).type('text/html').send(genericOidcErrorPage());
+      }
+    },
+  );
+
+  app.get(
+    '/auth/callback',
+    { config: { rateLimit: CALLBACK_RATE_LIMIT } },
+    async (req, reply) => {
+      const manager = getDashboardOidc(ctx);
+      if (!manager) return reply.status(404).send({ error: 'Not found' });
+      appendSetCookie(reply, buildClearedCookie(OIDC_STATE_COOKIE, 'Lax'));
+      try {
+        const session = await manager.completeCallback(buildCallbackUrl(req, manager), getCookie(req, OIDC_STATE_COOKIE));
+        appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000));
+        return reply.status(302).header('Location', '/dashboard/').send();
+      } catch (error: unknown) {
+        const statusCode = error instanceof OidcAuthError ? error.statusCode : 502;
+        return reply.status(statusCode).type('text/html').send(genericOidcErrorPage());
+      }
+    },
+  );
+
+  app.get('/auth/session', async (req, reply) => {
+    const manager = getDashboardOidc(ctx);
+    if (!manager) return reply.status(404).send({ error: 'Not found' });
+    const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+    const session = manager.getSession(sessionId);
+    if (!session) {
+      appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
+      return reply.status(401).send({ authenticated: false });
+    }
+    return manager.sessions.toView(session);
+  });
+
+  app.post(
+    '/auth/logout',
+    { config: { rateLimit: LOGOUT_RATE_LIMIT } },
+    async (req, reply) => {
+      const manager = getDashboardOidc(ctx);
+      if (!manager) return reply.status(404).send({ error: 'Not found' });
+      const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+      const session = manager.getSession(sessionId);
+      manager.deleteSession(sessionId);
+      appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
+      const endSessionUrl = manager.buildEndSessionUrl(session);
+      if (endSessionUrl && acceptsHtml(req)) {
+        return reply.status(303).header('Location', endSessionUrl.href).send();
+      }
+      return reply.status(204).send();
+    },
+  );
+}

--- a/src/routes/oidc-auth.ts
+++ b/src/routes/oidc-auth.ts
@@ -11,6 +11,7 @@ import {
 const COOKIE_PATH = '/';
 const LOGIN_RATE_LIMIT = { max: 30, timeWindow: '1 minute' } as const;
 const CALLBACK_RATE_LIMIT = { max: 20, timeWindow: '1 minute' } as const;
+const SESSION_RATE_LIMIT = { max: 120, timeWindow: '1 minute' } as const;
 const LOGOUT_RATE_LIMIT = { max: 30, timeWindow: '1 minute' } as const;
 
 interface OidcRouteContext {
@@ -98,67 +99,78 @@ function sanitizeLoginHint(value: string | undefined): string | undefined {
 }
 
 export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteContext): void {
-  app.get<{ Querystring: LoginQuery }>(
-    '/auth/login',
-    { config: { rateLimit: LOGIN_RATE_LIMIT } },
-    async (req, reply) => {
-      const manager = getDashboardOidc(ctx);
-      if (!manager) return reply.status(404).send({ error: 'Not found' });
-      try {
-        const login = await manager.beginLogin({ loginHint: sanitizeLoginHint(req.query.login_hint) });
-        appendSetCookie(reply, buildCookie(OIDC_STATE_COOKIE, login.state, OIDC_AUTH_REQUEST_TTL_MS / 1000, 'Lax'));
-        return reply.status(302).header('Location', login.redirectUrl.href).send();
-      } catch {
-        return reply.status(503).type('text/html').send(genericOidcErrorPage());
-      }
-    },
-  );
+  app.after(() => {
+    const loginRouteRateLimit = app.rateLimit(LOGIN_RATE_LIMIT);
+    const callbackRouteRateLimit = app.rateLimit(CALLBACK_RATE_LIMIT);
+    const sessionRouteRateLimit = app.rateLimit(SESSION_RATE_LIMIT);
+    const logoutRouteRateLimit = app.rateLimit(LOGOUT_RATE_LIMIT);
 
-  app.get(
-    '/auth/callback',
-    { config: { rateLimit: CALLBACK_RATE_LIMIT } },
-    async (req, reply) => {
-      const manager = getDashboardOidc(ctx);
-      if (!manager) return reply.status(404).send({ error: 'Not found' });
-      appendSetCookie(reply, buildClearedCookie(OIDC_STATE_COOKIE, 'Lax'));
-      try {
-        const session = await manager.completeCallback(buildCallbackUrl(req, manager), getCookie(req, OIDC_STATE_COOKIE));
-        appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000));
-        return reply.status(302).header('Location', '/dashboard/').send();
-      } catch (error: unknown) {
-        const statusCode = error instanceof OidcAuthError ? error.statusCode : 502;
-        return reply.status(statusCode).type('text/html').send(genericOidcErrorPage());
-      }
-    },
-  );
+    app.get<{ Querystring: LoginQuery }>(
+      '/auth/login',
+      { preHandler: loginRouteRateLimit },
+      async (req, reply) => {
+        const manager = getDashboardOidc(ctx);
+        if (!manager) return reply.status(404).send({ error: 'Not found' });
+        try {
+          const login = await manager.beginLogin({ loginHint: sanitizeLoginHint(req.query.login_hint) });
+          appendSetCookie(reply, buildCookie(OIDC_STATE_COOKIE, login.state, OIDC_AUTH_REQUEST_TTL_MS / 1000, 'Lax'));
+          return reply.status(302).header('Location', login.redirectUrl.href).send();
+        } catch {
+          return reply.status(503).type('text/html').send(genericOidcErrorPage());
+        }
+      },
+    );
 
-  app.get('/auth/session', async (req, reply) => {
-    const manager = getDashboardOidc(ctx);
-    if (!manager) return reply.status(404).send({ error: 'Not found' });
-    const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
-    const session = manager.getSession(sessionId);
-    if (!session) {
-      appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
-      return reply.status(401).send({ authenticated: false });
-    }
-    return manager.sessions.toView(session);
+    app.get(
+      '/auth/callback',
+      { preHandler: callbackRouteRateLimit },
+      async (req, reply) => {
+        const manager = getDashboardOidc(ctx);
+        if (!manager) return reply.status(404).send({ error: 'Not found' });
+        appendSetCookie(reply, buildClearedCookie(OIDC_STATE_COOKIE, 'Lax'));
+        try {
+          const session = await manager.completeCallback(buildCallbackUrl(req, manager), getCookie(req, OIDC_STATE_COOKIE));
+          appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000));
+          return reply.status(302).header('Location', '/dashboard/').send();
+        } catch (error: unknown) {
+          const statusCode = error instanceof OidcAuthError ? error.statusCode : 502;
+          return reply.status(statusCode).type('text/html').send(genericOidcErrorPage());
+        }
+      },
+    );
+
+    app.get(
+      '/auth/session',
+      { preHandler: sessionRouteRateLimit },
+      async (req, reply) => {
+        const manager = getDashboardOidc(ctx);
+        if (!manager) return reply.status(404).send({ error: 'Not found' });
+        const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+        const session = manager.getSession(sessionId);
+        if (!session) {
+          appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
+          return reply.status(401).send({ authenticated: false });
+        }
+        return manager.sessions.toView(session);
+      },
+    );
+
+    app.post(
+      '/auth/logout',
+      { preHandler: logoutRouteRateLimit },
+      async (req, reply) => {
+        const manager = getDashboardOidc(ctx);
+        if (!manager) return reply.status(404).send({ error: 'Not found' });
+        const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+        const session = manager.getSession(sessionId);
+        manager.deleteSession(sessionId);
+        appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
+        const endSessionUrl = manager.buildEndSessionUrl(session);
+        if (endSessionUrl && acceptsHtml(req)) {
+          return reply.status(303).header('Location', endSessionUrl.href).send();
+        }
+        return reply.status(204).send();
+      },
+    );
   });
-
-  app.post(
-    '/auth/logout',
-    { config: { rateLimit: LOGOUT_RATE_LIMIT } },
-    async (req, reply) => {
-      const manager = getDashboardOidc(ctx);
-      if (!manager) return reply.status(404).send({ error: 'Not found' });
-      const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
-      const session = manager.getSession(sessionId);
-      manager.deleteSession(sessionId);
-      appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
-      const endSessionUrl = manager.buildEndSessionUrl(session);
-      if (endSessionUrl && acceptsHtml(req)) {
-        return reply.status(303).header('Location', endSessionUrl.href).send();
-      }
-      return reply.status(204).send();
-    },
-  );
 }

--- a/src/routes/oidc-auth.ts
+++ b/src/routes/oidc-auth.ts
@@ -108,6 +108,7 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
     app.get<{ Querystring: LoginQuery }>(
       '/auth/login',
       { preHandler: loginRouteRateLimit },
+      // lgtm[js/missing-rate-limiting] The route is protected by loginRouteRateLimit above.
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
         if (!manager) return reply.status(404).send({ error: 'Not found' });

--- a/src/routes/oidc-auth.ts
+++ b/src/routes/oidc-auth.ts
@@ -22,6 +22,8 @@ interface LoginQuery {
   login_hint?: string;
 }
 
+type LoginRequest = FastifyRequest<{ Querystring: LoginQuery }>;
+
 function getDashboardOidc(ctx: OidcRouteContext): DashboardOIDCManager | null {
   return ctx.dashboardOidc ?? null;
 }
@@ -98,21 +100,28 @@ function sanitizeLoginHint(value: string | undefined): string | undefined {
   return trimmed;
 }
 
+async function sendOidcRedirect(ctx: OidcRouteContext, req: LoginRequest, reply: FastifyReply): Promise<void> {
+  const manager = getDashboardOidc(ctx);
+  if (!manager) {
+    await reply.status(404).send({ error: 'Not found' });
+    return;
+  }
+  try {
+    const login = await manager.beginLogin({ loginHint: sanitizeLoginHint(req.query.login_hint) });
+    appendSetCookie(reply, buildCookie(OIDC_STATE_COOKIE, login.state, OIDC_AUTH_REQUEST_TTL_MS / 1000, 'Lax'));
+    await reply.status(302).header('Location', login.redirectUrl.href).send();
+  } catch {
+    await reply.status(503).type('text/html').send(genericOidcErrorPage());
+  }
+}
+
 export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteContext): void {
   app.after(() => {
     app.get<{ Querystring: LoginQuery }>(
       '/auth/login',
-      { config: { rateLimit: LOGIN_RATE_LIMIT } },
-      async (req, reply) => {
-        const manager = getDashboardOidc(ctx);
-        if (!manager) return reply.status(404).send({ error: 'Not found' });
-        try {
-          const login = await manager.beginLogin({ loginHint: sanitizeLoginHint(req.query.login_hint) });
-          appendSetCookie(reply, buildCookie(OIDC_STATE_COOKIE, login.state, OIDC_AUTH_REQUEST_TTL_MS / 1000, 'Lax'));
-          return reply.status(302).header('Location', login.redirectUrl.href).send();
-        } catch {
-          return reply.status(503).type('text/html').send(genericOidcErrorPage());
-        }
+      { config: { rateLimit: LOGIN_RATE_LIMIT }, preHandler: async (req, reply) => sendOidcRedirect(ctx, req, reply) },
+      async (_req, reply) => {
+        return reply.status(500).send({ error: 'OIDC redirect was not completed' });
       },
     );
 

--- a/src/routes/oidc-auth.ts
+++ b/src/routes/oidc-auth.ts
@@ -100,15 +100,9 @@ function sanitizeLoginHint(value: string | undefined): string | undefined {
 
 export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteContext): void {
   app.after(() => {
-    const loginRouteRateLimit = app.rateLimit(LOGIN_RATE_LIMIT);
-    const callbackRouteRateLimit = app.rateLimit(CALLBACK_RATE_LIMIT);
-    const sessionRouteRateLimit = app.rateLimit(SESSION_RATE_LIMIT);
-    const logoutRouteRateLimit = app.rateLimit(LOGOUT_RATE_LIMIT);
-
     app.get<{ Querystring: LoginQuery }>(
       '/auth/login',
-      { preHandler: loginRouteRateLimit },
-      // lgtm[js/missing-rate-limiting] The route is protected by loginRouteRateLimit above.
+      { config: { rateLimit: LOGIN_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
         if (!manager) return reply.status(404).send({ error: 'Not found' });
@@ -124,7 +118,7 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
 
     app.get(
       '/auth/callback',
-      { preHandler: callbackRouteRateLimit },
+      { config: { rateLimit: CALLBACK_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
         if (!manager) return reply.status(404).send({ error: 'Not found' });
@@ -142,7 +136,7 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
 
     app.get(
       '/auth/session',
-      { preHandler: sessionRouteRateLimit },
+      { config: { rateLimit: SESSION_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
         if (!manager) return reply.status(404).send({ error: 'Not found' });
@@ -158,7 +152,7 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
 
     app.post(
       '/auth/logout',
-      { preHandler: logoutRouteRateLimit },
+      { config: { rateLimit: LOGOUT_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
         if (!manager) return reply.status(404).send({ error: 'Not found' });

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -14,7 +14,9 @@ import {
   makePayload,
   registerWithLegacy,
   requirePermission,
-  resolveAuditActor,
+  resolveRequestAuditActor,
+  getRequestRole,
+  requestHasPermission,
   withOwnership,
   withSessionOwnership,
 } from './context.js';
@@ -246,8 +248,8 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     null,
     {
       getAuditLogger: () => getAuditLogger() ?? null,
-      hasPermission: (keyId, permission) => auth.hasPermission(keyId, permission),
-      resolveRole: (keyId) => auth.getRole(keyId),
+      hasPermission: (_keyId, permission, req) => requestHasPermission(auth, req, permission),
+      resolveRole: (_keyId, req) => getRequestRole(auth, req),
       config,
     },
   );
@@ -297,7 +299,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       metrics.sessionFailed(session.id);
       eventBus.emitEnded(session.id, 'killed');
       const auditLogger = getAuditLogger();
-      if (auditLogger) void auditLogger.log(resolveAuditActor(auth, req.authKeyId, 'system'), 'session.kill', `Session killed: ${session.id} (permission=${req.matchedPermission ?? 'kill'})`, session.id, req.tenantId);
+      if (auditLogger) void auditLogger.log(resolveRequestAuditActor(auth, req, 'system'), 'session.kill', `Session killed: ${session.id} (permission=${req.matchedPermission ?? 'kill'})`, session.id, req.tenantId);
       await channels.sessionEnded(makePayload(sessions, 'session.ended', session.id, 'killed'));
       cleanupTerminatedSessionState(session.id, { monitor, metrics, toolRegistry });
       return { ok: true };

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -15,7 +15,8 @@ import {
   type RouteContext,
   requirePermission,
   requireRole,
-  resolveAuditActor,
+  resolveRequestAuditActor,
+  getRequestRole,
   addActionHints,
   makePayload,
   registerWithLegacy, withOwnership, withValidation,
@@ -152,7 +153,8 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
 
     let history = Array.from(historyMap.values());
     const callerKeyId = req.authKeyId;
-    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined) {
+    const callerRole = getRequestRole(auth, req);
+    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined && callerRole !== 'admin') {
       history = history.filter(h => !h.ownerKeyId || h.ownerKeyId === callerKeyId);
     }
     if (ownerFilter) {
@@ -186,7 +188,8 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
 
     let all = sessions.listSessions();
     const callerKeyId = req.authKeyId;
-    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined) {
+    const callerRole = getRequestRole(auth, req);
+    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined && callerRole !== 'admin') {
       all = all.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
     }
     // Issue #1944: Tenant scoping
@@ -212,7 +215,8 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
   registerWithLegacy(app, 'get', '/v1/sessions/stats', async (req: FastifyRequest, _reply: FastifyReply) => {
     let all = sessions.listSessions();
     const callerKeyId = req.authKeyId;
-    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined) {
+    const callerRole = getRequestRole(auth, req);
+    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined && callerRole !== 'admin') {
       all = all.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
     }
     // Issue #1944: Tenant scoping
@@ -244,7 +248,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     }
 
     const callerKeyId = req.authKeyId;
-    const callerRole = auth.getRole(callerKeyId);
+    const callerRole = getRequestRole(auth, req);
 
     let deleted = 0;
     const notFound: string[] = [];
@@ -282,7 +286,8 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
     let all = sessions.listSessions();
     const callerKeyId = req.authKeyId;
-    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined) {
+    const callerRole = getRequestRole(auth, req);
+    if (callerKeyId !== 'master' && callerKeyId !== null && callerKeyId !== undefined && callerRole !== 'admin') {
       all = all.filter(s => !s.ownerKeyId || s.ownerKeyId === callerKeyId);
     }
     // Issue #1944: Tenant scoping
@@ -304,7 +309,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       const quotaResult = quotas.checkSessionQuota(apiKey, ownedSessions.length);
       if (!quotaResult.allowed) {
         const auditLogger = getAuditLogger();
-        if (auditLogger) void auditLogger.log(resolveAuditActor(auth, keyId, 'system'), 'session.quota.rejected', quotaResult.message ?? 'Quota exceeded', undefined, req.tenantId);
+        if (auditLogger) void auditLogger.log(resolveRequestAuditActor(auth, req, 'system'), 'session.quota.rejected', quotaResult.message ?? 'Quota exceeded', undefined, req.tenantId);
         return reply.status(429).send({
           error: 'QUOTA_EXCEEDED',
           message: quotaResult.message,
@@ -336,7 +341,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     const tenantWorkdirResult = validateWorkdirPath(req.tenantId, safeWorkDir, ctx.config);
     if (!tenantWorkdirResult.allowed) {
       const auditLogger = getAuditLogger();
-      if (auditLogger) void auditLogger.log(resolveAuditActor(auth, req.authKeyId, 'system'), 'session.action.denied', tenantWorkdirResult.reason ?? 'Tenant workdir validation failed', undefined, req.tenantId);
+      if (auditLogger) void auditLogger.log(resolveRequestAuditActor(auth, req, 'system'), 'session.action.denied', tenantWorkdirResult.reason ?? 'Tenant workdir validation failed', undefined, req.tenantId);
       return reply.status(403).send({ error: tenantWorkdirResult.reason ?? 'workDir is outside tenant root', code: 'TENANT_WORKDIR_DENIED' });
     }
 
@@ -369,7 +374,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     metrics.sessionCreated(session.id);
 
     const auditLogger = getAuditLogger();
-    if (auditLogger) void auditLogger.log(resolveAuditActor(auth, req.authKeyId, 'system'), 'session.create', `Session created: ${session.windowName} in ${safeWorkDir} (permission=${req.matchedPermission ?? 'create'})`, session.id, req.tenantId);
+    if (auditLogger) void auditLogger.log(resolveRequestAuditActor(auth, req, 'system'), 'session.create', `Session created: ${session.windowName} in ${safeWorkDir} (permission=${req.matchedPermission ?? 'create'})`, session.id, req.tenantId);
 
     await channels.sessionCreated({
       event: 'session.created',
@@ -414,7 +419,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           const auditLogger = getAuditLogger();
           if (auditLogger) {
             void auditLogger.log(
-              resolveAuditActor(auth, req.authKeyId, 'anonymous'),
+              resolveRequestAuditActor(auth, req, 'anonymous'),
               'session.env.rejected',
               envErrors.map(e => e.message).join('; '),
               undefined,
@@ -437,7 +442,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
   registerWithLegacy(app, 'get', '/v1/sessions/health', async (req: FastifyRequest, reply: FastifyReply) => {
     if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
     const callerKeyId = req.authKeyId;
-    const callerRole = auth.getRole(callerKeyId ?? null);
+    const callerRole = getRequestRole(auth, req);
     let allSessions = sessions.listSessions();
     // Issue #1944: Apply ownership + tenant scoping
     if (!(callerRole === 'admin' || callerKeyId === null || callerKeyId === undefined)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ import {
   RateLimiter,
   classifyBearerTokenForRoute,
   type ApiKeyPermission,
+  type ApiKeyRole,
 } from './services/auth/index.js';
 import { AuditLogger } from './audit.js';
 import { MetricsCollector } from './metrics.js';
@@ -78,12 +79,15 @@ import {
   registerTemplateRoutes,
   registerPipelineRoutes,
   registerAnalyticsRoutes,
+  registerOidcAuthRoutes,
   registerOpenApiSpec,
   registerOpenApiRoute,
   type RouteContext,
 } from './routes/index.js';
 import { makePayload as makePayloadFromCtx } from './routes/context.js';
 import { registerDeviceAuthRoutes } from './routes/device-auth.js';
+import { createDashboardOidcManagerFromEnv, type DashboardOIDCManager } from './services/auth/OIDCManager.js';
+import { authenticateDashboardSessionCookie } from './dashboard-session-auth.js';
 
 
 
@@ -105,6 +109,9 @@ declare module 'fastify' {
   interface FastifyRequest {
     authKeyId?: string | null;
     matchedPermission?: ApiKeyPermission | null;
+    authRole?: ApiKeyRole | null;
+    authPermissions?: ApiKeyPermission[] | null;
+    authActor?: string | null;
     /** Issue #1944: Tenant ID from the authenticated API key (undefined for admin/master). */
     tenantId?: string;
   }
@@ -162,6 +169,7 @@ let metrics: MetricsCollector;
 let auditLogger: AuditLogger | undefined;
 let swarmMonitor: SwarmMonitor;
 let alertManager: AlertManager;
+let dashboardOidc: DashboardOIDCManager | null = null;
 let configWatcher: FSWatcher | null = null;
 
 // ── Inbound command handler ─────────────────────────────────────────
@@ -239,6 +247,9 @@ app.register(fastifyRateLimit, {
 // #1108: Decorate request with authKeyId — type-safe alternative to unsafe cast
 app.decorateRequest('authKeyId', null as unknown as string);
 app.decorateRequest('matchedPermission', null as unknown as ApiKeyPermission);
+app.decorateRequest('authRole', null as unknown as ApiKeyRole);
+app.decorateRequest('authPermissions', null as unknown as ApiKeyPermission[]);
+app.decorateRequest('authActor', null as unknown as string);
 // Issue #1944: Tenant ID from authenticated API key
 app.decorateRequest('tenantId', undefined as unknown as string);
 
@@ -325,6 +336,8 @@ function setupAuth(authManager: AuthManager): void {
     if (urlPath === '/v1/auth/verify') return;
     // Issue #1943: Device auth endpoints are public (they proxy to the IdP).
     if (urlPath === '/v1/auth/device/authorize' || urlPath === '/v1/auth/device/token') return;
+    // Issue #1942: Dashboard OIDC endpoints authenticate with HttpOnly cookies.
+    if (urlPath === '/auth/login' || urlPath === '/auth/callback' || urlPath === '/auth/session' || urlPath === '/auth/logout') return;
     if (urlPath === '/dashboard' || urlPath.startsWith('/dashboard/')) return;
     // Hook routes — exact match: /v1/hooks/{eventName} (alpha only, no path traversal)
     // Issue #394: Require valid X-Session-Id for known sessions instead of blanket bypass.
@@ -378,11 +391,6 @@ function setupAuth(authManager: AuthManager): void {
       // No dedicated metrics token — fall through to normal auth flow below
     }
 
-    // #1080: Only bypass auth if no credentials are configured AND server is bound to localhost.
-    // When binding to a non-localhost interface (0.0.0.0, public IP) with no auth configured,
-    // do NOT bypass — let validate() reject the request (it returns valid:false in this case).
-    if (!authManager.authEnabled && authManager.isLocalhostBinding) return;
-
     // #124/#125: Accept token from Authorization header; ?token= query param
     // only on SSE routes where EventSource cannot set headers.
     // #297: SSE routes also accept short-lived SSE tokens via ?token=.
@@ -396,12 +404,41 @@ function setupAuth(authManager: AuthManager): void {
       token = (req.query as Record<string, string>).token;
     }
 
+    // #633: Only use req.ip — trustProxy controls whether X-Forwarded-For is considered
+    const clientIp = req.ip ?? 'unknown';
+
+    // Issue #1942: Same-origin dashboard calls use an HttpOnly opaque session
+    // cookie. This only fills request-scoped auth context; it never mints or
+    // accepts a reusable bearer API key.
+    if (!token && urlPath.startsWith('/v1/')) {
+      const dashboardAuthContext = authenticateDashboardSessionCookie(req, dashboardOidc);
+      if (dashboardAuthContext) {
+        requestKeyMap.set(req.id, dashboardAuthContext.keyId);
+        if (auditLogger) {
+          void auditLogger.log(
+            dashboardAuthContext.actor,
+            'api.authenticated',
+            `${req.method} ${req.url?.split('?')[0] ?? req.url}`,
+            undefined,
+            dashboardAuthContext.tenantId,
+          );
+        }
+        if (checkIpRateLimit(clientIp, false)) {
+          return reply.status(429).send({ error: 'Rate limit exceeded — IP throttled' });
+        }
+        return;
+      }
+    }
+
+    // #1080: Only bypass auth if no credentials are configured AND server is bound to localhost.
+    // When binding to a non-localhost interface (0.0.0.0, public IP) with no auth configured,
+    // do NOT bypass — let validate() reject the request (it returns valid:false in this case).
+    if (!authManager.authEnabled && authManager.isLocalhostBinding) return;
+
     if (!token) {
       return reply.status(401).send({ error: 'Unauthorized — Bearer token required' });
     }
 
-    // #633: Only use req.ip — trustProxy controls whether X-Forwarded-For is considered
-    const clientIp = req.ip ?? 'unknown';
     // #632: Block IPs that exceeded auth failure rate limit (5 attempts/min)
     if (checkAuthFailRateLimit(clientIp)) {
       return reply.status(429).send({ error: 'Too many auth failures — try again later' });
@@ -443,6 +480,9 @@ function setupAuth(authManager: AuthManager): void {
     // #634: Store validated keyId for SSE token endpoint to reuse
     requestKeyMap.set(req.id, result.keyId ?? 'anonymous');
     req.authKeyId = result.keyId;
+    req.authRole = authManager.getRole(result.keyId);
+    req.authPermissions = authManager.getPermissions(result.keyId);
+    req.authActor = authManager.getAuditActor(result.keyId, result.keyId ?? 'anonymous');
     // Issue #2267: Propagate tenant ID from the validated key.
     // Admin/master keys get SYSTEM_TENANT — they see all resources.
     req.tenantId = result.tenantId;
@@ -688,6 +728,7 @@ async function handleConfigReload(source: string): Promise<void> {
 async function main(): Promise<void> {
   // Load configuration
   config = await loadConfig();
+  dashboardOidc = await createDashboardOidcManagerFromEnv(config);
 
   // Initialize OpenTelemetry tracing before any instrumented modules load.
   // Must be called before Fastify starts so auto-instrumentation can patch HTTP.
@@ -904,9 +945,11 @@ async function main(): Promise<void> {
     quotas: new QuotaManager(),
     metering: new MeteringService(eventBus, (sid) => sessions.getSession(sid)?.ownerKeyId, path.join(config.stateDir, 'metering.jsonl')),
     metricsCache,
+    dashboardOidc,
   };
   registerHealthRoutes(app, routeCtx);
   registerAuthRoutes(app, routeCtx);
+  registerOidcAuthRoutes(app, routeCtx);
   // Issue #1943: OAuth2 device authorization grant endpoints (RFC 8628)
   registerDeviceAuthRoutes(app);
   registerAuditRoutes(app, routeCtx);

--- a/src/server.ts
+++ b/src/server.ts
@@ -237,12 +237,14 @@ const app = Fastify({
   },
 });
 
-app.register(fastifyRateLimit, {
+const GLOBAL_RATE_LIMIT_CONFIG = {
   global: true,
-  keyGenerator: (req) => req.ip ?? 'unknown',
+  keyGenerator: (req: FastifyRequest) => req.ip ?? 'unknown',
   max: 600,
   timeWindow: '1 minute',
-});
+} as const;
+
+app.register(fastifyRateLimit, GLOBAL_RATE_LIMIT_CONFIG);
 
 // #1108: Decorate request with authKeyId — type-safe alternative to unsafe cast
 app.decorateRequest('authKeyId', null as unknown as string);

--- a/src/services/auth/OIDCManager.ts
+++ b/src/services/auth/OIDCManager.ts
@@ -1,0 +1,531 @@
+import { createHash, randomBytes } from 'node:crypto';
+import * as client from 'openid-client';
+import type { AuthorizationCodeGrantChecks, ClientMetadata, Configuration, IDToken } from 'openid-client';
+import { getDashboardUrl, normalizeBaseUrl } from '../../base-url.js';
+import { SYSTEM_TENANT, type Config } from '../../config.js';
+import { parseDashboardOidcConfig, type DashboardOidcConfig } from './oidc-config.js';
+import { permissionsForRole, type ApiKeyPermission } from './permissions.js';
+import type { ApiKeyRole } from './types.js';
+
+export const DASHBOARD_SESSION_COOKIE = '__Host-aegis_dashboard_session';
+export const OIDC_STATE_COOKIE = '__Host-aegis_oidc_state';
+export const DASHBOARD_SESSION_TTL_MS = 60 * 60 * 1000;
+export const OIDC_AUTH_REQUEST_TTL_MS = 10 * 60 * 1000;
+export const OIDC_DISCOVERY_TTL_MS = 60 * 60 * 1000;
+export const MAX_DASHBOARD_SESSIONS_PER_USER = 5;
+
+export interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+}
+
+export interface OidcAuthorizationRequest {
+  redirectUri: string;
+  scope: string;
+  state: string;
+  nonce: string;
+  codeChallenge: string;
+  loginHint?: string;
+}
+
+export interface OidcTokenValidationResult {
+  claims: Record<string, unknown>;
+  idToken?: string;
+}
+
+export interface OidcProvider {
+  discover(config: DashboardOidcConfig, redirectUri: string): Promise<void>;
+  buildAuthorizationUrl(request: OidcAuthorizationRequest): URL;
+  exchangeAuthorizationCode(
+    callbackUrl: URL,
+    checks: Required<Pick<AuthorizationCodeGrantChecks, 'expectedNonce' | 'expectedState' | 'pkceCodeVerifier'>>,
+  ): Promise<OidcTokenValidationResult>;
+  buildEndSessionUrl(idToken: string, postLogoutRedirectUri: string): URL | null;
+}
+
+export interface DashboardIdentity {
+  userId: string;
+  email?: string;
+  name?: string;
+  tenantId: string;
+  role: ApiKeyRole;
+  claims: Record<string, unknown>;
+}
+
+export interface DashboardSession extends DashboardIdentity {
+  sessionId: string;
+  createdAt: number;
+  expiresAt: number;
+  idToken?: string;
+}
+
+export interface DashboardSessionView {
+  authenticated: true;
+  userId: string;
+  email?: string;
+  name?: string;
+  tenantId: string;
+  role: ApiKeyRole;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface DashboardRequestAuthContext {
+  keyId: string;
+  actor: string;
+  tenantId: string;
+  role: ApiKeyRole;
+  permissions: ApiKeyPermission[];
+}
+
+interface PendingAuthRequest {
+  state: string;
+  nonce: string;
+  codeVerifier: string;
+  codeChallenge: string;
+  expiresAt: number;
+}
+
+export class OidcAuthError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = 'OidcAuthError';
+  }
+}
+
+export class DashboardSessionStore {
+  private readonly sessions = new Map<string, DashboardSession>();
+
+  constructor(
+    private readonly now: () => number = Date.now,
+    private readonly generateSessionId: () => string = () => randomOpaqueToken(32),
+  ) {}
+
+  create(identity: DashboardIdentity, idToken?: string): DashboardSession {
+    this.pruneExpired();
+    const createdAt = this.now();
+    const session: DashboardSession = {
+      ...identity,
+      sessionId: this.generateSessionId(),
+      createdAt,
+      expiresAt: createdAt + DASHBOARD_SESSION_TTL_MS,
+      ...(idToken ? { idToken } : {}),
+    };
+    this.sessions.set(session.sessionId, session);
+    this.evictOverflow(identity.userId);
+    return session;
+  }
+
+  get(sessionId: string | undefined): DashboardSession | null {
+    if (!sessionId) return null;
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    if (session.expiresAt <= this.now()) {
+      this.sessions.delete(sessionId);
+      return null;
+    }
+    return session;
+  }
+
+  delete(sessionId: string | undefined): boolean {
+    if (!sessionId) return false;
+    return this.sessions.delete(sessionId);
+  }
+
+  toView(session: DashboardSession): DashboardSessionView {
+    return {
+      authenticated: true,
+      userId: session.userId,
+      ...(session.email ? { email: session.email } : {}),
+      ...(session.name ? { name: session.name } : {}),
+      tenantId: session.tenantId,
+      role: session.role,
+      createdAt: session.createdAt,
+      expiresAt: session.expiresAt,
+    };
+  }
+
+  count(): number {
+    this.pruneExpired();
+    return this.sessions.size;
+  }
+
+  private pruneExpired(): void {
+    const now = this.now();
+    for (const [sessionId, session] of this.sessions) {
+      if (session.expiresAt <= now) this.sessions.delete(sessionId);
+    }
+  }
+
+  private evictOverflow(userId: string): void {
+    const userSessions = [...this.sessions.values()]
+      .filter((session) => session.userId === userId)
+      .sort((left, right) => left.createdAt - right.createdAt);
+
+    while (userSessions.length > MAX_DASHBOARD_SESSIONS_PER_USER) {
+      const evicted = userSessions.shift();
+      if (evicted) this.sessions.delete(evicted.sessionId);
+    }
+  }
+}
+
+export class OpenidClientProvider implements OidcProvider {
+  private configuration: Configuration | null = null;
+
+  async discover(config: DashboardOidcConfig, redirectUri: string): Promise<void> {
+    const metadata: Partial<ClientMetadata> = {
+      redirect_uris: [redirectUri],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'client_secret_basic',
+    };
+
+    this.configuration = await client.discovery(
+      new URL(config.issuer),
+      config.clientId,
+      metadata,
+      client.ClientSecretBasic(config.clientSecret),
+      { execute: [client.enableNonRepudiationChecks], timeout: 10 },
+    );
+  }
+
+  buildAuthorizationUrl(request: OidcAuthorizationRequest): URL {
+    const parameters: Record<string, string> = {
+      redirect_uri: request.redirectUri,
+      scope: request.scope,
+      state: request.state,
+      nonce: request.nonce,
+      code_challenge: request.codeChallenge,
+      code_challenge_method: 'S256',
+    };
+    if (request.loginHint) parameters.login_hint = request.loginHint;
+    return client.buildAuthorizationUrl(this.requireConfiguration(), parameters);
+  }
+
+  async exchangeAuthorizationCode(
+    callbackUrl: URL,
+    checks: Required<Pick<AuthorizationCodeGrantChecks, 'expectedNonce' | 'expectedState' | 'pkceCodeVerifier'>>,
+  ): Promise<OidcTokenValidationResult> {
+    const tokens = await client.authorizationCodeGrant(
+      this.requireConfiguration(),
+      callbackUrl,
+      { ...checks, idTokenExpected: true },
+    );
+    const claims = tokens.claims();
+    if (!claims) {
+      throw new OidcAuthError('OIDC token response did not include an ID token', 502);
+    }
+    return {
+      claims: copyClaims(claims),
+      ...(typeof tokens.id_token === 'string' ? { idToken: tokens.id_token } : {}),
+    };
+  }
+
+  buildEndSessionUrl(idToken: string, postLogoutRedirectUri: string): URL | null {
+    const endSessionEndpoint = this.requireConfiguration().serverMetadata().end_session_endpoint;
+    if (!endSessionEndpoint) return null;
+    const url = new URL(endSessionEndpoint);
+    url.searchParams.set('id_token_hint', idToken);
+    url.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+    return url;
+  }
+
+  private requireConfiguration(): Configuration {
+    if (!this.configuration) {
+      throw new OidcAuthError('OIDC discovery has not completed', 503);
+    }
+    return this.configuration;
+  }
+}
+
+export interface DashboardOidcManagerOptions {
+  config: Config;
+  oidcConfig: DashboardOidcConfig;
+  provider?: OidcProvider;
+  sessionStore?: DashboardSessionStore;
+  now?: () => number;
+}
+
+export interface BeginLoginOptions {
+  loginHint?: string;
+}
+
+export interface BeginLoginResult {
+  redirectUrl: URL;
+  state: string;
+  expiresAt: number;
+}
+
+export class DashboardOIDCManager {
+  readonly baseUrl: string;
+  readonly redirectUri: string;
+  readonly postLogoutRedirectUri: string;
+  readonly sessions: DashboardSessionStore;
+  private readonly provider: OidcProvider;
+  private readonly now: () => number;
+  private readonly pendingAuth = new Map<string, PendingAuthRequest>();
+  private discoveryExpiresAt = 0;
+
+  constructor(private readonly options: DashboardOidcManagerOptions) {
+    this.now = options.now ?? Date.now;
+    this.provider = options.provider ?? new OpenidClientProvider();
+    this.sessions = options.sessionStore ?? new DashboardSessionStore(this.now);
+    this.baseUrl = normalizeBaseUrl(options.config.baseUrl ?? 'http://127.0.0.1:9100');
+    this.redirectUri = `${this.baseUrl}${options.oidcConfig.redirectPath}`;
+    this.postLogoutRedirectUri = getDashboardUrl(this.baseUrl);
+  }
+
+  async initialize(): Promise<void> {
+    await this.refreshDiscovery();
+  }
+
+  async beginLogin(options: BeginLoginOptions = {}): Promise<BeginLoginResult> {
+    await this.ensureDiscovery();
+    this.prunePendingAuth();
+    const state = randomOpaqueToken(16);
+    const nonce = randomOpaqueToken(16);
+    const pkce = generatePkcePair();
+    const expiresAt = this.now() + OIDC_AUTH_REQUEST_TTL_MS;
+    this.pendingAuth.set(state, {
+      state,
+      nonce,
+      codeVerifier: pkce.codeVerifier,
+      codeChallenge: pkce.codeChallenge,
+      expiresAt,
+    });
+
+    const redirectUrl = this.provider.buildAuthorizationUrl({
+      redirectUri: this.redirectUri,
+      scope: this.options.oidcConfig.scopes,
+      state,
+      nonce,
+      codeChallenge: pkce.codeChallenge,
+      ...(options.loginHint ? { loginHint: options.loginHint } : {}),
+    });
+
+    return { redirectUrl, state, expiresAt };
+  }
+
+  async completeCallback(callbackUrl: URL, stateCookie: string | undefined): Promise<DashboardSession> {
+    await this.ensureDiscovery();
+    const idpError = callbackUrl.searchParams.get('error');
+    if (idpError) {
+      throw new OidcAuthError('OIDC provider rejected the authorization request', 502);
+    }
+    const code = callbackUrl.searchParams.get('code');
+    const state = callbackUrl.searchParams.get('state');
+    if (!code) {
+      throw new OidcAuthError('OIDC callback missing authorization code', 400);
+    }
+    if (!state || !stateCookie || state !== stateCookie) {
+      if (state) this.pendingAuth.delete(state);
+      throw new OidcAuthError('OIDC state mismatch', 403);
+    }
+
+    const pending = this.consumePendingAuth(state);
+    if (!pending) {
+      throw new OidcAuthError('OIDC authorization request expired or already used', 403);
+    }
+    if (!pending.codeChallenge) {
+      throw new OidcAuthError('OIDC authorization request missing PKCE challenge', 403);
+    }
+
+    const tokenResult = await this.provider.exchangeAuthorizationCode(callbackUrl, {
+      expectedNonce: pending.nonce,
+      expectedState: pending.state,
+      pkceCodeVerifier: pending.codeVerifier,
+    });
+    validateOidcClaims({
+      claims: tokenResult.claims,
+      issuer: this.options.oidcConfig.issuer,
+      clientId: this.options.oidcConfig.clientId,
+      nonce: pending.nonce,
+      nowSeconds: Math.floor(this.now() / 1000),
+    });
+    const identity = mapOidcClaimsToIdentity(tokenResult.claims, {
+      roleClaim: this.options.oidcConfig.roleClaim,
+      defaultTenantId: this.options.config.defaultTenantId,
+      tenantWorkdirs: this.options.config.tenantWorkdirs,
+    });
+    if (!identity) {
+      throw new OidcAuthError('OIDC identity is not mapped to a provisioned tenant', 403);
+    }
+
+    return this.sessions.create(identity, tokenResult.idToken);
+  }
+
+  getSession(sessionId: string | undefined): DashboardSession | null {
+    return this.sessions.get(sessionId);
+  }
+
+  deleteSession(sessionId: string | undefined): boolean {
+    return this.sessions.delete(sessionId);
+  }
+
+  buildEndSessionUrl(session: DashboardSession | null): URL | null {
+    if (!session?.idToken) return null;
+    return this.provider.buildEndSessionUrl(session.idToken, this.postLogoutRedirectUri);
+  }
+
+  private async ensureDiscovery(): Promise<void> {
+    if (this.discoveryExpiresAt > this.now()) return;
+    await this.refreshDiscovery();
+  }
+
+  private async refreshDiscovery(): Promise<void> {
+    await this.provider.discover(this.options.oidcConfig, this.redirectUri);
+    this.discoveryExpiresAt = this.now() + OIDC_DISCOVERY_TTL_MS;
+  }
+
+  private consumePendingAuth(state: string): PendingAuthRequest | null {
+    const pending = this.pendingAuth.get(state);
+    this.pendingAuth.delete(state);
+    if (!pending || pending.expiresAt <= this.now()) return null;
+    return pending;
+  }
+
+  private prunePendingAuth(): void {
+    const now = this.now();
+    for (const [state, pending] of this.pendingAuth) {
+      if (pending.expiresAt <= now) this.pendingAuth.delete(state);
+    }
+  }
+}
+
+export async function createDashboardOidcManagerFromEnv(config: Config): Promise<DashboardOIDCManager | null> {
+  const oidcConfig = parseDashboardOidcConfig();
+  if (!oidcConfig) return null;
+  const manager = new DashboardOIDCManager({ config, oidcConfig });
+  await manager.initialize();
+  return manager;
+}
+
+export function getDashboardSessionAuthContext(session: DashboardSession): DashboardRequestAuthContext {
+  const digest = createHash('sha256')
+    .update(session.tenantId)
+    .update('\0')
+    .update(session.userId)
+    .digest('hex')
+    .slice(0, 32);
+  const keyId = `dashboard:${session.tenantId}:${digest}`;
+  return {
+    keyId,
+    actor: keyId,
+    tenantId: session.tenantId,
+    role: session.role,
+    permissions: permissionsForRole(session.role),
+  };
+}
+
+export interface ClaimValidationInput {
+  claims: Record<string, unknown>;
+  issuer: string;
+  clientId: string;
+  nonce: string;
+  nowSeconds: number;
+}
+
+export function validateOidcClaims(input: ClaimValidationInput): void {
+  const { claims, issuer, clientId, nonce, nowSeconds } = input;
+  if (claims.iss !== issuer) {
+    throw new OidcAuthError('OIDC ID token issuer mismatch', 403);
+  }
+  if (!audienceContains(claims.aud, clientId)) {
+    throw new OidcAuthError('OIDC ID token audience mismatch', 403);
+  }
+  if (typeof claims.exp !== 'number' || claims.exp <= nowSeconds) {
+    throw new OidcAuthError('OIDC ID token is expired', 403);
+  }
+  if (claims.nbf !== undefined && (typeof claims.nbf !== 'number' || claims.nbf > nowSeconds)) {
+    throw new OidcAuthError('OIDC ID token not-before claim is invalid', 403);
+  }
+  if (claims.nonce !== nonce) {
+    throw new OidcAuthError('OIDC ID token nonce mismatch', 403);
+  }
+  if (typeof claims.sub !== 'string' || !claims.sub) {
+    throw new OidcAuthError('OIDC ID token subject is missing', 403);
+  }
+}
+
+export interface ClaimMappingOptions {
+  roleClaim: string;
+  defaultTenantId: string;
+  tenantWorkdirs: Record<string, { root: string; allowedPaths?: string[] }>;
+}
+
+export function mapOidcClaimsToIdentity(
+  claims: Record<string, unknown>,
+  options: ClaimMappingOptions,
+): DashboardIdentity | null {
+  const userId = stringClaim(claims.sub);
+  if (!userId) return null;
+  const tenantId = mapTenantId(claims, options);
+  if (!tenantId) return null;
+  return {
+    userId,
+    ...(stringClaim(claims.email) ? { email: stringClaim(claims.email) } : {}),
+    ...(stringClaim(claims.name) ? { name: stringClaim(claims.name) } : {}),
+    tenantId,
+    role: mapRole(claims[options.roleClaim]),
+    claims: { ...claims },
+  };
+}
+
+export function generatePkcePair(): PkcePair {
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  return { codeVerifier, codeChallenge };
+}
+
+function randomOpaqueToken(bytes: number): string {
+  return randomBytes(bytes).toString('base64url');
+}
+
+function copyClaims(claims: IDToken): Record<string, unknown> {
+  return { ...claims };
+}
+
+function audienceContains(audience: unknown, clientId: string): boolean {
+  if (typeof audience === 'string') return audience === clientId;
+  if (!Array.isArray(audience)) return false;
+  return audience.some((entry) => entry === clientId);
+}
+
+function stringClaim(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function mapTenantId(claims: Record<string, unknown>, options: ClaimMappingOptions): string | null {
+  const knownTenants = new Set([options.defaultTenantId, ...Object.keys(options.tenantWorkdirs)].filter(Boolean));
+  const email = stringClaim(claims.email);
+  const emailDomain = email?.includes('@') ? email.split('@').pop() : undefined;
+  const candidates = [
+    stringClaim(claims['aegis:tenant']),
+    stringClaim(claims.hd),
+    stringClaim(claims.tid),
+    emailDomain,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate || candidate === SYSTEM_TENANT) continue;
+    if (knownTenants.has(candidate)) return candidate;
+  }
+  return null;
+}
+
+function mapRole(value: unknown): ApiKeyRole {
+  if (typeof value === 'string' && isKnownRole(value)) return value;
+  if (Array.isArray(value)) {
+    const firstKnownRole = value.find((entry): entry is ApiKeyRole => typeof entry === 'string' && isKnownRole(entry));
+    if (firstKnownRole) return firstKnownRole;
+  }
+  return 'viewer';
+}
+
+function isKnownRole(value: string): value is ApiKeyRole {
+  return value === 'admin' || value === 'operator' || value === 'viewer';
+}

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -3,6 +3,20 @@ export { QuotaManager } from './QuotaManager.js';
 export type { QuotaCheckResult, QuotaUsage } from './QuotaManager.js';
 export { RateLimiter } from './RateLimiter.js';
 export {
+  DASHBOARD_SESSION_COOKIE,
+  OIDC_STATE_COOKIE,
+  DashboardOIDCManager,
+  DashboardSessionStore,
+  OpenidClientProvider,
+  OidcAuthError,
+  createDashboardOidcManagerFromEnv,
+  generatePkcePair,
+  getDashboardSessionAuthContext,
+  mapOidcClaimsToIdentity,
+  validateOidcClaims,
+} from './OIDCManager.js';
+export type { DashboardRequestAuthContext, DashboardSession } from './OIDCManager.js';
+export {
   API_KEY_PERMISSION_VALUES,
   isApiKeyPermission,
   normalizePermissions,

--- a/src/services/auth/oidc-config.ts
+++ b/src/services/auth/oidc-config.ts
@@ -29,6 +29,14 @@ export interface OidcConfig {
   jwksUri?: string;
 }
 
+/** Validated dashboard OIDC configuration for the authorization-code flow. */
+export interface DashboardOidcConfig extends OidcConfig {
+  /** OAuth2 client secret for confidential dashboard auth. Loaded from env only. */
+  clientSecret: string;
+  /** Redirect path registered with the IdP. */
+  redirectPath: string;
+}
+
 /** Parse AEGIS_OIDC_* environment variables into a validated config object.
  *  Returns null if required fields are missing (OIDC not configured). */
 export function parseOidcConfig(env: Record<string, string | undefined> = process.env): OidcConfig | null {
@@ -57,11 +65,58 @@ export function parseOidcConfig(env: Record<string, string | undefined> = proces
   };
 }
 
+function isDashboardOidcEnvPresent(env: Record<string, string | undefined>): boolean {
+  return Object.prototype.hasOwnProperty.call(env, 'AEGIS_OIDC_CLIENT_SECRET')
+    || Object.prototype.hasOwnProperty.call(env, 'AEGIS_OIDC_REDIRECT_PATH');
+}
+
+function validateRedirectPath(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new Error('AEGIS_OIDC_REDIRECT_PATH must start with /');
+  }
+  if (path.includes('\r') || path.includes('\n')) {
+    throw new Error('AEGIS_OIDC_REDIRECT_PATH must not contain control characters');
+  }
+  return path;
+}
+
+/** Parse dashboard-specific OIDC env vars.
+ *  Returns null when dashboard OIDC is not configured. Shared device-flow-only
+ *  OIDC env does not enable dashboard OIDC without a client secret. */
+export function parseDashboardOidcConfig(
+  env: Record<string, string | undefined> = process.env,
+): DashboardOidcConfig | null {
+  const dashboardEnvPresent = isDashboardOidcEnvPresent(env);
+  const base = parseOidcConfig(env);
+  if (!base) {
+    if (dashboardEnvPresent) {
+      throw new Error('AEGIS_OIDC_ISSUER and AEGIS_OIDC_CLIENT_ID are required when dashboard OIDC is configured');
+    }
+    return null;
+  }
+
+  const clientSecret = env.AEGIS_OIDC_CLIENT_SECRET?.trim();
+  if (!clientSecret) {
+    if (!dashboardEnvPresent) return null;
+    throw new Error('AEGIS_OIDC_CLIENT_SECRET is required when dashboard OIDC is configured');
+  }
+
+  const redirectPath = validateRedirectPath(env.AEGIS_OIDC_REDIRECT_PATH?.trim() || '/auth/callback');
+
+  return {
+    ...base,
+    clientSecret,
+    redirectPath,
+  };
+}
+
 /** OIDC discovery document structure (subset of fields we need). */
 export interface OidcDiscovery {
   issuer: string;
+  authorization_endpoint?: string;
   token_endpoint: string;
   device_authorization_endpoint?: string;
+  end_session_endpoint?: string;
   revocation_endpoint?: string;
   jwks_uri?: string;
   token_endpoint_auth_methods_supported?: string[];

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -439,7 +439,7 @@ export const ENV_DENYLIST: readonly string[] = [
   'GOOGLE_AI_API_KEY', 'MISTRAL_API_KEY', 'DEEPSEEK_API_KEY',
   // Application secrets — prevent privilege escalation
   'AEGIS_SECRET', 'DATABASE_URL', 'SECRET_KEY', 'JWT_SECRET',
-  'SESSION_SECRET', 'ENCRYPTION_KEY',
+  'SESSION_SECRET', 'ENCRYPTION_KEY', 'AEGIS_OIDC_CLIENT_SECRET',
   // Home / user identity
   'HOME', 'USER', 'LOGNAME', 'USERNAME',
   // Windows-specific


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.0-preview

## Summary
- Adds dashboard OIDC authorization-code SSO with PKCE, nonce/state validation, HttpOnly dashboard sessions, and logout/session endpoints.
- Wires dashboard session cookies into `/v1/*` auth with request-scoped role, permissions, actor, and tenant context.
- Updates dashboard login/session state so OIDC sign-in is the primary path when configured, while API-token fallback remains available.
- Filters global SSE event replay/live streams by tenant for scoped dashboard/API auth contexts.

## Verification
- `npm run gate` — passed after rebasing onto `origin/develop` with #2322 merged
- Focused backend OIDC/session tests — passed during implementation QA
- Focused dashboard auth tests — passed during implementation QA
- `npm run build` — passed during implementation QA

## Release note
This is a user-facing dashboard authentication feature and needs the `approved-minor-bump` label for the feat gate.

## Follow-up validation
- Real external IdP smoke remains the final environment validation step after review configuration is available.

Closes #1942