### PR TITLE
ci: gate TypeScript SDK drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,18 @@ jobs:
             if (labels.includes('approved-minor-bump')) {\n  core.info('approved-minor-bump\
             \ label present; feat gate passed.');\n  return;\n}\n\ncore.setFailed('feat:\
             \ PRs require the approved-minor-bump label before CI can pass.');\n"
+  sdk-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Check generated TypeScript SDK
+        run: npm run sdk:ts:check
   test:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:smoke": "node scripts/uat-smoke.mjs",
     "test:smoke:byo-llm": "node scripts/byo-llm-smoke.mjs",
     "test:fault-harness": "vitest run src/__tests__/fault-injection-harness-901.test.ts",
+    "sdk:ts:check": "npm --prefix packages/client ci && npm --prefix packages/client run generate:check",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write src scripts",

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -67,6 +67,13 @@ npm run generate
 npm run build
 ```
 
+Before opening a PR, verify the checked-in generated client matches the root
+OpenAPI contract:
+
+```bash
+npm run sdk:ts:check
+```
+
 ## Versioning
 
 | Version | Notes |

--- a/packages/client/hey-api.config.ts
+++ b/packages/client/hey-api.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@hey-api/openapi-ts';
 
 export default defineConfig({
-  input: '../openapi.yaml',
+  input: '../../openapi.yaml',
   output: {
     path: 'src/generated',
     format: 'prettier',

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,18 +1,16 @@
 {
   "name": "@onestepat4time/aegis-client",
-  "version": "0.3.2-alpha",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onestepat4time/aegis-client",
-      "version": "0.3.2-alpha",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
-        "@hey-api/openapi-ts": "^0.96.1"
-      },
-      "peerDependencies": {
-        "zod": ">=3.0.0"
+        "@hey-api/openapi-ts": "^0.96.1",
+        "typescript": "^5.7.0"
       }
     },
     "node_modules/@hey-api/codegen-core": {
@@ -595,12 +593,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -656,16 +653,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "generate": "openapi-ts --input ../openapi.yaml --output src/generated",
+    "generate": "openapi-ts --input ../../openapi.yaml --output src/generated",
+    "generate:check": "npm run generate && git diff --exit-code -- src/generated",
     "clean": "rm -rf dist src/generated"
   },
   "repository": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    exclude: ['node_modules', 'dist', 'dashboard/**', '.worktrees/**', '.claude-internals/**'],
+    exclude: ['**/node_modules/**', 'dist', 'dashboard/**', '.worktrees/**', '.claude-internals/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.0-preview

## Summary
- add a CI `sdk-drift` job on Node 22 for the generated TypeScript SDK
- fix the client generator input path so clean installs read the repo-root `openapi.yaml`
- refresh the client lockfile and document the drift check command
- exclude nested `node_modules` from root Vitest discovery after package-local installs

## Validation
- `npm run sdk:ts:check`
- `npm --prefix packages/client run build`
- `npm run gate` (217 test files passed, 3,782 tests passed, 20 skipped)
- `git diff --check`
- `git ls-files --others --exclude-standard` (no output)

## Follow-up
- Opened #2332 for the broader generated OpenAPI/root contract parity drift found while testing this guardrail.

Closes #2331