### PR TITLE
fix: harden dashboard dogfood flows

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -13,9 +13,6 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Aegis" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   </head>
   <body class="antialiased">
     <div id="root"></div>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Suspense, lazy, useState, useEffect } from 'react';
-import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -12,6 +12,7 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useDrawerStore } from './store/useDrawerStore';
 import { FirstRunTour, isTourCompleted } from './components/tour/FirstRunTour';
 import { OnboardingScreen } from './components/brand/OnboardingScreen';
+import { useAuthStore } from './store/useAuthStore';
 
 const AuditPage = lazy(() => import('./pages/AuditPage'));
 const MetricsPage = lazy(() => import('./pages/MetricsPage'));
@@ -54,18 +55,25 @@ function NewSessionRedirect() {
 }
 
 export default function App() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const location = useLocation();
   const [showHelp, setShowHelp] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showTour, setShowTour] = useState(false);
 
   useEffect(() => {
+    if (!isAuthenticated || location.pathname === '/login') {
+      setShowOnboarding(false);
+      setShowTour(false);
+      return;
+    }
     const hasOnboarded = localStorage.getItem('aegis:onboarded');
     if (!hasOnboarded) {
       setShowOnboarding(true);
     } else if (!isTourCompleted()) {
       setShowTour(true);
     }
-  }, []);
+  }, [isAuthenticated, location.pathname]);
 
   useKeyboardShortcuts({
     onShortcut: (shortcut) => {
@@ -76,7 +84,7 @@ export default function App() {
     },
   });
 
-  if (showOnboarding) {
+  if (isAuthenticated && showOnboarding) {
     return <OnboardingScreen onComplete={() => {
       setShowOnboarding(false);
       if (!isTourCompleted()) setShowTour(true);

--- a/dashboard/src/__tests__/App.auth-routing.test.tsx
+++ b/dashboard/src/__tests__/App.auth-routing.test.tsx
@@ -40,6 +40,19 @@ describe('App auth routing', () => {
     expect(await screen.findByText('Login Page')).toBeDefined();
   });
 
+  it('does not show onboarding over the login route', async () => {
+    localStorage.removeItem('aegis:onboarded');
+
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Login Page')).toBeDefined();
+    expect(screen.queryByText('Open Dashboard →')).toBeNull();
+  });
+
   it('guards non-login routes by redirecting to /login', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>

--- a/dashboard/src/__tests__/Layout.mobile-nav-drawer.test.tsx
+++ b/dashboard/src/__tests__/Layout.mobile-nav-drawer.test.tsx
@@ -154,6 +154,10 @@ describe('Layout mobile nav drawer (#2352)', () => {
     it('header actions container has pointer-events-none when mobile drawer is open', () => {
       // Open drawer BEFORE rendering so component renders with isMobileOpen=true
       useSidebarStore.setState({ isMobileOpen: true });
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+      });
       renderLayout();
 
       const header = document.querySelector('header');

--- a/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
@@ -172,6 +172,39 @@ describe('Layout mobile responsive', () => {
       expect(screen.getByRole('button', { name: 'Open menu' })).toBeDefined();
     });
 
+    it('hides the closed drawer close button from tab and accessibility flows', () => {
+      renderLayout();
+
+      resizeToMobile();
+
+      const sidebar = document.querySelector('aside');
+      expect(sidebar).not.toBeNull();
+      expect(sidebar!.hasAttribute('inert')).toBe(false);
+
+      const closeButton = screen.getByRole('button', { name: 'Close menu' });
+      expect(closeButton.tabIndex).toBe(0);
+      expect(closeButton.getAttribute('aria-hidden')).toBeNull();
+
+      fireEvent.click(closeButton);
+
+      expect(useSidebarStore.getState().isMobileOpen).toBe(false);
+      expect(sidebar!.getAttribute('aria-hidden')).toBe('true');
+      expect(sidebar!.hasAttribute('inert')).toBe(true);
+      expect(screen.queryByRole('button', { name: 'Close menu' })).toBeNull();
+
+      const hiddenCloseButton = document.querySelector<HTMLButtonElement>(
+        'aside button[aria-label="Close menu"]',
+      );
+      expect(hiddenCloseButton).not.toBeNull();
+      if (!hiddenCloseButton) {
+        throw new Error('Expected the off-canvas close button to remain in the sidebar DOM');
+      }
+
+      expect(hiddenCloseButton.tabIndex).toBe(-1);
+      expect(hiddenCloseButton.disabled).toBe(true);
+      expect(hiddenCloseButton.getAttribute('aria-hidden')).toBe('true');
+    });
+
     it('closes a desktop-to-mobile resized drawer with Escape', () => {
       renderLayout();
 

--- a/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const mockSubscribeGlobalSSE = vi.fn();
@@ -29,6 +29,20 @@ import Layout from '../components/Layout';
 import { useSidebarStore } from '../store/useSidebarStore';
 
 const SIDEBAR_STORAGE_KEY = 'aegis-sidebar-collapsed';
+const MOBILE_SIDEBAR_QUERY = '(max-width: 767px)';
+
+interface MatchMediaController {
+  setMatches: (matches: boolean) => void;
+}
+
+interface MockMediaQueryChangeEvent {
+  matches: boolean;
+  media: string;
+}
+
+type MockMediaQueryListener = (event: MockMediaQueryChangeEvent) => void;
+
+let matchMediaController: MatchMediaController;
 
 function renderLayout(): ReturnType<typeof render> {
   return render(
@@ -42,11 +56,55 @@ function renderLayout(): ReturnType<typeof render> {
   );
 }
 
-function setupDefaults() {
+function installMatchMedia(initialMatches: boolean): MatchMediaController {
+  let mobileMatches = initialMatches;
+  const listenersByQuery = new Map<string, Set<MockMediaQueryListener>>();
+
+  function listenersFor(query: string): Set<MockMediaQueryListener> {
+    const existing = listenersByQuery.get(query);
+    if (existing) return existing;
+
+    const listeners = new Set<MockMediaQueryListener>();
+    listenersByQuery.set(query, listeners);
+    return listeners;
+  }
+
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
-    value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+    value: vi.fn((query: string) => ({
+      get matches() {
+        return query === MOBILE_SIDEBAR_QUERY ? mobileMatches : false;
+      },
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn((eventName: string, listener: MockMediaQueryListener) => {
+        if (eventName === 'change') {
+          listenersFor(query).add(listener);
+        }
+      }),
+      removeEventListener: vi.fn((eventName: string, listener: MockMediaQueryListener) => {
+        if (eventName === 'change') {
+          listenersFor(query).delete(listener);
+        }
+      }),
+      addListener: vi.fn((listener: MockMediaQueryListener) => listenersFor(query).add(listener)),
+      removeListener: vi.fn((listener: MockMediaQueryListener) => listenersFor(query).delete(listener)),
+      dispatchEvent: vi.fn(),
+    })),
   });
+
+  return {
+    setMatches(nextMatches: boolean): void {
+      mobileMatches = nextMatches;
+      listenersFor(MOBILE_SIDEBAR_QUERY).forEach((listener) => {
+        listener({ matches: nextMatches, media: MOBILE_SIDEBAR_QUERY });
+      });
+    },
+  };
+}
+
+function setupDefaults() {
+  matchMediaController = installMatchMedia(false);
   vi.clearAllMocks();
   vi.spyOn(console, 'error').mockImplementation(() => {});
   vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -70,6 +128,12 @@ function setupDefaults() {
   useSidebarStore.setState({ isCollapsed: false, isMobileOpen: false });
 }
 
+function resizeToMobile(): void {
+  act(() => {
+    matchMediaController.setMatches(true);
+  });
+}
+
 describe('Layout mobile responsive', () => {
   beforeEach(() => {
     setupDefaults();
@@ -80,6 +144,61 @@ describe('Layout mobile responsive', () => {
     vi.restoreAllMocks();
     localStorage.removeItem(SIDEBAR_STORAGE_KEY);
     localStorage.removeItem('aegis-dashboard-theme');
+  });
+
+  describe('mobile drawer', () => {
+    it('keeps a desktop-to-mobile resized drawer closeable without exposing the background opener', () => {
+      renderLayout();
+
+      resizeToMobile();
+
+      const sidebar = document.querySelector('aside');
+      expect(sidebar).not.toBeNull();
+      expect(useSidebarStore.getState().isMobileOpen).toBe(true);
+      expect(sidebar!.classList.contains('translate-x-0')).toBe(true);
+      expect(sidebar!.classList.contains('-translate-x-full')).toBe(false);
+      expect(screen.queryByRole('button', { name: 'Open menu' })).toBeNull();
+
+      const closeButton = screen.getByRole('button', { name: 'Close menu' });
+      expect(closeButton.classList.contains('h-11')).toBe(true);
+      expect(closeButton.classList.contains('w-11')).toBe(true);
+
+      fireEvent.click(closeButton);
+
+      expect(useSidebarStore.getState().isMobileOpen).toBe(false);
+      expect(sidebar!.getAttribute('aria-hidden')).toBe('true');
+      expect(sidebar!.classList.contains('-translate-x-full')).toBe(true);
+      expect(screen.queryByRole('button', { name: 'Close menu' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Open menu' })).toBeDefined();
+    });
+
+    it('closes a desktop-to-mobile resized drawer with Escape', () => {
+      renderLayout();
+
+      resizeToMobile();
+      expect(useSidebarStore.getState().isMobileOpen).toBe(true);
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      expect(useSidebarStore.getState().isMobileOpen).toBe(false);
+      expect(screen.queryByRole('button', { name: 'Close menu' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Open menu' })).toBeDefined();
+    });
+
+    it('closes a desktop-to-mobile resized drawer with the backdrop', () => {
+      renderLayout();
+
+      resizeToMobile();
+      expect(useSidebarStore.getState().isMobileOpen).toBe(true);
+
+      const backdrop = screen.getByTestId('mobile-sidebar-backdrop');
+      fireEvent.click(backdrop);
+
+      expect(useSidebarStore.getState().isMobileOpen).toBe(false);
+      expect(screen.queryByTestId('mobile-sidebar-backdrop')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Close menu' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Open menu' })).toBeDefined();
+    });
   });
 
   describe('footer', () => {

--- a/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/Layout.mobile-responsive.test.tsx
@@ -174,6 +174,8 @@ describe('Layout mobile responsive', () => {
       const themeBtn = screen.getByRole('button', { name: /Switch to/i });
       expect(themeBtn).toBeDefined();
       expect(themeBtn.classList.contains('hidden')).toBe(false);
+      expect(themeBtn.classList.contains('h-11')).toBe(true);
+      expect(themeBtn.classList.contains('w-11')).toBe(true);
     });
 
     it('New Session button is always visible', () => {
@@ -182,6 +184,8 @@ describe('Layout mobile responsive', () => {
       const newSessionBtn = screen.getByRole('button', { name: /New Session/i });
       expect(newSessionBtn).toBeDefined();
       expect(newSessionBtn.classList.contains('hidden')).toBe(false);
+      expect(newSessionBtn.classList.contains('h-11')).toBe(true);
+      expect(newSessionBtn.classList.contains('w-11')).toBe(true);
     });
   });
 

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act, type RenderResult } from '@testing-library/react';
+import { fireEvent, render, screen, act, type RenderResult } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const mockSubscribeGlobalSSE = vi.fn();
@@ -361,6 +361,37 @@ describe('Layout sidebar', () => {
     renderLayout();
 
     expect(screen.getByRole('button', { name: 'Open menu' })).toBeDefined();
+  });
+
+  it('closes the mobile menu with Escape and the backdrop (#2352)', () => {
+    mockSubscribeGlobalSSE.mockReturnValue(() => {});
+
+    renderLayout();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(useSidebarStore.getState().isMobileOpen).toBe(true);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useSidebarStore.getState().isMobileOpen).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const backdrop = document.querySelector('.fixed.inset-0.z-30');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+    expect(useSidebarStore.getState().isMobileOpen).toBe(false);
+  });
+
+  it('provides an in-sidebar close button when the mobile menu is open (#2352)', () => {
+    mockSubscribeGlobalSSE.mockReturnValue(() => {});
+
+    renderLayout();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const closeButtons = screen.getAllByRole('button', { name: 'Close menu' });
+    expect(closeButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(closeButtons[0]);
+    expect(useSidebarStore.getState().isMobileOpen).toBe(false);
   });
 
   it('renders collapse toggle button', () => {

--- a/dashboard/src/__tests__/LoginPage.test.tsx
+++ b/dashboard/src/__tests__/LoginPage.test.tsx
@@ -107,8 +107,11 @@ describe('LoginPage', () => {
 
     const input = screen.getByLabelText('API token') as HTMLInputElement;
     expect(input.type).toBe('password');
+    expect(input.classList.contains('min-h-[44px]')).toBe(true);
 
     const toggle = screen.getByRole('button', { name: 'Show token' });
+    expect(toggle.classList.contains('h-11')).toBe(true);
+    expect(toggle.classList.contains('w-11')).toBe(true);
     fireEvent.click(toggle);
     expect(input.type).toBe('text');
 

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -344,7 +344,9 @@ describe('dashboard OIDC session client (#1942)', () => {
 
   it('returns only dashboard identity fields for authenticated OIDC sessions', async () => {
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      oidcAvailable: true,
       authenticated: true,
+      authMethod: 'oidc',
       userId: 'user-123',
       email: 'dev@example.com',
       name: 'Dev User',
@@ -366,6 +368,7 @@ describe('dashboard OIDC session client (#1942)', () => {
     expect(result).toEqual({
       oidcAvailable: true,
       authenticated: true,
+      authMethod: 'oidc',
       identity: {
         authenticated: true,
         userId: 'user-123',
@@ -379,6 +382,17 @@ describe('dashboard OIDC session client (#1942)', () => {
     });
     expect(JSON.stringify(result)).not.toContain('secret');
     expect(localStorage.length).toBe(0);
+  });
+
+  it('treats clean /auth/session unauthenticated responses as token-auth mode without 404 noise', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ oidcAvailable: false, authenticated: false }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { getDashboardSession } = await import('../api/client');
+
+    await expect(getDashboardSession()).resolves.toEqual({ oidcAvailable: false, authenticated: false });
   });
 
   it('posts OIDC logout with cookies and no bearer token', async () => {

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -411,6 +411,102 @@ describe('dashboard OIDC session client (#1942)', () => {
   });
 });
 
+describe('dashboard cookie-backed API requests (#2351)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const healthPayload = {
+    status: 'ok',
+    version: '2.4.1',
+    platform: 'win32',
+    uptime: 12,
+    sessions: { active: 0, total: 0 },
+    timestamp: '2026-04-17T10:30:00.000Z',
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('sends the HttpOnly dashboard session cookie on API requests after token login upgrade', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ oidcAvailable: false, authenticated: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ valid: true, role: 'admin' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        oidcAvailable: false,
+        authenticated: true,
+        authMethod: 'token',
+        userId: 'api-key:key-1',
+        tenantId: 'default',
+        role: 'admin',
+        createdAt: 1,
+        expiresAt: 2,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(healthPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+    const [{ useAuthStore }, { getHealth }] = await Promise.all([
+      import('../store/useAuthStore'),
+      import('../api/client'),
+    ]);
+
+    await useAuthStore.getState().init();
+    await expect(useAuthStore.getState().login('my-token')).resolves.toBe(true);
+    await expect(getHealth()).resolves.toMatchObject({ version: '2.4.1' });
+
+    const verifyInit = fetchMock.mock.calls[1][1] as RequestInit;
+    expect(verifyInit.credentials).toBe('include');
+
+    const healthInit = fetchMock.mock.calls[3][1] as RequestInit;
+    expect(fetchMock.mock.calls[3][0]).toBe('/v1/health');
+    expect(healthInit.credentials).toBe('include');
+    expect(healthInit.headers).toEqual(expect.not.objectContaining({ Authorization: expect.anything() }));
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(localStorage.getItem('aegis_token')).toBeNull();
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it('includes credentials by default for API calls with no in-memory bearer token', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(healthPayload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const { getHealth, setTokenAccessor } = await import('../api/client');
+    setTokenAccessor(() => null);
+
+    await expect(getHealth()).resolves.toMatchObject({ status: 'ok' });
+
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(fetchMock.mock.calls[0][0]).toBe('/v1/health');
+    expect(requestInit.credentials).toBe('include');
+    expect(requestInit.headers).toEqual(expect.not.objectContaining({ Authorization: expect.anything() }));
+  });
+});
+
 describe('SSE bearer token fallback (#408)', () => {
   // #408: Verify that when SSE token creation fails, the code NEVER falls back
   // to using the long-lived bearer token in the SSE URL query parameter.

--- a/dashboard/src/__tests__/store.test.ts
+++ b/dashboard/src/__tests__/store.test.ts
@@ -146,19 +146,19 @@ describe('useStore', () => {
   });
 });
 
-  it('persists token to sessionStorage and restores on init (issue #2351)', () => {
-    // sessionStorage is available in vitest jsdom environment
+describe('auth token storage (#2351)', () => {
+  it('keeps token state in memory without writing API tokens to Web Storage', () => {
     sessionStorage.clear();
+    localStorage.clear();
 
-    // Set token
     useStore.getState().setToken('test-api-key-123');
     expect(useStore.getState().token).toBe('test-api-key-123');
-    expect(sessionStorage.getItem('aegis:auth:token')).toBe('test-api-key-123');
+    expect(sessionStorage.getItem('aegis:auth:token')).toBeNull();
+    expect(localStorage.getItem('aegis:auth:token')).toBeNull();
 
-    // Clear token
     useStore.getState().clearToken();
     expect(useStore.getState().token).toBeNull();
     expect(sessionStorage.getItem('aegis:auth:token')).toBeNull();
-
-    sessionStorage.clear();
+    expect(localStorage.getItem('aegis:auth:token')).toBeNull();
   });
+});

--- a/dashboard/src/__tests__/useAuthStore.test.ts
+++ b/dashboard/src/__tests__/useAuthStore.test.ts
@@ -32,6 +32,7 @@ describe('useAuthStore', () => {
     mockLogoutDashboardSession.mockResolvedValue('logged-out');
     mockGetOidcLoginUrl.mockReturnValue('/auth/login');
     localStorage.removeItem('aegis_token');
+    sessionStorage.clear();
     useAuthStore.setState({
       token: null,
       authMode: null,
@@ -46,6 +47,7 @@ describe('useAuthStore', () => {
 
   afterEach(() => {
     localStorage.removeItem('aegis_token');
+    sessionStorage.clear();
     useStore.getState().clearToken();
     vi.restoreAllMocks();
   });
@@ -63,6 +65,34 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().identity).toBeNull();
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
       expect(useStore.getState().token).toBe('my-token');
+      expect(localStorage.getItem('aegis_token')).toBeNull();
+    });
+
+    it('upgrades token login to an HttpOnly dashboard session without Web Storage persistence (#2351)', async () => {
+      const identity: DashboardSessionIdentity = {
+        authenticated: true,
+        userId: 'api-key:key-1',
+        tenantId: 'default',
+        role: 'admin',
+        createdAt: 1,
+        expiresAt: 2,
+      };
+      mockVerifyToken.mockResolvedValue({ valid: true, role: 'admin' });
+      mockGetDashboardSession.mockResolvedValueOnce({
+        oidcAvailable: false,
+        authenticated: true,
+        authMethod: 'token',
+        identity,
+      });
+
+      const success = await useAuthStore.getState().login('my-token');
+
+      expect(success).toBe(true);
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(useAuthStore.getState().authMode).toBe('token');
+      expect(useAuthStore.getState().identity).toEqual(identity);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useStore.getState().token).toBeNull();
       expect(localStorage.getItem('aegis_token')).toBeNull();
     });
 
@@ -136,6 +166,30 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
       expect(useStore.getState().token).toBeNull();
     });
+
+    it('posts logout for cookie-backed token sessions and clears local state', async () => {
+      useAuthStore.setState({
+        token: null,
+        authMode: 'token',
+        identity: {
+          authenticated: true,
+          userId: 'api-key:key-1',
+          tenantId: 'default',
+          role: 'viewer',
+          createdAt: 1,
+          expiresAt: 2,
+        },
+        oidcAvailable: false,
+        isAuthenticated: true,
+      });
+
+      await useAuthStore.getState().logout();
+
+      expect(mockLogoutDashboardSession).toHaveBeenCalledTimes(1);
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(useAuthStore.getState().authMode).toBeNull();
+      expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    });
   });
 
   describe('init', () => {
@@ -167,6 +221,7 @@ describe('useAuthStore', () => {
       mockGetDashboardSession.mockResolvedValueOnce({
         oidcAvailable: true,
         authenticated: true,
+        authMethod: 'oidc',
         identity,
       });
 
@@ -179,6 +234,34 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
       expect(useStore.getState().token).toBeNull();
       expect(localStorage.getItem('aegis_token')).toBeNull();
+      expect(mockVerifyToken).not.toHaveBeenCalled();
+    });
+
+    it('restores a cookie-backed token dashboard session on reload without sessionStorage/localStorage token (#2351)', async () => {
+      const identity: DashboardSessionIdentity = {
+        authenticated: true,
+        userId: 'api-key:key-1',
+        tenantId: 'default',
+        role: 'operator',
+        createdAt: 1,
+        expiresAt: 2,
+      };
+      mockGetDashboardSession.mockResolvedValueOnce({
+        oidcAvailable: false,
+        authenticated: true,
+        authMethod: 'token',
+        identity,
+      });
+
+      await useAuthStore.getState().init();
+
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(useAuthStore.getState().authMode).toBe('token');
+      expect(useAuthStore.getState().identity).toEqual(identity);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useStore.getState().token).toBeNull();
+      expect(localStorage.getItem('aegis_token')).toBeNull();
+      expect(sessionStorage.length).toBe(0);
       expect(mockVerifyToken).not.toHaveBeenCalled();
     });
 

--- a/dashboard/src/__tests__/useAuthStore.test.ts
+++ b/dashboard/src/__tests__/useAuthStore.test.ts
@@ -96,6 +96,45 @@ describe('useAuthStore', () => {
       expect(localStorage.getItem('aegis_token')).toBeNull();
     });
 
+    it('keeps a cookie-backed token session after a later init when OIDC is unavailable (#2356)', async () => {
+      const identity: DashboardSessionIdentity = {
+        authenticated: true,
+        userId: 'api-key:master',
+        tenantId: '_system',
+        role: 'admin',
+        createdAt: 1,
+        expiresAt: 2,
+      };
+      mockVerifyToken.mockResolvedValue({ valid: true, role: 'admin' });
+      mockGetDashboardSession
+        .mockResolvedValueOnce({
+          oidcAvailable: false,
+          authenticated: true,
+          authMethod: 'token',
+          identity,
+        })
+        .mockResolvedValueOnce({
+          oidcAvailable: false,
+          authenticated: true,
+          authMethod: 'token',
+          identity,
+        });
+
+      const success = await useAuthStore.getState().login('my-token');
+      await useAuthStore.getState().init();
+
+      expect(success).toBe(true);
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(useAuthStore.getState().authMode).toBe('token');
+      expect(useAuthStore.getState().identity).toEqual(identity);
+      expect(useAuthStore.getState().oidcAvailable).toBe(false);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useStore.getState().token).toBeNull();
+      expect(localStorage.getItem('aegis_token')).toBeNull();
+      expect(sessionStorage.length).toBe(0);
+      expect(mockGetDashboardSession).toHaveBeenCalledTimes(2);
+    });
+
     it('does not store token on failure', async () => {
       mockVerifyToken.mockResolvedValue({ valid: false });
 

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -3,6 +3,7 @@
  *
  * Typed fetch wrapper for all Aegis v1 endpoints.
  * Reads Bearer token from an in-memory accessor registered by the auth store (#1924).
+ * Reload-safe dashboard login uses an HttpOnly cookie; API tokens are not stored in Web Storage.
  */
 
 import { z } from 'zod';
@@ -670,6 +671,7 @@ export function getPipeline(id: string): Promise<PipelineInfo> {
 export function verifyToken(token: string): Promise<VerifyTokenResponse> {
   return request('/v1/auth/verify', {
     method: 'POST',
+    credentials: 'include',
     body: JSON.stringify({ token }),
   });
 }
@@ -687,10 +689,11 @@ export interface DashboardSessionIdentity {
   expiresAt: number;
 }
 
+export type DashboardAuthMethod = 'oidc' | 'token';
+
 export type DashboardSessionResult =
-  | { oidcAvailable: false; authenticated: false }
-  | { oidcAvailable: true; authenticated: false }
-  | { oidcAvailable: true; authenticated: true; identity: DashboardSessionIdentity };
+  | { oidcAvailable: boolean; authenticated: false }
+  | { oidcAvailable: boolean; authenticated: true; authMethod: DashboardAuthMethod; identity: DashboardSessionIdentity };
 
 export type DashboardLogoutResult = 'logged-out' | 'unavailable';
 
@@ -746,9 +749,14 @@ export async function getDashboardSession(): Promise<DashboardSessionResult> {
   }
 
   const body = await readJsonOrNull(response);
+  if (isRecord(body) && body.authenticated === false) {
+    return { oidcAvailable: body.oidcAvailable === true, authenticated: false };
+  }
   if (!isDashboardSessionIdentity(body)) {
     throw new Error('Invalid dashboard session response');
   }
+  const rawAuthMethod = isRecord(body) ? body.authMethod : undefined;
+  const authMethod: DashboardAuthMethod = rawAuthMethod === 'oidc' ? 'oidc' : 'token';
   const identity: DashboardSessionIdentity = {
     authenticated: true,
     userId: body.userId,
@@ -759,7 +767,7 @@ export async function getDashboardSession(): Promise<DashboardSessionResult> {
     createdAt: body.createdAt,
     expiresAt: body.expiresAt,
   };
-  return { oidcAvailable: true, authenticated: true, identity };
+  return { oidcAvailable: isRecord(body) ? body.oidcAvailable === true : false, authenticated: true, authMethod, identity };
 }
 
 export async function logoutDashboardSession(): Promise<DashboardLogoutResult> {

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -158,7 +158,11 @@ async function requestResponse(
 
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      const res = await fetch(`${BASE_URL}${path}`, { ...fetchOptions, headers });
+      const res = await fetch(`${BASE_URL}${path}`, {
+        ...fetchOptions,
+        credentials: fetchOptions.credentials ?? 'include',
+        headers,
+      });
       if (!res.ok) {
         if (res.status === 401) {
           unauthorizedHandler?.();

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -252,6 +252,7 @@ export default function Layout() {
 
   const isMobileDrawerOpen = isMobileViewport && isMobileOpen;
   const isMobileSidebarHidden = isMobileViewport && !isMobileOpen;
+  const hiddenMobileSidebarControlTabIndex = isMobileSidebarHidden ? -1 : undefined;
 
   useEffect(() => {
     if (!isMobileOpen) return undefined;
@@ -403,6 +404,7 @@ export default function Layout() {
           group/sidebar
         `}
         aria-hidden={isMobileSidebarHidden ? 'true' : undefined}
+        inert={isMobileSidebarHidden ? true : undefined}
         style={{ backgroundImage: 'var(--sidebar-glow)' }}
       >
         <div className="flex items-center justify-between gap-3 px-6 py-6 border-b border-white/5">
@@ -410,8 +412,11 @@ export default function Layout() {
           <button
             type="button"
             onClick={() => setMobileOpen(false)}
+            tabIndex={hiddenMobileSidebarControlTabIndex}
+            disabled={isMobileSidebarHidden}
             className="md:hidden inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200"
             aria-label="Close menu"
+            aria-hidden={isMobileSidebarHidden ? 'true' : undefined}
           >
             <X className="h-5 w-5" />
           </button>
@@ -431,6 +436,7 @@ export default function Layout() {
                   key={to}
                   to={to}
                   end={to === '/'}
+                  tabIndex={hiddenMobileSidebarControlTabIndex}
                   onClick={handleNavClick}
                   className={({ isActive }) =>
                     `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
@@ -463,6 +469,7 @@ export default function Layout() {
           {/* Settings link */}
           <NavLink
             to="/settings"
+            tabIndex={hiddenMobileSidebarControlTabIndex}
             onClick={handleNavClick}
             className={({ isActive }) =>
               `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
@@ -497,6 +504,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={handleLogout}
+            tabIndex={hiddenMobileSidebarControlTabIndex}
             className={`flex min-h-[44px] items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
             title={isCollapsed ? 'Sign out' : undefined}
           >

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -89,6 +89,15 @@ interface CachedUpdateCheckResult extends UpdateCheckResult {
 const SSE_RECONNECTING_MESSAGE = 'Reconnecting to real-time updates. Overview widgets are using fallback polling where available.';
 const SSE_UNAVAILABLE_MESSAGE = 'Real-time updates unavailable. Overview widgets are using fallback polling where available.';
 const SSE_SUBSCRIPTION_RETRY_MESSAGE = 'Connecting real-time updates failed. Retrying now.';
+const MOBILE_SIDEBAR_QUERY = '(max-width: 767px)';
+
+function isMobileSidebarViewport(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(MOBILE_SIDEBAR_QUERY).matches;
+}
 
 export default function Layout() {
   const sseConnected = useStore((s) => s.sseConnected);
@@ -114,6 +123,7 @@ export default function Layout() {
   const [updateCheckError, setUpdateCheckError] = useState<string | null>(null);
   const [updateResult, setUpdateResult] = useState<UpdateCheckResult | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [isMobileViewport, setIsMobileViewport] = useState(isMobileSidebarViewport);
   
   function readCachedUpdate(version: string): UpdateCheckResult | null {
     try {
@@ -214,6 +224,34 @@ export default function Layout() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(MOBILE_SIDEBAR_QUERY);
+    let wasMobileViewport = mediaQuery.matches;
+
+    const handleViewportChange = () => {
+      const nextIsMobileViewport = mediaQuery.matches;
+      setIsMobileViewport(nextIsMobileViewport);
+
+      if (!wasMobileViewport && nextIsMobileViewport) {
+        setMobileOpen(true);
+      }
+
+      wasMobileViewport = nextIsMobileViewport;
+    };
+
+    handleViewportChange();
+    mediaQuery.addEventListener('change', handleViewportChange);
+
+    return () => mediaQuery.removeEventListener('change', handleViewportChange);
+  }, [setMobileOpen]);
+
+  const isMobileDrawerOpen = isMobileViewport && isMobileOpen;
+  const isMobileSidebarHidden = isMobileViewport && !isMobileOpen;
 
   useEffect(() => {
     if (!isMobileOpen) return undefined;
@@ -317,7 +355,7 @@ export default function Layout() {
       : 'SSE Off';
 
   function handleNavClick(): void {
-    if (isMobileOpen) {
+    if (isMobileDrawerOpen) {
       setMobileOpen(false);
     }
   }
@@ -326,7 +364,9 @@ export default function Layout() {
     void logout();
   }
 
-  const sidebarWidth = isCollapsed ? 'w-16' : 'w-56';
+  const sidebarWidth = isCollapsed
+    ? 'w-16 max-md:w-56 max-w-[calc(100vw-2rem)] md:max-w-none'
+    : 'w-56 max-w-[calc(100vw-2rem)] md:max-w-none';
   const identityLabel = identity?.email ?? identity?.name ?? identity?.userId;
   const identityDetailLabel = identity ? `${identity.role} - ${identity.tenantId}` : null;
 
@@ -344,6 +384,7 @@ export default function Layout() {
       {/* ── Mobile backdrop ─────────────────────────────────── */}
       {isMobileOpen && (
         <div
+          data-testid="mobile-sidebar-backdrop"
           className="fixed inset-0 z-30 bg-black/50 md:hidden"
           onClick={() => setMobileOpen(false)}
           aria-hidden="true"
@@ -357,9 +398,11 @@ export default function Layout() {
           transition-all duration-300 ease-in-out
           ${sidebarWidth}
           ${isMobileOpen ? 'translate-x-0' : '-translate-x-full'}
+          ${isMobileSidebarHidden ? 'pointer-events-none md:pointer-events-auto' : ''}
           md:relative md:translate-x-0 md:shrink-0
           group/sidebar
         `}
+        aria-hidden={isMobileSidebarHidden ? 'true' : undefined}
         style={{ backgroundImage: 'var(--sidebar-glow)' }}
       >
         <div className="flex items-center justify-between gap-3 px-6 py-6 border-b border-white/5">
@@ -367,7 +410,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={() => setMobileOpen(false)}
-            className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200"
+            className="md:hidden inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200"
             aria-label="Close menu"
           >
             <X className="h-5 w-5" />
@@ -473,8 +516,10 @@ export default function Layout() {
               <button
                 type="button"
                 onClick={toggleMobile}
+                tabIndex={isMobileDrawerOpen ? -1 : undefined}
+                aria-hidden={isMobileDrawerOpen ? 'true' : undefined}
                 className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors"
-                aria-label={isMobileOpen ? 'Close menu' : 'Open menu'}
+                aria-label="Open menu"
               >
                 <Menu className="h-5 w-5" />
               </button>
@@ -567,8 +612,8 @@ export default function Layout() {
         <div className="flex flex-1 overflow-hidden">
           <main
             id="main-content"
-            aria-hidden={isMobileOpen ? 'true' : undefined}
-            className={`flex-1 overflow-auto overscroll-contain p-3 sm:p-6 md:p-10 transition-all duration-500 animate-slide-in ${isMobileOpen ? 'pointer-events-none select-none blur-[1px] md:pointer-events-auto md:select-auto md:blur-none' : ''}`}
+            aria-hidden={isMobileDrawerOpen ? 'true' : undefined}
+            className={`flex-1 overflow-auto overscroll-contain p-3 sm:p-6 md:p-10 transition-all duration-500 animate-slide-in ${isMobileDrawerOpen ? 'pointer-events-none select-none blur-[1px] md:pointer-events-auto md:select-auto md:blur-none' : ''}`}
           >
             <ErrorBoundary>
               <Outlet />

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -28,6 +28,7 @@ import {
   TrendingUp,
   Cog,
   Terminal,
+  X,
 } from 'lucide-react';
 import { useStore } from '../store/useStore';
 import { useAuthStore } from '../store/useAuthStore.js';
@@ -103,6 +104,7 @@ export default function Layout() {
   const isMobileOpen = useSidebarStore((s) => s.isMobileOpen);
   const toggleSidebar = useSidebarStore((s) => s.toggle);
   const toggleMobile = useSidebarStore((s) => s.toggleMobile);
+  const setMobileOpen = useSidebarStore((s) => s.setMobileOpen);
   const openNewSession = useDrawerStore((s) => s.openNewSession);
 
   const [sseRetryCount, setSseRetryCount] = useState(0);
@@ -213,6 +215,17 @@ export default function Layout() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
+  useEffect(() => {
+    if (!isMobileOpen) return undefined;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setMobileOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isMobileOpen, setMobileOpen]);
+
   // Cmd+N global shortcut to open new session drawer
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -305,7 +318,7 @@ export default function Layout() {
 
   function handleNavClick(): void {
     if (isMobileOpen) {
-      toggleMobile();
+      setMobileOpen(false);
     }
   }
 
@@ -332,7 +345,7 @@ export default function Layout() {
       {isMobileOpen && (
         <div
           className="fixed inset-0 z-30 bg-black/50 md:hidden"
-          onClick={toggleMobile}
+          onClick={() => setMobileOpen(false)}
           aria-hidden="true"
         />
       )}
@@ -349,8 +362,16 @@ export default function Layout() {
         `}
         style={{ backgroundImage: 'var(--sidebar-glow)' }}
       >
-        <div className="flex items-center gap-3 px-6 py-6 border-b border-white/5">
+        <div className="flex items-center justify-between gap-3 px-6 py-6 border-b border-white/5">
           <ShieldWordmark size="md" collapsed={isCollapsed} />
+          <button
+            type="button"
+            onClick={() => setMobileOpen(false)}
+            className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200"
+            aria-label="Close menu"
+          >
+            <X className="h-5 w-5" />
+          </button>
         </div>
 
         {/* Nav links */}
@@ -433,7 +454,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={handleLogout}
-            className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
+            className={`flex min-h-[44px] items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
             title={isCollapsed ? 'Sign out' : undefined}
           >
             <LogOut className="h-4 w-4 shrink-0" />
@@ -452,8 +473,8 @@ export default function Layout() {
               <button
                 type="button"
                 onClick={toggleMobile}
-                className="md:hidden inline-flex items-center justify-center rounded-lg p-1.5 text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors"
-                aria-label="Open menu"
+                className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors"
+                aria-label={isMobileOpen ? 'Close menu' : 'Open menu'}
               >
                 <Menu className="h-5 w-5" />
               </button>
@@ -474,7 +495,7 @@ export default function Layout() {
                 onClick={openNewSession}
                 aria-label="New Session (⌘N)"
                 title="New Session (⌘N)"
-                className="inline-flex items-center justify-center rounded-lg p-1.5 text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors"
+                className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors sm:h-8 sm:w-8"
               >
                 <Plus className="h-4 w-4" />
               </button>
@@ -495,7 +516,7 @@ export default function Layout() {
                 <button
                   type="button"
                   onClick={toggleTheme}
-                  className="rounded p-1 sm:p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-zinc-400 dark:hover:bg-void-lighter dark:hover:text-zinc-200"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-zinc-400 dark:hover:bg-void-lighter dark:hover:text-zinc-200 sm:h-8 sm:w-8"
                   aria-label={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                   title={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                 >
@@ -544,7 +565,11 @@ export default function Layout() {
 
         {/* Content + LiveAuditStream side rail */}
         <div className="flex flex-1 overflow-hidden">
-          <main id="main-content" className="flex-1 overflow-auto overscroll-contain p-3 sm:p-6 md:p-10 transition-all duration-500 animate-slide-in">
+          <main
+            id="main-content"
+            aria-hidden={isMobileOpen ? 'true' : undefined}
+            className={`flex-1 overflow-auto overscroll-contain p-3 sm:p-6 md:p-10 transition-all duration-500 animate-slide-in ${isMobileOpen ? 'pointer-events-none select-none blur-[1px] md:pointer-events-auto md:select-auto md:blur-none' : ''}`}
+          >
             <ErrorBoundary>
               <Outlet />
             </ErrorBoundary>

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -540,7 +540,7 @@ export default function Layout() {
               </div>
             </div>
 
-            <div className={`flex items-center justify-end gap-1.5 sm:gap-3 transition-opacity ${isMobileOpen ? "pointer-events-none opacity-30" : ""}`}>
+            <div className={`flex items-center justify-end gap-1.5 sm:gap-3 transition-opacity ${isMobileDrawerOpen ? "pointer-events-none opacity-30" : ""}`}>
               {/* PREVIEW badge — hidden on very small screens */}
               <span className="hidden sm:inline-flex rounded-md border border-transparent bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-blue-800 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-500/10 dark:text-blue-400 dark:ring-0">
                 PREVIEW

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -817,7 +817,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
         <div className="flex flex-col gap-4 border-b border-white/5 bg-white/5 p-4 backdrop-blur-md xl:flex-row xl:items-start xl:justify-between">
           <div className="flex-1 space-y-3">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
-              <label className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-white/10 bg-[var(--color-void)] px-3 py-2 text-sm text-gray-300 focus-within:border-[var(--color-accent-cyan)] focus-within:ring-1 focus-within:ring-[var(--color-accent-cyan)]/30 transition-all shadow-inner">
+              <label className="flex min-h-[44px] min-w-0 flex-1 items-center gap-2 rounded-lg border border-white/10 bg-[var(--color-void)] px-3 py-2 text-sm text-gray-300 shadow-inner transition-all focus-within:border-[var(--color-accent-cyan)] focus-within:ring-1 focus-within:ring-[var(--color-accent-cyan)]/30">
                 <Search className="h-4 w-4 text-gray-500" />
                 <input
                   value={searchInput}
@@ -826,7 +826,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                     setPage(1);
                   }}
                   placeholder="Search by session name or work directory"
-                  className="w-full bg-transparent text-sm text-gray-100 outline-none placeholder:text-gray-500"
+                   className="min-h-8 w-full bg-transparent text-sm text-gray-100 outline-none placeholder:text-gray-500"
                   aria-label="Search sessions"
                 />
               </label>
@@ -840,7 +840,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                     setPage(1);
                   }}
                   aria-label="Filter by status"
-                  className="rounded-md border border-void-lighter bg-void px-3 py-2 text-sm text-gray-100 outline-none focus:border-cyan"
+                  className="min-h-[44px] rounded-md border border-void-lighter bg-void px-3 py-2 text-sm text-gray-100 outline-none focus:border-cyan"
                 >
                   {STATUS_FILTERS.map((status) => (
                     <option key={status} value={status}>
@@ -855,7 +855,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                 onClick={() => setGroupByDir((prev) => !prev)}
                 aria-label={groupByDir ? 'Show ungrouped session list' : 'Group sessions by directory'}
                 aria-pressed={groupByDir}
-                className={`flex items-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium transition-colors ${groupByDir
+                className={`flex min-h-[36px] items-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium transition-colors ${groupByDir
                   ? 'border-cyan bg-cyan/10 text-cyan'
                   : 'border-void-lighter bg-void text-gray-400 hover:border-cyan/40 hover:text-gray-200'}`}
               >
@@ -877,7 +877,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                       setStatusFilter(status);
                       setPage(1);
                     }}
-                    className={`rounded-full border px-3 py-1 text-xs transition-colors ${isActive
+                    className={`min-h-[36px] rounded-full border px-3 py-1.5 text-xs transition-colors ${isActive
                       ? 'border-cyan bg-cyan/10 text-cyan'
                       : 'border-void-lighter bg-void text-gray-400 hover:border-cyan/40 hover:text-gray-200'}`}
                   >

--- a/dashboard/src/components/shared/CommandPalette.tsx
+++ b/dashboard/src/components/shared/CommandPalette.tsx
@@ -206,7 +206,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
           >
             <div className="card-glass overflow-hidden shadow-palette">
               {/* Search input */}
-              <div className="flex items-center gap-3 border-b border-white/5 px-4 py-3.5">
+              <div className="flex min-h-[44px] items-center gap-3 border-b border-white/5 px-4 py-3.5">
                 <Search className="h-4 w-4 shrink-0 text-slate-500" />
                 <input
                   ref={inputRef}
@@ -220,7 +220,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
                   onChange={(e) => setQuery(e.target.value)}
                   onKeyDown={handleInputKeyDown}
                   placeholder="Search sessions, navigate, run commands…"
-                  className="flex-1 bg-transparent text-sm text-white placeholder:text-slate-500 outline-none"
+                  className="min-h-8 flex-1 bg-transparent text-sm text-white placeholder:text-slate-500 outline-none"
                 />
                 <kbd className="shrink-0 rounded border border-white/10 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">
                   ESC

--- a/dashboard/src/components/shared/NLFilterBar.tsx
+++ b/dashboard/src/components/shared/NLFilterBar.tsx
@@ -202,18 +202,18 @@ export function NLFilterBar({ onFilter, placeholder = 'Filter: "active sessions 
   };
 
   return (
-    <div className={`flex flex-wrap items-center gap-1.5 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-2 focus-within:border-[var(--color-accent-cyan)]/50 ${className ?? ''}`}>
+    <div className={`flex min-h-[44px] flex-wrap items-center gap-1.5 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-2 focus-within:border-[var(--color-accent-cyan)]/50 ${className ?? ''}`}>
       {chips.map((chip, i) => (
         <span
           key={`${chip.field}-${chip.value}-${i}`}
-          className="inline-flex items-center gap-1 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-2 py-0.5 text-xs text-[var(--color-accent-cyan)]"
+          className="inline-flex min-h-8 items-center gap-1 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-2 py-1 text-xs text-[var(--color-accent-cyan)]"
         >
           {chip.display}
           <button
             type="button"
             onClick={() => removeChip(i)}
             aria-label={`Remove filter ${chip.display}`}
-            className="ml-0.5 rounded opacity-70 hover:opacity-100 transition-opacity"
+            className="ml-0.5 inline-flex h-8 w-8 items-center justify-center rounded opacity-70 transition-opacity hover:opacity-100"
           >
             <Icon name="X" size={12} />
           </button>
@@ -227,7 +227,7 @@ export function NLFilterBar({ onFilter, placeholder = 'Filter: "active sessions 
         onKeyDown={handleKeyDown}
         onBlur={() => { if (inputValue.trim()) commitInput(); }}
         placeholder={chips.length === 0 ? placeholder : 'Add filter…'}
-        className="min-w-[200px] flex-1 bg-transparent text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none"
+        className="min-h-8 min-w-[200px] flex-1 bg-transparent text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none"
         aria-label="Natural language filter"
       />
       {(chips.length > 0 || inputValue) && (
@@ -235,7 +235,7 @@ export function NLFilterBar({ onFilter, placeholder = 'Filter: "active sessions 
           type="button"
           onClick={clearAll}
           aria-label="Clear all filters"
-          className="ml-1 rounded p-0.5 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+          className="ml-1 inline-flex h-8 w-8 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
         >
           <Icon name="X" size={16} />
         </button>

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -4,7 +4,8 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* ================================================================
- * Variable fonts with font-display: swap and size-adjust for CLS prevention
+ * Local font preferences. External font downloads are intentionally avoided
+ * so the dashboard's strict CSP stays quiet on first load.
  * ================================================================ */
 
 /* DM Sans variable (weight 100-1000) — body text */
@@ -15,8 +16,7 @@
   font-display: swap;
   size-adjust: 100%;
   src: local('DM Sans Variable'),
-       local('DM Sans'),
-       url('https://fonts.gstatic.com/s/dmsans/v15/rP2Fp2ywxg089UriI5-g4vlH9VoD8Cmcqbu0-K6p.woff2') format('woff2-variations');
+       local('DM Sans');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -28,8 +28,7 @@
   font-display: swap;
   size-adjust: 100%;
   src: local('JetBrains Mono Variable'),
-       local('JetBrains Mono'),
-       url('https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbV2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxjPVmUsaaDhw.woff2') format('woff2-variations');
+       local('JetBrains Mono');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -39,8 +38,7 @@
   font-style: normal;
   font-weight: 400 700;
   font-display: swap;
-  src: local('Atkinson Hyperlegible'),
-       url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt23C1KxNDXMspQ1lPyU89-1h6ONRlW45GE5ZgpewSSbQ.woff2') format('woff2');
+  src: local('Atkinson Hyperlegible');
 }
 
 /* OpenDyslexic — dyslexia-friendly reading font */
@@ -49,8 +47,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: local('OpenDyslexic'),
-       url('https://cdn.jsdelivr.net/npm/open-dyslexic@1.0.3/fonts/OpenDyslexic-Regular.woff') format('woff');
+  src: local('OpenDyslexic');
 }
 
 @theme {

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -83,7 +83,7 @@ export default function LoginPage() {
           <button
             type="button"
             onClick={handleOidcLogin}
-            className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500"
+            className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500"
           >
             <LogIn className="h-4 w-4" />
             <span>Sign in with SSO</span>
@@ -101,12 +101,12 @@ export default function LoginPage() {
                 placeholder="API token"
                 autoFocus
                 autoComplete="current-password"
-                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 pr-10 text-sm text-gray-200 placeholder-gray-500 focus:border-blue-500 focus:outline-none touch-action-manipulation"
+                className="min-h-[44px] w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 pr-12 text-sm text-gray-200 placeholder-gray-500 focus:border-blue-500 focus:outline-none touch-action-manipulation"
               />
               <button
                 type="button"
                 onClick={() => setShowToken(!showToken)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+                className="absolute right-0 top-1/2 inline-flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-lg text-gray-400 hover:text-gray-200"
                 aria-label={showToken ? 'Hide token' : 'Show token'}
               >
                 {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -120,7 +120,7 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={loading || !token.trim()}
-              className="rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+              className="min-h-[44px] rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {loading ? t('login.verifying') : t('login.signInButton')}
             </button>

--- a/dashboard/src/store/useAuthStore.ts
+++ b/dashboard/src/store/useAuthStore.ts
@@ -1,8 +1,9 @@
 /**
  * store/useAuthStore.ts — Zustand store for authentication state.
  *
- * #1924: Token is held in memory only. Clearing on tab close / reload is
- * intentional; users re-authenticate via the login form. See ADR-0024.
+ * #1924/#2351: API tokens are never persisted in Web Storage. Successful
+ * token login is upgraded to an HttpOnly same-origin dashboard session cookie
+ * by the server so reloads/deep links survive without exposing the token to JS.
  */
 
 import { create } from 'zustand';
@@ -77,17 +78,19 @@ function clearAuthState(
   set(partial);
 }
 
-function setOidcAuthState(
+function setDashboardSessionAuthState(
   set: (partial: Partial<AuthState>) => void,
   identity: DashboardSessionIdentity,
+  oidcAvailable: boolean,
+  authMode: Exclude<AuthMode, null>,
 ): void {
   purgeLegacyToken();
   syncAuthToken(null);
   set({
     token: null,
-    authMode: 'oidc',
+    authMode,
     identity,
-    oidcAvailable: true,
+    oidcAvailable,
     isAuthenticated: true,
     isVerifying: false,
     lastVerifiedAt: null,
@@ -109,15 +112,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     try {
       const result = await verifyToken(token);
       if (result.valid) {
-        syncAuthToken(token);
-        set({
-          token,
-          authMode: 'token',
-          identity: null,
-          isAuthenticated: true,
-          isVerifying: false,
-          lastVerifiedAt: Date.now(),
-        });
+        purgeLegacyToken();
+        syncAuthToken(null);
+        const session = await getDashboardSession().catch(() => null);
+        if (session?.authenticated) {
+          setDashboardSessionAuthState(set, session.identity, session.oidcAvailable, 'token');
+        } else {
+          set({
+            token,
+            authMode: 'token',
+            identity: null,
+            isAuthenticated: true,
+            isVerifying: false,
+            lastVerifiedAt: Date.now(),
+          });
+          syncAuthToken(token);
+        }
         return true;
       }
       clearAuthState(set, { oidcAvailable: get().oidcAvailable });
@@ -134,9 +144,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   logout: async () => {
     const state = get();
-    const wasOidcSession = state.authMode === 'oidc';
+    const wasCookieSession = state.authMode === 'oidc' || (state.authMode === 'token' && state.token === null);
     clearAuthState(set, { oidcAvailable: state.oidcAvailable });
-    if (!wasOidcSession) return;
+    if (!wasCookieSession) return;
 
     try {
       const result = await logoutDashboardSession();
@@ -165,7 +175,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     try {
       const session = await getDashboardSession();
       if (session.authenticated) {
-        setOidcAuthState(set, session.identity);
+        setDashboardSessionAuthState(set, session.identity, session.oidcAvailable, session.authMethod === 'oidc' ? 'oidc' : 'token');
         return;
       }
       set({ oidcAvailable: session.oidcAvailable });
@@ -175,8 +185,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     const state = get();
     if (!state.token) {
-      // No persisted token to restore. When OIDC is configured, the login page
-      // will show the provider sign-in action; otherwise it falls back to API token login.
+      // No bearer token is persisted. If /auth/session did not restore an
+      // HttpOnly dashboard cookie, fall back to the login page.
       clearAuthState(set, { oidcAvailable: state.oidcAvailable });
       return;
     }
@@ -195,8 +205,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     const state = get();
     const token = state.token;
     if (!token) {
-      if (state.authMode === 'oidc' && state.isAuthenticated) {
-        return true;
+      if ((state.authMode === 'oidc' || state.authMode === 'token') && state.isAuthenticated) {
+        try {
+          const session = await getDashboardSession();
+          if (session.authenticated) {
+            setDashboardSessionAuthState(set, session.identity, session.oidcAvailable, session.authMethod === 'oidc' ? 'oidc' : 'token');
+            return true;
+          }
+        } catch {
+          // Keep an already-authenticated cookie session during transient probes.
+          return true;
+        }
       }
       clearAuthState(set, { oidcAvailable: state.oidcAvailable });
       return false;

--- a/dashboard/src/store/useAuthStore.ts
+++ b/dashboard/src/store/useAuthStore.ts
@@ -191,6 +191,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     const state = get();
     if (!state.token) {
+      if ((state.authMode === 'oidc' || state.authMode === 'token') && state.isAuthenticated) {
+        await get().revalidate();
+        return;
+      }
+
       // No bearer token is persisted. If /auth/session did not restore an
       // HttpOnly dashboard cookie, fall back to the login page.
       clearAuthState(set, { oidcAvailable: state.oidcAvailable });

--- a/dashboard/src/store/useSidebarStore.ts
+++ b/dashboard/src/store/useSidebarStore.ts
@@ -11,6 +11,7 @@ interface SidebarState {
   isMobileOpen: boolean;
   toggle: () => void;
   toggleMobile: () => void;
+  setMobileOpen: (open: boolean) => void;
   setCollapsed: (collapsed: boolean) => void;
 }
 
@@ -40,6 +41,9 @@ export const useSidebarStore = create<SidebarState>((set) => ({
 
   toggleMobile: () =>
     set((state) => ({ isMobileOpen: !state.isMobileOpen })),
+
+  setMobileOpen: (open: boolean) =>
+    set({ isMobileOpen: open }),
 
   setCollapsed: (collapsed: boolean) => {
     try {

--- a/dashboard/src/store/useStore.ts
+++ b/dashboard/src/store/useStore.ts
@@ -118,16 +118,13 @@ export interface AppState {
 }
 
 export const useStore = create<AppState>((set) => ({
-  // Auth (#1924 → #2351: sessionStorage persistence for tab-lifetime token survival)
-  // Token survives reloads and deep links within the same tab, cleared on tab close.
-  // This is more secure than localStorage while meeting the UX expectation.
-  token: (() => { try { return sessionStorage.getItem('aegis:auth:token'); } catch { return null; } })(),
+  // Auth (#1924/#2351: token is in-memory only; reload survival uses the
+  // HttpOnly dashboard session cookie managed by useAuthStore.
+  token: null,
   setToken: (token) => {
-    try { sessionStorage.setItem('aegis:auth:token', token); } catch { /* storage disabled */ }
     set({ token });
   },
   clearToken: () => {
-    try { sessionStorage.removeItem('aegis:auth:token'); } catch { /* storage disabled */ }
     set({ token: null });
   },
 

--- a/src/__tests__/content-length-static.test.ts
+++ b/src/__tests__/content-length-static.test.ts
@@ -23,6 +23,7 @@ const projectsDir = join(sandboxRoot, 'projects');
 
 let capturedApp: FastifyInstance | null = null;
 const dashboardDir = join(process.cwd(), 'src', 'dashboard');
+const dashboardAssetsDir = join(dashboardDir, 'assets');
 
 vi.mock('../startup.js', () => ({
   listenWithRetry: vi.fn(async (app: FastifyInstance) => {
@@ -37,10 +38,12 @@ beforeAll(async () => {
   mkdirSync(stateDir, { recursive: true });
   mkdirSync(projectsDir, { recursive: true });
   mkdirSync(dashboardDir, { recursive: true });
+  mkdirSync(dashboardAssetsDir, { recursive: true });
 
   // Create deterministic static assets for the test (do NOT commit these files)
   writeFileSync(join(dashboardDir, 'index.html'), '<html><body>index</body></html>', 'utf8');
   writeFileSync(join(dashboardDir, 'asset.txt'), 'hello world\n', 'utf8');
+  writeFileSync(join(dashboardAssetsDir, 'index-AbCdEf12.js'), 'console.log("hashed");\n', 'utf8');
 
   process.env.AEGIS_STATE_DIR = stateDir;
   process.env.AEGIS_CLAUDE_PROJECTS_DIR = projectsDir;
@@ -62,6 +65,9 @@ afterAll(async () => {
   // cleanup files
   try { unlinkSync(join(dashboardDir, 'index.html')); } catch {}
   try { unlinkSync(join(dashboardDir, 'asset.txt')); } catch {}
+  try { unlinkSync(join(dashboardAssetsDir, 'index-AbCdEf12.js')); } catch {}
+  try { rmSync(dashboardAssetsDir, { recursive: true, force: true }); } catch {}
+  try { rmSync(dashboardDir, { recursive: false, force: true }); } catch {}
   rmSync(sandboxRoot, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
@@ -77,6 +83,14 @@ describe('Content-Length correctness (static assets)', () => {
     const resAsset = await app.inject({ method: 'GET', url: '/dashboard/asset.txt' });
     expect(resAsset.statusCode).toBe(200);
     expect(Number(resAsset.headers['content-length'])).toBe(Buffer.byteLength(resAsset.body, 'utf8'));
+  });
+
+  it('serves hashed dashboard assets with immutable Cache-Control (#2345)', async () => {
+    const app = capturedApp as FastifyInstance;
+
+    const resAsset = await app.inject({ method: 'GET', url: '/dashboard/assets/index-AbCdEf12.js' });
+    expect(resAsset.statusCode).toBe(200);
+    expect(resAsset.headers['cache-control']).toBe('public, max-age=31536000, immutable');
   });
 
   it('serves the dashboard with the hardened CSP on static and SPA fallback routes', async () => {

--- a/src/__tests__/oidc-auth-routes.test.ts
+++ b/src/__tests__/oidc-auth-routes.test.ts
@@ -164,6 +164,16 @@ describe('OIDC auth routes', () => {
     expect(response.statusCode).toBe(404);
   });
 
+  it('returns a clean unauthenticated /auth/session response when OIDC is disabled (#2348)', async () => {
+    const created = await createApp(false);
+    app = created.app;
+
+    const response = await app.inject({ method: 'GET', url: '/auth/session' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ oidcAvailable: false, authenticated: false });
+  });
+
   it('login redirects to IdP and sets an HttpOnly SameSite=Lax state cookie', async () => {
     const created = await createApp();
     app = created.app;

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -17,7 +17,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 import type { FastifyRequest, FastifyReply } from 'fastify';
 
 import { SessionManager } from '../session.js';
-import { AuthManager, QuotaManager, type ApiKeyPermission } from '../services/auth/index.js';
+import { AuthManager, DASHBOARD_SESSION_COOKIE, DashboardSessionStore, QuotaManager, type ApiKeyPermission } from '../services/auth/index.js';
 import { MetricsCollector } from '../metrics.js';
 import { SessionMonitor } from '../monitor.js';
 import { SessionEventBus } from '../events.js';
@@ -43,7 +43,7 @@ import {
 } from '../routes/index.js';
 
 import { createMockTmuxManager, type MockTmuxManager } from './helpers/mock-tmux.js';
-import type { Config } from '../config.js';
+import { SYSTEM_TENANT, type Config } from '../config.js';
 
 const MASTER_TOKEN = 'aegis-master-token-2026';
 
@@ -133,6 +133,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
   );
 
   const requestKeyMap = new Map<string, string>();
+  const dashboardTokenSessions = new DashboardSessionStore();
 
   const ctx: RouteContext = {
     sessions,
@@ -173,6 +174,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
       recordCount: 0,
     } as unknown as import('../metering.js').MeteringService,
     metricsCache: { getMetrics: vi.fn(() => ({ sessionVolume: [], tokenUsageByModel: [], costTrends: [], topApiKeys: [], durationTrends: [], errorRates: { totalSessions: 0, failedSessions: 0, failureRate: 0, permissionPrompts: 0, approvals: 0, autoApprovals: 0 }, generatedAt: new Date().toISOString() })), start: vi.fn(async () => {}), stop: vi.fn(async () => {}), invalidate: vi.fn(), flush: vi.fn(async () => {}) } as unknown as RouteContext['metricsCache'],
+    dashboardTokenSessions,
   };
 
   return { ctx, mockTmux, sessions, auth };
@@ -193,6 +195,9 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     app.decorateRequest('authKeyId', null as unknown as string);
     app.decorateRequest('tenantId', undefined as unknown as string);
     app.decorateRequest('matchedPermission', null as unknown as ApiKeyPermission);
+    app.decorateRequest('authRole', null);
+    app.decorateRequest('authPermissions', null);
+    app.decorateRequest('authActor', null);
 
     // Auth middleware — mirrors server.ts setupAuth() in simplified form.
     // For the smoke test, validate against the master token only.
@@ -282,7 +287,12 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     const body = res.json();
     expect(body.status).toBe('ok');
     expect(body.version).toBeDefined();
+    expect(body.platform).toBe(process.platform);
+    expect(body.uptime).toBeDefined();
     expect(body.sessions).toBeDefined();
+    expect(body.sessions.total).toBeDefined();
+    expect(body.tmux).toBeDefined();
+    expect(body.claude).toBeDefined();
   });
 
   it('GET /v1/health unauthenticated returns minimal data (Issue #2066)', async () => {
@@ -298,6 +308,37 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     expect(body.sessions).toBeDefined();
     expect(body.sessions.active).toBeDefined();
     expect(body.sessions.total).toBeUndefined(); // stripped for unauthenticated
+    expect(body.tmux).toBeUndefined();
+    expect(body.claude).toBeUndefined();
+  });
+
+  it('GET /v1/health accepts dashboard session cookie for full data', async () => {
+    const session = routeContext.ctx.dashboardTokenSessions?.create({
+      userId: 'api-key:master',
+      tenantId: SYSTEM_TENANT,
+      role: 'admin',
+      permissions: routeContext.auth.getPermissions('master'),
+      claims: { authMethod: 'token', keyId: 'master' },
+    });
+
+    expect(session).toBeDefined();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/health',
+      headers: {
+        cookie: `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(session?.sessionId ?? '')}`,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe('ok');
+    expect(body.version).toBeDefined();
+    expect(body.platform).toBe(process.platform);
+    expect(body.uptime).toBeDefined();
+    expect(body.sessions.total).toBeDefined();
+    expect(body.tmux).toBeDefined();
+    expect(body.claude).toBeDefined();
   });
 
   // ── Step 2: Create session ────────────────────────────────────────

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -8,6 +8,8 @@ import { authKeySchema } from '../validation.js';
 import { SYSTEM_TENANT } from '../config.js';
 import { filterByTenant } from '../utils/tenant-filter.js';
 import { type RouteContext, requireRole, registerWithLegacy, withValidation } from './context.js';
+import { appendSetCookie, buildCookie } from './oidc-auth.js';
+import { DASHBOARD_SESSION_COOKIE, DASHBOARD_SESSION_TTL_MS } from '../services/auth/OIDCManager.js';
 
 const setQuotasSchema = z.object({
   maxConcurrentSessions: z.number().int().positive().nullable().optional(),
@@ -36,11 +38,22 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
 
   // Auth verify — public bootstrap endpoint for dashboard login
   registerWithLegacy(app, 'post', '/v1/auth/verify', withValidation(verifyTokenSchema, async (req: FastifyRequest, reply: FastifyReply, data) => {
+    const clientIp = req.ip ?? 'unknown';
     if (!auth.authEnabled) {
-      return { valid: true, role: 'admin' };
+      const role = 'admin';
+      const session = ctx.dashboardTokenSessions?.create({
+        userId: `local-dashboard:${clientIp}`,
+        tenantId: SYSTEM_TENANT,
+        role,
+        permissions: auth.getPermissions(null),
+        claims: { authMethod: 'token', keyId: null },
+      });
+      if (session) {
+        appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000));
+      }
+      return { valid: true, role };
     }
 
-    const clientIp = req.ip ?? 'unknown';
     const result = auth.validate(data.token);
     if (result.rateLimited) {
       return reply.status(429).send({ valid: false });
@@ -49,7 +62,18 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
       return reply.status(401).send({ valid: false });
     }
 
-    return { valid: true, role: auth.getRole(result.keyId) };
+    const role = auth.getRole(result.keyId);
+    const session = ctx.dashboardTokenSessions?.create({
+      userId: result.keyId ? `api-key:${result.keyId}` : `local-dashboard:${clientIp}`,
+      tenantId: result.tenantId ?? SYSTEM_TENANT,
+      role,
+      permissions: auth.getPermissions(result.keyId),
+      claims: { authMethod: 'token', keyId: result.keyId },
+    });
+    if (session) {
+      appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000));
+    }
+    return { valid: true, role };
   }));
 
   registerWithLegacy(app, 'post', '/v1/auth/keys', withValidation(authKeySchema, async (req: FastifyRequest, reply: FastifyReply, data) => {

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -33,7 +33,7 @@ import type { SSEConnectionLimiter } from '../sse-limiter.js';
 import type { MemoryBridge } from '../memory-bridge.js';
 import type { MeteringService } from '../metering.js';
 import type { MetricsCache } from '../services/metrics-cache.js';
-import type { DashboardOIDCManager } from '../services/auth/OIDCManager.js';
+import type { DashboardOIDCManager, DashboardSessionStore } from '../services/auth/OIDCManager.js';
 
 /** Shared route handler types */
 export type IdParams = { Params: { id: string } };
@@ -70,6 +70,8 @@ export interface RouteContext {
   metricsCache: MetricsCache;
   /** Issue #1942: Dashboard SSO/OIDC session manager. */
   dashboardOidc?: DashboardOIDCManager | null;
+  /** Same-origin opaque sessions created after dashboard API-token login. */
+  dashboardTokenSessions?: DashboardSessionStore | null;
 }
 
 export function getRequestRole(auth: AuthManager, req: FastifyRequest): ApiKeyRole {

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -10,6 +10,7 @@ import { negotiate, type HandshakeRequest } from '../handshake.js';
 import { promRegistry, METRICS_CONTENT_TYPE } from '../prometheus.js';
 import { MIN_CC_VERSION, compareSemver, extractCCVersion } from '../validation.js';
 import { handshakeRequestSchema } from '../validation.js';
+import { authenticateDashboardSessionCookie } from '../dashboard-session-auth.js';
 import { type RouteContext, requireRole, registerWithLegacy, withValidation } from './context.js';
 
 const execFileAsync = promisify(execFile);
@@ -98,7 +99,11 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
     // fields when auth IS configured and the caller provides no valid token).
     const authHeader = req.headers.authorization;
     const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
-    const isAuthenticated = ctx.auth.validate(token ?? '').valid;
+    const isBearerAuthenticated = ctx.auth.validate(token ?? '').valid;
+    const isAuthenticated = isBearerAuthenticated || (!token && authenticateDashboardSessionCookie(req, {
+      getSession: (sessionId: string | undefined) =>
+        ctx.dashboardTokenSessions?.get(sessionId) ?? ctx.dashboardOidc?.getSession(sessionId) ?? null,
+    }) !== null);
 
     const base = { status, timestamp: new Date().toISOString() };
 

--- a/src/routes/oidc-auth.ts
+++ b/src/routes/oidc-auth.ts
@@ -5,6 +5,7 @@ import {
   OIDC_AUTH_REQUEST_TTL_MS,
   OIDC_STATE_COOKIE,
   OidcAuthError,
+  type DashboardSessionStore,
   type DashboardOIDCManager,
 } from '../services/auth/OIDCManager.js';
 
@@ -16,6 +17,7 @@ const LOGOUT_RATE_LIMIT = { max: 30, timeWindow: '1 minute' } as const;
 
 interface OidcRouteContext {
   dashboardOidc?: DashboardOIDCManager | null;
+  dashboardTokenSessions?: DashboardSessionStore | null;
 }
 
 interface LoginQuery {
@@ -43,7 +45,7 @@ function getCookie(req: FastifyRequest, name: string): string | undefined {
   return parseCookies(req.headers.cookie).get(name);
 }
 
-function appendSetCookie(reply: FastifyReply, cookie: string): void {
+export function appendSetCookie(reply: FastifyReply, cookie: string): void {
   const existing = reply.getHeader('Set-Cookie');
   if (Array.isArray(existing)) {
     reply.header('Set-Cookie', [...existing.map(String), cookie]);
@@ -58,7 +60,7 @@ function appendSetCookie(reply: FastifyReply, cookie: string): void {
 
 type CookieSameSite = 'Strict' | 'Lax';
 
-function buildCookie(name: string, value: string, maxAgeSeconds: number, sameSite: CookieSameSite = 'Strict'): string {
+export function buildCookie(name: string, value: string, maxAgeSeconds: number, sameSite: CookieSameSite = 'Strict'): string {
   return [
     `${name}=${encodeURIComponent(value)}`,
     'Path=' + COOKIE_PATH,
@@ -69,7 +71,7 @@ function buildCookie(name: string, value: string, maxAgeSeconds: number, sameSit
   ].join('; ');
 }
 
-function buildClearedCookie(name: string, sameSite: CookieSameSite = 'Strict'): string {
+export function buildClearedCookie(name: string, sameSite: CookieSameSite = 'Strict'): string {
   return [
     `${name}=`,
     'Path=' + COOKIE_PATH,
@@ -148,14 +150,19 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
       { config: { rateLimit: SESSION_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
-        if (!manager) return reply.status(404).send({ error: 'Not found' });
         const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+        const tokenSessionStore = ctx.dashboardTokenSessions ?? null;
+        const tokenSession = tokenSessionStore?.get(sessionId) ?? null;
+        if (tokenSession && tokenSessionStore) {
+          return { oidcAvailable: manager !== null, authMethod: 'token', ...tokenSessionStore.toView(tokenSession) };
+        }
+        if (!manager) return { oidcAvailable: false, authenticated: false };
         const session = manager.getSession(sessionId);
         if (!session) {
           appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
-          return reply.status(401).send({ authenticated: false });
+          return reply.status(401).send({ oidcAvailable: true, authenticated: false });
         }
-        return manager.sessions.toView(session);
+        return { oidcAvailable: true, authMethod: 'oidc', ...manager.sessions.toView(session) };
       },
     );
 
@@ -164,11 +171,16 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
       { config: { rateLimit: LOGOUT_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
-        if (!manager) return reply.status(404).send({ error: 'Not found' });
         const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+        const tokenSessionDeleted = ctx.dashboardTokenSessions?.delete(sessionId) ?? false;
+        if (!manager) {
+          appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
+          return reply.status(204).send();
+        }
         const session = manager.getSession(sessionId);
         manager.deleteSession(sessionId);
         appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE));
+        if (tokenSessionDeleted) return reply.status(204).send();
         const endSessionUrl = manager.buildEndSessionUrl(session);
         if (endSessionUrl && acceptsHtml(req)) {
           return reply.status(303).header('Location', endSessionUrl.href).send();

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,7 +87,11 @@ import {
 } from './routes/index.js';
 import { makePayload as makePayloadFromCtx } from './routes/context.js';
 import { registerDeviceAuthRoutes } from './routes/device-auth.js';
-import { createDashboardOidcManagerFromEnv, type DashboardOIDCManager } from './services/auth/OIDCManager.js';
+import {
+  createDashboardOidcManagerFromEnv,
+  DashboardSessionStore,
+  type DashboardOIDCManager,
+} from './services/auth/OIDCManager.js';
 import { authenticateDashboardSessionCookie } from './dashboard-session-auth.js';
 
 
@@ -151,6 +155,30 @@ function applyDashboardResponseHeaders(reply: FastifyReply): void {
   }
 }
 
+function normalizeDashboardStaticPath(dashboardRoot: string, pathname: string): string {
+  const urlLike = pathname.replace(/\\/g, '/');
+  if (urlLike === '/' || urlLike === '/index.html' || urlLike.startsWith('/dashboard/') || urlLike.startsWith('/assets/')) {
+    return urlLike.replace(/^\/(?:dashboard\/)?/, '');
+  }
+  const normalized = path.normalize(pathname);
+  const relative = path.isAbsolute(normalized)
+    ? path.relative(dashboardRoot, normalized)
+    : normalized.replace(/^[\\/]+/, '');
+  return relative.split(path.sep).join('/');
+}
+
+function dashboardCacheControl(dashboardRoot: string, pathname: string): string {
+  const relative = normalizeDashboardStaticPath(dashboardRoot, pathname);
+  const basename = path.posix.basename(relative);
+  if (relative === '' || relative === 'index.html' || basename.endsWith('.html')) {
+    return 'no-cache, no-store, must-revalidate';
+  }
+  if (relative.startsWith('assets/') && /-[A-Za-z0-9_-]{6,}\.[A-Za-z0-9]+$/.test(basename)) {
+    return 'public, max-age=31536000, immutable';
+  }
+  return 'public, max-age=0, must-revalidate';
+}
+
 // Config loaded at startup; env vars override file values
 let config: Config;
 
@@ -171,6 +199,7 @@ let auditLogger: AuditLogger | undefined;
 let swarmMonitor: SwarmMonitor;
 let alertManager: AlertManager;
 let dashboardOidc: DashboardOIDCManager | null = null;
+let dashboardTokenSessions = new DashboardSessionStore();
 let configWatcher: FSWatcher | null = null;
 
 // ── Inbound command handler ─────────────────────────────────────────
@@ -414,7 +443,10 @@ function setupAuth(authManager: AuthManager): void {
     // cookie. This only fills request-scoped auth context; it never mints or
     // accepts a reusable bearer API key.
     if (!token && urlPath.startsWith('/v1/')) {
-      const dashboardAuthContext = authenticateDashboardSessionCookie(req, dashboardOidc);
+      const dashboardAuthContext = authenticateDashboardSessionCookie(req, {
+        getSession: (sessionId: string | undefined) =>
+          dashboardTokenSessions.get(sessionId) ?? dashboardOidc?.getSession(sessionId) ?? null,
+      });
       if (dashboardAuthContext) {
         requestKeyMap.set(req.id, dashboardAuthContext.keyId);
         if (auditLogger) {
@@ -731,6 +763,7 @@ async function handleConfigReload(source: string): Promise<void> {
 async function main(): Promise<void> {
   // Load configuration
   config = await loadConfig();
+  dashboardTokenSessions = new DashboardSessionStore();
   dashboardOidc = await createDashboardOidcManagerFromEnv(config);
 
   // Initialize OpenTelemetry tracing before any instrumented modules load.
@@ -949,6 +982,7 @@ async function main(): Promise<void> {
     metering: new MeteringService(eventBus, (sid) => sessions.getSession(sid)?.ownerKeyId, path.join(config.stateDir, 'metering.jsonl')),
     metricsCache,
     dashboardOidc,
+    dashboardTokenSessions,
   };
   registerHealthRoutes(app, routeCtx);
   registerAuthRoutes(app, routeCtx);
@@ -1336,17 +1370,13 @@ async function main(): Promise<void> {
     await app.register(fastifyStatic, {
       root: dashboardRoot,
       prefix: "/dashboard/",
+      cacheControl: false,
       // #146: Cache hashed assets aggressively, no-cache for index.html
       setHeaders: (reply, pathname) => {
         for (const [header, value] of Object.entries(DASHBOARD_RESPONSE_HEADERS)) {
           reply.setHeader(header, value);
         }
-        // Cache control (#146)
-        if (pathname === '/index.html' || pathname === '/') {
-          reply.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-        } else {
-          reply.setHeader('Cache-Control', 'public, max-age=604800, immutable');
-        }
+        reply.setHeader('Cache-Control', dashboardCacheControl(dashboardRoot, pathname));
 
         // Defensive: ensure Content-Length is present and correct for static assets
         // Only set header when not already provided by the static plugin (avoid interfering with compression plugins).

--- a/src/services/auth/OIDCManager.ts
+++ b/src/services/auth/OIDCManager.ts
@@ -49,6 +49,7 @@ export interface DashboardIdentity {
   name?: string;
   tenantId: string;
   role: ApiKeyRole;
+  permissions?: ApiKeyPermission[];
   claims: Record<string, unknown>;
 }
 
@@ -415,7 +416,7 @@ export function getDashboardSessionAuthContext(session: DashboardSession): Dashb
     actor: keyId,
     tenantId: session.tenantId,
     role: session.role,
-    permissions: permissionsForRole(session.role),
+    permissions: session.permissions ? [...session.permissions] : permissionsForRole(session.role),
   };
 }
 


### PR DESCRIPTION
## Summary
- harden dashboard token login by upgrading API-token sign-in to an HttpOnly dashboard session cookie without storing tokens in Web Storage
- make cookie-backed dashboard requests work across reload/deep links, including `/v1/health`
- fix dashboard static cache headers, CSP font noise, onboarding/login overlap, and mobile drawer/touch-target regressions

## Validation
- `npm run gate`
- live dashboard smoke on `127.0.0.1:9123` with token login
- verified `/auth/session` returns authenticated token session and `/v1/health` returns full health payload with cookie auth
- verified localStorage/sessionStorage do not contain the API token
- verified reload/deep link `/dashboard/sessions` stays authenticated
- verified mobile drawer close button, Escape close, backdrop close, hidden closed controls, and 44x44 header touch targets
- verified hashed dashboard asset returns `Cache-Control: public, max-age=31536000, immutable`

Closes #2345
Closes #2346
Closes #2348
Closes #2350
Closes #2351
Closes #2352

Does not address #2347 (terminal streaming after UI-created sessions), which remains separate.