### PR TITLE
fix(terminal): assistant bullet ● no longer triggers false working state (#2381)

### DIFF
--- a/src/__tests__/terminal-parser.test.ts
+++ b/src/__tests__/terminal-parser.test.ts
@@ -977,6 +977,51 @@ Would you like to proceed?
   });
 });
 
+
+  describe('issue #2381: assistant bullet ● does not trigger working', () => {
+    it('● followed by plain text (no ellipsis) is NOT detected as working', () => {
+      const pane = `
+● AEGIS_REAL_USER_SMOKE_OK
+
+✻ Crunched for 2s
+
+────────────────────────────────────────────────────────────────────────────────
+
+❯
+`;
+      expect(detectUIState(pane)).toBe('idle');
+    });
+
+    it('● followed by plain text WITHOUT chrome separator returns unknown (not working)', () => {
+      const pane = `
+● AEGIS_REAL_USER_SMOKE_OK
+
+✻ Crunched for 2s
+
+❯
+`;
+      expect(detectUIState(pane)).not.toBe('working');
+    });
+
+    it('● followed by ellipsis IS detected as working (real spinner)', () => {
+      const padding = Array(10).fill('').join('\n');
+      const pane = padding + `● Reading file…\n` + padding + '\n❯\n';
+      expect(detectUIState(pane)).toBe('working');
+    });
+
+    it('● turn counter (digits only) is NOT detected as working', () => {
+      const pane = `
+● 4
+
+────────────────────────────────────────────────────────────────────────────────
+
+❯
+`;
+      expect(detectUIState(pane)).toBe('idle');
+    });
+  });
+
+
 describe('parseStatusLine', () => {
   it('extracts status text from spinner line', () => {
     const status = parseStatusLine(WORKING_SPINNER);

--- a/src/terminal-parser.ts
+++ b/src/terminal-parser.ts
@@ -237,8 +237,10 @@ function hasSpinnerAnywhere(lines: string[]): boolean {
       // For `*` (also a markdown bullet), require `* ` + ellipsis/dots to avoid false positives
       if (firstChar === '*') {
         if (stripped[1] !== ' ' || !(stripped.includes('…') || stripped.includes('...'))) continue;
-      } else if (firstChar === '●' && /^\d+\s*$/.test(stripped.slice(1).trim())) {
-        continue;
+      } else if (firstChar === '●') {
+        // ● is used for turn counters (● 4), assistant response bullets (● Reply text),
+        // and active spinners (● Reading file…). Only treat as spinner if it has ellipsis.
+        if (!(stripped.includes('…') || stripped.includes('...'))) continue;
       } else if (!(stripped.includes('…') || stripped.includes('...') || /[^\s\u00a0]/.test(stripped.slice(1)))) {
         continue;
       }
@@ -365,9 +367,10 @@ export function parseStatusLine(paneText: string): string | null {
         // Not a real spinner line — skip
         continue;
       }
-      // Exclude bare bullet + number (turn counter, e.g. "● 4") — not an active spinner
-      if (line[0] === '●' && /^\d+\s*$/.test(line.slice(1).trim())) {
-        continue;
+      // ● is used for turn counters, assistant response bullets, and active spinners.
+      // Only treat as spinner if it has ellipsis/dots.
+      if (line[0] === '●') {
+        if (!(line.includes('…') || line.includes('...'))) continue;
       }
       return line.slice(1).trim();
     }


### PR DESCRIPTION
## Summary
Fixes #2381 — Session remains `working` after completed reply is visible.

**Root cause:** Claude Code v2.1+ uses `●` as a bullet character for assistant responses (e.g., `● AEGIS_REAL_USER_SMOKE_OK`). The terminal parser's spinner detector treated ALL lines starting with `●` as active spinners, causing `detectUIState()` to return `working` even after Claude finished and returned to the idle prompt.

**Fix:** `●` is now only treated as an active spinner when followed by ellipsis (`…` or `...`). Applied in both `hasSpinnerAnywhere()` and `parseStatusLine()`.

**Before:** `● AEGIS_REAL_USER_SMOKE_OK` → `working`
**After:** `● AEGIS_REAL_USER_SMOKE_OK` → `idle` (when prompt + chrome present)

## Verification
```
tsc --noEmit  ✅ zero errors
npm run build ✅ success
npm test      ✅ 3808 passed, 218 test files
```

## Test coverage
4 new regression tests:
- `●` with plain text (no ellipsis) → not working
- `●` with plain text, no chrome separator → not working  
- `●` with ellipsis → working (real spinner)
- `●` with turn counter (digits) → not working
