### PR TITLE
fix(dashboard): bundle fonts locally and suppress /auth/session 404 noise

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,6 +8,9 @@
       "name": "aegis-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/atkinson-hyperlegible": "^5.2.8",
+        "@fontsource/dm-sans": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@tanstack/react-virtual": "^3.13.24",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
@@ -15,6 +18,7 @@
         "dompurify": "^3.3.3",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.8.0",
+        "open-dyslexic": "^1.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2",
@@ -332,6 +336,33 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/atkinson-hyperlegible": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-5.2.8.tgz",
+      "integrity": "sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/dm-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-sans/-/dm-sans-5.2.8.tgz",
+      "integrity": "sha512-tlovG42m9ESG28WiHpLq3F5umAlm64rv0RkqTbYowRn70e9OlRr5a3yTJhrhrY+k5lftR/OFJjPzOLQzk8EfCA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2393,6 +2424,12 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/open-dyslexic": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/open-dyslexic/-/open-dyslexic-1.0.3.tgz",
+      "integrity": "sha512-pZ6LuLvnwT/T/HiDc6hGj2bTs+HimGrYHGQEaexQcou4E9euHhSmgJ6GvUOZQRSU+mYSvdu2M8RgiUcqqAAaCQ==",
+      "license": "SEE LICENSE IN README.md"
     },
     "node_modules/parse5": {
       "version": "8.0.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource/atkinson-hyperlegible": "^5.2.8",
+    "@fontsource/dm-sans": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@tanstack/react-virtual": "^3.13.24",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
@@ -22,6 +25,7 @@
     "dompurify": "^3.3.3",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.8.0",
+    "open-dyslexic": "^1.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2",

--- a/dashboard/src/__tests__/useAuthStore.test.ts
+++ b/dashboard/src/__tests__/useAuthStore.test.ts
@@ -259,3 +259,28 @@ describe('useAuthStore', () => {
     });
   });
 });
+
+    it('skips /auth/session probe when OIDC was previously determined unavailable (issue #2348)', async () => {
+      // First init: OIDC returns 404 → oidcAvailable = false
+      mockGetDashboardSession.mockResolvedValueOnce({ oidcAvailable: false, authenticated: false });
+      await useAuthStore.getState().init();
+      expect(useAuthStore.getState().oidcAvailable).toBe(false);
+      expect(mockGetDashboardSession).toHaveBeenCalledTimes(1);
+
+      // Reset the store to simulate a page reload / re-init
+      useAuthStore.setState({
+        token: null,
+        authMode: null,
+        identity: null,
+        isAuthenticated: false,
+        isVerifying: true,
+        lastVerifiedAt: null,
+        oidcAvailable: false, // previously determined
+      });
+
+      // Second init: should NOT probe /auth/session again
+      mockGetDashboardSession.mockClear();
+      await useAuthStore.getState().init();
+      expect(mockGetDashboardSession).not.toHaveBeenCalled();
+      expect(useAuthStore.getState().oidcAvailable).toBe(false);
+    });

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -4,53 +4,21 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* ================================================================
- * Variable fonts with font-display: swap and size-adjust for CLS prevention
+ * Self-hosted fonts via @fontsource (no CDN — CSP compliant)
+ * Issue #2348: replaced Google Fonts CDN + jsdelivr CDN references
  * ================================================================ */
+@import "@fontsource/dm-sans/latin.css";
+@import "@fontsource/jetbrains-mono/latin.css";
+@import "@fontsource/atkinson-hyperlegible/index.css";
 
