### PR TITLE
docs: add rate_limit to session status documentation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -185,6 +185,8 @@ Paginated transcript with cursor-based navigation. Use `before_id` for paginatio
 }
 ```
 
+> **Session status values:** `idle`, `working`, `compacting`, `context_warning`, `waiting_for_input`, `permission_prompt`, `plan_mode`, `ask_question`, `bash_approval`, `settings`, `error`, `rate_limit`, `unknown`. The `rate_limit` status indicates Claude Code hit a rate limit and is displaying an interactive menu — send a message or wait for the limit to reset.
+
 ### Send Message
 
 ```bash

--- a/docs/enterprise/00-gap-analysis.md
+++ b/docs/enterprise/00-gap-analysis.md
@@ -26,7 +26,7 @@ The gap to enterprise is not quality — it is **posture**: the product is singl
 
 1. **No SDK lock-in, no browser automation** — pure tmux + JSONL parsing of Claude Code's native transcript.
 2. **Unified bridge** — one server exposes the same sessions to REST, MCP tools, SSE, WebSocket, CLI, Telegram, Slack, Email, and webhooks.
-3. **Deterministic state machine** — sessions classified as `working | idle | asking | permission_prompt | stalled` via regex-based terminal parsing, not LLM-parsing.
+3. **Deterministic state machine** — sessions classified as `working | idle | asking | permission_prompt | rate_limit | stalled` via regex-based terminal parsing, not LLM-parsing.
 4. **Multi-agent orchestration primitives** — pipelines, batches, consensus, memory bridge, templates, capability handshake.
 5. **Security-first defaults** — API-key RBAC, path allowlists, SSRF blocklist, hook-secret encryption, audit trail with SHA-256 chaining.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -22,7 +22,7 @@ List Aegis-managed Claude Code sessions. Optionally filter by status or workDir 
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `status` | string | no | Filter by status (`idle`, `working`, `permission_prompt`) |
+| `status` | string | no | Filter by status (`idle`, `working`, `permission_prompt`, `rate_limit`, etc.) |
 | `workDir` | string | no | Filter by workDir substring |
 
 **Example:**

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -69,13 +69,17 @@ The response includes a session ID. Save it for subsequent API calls.
 ```
 create → working → permission_prompt? → idle → done
                     ↑_______________|
+                rate_limit?
+                    |
+              (interactive menu)
 ```
 
 1. **create** — Session starts, Claude Code initializes
 2. **working** — Claude Code is processing
 3. **permission_prompt** — Waiting for approval (see Permission Modes below)
 4. **idle** — Claude Code finished, ready for next prompt
-5. **done** — Session terminated
+5. **rate_limit** — Claude Code hit a rate limit and is showing an interactive menu (choose an option or wait)
+6. **done** — Session terminated
 
 Poll for status:
 ```bash


### PR DESCRIPTION
## Summary

PR #2369 added a new `rate_limit` session status to the Zod schema in `src/routes/sessions.ts` and terminal parser. This status fires when Claude Code hits a rate limit and displays an interactive menu (numbered options).

The status was not documented anywhere — this PR fixes that.

## Changes

- **docs/onboarding.md** — Added `rate_limit` to the session lifecycle diagram with description
- **docs/api-reference.md** — Added full session status enum reference with `rate_limit` explanation
- **docs/mcp-tools.md** — Updated `list_sessions` status filter to include `rate_limit`
- **docs/enterprise/00-gap-analysis.md** — Updated deterministic state machine description

## Verification

- All status values match the Zod enum in `src/routes/sessions.ts:55`
- Lifecycle diagram accurately reflects the new flow

**Reviewers:** @ag-argus