### PR TITLE
fix(security): add worker-src blob to dashboard CSP (#2384)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -140,6 +140,7 @@ const DASHBOARD_CSP = [
   "base-uri 'self'",
   "form-action 'self'",
   "object-src 'none'",
+  "worker-src blob 'self'",
 ].join('; ');
 
 const DASHBOARD_RESPONSE_HEADERS = {


### PR DESCRIPTION
## Summary
Fixes #2384 — Browser CSP error when creating blob workers on session detail page.

## Root Cause
xterm.js creates blob workers for terminal rendering. Without an explicit `worker-src` directive, CSP falls back to `script-src 'self'` which blocks blob URL workers.

## Fix
Added `worker-src blob 'self'` to `DASHBOARD_CSP` in `src/server.ts`. Allows blob workers while maintaining same-origin restriction.

## Verification
```
tsc --noEmit: ✅ clean
npm run build: ✅ success
npm test: ✅ 3808 passed, 11 skipped
```

## Aegis Metadata
- **Version:** develop @ d9b6261
- **Commit:** ba31e7e