-/* DM Sans variable (weight 100-1000) — body text */
-@font-face {
-  font-family: 'DM Sans';
-  font-style: normal;
-  font-weight: 100 1000;
-  font-display: swap;
-  size-adjust: 100%;
-  src: local('DM Sans Variable'),
-       local('DM Sans'),
-       url('https://fonts.gstatic.com/s/dmsans/v15/rP2Fp2ywxg089UriI5-g4vlH9VoD8Cmcqbu0-K6p.woff2') format('woff2-variations');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* JetBrains Mono variable (weight 100-800) — monospace */
-@font-face {
-  font-family: 'JetBrains Mono';
-  font-style: normal;
-  font-weight: 100 800;
-  font-display: swap;
-  size-adjust: 100%;
-  src: local('JetBrains Mono Variable'),
-       local('JetBrains Mono'),
-       url('https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbV2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxjPVmUsaaDhw.woff2') format('woff2-variations');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* Atkinson Hyperlegible — accessibility reading font */
-@font-face {
-  font-family: 'Atkinson Hyperlegible';
-  font-style: normal;
-  font-weight: 400 700;
-  font-display: swap;
-  src: local('Atkinson Hyperlegible'),
-       url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt23C1KxNDXMspQ1lPyU89-1h6ONRlW45GE5ZgpewSSbQ.woff2') format('woff2');
-}
-
-/* OpenDyslexic — dyslexia-friendly reading font */
+/* OpenDyslexic — dyslexia-friendly reading font (self-hosted via npm) */
 @font-face {
   font-family: 'OpenDyslexic';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
   src: local('OpenDyslexic'),
-       url('https://cdn.jsdelivr.net/npm/open-dyslexic@1.0.3/fonts/OpenDyslexic-Regular.woff') format('woff');
+       url('open-dyslexic/woff/OpenDyslexic-Regular.woff') format('woff');
 }
 
 @theme {

--- a/dashboard/src/store/useAuthStore.ts
+++ b/dashboard/src/store/useAuthStore.ts
@@ -162,15 +162,21 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     set({ isVerifying: true });
 
-    try {
-      const session = await getDashboardSession();
-      if (session.authenticated) {
-        setOidcAuthState(set, session.identity);
-        return;
+    // Skip /auth/session probe if OIDC was already determined unavailable
+    // to avoid repeated 404 noise in token-auth-only deployments (issue #2348).
+    if (get().oidcAvailable === false) {
+      // OIDC not available — proceed directly to token auth restoration.
+    } else {
+      try {
+        const session = await getDashboardSession();
+        if (session.authenticated) {
+          setOidcAuthState(set, session.identity);
+          return;
+        }
+        set({ oidcAvailable: session.oidcAvailable });
+      } catch {
+        set({ oidcAvailable: false });
       }
-      set({ oidcAvailable: session.oidcAvailable });
-    } catch {
-      set({ oidcAvailable: false });
     }
 
     const state = get();

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'open-dyslexic': path.resolve(__dirname, 'node_modules/open-dyslexic'),
+    },
+  },
   base: '/dashboard/',
   build: {
     sourcemap: 'hidden',


### PR DESCRIPTION
## Summary
Fixes #2348

### CSP font errors
- Replaced Google Fonts CDN `@font-face` declarations with self-hosted `@fontsource` packages:
  - `@fontsource/dm-sans` — body text
  - `@fontsource/jetbrains-mono` — monospace
  - `@fontsource/atkinson-hyperlegible` — accessibility reading font
- Bundled `OpenDyslexic` from local npm package instead of jsdelivr CDN
- Added Vite alias for `open-dyslexic` package resolution
- No more CSP violations for `font-src` — all fonts served from `'self'`

### /auth/session 404 noise
- Auth store now caches OIDC availability: when `oidcAvailable` is already `false`, subsequent `init()` calls skip the `/auth/session` probe entirely
- Eliminates repeated 404 requests in token-auth-only deployments

## Changes
- `dashboard/src/index.css` — replaced 4 CDN `@font-face` blocks with `@fontsource` imports
- `dashboard/src/store/useAuthStore.ts` — skip OIDC probe when already known unavailable
- `dashboard/vite.config.ts` — added `open-dyslexic` path alias
- `dashboard/package.json` — added `@fontsource/dm-sans`, `@fontsource/jetbrains-mono`, `@fontsource/atkinson-hyperlegible`, `open-dyslexic`

## Verification
- 795 tests pass (+1 new test for OIDC probe caching)
- `tsc --noEmit` clean
- `npm run build` clean — fonts bundled in `dist/assets/` as hashed woff2/woff files