### PR TITLE
fix(dashboard): increase mobile touch targets to 44x44px minimum

### DIFF
--- a/dashboard/src/__tests__/touch-targets.test.ts
+++ b/dashboard/src/__tests__/touch-targets.test.ts
@@ -1,0 +1,68 @@
+/**
+ * touch-targets.test.ts — Verify minimum mobile touch target sizes.
+ * Issue #2350: Interactive controls should meet 44x44 CSS px minimum.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readSrc(relativePath: string): string {
+  return readFileSync(resolve(__dirname, '..', relativePath), 'utf-8');
+}
+
+describe('Mobile touch targets (issue #2350)', () => {
+  it('New Session button has min-h-[44px] and min-w-[44px]', () => {
+    const src = readSrc('components/Layout.tsx');
+    // Find the className near the New Session aria-label (within 5 lines)
+    const lines = src.split('\n');
+    let found = false;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes('aria-label="New Session')) {
+        // Search within 5 lines in both directions for className with min-h
+        for (let j = Math.max(0, i - 5); j <= Math.min(lines.length - 1, i + 5); j++) {
+          if (lines[j].includes('className="') && lines[j].includes('min-h-[44px]')) {
+            found = true;
+            break;
+          }
+        }
+      }
+      if (found) break;
+    }
+    expect(found).toBe(true);
+  });
+
+  it('Theme toggle button has min-h-[44px] and min-w-[44px]', () => {
+    const src = readSrc('components/Layout.tsx');
+    // The theme toggle className should have min-h-[44px]
+    expect(src).toMatch(/min-h-\[44px\].*min-w-\[44px\].*text-slate-500.*transition-colors.*hover:bg-slate-100/s);
+  });
+
+  it('Sign out button has min-h-[44px]', () => {
+    const src = readSrc('components/Layout.tsx');
+    expect(src).toMatch(/px-3 py-3 min-h-\[44px\].*text-sm font-medium/);
+  });
+
+  it('Login show/hide token button has min-h-[44px] and min-w-[44px]', () => {
+    const src = readSrc('pages/LoginPage.tsx');
+    expect(src).toContain('min-h-[44px]');
+    expect(src).toContain('min-w-[44px]');
+    // Verify it's on the eye/eyeoff button area
+    expect(src).toMatch(/flex items-center justify-center p-2 min-h-\[44px\] min-w-\[44px\]/);
+  });
+
+  it('Session search input has min-h-[44px]', () => {
+    const src = readSrc('components/overview/SessionTable.tsx');
+    expect(src).toMatch(/py-3 min-h-\[44px\].*text-sm text-gray-300/);
+  });
+
+  it('Session tab buttons have min-h-[44px]', () => {
+    const src = readSrc('pages/SessionsPage.tsx');
+    const matches = src.match(/py-3 min-h-\[44px\]/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -455,7 +455,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={handleLogout}
-            className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
+            className={`flex items-center gap-2.5 rounded-lg px-3 py-3 min-h-[44px] text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
             title={isCollapsed ? 'Sign out' : undefined}
           >
             <LogOut className="h-4 w-4 shrink-0" />
@@ -496,7 +496,7 @@ export default function Layout() {
                 onClick={openNewSession}
                 aria-label="New Session (⌘N)"
                 title="New Session (⌘N)"
-                className="inline-flex items-center justify-center rounded-lg p-1.5 text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors"
+                className="inline-flex items-center justify-center rounded-lg p-2.5 min-h-[44px] min-w-[44px] text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors"
               >
                 <Plus className="h-4 w-4" />
               </button>
@@ -517,7 +517,7 @@ export default function Layout() {
                 <button
                   type="button"
                   onClick={toggleTheme}
-                  className="rounded p-1 sm:p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-zinc-400 dark:hover:bg-void-lighter dark:hover:text-zinc-200"
+                  className="rounded p-2 sm:p-2.5 min-h-[44px] min-w-[44px] text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-zinc-400 dark:hover:bg-void-lighter dark:hover:text-zinc-200"
                   aria-label={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                   title={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                 >

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -817,7 +817,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
         <div className="flex flex-col gap-4 border-b border-white/5 bg-white/5 p-4 backdrop-blur-md xl:flex-row xl:items-start xl:justify-between">
           <div className="flex-1 space-y-3">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
-              <label className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-white/10 bg-[var(--color-void)] px-3 py-2 text-sm text-gray-300 focus-within:border-[var(--color-accent-cyan)] focus-within:ring-1 focus-within:ring-[var(--color-accent-cyan)]/30 transition-all shadow-inner">
+              <label className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-white/10 bg-[var(--color-void)] px-3 py-3 min-h-[44px] text-sm text-gray-300 focus-within:border-[var(--color-accent-cyan)] focus-within:ring-1 focus-within:ring-[var(--color-accent-cyan)]/30 transition-all shadow-inner">
                 <Search className="h-4 w-4 text-gray-500" />
                 <input
                   value={searchInput}

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -106,7 +106,7 @@ export default function LoginPage() {
               <button
                 type="button"
                 onClick={() => setShowToken(!showToken)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+                className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center p-2 min-h-[44px] min-w-[44px] text-gray-400 hover:text-gray-200"
                 aria-label={showToken ? 'Hide token' : 'Show token'}
               >
                 {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}

--- a/dashboard/src/pages/SessionsPage.tsx
+++ b/dashboard/src/pages/SessionsPage.tsx
@@ -53,7 +53,7 @@ export default function SessionsPage() {
           aria-selected={tab === 'active'}
           aria-controls="tab-panel-active"
           onClick={() => setTab('active')}
-          className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+          className={`px-4 py-3 min-h-[44px] text-sm font-medium transition-colors border-b-2 -mb-px ${
             tab === 'active'
               ? 'border-[var(--color-accent-cyan)] text-[var(--color-accent-cyan)]'
               : 'border-transparent text-gray-400 hover:text-gray-200 hover:border-gray-400'
@@ -67,7 +67,7 @@ export default function SessionsPage() {
           aria-selected={tab === 'all'}
           aria-controls="tab-panel-all"
           onClick={() => setTab('all')}
-          className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+          className={`px-4 py-3 min-h-[44px] text-sm font-medium transition-colors border-b-2 -mb-px ${
             tab === 'all'
               ? 'border-[var(--color-accent-cyan)] text-[var(--color-accent-cyan)]'
               : 'border-transparent text-gray-400 hover:text-gray-200 hover:border-gray-400'


### PR DESCRIPTION
## Summary
Fixes #2350

Six interactive controls were below the 44x44 CSS px mobile touch target guideline.

### Changes

| Control | Before | After |
|---------|--------|-------|
| New Session button | 28x28 (p-1.5) | min 44x44 (p-2.5) |
| Theme toggle | 24x24 (p-1) | min 44x44 (p-2) |
| Show/hide token | 16x16 (no padding) | min 44x44 (p-2) |
| Session search | ~19px height | min 44px (py-3) |
| Active/All tabs | ~26px height | min 44px (py-3) |
| Sign out button | ~35px height | min 44px (py-3) |

All controls now enforce `min-h-[44px]` and (where appropriate) `min-w-[44px]` via Tailwind utilities.

## Verification
- 800 tests pass (+6 new touch target assertion tests)
- tsc clean