### PR TITLE
docs: align agent policy with phase 3

### DIFF
--- a/.claude/rules/positioning.md
+++ b/.claude/rules/positioning.md
@@ -73,5 +73,5 @@ Activation happens via a maintainer-approved PR that:
 
 ## Current phase
 
-Phase 1 — Foundations. Scope is defined in
-[.claude/epics/phase-1-foundations/epic.md](../epics/phase-1-foundations/epic.md).
+Phase 3 — Team & Early-Enterprise. Scope is defined in
+[.claude/epics/phase-3-team-early-enterprise/epic.md](../epics/phase-3-team-early-enterprise/epic.md).

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -18,8 +18,8 @@ Roadmap phase  →  Epic  →  Issue  →  Worktree branch  →  PR to develop
 
 - Every change of non-trivial size maps to a GitHub issue.
 - Use the right template and labels: phase (`phase-1`, `phase-2`, …), type (`bug`, `enhancement`, `security`, …), priority (`P0`–`P3`).
-- For issues that come straight from an epic, reference the epic file:
-  `Epic: .claude/epics/phase-1-foundations/epic.md` in the issue body.
+- For issues that come straight from an epic, reference the current phase's epic file:
+  `Epic: .claude/epics/phase-3-team-early-enterprise/epic.md` in the issue body.
 
 ## 3. Worktree, not main checkout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,12 @@ Windsurf, Aider, etc.) working on this repository.
 
 ## Current Phase
 
-Aegis is in **Phase 1 — Foundations**. Pick work only from:
+Aegis is in **Phase 3 — Team & Early-Enterprise**. Pick work only from:
 
-- [ROADMAP.md](./ROADMAP.md) → Phase 1 checklist
-- [.claude/epics/phase-1-foundations/epic.md](./.claude/epics/phase-1-foundations/epic.md)
+- [ROADMAP.md](./ROADMAP.md) → Phase 3 checklist
+- [.claude/epics/phase-3-team-early-enterprise/epic.md](./.claude/epics/phase-3-team-early-enterprise/epic.md)
 
-Do **not** start work on Phase 2, 3, or 4 items without a maintainer
+Do **not** start work on Phase 4 items without a maintainer
 explicitly assigning the issue.
 
 ## Scoped Rules (load on demand)


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.0-preview

## Summary
- Updates repository agent policy to identify Phase 3 as the active phase.
- Points issue workflow examples at the Phase 3 epic file.
- Preserves the Phase 4 `status: not-active` guardrails.

## Verification
- `git diff --check -- AGENTS.md .claude/rules/positioning.md .claude/rules/workflow.md` — passed before commit
- `npm test -- src/__tests__/device-flow-cli.test.ts -t "shows all servers when multiple exist"` — passed after transient timeout
- `npm run gate` — passed on rerun

Closes #2323