### PR TITLE
fix(dashboard): add aria-labels to all Settings page form controls

### DIFF
--- a/dashboard/src/__tests__/SettingsPage.test.tsx
+++ b/dashboard/src/__tests__/SettingsPage.test.tsx
@@ -174,4 +174,40 @@ describe('SettingsPage', () => {
 
     expect(values).toEqual(['10', '30', '60', '120', '300']);
   });
+
+  it('all form controls have accessible names (issue #2365)', () => {
+    const { container } = render(<SettingsPage />);
+
+    // Always-visible controls
+    expect(screen.getByLabelText('Default page size')).toBeDefined();
+    expect(screen.getByLabelText('Language and region')).toBeDefined();
+    expect(screen.getByRole('switch', { name: /Enable auto-refresh/ })).toBeDefined();
+    expect(screen.getByRole('switch', { name: /Enable budget alerts/ })).toBeDefined();
+
+    // Budget section — conditionally visible when budgetAlertEnabled is true (default)
+    const dailyInput = screen.queryByLabelText('Daily spending cap (USD)');
+    const monthlyInput = screen.queryByLabelText('Monthly spending cap (USD)');
+    const hardStop = screen.queryByLabelText('Hard stop at 100%');
+    const refreshSelect = screen.queryByLabelText('Refresh interval');
+
+    if (dailyInput) {
+      expect(dailyInput.getAttribute('type')).toBe('number');
+    }
+    if (monthlyInput) {
+      expect(monthlyInput.getAttribute('type')).toBe('number');
+    }
+    if (hardStop) {
+      expect(hardStop).toBeDefined();
+    }
+    if (refreshSelect) {
+      expect(refreshSelect).toBeDefined();
+    }
+
+    // Verify aria-label attributes exist in source
+    expect(container.innerHTML).toContain('aria-label="Default page size"');
+    expect(container.innerHTML).toContain('aria-label="Language and region"');
+    expect(container.innerHTML).toContain('aria-label="Daily spending cap (USD)"');
+    expect(container.innerHTML).toContain('aria-label="Monthly spending cap (USD)"');
+    expect(container.innerHTML).toContain('aria-label="Refresh interval"');
+  });
 });

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -163,6 +163,7 @@ export default function SettingsPage() {
               value={settings.defaultPageSize}
               onChange={(e) => update('defaultPageSize', Number(e.target.value))}
               className="rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+              aria-label="Default page size"
             >
               <option value={10}>10</option>
               <option value={25}>25</option>
@@ -205,6 +206,7 @@ export default function SettingsPage() {
               value={locale}
               onChange={(e) => setLocale(e.target.value)}
               className="rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+              aria-label="Language and region"
             >
               {LOCALES.map(({ value, label, flag }) => (
                 <option key={value} value={value}>
@@ -254,6 +256,7 @@ export default function SettingsPage() {
                 value={settings.refreshIntervalSec}
                 onChange={(e) => update('refreshIntervalSec', Number(e.target.value))}
                 className="rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+                aria-label="Refresh interval"
               >
                 <option value={10}>10 seconds</option>
                 <option value={30}>30 seconds</option>
@@ -311,6 +314,7 @@ export default function SettingsPage() {
                     value={settings.budgetDailyCapUsd}
                     onChange={(e) => update('budgetDailyCapUsd', Number(e.target.value))}
                     className="w-24 rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] font-mono"
+                    aria-label="Daily spending cap (USD)"
                   />
                 </div>
               </div>
@@ -329,6 +333,7 @@ export default function SettingsPage() {
                     value={settings.budgetMonthlyCapUsd}
                     onChange={(e) => update('budgetMonthlyCapUsd', Number(e.target.value))}
                     className="w-24 rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] font-mono"
+                    aria-label="Monthly spending cap (USD)"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Fixes #2365

Added `aria-label` attributes to all form controls on the Settings page that were missing accessible names, resolving axe-core critical violations.

### Controls fixed
| Control | aria-label added |
|---------|-----------------|
| Default page size select | `Default page size` |
| Language and region select | `Language and region` |
| Refresh interval select | `Refresh interval` |
| Daily spending cap input | `Daily spending cap (USD)` |
| Monthly spending cap input | `Monthly spending cap (USD)` |

### Already accessible (no changes needed)
- Auto theme checkbox — `aria-label='Auto theme'`
- Budget hard stop checkbox — `aria-label='Hard stop at 100%'`
- Auto-refresh toggle — `role='switch' aria-label='Enable auto-refresh'`
- Budget alerts toggle — `role='switch' aria-label='Enable budget alerts'`

## Verification
- 12 SettingsPage tests pass (+1 new a11y test)
- tsc clean