### PR TITLE
fix(ci): remove secrets from step if conditions in discord-notify

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -49,11 +49,12 @@ jobs:
           fi
 
       - name: Notify — Star ⭐
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'star' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'star'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           STAR_COUNT: ${{ steps.stars.outputs.count }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           COUNT="${STAR_COUNT}"
           
           # Milestone messages
@@ -91,10 +92,11 @@ jobs:
           curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 
       - name: Notify — External Issue 🐛
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issues' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issues'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           TEAM="<@1490090121679339814> <@1490089830472880218>"
 
           PAYLOAD=$(cat <<EOF
@@ -114,10 +116,11 @@ jobs:
           curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 
       - name: Notify — External PR 🔀
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'pull_request' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'pull_request'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           TEAM="<@1490090121679339814> <@1490089830472880218>"
 
           PAYLOAD=$(cat <<EOF
@@ -137,10 +140,11 @@ jobs:
           curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 
       - name: Notify — External Comment 💬
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issue_comment' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issue_comment'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           # Only notify on issues (not PRs) to reduce noise
           PAYLOAD=$(cat <<EOF
           {


### PR DESCRIPTION
## Problem

`discord-notify.yml` has been failing on every push to `develop` with zero jobs created (workflow parse failure).

## Root Cause

PR #2229 added `secrets.DISCORD_WEBHOOK != ''` checks in step-level `if:` conditions. GitHub Actions does not support `secrets.*` references in step `if` expressions — this causes the workflow parser to fail before any jobs are created.

Note: `main` was unaffected because it still has the pre-#2229 version of the file.

## Fix

- Remove `&& secrets.DISCORD_WEBHOOK != ''` from all 4 step `if:` conditions
- Add shell-level guard `[[ -z "$DISCORD_WEBHOOK" ]] && exit 0` at the top of each step's `run:` block
- Same behavior (skip notification when webhook is unset) but uses valid Actions syntax

## Verification

- Local YAML parse: passes
- No `secrets.*` references remain in `if:` conditions (only in `env:` blocks, which is valid)
- Target: `develop`