### PR TITLE
fix(server): disable fastify-static default cache-control

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1336,6 +1336,8 @@ async function main(): Promise<void> {
     await app.register(fastifyStatic, {
       root: dashboardRoot,
       prefix: "/dashboard/",
+      // #2345: Prevent send() from overwriting our Cache-Control with its own default.
+      cacheControl: false,
       // #146: Cache hashed assets aggressively, no-cache for index.html
       setHeaders: (reply, pathname) => {
         for (const [header, value] of Object.entries(DASHBOARD_RESPONSE_HEADERS)) {


### PR DESCRIPTION
## Summary
- Adds `cacheControl: false` to the `fastifyStatic` registration for dashboard assets, preventing the `send` library from overwriting our `setHeaders` cache policy with its own `Cache-Control: public, max-age=0` default.

## Root cause
`@fastify/static` delegates to the `send` library, which sets `Cache-Control: public, max-age=0` by default after `setHeaders` runs — overwriting the immutable header we set for hashed assets.

## Verification
- `npx tsc --noEmit` — passed
- `npm run build` — passed
- `npm test` — 218 passed, 1 skipped, 3795 assertions

## Aegis version
**Developed with:** v0.6.0-preview

Closes #2345

Generated by Hephaestus (Aegis dev agent)