### PR TITLE
fix(dashboard): resolve audit accessibility regressions

### DIFF
--- a/dashboard/e2e/a11y/pages.a11y.spec.ts
+++ b/dashboard/e2e/a11y/pages.a11y.spec.ts
@@ -5,7 +5,7 @@
  * Run: npm run a11y:check
  */
 import { test, expect } from '@playwright/test';
-import { injectAxe, checkA11y } from 'axe-playwright';
+import { injectAxe, getViolations } from 'axe-playwright';
 import { mockDashboardFixtures } from '../helpers/dashboard-fixtures';
 
 const BASE_URL = 'http://localhost:5200/dashboard';
@@ -20,36 +20,44 @@ test.beforeEach(async ({ page }) => {
 for (const theme of THEMES) {
   for (const route of ROUTES) {
     test(`[${theme}] ${route} has no axe violations`, async ({ page }) => {
+      test.setTimeout(60_000);
       // Navigate to the route — auth is already set up by beforeEach
       await page.goto(BASE_URL + route);
+      await expect(page.locator('main#main-content')).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator('main#main-content h1')).toBeVisible({ timeout: 15_000 });
       await page.waitForLoadState('networkidle');
 
       // Set theme after navigation
       await page.evaluate((t) => {
-        document.documentElement.setAttribute('data-theme', t === 'light' ? 'light' : '');
+        document.documentElement.setAttribute('data-theme', t);
+        document.documentElement.classList.toggle('dark', t === 'dark');
         localStorage.setItem('aegis-dashboard-theme', t);
       }, theme);
 
       // Inject axe-core explicitly (required for axe-playwright v2)
       await injectAxe(page);
 
-      // Run axe audit — disable known pre-existing issues tracked separately
-      await checkA11y(page, undefined, {
-        axeOptions: {
-          rules: {
-            // Dashboard uses h2 headings by design — tracked in dashboard-perfection epic
-            'page-has-heading-one': { enabled: false },
-            // Heading order issues from nested h2→h3 in sidebar — tracked separately
-            'heading-order': { enabled: false },
-            // Settings page form labels — tracked separately
-            'label': { enabled: false },
-            // Settings page select elements — tracked separately
-            'select-name': { enabled: false },
-            // Colour-contrast issues in dark-mode sidebar (muted tokens) — tracked separately
-            'color-contrast': { enabled: false },
-          },
+      // Run axe audit — disable known pre-existing heading-order noise while
+      // enforcing the route-level rules fixed by the dashboard audit patch.
+      const violations = await getViolations(page, undefined, {
+        rules: {
+          // Heading order issues from nested h2→h3 in sidebar — tracked separately
+          'heading-order': { enabled: false },
+          // Axe miscomputes contrast over glass/backdrop surfaces; token gates
+          // and targeted CSS shims cover the concrete contrast regressions.
+          'color-contrast': { enabled: false },
         },
       });
+      const summary = violations.map((violation) => ({
+        id: violation.id,
+        impact: violation.impact,
+        nodes: violation.nodes.map((node) => ({
+          target: node.target,
+          html: node.html,
+          failureSummary: node.failureSummary,
+        })),
+      }));
+      expect(summary).toEqual([]);
 
       // Also assert the page rendered something meaningful
       const body = await page.locator('body').innerText();

--- a/dashboard/e2e/session-list.spec.ts
+++ b/dashboard/e2e/session-list.spec.ts
@@ -96,7 +96,7 @@ test.describe('Session History Page', () => {
   });
 
   test('row size selector is visible', async ({ page }) => {
-    await expect(page.getByLabel(/rows/i)).toBeVisible();
+    await expect(page.locator('#history-page-size')).toBeVisible();
   });
 
   test('select all checkbox visible in table header', async ({ page }) => {

--- a/dashboard/src/__tests__/RateLimitForecastCard.test.tsx
+++ b/dashboard/src/__tests__/RateLimitForecastCard.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { RateLimitForecastCard } from '../components/analytics/RateLimitForecastCard';
 import type { RateLimitForecast } from '../types';
 
@@ -24,9 +24,14 @@ describe('<RateLimitForecastCard>', () => {
       bottleneck: null,
     };
     render(<RateLimitForecastCard forecast={forecast} />);
-    expect(screen.getByText('50')).toBeTruthy();
-    const indicators = screen.getAllByLabelText(/indicator/i);
-    expect(indicators.length).toBeGreaterThanOrEqual(1);
+    const card = screen.getByRole('region', { name: /rate-limit forecast/i });
+    expect(within(card).getByText('Estimated Sessions Remaining')).toBeTruthy();
+    expect(within(card).getByText('50')).toBeTruthy();
+    expect(within(card).getByText('No bottleneck detected')).toBeTruthy();
+
+    const indicators = card.querySelectorAll('div[aria-hidden="true"]');
+    expect(indicators).toHaveLength(2);
+    expect(indicators[0]?.getAttribute('style')).toContain('var(--color-success)');
   });
 
   it('renders amber severity when remaining is 1-10', () => {

--- a/dashboard/src/__tests__/a11y-pages.test.tsx
+++ b/dashboard/src/__tests__/a11y-pages.test.tsx
@@ -18,6 +18,7 @@ import MetricsPage from '../pages/MetricsPage';
 import CostPage from '../pages/CostPage';
 import AnalyticsPage from '../pages/AnalyticsPage';
 import PipelineDetailPage from '../pages/PipelineDetailPage';
+import Layout from '../components/Layout';
 
 // ── Shared Mocks ──────────────────────────────────────────────
 
@@ -35,6 +36,26 @@ vi.mock('../components/overview/SessionTable', () => ({
 
 vi.mock('../components/shared/LiveStatusIndicator', () => ({
   default: () => <span data-testid="live-status">Live</span>,
+}));
+
+vi.mock('../components/shared/LiveAuditStream', () => ({
+  default: () => <div data-testid="audit-stream">AuditStream</div>,
+}));
+
+vi.mock('../components/shared/CommandPalette', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/NewSessionDrawer', () => ({
+  NewSessionDrawer: () => null,
+}));
+
+vi.mock('../components/ConnectionBanner', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/ToastContainer', () => ({
+  default: () => null,
 }));
 
 vi.mock('../components/CreateSessionModal', () => ({
@@ -165,7 +186,14 @@ vi.mock('../store/useAuthStore.js', () => ({
 
 vi.mock('../store/useSidebarStore.js', () => ({
   useSidebarStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ isCollapsed: false, isMobileOpen: false, toggle: vi.fn(), toggleMobile: vi.fn() }),
+    selector({
+      isCollapsed: false,
+      isMobileOpen: false,
+      toggle: vi.fn(),
+      toggleMobile: vi.fn(),
+      setMobileOpen: vi.fn(),
+      closeMobile: vi.fn(),
+    }),
 }));
 
 vi.mock('../store/useDrawerStore', () => ({
@@ -183,6 +211,40 @@ function renderWithRouter(ui: React.ReactElement): ReturnType<typeof render> {
   return render(<MemoryRouter><I18nProvider>{ui}</I18nProvider></MemoryRouter>);
 }
 
+function renderWithLayout(
+  initialEntry: string,
+  routePath: string,
+  ui: React.ReactElement,
+): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <I18nProvider>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path={routePath} element={ui} />
+          </Route>
+        </Routes>
+      </I18nProvider>
+    </MemoryRouter>,
+  );
+}
+
+const layoutLandmarkCases: {
+  name: string;
+  initialEntry: string;
+  routePath: string;
+  element: React.ReactElement;
+  headingName: string;
+}[] = [
+  { name: 'OverviewPage', initialEntry: '/', routePath: '/', element: <OverviewPage />, headingName: 'Overview' },
+  { name: 'ActivityPage', initialEntry: '/activity', routePath: '/activity', element: <ActivityPage />, headingName: 'Live Activity' },
+  { name: 'PipelinesPage', initialEntry: '/pipelines', routePath: '/pipelines', element: <PipelinesPage />, headingName: 'Pipelines' },
+  { name: 'TemplatesPage', initialEntry: '/templates', routePath: '/templates', element: <TemplatesPage />, headingName: 'Templates' },
+  { name: 'MetricsPage', initialEntry: '/metrics', routePath: '/metrics', element: <MetricsPage />, headingName: 'Metrics' },
+  { name: 'CostPage', initialEntry: '/cost', routePath: '/cost', element: <CostPage />, headingName: 'Cost & Billing' },
+  { name: 'AnalyticsPage', initialEntry: '/analytics', routePath: '/analytics', element: <AnalyticsPage />, headingName: 'Analytics' },
+];
+
 // ── Tests ─────────────────────────────────────────────────────
 
 describe('a11y: page landmarks and ARIA', () => {
@@ -190,12 +252,27 @@ describe('a11y: page landmarks and ARIA', () => {
     vi.clearAllMocks();
   });
 
+  it.each(layoutLandmarkCases)(
+    '$name renders inside exactly one Layout main landmark without nested main roles',
+    async ({ initialEntry, routePath, element, headingName }) => {
+      renderWithLayout(initialEntry, routePath, element);
+
+      const pageHeading = await screen.findByRole('heading', { level: 1, name: headingName });
+      const mainLandmarks = screen.getAllByRole('main');
+
+      expect(mainLandmarks).toHaveLength(1);
+      expect(mainLandmarks[0].tagName).toBe('MAIN');
+      expect(mainLandmarks[0].getAttribute('id')).toBe('main-content');
+      expect(mainLandmarks[0].querySelector('main, [role="main"]')).toBeNull();
+      expect(mainLandmarks[0].contains(pageHeading)).toBe(true);
+    },
+  );
+
   describe('OverviewPage', () => {
-    it('has role="main" with aria-label on the page container', async () => {
+    it('renders a page-level h1', async () => {
       renderWithRouter(<OverviewPage />);
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Overview"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Overview' })).toBeDefined();
       });
     });
 
@@ -208,11 +285,10 @@ describe('a11y: page landmarks and ARIA', () => {
   });
 
   describe('ActivityPage', () => {
-    it('has role="main" with aria-label', async () => {
+    it('renders a page-level h1', async () => {
       renderWithRouter(<ActivityPage />);
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Live Activity"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Live Activity' })).toBeDefined();
       });
     });
   });
@@ -233,11 +309,10 @@ describe('a11y: page landmarks and ARIA', () => {
   });
 
   describe('PipelinesPage', () => {
-    it('has role="main" with aria-label after loading', async () => {
+    it('renders a page-level h1 after loading', async () => {
       renderWithRouter(<PipelinesPage />);
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Pipelines"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Pipelines' })).toBeDefined();
       });
     });
 
@@ -274,11 +349,10 @@ describe('a11y: page landmarks and ARIA', () => {
   });
 
   describe('TemplatesPage', () => {
-    it('has role="main" with aria-label after loading', async () => {
+    it('renders a page-level h1 after loading', async () => {
       renderWithRouter(<TemplatesPage />);
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Templates"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Templates' })).toBeDefined();
       });
     });
 
@@ -300,11 +374,10 @@ describe('a11y: page landmarks and ARIA', () => {
   });
 
   describe('MetricsPage', () => {
-    it('has role="main" with aria-label', async () => {
+    it('renders a page-level h1', async () => {
       renderWithRouter(<MetricsPage />);
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Metrics"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Metrics' })).toBeDefined();
       });
     });
 
@@ -313,8 +386,7 @@ describe('a11y: page landmarks and ARIA', () => {
       await waitFor(() => {
         
         // Table may not render if no data, so we just check the page loaded
-        const main = document.querySelector('[role="main"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Metrics' })).toBeDefined();
       });
     });
 
@@ -330,11 +402,10 @@ describe('a11y: page landmarks and ARIA', () => {
   });
 
   describe('CostPage', () => {
-    it('has role="main" with aria-label', async () => {
+    it('renders a page-level h1', async () => {
       renderWithRouter(<CostPage />);
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Cost and Billing"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Cost & Billing' })).toBeDefined();
       });
     });
 
@@ -348,11 +419,10 @@ describe('a11y: page landmarks and ARIA', () => {
   });
 
   describe('AnalyticsPage', () => {
-    it('has role="main" with aria-label after loading', async () => {
+    it('renders a page-level h1 after loading', async () => {
       renderWithRouter(<AnalyticsPage />);
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Analytics"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1, name: 'Analytics' })).toBeDefined();
       });
     });
 
@@ -394,7 +464,7 @@ describe('a11y: page landmarks and ARIA', () => {
       }, { timeout: 3000 });
     });
 
-    it('has role="main" with aria-label after loading', async () => {
+    it('renders a page-level h1 after loading', async () => {
       render(
         <MemoryRouter initialEntries={['/pipelines/test-pipeline-id']}>
           <Routes>
@@ -403,8 +473,7 @@ describe('a11y: page landmarks and ARIA', () => {
         </MemoryRouter>,
       );
       await waitFor(() => {
-        const main = document.querySelector('[role="main"][aria-label="Pipeline Detail"]');
-        expect(main).not.toBeNull();
+        expect(screen.getByRole('heading', { level: 1 })).toBeDefined();
       }, { timeout: 3000 });
     });
   });

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -398,6 +398,7 @@ export default function Layout() {
 
       {/* ── Sidebar ─────────────────────────────────────────── */}
       <aside
+        aria-label="Primary sidebar"
         className={`
           fixed inset-y-0 left-0 z-40 flex flex-col border-r border-white/5 bg-transparent backdrop-blur-xl
           transition-all duration-300 ease-in-out
@@ -492,7 +493,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={toggleSidebar}
-            className="hidden md:flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full"
+            className="hidden min-h-[44px] md:flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-void-lighter dark:hover:text-gray-200 transition-colors w-full"
             aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
@@ -561,11 +562,11 @@ export default function Layout() {
               <button
                 type="button"
                 onClick={() => setPaletteOpen(true)}
-                className="hidden sm:inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-500 hover:bg-slate-50 hover:text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-300 transition-all"
+                className="hidden min-h-[44px] sm:inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-slate-50 hover:text-[var(--color-text-primary)] dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10 transition-all"
               >
                 <Search className="h-3 w-3" />
                 <span>Search…</span>
-                <kbd className="ml-1 font-mono text-[10px] text-slate-600 border border-white/10 rounded px-1">⌘K</kbd>
+                <kbd className="ml-1 font-mono text-[10px] text-[var(--color-text-primary)] border border-white/10 rounded px-1">⌘K</kbd>
               </button>
 
               {/* Version + theme toggle */}
@@ -587,7 +588,7 @@ export default function Layout() {
                 type="button"
                 onClick={handleCheckUpdates}
                 disabled={updateCheckLoading || aegisVersion === '...'}
-                className="hidden sm:inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-100 dark:border-void-lighter dark:text-gray-300 dark:hover:bg-void-lighter disabled:cursor-not-allowed disabled:opacity-50"
+                className="hidden min-h-[44px] sm:inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-xs text-[var(--color-text-primary)] hover:bg-slate-100 dark:border-void-lighter dark:hover:bg-void-lighter disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RefreshCw className={`h-3 w-3 ${updateCheckLoading ? 'animate-spin' : ''}`} />
                 {updateCheckLoading ? 'Checking…' : 'Check updates'}
@@ -661,9 +662,9 @@ export default function Layout() {
           <button
             type="button"
             onClick={() => setPaletteOpen(true)}
-            className="hidden md:flex items-center gap-1.5 text-[11px] text-slate-600 hover:text-slate-400 transition-colors"
+             className="hidden min-h-[44px] md:flex items-center gap-1.5 text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <kbd className="font-mono text-[10px] border border-white/10 bg-white/5 rounded px-1">⌘K</kbd>
+            <kbd className="font-mono text-[10px] border border-white/10 bg-white/5 rounded px-1 text-[var(--color-text-primary)]">⌘K</kbd>
             Command palette
           </button>
 

--- a/dashboard/src/components/analytics/RateLimitChart.tsx
+++ b/dashboard/src/components/analytics/RateLimitChart.tsx
@@ -153,7 +153,7 @@ export function RateLimitChart({ perKey }: RateLimitChartProps) {
       </div>
 
       {/* Bar chart — shows max session ratio as the primary bar */}
-      <ResponsiveContainer width="100%" height={Math.max(200, data.length * 60)}>
+      <ResponsiveContainer width="100%" height={Math.max(200, data.length * 60)} minWidth={1} minHeight={1}>
         <BarChart
           data={data}
           layout="vertical"

--- a/dashboard/src/components/analytics/RateLimitForecastCard.tsx
+++ b/dashboard/src/components/analytics/RateLimitForecastCard.tsx
@@ -61,7 +61,7 @@ export function RateLimitForecastCard({ forecast }: RateLimitForecastCardProps) 
           <div
             className="h-3 w-3 rounded-full"
             style={{ backgroundColor: color }}
-            aria-label={`${severity} indicator`}
+            aria-hidden="true"
           />
           <div>
             <div className="text-xs text-[var(--color-text-muted)]">Estimated Sessions Remaining</div>
@@ -76,7 +76,7 @@ export function RateLimitForecastCard({ forecast }: RateLimitForecastCardProps) 
           <div
             className="h-3 w-3 rounded-full"
             style={{ backgroundColor: bottleneck ? SEVERITY_COLORS.amber : SEVERITY_COLORS.green }}
-            aria-label={bottleneck ? 'Bottleneck detected' : 'No bottleneck'}
+            aria-hidden="true"
           />
           <div>
             <div className="text-xs text-[var(--color-text-muted)]">Bottleneck</div>

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -251,7 +251,7 @@ const SessionMobileCard = memo(function SessionMobileCard({
               <StatusDot status={session.status} health={health} />
               <Link
                 to={`/sessions/${encodeURIComponent(session.id)}`}
-                className="truncate font-medium text-gray-200 transition-colors hover:text-cyan"
+                className="inline-flex min-h-[44px] items-center truncate font-medium text-gray-200 transition-colors hover:text-cyan"
               >
                 {session.windowName || session.id}
               </Link>
@@ -826,7 +826,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                     setPage(1);
                   }}
                   placeholder="Search by session name or work directory"
-                   className="min-h-8 w-full bg-transparent text-sm text-gray-100 outline-none placeholder:text-gray-500"
+                   className="min-h-[44px] w-full bg-transparent text-sm text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-muted)]"
                   aria-label="Search sessions"
                 />
               </label>
@@ -877,7 +877,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                       setStatusFilter(status);
                       setPage(1);
                     }}
-                    className={`min-h-[36px] rounded-full border px-3 py-1.5 text-xs transition-colors ${isActive
+                    className={`min-h-[44px] rounded-full border px-3 py-1.5 text-xs transition-colors ${isActive
                       ? 'border-cyan bg-cyan/10 text-cyan'
                       : 'border-void-lighter bg-void text-gray-400 hover:border-cyan/40 hover:text-gray-200'}`}
                   >
@@ -926,7 +926,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                 onClick={() => runBulkAction('interrupt')}
                 disabled={bulkAction !== null}
                 aria-label={`Interrupt ${selectedIds.length} selected session${selectedIds.length === 1 ? '' : 's'}`}
-                className="rounded-md bg-yellow-900/30 px-3 py-2 text-sm font-medium text-yellow-300 transition-colors hover:bg-yellow-900/50 disabled:pointer-events-none disabled:opacity-40"
+                className="min-h-[44px] rounded-md bg-yellow-900/30 px-3 py-2 text-sm font-medium text-yellow-300 transition-colors hover:bg-yellow-900/50 disabled:pointer-events-none disabled:opacity-40"
               >
                 Interrupt Selected
               </button>
@@ -935,7 +935,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                 onClick={() => runBulkAction('kill')}
                 disabled={bulkAction !== null}
                 aria-label={`Kill ${selectedIds.length} selected session${selectedIds.length === 1 ? '' : 's'}`}
-                className="rounded-md bg-red-900/30 px-3 py-2 text-sm font-medium text-red-300 transition-colors hover:bg-red-900/50 disabled:pointer-events-none disabled:opacity-40"
+                className="min-h-[44px] rounded-md bg-red-900/30 px-3 py-2 text-sm font-medium text-red-300 transition-colors hover:bg-red-900/50 disabled:pointer-events-none disabled:opacity-40"
               >
                 Kill Selected
               </button>
@@ -944,7 +944,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                 onClick={() => setSelectedIds([])}
                 disabled={bulkAction !== null}
                 aria-label="Clear selection"
-                className="rounded-md border border-void-lighter px-3 py-2 text-sm text-gray-400 transition-colors hover:border-gray-500 hover:text-gray-200 disabled:pointer-events-none disabled:opacity-40"
+                className="min-h-[44px] rounded-md border border-void-lighter px-3 py-2 text-sm text-gray-400 transition-colors hover:border-gray-500 hover:text-gray-200 disabled:pointer-events-none disabled:opacity-40"
               >
                 Clear
               </button>
@@ -1033,7 +1033,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                     <Fragment key={`group-${dirKey}`}>
                       <button
                         type="button"
-                        className="flex items-center gap-2 w-full rounded-md border border-void-lighter bg-[var(--color-void)] px-4 py-2 text-sm text-slate-400 transition-colors hover:border-cyan/40 hover:text-slate-300"
+                        className="flex min-h-[44px] items-center gap-2 w-full rounded-md border border-void-lighter bg-[var(--color-void)] px-4 py-2 text-sm text-slate-400 transition-colors hover:border-cyan/40 hover:text-slate-300"
                         onClick={() => toggleGroup(dirKey)}
                         aria-expanded={!isCollapsed}
                       >
@@ -1080,10 +1080,10 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
             }
           </div>
 
-          <div className="hidden overflow-x-auto rounded-lg border border-void-lighter bg-[var(--color-surface)] md:block">
+          <div className="hidden overflow-x-auto rounded-lg border border-void-lighter bg-[var(--color-surface)] md:block" tabIndex={0} aria-label="Sessions table scroll region">
             <table className="w-full text-left text-sm" aria-label="Sessions table">
               <thead>
-                <tr className="border-b border-void-lighter text-[#666]">
+                <tr className="border-b border-void-lighter text-[var(--color-text-muted)]">
                   <th className="px-4 py-3 font-medium">
                     <input
                       type="checkbox"
@@ -1135,7 +1135,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                   onClick={() => setPage((current) => Math.max(1, current - 1))}
                   disabled={pagination.page <= 1}
                   aria-label="Go to previous page"
-                  className="flex items-center gap-1 rounded-md border border-void-lighter px-3 py-2 transition-colors hover:border-gray-500 hover:text-gray-200 disabled:pointer-events-none disabled:opacity-40"
+                  className="flex min-h-[44px] items-center gap-1 rounded-md border border-void-lighter px-3 py-2 transition-colors hover:border-gray-500 hover:text-gray-200 disabled:pointer-events-none disabled:opacity-40"
                 >
                   <ChevronLeft className="h-4 w-4" /> Previous
                 </button>
@@ -1144,7 +1144,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                   onClick={() => setPage((current) => Math.min(pagination.totalPages, current + 1))}
                   disabled={pagination.page >= pagination.totalPages}
                   aria-label="Go to next page"
-                  className="flex items-center gap-1 rounded-md border border-void-lighter px-3 py-2 transition-colors hover:border-gray-500 hover:text-gray-200 disabled:pointer-events-none disabled:opacity-40"
+                  className="flex min-h-[44px] items-center gap-1 rounded-md border border-void-lighter px-3 py-2 transition-colors hover:border-gray-500 hover:text-gray-200 disabled:pointer-events-none disabled:opacity-40"
                 >
                   Next <ChevronRight className="h-4 w-4" />
                 </button>

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -56,7 +56,7 @@ export interface VirtualizedSessionListProps {
 // ── Constants ───────────────────────────────────────────────
 
 const ROW_HEIGHT = 52;
-const GROUP_ROW_HEIGHT = 40;
+const GROUP_ROW_HEIGHT = 44;
 const DEFAULT_MAX_VISIBLE_ROWS = 12;
 const OVERSCAN_COUNT = 5;
 
@@ -87,7 +87,7 @@ function VirtualizedRow(props: {
   index: number;
   style: CSSProperties;
 } & SessionRowExtraProps): ReactElement {
-  const { index, style, items, onToggleSelect, onInterrupt, onKill, onToggleGroup } = props;
+  const { ariaAttributes, index, style, items, onToggleSelect, onInterrupt, onKill, onToggleGroup } = props;
   const item = items[index];
 
   if (item.type === 'group') {
@@ -95,20 +95,23 @@ function VirtualizedRow(props: {
     return (
       <div
         style={style}
-        className="flex items-center gap-2 px-4 border-b border-white/5 bg-white/[0.02] text-sm text-gray-400 cursor-pointer hover:bg-white/5"
-        onClick={() => onToggleGroup(dirKey)}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onToggleGroup(dirKey); }}
-        role="button"
-        tabIndex={0}
-        aria-expanded={!isCollapsed}
-        aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${dirKey} group, ${count} sessions`}
+        className="border-b border-white/5 bg-white/[0.02]"
+        {...ariaAttributes}
       >
-        {isCollapsed
-          ? <ChevronRight className="h-3.5 w-3.5 text-gray-500" />
-          : <ChevronDown className="h-3.5 w-3.5 text-gray-500" />}
-        <FolderOpen className="h-3.5 w-3.5 text-gray-500" />
-        <span className="font-mono text-xs">{dirKey}</span>
-        <span className="text-gray-600">({count})</span>
+        <button
+          type="button"
+          className="flex h-full min-h-[44px] w-full items-center gap-2 px-4 text-left text-sm text-gray-400 transition-colors hover:bg-white/5"
+          onClick={() => onToggleGroup(dirKey)}
+          aria-expanded={!isCollapsed}
+          aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${dirKey} group, ${count} sessions`}
+        >
+          {isCollapsed
+            ? <ChevronRight className="h-3.5 w-3.5 text-gray-500" />
+            : <ChevronDown className="h-3.5 w-3.5 text-gray-500" />}
+          <FolderOpen className="h-3.5 w-3.5 text-gray-500" />
+          <span className="font-mono text-xs">{dirKey}</span>
+          <span className="text-gray-600">({count})</span>
+        </button>
       </div>
     );
   }
@@ -125,6 +128,7 @@ function VirtualizedRow(props: {
           : 'hover:bg-white/5 hover:scale-[1.002] cursor-pointer'
       }`}
       data-session-id={session.id}
+      {...ariaAttributes}
     >
       <div className="flex items-center px-3">
         <input
@@ -147,7 +151,7 @@ function VirtualizedRow(props: {
       <div className="flex items-center px-3">
         <Link
           to={`/sessions/${encodeURIComponent(session.id)}`}
-          className="font-medium text-gray-200 transition-colors hover:text-cyan"
+          className="inline-flex min-h-[44px] items-center font-medium text-gray-200 transition-colors hover:text-cyan"
         >
           {session.windowName || session.id}
         </Link>
@@ -187,7 +191,7 @@ function VirtualizedRow(props: {
           type="button"
           onClick={(e) => onInterrupt(e, session.id)}
           aria-label={`Interrupt session ${session.windowName || session.id}`}
-          className="p-1 rounded text-gray-500 hover:text-yellow-400 hover:bg-yellow-400/10 transition-colors"
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-gray-500 hover:text-yellow-400 hover:bg-yellow-400/10 transition-colors"
           title="Interrupt"
         >
           <Ban className="h-3.5 w-3.5" />
@@ -196,7 +200,7 @@ function VirtualizedRow(props: {
           type="button"
           onClick={(e) => onKill(e, session.id)}
           aria-label={`Kill session ${session.windowName || session.id}`}
-          className="p-1 rounded text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors"
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors"
           title="Kill"
         >
           <XCircle className="h-3.5 w-3.5" />

--- a/dashboard/src/components/shared/LiveAuditStream.tsx
+++ b/dashboard/src/components/shared/LiveAuditStream.tsx
@@ -68,7 +68,7 @@ export default function LiveAuditStream() {
   const events = useMemo(() => activities.slice(0, maxEvents), [activities]);
 
   return (
-    <aside className="hidden xl:flex w-[var(--side-rail-width)] shrink-0 flex-col border-l border-white/5 bg-transparent backdrop-blur-md overflow-hidden">
+    <aside aria-label="Live audit stream" className="hidden xl:flex w-[var(--side-rail-width)] shrink-0 flex-col border-l border-white/5 bg-transparent backdrop-blur-md overflow-hidden">
       {/* Header */}
       <div className="shrink-0 border-b border-white/5 px-4 py-3 flex items-center gap-2">
         <Activity className="h-4 w-4 text-[var(--color-accent-cyan)]" />

--- a/dashboard/src/components/shared/SparklineCard.tsx
+++ b/dashboard/src/components/shared/SparklineCard.tsx
@@ -34,8 +34,8 @@ export function SparklineCard({ label, value, data, color = 'var(--color-accent-
       <div className="mb-3 text-2xl font-bold font-mono text-[var(--color-text-primary)]">{value}</div>
       
       {data.length > 0 && (
-        <div className="h-12 w-full">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-12 w-full min-w-0">
+          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <LineChart data={data}>
               <Tooltip content={<SparklineTooltip />} />
               <Line 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -169,6 +169,10 @@
 
   /* Accent: blue-600 ≥ 4.5:1 on #f8fafc (AA normal + large). */
   --color-accent-on-light: #2563eb;
+  --color-accent-cyan: #0e7490; /* cyan-700 on white ≈ 5.0:1 */
+  --color-success: #047857;     /* emerald-700 on white ≈ 6.3:1 */
+  --color-warning: #b45309;     /* amber-700 on white ≈ 4.9:1 */
+  --color-danger: #dc2626;      /* red-600 on white ≈ 4.8:1 */
 
   /* Primary CTA: emerald-600 on white ≈ 4.6:1 (AA normal). */
   --color-cta-bg: #059669;
@@ -199,6 +203,10 @@
 
   --color-brand: #0a0a0a;
   --color-accent-on-light: #1d4ed8; /* blue-700 for saturation shift */
+  --color-accent-cyan: #0e7490;
+  --color-success: #047857;
+  --color-warning: #a16207;
+  --color-danger: #b91c1c;
 
   --color-cta-bg: #059669;
   --color-cta-text: #ffffff;
@@ -227,6 +235,10 @@
 
   --color-brand: #000000;
   --color-accent-on-light: #1d4ed8; /* blue-700 on white ≈ 7.9:1 (AAA) */
+  --color-accent-cyan: #155e75;
+  --color-success: #065f46;
+  --color-warning: #854d0e;
+  --color-danger: #991b1b;
 
   --color-cta-bg: #047857;         /* emerald-700 on white ≈ 6.3:1 */
   --color-cta-text: #ffffff;
@@ -362,7 +374,7 @@ body::before {
 
 /* --- Cyber-Noir Glassmorphism 2.0 Elements --- */
 .card-glass {
-  background: rgba(15, 23, 42, 0.45);
+  background: var(--color-surface-strong);
   backdrop-filter: blur(24px) saturate(190%);
   -webkit-backdrop-filter: blur(24px) saturate(190%);
   border: 1px solid rgba(255, 255, 255, 0.05);
@@ -471,6 +483,34 @@ body::before {
 }
 
 /* ------------------------------------------------------------------
+ * Dark-mode readability shim for legacy utility classes.
+ * Several dashboard surfaces use tokenized dark backgrounds without the
+ * `.dark` class active, so plain gray/slate utilities need dark-safe ink.
+ * ------------------------------------------------------------------ */
+.text-gray-400,
+.text-slate-400,
+.text-zinc-400,
+.text-gray-500,
+.text-slate-500,
+.text-zinc-500,
+.text-gray-600,
+.text-slate-600,
+.text-zinc-600 {
+  color: var(--color-text-muted) !important;
+}
+.text-gray-300,
+.text-slate-300,
+.text-zinc-300,
+.text-gray-200,
+.text-slate-200,
+.text-zinc-200,
+.text-gray-100,
+.text-slate-100,
+.text-zinc-100 {
+  color: var(--color-text-primary) !important;
+}
+
+/* ------------------------------------------------------------------
  * Light-mode readability shim for issue #002.
  *
  * A large number of components use Tailwind's default `text-gray-400`,
@@ -513,6 +553,36 @@ body::before {
 [data-theme="light-aaa"] .text-slate-600,
 [data-theme="light-aaa"] .text-zinc-600 {
   color: var(--color-text-muted) !important;
+}
+[data-theme="light"] .text-cyan,
+[data-theme="light"] .text-cyan-300,
+[data-theme="light"] .text-cyan-400,
+[data-theme="light-paper"] .text-cyan,
+[data-theme="light-paper"] .text-cyan-300,
+[data-theme="light-paper"] .text-cyan-400,
+[data-theme="light-aaa"] .text-cyan,
+[data-theme="light-aaa"] .text-cyan-300,
+[data-theme="light-aaa"] .text-cyan-400 {
+  color: var(--color-accent-cyan) !important;
+}
+[data-theme="light"] .text-emerald-300,
+[data-theme="light"] .text-emerald-400,
+[data-theme="light"] .text-green-400,
+[data-theme="light-paper"] .text-emerald-300,
+[data-theme="light-paper"] .text-emerald-400,
+[data-theme="light-paper"] .text-green-400,
+[data-theme="light-aaa"] .text-emerald-300,
+[data-theme="light-aaa"] .text-emerald-400,
+[data-theme="light-aaa"] .text-green-400 {
+  color: var(--color-success) !important;
+}
+[data-theme="light"] .text-amber-300,
+[data-theme="light"] .text-amber-400,
+[data-theme="light-paper"] .text-amber-300,
+[data-theme="light-paper"] .text-amber-400,
+[data-theme="light-aaa"] .text-amber-300,
+[data-theme="light-aaa"] .text-amber-400 {
+  color: var(--color-warning) !important;
 }
 /* Brand-wordmark utility — replaces the dark-only gradient in Layout.tsx
  * with a solid ink color that remains crisp under each sub-theme. */

--- a/dashboard/src/pages/ActivityPage.tsx
+++ b/dashboard/src/pages/ActivityPage.tsx
@@ -10,11 +10,11 @@ import { useT } from '../i18n/context';
 export default function ActivityPage() {
   const t = useT();
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label={t('activity.title')}>
+    <div className="flex flex-col gap-6">
       {/* Page header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Live Activity</h2>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Live Activity</h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-slate-400 flex items-center gap-2">
             {t('activity.subtitle')}
             <LiveStatusIndicator />

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -138,12 +138,12 @@ export default function AnalyticsPage() {
     : 0;
 
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label="Analytics">
+    <div className="flex flex-col gap-6">
       {/* Page header */}
       <div className="flex items-center gap-3">
         <BarChart3 className="h-6 w-6 text-[var(--color-accent-cyan)]" />
         <div>
-          <h2 className="text-2xl font-bold text-[var(--color-text-primary)]">Analytics</h2>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Analytics</h1>
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">
             Session volume, token usage, cost trends, and error rates
           </p>
@@ -163,7 +163,7 @@ export default function AnalyticsPage() {
         {/* Session Volume */}
         <ChartCard title="Session Volume Over Time">
           {data.sessionVolume.length > 0 ? (
-            <ResponsiveContainer width="100%" height={260}>
+            <ResponsiveContainer width="100%" height={260} minWidth={1} minHeight={1}>
               <LineChart data={data.sessionVolume}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
@@ -197,8 +197,8 @@ export default function AnalyticsPage() {
         <ChartCard title="Token Usage by Model">
           {data.tokenUsageByModel.length > 0 ? (
             <div className="flex flex-col lg:flex-row items-center gap-4">
-              <div className="w-full lg:w-1/2 h-[220px]">
-                <ResponsiveContainer width="100%" height="100%">
+              <div className="h-[220px] w-full min-w-0 lg:w-1/2">
+                <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
                   <PieChart>
                     <Pie
                       data={data.tokenUsageByModel.map((m) => ({
@@ -254,7 +254,7 @@ export default function AnalyticsPage() {
         {/* Cost Trends */}
         <ChartCard title="Cost Trends (USD per Day)">
           {data.costTrends.length > 0 ? (
-            <ResponsiveContainer width="100%" height={260}>
+            <ResponsiveContainer width="100%" height={260} minWidth={1} minHeight={1}>
               <BarChart data={data.costTrends}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
@@ -318,7 +318,7 @@ export default function AnalyticsPage() {
         {/* Duration Trends */}
         <ChartCard title="Avg Session Duration Over Time">
           {data.durationTrends.length > 0 ? (
-            <ResponsiveContainer width="100%" height={260}>
+            <ResponsiveContainer width="100%" height={260} minWidth={1} minHeight={1}>
               <LineChart data={data.durationTrends}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
@@ -397,7 +397,7 @@ function SummaryCard({ label, value }: { label: string; value: string }) {
 
 function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
+    <section className="min-w-0 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
       <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">{title}</h3>
       {children}
     </section>

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -409,7 +409,7 @@ function DetailDrawer({
                 <p className="text-xs uppercase tracking-wide text-zinc-500">Hash</p>
                 <button
                   onClick={() => { void handleCopy('hash', record.hash); }}
-                  className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
+                  className="flex min-h-[44px] items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
                 >
                   <Copy className="h-3 w-3" />
                   {copied === 'hash' ? 'Copied' : 'Copy'}
@@ -423,7 +423,7 @@ function DetailDrawer({
                 <p className="text-xs uppercase tracking-wide text-zinc-500">Previous Hash</p>
                 <button
                   onClick={() => { void handleCopy('prevHash', record.prevHash); }}
-                  className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
+                  className="flex min-h-[44px] items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
                 >
                   <Copy className="h-3 w-3" />
                   {copied === 'prevHash' ? 'Copied' : 'Copy'}
@@ -438,7 +438,7 @@ function DetailDrawer({
                 <p className="text-xs uppercase tracking-wide text-zinc-500">Full Record (JSON)</p>
                 <button
                   onClick={() => { void handleCopy('json', JSON.stringify(record, null, 2)); }}
-                  className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
+                  className="flex min-h-[44px] items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
                 >
                   <Copy className="h-3 w-3" />
                   {copied === 'json' ? 'Copied' : 'Copy'}
@@ -652,7 +652,7 @@ export default function AuditPage() {
     <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Audit Trail</h2>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Audit Trail</h1>
           <p className="mt-1 text-sm text-gray-500">
             Query admin audit events, export CSV or NDJSON, and review chain-integrity metadata.
           </p>
@@ -663,7 +663,7 @@ export default function AuditPage() {
           <button
             onClick={() => setLiveTail((prev) => !prev)}
             disabled={page !== 1}
-            className={`flex items-center gap-1.5 rounded border px-3 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+            className={`flex min-h-[44px] items-center gap-1.5 rounded border px-3 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
               liveTail
                 ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20'
                 : 'border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-200 hover:bg-gray-100 dark:hover:bg-zinc-700'
@@ -677,7 +677,7 @@ export default function AuditPage() {
           <button
             onClick={() => { void fetchData(); }}
             disabled={loading}
-            className="flex items-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-50"
+            className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-50"
           >
             <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
             Refresh
@@ -685,7 +685,7 @@ export default function AuditPage() {
           <button
             onClick={() => { void handleExport('csv'); }}
             disabled={loading || exportingFormat !== null}
-            className="flex items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
+            className="flex min-h-[44px] items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
             aria-label="Export CSV"
           >
             <Download className="h-3.5 w-3.5" />
@@ -694,7 +694,7 @@ export default function AuditPage() {
           <button
             onClick={() => { void handleExport('ndjson'); }}
             disabled={loading || exportingFormat !== null}
-            className="flex items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
+            className="flex min-h-[44px] items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-50"
             aria-label="Export NDJSON"
           >
             <Download className="h-3.5 w-3.5" />
@@ -722,7 +722,7 @@ export default function AuditPage() {
               value={filters.actor}
               onChange={(event) => setFilters((current) => ({ ...current, actor: event.target.value }))}
               onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
 
@@ -736,7 +736,7 @@ export default function AuditPage() {
               value={filters.action}
               onChange={(event) => setFilters((current) => ({ ...current, action: event.target.value }))}
               onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
             <datalist id="audit-action-suggestions">
               {ACTION_SUGGESTIONS.map((action) => (
@@ -754,7 +754,7 @@ export default function AuditPage() {
               value={filters.sessionId}
               onChange={(event) => setFilters((current) => ({ ...current, sessionId: event.target.value }))}
               onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
 
@@ -765,7 +765,7 @@ export default function AuditPage() {
               type="datetime-local"
               value={filters.from}
               onChange={(event) => setFilters((current) => ({ ...current, from: event.target.value }))}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
 
@@ -776,7 +776,7 @@ export default function AuditPage() {
               type="datetime-local"
               value={filters.to}
               onChange={(event) => setFilters((current) => ({ ...current, to: event.target.value }))}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
         </div>
@@ -784,13 +784,13 @@ export default function AuditPage() {
         <div className="mt-4 flex flex-wrap items-center gap-3">
           <button
             onClick={applyFilters}
-            className="rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
+            className="min-h-[44px] rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
           >
             Apply
           </button>
           <button
             onClick={clearFilters}
-            className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-zinc-400 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
+            className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-zinc-400 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
           >
             Clear
           </button>
@@ -830,7 +830,7 @@ export default function AuditPage() {
           </button>
         </div>
       ) : loading ? (
-        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-zinc-800 bg-gray-50 dark:bg-zinc-900/50">
+        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-zinc-800 bg-gray-50 dark:bg-zinc-900/50" tabIndex={0} aria-label="Audit records loading table">
           <table className="w-full text-left">
             <thead>
               <tr className="border-b border-gray-200 dark:border-zinc-800">
@@ -857,7 +857,7 @@ export default function AuditPage() {
         </div>
       ) : (
         <>
-          <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-zinc-800 bg-gray-50 dark:bg-zinc-900/50">
+          <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-zinc-800 bg-gray-50 dark:bg-zinc-900/50" tabIndex={0} aria-label="Audit records table">
             <table className="w-full text-left">
               <thead>
                 <tr className="border-b border-gray-200 dark:border-zinc-800">
@@ -892,7 +892,7 @@ export default function AuditPage() {
                   setPageSize(Number(event.target.value));
                   setPage(1);
                 }}
-                className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+                className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
               >
                 {PAGE_SIZE_OPTIONS.map((size) => (
                   <option key={size} value={size}>{size} / page</option>
@@ -907,7 +907,7 @@ export default function AuditPage() {
               <button
                 onClick={() => setPage((current) => Math.max(1, current - 1))}
                 disabled={page <= 1}
-                className="inline-flex items-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label="Previous page"
               >
                 <ChevronLeft className="h-3.5 w-3.5" />
@@ -915,7 +915,7 @@ export default function AuditPage() {
               <button
                 onClick={() => setPage((current) => current + 1)}
                 disabled={!hasMore || page >= totalPages}
-                className="inline-flex items-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label="Next page"
               >
                 <ChevronRight className="h-3.5 w-3.5" />

--- a/dashboard/src/pages/AuthKeysPage.tsx
+++ b/dashboard/src/pages/AuthKeysPage.tsx
@@ -221,7 +221,7 @@ export default function AuthKeysPage() {
       ) : null}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Auth Keys</h2>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Auth Keys</h1>
           <p className="mt-1 text-sm text-gray-500">
             Create, review, and revoke dashboard API keys without exposing stored secrets.
           </p>

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -131,12 +131,12 @@ export default function CostPage() {
   const projectedMonthCost = (totalCost / Math.min(daysPassed, 14)) * daysInMonth;
   
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label="Cost and Billing">
+    <div className="flex flex-col gap-6">
       {/* Page header */}
       <div className="flex items-center gap-3">
         <DollarSign className="h-6 w-6 text-[var(--color-accent-cyan)]" />
         <div>
-          <h2 className="text-2xl font-bold text-[var(--color-text-primary)]">Cost & Billing</h2>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Cost & Billing</h1>
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">
             Usage tracking, burn rate, and budget alerts
             {sseConnected && (
@@ -197,8 +197,8 @@ export default function CostPage() {
         <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
           Daily Spend (Last 14 Days)
         </h3>
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-64 min-w-0">
+          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <BarChart data={dailyData}>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
               <XAxis
@@ -231,8 +231,8 @@ export default function CostPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Cost by Model
           </h3>
-          <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
+          <div className="h-64 min-w-0">
+            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <PieChart>
                 <Pie
                   data={modelData}
@@ -299,7 +299,7 @@ export default function CostPage() {
               <button
                 type="button"
                 onClick={() => window.location.hash = '#budget'}
-                className="underline hover:text-amber-200"
+                className="inline-flex min-h-[44px] items-center underline hover:text-amber-200"
               >
                 Settings
               </button>

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -105,12 +105,12 @@ export default function MetricsPage() {
   const summary = data?.summary;
 
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label="Metrics">
+    <div className="flex flex-col gap-6">
       {/* Page header */}
       <div className="flex items-center gap-3">
         <BarChart3 className="h-6 w-6 text-[var(--color-accent-cyan)]" />
         <div>
-          <h2 className="text-2xl font-bold text-[var(--color-text-primary)]">Metrics</h2>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Metrics</h1>
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">
             Aggregated usage analytics across sessions
             {sseConnected && (
@@ -124,15 +124,15 @@ export default function MetricsPage() {
       </div>
 
       {/* Controls */}
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-wrap items-center gap-2">
           {/* Range selector */}
           {(['7d', '30d', '90d'] as RangePreset[]).map((r) => (
             <button
               key={r}
               type="button"
               onClick={() => setRange(r)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              className={`min-h-[44px] rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
                 range === r
                   ? 'bg-[var(--color-accent-cyan)] text-[var(--color-void-dark)]'
                   : 'bg-[var(--color-surface-strong)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
@@ -142,7 +142,7 @@ export default function MetricsPage() {
             </button>
           ))}
 
-          <span className="mx-2 h-4 w-px bg-[var(--color-border-strong)]" />
+          <span className="mx-2 hidden h-4 w-px bg-[var(--color-border-strong)] sm:block" />
 
           {/* Granularity selector */}
           {(['day', 'hour', 'key'] as Granularity[]).map((g) => (
@@ -150,7 +150,7 @@ export default function MetricsPage() {
               key={g}
               type="button"
               onClick={() => setGranularity(g)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
+              className={`min-h-[44px] rounded-md px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
                 granularity === g
                   ? 'bg-[var(--color-accent-cyan)] text-[var(--color-void-dark)]'
                   : 'bg-[var(--color-surface-strong)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
@@ -165,7 +165,7 @@ export default function MetricsPage() {
           type="button"
           onClick={handleExport}
           disabled={!data}
-          className="flex items-center gap-1.5 rounded-md bg-[var(--color-surface-strong)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] disabled:opacity-40"
+          className="flex min-h-[44px] items-center gap-1.5 rounded-md bg-[var(--color-surface-strong)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] disabled:opacity-40"
         >
           <Download className="h-3.5 w-3.5" />
           Export CSV
@@ -257,8 +257,8 @@ export default function MetricsPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Sessions &amp; Cost Over Time
           </h3>
-          <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
+          <div className="h-64 min-w-0">
+            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <BarChart data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
@@ -299,8 +299,8 @@ export default function MetricsPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Token Cost Trend
           </h3>
-          <div className="h-48">
-            <ResponsiveContainer width="100%" height="100%">
+          <div className="h-48 min-w-0">
+            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <LineChart data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
@@ -335,7 +335,7 @@ export default function MetricsPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Breakdown by API Key
           </h3>
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto" tabIndex={0} aria-label="Metrics breakdown table">
             <table className="w-full text-sm" aria-label="Metrics breakdown by API key">
               <thead>
                 <tr className="border-b border-[var(--color-border-strong)]">

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -46,11 +46,11 @@ export default function OverviewPage() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label={t("overview.title")}>
+    <div className="flex flex-col gap-6">
       {/* Page header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{t("overview.title")}</h2>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{t("overview.title")}</h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-slate-400 flex items-center gap-2">
             {t("overview.subtitle")}
             <LiveStatusIndicator />
@@ -63,7 +63,7 @@ export default function OverviewPage() {
         </div>
         <button
           onClick={() => setModalOpen(true)}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-4 py-2 text-xs font-semibold text-cyan-700 dark:text-cyan-300 transition-all hover:bg-cyan-500/20 hover:border-cyan-500/50"
+          className="inline-flex min-h-[44px] items-center justify-center gap-1.5 rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-4 py-2 text-xs font-semibold text-cyan-700 dark:text-cyan-300 transition-all hover:bg-cyan-500/20 hover:border-cyan-500/50"
         >
           <Plus className="h-3.5 w-3.5" />
           New Session

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -116,9 +116,9 @@ export default function PipelineDetailPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label="Pipeline Detail">
+    <div className="flex flex-col gap-6">
       {/* Breadcrumb */}
-      <nav className="text-xs text-gray-500 flex items-center gap-1">
+      <nav className="text-xs text-gray-500 flex items-center gap-1" aria-label="Pipeline breadcrumb">
         <Link to="/pipelines" className="hover:text-[var(--color-accent-cyan)] transition-colors">
           Pipelines
         </Link>
@@ -131,7 +131,7 @@ export default function PipelineDetailPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{pipeline.name}</h2>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{pipeline.name}</h1>
           <PipelineStatusBadge status={pipeline.status} />
         </div>
         <div className="text-xs text-gray-500">
@@ -151,7 +151,7 @@ export default function PipelineDetailPage() {
             No steps yet
           </div>
         ) : (
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto" tabIndex={0} aria-label="Pipeline steps table">
           <table className="w-full text-left text-sm" aria-label="Pipeline steps">
             <thead>
               <tr className="border-b border-void-lighter text-gray-600">

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -207,18 +207,18 @@ export default function PipelinesPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label={t("pipelines.title")}>
+    <div className="flex flex-col gap-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t("pipelines.title")}</h2>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t("pipelines.title")}</h1>
           <p className="mt-1 text-sm text-gray-500">
             Manage and monitor session pipelines
           </p>
         </div>
         <button
           onClick={() => setModalOpen(true)}
-          className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded bg-[var(--color-accent-cyan)]]/10 hover:bg-[var(--color-accent-cyan)]]/20 text-[var(--color-accent-cyan)]] border border-[var(--color-accent-cyan)]]/30 transition-colors"
+          className="flex min-h-[44px] items-center gap-1.5 px-3 py-2 text-xs font-medium rounded bg-[var(--color-accent-cyan)]]/10 hover:bg-[var(--color-accent-cyan)]]/20 text-[var(--color-accent-cyan)]] border border-[var(--color-accent-cyan)]]/30 transition-colors"
         >
           <Plus className="h-3.5 w-3.5" />
           New Pipeline
@@ -232,12 +232,12 @@ export default function PipelinesPage() {
           placeholder={t("pipelines.searchPlaceholder")} aria-label="Search pipelines"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="flex-1 min-w-[200px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 placeholder-gray-500 focus:outline-none focus:border-[var(--color-accent-cyan)]"
+          className="min-h-[44px] flex-1 min-w-[200px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 placeholder-gray-500 focus:outline-none focus:border-[var(--color-accent-cyan)]"
         />
         <select aria-label="Filter by status"
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 focus:outline-none focus:border-[var(--color-accent-cyan)]"
+          className="min-h-[44px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 focus:outline-none focus:border-[var(--color-accent-cyan)]"
         >
           <option value="all">All</option>
           <option value="running">Running</option>
@@ -248,7 +248,7 @@ export default function PipelinesPage() {
         <select aria-label="Sort by"
           value={sortBy}
           onChange={(e) => setSortBy(e.target.value as 'name'|'createdAt'|'status')}
-          className="px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 focus:outline-none focus:border-[var(--color-accent-cyan)]"
+          className="min-h-[44px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 focus:outline-none focus:border-[var(--color-accent-cyan)]"
         >
           <option value="createdAt">Date</option>
           <option value="name">Name</option>
@@ -256,7 +256,7 @@ export default function PipelinesPage() {
         </select>
         <button
           onClick={() => setSortAsc(!sortAsc)}
-          className="px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 hover:border-[var(--color-accent-cyan)]/50 transition-colors"
+          className="min-h-[44px] min-w-[44px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-gray-200 hover:border-[var(--color-accent-cyan)]/50 transition-colors"
           aria-label={sortAsc ? 'Sort ascending' : 'Sort descending'}
           title={sortAsc ? 'Ascending' : 'Descending'}
         >
@@ -290,7 +290,7 @@ export default function PipelinesPage() {
               <button
                 type="button"
                 onClick={handleSurpriseMe}
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 text-sm font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
+                className="inline-flex min-h-[44px] items-center gap-2 px-4 py-2 rounded-lg border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 text-sm font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
               >
                 <Sparkles className="h-4 w-4" />
                 Surprise me

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -399,7 +399,7 @@ export default function SessionHistoryPage() {
           <button
             onClick={() => { void fetchData(); }}
             disabled={loading}
-            className="flex items-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-50"
+            className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-50"
           >
             <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
             Refresh
@@ -407,7 +407,7 @@ export default function SessionHistoryPage() {
           {records.length > 0 && (
             <button
               onClick={() => handleExport()}
-              className="flex items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-xs font-medium text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
+              className="flex min-h-[44px] items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-xs font-medium text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
               aria-label="Export session history as CSV"
             >
               <Download className="h-3.5 w-3.5" />
@@ -436,7 +436,7 @@ export default function SessionHistoryPage() {
               onChange={(e) => setFilterSearch(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
               placeholder="Search name or prompt…"
-              className="w-48 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] w-48 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
 
@@ -449,7 +449,7 @@ export default function SessionHistoryPage() {
               onChange={(e) => setFilterOwnerInput(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
               placeholder="e.g. admin-main"
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
 
@@ -459,7 +459,7 @@ export default function SessionHistoryPage() {
               id="status-filter"
               value={filterStatusInput}
               onChange={(e) => setFilterStatusInput(e.target.value)}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             >
               {STATUS_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -473,7 +473,7 @@ export default function SessionHistoryPage() {
               id="date-filter"
               value={filterDateRange}
               onChange={(e) => setFilterDateRange(e.target.value as DateRange)}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             >
               {DATE_RANGE_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -489,7 +489,7 @@ export default function SessionHistoryPage() {
                 type="date"
                 value={customDateFrom}
                 onChange={(e) => setCustomDateFrom(e.target.value)}
-                className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+                className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
               />
             </div>
           )}
@@ -502,7 +502,7 @@ export default function SessionHistoryPage() {
                 type="date"
                 value={customDateTo}
                 onChange={(e) => setCustomDateTo(e.target.value)}
-                className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+                className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
               />
             </div>
           )}
@@ -513,7 +513,7 @@ export default function SessionHistoryPage() {
               id="sort-filter"
               value={filterSort}
               onChange={(e) => { setFilterSort(e.target.value as typeof filterSort); }}
-              className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             >
               <option value="newest">Newest first</option>
               <option value="oldest">Oldest first</option>
@@ -523,14 +523,14 @@ export default function SessionHistoryPage() {
 
           <button
             onClick={applyFilters}
-            className="rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
+            className="min-h-[44px] rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
           >
             Apply
           </button>
 
           <button
             onClick={clearFilters}
-            className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-zinc-400 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
+            className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-zinc-400 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
           >
             Clear
           </button>
@@ -558,28 +558,28 @@ export default function SessionHistoryPage() {
               <span className="text-sm font-medium text-[var(--color-accent-cyan)]">{selectedIds.size} selected</span>
               <button
                 onClick={() => handleExport()}
-                className="flex items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
+                className="flex min-h-[44px] items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
               >
                 <Icon name="Download" size={12} />
                 Export
               </button>
               <button
                 onClick={() => setConfirmDeleteOpen(true)}
-                className="flex items-center gap-1.5 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-300 transition-colors hover:bg-rose-500/20"
+                className="flex min-h-[44px] items-center gap-1.5 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-300 transition-colors hover:bg-rose-500/20"
               >
                 <Trash2 className="h-3 w-3" />
                 Kill
               </button>
               <button
                 onClick={handleShareLink}
-                className="flex items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
+                className="flex min-h-[44px] items-center gap-1.5 rounded border border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-zinc-300 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700"
               >
                 <Share2 className="h-3 w-3" />
                 Share link
               </button>
               <button
                 onClick={() => setSelectedIds(new Set())}
-                className="ml-auto flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
+                className="ml-auto flex min-h-[44px] items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
               >
                 <X className="h-3 w-3" />
                 Clear
@@ -587,7 +587,7 @@ export default function SessionHistoryPage() {
             </div>
           )}
 
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto" tabIndex={0} aria-label="Session history table">
             <table className="min-w-full text-left">
               <thead className="border-b border-gray-200 dark:border-zinc-800 bg-gray-50/80 dark:bg-zinc-900/80">
                 <tr>
@@ -646,6 +646,7 @@ export default function SessionHistoryPage() {
                     >
                       <td className="px-4 py-3" data-no-nav>
                         <input
+                          aria-label="Select all history rows"
                           type="checkbox"
                           checked={selectedIds.has(record.id)}
                           onChange={() => toggleSelect(record.id)}
@@ -665,7 +666,7 @@ export default function SessionHistoryPage() {
                           <button
                             data-no-nav
                             onClick={(e) => copySessionId(record.id, e)}
-                            className="opacity-0 group-hover/id:opacity-100 rounded p-0.5 text-zinc-500 hover:text-zinc-300 transition-opacity"
+                            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-zinc-500 opacity-0 transition-opacity hover:text-zinc-300 group-hover/id:opacity-100"
                             aria-label="Copy session ID"
                           >
                             <Copy className="h-3 w-3" />
@@ -713,7 +714,7 @@ export default function SessionHistoryPage() {
                   setPageSize(Number(e.target.value));
                   setPage(1);
                 }}
-                className="rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+                className="min-h-[44px] rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-900 dark:text-zinc-100 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
               >
                 {PAGE_SIZE_OPTIONS.map((size) => (
                   <option key={size} value={size}>{size}</option>
@@ -723,7 +724,7 @@ export default function SessionHistoryPage() {
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1 || loading}
-                className="inline-flex items-center gap-1 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-40"
+                className="inline-flex min-h-[44px] items-center gap-1 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-40"
               >
                 <ChevronLeft className="h-3 w-3" /> Prev
               </button>
@@ -731,7 +732,7 @@ export default function SessionHistoryPage() {
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page >= totalPages || loading}
-                className="inline-flex items-center gap-1 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-40"
+                className="inline-flex min-h-[44px] items-center gap-1 rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-2 py-1 text-xs text-gray-700 dark:text-zinc-200 transition-colors hover:bg-gray-100 dark:hover:bg-zinc-700 disabled:opacity-40"
               >
                 Next <ChevronRight className="h-3 w-3" />
               </button>

--- a/dashboard/src/pages/SessionsPage.tsx
+++ b/dashboard/src/pages/SessionsPage.tsx
@@ -39,7 +39,7 @@ export default function SessionsPage() {
     <div className="flex flex-col gap-6">
       {/* Page header */}
       <div>
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{translate("sessions.title")}</h2>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{translate("sessions.title")}</h1>
         <p className="mt-1 text-sm text-gray-500 dark:text-slate-400">
           {translate("sessions.subtitle")}
         </p>

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -64,6 +64,63 @@ const LOCALES: { value: string; label: string; flag: string }[] = [
   { value: 'ar-SA', label: 'العربية', flag: '🇸🇦' },
 ];
 
+interface TouchTargetCheckboxProps {
+  checked: boolean;
+  id: string;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+function TouchTargetCheckbox({ checked, id, label, onCheckedChange }: TouchTargetCheckboxProps) {
+  return (
+    <label
+      htmlFor={id}
+      className="flex min-h-[44px] min-w-[44px] items-center justify-center"
+    >
+      <input
+        type="checkbox"
+        id={id}
+        checked={checked}
+        onChange={(e) => onCheckedChange(e.target.checked)}
+        className="h-4 w-4 cursor-pointer accent-blue-600"
+        aria-label={label}
+      />
+    </label>
+  );
+}
+
+interface SettingsSwitchProps {
+  checked: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function SettingsSwitch({ checked, label, onClick }: SettingsSwitchProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex min-h-[44px] min-w-[56px] items-center justify-center rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent-cyan)]"
+      role="switch"
+      aria-label={label}
+      aria-checked={checked}
+    >
+      <span
+        aria-hidden="true"
+        className={`relative h-7 w-12 rounded-full transition-colors ${
+          checked ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-zinc-700'
+        }`}
+      >
+        <span
+          className={`absolute left-1 top-1 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+            checked ? 'translate-x-6' : 'translate-x-0'
+          }`}
+        />
+      </span>
+    </button>
+  );
+}
+
 export default function SettingsPage() {
   const [settings, setSettings] = useState<Settings>(loadSettings);
   const { theme, resolvedTheme, toggleTheme, setTheme } = useTheme();
@@ -85,7 +142,7 @@ export default function SettingsPage() {
       <div className="flex items-center gap-3">
         <Settings className="h-6 w-6 text-[var(--color-accent-cyan)]" />
         <div>
-          <h2 className="text-2xl font-bold text-[var(--color-text-primary)]">Settings</h2>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Settings</h1>
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">Dashboard preferences</p>
         </div>
       </div>
@@ -105,7 +162,7 @@ export default function SettingsPage() {
             </div>
             <button
               onClick={toggleTheme}
-              className="rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+              className="min-h-[44px] rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
             >
               {resolvedTheme === 'dark' ? '🌙 Dark' : '☀️ Light'}
             </button>
@@ -124,7 +181,7 @@ export default function SettingsPage() {
                     key={value}
                     onClick={() => setTheme(value)}
                     title={description}
-                    className={`px-2.5 py-1 text-xs rounded border transition-colors ${
+                    className={`min-h-[44px] px-2.5 py-1 text-xs rounded border transition-colors ${
                       theme === value || (theme === 'auto' && value === 'light')
                         ? 'border-blue-500 bg-blue-50 text-blue-700 font-medium dark:bg-blue-500/10 dark:text-blue-300'
                         : 'border-[var(--color-border-strong)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
@@ -143,13 +200,11 @@ export default function SettingsPage() {
               <p className="text-sm text-[var(--color-text-primary)]">Auto theme</p>
               <p className="text-xs text-[var(--color-text-muted)]">Follow system <code className="font-mono text-[11px]">prefers-color-scheme</code></p>
             </div>
-            <input
-              type="checkbox"
+            <TouchTargetCheckbox
               id="auto-theme-toggle"
               checked={theme === 'auto'}
-              onChange={(e) => setTheme(e.target.checked ? 'auto' : resolvedTheme)}
-              className="h-4 w-4 cursor-pointer accent-blue-600"
-              aria-label="Auto theme"
+              onCheckedChange={(checked) => setTheme(checked ? 'auto' : resolvedTheme)}
+              label="Auto theme"
             />
           </div>
 
@@ -160,9 +215,10 @@ export default function SettingsPage() {
               <p className="text-xs text-[var(--color-text-muted)]">Rows per page in session history</p>
             </div>
             <select
+              aria-label="Default page size"
               value={settings.defaultPageSize}
               onChange={(e) => update('defaultPageSize', Number(e.target.value))}
-              className="rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+              className="min-h-[44px] rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
             >
               <option value={10}>10</option>
               <option value={25}>25</option>
@@ -183,7 +239,7 @@ export default function SettingsPage() {
                   key={value}
                   onClick={() => setReadingFont(value)}
                   title={description}
-                  className={`px-2.5 py-1 text-xs rounded border transition-colors ${
+                  className={`min-h-[44px] px-2.5 py-1 text-xs rounded border transition-colors ${
                     readingFont === value
                       ? 'border-blue-500 bg-blue-50 text-blue-700 font-medium dark:bg-blue-500/10 dark:text-blue-300'
                       : 'border-[var(--color-border-strong)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
@@ -202,9 +258,10 @@ export default function SettingsPage() {
               <p className="text-xs text-[var(--color-text-muted)]">Set display language and regional formats</p>
             </div>
             <select
+              aria-label="Language and region"
               value={locale}
               onChange={(e) => setLocale(e.target.value)}
-              className="rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+              className="min-h-[44px] rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
             >
               {LOCALES.map(({ value, label, flag }) => (
                 <option key={value} value={value}>
@@ -228,21 +285,11 @@ export default function SettingsPage() {
               <p className="text-sm text-[var(--color-text-primary)]">Enable auto-refresh</p>
               <p className="text-xs text-[var(--color-text-muted)]">Automatically update dashboard data</p>
             </div>
-            <button
+            <SettingsSwitch
+              checked={settings.autoRefresh}
+              label="Enable auto-refresh"
               onClick={() => update('autoRefresh', !settings.autoRefresh)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                settings.autoRefresh ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-zinc-700'
-              }`}
-              role="switch"
-              aria-label="Enable auto-refresh"
-              aria-checked={settings.autoRefresh}
-            >
-              <span
-                className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
-                  settings.autoRefresh ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
+            />
           </div>
           {settings.autoRefresh && (
             <div className="flex items-center justify-between">
@@ -251,9 +298,10 @@ export default function SettingsPage() {
                 <p className="text-xs text-[var(--color-text-muted)]">How often to poll for updates</p>
               </div>
               <select
+                aria-label="Refresh interval"
                 value={settings.refreshIntervalSec}
                 onChange={(e) => update('refreshIntervalSec', Number(e.target.value))}
-                className="rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+                className="min-h-[44px] rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
               >
                 <option value={10}>10 seconds</option>
                 <option value={30}>30 seconds</option>
@@ -278,21 +326,11 @@ export default function SettingsPage() {
               <p className="text-sm text-[var(--color-text-primary)]">Enable budget alerts</p>
               <p className="text-xs text-[var(--color-text-muted)]">Warning at 80% of cap</p>
             </div>
-            <button
+            <SettingsSwitch
+              checked={settings.budgetAlertEnabled}
+              label="Enable budget alerts"
               onClick={() => update('budgetAlertEnabled', !settings.budgetAlertEnabled)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                settings.budgetAlertEnabled ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-zinc-700'
-              }`}
-              role="switch"
-              aria-label="Enable budget alerts"
-              aria-checked={settings.budgetAlertEnabled}
-            >
-              <span
-                className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
-                  settings.budgetAlertEnabled ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
+            />
           </div>
 
           {settings.budgetAlertEnabled && (
@@ -305,12 +343,13 @@ export default function SettingsPage() {
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-[var(--color-text-muted)]">$</span>
                   <input
+                    aria-label="Daily spending cap"
                     type="number"
                     min="1"
                     step="10"
                     value={settings.budgetDailyCapUsd}
                     onChange={(e) => update('budgetDailyCapUsd', Number(e.target.value))}
-                    className="w-24 rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] font-mono"
+                    className="min-h-[44px] w-24 rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] font-mono"
                   />
                 </div>
               </div>
@@ -323,12 +362,13 @@ export default function SettingsPage() {
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-[var(--color-text-muted)]">$</span>
                   <input
+                    aria-label="Monthly spending cap"
                     type="number"
                     min="1"
                     step="100"
                     value={settings.budgetMonthlyCapUsd}
                     onChange={(e) => update('budgetMonthlyCapUsd', Number(e.target.value))}
-                    className="w-24 rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] font-mono"
+                    className="min-h-[44px] w-24 rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] font-mono"
                   />
                 </div>
               </div>
@@ -338,13 +378,11 @@ export default function SettingsPage() {
                   <p className="text-sm text-[var(--color-text-primary)]">Hard stop at 100%</p>
                   <p className="text-xs text-[var(--color-text-muted)]">Block new sessions when cap reached</p>
                 </div>
-                <input
-                  type="checkbox"
+                <TouchTargetCheckbox
                   id="budget-hard-stop"
                   checked={settings.budgetHardStopEnabled}
-                  onChange={(e) => update('budgetHardStopEnabled', e.target.checked)}
-                  className="h-4 w-4 cursor-pointer accent-blue-600"
-                  aria-label="Hard stop at 100%"
+                  onCheckedChange={(checked) => update('budgetHardStopEnabled', checked)}
+                  label="Hard stop at 100%"
                 />
               </div>
             </>

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -157,11 +157,11 @@ export default function TemplatesPage() {
   // ── Render ──────────────────────────────────────────────────────
 
   return (
-    <div className="flex flex-col gap-6" role="main" aria-label="Templates">
+    <div className="flex flex-col gap-6">
       {/* Header */}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Templates</h2>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Templates</h1>
           <p className="mt-1 text-sm text-gray-500">
             Create reusable session configurations to standardize agent launches.
           </p>


### PR DESCRIPTION
## Summary

- Fix dashboard production accessibility regressions across core authenticated routes.
- Add accessible names and proper 44px touch targets for Settings controls, session controls, audit pagination, and related dashboard interactions.
- Stabilize chart containers so Recharts does not mount with invalid `-1` dimensions.
- Strengthen dashboard a11y tests around main landmarks, h1 headings, and axe checks.

## Aegis version

0.6.0-preview

## Checks

- `npm run gate`
- `npm run dashboard:a11y:check`
- `npm run dashboard:tokens:gate`
- `npm run dashboard:clickable:gate`
- `npx tsc --noEmit`
- `npm run build`

Closes #2364
Closes #2365
Closes #2366
Closes #2367
