### PR TITLE
fix(dashboard): suppress tour while New Session drawer is open

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -60,6 +60,7 @@ export default function App() {
   const [showHelp, setShowHelp] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showTour, setShowTour] = useState(false);
+  const newSessionOpen = useDrawerStore((s) => s.newSessionOpen);
 
   useEffect(() => {
     if (!isAuthenticated || location.pathname === '/login') {
@@ -85,10 +86,11 @@ export default function App() {
       && !showOnboarding
       && !isTourCompleted()
       && !showTour
+      && !newSessionOpen
     ) {
       setShowTour(true);
     }
-  }, [isAuthenticated, location.pathname, showOnboarding, showTour]);
+  }, [isAuthenticated, location.pathname, showOnboarding, showTour, newSessionOpen]);
 
   useKeyboardShortcuts({
     onShortcut: (shortcut) => {


### PR DESCRIPTION
## Summary
Fixes #2383

The first-run tour overlay and New Session drawer competed for backdrop
ownership on first-run. Clicking the tour Skip button was intercepted by
the drawer backdrop, blocking the user.

## Fix
Added `newSessionOpen` from `useDrawerStore` to the tour trigger guard
in App.tsx. The tour now defers until the drawer is closed.

## Verification
- tsc clean | 842 tests pass
- Manual: navigate to /dashboard/sessions/new on fresh profile — tour
  no longer fires while drawer is open