### PR TITLE
fix(dashboard): defer onboarding tour until after authentication

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useDrawerStore } from './store/useDrawerStore';
 import { FirstRunTour, isTourCompleted } from './components/tour/FirstRunTour';
 import { OnboardingScreen } from './components/brand/OnboardingScreen';
+import { useAuthStore } from './store/useAuthStore';
 
 const AuditPage = lazy(() => import('./pages/AuditPage'));
 const MetricsPage = lazy(() => import('./pages/MetricsPage'));
@@ -57,15 +58,23 @@ export default function App() {
   const [showHelp, setShowHelp] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showTour, setShowTour] = useState(false);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
   useEffect(() => {
     const hasOnboarded = localStorage.getItem('aegis:onboarded');
     if (!hasOnboarded) {
       setShowOnboarding(true);
-    } else if (!isTourCompleted()) {
+    }
+    // Only show tour after authentication — prevent tour overlay from
+    // intercepting the login form (issue #2346).
+  }, []);
+
+  // Show tour only when authenticated and not yet completed
+  useEffect(() => {
+    if (isAuthenticated && !showOnboarding && !isTourCompleted() && !showTour) {
       setShowTour(true);
     }
-  }, []);
+  }, [isAuthenticated, showOnboarding, showTour]);
 
   useKeyboardShortcuts({
     onShortcut: (shortcut) => {


### PR DESCRIPTION
## Summary
Fixes #2346

The first-run onboarding tour was rendering on top of the login form, intercepting pointer events and blocking the Sign in button. Fresh users had to dismiss the tour before they could authenticate.

### Fix
- Tour now only activates after both:
  1. Onboarding screen is dismissed
  2. User is authenticated (`isAuthenticated === true`)
- Unauthenticated users see the login form without any tour overlay

## Changes
- `dashboard/src/App.tsx` — gated `showTour` on `isAuthenticated` state from auth store

## Verification
- 794 tests pass
- tsc clean