### PR TITLE
fix(dashboard): resolve real-user audit regressions

### DIFF
--- a/dashboard/src/__tests__/SessionHistoryPage.test.tsx
+++ b/dashboard/src/__tests__/SessionHistoryPage.test.tsx
@@ -110,3 +110,83 @@ describe('SessionHistoryPage', () => {
     expect(navigateMock).toHaveBeenCalledWith('/sessions/sess-click');
   });
 });
+
+describe('SessionHistoryPage a11y (issue #2378)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('per-row checkbox has a descriptive aria-label referencing the session ID', async () => {
+    fetchSessionHistoryMock.mockResolvedValueOnce({
+      records: [
+        {
+          id: 'sess-a11y-01',
+          ownerKeyId: 'admin-main',
+          createdAt: Date.now() - 10 * 60_000,
+          lastSeenAt: Date.now() - 30_000,
+          finalStatus: 'active',
+          source: 'audit+live',
+        },
+      ],
+      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
+    });
+
+    renderPage();
+
+    const checkbox = await screen.findByRole('checkbox', { name: /Select session sess-a11y-01/i });
+    expect(checkbox).toBeDefined();
+  });
+
+  it('empty chevron column header is hidden from assistive technology', async () => {
+    fetchSessionHistoryMock.mockResolvedValueOnce({
+      records: [
+        {
+          id: 'sess-th-hidden',
+          ownerKeyId: 'admin-main',
+          createdAt: Date.now() - 5 * 60_000,
+          lastSeenAt: Date.now() - 10_000,
+          finalStatus: 'active',
+          source: 'live',
+        },
+      ],
+      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
+    });
+
+    renderPage();
+
+    // The narrow chevron column header should have aria-hidden=true
+    const table = await screen.findByRole('table');
+    const allTh = table.querySelectorAll('th');
+    // Find the empty th (w-8 class) — it should be aria-hidden
+    const hiddenTh = Array.from(allTh).find(
+      (th) => th.getAttribute('aria-hidden') === 'true',
+    );
+    expect(hiddenTh).toBeDefined();
+  });
+
+  it('empty Name cell placeholder is hidden from assistive technology', async () => {
+    fetchSessionHistoryMock.mockResolvedValueOnce({
+      records: [
+        {
+          id: 'sess-name-hidden',
+          ownerKeyId: 'admin-main',
+          createdAt: Date.now() - 5 * 60_000,
+          lastSeenAt: Date.now() - 10_000,
+          finalStatus: 'active',
+          source: 'live',
+        },
+      ],
+      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
+    });
+
+    renderPage();
+
+    // The "—" placeholder in the Name column should be aria-hidden
+    const table = await screen.findByRole('table');
+    const allTd = table.querySelectorAll('td');
+    const hiddenTd = Array.from(allTd).find(
+      (td) => td.getAttribute('aria-hidden') === 'true' && td.textContent === '—',
+    );
+    expect(hiddenTd).toBeDefined();
+  });
+});

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -583,6 +583,7 @@ body::before {
 [data-theme="light-aaa"] .text-amber-300,
 [data-theme="light-aaa"] .text-amber-400 {
   color: var(--color-warning) !important;
+}
 /* ------------------------------------------------------------------
  * Light-mode readability shim for rose/red/sky utility classes (issue #2378).
  * These Tailwind color utilities default to dark-mode-safe shades that

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -583,7 +583,6 @@ body::before {
 [data-theme="light-aaa"] .text-amber-300,
 [data-theme="light-aaa"] .text-amber-400 {
   color: var(--color-warning) !important;
-}
 /* ------------------------------------------------------------------
  * Light-mode readability shim for rose/red/sky utility classes (issue #2378).
  * These Tailwind color utilities default to dark-mode-safe shades that

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -583,6 +583,39 @@ body::before {
 [data-theme="light-aaa"] .text-amber-300,
 [data-theme="light-aaa"] .text-amber-400 {
   color: var(--color-warning) !important;
+/* ------------------------------------------------------------------
+ * Light-mode readability shim for rose/red/sky utility classes (issue #2378).
+ * These Tailwind color utilities default to dark-mode-safe shades that
+ * fail WCAG contrast on light backgrounds.
+ * ------------------------------------------------------------------ */
+[data-theme="light"] .text-rose-300,
+[data-theme="light"] .text-rose-400,
+[data-theme="light-paper"] .text-rose-300,
+[data-theme="light-paper"] .text-rose-400,
+[data-theme="light-aaa"] .text-rose-300,
+[data-theme="light-aaa"] .text-rose-400 {
+  color: var(--color-danger) !important;
+}
+[data-theme="light"] .text-red-300,
+[data-theme="light"] .text-red-400,
+[data-theme="light"] .text-red-500,
+[data-theme="light-paper"] .text-red-300,
+[data-theme="light-paper"] .text-red-400,
+[data-theme="light-paper"] .text-red-500,
+[data-theme="light-aaa"] .text-red-300,
+[data-theme="light-aaa"] .text-red-400,
+[data-theme="light-aaa"] .text-red-500 {
+  color: var(--color-danger) !important;
+}
+[data-theme="light"] .text-sky-300,
+[data-theme="light"] .text-sky-400,
+[data-theme="light-paper"] .text-sky-300,
+[data-theme="light-paper"] .text-sky-400,
+[data-theme="light-aaa"] .text-sky-300,
+[data-theme="light-aaa"] .text-sky-400 {
+  color: var(--color-info) !important;
+}
+
 }
 /* Brand-wordmark utility — replaces the dark-only gradient in Layout.tsx
  * with a solid ink color that remains crisp under each sub-theme. */

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -583,10 +583,13 @@ body::before {
 [data-theme="light-aaa"] .text-amber-300,
 [data-theme="light-aaa"] .text-amber-400 {
   color: var(--color-warning) !important;
+}
+
 /* ------------------------------------------------------------------
  * Light-mode readability shim for rose/red/sky utility classes (issue #2378).
  * These Tailwind color utilities default to dark-mode-safe shades that
  * fail WCAG contrast on light backgrounds.
+ * Placed AFTER body::before closes so rules are top-level.
  * ------------------------------------------------------------------ */
 [data-theme="light"] .text-rose-300,
 [data-theme="light"] .text-rose-400,
@@ -616,7 +619,6 @@ body::before {
   color: var(--color-info) !important;
 }
 
-}
 /* Brand-wordmark utility — replaces the dark-only gradient in Layout.tsx
  * with a solid ink color that remains crisp under each sub-theme. */
 .brand-wordmark {

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -197,7 +197,7 @@ export default function CostPage() {
         <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
           Daily Spend (Last 14 Days)
         </h3>
-        <div className="h-64 min-w-0">
+        <div className="h-64" style={{ minWidth: 200 }}>
           <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <BarChart data={dailyData}>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
@@ -231,7 +231,7 @@ export default function CostPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Cost by Model
           </h3>
-          <div className="h-64 min-w-0">
+          <div className="h-64" style={{ minWidth: 200 }}>
             <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <PieChart>
                 <Pie

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -257,7 +257,7 @@ export default function MetricsPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Sessions &amp; Cost Over Time
           </h3>
-          <div className="h-64 min-w-0">
+          <div className="h-64" style={{ minWidth: 200 }}>
             <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <BarChart data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
@@ -299,7 +299,7 @@ export default function MetricsPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Token Cost Trend
           </h3>
-          <div className="h-48 min-w-0">
+          <div className="h-48" style={{ minWidth: 200 }}>
             <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <LineChart data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -606,7 +606,7 @@ export default function SessionHistoryPage() {
                   {sortableHeader("Source", "source")}
                   {sortableHeader("Created", "createdAt")}
                   {sortableHeader("Last seen", "lastSeenAt")}
-                  <th className="w-8" />
+                  <th className="w-8" aria-hidden="true" />
                 </tr>
               </thead>
               <tbody>
@@ -646,7 +646,7 @@ export default function SessionHistoryPage() {
                     >
                       <td className="px-4 py-3" data-no-nav>
                         <input
-                          aria-label="Select all history rows"
+                          aria-label={`Select session ${record.id}`}
                           type="checkbox"
                           checked={selectedIds.has(record.id)}
                           onChange={() => toggleSelect(record.id)}
@@ -654,7 +654,7 @@ export default function SessionHistoryPage() {
                           className="h-4 w-4 rounded border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-cyan-500 focus:ring-cyan-500/30"
                         />
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-500 dark:text-zinc-500">—</td>
+                      <td className="px-4 py-3 text-sm text-gray-500 dark:text-zinc-500" aria-hidden="true">—</td>
                       <td className="px-4 py-3">
                         <span className="inline-flex items-center gap-1.5 group/id">
                           <span


### PR DESCRIPTION
## Summary
Fixes #2378 — live real-user dashboard audit regressions found on latest `develop`.

## Changes

### Category 1: Light-theme contrast violations (8 routes)
- Added CSS overrides in `index.css` for `text-rose-300/400`, `text-red-300/400/500`, and `text-sky-300/400` across light themes
- These classes mapped to colors under 3:1 contrast on light backgrounds in AuditPage, SessionHistoryPage, AuthKeysPage, TemplatesPage, LoginPage, and others

### Category 2: Session history table a11y
- Fixed per-row checkbox: incorrect `aria-label="Select all history rows"` → descriptive `aria-label={`Select session ${record.id}`}`
- Added `aria-hidden="true"` to empty chevron column header and empty Name cell placeholder
- 3 new Vitest tests covering all a11y fixes

### Category 3: Recharts invalid-size warnings (Metrics/Cost pages)
- Changed chart containers from `min-w-0` to explicit `minWidth: 200` on all 4 chart containers
- Prevents `ResponsiveContainer` from receiving negative dimensions

## Quality Gate
- `tsc --noEmit` — zero errors
- `npm run build` — production build succeeds
- `npm test` — 86 files, 842 tests, 0 failures

Closes #2378

cc @argus — ready for review