### PR TITLE
fix(dashboard): increase touch targets for session controls, tabs, and pagination

### DIFF
--- a/dashboard/src/__tests__/touch-targets.test.ts
+++ b/dashboard/src/__tests__/touch-targets.test.ts
@@ -66,3 +66,21 @@ describe('Mobile touch targets (issue #2350)', () => {
     expect(matches!.length).toBeGreaterThanOrEqual(2);
   });
 });
+
+  it('session table checkboxes have min-h-[44px] and min-w-[44px]', () => {
+    const src = readSrc('components/overview/SessionTable.tsx');
+    expect(src).toMatch(/min-h-\[44px\] min-w-\[44px\].*rounded border/);
+  });
+
+  it('session detail tabs have min-h-[44px]', () => {
+    const src = readSrc('pages/SessionDetailPage.tsx');
+    expect(src).toMatch(/min-h-\[44px\].*rounded-full.*px-4 py-2\.5/);
+  });
+
+  it('audit pagination buttons have min-h-[44px] and min-w-[44px]', () => {
+    const src = readSrc('pages/AuditPage.tsx');
+    expect(src).toContain('min-h-[44px]');
+    expect(src).toContain('min-w-[44px]');
+    expect(src).toContain('aria-label="Previous page"');
+    expect(src).toContain('aria-label="Next page"');
+  });

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -244,7 +244,7 @@ const SessionMobileCard = memo(function SessionMobileCard({
             aria-label={`Select session ${session.windowName || session.id}`}
             checked={selected}
             onChange={(e) => onToggleSelect(session.id, e.target.checked)}
-            className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+            className="h-5 w-5 min-h-[44px] min-w-[44px] rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
           />
           <div className="min-w-0">
             <div className="flex min-w-0 items-center gap-2">
@@ -339,7 +339,7 @@ export const SessionDesktopRow = memo(function SessionDesktopRow({
           aria-label={`Select session ${session.windowName || session.id}`}
           checked={selected}
           onChange={(e) => onToggleSelect(session.id, e.target.checked)}
-          className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+          className="h-5 w-5 min-h-[44px] min-w-[44px] rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
         />
       </td>
 
@@ -1019,7 +1019,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                   aria-label="Select all visible sessions"
                   checked={allVisibleSelected}
                   onChange={(e) => handleToggleSelectAll(e.target.checked)}
-                  className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+                  className="h-5 w-5 min-h-[44px] min-w-[44px] rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
                 />
                 Select visible
               </label>
@@ -1090,7 +1090,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                       aria-label="Select all visible sessions"
                       checked={allVisibleSelected}
                       onChange={(e) => handleToggleSelectAll(e.target.checked)}
-                      className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+                      className="h-5 w-5 min-h-[44px] min-w-[44px] rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
                     />
                   </th>
                   <th className="px-4 py-3 font-medium">Status</th>

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -907,7 +907,7 @@ export default function AuditPage() {
               <button
                 onClick={() => setPage((current) => Math.max(1, current - 1))}
                 disabled={page <= 1}
-                className="inline-flex items-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label="Previous page"
               >
                 <ChevronLeft className="h-3.5 w-3.5" />
@@ -915,7 +915,7 @@ export default function AuditPage() {
               <button
                 onClick={() => setPage((current) => current + 1)}
                 disabled={!hasMore || page >= totalPages}
-                className="inline-flex items-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label="Next page"
               >
                 <ChevronRight className="h-3.5 w-3.5" />

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -603,7 +603,7 @@ export default function SessionDetailPage() {
                 aria-selected={activeTab === tab.id}
                 aria-controls={`panel-${tab.id}`}
                 tabIndex={activeTab === tab.id ? 0 : -1}
-                className={`relative z-10 min-h-[36px] rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                className={`relative z-10 min-h-[44px] rounded-full px-4 py-2.5 text-sm font-medium transition-colors ${
                   activeTab === tab.id
                     ? 'text-[var(--color-void)] dark:text-[var(--color-text-primary)]'
                     : 'border border-[var(--color-void-lighter)] bg-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'


### PR DESCRIPTION
## Summary
Fixes #2366

Extended mobile touch target fixes beyond the initial #2350 batch:

| Control | Before | After |
|---------|--------|-------|
| Session checkboxes | 16x16 (h-4 w-4) | 20x20 visible + 44x44 min hit area |
| Session detail tabs | 36px min height | 44px min height |
| Audit prev/next buttons | ~32x24 | 44x44 min hit area |

## Verification
- 9 touch target tests pass (+3 new)
- tsc clean