### PR TITLE
docs: sync Phase 3 shipped status

### DIFF
--- a/.claude/epics/phase-3-team-early-enterprise/epic.md
+++ b/.claude/epics/phase-3-team-early-enterprise/epic.md
@@ -29,26 +29,29 @@ request before work begins; speculative work is deferred to Phase 4.
 | # | Item | Gap ref | Status |
 |---|---|---|---|
 | 3.1 | Pluggable `SessionStore` interface + `PostgresStore` | P0-5 | ✅ Shipped (#2201) |
-| 3.2 | Pipeline state persistence on the same interface | P0-5 | 🔲 Ready |
-| 3.3 | OpenTelemetry end-to-end: HTTP → service → tmux → channels | P1-3 / ADR-0017 | 🔲 Ready |
-| 3.4 | Generated TypeScript SDK from OpenAPI | P2-5 | 🔲 Ready |
-| 3.5 | Generated Python SDK from OpenAPI | P2-5 | 🔲 Ready |
-| 3.6 | SSO / OIDC for dashboard (Entra ID, Google, Okta, Keycloak, Authentik) | P1-2 | 🔲 Ready |
-| 3.7 | OAuth2 device flow for CLI (`ag login`) | P1-2 | 🔲 Ready |
-| 3.8 | Multi-tenancy primitives: `tenantId` on keys / sessions / audit | P1-1 | 🔲 Ready |
-| 3.9 | Workdir namespacing per tenant | P1-1 | 🔲 Ready |
-| 3.10 | Dashboard list virtualization (transcripts, session history) | P1-7 | 🔲 Ready |
-| 3.11 | Dashboard full a11y pass (focus traps, ARIA, contrast) | P1-7 | 🔄 In progress (#2230) |
-| 3.12 | i18n scaffolding (EN + IT to start) | — | 🔲 Ready |
+| 3.2 | Pipeline state persistence on the same interface | P0-5 | ✅ Shipped (#2253) |
+| 3.3 | OpenTelemetry end-to-end: HTTP → service → tmux → channels | P1-3 / ADR-0017 | ✅ Shipped (#2242) |
+| 3.4 | Generated TypeScript SDK from OpenAPI | P2-5 | ✅ Shipped (#2232) |
+| 3.5 | Generated Python SDK from OpenAPI | P2-5 | ✅ Shipped (#2234) |
+| 3.6 | SSO / OIDC for dashboard (Entra ID, Google, Okta, Keycloak, Authentik) | P1-2 | ✅ Shipped (#2325) |
+| 3.7 | OAuth2 device flow for CLI (`ag login`) | P1-2 | ✅ Shipped (#2311, #2316) |
+| 3.8 | Multi-tenancy primitives: `tenantId` on keys / sessions / audit | P1-1 | ✅ Shipped (#2244) |
+| 3.9 | Workdir namespacing per tenant | P1-1 | ✅ Shipped (#2252) |
+| 3.10 | Dashboard list virtualization (transcripts, session history) | P1-7 | ✅ Shipped (#2181) |
+| 3.11 | Dashboard full a11y pass (focus traps, ARIA, contrast) | P1-7 | ✅ Shipped (#2230) |
+| 3.12 | i18n scaffolding (EN + IT to start) | — | ✅ Shipped (#2235, #2241) |
 
-## Architectural decisions to formalise during Phase 3
+## Architectural decisions formalised during Phase 3
 
-Each of these needs its own ADR before implementation:
+Completed decisions:
 
-- ADR-TBD: `SessionStore` interface and lifecycle semantics.
-- ADR-TBD: Tenant-aware authorization model (extension of ADR-0019).
-- ADR-TBD: OIDC trust model, claim mapping, and logout semantics.
-- ADR-TBD: SDK generation pipeline and release cadence.
+- [ADR-0025](../../../docs/adr/0025-tenant-authz-model.md): Tenant-aware authorization model.
+- [ADR-0026](../../../docs/adr/0026-oidc-trust-model.md): OIDC trust model, claim mapping, and logout semantics.
+
+Remaining follow-up documentation candidates:
+
+- `SessionStore` lifecycle semantics ADR, if the abstraction changes again.
+- SDK generation pipeline and release cadence ADR, before further automation.
 
 ## Explicitly out of scope for Phase 3
 
@@ -69,7 +72,7 @@ Each of these needs its own ADR before implementation:
 
 ## Exit checklist
 
-- [ ] All items shipped, or consciously demoted to Phase 4 with written
+- [x] All items shipped, or consciously demoted to Phase 4 with written
   rationale.
 - [ ] OpenAPI is the single source of truth; SDK releases are automated.
 - [ ] At least one external team is running Aegis in production under their

--- a/.claude/prds/documentation-overhaul.md
+++ b/.claude/prds/documentation-overhaul.md
@@ -8,12 +8,12 @@ created: 2026-04-14T19:04:00Z
 # PRD: Documentation Overhaul
 
 ## Problem
-8 dashboard features shipped today with ZERO documentation. Critical files missing (CONTRIBUTING, SECURITY, DEPLOYMENT). Getting-started.md outdated. This is not enterprise-grade.
+8 dashboard features shipped today with ZERO documentation. Critical files missing (CONTRIBUTING, SECURITY, deployment docs under `docs/`). Getting-started.md outdated. This is not enterprise-grade.
 
 ## Missing Files (Priority Order)
 1. **CONTRIBUTING.md** — how to contribute, worktree rules, PR process, code style
 2. **SECURITY.md** — security policy, reporting vulnerabilities, auth model
-3. **DEPLOYMENT.md** — production deployment, Docker, systemd, env vars
+3. **docs/deployment.md** — production deployment, Docker, systemd, env vars
 4. **CHANGELOG.md** — release history (or link to GitHub releases)
 
 ## Outdated Files

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,13 +78,19 @@ deployment guide: [EXTERNAL_DEPLOYMENT_GUIDE.md](./EXTERNAL_DEPLOYMENT_GUIDE.md)
 
 **Goal:** first external team of 10 + can run Aegis in production.
 
+Implementation checklist shipped; Phase 3 remains active until the external
+production-use exit evidence is documented.
+
 - [x] Pluggable `SessionStore` with Postgres implementation (P0-5) ✅ #2201
-- [ ] OpenTelemetry wired end-to-end ([ADR-0017](docs/adr/0017-opentelemetry-tracing.md), P1-3)
-- [ ] SDKs for TypeScript and Python generated from OpenAPI (P2-5)
-- [ ] SSO / OIDC (Entra ID, Google, Okta, Keycloak, Authentik) (P1-2)
-- [ ] Multi-tenancy primitives: `tenantId` on keys / sessions / audit (P1-1)
-- [ ] Dashboard virtualization + full a11y pass (P1-7)
-- [ ] i18n scaffolding (EN + IT to start)
+- [x] Pipeline state persistence on `StateStore` ✅ #2253
+- [x] OpenTelemetry wired end-to-end ([ADR-0017](docs/adr/0017-opentelemetry-tracing.md), P1-3) ✅ #2242
+- [x] SDKs for TypeScript and Python generated from OpenAPI (P2-5) ✅ #2232, #2234
+- [x] SSO / OIDC (Entra ID, Google, Okta, Keycloak, Authentik) (P1-2) ✅ #2325
+- [x] OAuth2 device flow for CLI (`ag login`) (P1-2) ✅ #2311, #2316
+- [x] Multi-tenancy primitives: `tenantId` on keys / sessions / audit (P1-1) ✅ #2244
+- [x] Workdir namespacing per tenant (P1-1) ✅ #2252
+- [x] Dashboard virtualization + full a11y pass (P1-7) ✅ #2181, #2230
+- [x] i18n scaffolding (EN + IT to start) ✅ #2235, #2241
 
 ---
 


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.0-preview (local `http://localhost:9100/v1/health` timed out)

## Summary
- Mark Phase 3 roadmap and epic implementation items as shipped with merged PR references.
- Keep Phase 3 active pending documented external-production exit evidence.
- Replace the stale root `DEPLOYMENT.md` PRD reference with `docs/deployment.md` from the hygiene check.

## Validation
- `npm run gate` — passed; 217 test files passed, 3,782 tests passed, 20 skipped.
- Mandatory obsolete-artifact grep rerun after the PRD correction; remaining matches are the hygiene rule definitions/check commands.

Closes #2329