### PR TITLE
fix(dashboard): resolve real-user audit regressions

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -204,8 +204,8 @@ async function request<T>(
 
 // ── Health ──────────────────────────────────────────────────────
 
-export function getHealth(): Promise<HealthResponse> {
-  return request('/v1/health', { schema: HealthResponseSchema, schemaContext: 'getHealth' });
+export function getHealth(signal?: AbortSignal): Promise<HealthResponse> {
+  return request('/v1/health', { schema: HealthResponseSchema, schemaContext: 'getHealth', signal });
 }
 
 export interface UpdateCheckResult {

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -185,15 +185,17 @@ export default function Layout() {
 
   useEffect(() => {
     let cancelled = false;
+    const controller = new AbortController();
 
     const loadVersion = async () => {
       try {
-        const health = await getHealth();
+        const health = await getHealth(controller.signal);
         if (!cancelled) {
           setAegisVersion(health.version);
           void runUpdateCheck(health.version, false);
         }
       } catch (err) {
+        if (cancelled || (err instanceof Error && err.name === 'AbortError')) return;
         console.warn('Failed to load Aegis version', err);
         if (!cancelled) setAegisVersion('unknown');
       }
@@ -203,6 +205,7 @@ export default function Layout() {
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, []);
 
@@ -588,7 +591,7 @@ export default function Layout() {
                 type="button"
                 onClick={handleCheckUpdates}
                 disabled={updateCheckLoading || aegisVersion === '...'}
-                className="hidden min-h-[44px] sm:inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-xs text-[var(--color-text-primary)] hover:bg-slate-100 dark:border-void-lighter dark:hover:bg-void-lighter disabled:cursor-not-allowed disabled:opacity-50"
+                className="hidden min-h-[44px] sm:inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-xs text-[var(--color-text-primary)] hover:bg-slate-100 dark:border-void-lighter dark:hover:bg-void-lighter disabled:cursor-not-allowed disabled:border-slate-300 disabled:bg-slate-50 disabled:text-slate-700 dark:disabled:border-void-lighter dark:disabled:bg-transparent dark:disabled:text-zinc-400"
               >
                 <RefreshCw className={`h-3 w-3 ${updateCheckLoading ? 'animate-spin' : ''}`} />
                 {updateCheckLoading ? 'Checking…' : 'Check updates'}

--- a/dashboard/src/components/LiveAuditStream.tsx
+++ b/dashboard/src/components/LiveAuditStream.tsx
@@ -26,20 +26,20 @@ import { describeEvent } from './ActivityStream';
 const EVENT_META: Record<GlobalSSEEventType, {
   icon: typeof Activity;
   label: string;
-  color: string;        // icon + dot color
+  color: string;
   category: 'health' | 'action' | 'security' | 'error';
 }> = {
-  session_status_change: { icon: RefreshCw,   label: 'Status',     color: '#67e8f9', category: 'health'   }, // cyan
-  session_message:       { icon: MessageSquare,label: 'Message',    color: '#e2e8f0', category: 'action'   }, // silver
-  session_approval:      { icon: ShieldAlert,  label: 'Approval',   color: '#fbbf24', category: 'security' }, // amber
-  session_ended:         { icon: Power,        label: 'Ended',      color: '#94a3b8', category: 'action'   }, // slate
-  session_created:       { icon: PlusCircle,   label: 'Created',    color: '#818cf8', category: 'action'   }, // indigo
-  session_stall:         { icon: AlertTriangle,label: 'Stall',      color: '#f59e0b', category: 'security' }, // amber
-  session_dead:          { icon: Skull,        label: 'Dead',       color: '#ef4444', category: 'error'    }, // crimson
-  session_subagent_start:{ icon: Users,        label: 'Subagent',   color: '#67e8f9', category: 'health'   }, // cyan
-  session_subagent_stop: { icon: UserCheck,    label: 'Done',       color: '#34d399', category: 'health'   }, // emerald
-  session_verification:  { icon: ShieldAlert,  label: 'Verify',     color: '#fbbf24', category: 'security' }, // amber
-  shutdown:              { icon: Power,        label: 'Shutdown',   color: '#ef4444', category: 'error'    }, // crimson
+  session_status_change: { icon: RefreshCw, label: 'Status', color: 'var(--color-accent-cyan)', category: 'health' },
+  session_message: { icon: MessageSquare, label: 'Message', color: 'var(--color-text-primary)', category: 'action' },
+  session_approval: { icon: ShieldAlert, label: 'Approval', color: 'var(--color-warning)', category: 'security' },
+  session_ended: { icon: Power, label: 'Ended', color: 'var(--color-text-muted)', category: 'action' },
+  session_created: { icon: PlusCircle, label: 'Created', color: 'var(--color-accent-purple)', category: 'action' },
+  session_stall: { icon: AlertTriangle, label: 'Stall', color: 'var(--color-warning)', category: 'security' },
+  session_dead: { icon: Skull, label: 'Dead', color: 'var(--color-danger)', category: 'error' },
+  session_subagent_start: { icon: Users, label: 'Subagent', color: 'var(--color-accent-cyan)', category: 'health' },
+  session_subagent_stop: { icon: UserCheck, label: 'Done', color: 'var(--color-success)', category: 'health' },
+  session_verification: { icon: ShieldAlert, label: 'Verify', color: 'var(--color-warning)', category: 'security' },
+  shutdown: { icon: Power, label: 'Shutdown', color: 'var(--color-danger)', category: 'error' },
 };
 
 function formatTime(ts: string): string {
@@ -95,8 +95,8 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
               onClick={() => setFilterMode(mode)}
               className={`px-2.5 py-1 rounded-md text-[10px] font-bold uppercase tracking-widest transition-all ${
                 filterMode === mode
-                  ? 'bg-white/10 text-white shadow-inner'
-                  : 'text-slate-600 hover:text-slate-400'
+                  ? 'bg-slate-200 text-slate-900 shadow-inner dark:bg-white/10 dark:text-white'
+                  : 'text-slate-600 hover:text-slate-900 dark:text-slate-500 dark:hover:text-slate-300'
               }`}
             >
               {mode === 'errors' ? '⚠ Errors' : mode === 'actions' ? '⚡ Actions' : 'All'}
@@ -110,7 +110,7 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
             <span className={`relative inline-flex h-2 w-2 rounded-full ${sseConnected ? 'bg-cyan-400 shadow-[0_0_6px_#67e8f9]' : 'bg-slate-600'}`} />
           </span>
           {sseConnected ? (
-            <span className="text-[9px] font-bold uppercase tracking-widest text-cyan-500/70 flex items-center gap-1">
+            <span className="flex items-center gap-1 text-[9px] font-bold uppercase tracking-widest text-[var(--color-accent-cyan)]">
               <Radio className="h-3 w-3" />LIVE
             </span>
           ) : (
@@ -154,9 +154,9 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
                   <div
                     className="relative z-10 mt-0.5 flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full transition-all duration-200 group-hover:scale-110"
                     style={{
-                      background: `${meta.color}15`,
-                      border: `1px solid ${meta.color}30`,
-                      boxShadow: isFirst ? `0 0 10px ${meta.color}40` : undefined,
+                      background: `color-mix(in srgb, ${meta.color} 8%, transparent)`,
+                      border: `1px solid color-mix(in srgb, ${meta.color} 30%, transparent)`,
+                      boxShadow: isFirst ? `0 0 10px color-mix(in srgb, ${meta.color} 25%, transparent)` : undefined,
                     }}
                   >
                     <Icon
@@ -193,7 +193,7 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
           </div>
 
           {/* Bottom fade to suggest infinite scroll */}
-          <div className="sticky bottom-0 h-10 bg-gradient-to-t from-[#020617] to-transparent pointer-events-none" />
+          <div className="sticky bottom-0 h-10 bg-gradient-to-t from-[var(--color-void)] to-transparent pointer-events-none" />
         </div>
       )}
     </div>

--- a/dashboard/src/components/shared/ChartFrame.tsx
+++ b/dashboard/src/components/shared/ChartFrame.tsx
@@ -1,0 +1,52 @@
+import { type ReactElement, type ReactNode, useEffect, useRef, useState } from 'react';
+
+interface ChartFrameSize {
+  width: number;
+  height: number;
+}
+
+interface ChartFrameProps {
+  children: (size: ChartFrameSize) => ReactNode;
+  className: string;
+  label: string;
+}
+
+export function ChartFrame({ children, className, label }: ChartFrameProps): ReactElement {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState<ChartFrameSize | null>(null);
+
+  useEffect(() => {
+    const element = frameRef.current;
+    if (!element) return;
+
+    const updateSize = () => {
+      const rect = element.getBoundingClientRect();
+      setSize(rect.width > 0 && rect.height > 0
+        ? { width: Math.floor(rect.width), height: Math.floor(rect.height) }
+        : null);
+    };
+
+    updateSize();
+
+    if (typeof ResizeObserver === 'undefined') {
+      const timeout = window.setTimeout(updateSize, 0);
+      return () => window.clearTimeout(timeout);
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect;
+      setSize(rect && rect.width > 0 && rect.height > 0
+        ? { width: Math.floor(rect.width), height: Math.floor(rect.height) }
+        : null);
+    });
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={frameRef} className={className}>
+      {size ? children(size) : <div className="h-full min-h-[1px]" role="status" aria-label={label} />}
+    </div>
+  );
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -671,7 +671,7 @@ button:active:not(:disabled) {
 .animate-bento-reveal:nth-child(6) { animation-delay: 0.25s; }
 
 @keyframes bento-reveal {
-  0% { opacity: 1; transform: translateY(20px) scale(0.98); }
+  0% { opacity: 0; transform: translateY(20px) scale(0.98); }
   100% { opacity: 1; transform: translateY(0) scale(1); }
 }
 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -167,11 +167,11 @@
   /* Brand. */
   --color-brand: #0f172a;         /* slate-900 for the Aegis wordmark       */
 
-  /* Accent: blue-600 ≥ 4.5:1 on #f8fafc (AA normal + large). */
+  /* Accent: cyan-800 keeps action text ≥ 4.5:1 on tinted light surfaces. */
   --color-accent-on-light: #2563eb;
-  --color-accent-cyan: #0e7490; /* cyan-700 on white ≈ 5.0:1 */
+  --color-accent-cyan: #155e75; /* cyan-800 on white ≈ 7.5:1 */
   --color-success: #047857;     /* emerald-700 on white ≈ 6.3:1 */
-  --color-warning: #b45309;     /* amber-700 on white ≈ 4.9:1 */
+  --color-warning: #92400e;     /* amber-800 on tinted light surfaces clears AA */
   --color-danger: #dc2626;      /* red-600 on white ≈ 4.8:1 */
 
   /* Primary CTA: emerald-600 on white ≈ 4.6:1 (AA normal). */
@@ -203,7 +203,7 @@
 
   --color-brand: #0a0a0a;
   --color-accent-on-light: #1d4ed8; /* blue-700 for saturation shift */
-  --color-accent-cyan: #0e7490;
+  --color-accent-cyan: #155e75;
   --color-success: #047857;
   --color-warning: #a16207;
   --color-danger: #b91c1c;
@@ -584,6 +584,20 @@ body::before {
 [data-theme="light-aaa"] .text-amber-400 {
   color: var(--color-warning) !important;
 }
+[data-theme="light"] .text-red-300,
+[data-theme="light"] .text-red-400,
+[data-theme="light"] .text-rose-300,
+[data-theme="light"] .text-rose-400,
+[data-theme="light-paper"] .text-red-300,
+[data-theme="light-paper"] .text-red-400,
+[data-theme="light-paper"] .text-rose-300,
+[data-theme="light-paper"] .text-rose-400,
+[data-theme="light-aaa"] .text-red-300,
+[data-theme="light-aaa"] .text-red-400,
+[data-theme="light-aaa"] .text-rose-300,
+[data-theme="light-aaa"] .text-rose-400 {
+  color: var(--color-danger) !important;
+}
 /* Brand-wordmark utility — replaces the dark-only gradient in Layout.tsx
  * with a solid ink color that remains crisp under each sub-theme. */
 .brand-wordmark {
@@ -657,7 +671,7 @@ button:active:not(:disabled) {
 .animate-bento-reveal:nth-child(6) { animation-delay: 0.25s; }
 
 @keyframes bento-reveal {
-  0% { opacity: 0; transform: translateY(20px) scale(0.98); }
+  0% { opacity: 1; transform: translateY(20px) scale(0.98); }
   100% { opacity: 1; transform: translateY(0) scale(1); }
 }
 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -675,6 +675,17 @@ button:active:not(:disabled) {
   100% { opacity: 1; transform: translateY(0) scale(1); }
 }
 
+[data-theme="light"] .animate-bento-reveal,
+[data-theme="light-paper"] .animate-bento-reveal,
+[data-theme="light-aaa"] .animate-bento-reveal {
+  animation-name: bento-reveal-light;
+}
+
+@keyframes bento-reveal-light {
+  0% { opacity: 1; transform: translateY(20px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 /* Seamless nav active indicators */
 .nav-link {
   transition: all 0.2s ease;

--- a/dashboard/src/pages/AuthKeysPage.tsx
+++ b/dashboard/src/pages/AuthKeysPage.tsx
@@ -414,7 +414,7 @@ export default function AuthKeysPage() {
                       type="button"
                       onClick={() => void handleRevoke(key.id, key.name)}
                       disabled={revokingId === key.id}
-                      className="flex min-h-[40px] items-center justify-center gap-2 rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                       className="flex min-h-[40px] items-center justify-center gap-2 rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-700 dark:text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                       {revokingId === key.id ? 'Revoking…' : 'Revoke'}

--- a/dashboard/src/pages/AuthKeysPage.tsx
+++ b/dashboard/src/pages/AuthKeysPage.tsx
@@ -51,7 +51,7 @@ function PermissionBadges({ permissions }: { permissions?: readonly string[] }) 
       {permissions.map((permission) => (
         <span
           key={permission}
-          className="rounded-full border border-[var(--color-void-lighter)]] bg-[var(--color-surface)]] px-2 py-1 font-mono text-[11px] text-[var(--color-accent-cyan)]]"
+          className="rounded-full border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-2 py-1 font-mono text-[11px] text-[var(--color-accent-cyan)]"
         >
           {permission}
         </span>
@@ -230,7 +230,7 @@ export default function AuthKeysPage() {
           type="button"
           onClick={() => void fetchKeys(true)}
           disabled={refreshing}
-          className="flex min-h-[44px] items-center justify-center gap-2 rounded border border-[var(--color-void-lighter)]] bg-[var(--color-surface)]] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]]/30 hover:text-[var(--color-accent-cyan)]] disabled:cursor-not-allowed disabled:opacity-60"
+          className="flex min-h-[44px] items-center justify-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)] disabled:cursor-not-allowed disabled:opacity-60"
         >
           <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
           Refresh
@@ -238,9 +238,9 @@ export default function AuthKeysPage() {
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
-        <section className="rounded-lg border border-[var(--color-void-lighter)]] bg-[var(--color-surface)]] p-5">
+        <section className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-5">
           <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
-            <Plus className="h-4 w-4 text-[var(--color-accent-cyan)]]" />
+            <Plus className="h-4 w-4 text-[var(--color-accent-cyan)]" />
             Create Key
           </div>
           <p className="mt-2 text-sm text-gray-500">
@@ -258,14 +258,14 @@ export default function AuthKeysPage() {
                 value={name}
                 onChange={(event) => setName(event.target.value)}
                 placeholder="ops-primary"
-                className="min-h-[44px] w-full rounded border border-[var(--color-void-lighter)]] bg-[var(--color-void)]] px-3 py-2.5 text-sm text-gray-200 placeholder-gray-600 focus:border-[var(--color-accent-cyan)]] focus:outline-none"
+                className="min-h-[44px] w-full rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2.5 text-sm text-gray-200 placeholder-gray-600 focus:border-[var(--color-accent-cyan)] focus:outline-none"
               />
             </div>
 
             <button
               type="submit"
               disabled={creating || !name.trim()}
-              className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded border border-[var(--color-accent-cyan)]]/30 bg-[var(--color-accent-cyan)]]/10 px-3 py-2 text-sm font-medium text-[var(--color-accent-cyan)]] transition-colors hover:bg-[var(--color-accent-cyan)]]/20 disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-sm font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <KeyRound className="h-4 w-4" />
               {creating ? 'Creating…' : 'Create Auth Key'}
@@ -300,7 +300,7 @@ export default function AuthKeysPage() {
                 </div>
                 <div>
                   <dt className="text-xs uppercase tracking-wide text-gray-500">Secret</dt>
-                  <dd className="mt-1 rounded border border-[var(--color-void-lighter)]] bg-[var(--color-void)]] px-3 py-2 font-mono text-xs text-[var(--color-accent-cyan)]]">
+                  <dd className="mt-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 font-mono text-xs text-[var(--color-accent-cyan)]">
                     {secretVisible ? createdKey.key : maskKey(createdKey.key)}
                   </dd>
                 </div>
@@ -316,7 +316,7 @@ export default function AuthKeysPage() {
                 <button
                   type="button"
                   onClick={() => setSecretVisible((current) => !current)}
-                  className="flex min-h-[40px] items-center gap-2 rounded border border-[var(--color-void-lighter)]] bg-[var(--color-void)]] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]]/30 hover:text-[var(--color-accent-cyan)]]"
+                  className="flex min-h-[40px] items-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
                 >
                   {secretVisible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                   {secretVisible ? 'Hide secret' : 'Reveal secret'}
@@ -324,7 +324,7 @@ export default function AuthKeysPage() {
                 <button
                   type="button"
                   onClick={() => void handleCopySecret()}
-                  className="flex min-h-[40px] items-center gap-2 rounded border border-[var(--color-void-lighter)]] bg-[var(--color-void)]] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]]/30 hover:text-[var(--color-accent-cyan)]]"
+                  className="flex min-h-[40px] items-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
                 >
                   <Copy className="h-3.5 w-3.5" />
                   Copy secret
@@ -334,8 +334,8 @@ export default function AuthKeysPage() {
           ) : null}
         </section>
 
-        <section className="rounded-lg border border-[var(--color-void-lighter)]] bg-[var(--color-surface)]] p-5">
-          <div className="flex items-center justify-between gap-3 border-b border-[var(--color-void-lighter)]] pb-4">
+        <section className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-5">
+          <div className="flex items-center justify-between gap-3 border-b border-[var(--color-void-lighter)] pb-4">
             <div>
               <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Existing Keys</h3>
               <p className="mt-1 text-xs text-gray-500">
@@ -361,7 +361,7 @@ export default function AuthKeysPage() {
               </button>
             </div>
           ) : keys.length === 0 ? (
-            <div className="flex min-h-[240px] flex-col items-center justify-center rounded-lg border border-dashed border-[var(--color-void-lighter)]] bg-[var(--color-void)]] px-6 text-center">
+            <div className="flex min-h-[240px] flex-col items-center justify-center rounded-lg border border-dashed border-[var(--color-void-lighter)] bg-[var(--color-void)] px-6 text-center">
               <KeyRound className="h-8 w-8 text-gray-600" />
               <p className="mt-4 text-sm font-medium text-gray-300">No auth keys yet</p>
               <p className="mt-1 max-w-md text-sm text-gray-500">
@@ -390,13 +390,13 @@ export default function AuthKeysPage() {
               {keys.map((key) => (
                 <article
                   key={key.id}
-                  className="rounded-lg border border-[var(--color-void-lighter)]] bg-[var(--color-void)]] p-4"
+                  className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-4"
                 >
                   <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                      <div className="min-w-0">
                        <div className="group flex items-center gap-2">
                          <span className="truncate font-medium text-gray-900 dark:text-gray-100">{key.name}</span>
-                         <span className="flex items-center gap-1 rounded-full border border-[var(--color-void-lighter)]] bg-[var(--color-surface)]] px-2 py-0.5 font-mono text-[11px] text-gray-500">
+                         <span className="flex items-center gap-1 rounded-full border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-2 py-0.5 font-mono text-[11px] text-gray-500">
                            {key.id}
                            <CopyButton value={key.id} label="key ID" size={16} />
                          </span>

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -11,7 +11,6 @@ import {
   PieChart,
   Pie,
   Cell,
-  ResponsiveContainer,
   XAxis,
   YAxis,
   Tooltip,
@@ -20,6 +19,7 @@ import {
 import { useStore } from '../store/useStore';
 import { formatCurrency } from '../utils/formatNumber';
 import { formatDateShort } from '../utils/formatDate';
+import { ChartFrame } from '../components/shared/ChartFrame';
 
 // Mock data structure (will be replaced with real API data)
 interface DailyCost {
@@ -197,9 +197,9 @@ export default function CostPage() {
         <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
           Daily Spend (Last 14 Days)
         </h3>
-        <div className="h-64 min-w-0">
-          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
-            <BarChart data={dailyData}>
+        <ChartFrame className="h-64 min-w-0" label="Loading daily spend chart">
+          {({ width, height }) => (
+            <BarChart width={width} height={height} data={dailyData}>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
               <XAxis
                 dataKey="date"
@@ -220,8 +220,8 @@ export default function CostPage() {
                 radius={[4, 4, 0, 0]}
               />
             </BarChart>
-          </ResponsiveContainer>
-        </div>
+          )}
+        </ChartFrame>
       </section>
       
       {/* Model breakdown */}
@@ -231,9 +231,9 @@ export default function CostPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Cost by Model
           </h3>
-          <div className="h-64 min-w-0">
-            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
-              <PieChart>
+          <ChartFrame className="h-64 min-w-0" label="Loading cost by model chart">
+            {({ width, height }) => (
+              <PieChart width={width} height={height}>
                 <Pie
                   data={modelData}
                   dataKey="cost"
@@ -253,8 +253,8 @@ export default function CostPage() {
                 </Pie>
                 <Tooltip content={<CustomTooltip />} />
               </PieChart>
-            </ResponsiveContainer>
-          </div>
+            )}
+          </ChartFrame>
         </section>
         
         {/* Model list */}

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -10,7 +10,6 @@ import {
   Bar,
   LineChart,
   Line,
-  ResponsiveContainer,
   XAxis,
   YAxis,
   Tooltip,
@@ -21,6 +20,7 @@ import { useStore } from '../store/useStore';
 import { formatCurrency } from '../utils/formatNumber';
 import { formatDateShort } from '../utils/formatDate';
 import { downloadCSV } from '../utils/csv-export';
+import { ChartFrame } from '../components/shared/ChartFrame';
 
 type RangePreset = '7d' | '30d' | '90d';
 type Granularity = 'day' | 'hour' | 'key';
@@ -165,7 +165,7 @@ export default function MetricsPage() {
           type="button"
           onClick={handleExport}
           disabled={!data}
-          className="flex min-h-[44px] items-center gap-1.5 rounded-md bg-[var(--color-surface-strong)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] disabled:opacity-40"
+          className="flex min-h-[44px] items-center gap-1.5 rounded-md bg-[var(--color-surface-strong)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-cyan)] disabled:cursor-not-allowed disabled:text-[var(--color-text-muted)]"
         >
           <Download className="h-3.5 w-3.5" />
           Export CSV
@@ -257,9 +257,9 @@ export default function MetricsPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Sessions &amp; Cost Over Time
           </h3>
-          <div className="h-64 min-w-0">
-            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
-              <BarChart data={data.timeSeries}>
+          <ChartFrame className="h-64 min-w-0" label="Loading sessions and cost chart">
+            {({ width, height }) => (
+              <BarChart width={width} height={height} data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
                   dataKey="timestamp"
@@ -288,8 +288,8 @@ export default function MetricsPage() {
                   radius={[4, 4, 0, 0]}
                 />
               </BarChart>
-            </ResponsiveContainer>
-          </div>
+            )}
+          </ChartFrame>
         </section>
       )}
 
@@ -299,9 +299,9 @@ export default function MetricsPage() {
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Token Cost Trend
           </h3>
-          <div className="h-48 min-w-0">
-            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
-              <LineChart data={data.timeSeries}>
+          <ChartFrame className="h-48 min-w-0" label="Loading token cost trend chart">
+            {({ width, height }) => (
+              <LineChart width={width} height={height} data={data.timeSeries}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
                 <XAxis
                   dataKey="timestamp"
@@ -324,8 +324,8 @@ export default function MetricsPage() {
                   dot={false}
                 />
               </LineChart>
-            </ResponsiveContainer>
-          </div>
+            )}
+          </ChartFrame>
         </section>
       )}
 

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -218,7 +218,7 @@ export default function PipelinesPage() {
         </div>
         <button
           onClick={() => setModalOpen(true)}
-          className="flex min-h-[44px] items-center gap-1.5 px-3 py-2 text-xs font-medium rounded bg-[var(--color-accent-cyan)]]/10 hover:bg-[var(--color-accent-cyan)]]/20 text-[var(--color-accent-cyan)]] border border-[var(--color-accent-cyan)]]/30 transition-colors"
+          className="flex min-h-[44px] items-center gap-1.5 px-3 py-2 text-xs font-medium rounded bg-[var(--color-accent-cyan)]/10 hover:bg-[var(--color-accent-cyan)]/20 text-[var(--color-accent-cyan)] border border-[var(--color-accent-cyan)]/30 transition-colors"
         >
           <Plus className="h-3.5 w-3.5" />
           New Pipeline
@@ -309,7 +309,7 @@ export default function PipelinesPage() {
             <Link
               key={pipeline.id}
               to={`/pipelines/${pipeline.id}`}
-              className="block rounded-lg border border-[var(--color-void-lighter)]] bg-[var(--color-surface)]] p-4 hover:border-[var(--color-accent-cyan)]]/30 transition-colors"
+              className="block rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-4 hover:border-[var(--color-accent-cyan)]/30 transition-colors"
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3 min-w-0">

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -591,8 +591,10 @@ export default function SessionHistoryPage() {
             <table className="min-w-full text-left">
               <thead className="border-b border-gray-200 dark:border-zinc-800 bg-gray-50/80 dark:bg-zinc-900/80">
                 <tr>
-                  <th className="px-4 py-3">
+                  <th className="px-4 py-3" scope="col">
+                    <span className="sr-only">Select history rows</span>
                     <input
+                      aria-label="Select all history rows"
                       type="checkbox"
                       checked={sortedRecords.length > 0 && selectedIds.size === sortedRecords.length}
                       onChange={toggleSelectAll}

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -63,14 +63,14 @@ function formatTimestamp(ts?: number): string {
 }
 
 function statusClass(status: SessionHistoryRecord['finalStatus']): string {
-  if (status === 'active') return 'text-emerald-300 bg-emerald-500/10 border-emerald-500/25';
-  if (status === 'killed') return 'text-rose-300 bg-rose-500/10 border-rose-500/25';
+  if (status === 'active') return 'text-emerald-700 dark:text-emerald-300 bg-emerald-500/10 border-emerald-500/25';
+  if (status === 'killed') return 'text-rose-700 dark:text-rose-300 bg-rose-500/10 border-rose-500/25';
   return 'text-gray-600 dark:text-zinc-300 bg-gray-200/60 dark:bg-zinc-700/40 border-gray-300 dark:border-zinc-700';
 }
 
 function sourceClass(source: SessionHistoryRecord['source']): string {
-  if (source === 'audit+live') return 'text-cyan-300 bg-cyan-500/10 border-cyan-500/25';
-  if (source === 'live') return 'text-sky-300 bg-sky-500/10 border-sky-500/25';
+  if (source === 'audit+live') return 'text-cyan-700 dark:text-cyan-300 bg-cyan-500/10 border-cyan-500/25';
+  if (source === 'live') return 'text-sky-700 dark:text-sky-300 bg-sky-500/10 border-sky-500/25';
   return 'text-gray-600 dark:text-zinc-300 bg-gray-200/60 dark:bg-zinc-700/40 border-gray-300 dark:border-zinc-700';
 }
 
@@ -591,9 +591,11 @@ export default function SessionHistoryPage() {
             <table className="min-w-full text-left">
               <thead className="border-b border-gray-200 dark:border-zinc-800 bg-gray-50/80 dark:bg-zinc-900/80">
                 <tr>
-                  <th className="px-4 py-3">
+                  <th className="px-4 py-3" scope="col">
+                    <span className="sr-only">Select history rows</span>
                     <input
                       type="checkbox"
+                      aria-label="Select all visible history rows"
                       checked={sortedRecords.length > 0 && selectedIds.size === sortedRecords.length}
                       onChange={toggleSelectAll}
                       className="h-4 w-4 rounded border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-cyan-500 focus:ring-cyan-500/30"
@@ -606,7 +608,9 @@ export default function SessionHistoryPage() {
                   {sortableHeader("Source", "source")}
                   {sortableHeader("Created", "createdAt")}
                   {sortableHeader("Last seen", "lastSeenAt")}
-                  <th className="w-8" />
+                  <th className="w-8" scope="col">
+                    <span className="sr-only">Actions</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -646,7 +650,7 @@ export default function SessionHistoryPage() {
                     >
                       <td className="px-4 py-3" data-no-nav>
                         <input
-                          aria-label="Select all history rows"
+                          aria-label={`Select history row ${shortId(record.id)}`}
                           type="checkbox"
                           checked={selectedIds.has(record.id)}
                           onChange={() => toggleSelect(record.id)}

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -292,7 +292,7 @@ export default function TemplatesPage() {
                     type="button"
                     onClick={() => setDeleteTarget({ id: template.id, name: template.name })}
                     disabled={deletingId === template.id}
-                    className="flex min-h-[40px] items-center justify-center gap-1.5 rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="flex min-h-[40px] items-center justify-center gap-1.5 rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-700 dark:text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
                     {deletingId === template.id ? 'Deleting…' : 'Delete'}


### PR DESCRIPTION
## Summary
- Fixes real-user dashboard audit regressions found on latest develop.
- Resolves light-theme contrast failures, malformed Tailwind arbitrary-value classes, session-history table a11y labels, and Recharts invalid-size warnings.
- Keeps light-theme bento reveal readable during animation and prevents expected route-change health aborts from logging warnings.

Closes #2378

## Validation
- Real-user dashboard audit against built Aegis v0.6.0-preview on 127.0.0.1:9100: 30/30 checks passed, 0 axe groups, 0 serious/critical axe groups, 0 console errors, 0 console warnings, 0 real network errors.
- npm --prefix dashboard run build
- npm --prefix dashboard run test
- npm --prefix dashboard run a11y:check
- npm run gate

## Notes
- Browser navigation aborts (net::ERR_ABORTED during route changes/lazy chunk cancellation) are recorded separately by the audit script and are not product network failures.