### PR TITLE
fix(routes): register usage routes in server startup (#2341)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -80,6 +80,7 @@ import {
   registerPipelineRoutes,
   registerAnalyticsRoutes,
   registerOidcAuthRoutes,
+  registerUsageRoutes,
   registerOpenApiSpec,
   registerOpenApiRoute,
   type RouteContext,
@@ -962,6 +963,7 @@ async function main(): Promise<void> {
   registerTemplateRoutes(app, routeCtx);
   registerPipelineRoutes(app, routeCtx);
   registerAnalyticsRoutes(app, routeCtx);
+  registerUsageRoutes(app, routeCtx);
 
   // OpenAPI spec registration and route (issue #1909)
   registerOpenApiSpec();


### PR DESCRIPTION
## Summary

Fixes #2341 — registers the missing usage routes in server startup.

All `/v1/usage*` REST endpoints were returning 404 because `registerUsageRoutes` was exported from `src/routes/index.ts` but never imported or invoked in `src/server.ts`.

## Changes

| File | Change |
|------|--------|
| `src/server.ts` | Import `registerUsageRoutes` + invoke `registerUsageRoutes(app, routeCtx)` |

Also swept for other uninvoked barrel exports — `registerUsageRoutes` was the only one missing.

## Verification

- **tsc --noEmit:** ✅ Zero errors
- **npm run build:** ✅ Success
- **npm test:** ✅ 218 suites, 3794 tests passed, 0 failures

## Session Info
- Commit: `d1002cb`
- Aegis API: unavailable (CC not authenticated — emergency direct fix)
