### PR TITLE
test(dashboard): wait for audit export buttons

### DIFF
--- a/dashboard/src/__tests__/AuditPage.test.tsx
+++ b/dashboard/src/__tests__/AuditPage.test.tsx
@@ -270,7 +270,12 @@ describe('AuditPage', () => {
       }));
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    const exportCsvButton = screen.getByRole('button', { name: 'Export CSV' }) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(exportCsvButton.disabled).toBe(false);
+    });
+
+    fireEvent.click(exportCsvButton);
 
     await waitFor(() => {
       expect(mockExportAuditLogs).toHaveBeenCalledWith(expect.objectContaining({
@@ -319,7 +324,12 @@ describe('AuditPage', () => {
       }));
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export NDJSON' }));
+    const exportNdjsonButton = screen.getByRole('button', { name: 'Export NDJSON' }) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(exportNdjsonButton.disabled).toBe(false);
+    });
+
+    fireEvent.click(exportNdjsonButton);
 
     await waitFor(() => {
       expect(mockExportAuditLogs).toHaveBeenCalledWith(expect.objectContaining({


### PR DESCRIPTION
## Summary
- make AuditPage export tests wait until filtered fetch loading completes and export buttons are enabled before clicking
- fixes the Node 20 CI race seen on main promotion PR #2400

## Validation
- `cd dashboard; npx vitest run src/__tests__/AuditPage.test.tsx`
- `node scripts/hygiene-check.cjs`
- `node scripts/check-no-shell-true.cjs`
- `node scripts/dashboard-tokens-gate.cjs`
- `node scripts/clickable-gate.cjs`
- `npx tsc --noEmit`