### PR TITLE
fix(dashboard): add minHeight to ResponsiveContainer to prevent -1 dimension warnings

### DIFF
--- a/dashboard/src/components/shared/SparklineCard.tsx
+++ b/dashboard/src/components/shared/SparklineCard.tsx
@@ -35,7 +35,7 @@ export function SparklineCard({ label, value, data, color = 'var(--color-accent-
       
       {data.length > 0 && (
         <div className="h-12 w-full">
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minHeight={0}>
             <LineChart data={data}>
               <Tooltip content={<SparklineTooltip />} />
               <Line 

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -198,7 +198,7 @@ export default function AnalyticsPage() {
           {data.tokenUsageByModel.length > 0 ? (
             <div className="flex flex-col lg:flex-row items-center gap-4">
               <div className="w-full lg:w-1/2 h-[220px]">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minHeight={0}>
                   <PieChart>
                     <Pie
                       data={data.tokenUsageByModel.map((m) => ({

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -198,7 +198,7 @@ export default function CostPage() {
           Daily Spend (Last 14 Days)
         </h3>
         <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minHeight={0}>
             <BarChart data={dailyData}>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
               <XAxis
@@ -232,7 +232,7 @@ export default function CostPage() {
             Cost by Model
           </h3>
           <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" height="100%" minHeight={0}>
               <PieChart>
                 <Pie
                   data={modelData}

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -258,7 +258,7 @@ export default function MetricsPage() {
             Sessions &amp; Cost Over Time
           </h3>
           <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" height="100%" minHeight={0}>
               <BarChart data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
@@ -300,7 +300,7 @@ export default function MetricsPage() {
             Token Cost Trend
           </h3>
           <div className="h-48">
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" height="100%" minHeight={0}>
               <LineChart data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis


### PR DESCRIPTION
## Summary
Fixes #2367

Recharts `ResponsiveContainer` with `height='100%'` resolves to `-1` when the parent container is hidden, collapsed, or not yet measured during mount.

### Fix
Added `minHeight={0}` to all `ResponsiveContainer` instances using percentage height. This tells Recharts to use 0 as the minimum dimension instead of triggering the console warning.

### Files changed
- `MetricsPage.tsx` — 2 containers
- `CostPage.tsx` — 2 containers  
- `AnalyticsPage.tsx` — 1 container
- `SparklineCard.tsx` — 1 container

## Verification
- tsc clean
- build clean
- All chart-related tests pass