### PR TITLE
test(hygiene): lower entropy credential fixture

### DIFF
--- a/src/__tests__/hygiene-check-1905.test.ts
+++ b/src/__tests__/hygiene-check-1905.test.ts
@@ -78,7 +78,7 @@ describe('hygiene-check credential scan (Issue #1905)', () => {
     );
     writeFileSync(
       join(repoDir, 'untracked.txt'),
-      '{"ANTHROPIC_AUTH_TOKEN":"319875494edc4cb39dd7d79b14e262a8.AfHVUkl0vrDrlLeH"}\n',
+      '{"ANTHROPIC_AUTH_TOKEN":"fake-untracked-token-not-scanned"}\n',
     );
     execFileSync('git', ['add', 'tracked.txt'], { cwd: repoDir });
 


### PR DESCRIPTION
## Summary
- replace a high-entropy untracked-file fixture value with an obvious fake low-entropy placeholder
- keeps the hygiene-check regression intent intact while avoiding GitGuardian promotion scan failures

## Validation
- `npx vitest run src/__tests__/hygiene-check-1905.test.ts`
- `node scripts/hygiene-check.cjs`
- `node scripts/check-no-shell-true.cjs`
- `npx tsc --noEmit`