### PR TITLE
fix(audit): accept v2 PBKDF2 and v1-no-actor legacy hashes

### DIFF
--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -189,6 +189,16 @@ describe('AuditLogger (Issue #1419)', () => {
       expect(result).toEqual({ valid: true });
     });
 
+    it('accepts pre-upgrade v2 PBKDF2 fixture file with chained records (#2342)', async () => {
+      const fixturePath = join(__dirname, 'fixtures', 'audit', 'audit-v2-pbkdf2-legacy.fixture');
+      const fixtureContent = await readFile(fixturePath, 'utf-8');
+      const targetFile = join(tmpDir, 'audit-2026-04-11.log');
+      await writeFile(targetFile, fixtureContent);
+
+      const result = await audit.verify();
+      expect(result).toEqual({ valid: true });
+    });
+
     it('returns invalid when audit storage cannot be read', async () => {
       const fileBackedPath = join(tmpDir, 'not-a-directory');
       await writeFile(fileBackedPath, 'blocked');

--- a/src/__tests__/fixtures/audit/audit-v2-pbkdf2-legacy.fixture
+++ b/src/__tests__/fixtures/audit/audit-v2-pbkdf2-legacy.fixture
@@ -1,0 +1,2 @@
+{"ts":"2026-04-11T15:16:05.116Z","actor":"master","action":"api.authenticated","sessionId":"","detail":"GET /v1/sessions/test-session-id","prevHash":"","hash":"518f83fe87841d43c2dd105428e6d5f8c725c86c9f8a27f1bd49af5f4ebe344e"}
+{"ts":"2026-04-11T15:16:06.000Z","actor":"master","action":"session.create","sessionId":"sess-abc123","detail":"Created session sess-abc123","prevHash":"518f83fe87841d43c2dd105428e6d5f8c725c86c9f8a27f1bd49af5f4ebe344e","hash":"c44d486bd1509e726330a9497a6bb3a0b52f072b831ce4446435d0dcdf507755"}

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -11,7 +11,7 @@
  * libuv's thread pool under audit-heavy workloads.
  */
 
-import { createHash, createHmac, scryptSync } from 'node:crypto';
+import { createHash, createHmac, pbkdf2Sync, scryptSync } from 'node:crypto';
 import { appendFile, readFile, mkdir, readdir, lstat } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
@@ -162,14 +162,35 @@ function dateToFileDate(d: Date): string {
 
 // Issue #1642: v3 chain uses SHA-256 (fast, non-blocking) instead of PBKDF2.
 // v4 records use HMAC with a scrypt-derived actor component. Verification also accepts
-// v1 records (plain SHA-256 with raw actor in payload) so pre-upgrade logs remain valid.
+// v1 records (plain SHA-256 with raw actor in payload) and v2 records (PBKDF2-120k/sha512
+// with the same payload) so pre-upgrade logs remain verifiable after rollouts. PBKDF2
+// recompute is synchronous because verify() is a one-shot tooling path (`ag doctor`),
+// not a hot write path.
 const AUDIT_CHAIN_DOMAIN = 'aegis-audit-chain-v4';
 const AUDIT_ACTOR_DOMAIN = 'aegis-audit-actor-v1';
+// Issue #2342: pre-upgrade v2 records hash with PBKDF2 keyed by `aegis-audit-chain-v2|<prevHash>`.
+const AUDIT_V2_HASH_SALT_PREFIX = 'aegis-audit-chain-v2';
+const AUDIT_V2_HASH_ITERATIONS = 120_000;
+const AUDIT_V2_HASH_KEY_LENGTH = 32;
+const AUDIT_V2_HASH_DIGEST = 'sha512';
 const actorHashComponentCache = new Map<string, string>();
 
 function computeLegacyHash(record: Omit<AuditRecord, 'hash'>): string {
   const payload = `${record.ts}|${record.actor}|${record.action}|${record.sessionId ?? ''}|${record.detail}|${record.prevHash}`;
   return createHash('sha256').update(payload).digest('hex');
+}
+
+// Pre-#3d525774 v1 records were written without the actor in the payload.
+// Restored alongside #2349 so chains crossing that revert verify cleanly.
+function computeLegacyHashWithoutActor(record: Omit<AuditRecord, 'hash'>): string {
+  const payload = `${record.ts}|${record.action}|${record.sessionId ?? ''}|${record.detail}|${record.prevHash}`;
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function computeV2LegacyHash(record: Omit<AuditRecord, 'hash'>): string {
+  const payload = `${record.ts}|${record.actor}|${record.action}|${record.sessionId ?? ''}|${record.detail}|${record.prevHash}`;
+  const salt = `${AUDIT_V2_HASH_SALT_PREFIX}|${record.prevHash}`;
+  return pbkdf2Sync(payload, salt, AUDIT_V2_HASH_ITERATIONS, AUDIT_V2_HASH_KEY_LENGTH, AUDIT_V2_HASH_DIGEST).toString('hex');
 }
 
 function computeActorHashComponent(actor: string): string {
@@ -190,7 +211,10 @@ function computeHash(record: Omit<AuditRecord, 'hash'>): string {
 }
 
 function matchesKnownHashFormat(record: AuditRecord): boolean {
-  return record.hash === computeHash(record) || record.hash === computeLegacyHash(record);
+  return record.hash === computeHash(record)
+    || record.hash === computeLegacyHash(record)
+    || record.hash === computeLegacyHashWithoutActor(record)
+    || record.hash === computeV2LegacyHash(record);
 }
 
 function csvEscape(value: string | undefined): string {


### PR DESCRIPTION
## Summary

`ag doctor` was still flagging pre-upgrade audit logs as invalid after #2349, because two earlier hash formats remained unrecognized:

- **v2 PBKDF2** — `pbkdf2(120000 iters, sha512, salt='aegis-audit-chain-v2|<prevHash>')` used before #1642 swapped to SHA-256
- **v1 no-actor SHA-256** — payload `ts|action|sessionId|detail|prevHash` written between the actor-removed and actor-restored revisions on 2026-04-12

`matchesKnownHashFormat()` now also tries `computeV2LegacyHash` and `computeLegacyHashWithoutActor`, so chains that cross those revisions verify cleanly.

## Reproducer (before this PR)

```bash
$ node dist/cli.js doctor --json | jq '.checks[] | select(.key=="audit-chain")'
{ "key": "audit-chain", "status": "fail", "message": "invalid at audit-2026-04-11.log line 1" }
```

Hash recompute against `audit-2026-04-11.log` line 1:

```js
const { pbkdf2Sync } = require('crypto');
const payload = '2026-04-11T15:16:05.116Z|master|api.authenticated||GET /v1/sessions/64381c3a-b89c-4191-99f0-7c4a95138526|';
pbkdf2Sync(payload, 'aegis-audit-chain-v2|', 120000, 32, 'sha512').toString('hex');
// → 7717f19a4c0bb19e5326fc907aa029b5af80e49b23174a9622db6b598146531e   ← matches stored hash
```

After this PR the v2 line and the subsequent no-actor v1 lines verify; the only remaining `audit-chain: fail` on real local logs is a genuine `prevHash` mismatch around a server-restart boundary, which is a separate issue (chain-reset detection, not hash format).

## Notes

- PBKDF2 recompute is synchronous because `verify()` is one-shot tooling (`ag doctor`), not the audit write path. Steady-state writes still use the fast HMAC + scrypt-derived actor (`computeHash`).
- Adds `src/__tests__/fixtures/audit/audit-v2-pbkdf2-legacy.fixture` mirroring the existing v1 fixture.
- `npm run gate` passes locally (217 files, 3795 tests, 0 failed).

Closes #2342.

## Aegis version
**Developed with:** v0.6.0-preview