### PR TITLE
docs: update i18n section — add batch 2 localized pages

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -20,7 +20,8 @@ The dashboard supports multiple languages. Users can switch languages from the h
 - **Supported languages:** English (default), Italian
 - **Language switcher** in the header — select your preferred language
 - **Persistence** — choice saved in `localStorage` across sessions
-- **5 pages localized** (batch 1): NotFound, Activity, Login, Overview, Sessions
+- **9 pages localized** (batch 1): NotFound, Activity, Login, Overview, Sessions
+- **4 pages localized** (batch 2): Analytics, Audit, Cost, Metrics
 - **Catalog** — `dashboard/src/i18n/` contains translation files per language
 
 ### Keyboard Shortcuts


### PR DESCRIPTION
## Summary

The dashboard i18n docs still listed only 5 pages (batch 1). Commit `948f022` added localization to 4 more pages (Analytics, Audit, Cost, Metrics) — this PR updates the docs to reflect the current state.

## Changes
- `docs/dashboard.md`: Update i18n section — now lists 9 pages in batch 1 + 4 in batch 2