### PR TITLE
docs: document v0.6.5-preview release fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6.5-preview](https://github.com/OneStepAt4time/aegis/compare/v0.6.1-preview...v0.6.5-preview) (2026-05-02)
+
+### Added
+
+* **dashboard:** add OIDC SSO support and supporting CLI/device-flow documentation ([#2325](https://github.com/OneStepAt4time/aegis/pull/2325), [#2335](https://github.com/OneStepAt4time/aegis/pull/2335), [#2339](https://github.com/OneStepAt4time/aegis/pull/2339)).
+* **usage:** document and register usage/metering routes for Phase 3 early-enterprise deployments ([#2344](https://github.com/OneStepAt4time/aegis/pull/2344), [#2353](https://github.com/OneStepAt4time/aegis/pull/2353)).
+
+### Changed
+
+* **release:** automate SDK publishing paths and gate TypeScript SDK drift before release ([#2333](https://github.com/OneStepAt4time/aegis/pull/2333), [#2377](https://github.com/OneStepAt4time/aegis/pull/2377)).
+* **docs:** align Phase 3 policy, roadmap, and agent guidance with shipped features ([#2327](https://github.com/OneStepAt4time/aegis/pull/2327), [#2330](https://github.com/OneStepAt4time/aegis/pull/2330)).
+
+### Fixed
+
+* **terminal:** detect Claude Code rate-limit menus, BYO completion states, and completed assistant responses that start with a plain `●` bullet without leaving the session stuck in `working` ([#2369](https://github.com/OneStepAt4time/aegis/pull/2369), [#2381](https://github.com/OneStepAt4time/aegis/issues/2381)).
+* **dashboard:** harden real-user dashboard flows across authentication, onboarding, navigation, mobile touch targets, terminal streaming errors, and audit views ([#2355](https://github.com/OneStepAt4time/aegis/pull/2355), [#2356](https://github.com/OneStepAt4time/aegis/pull/2356), [#2357](https://github.com/OneStepAt4time/aegis/pull/2357), [#2358](https://github.com/OneStepAt4time/aegis/pull/2358), [#2359](https://github.com/OneStepAt4time/aegis/pull/2359), [#2360](https://github.com/OneStepAt4time/aegis/pull/2360), [#2361](https://github.com/OneStepAt4time/aegis/pull/2361), [#2373](https://github.com/OneStepAt4time/aegis/pull/2373), [#2379](https://github.com/OneStepAt4time/aegis/pull/2379), [#2380](https://github.com/OneStepAt4time/aegis/pull/2380)).
+* **dashboard:** keep the first-run tour from overlapping the New Session drawer, so drawer backdrops no longer block tour controls ([#2383](https://github.com/OneStepAt4time/aegis/issues/2383), [#2385](https://github.com/OneStepAt4time/aegis/pull/2385)).
+* **dashboard:** render Windows worktree paths and long session names predictably, and truncate long audit Actor, Action, and Session ID cells with tooltips instead of overflowing the table ([#2388](https://github.com/OneStepAt4time/aegis/issues/2388)).
+* **security:** allow expected xterm.js blob workers through the dashboard CSP with an explicit `worker-src` directive, removing Session Detail CSP console errors while keeping `script-src` locked down ([#2384](https://github.com/OneStepAt4time/aegis/issues/2384), [#2387](https://github.com/OneStepAt4time/aegis/pull/2387)).
+* **security:** remove create permission from viewer role and improve audit hash compatibility for legacy records ([#2343](https://github.com/OneStepAt4time/aegis/pull/2343), [#2349](https://github.com/OneStepAt4time/aegis/pull/2349), [#2382](https://github.com/OneStepAt4time/aegis/pull/2382)).
+* **api:** reconcile OpenAPI drift, restore overridden operations, add missing `SessionInfo` contract fields, and sync the `rate_limit` response contract ([#2336](https://github.com/OneStepAt4time/aegis/pull/2336), [#2338](https://github.com/OneStepAt4time/aegis/pull/2338), [#2374](https://github.com/OneStepAt4time/aegis/pull/2374), [#2376](https://github.com/OneStepAt4time/aegis/pull/2376)).
+
 ## [0.5.3-alpha](https://github.com/OneStepAt4time/aegis/compare/v0.5.2-alpha...v0.5.3-alpha) (2026-04-13)
 
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -54,6 +54,7 @@ The Sessions page (`/dashboard/sessions`) supports real-time search and filterin
   - 🟢 **Green** — session running normally
   - 🟡 **Amber (slow pulse)** — session stalled (no activity detected)
   - 🔴 **Red (fast pulse)** — session dead (terminated or unresponsive)
+- **Windows-aware paths** — work directories are normalized across `/` and `\`, `C:\Users\<name>\` paths abbreviate to `C:/…/`, and long names truncate in the cell instead of overflowing the list.
 
 ### CSV Export
 
@@ -117,6 +118,7 @@ The session detail page (`/dashboard/sessions/:id`) includes tabbed views:
   - 🟢 Green — permission granted / approved
   - 🔴 Red — permission denied / rejected
   - 🟡 Amber — permission prompt / request
+  - Long Actor, Action, and Session ID values truncate with a hover title so the audit table remains readable on narrow screens.
 - **Metrics tab** — token usage, latency, and session statistics
 
 Navigation:
@@ -138,6 +140,8 @@ List of all sessions with search, filter, date range, and CSV export.
 Create a new Aegis session directly from the dashboard without using the API.
 
 **Template selector:** Click a template card to pre-fill the session fields (name, work directory, prompt, Claude command, and permission mode). Templates are loaded from the Templates page.
+
+The first-run guided tour pauses while the New Session drawer is open, preventing drawer backdrops from blocking tour controls.
 
 **Manual fields:**
 - **Name** — optional session name

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,6 +136,14 @@ curl -X POST http://localhost:9100/v1/sessions/<id>/kill \
 
 ---
 
+### Completed session still appears as "working"
+
+**Cause:** Older Aegis builds could treat Claude Code assistant output that starts with a plain `●` bullet as an active spinner, even after Claude returned to the prompt.
+
+**Fix:** Upgrade to `0.6.5-preview` or later. Aegis now treats `●` as active work only when it is followed by an ellipsis spinner (`…` or `...`), so completed assistant replies settle back to an idle/ready state.
+
+---
+
 ### Transcript returns 0 messages despite activity
 
 **Cause:** JSONL file is being written but byte offset tracking may be stale.
@@ -168,6 +176,28 @@ curl http://localhost:9100/v1/sessions/<id>/health \
 curl -X POST http://localhost:9100/v1/sessions/<id>/approve \
   -H "Authorization: Bearer $AEGIS_AUTH_TOKEN"
 ```
+
+---
+
+## Dashboard Issues
+
+### Session Detail logs a CSP worker error
+
+```text
+Creating a worker from 'blob:http://127.0.0.1:9100/...' violates the following Content Security Policy directive: "script-src 'self'".
+```
+
+**Cause:** Older Aegis builds did not set `worker-src`, so browsers fell back to `script-src` and blocked the blob workers used by the terminal renderer.
+
+**Fix:** Upgrade to `0.6.5-preview` or later. The dashboard CSP now explicitly allows the expected same-origin/blob worker path without widening `script-src`.
+
+---
+
+### Windows paths or audit columns overflow dashboard tables
+
+**Cause:** Older dashboard builds handled Unix-style paths better than Windows paths, and long actor/action/session identifiers could push audit columns off screen.
+
+**Fix:** Upgrade to `0.6.5-preview` or later. Sessions now group and truncate Windows paths consistently, and long audit values truncate with hover titles.
 
 ---
 


### PR DESCRIPTION
## Summary
- add 0.6.5-preview changelog coverage for the release train since v0.6.1-preview
- document the required release-gate fixes for #2381, #2384, and #2388
- add user-facing dashboard/troubleshooting notes for session status, CSP workers, Windows paths, and audit table overflow

## Release gate
This docs PR is intended to satisfy the docs gate blocking #2390. It documents #2381, #2384, and #2388 without closing implementation issues directly.

## Validation
- `npm run gate`