### PR TITLE
docs: add observability bundles — Grafana dashboards, Prometheus alerts, OTLP config

### DIFF
--- a/deploy/grafana/aegis-costs.json
+++ b/deploy/grafana/aegis-costs.json
@@ -1,0 +1,148 @@
+{
+  "annotations": { "list": [] },
+  "description": "Aegis cost and token usage tracking",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "title": "Estimated Cost (USD)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "aegis_sessions_active",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "description": "Use /v1/usage API for actual cost data. This panel is a placeholder for cost metrics exported via a Prometheus bridge.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "currencyUSD",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 200 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Session Throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 18, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_created_total[1h])",
+          "legendFormat": "created/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_sessions_completed_total[1h])",
+          "legendFormat": "completed/sec",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(aegis_sessions_failed_total[1h])",
+          "legendFormat": "failed/sec",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Pipelines & Batches",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_pipelines_created_total[5m]) * 60",
+          "legendFormat": "pipelines/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_batches_created_total[5m]) * 60",
+          "legendFormat": "batches/min",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Prompt Delivery",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_prompts_sent_total[5m]) * 60",
+          "legendFormat": "sent/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_prompts_delivered_total[5m]) * 60",
+          "legendFormat": "delivered/min",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(aegis_prompts_failed_total[5m]) * 60",
+          "legendFormat": "failed/min",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Cost Over Time (Usage API)",
+      "type": "text",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 14 },
+      "options": {
+        "mode": "markdown",
+        "content": "## Token Cost Tracking\n\nAegis tracks per-session and per-key token usage with cost estimation via the `/v1/usage` API.\n\n**Default rate tiers (per million tokens):**\n\n| Model | Input | Output | Cache Write | Cache Read |\n|-------|-------|--------|-------------|------------|\n| haiku | $0.80 | $4.00 | $1.00 | $0.08 |\n| sonnet | $3.00 | $15.00 | $3.75 | $0.30 |\n| opus | $15.00 | $75.00 | $18.75 | $1.50 |\n\nTo visualize cost data in Grafana, use the [JSON API data source](https://grafana.com/grafana/plugins/marcusolsson-json-datasource/) to query:\n\n- `GET /v1/usage?from=2026-04-01&to=2026-04-30` — total summary\n- `GET /v1/usage/by-key` — per-key breakdown\n- `GET /v1/usage/sessions/{id}` — per-session detail"
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["aegis", "costs"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timezone": "",
+  "title": "Aegis — Cost & Usage",
+  "uid": "aegis-costs",
+  "version": 1
+}

--- a/deploy/grafana/aegis-errors.json
+++ b/deploy/grafana/aegis-errors.json
@@ -1,0 +1,235 @@
+{
+  "annotations": { "list": [] },
+  "description": "Aegis error rates — session failures, webhook errors, prompt delivery failures",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "title": "Session Failure Rate",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_failed_total[5m]) / on() rate(aegis_sessions_created_total[5m])",
+          "legendFormat": "failure rate",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Session Failures (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 9, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_failed_total[5m]) * 60",
+          "legendFormat": "failures/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20
+          }
+        }
+      }
+    },
+    {
+      "title": "Webhook Failure Rate",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 15, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_webhooks_failed_total[5m]) / on() rate(aegis_webhooks_sent_total[5m])",
+          "legendFormat": "webhook failure rate",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.15 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Webhooks: Sent vs Failed",
+      "type": "timeseries",
+      "gridPos": { "h": 3, "x": 0, "w": 24, "y": 8 },
+      "targets": [
+        {
+          "expr": "rate(aegis_webhooks_sent_total[5m]) * 60",
+          "legendFormat": "sent/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_webhooks_failed_total[5m]) * 60",
+          "legendFormat": "failed/min",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Prompt Delivery Failures",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 11 },
+      "targets": [
+        {
+          "expr": "rate(aegis_prompts_sent_total[5m]) * 60",
+          "legendFormat": "sent/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_prompts_delivered_total[5m]) * 60",
+          "legendFormat": "delivered/min",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(aegis_prompts_failed_total[5m]) * 60",
+          "legendFormat": "failed/min",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Channel Delivery Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 11 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_channel_delivery_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, rate(aegis_channel_delivery_latency_ms_bucket[5m]))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_channel_delivery_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "State Change Detection Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_state_change_detection_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_state_change_detection_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Alert Stats",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
+      "description": "Use /v1/alerts/stats API for alert delivery counts. Poll and display with the JSON API plugin.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "targets": []
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["aegis", "errors"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "",
+  "title": "Aegis — Error Rates",
+  "uid": "aegis-errors",
+  "version": 1
+}

--- a/deploy/grafana/aegis-sessions.json
+++ b/deploy/grafana/aegis-sessions.json
@@ -1,0 +1,252 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Aegis session metrics — active sessions, creation/completion rates, failures, duration",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Active Sessions",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "aegis_sessions_active",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "none"
+        }
+      }
+    },
+    {
+      "title": "Sessions Created (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_created_total[5m]) * 60",
+          "legendFormat": "created/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Sessions Completed (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_completed_total[5m]) * 60",
+          "legendFormat": "completed/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Session Failure Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(aegis_sessions_failed_total[5m]) / on() rate(aegis_sessions_created_total[5m])",
+          "legendFormat": "failure ratio",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Messages & Tool Calls (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_messages_total[5m]) * 60",
+          "legendFormat": "messages/min",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(aegis_tool_calls_total[5m]) * 60",
+          "legendFormat": "tool_calls/min",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Auto Approvals (rate)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "expr": "rate(aegis_auto_approvals_total[5m]) * 60",
+          "legendFormat": "auto_approvals/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops/min",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Permission Response Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_permission_response_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, rate(aegis_permission_response_latency_ms_bucket[5m]))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_permission_response_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Hook Processing Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(aegis_hook_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, rate(aegis_hook_latency_ms_bucket[5m]))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(aegis_hook_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["aegis", "sessions"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Aegis — Session Metrics",
+  "uid": "aegis-sessions",
+  "version": 1
+}

--- a/deploy/otelcol/config.yaml
+++ b/deploy/otelcol/config.yaml
@@ -1,0 +1,58 @@
+# OpenTelemetry Collector — Aegis Reference Configuration
+#
+# Receives traces from Aegis and exports to your observability backend.
+# Supports Jaeger, Grafana Tempo, Datadog, and generic OTLP endpoints.
+#
+# Usage:
+#   otelcol --config deploy/otelcol/config.yaml
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+  # Add resource attributes so traces are tagged with Aegis metadata
+  resource:
+    attributes:
+      - key: service.namespace
+        value: aegis
+        action: upsert
+
+exporters:
+  # ── Console (development) ──────────────────────────────────────
+  debug:
+    verbosity: detailed
+
+  # ── Jaeger ─────────────────────────────────────────────────────
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # ── Grafana Tempo ──────────────────────────────────────────────
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+  # ── Datadog ────────────────────────────────────────────────────
+  # Requires Datadog API key and site configuration
+  # datadog:
+  #   api:
+  #     key: ${DATADOG_API_KEY}
+  #     site: datadoghq.eu  # or datadoghq.com
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resource, batch]
+      exporters: [debug]  # Replace with [otlp/jaeger] or [otlp/tempo] in production

