### PR TITLE
fix(api): sync rate_limit OpenAPI contract

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4089,6 +4089,7 @@ components:
             - "bash_approval"
             - "settings"
             - "error"
+            - "rate_limit"
             - "unknown"
 
 
@@ -4464,4 +4465,5 @@ components:
         - "bash_approval"
         - "settings"
         - "error"
+        - "rate_limit"
         - "unknown"

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -119,7 +119,7 @@ export type SessionInfo = {
     jsonlPath?: string;
     byteOffset?: number;
     monitorOffset?: number;
-    status?: 'idle' | 'working' | 'compacting' | 'context_warning' | 'waiting_for_input' | 'permission_prompt' | 'plan_mode' | 'ask_question' | 'bash_approval' | 'settings' | 'error' | 'unknown';
+    status?: 'idle' | 'working' | 'compacting' | 'context_warning' | 'waiting_for_input' | 'permission_prompt' | 'plan_mode' | 'ask_question' | 'bash_approval' | 'settings' | 'error' | 'rate_limit' | 'unknown';
     createdAt?: number;
     lastActivity?: number;
     stallThresholdMs?: number;
@@ -241,7 +241,7 @@ export type GlobalMetrics = {
     avgDurationSec?: number;
 };
 
-export type SessionStatusFilter = 'all' | 'idle' | 'working' | 'compacting' | 'context_warning' | 'waiting_for_input' | 'permission_prompt' | 'plan_mode' | 'ask_question' | 'bash_approval' | 'settings' | 'error' | 'unknown';
+export type SessionStatusFilter = 'all' | 'idle' | 'working' | 'compacting' | 'context_warning' | 'waiting_for_input' | 'permission_prompt' | 'plan_mode' | 'ask_question' | 'bash_approval' | 'settings' | 'error' | 'rate_limit' | 'unknown';
 
 /**
  * Session ID


### PR DESCRIPTION
## Summary
- adds the merged rate_limit session status to OpenAPI SessionInfo and SessionStatusFilter enums
- regenerates the TypeScript client status unions so SDK consumers can use rate_limit

Follow-up to #2369 after the branch merged before the contract sync landed.

## Validation
- npm run openapi:check
- npm --prefix packages/client run generate:check
- npm run gate