### PR TITLE
fix(release): align Python SDK PyPI package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,10 +497,10 @@ See [`packages/client/`](packages/client/) for the full SDK source.
 
 ## Python Client SDK
 
-Official `aegis-python-client` package generated from the OpenAPI contract — 53 methods, Pydantic v2 models, stdlib HTTP.
+Official `ag-client` package generated from the OpenAPI contract — 53 methods, Pydantic v2 models, stdlib HTTP.
 
 ```bash
-pip install aegis-python-client
+pip install ag-client
 ```
 
 ```python

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -278,7 +278,7 @@ See [`packages/client/`](../packages/client/) for source and the full README.
 ### Python SDK
 
 ```bash
-pip install aegis-python-client
+pip install ag-client
 ```
 
 ```python

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -87,7 +87,7 @@ Pushing a `v*` tag runs `.github/workflows/release.yml`. In addition to the root
 `@onestepat4time/aegis` npm package, the workflow publishes:
 
 - `@onestepat4time/aegis-client` from `packages/client` to npm.
-- `aegis-python-client` from `packages/python-client` to PyPI.
+- `ag-client` from `packages/python-client` to PyPI.
 
 The release workflow regenerates the root OpenAPI contract, regenerates each SDK
 from that contract, builds the SDK package, and then publishes it. npm packages
@@ -103,7 +103,7 @@ The validation gates are:
 - the normal release build and test steps
 
 PyPI publishing uses trusted publishing via GitHub OIDC; no PyPI token is stored
-in the repository. Maintainers must configure the `aegis-python-client` project
+in the repository. Maintainers must configure the `ag-client` project
 on PyPI with a trusted publisher for repository `OneStepAt4time/aegis`, workflow
 `.github/workflows/release.yml`, and environment `pypi`.
 

--- a/packages/python-client/README.md
+++ b/packages/python-client/README.md
@@ -1,11 +1,11 @@
-# aegis-python-client
+# ag-client
 
 Official Python client for [Aegis](https://github.com/OneStepAt4time/aegis) — orchestration middleware for Claude Code.
 
 ## Install
 
 ```bash
-pip install aegis-python-client
+pip install ag-client
 ```
 
 ## Quick Start

--- a/packages/python-client/pyproject.toml
+++ b/packages/python-client/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "aegis-python-client"
+name = "ag-client"
 version = "0.1.0"
 description = "Official Python client for Aegis — orchestration middleware for Claude Code"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Change the Python SDK distribution name to g-client to match the configured PyPI trusted publisher.
- Keep the existing egis_python_client import package unchanged.
- Update install and release verification docs from egis-python-client to g-client.

## Validation
- npm run sdk:py:check
- python -m build in packages/python-client produced g_client-0.1.0.tar.gz and g_client-0.1.0-py3-none-any.whl
- npm run gate
- Pre-PR hygiene checks

Closes #2394