### PR TITLE
fix: refresh overridden OpenAPI operations

### DIFF
--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -10,13 +10,13 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import YAML from 'yaml';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const __dirname = dirname(scriptPath);
 const distDir = join(__dirname, '..', 'dist');
 const rootOpenApiPath = join(__dirname, '..', 'openapi.yaml');
-const args = new Set(process.argv.slice(2));
 
 const operationIdOverrides = {
   'GET /v1/sessions/history': 'listSessionHistory',
@@ -34,50 +34,21 @@ const operationIdOverrides = {
   'GET /v1/audit': 'getAuditLog',
 };
 
-// Ensure dist exists
-mkdirSync(distDir, { recursive: true });
-
-// Dynamic import of compiled JS (must run after tsc)
-const { generateOpenApiDocument } = await import('../dist/openapi.js');
-const { registerOpenApiSpec } = await import('../dist/routes/openapi.js');
-
-// Register all endpoint descriptors then generate the document
-registerOpenApiSpec();
-const generatedDoc = generateOpenApiDocument();
-const doc = mergeWithRootContract(generatedDoc);
-
-// Write JSON
-const jsonPath = join(distDir, 'openapi.json');
-writeFileSync(jsonPath, JSON.stringify(doc, null, 2) + '\n');
-console.log(`✓ ${jsonPath}`);
-
-// Write YAML (manual serialization — no dependency needed)
-const yamlPath = join(distDir, 'openapi.yaml');
-writeFileSync(yamlPath, toYamlDocument(doc));
-console.log(`✓ ${yamlPath}`);
-
-if (args.has('--write-root')) {
-  writeFileSync(rootOpenApiPath, toYamlDocument(doc));
-  console.log(`✓ ${rootOpenApiPath}`);
-}
-
-if (args.has('--check-root')) {
-  const rootDoc = loadRootOpenApiDocument();
-  const actual = stableJson(rootDoc);
-  const expected = stableJson(doc);
-  if (actual !== expected) {
-    console.error('openapi.yaml is out of sync with the generated OpenAPI document.');
-    console.error('Run npm run openapi:sync to refresh the root contract.');
-    process.exit(1);
-  }
-  console.log('✓ openapi.yaml is in sync with the generated OpenAPI document');
+if (isMainModule()) {
+  await main();
 }
 
 function mergeWithRootContract(generatedDoc) {
-  const generated = withOperationIds(generatedDoc);
-  if (!existsSync(rootOpenApiPath)) return generated;
+  if (!existsSync(rootOpenApiPath)) return withOperationIds(generatedDoc);
 
   const rootDoc = loadRootOpenApiDocument();
+  return mergeOpenApiDocuments(generatedDoc, rootDoc);
+}
+
+export function mergeOpenApiDocuments(generatedDoc, rootDoc) {
+  const generated = withOperationIds(generatedDoc);
+  if (!rootDoc) return generated;
+
   const merged = deepClone(rootDoc);
   merged.openapi = generated.openapi;
   merged.paths = merged.paths ?? {};
@@ -90,10 +61,8 @@ function mergeWithRootContract(generatedDoc) {
 
     for (const [method, generatedOperation] of Object.entries(generatedPathItem)) {
       if (!isHttpMethod(method)) continue;
-      if (!merged.paths[path][method]) {
+      if (!merged.paths[path][method] || operationIdOverrides[`${method.toUpperCase()} ${path}`]) {
         merged.paths[path][method] = generatedOperation;
-      } else if (operationIdOverrides[`${method.toUpperCase()} ${path}`]) {
-        merged.paths[path][method].operationId = generatedOperation.operationId;
       } else if (!merged.paths[path][method].operationId) {
         merged.paths[path][method].operationId = generatedOperation.operationId;
       }
@@ -101,6 +70,53 @@ function mergeWithRootContract(generatedDoc) {
   }
 
   return merged;
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+
+  // Ensure dist exists
+  mkdirSync(distDir, { recursive: true });
+
+  // Dynamic import of compiled JS (must run after tsc)
+  const { generateOpenApiDocument } = await import('../dist/openapi.js');
+  const { registerOpenApiSpec } = await import('../dist/routes/openapi.js');
+
+  // Register all endpoint descriptors then generate the document
+  registerOpenApiSpec();
+  const generatedDoc = generateOpenApiDocument();
+  const doc = mergeWithRootContract(generatedDoc);
+
+  // Write JSON
+  const jsonPath = join(distDir, 'openapi.json');
+  writeFileSync(jsonPath, JSON.stringify(doc, null, 2) + '\n');
+  console.log(`✓ ${jsonPath}`);
+
+  // Write YAML (manual serialization — no dependency needed)
+  const yamlPath = join(distDir, 'openapi.yaml');
+  writeFileSync(yamlPath, toYamlDocument(doc));
+  console.log(`✓ ${yamlPath}`);
+
+  if (args.has('--write-root')) {
+    writeFileSync(rootOpenApiPath, toYamlDocument(doc));
+    console.log(`✓ ${rootOpenApiPath}`);
+  }
+
+  if (args.has('--check-root')) {
+    const rootDoc = loadRootOpenApiDocument();
+    const actual = stableJson(rootDoc);
+    const expected = stableJson(doc);
+    if (actual !== expected) {
+      console.error('openapi.yaml is out of sync with the generated OpenAPI document.');
+      console.error('Run npm run openapi:sync to refresh the root contract.');
+      process.exit(1);
+    }
+    console.log('✓ openapi.yaml is in sync with the generated OpenAPI document');
+  }
+}
+
+function isMainModule() {
+  return process.argv[1] ? scriptPath === resolve(process.argv[1]) : false;
 }
 
 function loadRootOpenApiDocument() {

--- a/src/__tests__/openapi.test.ts
+++ b/src/__tests__/openapi.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { z } from 'zod';
 import {
   zodToJsonSchema,
@@ -21,6 +22,12 @@ import {
   validationErrorResponse,
 } from '../openapi.js';
 import { registerOpenApiSpec } from '../routes/openapi.js';
+
+interface OpenApiTestDocument {
+  openapi: string;
+  info: Record<string, unknown>;
+  paths: Record<string, Record<string, unknown>>;
+}
 
 // ── zodToJsonSchema ─────────────────────────────────────────────────
 
@@ -231,6 +238,104 @@ describe('generateOpenApiDocument', () => {
     const info = doc.info as Record<string, unknown>;
     expect(typeof info.description).toBe('string');
     expect((info.description as string).length).toBeGreaterThan(0);
+  });
+});
+
+// ── generate-openapi contract merge ───────────────────────────────────
+
+describe('generate-openapi contract merge', () => {
+  it('refreshes overridden root operations from generated schemas', () => {
+    const generatedHistoryOperation = {
+      summary: 'Fresh runtime summary',
+      description: 'Fresh runtime description',
+      parameters: [
+        { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1 } },
+      ],
+      responses: {
+        '200': {
+          description: 'Fresh runtime response',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  fresh: { type: 'boolean' },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const rootOnlyOperation = {
+      operationId: 'rootOnly',
+      responses: { '200': { description: 'Root-only response' } },
+    };
+
+    const generatedDoc: OpenApiTestDocument = {
+      openapi: '3.1.0',
+      info: { title: 'Generated', version: '1.0.0' },
+      paths: {
+        '/v1/sessions/history': {
+          get: generatedHistoryOperation,
+        },
+      },
+    };
+    const rootDoc: OpenApiTestDocument = {
+      openapi: '3.1.0',
+      info: { title: 'Root', version: '1.0.0' },
+      paths: {
+        '/v1/sessions/history': {
+          get: {
+            operationId: 'staleListSessionHistory',
+            summary: 'Stale root summary',
+            description: 'Stale root description',
+            responses: {
+              '200': {
+                description: 'Stale root response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        stale: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/v1/root-only': {
+          get: rootOnlyOperation,
+        },
+      },
+    };
+    const output = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        [
+          "import { mergeOpenApiDocuments } from './scripts/generate-openapi.mjs';",
+          'const generatedDoc = JSON.parse(process.argv[1]);',
+          'const rootDoc = JSON.parse(process.argv[2]);',
+          'console.log(JSON.stringify(mergeOpenApiDocuments(generatedDoc, rootDoc)));',
+        ].join('\n'),
+        JSON.stringify(generatedDoc),
+        JSON.stringify(rootDoc),
+      ],
+      { cwd: process.cwd(), encoding: 'utf8' },
+    );
+    const merged = JSON.parse(output) as OpenApiTestDocument;
+
+    const historyOperation = merged.paths['/v1/sessions/history'].get;
+    expect(historyOperation).toEqual({
+      ...generatedHistoryOperation,
+      operationId: 'listSessionHistory',
+    });
+    expect(merged.paths['/v1/root-only'].get).toEqual(rootOnlyOperation);
   });
 });
 


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.0-preview

## Summary
- Refresh full generated OpenAPI operations for overridden endpoint operation IDs instead of patching only `operationId`.
- Add a regression test covering stale root operation metadata/schema being replaced by generated runtime descriptors while stable operation IDs are preserved.

## Validation
- `npx vitest run src\__tests__\openapi.test.ts`
- `npm run openapi:check`
- `npm run sdk:ts:check`
- `npm --prefix packages/client run build`
- `npm run gate` (217 test files passed, 3,785 tests passed, 20 skipped)

Follow-up to #2336.
Closes #2332