### PR TITLE
fix(security): remove create permission from viewer role (#2340)

### DIFF
--- a/src/__tests__/auth-rbac.test.ts
+++ b/src/__tests__/auth-rbac.test.ts
@@ -33,7 +33,7 @@ describe('API Key RBAC (Issue #1432)', () => {
     it('should default to viewer role when no role specified', async () => {
       const result = await auth.createKey('viewer-key');
       expect(result.role).toBe('viewer');
-      expect(result.permissions).toEqual(['create', 'audit']);
+      expect(result.permissions).toEqual(['audit']);
     });
 
     it('should create a key with admin role', async () => {
@@ -57,7 +57,7 @@ describe('API Key RBAC (Issue #1432)', () => {
       expect(admin?.role).toBe('admin');
       expect(viewer?.role).toBe('viewer');
       expect(admin?.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
-      expect(viewer?.permissions).toEqual(['create', 'audit']);
+      expect(viewer?.permissions).toEqual(['audit']);
     });
 
     it('supports custom permissions independent of role defaults', async () => {

--- a/src/__tests__/dashboard-session-auth.test.ts
+++ b/src/__tests__/dashboard-session-auth.test.ts
@@ -127,17 +127,13 @@ describe('dashboard session cookie request auth', () => {
     const created = await createApp(dashboardSession);
     app = created.app;
 
-    const response = await app.inject({
+    // Viewer no longer has 'create' permission — protected-create should be 403
+    const protectedCreate = await app.inject({
       method: 'GET',
       url: '/v1/protected-create',
       headers: { cookie: cookieHeader(dashboardSession.sessionId) },
     });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json() as { keyId: string; role: ApiKeyRole; tenantId: string; matchedPermission: ApiKeyPermission };
-    expect(body).toMatchObject({ role: 'viewer', tenantId: 'default', matchedPermission: 'create' });
-    expect(body.keyId).toMatch(/^dashboard:default:[a-f0-9]{32}$/);
-    expect(created.auth.validate(body.keyId).valid).toBe(false);
+    expect(protectedCreate.statusCode).toBe(403);
 
     const adminOnly = await app.inject({
       method: 'GET',
@@ -146,13 +142,16 @@ describe('dashboard session cookie request auth', () => {
     });
     expect(adminOnly.statusCode).toBe(403);
 
+    // Viewer can still access SSE events (authentication-only, no specific permission gate)
     const sseLike = await app.inject({
       method: 'GET',
       url: '/v1/events',
       headers: { cookie: cookieHeader(dashboardSession.sessionId) },
     });
     expect(sseLike.statusCode).toBe(200);
-    expect(sseLike.json()).toMatchObject({ keyId: body.keyId });
+    const sseBody = sseLike.json() as { keyId: string };
+    expect(sseBody.keyId).toMatch(/^dashboard:default:[a-f0-9]{32}$/);
+    expect(created.auth.validate(sseBody.keyId).valid).toBe(false);
   });
 
   it('authorizes sessions owned by the same dashboard user and denies other owners', async () => {

--- a/src/__tests__/oidc-dashboard-manager.test.ts
+++ b/src/__tests__/oidc-dashboard-manager.test.ts
@@ -277,7 +277,7 @@ describe('getDashboardSessionAuthContext', () => {
     expect(context.keyId).not.toContain('ada@example.com');
     expect(context.tenantId).toBe('default');
     expect(context.role).toBe('viewer');
-    expect(context.permissions).toEqual(['create', 'audit']);
+    expect(context.permissions).toEqual(['audit']);
   });
 });
 

--- a/src/services/auth/permissions.ts
+++ b/src/services/auth/permissions.ts
@@ -7,7 +7,7 @@ type PermissionRole = 'admin' | 'operator' | 'viewer';
 const DEFAULT_ROLE_PERMISSIONS: Record<PermissionRole, readonly ApiKeyPermission[]> = {
   admin: API_KEY_PERMISSION_VALUES,
   operator: API_KEY_PERMISSION_VALUES,
-  viewer: ['create', 'audit'],
+  viewer: ['audit'],
 };
 
 export function isApiKeyPermission(value: string): value is ApiKeyPermission {


### PR DESCRIPTION
## Summary

Fixes #2340 — removes the `create` permission from the `viewer` role.

The viewer role was incorrectly granted `create`, allowing viewer-scoped API keys to create Claude Code sessions via `POST /v1/sessions`. The role name implies read-only access; spawning sessions on the host is a privileged action that should be restricted to `admin` and `operator`.

## Changes

| File | Change |
|------|--------|
| `src/services/auth/permissions.ts` | `viewer: ['create', 'audit']` → `viewer: ['audit']` |
| `src/__tests__/auth-rbac.test.ts` | Update 2 assertions for viewer permissions |
| `src/__tests__/oidc-dashboard-manager.test.ts` | Update dashboard context permission assertion |
| `src/__tests__/dashboard-session-auth.test.ts` | Viewer dashboard sessions now get 403 on create-gated routes |

## Verification

- **tsc --noEmit:** ✅ Zero errors
- **npm run build:** ✅ Success
- **npm test:** ✅ 218 suites, 3794 tests passed, 0 failures

## Security

- No credentials or secrets in this PR
- Change reduces attack surface: viewer keys can no longer create sessions

## Session Info
- Commit: `80aca00`
- Aegis API: unavailable (CC not authenticated — emergency direct fix)