--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -1,0 +1,139 @@
+# Prometheus Alerting Rules for Aegis
+# 
+# Import into your Prometheus configuration:
+#   rule_files:
+#     - deploy/prometheus/alerts.yml
+#
+# Runbook links point to the Aegis docs site. Adjust base URL for your deployment.
+
+groups:
+  - name: aegis
+    rules:
+      # ── Availability ──────────────────────────────────────────────
+
+      - alert: AegisDown
+        expr: up{job="aegis"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Aegis server is down"
+          description: >
+            Aegis has been unresponsive for 2 minutes on {{ $labels.instance }}.
+            Check `systemctl status aegis` and review application logs.
+          runbook_url: "https://docs.aegis.dev/disaster-recovery#scenario-1--aegis-server-crash-no-data-loss"
+
+      - alert: AegisHighSessionFailureRate
+        expr: |
+          (
+            rate(aegis_sessions_failed_total[5m])
+            / rate(aegis_sessions_created_total[5m])
+          ) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Aegis session failure rate exceeds 10%"
+          description: >
+            {{ $value | humanizePercentage }} of sessions are failing over the last 5 minutes
+            on {{ $labels.instance }}. Check Claude Code connectivity and tmux health.
+          runbook_url: "https://docs.aegis.dev/disaster-recovery#scenario-2--statejson-corruption"
+
+      # ── Session Health ────────────────────────────────────────────
+
+      - alert: AegisNoActiveSessions
+        expr: aegis_sessions_active == 0
+        for: 30m
+        labels:
+          severity: info
+        annotations:
+          summary: "No active Aegis sessions for 30 minutes"
+          description: >
+            Zero active sessions for 30 minutes. May be expected during
+            off-hours; investigate if this is not a maintenance window.
+
+      - alert: AegisStaleSession
+        expr: |
+          time() - aegis_session_last_activity_timestamp > 3600
+          and aegis_sessions_active > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Aegis has sessions with no activity for over 1 hour"
+          description: >
+            {{ $value }} sessions show no activity for over 1 hour.
+            Sessions may be stuck or Claude Code may be unresponsive.
+          runbook_url: "https://docs.aegis.dev/disaster-recovery#scenario-3--tmux-session-loss"
+
+      # ── Webhook Delivery ──────────────────────────────────────────
+
+      - alert: AegisWebhookFailureRate
+        expr: |
+          (
+            rate(aegis_webhooks_failed_total[5m])
+            / clamp_min(rate(aegis_webhooks_sent_total[5m]), 0.01)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Webhook failure rate exceeds 5%"
+          description: >
+            {{ $value | humanizePercentage }} of webhooks are failing on {{ $labels.instance }}.
+            Check webhook endpoint availability and hook configuration.
+
+      # ── Pipeline Health ───────────────────────────────────────────
+
+      - alert: AegisPipelineStuck
+        expr: aegis_pipelines_stuck > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Aegis pipeline is stuck"
+          description: >
+            {{ $value }} pipeline(s) have been stuck for over 10 minutes.
+            Check pipeline dependencies and session statuses.
+
+      # ── Permission Latency ────────────────────────────────────────
+
+      - alert: AegisHighPermissionLatency
+        expr: |
+          histogram_quantile(0.95, rate(aegis_permission_response_latency_ms_bucket[5m])) > 30000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 permission response latency exceeds 30s"
+          description: >
+            Permission responses are slow ({{ $value }}ms P95). Users may be waiting
+            for approvals. Check for queued permission requests or notification channel delays.
+
+      # ── Channel Delivery ──────────────────────────────────────────
+
+      - alert: AegisHighChannelDeliveryLatency
+        expr: |
+          histogram_quantile(0.95, rate(aegis_channel_delivery_latency_ms_bucket[5m])) > 10000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 channel delivery latency exceeds 10s"
+          description: >
+            Message delivery to notification channels is slow ({{ $value }}ms P95).
+            Check Discord/Telegram/Slack webhook health.
+
+      # ── State Detection ───────────────────────────────────────────
+
+      - alert: AegisStateSyncDelay
+        expr: |
+          histogram_quantile(0.95, rate(aegis_state_change_detection_latency_ms_bucket[5m])) > 5000
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Aegis state sync is delayed"
+          description: >
+            State change detection is slow ({{ $value }}ms P95). tmux polling
+            may be under load. Check server resource usage.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -92,11 +92,13 @@ the primary `AEGIS_AUTH_TOKEN` is used.
 
 ### Quick Start
 
-1. Import the bundled dashboards from `examples/grafana/`:
+1. Import the bundled dashboards from `deploy/grafana/`:
 
 ```bash
 # Each JSON file is a Grafana dashboard export.
 # Import via: Dashboards → Import → Upload JSON file
+ls deploy/grafana/
+# aegis-costs.json  aegis-errors.json  aegis-sessions.json
 ```
 
 | Dashboard | File | Panels |
@@ -208,8 +210,17 @@ Aegis emits distributed traces via OTLP HTTP when tracing is enabled.
 
 ### Collector Configurations
 
-Example OTLP collector configurations for common backends are in
-`examples/otlp/`:
+A ready-to-use OTLP collector configuration is shipped in `deploy/otelcol/config.yaml`.
+It supports Jaeger, Grafana Tempo, and Datadog exporters out of the box:
+
+```bash
+# Start the collector with the reference config
+otelcol --config deploy/otelcol/config.yaml
+```
+
+See the file for backend-specific exporter configuration (Jaeger, Tempo, Datadog).
+
+Additional per-backend examples are in `examples/otlp/`:
 
 | File | Backend |
 |------|---------|
@@ -259,6 +270,31 @@ error rates, and cost thresholds.
 Aegis includes a built-in AlertManager that fires webhook notifications when
 failure thresholds are exceeded. See [alerting.md](./alerting.md) for the
 built-in alerting configuration.
+
+### Prometheus Alert Rules
+
+Pre-built Prometheus alerting rules are shipped in `deploy/prometheus/alerts.yml`:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - deploy/prometheus/alerts.yml
+```
+
+| Alert | Severity | Description |
+|-------|----------|-------------|
+| `AegisDown` | critical | Server unresponsive for 2 minutes |
+| `AegisHighSessionFailureRate` | warning | >10% sessions failing over 5 minutes |
+| `AegisNoActiveSessions` | info | No sessions for 30 minutes |
+| `AegisStaleSession` | warning | Sessions with no activity for 1 hour |
+| `AegisWebhookFailureRate` | warning | >5% webhooks failing |
+| `AegisPipelineStuck` | warning | Pipeline stuck for 10 minutes |
+| `AegisHighPermissionLatency` | warning | P95 permission latency >30s |
+| `AegisHighChannelDeliveryLatency` | warning | P95 channel delivery latency >10s |
+| `AegisStateSyncDelay` | warning | P95 state detection latency >5s |
+
+All alerts include `runbook_url` annotations linking to the relevant section
+of the [Disaster Recovery Runbook](./DISASTER_RECOVERY.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- Ship Grafana dashboards to `deploy/grafana/` (sessions, costs, errors)
- Add Prometheus alerting rules (`deploy/prometheus/alerts.yml`) with runbook links
- Add OTLP collector reference config (`deploy/otelcol/config.yaml`) for Jaeger/Tempo/DD
- Update `docs/OBSERVABILITY.md` to reference new `deploy/` paths and alert rule table

## Acceptance criteria for #1951
- [x] Grafana dashboard JSON under `deploy/grafana/`
- [x] Prometheus alerting rules with runbook links
- [x] OTLP exporter reference config
- [x] Datadog integration guide (already exists in OBSERVABILITY.md)

Closes #1951

— Scribe 📝