### PR TITLE
fix(dashboard): handle Windows paths and audit column overflow

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -182,11 +182,25 @@ interface SessionRowViewModel {
 const needsApproval = (session: SessionInfo): boolean =>
   session.status === 'permission_prompt' || session.status === 'bash_approval';
 
-const truncateDir = (dir: string, max = 40): string =>
-  dir.length > max ? `…${dir.slice(dir.length - max + 1)}` : dir;
+const truncateDir = (dir: string, max = 40): string => {
+  const normalized = dir.replace(/\\/g, '/');
+  const abbreviated = normalized
+    .replace(/^\/home\/[^/]+\//, '~/')
+    .replace(/^[A-Z]:\/Users\/[^/]+\//i, (m) => `${m[0]}:/…/`);
+  if (abbreviated.length <= max) return abbreviated;
+  const segments = abbreviated.split('/');
+  let result = segments[segments.length - 1] || abbreviated;
+  for (let i = segments.length - 2; i >= 0; i--) {
+    const candidate = segments.slice(i).join('/');
+    if (candidate.length > max) break;
+    result = candidate;
+  }
+  return result.length < abbreviated.length ? `…${result}` : `…${abbreviated.slice(abbreviated.length - max + 1)}`;
+};
 
 const extractDirKey = (workDir: string): string => {
-  const segments = workDir.replace(/\/+$/, '').split('/');
+  const normalized = workDir.replace(/\\/g, '/');
+  const segments = normalized.replace(/[\\/]+$/, '').split('/');
   return segments[segments.length - 1] || workDir;
 };
 

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -65,8 +65,19 @@ const GRID_COLUMNS = '36px 44px 90px 1fr 160px 100px 110px 100px 70px 90px';
 // ── Helpers ─────────────────────────────────────────────────
 
 function truncateDir(workDir: string, max = 24): string {
-  const dir = workDir.replace(/^\/home\//, '~/');
-  return dir.length > max ? `…${dir.slice(dir.length - max + 1)}` : dir;
+  const normalized = workDir.replace(/\\/g, '/');
+  const abbreviated = normalized
+    .replace(/^\/home\/[^/]+\//, '~/')
+    .replace(/^[A-Z]:\/Users\/[^/]+\//i, (m) => `${m[0]}:/…/`);
+  if (abbreviated.length <= max) return abbreviated;
+  const segments = abbreviated.split('/');
+  let result = segments[segments.length - 1] || abbreviated;
+  for (let i = segments.length - 2; i >= 0; i--) {
+    const candidate = segments.slice(i).join('/');
+    if (candidate.length > max) break;
+    result = candidate;
+  }
+  return result.length < abbreviated.length ? `…${result}` : `…${abbreviated.slice(abbreviated.length - max + 1)}`;
 }
 
 // ── Row Extra Props (what we pass via rowProps) ─────────────
@@ -148,10 +159,10 @@ function VirtualizedRow(props: {
           ? `${session.ownerKeyId.slice(0, 8)}${session.ownerKeyId.length > 8 ? '…' : ''}`
           : '—'}
       </div>
-      <div className="flex items-center px-3">
+      <div className="flex min-w-0 items-center px-3">
         <Link
           to={`/sessions/${encodeURIComponent(session.id)}`}
-          className="inline-flex min-h-[44px] items-center font-medium text-gray-200 transition-colors hover:text-cyan"
+          className="inline-flex min-h-[44px] min-w-0 items-center truncate font-medium text-gray-200 transition-colors hover:text-cyan"
         >
           {session.windowName || session.id}
         </Link>

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -179,16 +179,16 @@ function AuditRow({ record, index, onClick }: { record: AuditRecord; index: numb
       <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-zinc-400">
         {formatTimestamp(record.ts)}
       </td>
-      <td className="px-4 py-3 font-mono text-sm text-gray-700 dark:text-zinc-200">
+      <td className="max-w-[120px] truncate px-4 py-3 font-mono text-sm text-gray-700 dark:text-zinc-200" title={record.actor}>
         {record.actor}
       </td>
       <td className="px-4 py-3">
-        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${actionBadgeClass(record.action)}`}>
+        <span className={`inline-flex max-w-[160px] truncate rounded-full px-2 py-0.5 text-xs font-medium ${actionBadgeClass(record.action)}`} title={record.action}>
           {record.action}
         </span>
       </td>
-      <td className="px-4 py-3 font-mono text-sm text-gray-600 dark:text-zinc-300">
-        {record.sessionId ?? '—'}
+      <td className="max-w-[140px] truncate px-4 py-3 font-mono text-sm text-gray-600 dark:text-zinc-300" title={record.sessionId ?? ''}>
+        {record.sessionId ? truncateHash(record.sessionId, 12) : '—'}
       </td>
       <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-zinc-400" title={record.hash}>
         {truncateHash(record.hash)}


### PR DESCRIPTION
## Summary

- Fix `truncateDir` to normalize backslashes, abbreviate `C:\Users\<name>\` to `C:/…/`, and show trailing path segments instead of arbitrary tail-chop
- Fix `extractDirKey` to split on both `/` and `\` so Windows paths group correctly in session table
- Add `min-w-0` + `truncate` to virtualized session list Name column to prevent overflow
- Add `max-width`, `truncate`, and `title` tooltips to audit table Actor, Action, and Session ID columns

Closes #2388

## Aegis version
**Developed with:** v0.6.0-preview

## Test plan
- [x] `npm run build:dashboard` passes
- [x] `npx tsc --noEmit` passes
- [x] Dashboard tests pass (21/21 — SessionTable + AuditPage)
- [ ] Visual verification on Windows: session paths display correctly, audit columns don't overflow

Generated by Hephaestus (Aegis dev agent)