### PR TITLE
fix(release): prevent repeated preview publishes

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -90,7 +90,7 @@ jobs:
 
           npm --prefix packages/client run generate
           npm --prefix packages/client run build
-          npm --prefix packages/client pack --pack-destination "${DRY_RUN_DIR}"
+          (cd packages/client && npm pack --pack-destination "${DRY_RUN_DIR}")
           test -n "$(find "${DRY_RUN_DIR}" -maxdepth 1 -name 'onestepat4time-aegis-client-*.tgz' -print -quit)"
 
           python -m pip install --upgrade pip build

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -77,9 +77,10 @@ jobs:
             exit 1
           fi
 
-          tar -tzf "${ROOT_PACKAGE}" | grep -qx 'package/package.json'
-          tar -tzf "${ROOT_PACKAGE}" | grep -qx 'package/dist/cli.js'
-          tar -tzf "${ROOT_PACKAGE}" | grep -qx 'package/dist/dashboard/index.html'
+          tar -tzf "${ROOT_PACKAGE}" > "${DRY_RUN_DIR}/root-package-files.txt"
+          grep -qx 'package/package.json' "${DRY_RUN_DIR}/root-package-files.txt"
+          grep -qx 'package/dist/cli.js' "${DRY_RUN_DIR}/root-package-files.txt"
+          grep -qx 'package/dist/dashboard/index.html' "${DRY_RUN_DIR}/root-package-files.txt"
 
           INSTALL_DIR="${RUNNER_TEMP}/release-install-smoke"
           mkdir -p "${INSTALL_DIR}"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,121 @@
+name: Release Dry Run
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/release*.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'openapi.yaml'
+      - 'src/**'
+      - 'scripts/**'
+      - 'dashboard/**'
+      - 'packages/client/**'
+      - 'packages/python-client/**'
+      - 'deploy/helm/aegis/**'
+      - 'charts/aegis/**'
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/release*.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'openapi.yaml'
+      - 'src/**'
+      - 'scripts/**'
+      - 'dashboard/**'
+      - 'packages/client/**'
+      - 'packages/python-client/**'
+      - 'deploy/helm/aegis/**'
+      - 'charts/aegis/**'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release-dry-run:
+    name: Release dry run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: packages/python-client/pyproject.toml
+      - uses: azure/setup-helm@v5
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Build and validate release artifacts without publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          npm ci
+          npm run openapi:check
+          npm run sdk:ts:check
+          npm run sdk:py:check
+          AEGIS_REQUIRE_DASHBOARD_COPY=true npm run build
+
+          DRY_RUN_DIR="${RUNNER_TEMP}/release-dry-run"
+          mkdir -p "${DRY_RUN_DIR}"
+
+          npm pack --dry-run
+          npm pack --pack-destination "${DRY_RUN_DIR}"
+          ROOT_PACKAGE=$(find "${DRY_RUN_DIR}" -maxdepth 1 -name 'onestepat4time-aegis-*.tgz' -print -quit)
+          if [ -z "${ROOT_PACKAGE}" ] || [ ! -s "${ROOT_PACKAGE}" ]; then
+            echo "::error::Root npm package dry-run did not produce a tarball."
+            exit 1
+          fi
+
+          tar -tzf "${ROOT_PACKAGE}" | grep -qx 'package/package.json'
+          tar -tzf "${ROOT_PACKAGE}" | grep -qx 'package/dist/cli.js'
+          tar -tzf "${ROOT_PACKAGE}" | grep -qx 'package/dist/dashboard/index.html'
+
+          INSTALL_DIR="${RUNNER_TEMP}/release-install-smoke"
+          mkdir -p "${INSTALL_DIR}"
+          npm --prefix "${INSTALL_DIR}" init -y
+          npm --prefix "${INSTALL_DIR}" install "${ROOT_PACKAGE}"
+          test -f "${INSTALL_DIR}/node_modules/@onestepat4time/aegis/dist/cli.js"
+
+          npm --prefix packages/client run generate
+          npm --prefix packages/client run build
+          npm --prefix packages/client pack --pack-destination "${DRY_RUN_DIR}"
+          test -n "$(find "${DRY_RUN_DIR}" -maxdepth 1 -name 'onestepat4time-aegis-client-*.tgz' -print -quit)"
+
+          python -m pip install --upgrade pip build
+          python -m build packages/python-client --outdir "${DRY_RUN_DIR}/python"
+          test -n "$(find "${DRY_RUN_DIR}/python" -maxdepth 1 -name 'ag_client-*.tar.gz' -print -quit)"
+          test -n "$(find "${DRY_RUN_DIR}/python" -maxdepth 1 -name 'ag_client-*-py3-none-any.whl' -print -quit)"
+
+          helm lint deploy/helm/aegis
+          helm package deploy/helm/aegis --destination "${DRY_RUN_DIR}/helm"
+
+          CHECKSUM=$(sha256sum "${ROOT_PACKAGE}" | cut -d' ' -f1)
+          ROOT_VERSION=$(tar -xOf "${ROOT_PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.version);')
+          cat > "${DRY_RUN_DIR}/predicate.json" << EOF
+          {
+            "packageName": "@onestepat4time/aegis",
+            "version": "${ROOT_VERSION}",
+            "digest": "sha256:${CHECKSUM}",
+            "registry": "registry.npmjs.org",
+            "workflow": "https://github.com/OneStepAt4time/aegis/.github/workflows/release.yml"
+          }
+          EOF
+          python3 -m json.tool "${DRY_RUN_DIR}/predicate.json" > /dev/null
+
+          cosign attest-blob \
+            --yes \
+            --tlog-upload=false \
+            --bundle "${DRY_RUN_DIR}/package.sigstore" \
+            --predicate "${DRY_RUN_DIR}/predicate.json" \
+            "${ROOT_PACKAGE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,8 +157,193 @@ jobs:
           path: /tmp/checksums.txt
           retention-days: 30
 
+  release-preflight:
+    name: Release preflight
+    needs: generate-checksums
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: azure/setup-helm@v5
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - uses: actions/download-artifact@v8
+        with:
+          name: package
+          path: release-preflight/package
+      - uses: actions/download-artifact@v8
+        with:
+          name: checksums
+          path: release-preflight/checksums
+      - name: Validate pre-publish release surfaces
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          sanitize_log() {
+            python3 -c '
+          import os
+          import re
+          import sys
+
+          data = sys.stdin.read()
+          data = re.sub(
+              r"https://x-access-token:[^@]+@github\.com/",
+              "https://x-access-token:***@github.com/",
+              data,
+          )
+          for value in (os.environ.get("GITHUB_TOKEN", ""), os.environ.get("NODE_AUTH_TOKEN", "")):
+              if value:
+                  data = data.replace(value, "***")
+          sys.stdout.write(data)
+          '
+          }
+
+          shopt -s nullglob
+          packages=(release-preflight/package/onestepat4time-aegis-*.tgz)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one root npm tarball artifact, found ${#packages[@]}."
+            exit 1
+          fi
+          PACKAGE="${packages[0]}"
+          if [ ! -s "${PACKAGE}" ]; then
+            echo "::error::Root npm tarball artifact is empty: ${PACKAGE}"
+            exit 1
+          fi
+
+          CHECKSUMS="release-preflight/checksums/checksums.txt"
+          if [ ! -s "${CHECKSUMS}" ]; then
+            echo "::error::Missing checksums artifact: ${CHECKSUMS}"
+            exit 1
+          fi
+
+          PACKAGE_BASENAME=$(basename "${PACKAGE}")
+          CHECKSUM=$(sha256sum "${PACKAGE}" | cut -d' ' -f1)
+          ARTIFACT_CHECKSUM=$(awk -v file="${PACKAGE_BASENAME}" '$2 == file { print $1 }' "${CHECKSUMS}")
+          if [ -z "${ARTIFACT_CHECKSUM}" ]; then
+            echo "::error::Checksums artifact does not contain ${PACKAGE_BASENAME}."
+            exit 1
+          fi
+          if [ "${CHECKSUM}" != "${ARTIFACT_CHECKSUM}" ]; then
+            echo "::error::Checksum mismatch for ${PACKAGE_BASENAME}."
+            exit 1
+          fi
+
+          TARBALL_NAME=$(tar -xOf "${PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.name);')
+          TARBALL_VERSION=$(tar -xOf "${PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.version);')
+          TAG="${GITHUB_REF#refs/tags/}"
+          TAG_VERSION="${TAG#v}"
+          if [ "${TAG}" = "${GITHUB_REF}" ] || [ "${TAG}" = "${TAG_VERSION}" ]; then
+            echo "::error::Release workflow must run from a v-prefixed tag; got ${GITHUB_REF}."
+            exit 1
+          fi
+
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          TAG_COMMIT=$(git rev-list -n 1 "${GITHUB_REF_NAME}")
+          if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/main; then
+            echo "::error::Real release publishing is allowed only for tags whose commit is reachable from origin/main."
+            echo "::error::Tag ${TAG} points to ${TAG_COMMIT}, which is not contained in origin/main."
+            echo "::error::Use the release dry-run workflow on develop; promote to main before pushing a publishing tag."
+            exit 1
+          fi
+
+          if [ "${TARBALL_NAME}" != "@onestepat4time/aegis" ]; then
+            echo "::error::Unexpected root package name in tarball: ${TARBALL_NAME}"
+            exit 1
+          fi
+          if [ "${TARBALL_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::Tarball version ${TARBALL_VERSION} does not match tag version ${TAG_VERSION}."
+            exit 1
+          fi
+
+          if [[ "${TAG_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            DIST_TAG=latest
+          elif [[ "${TAG_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)([.-]?[0-9]+)?$ ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Unsupported release tag version: ${TAG_VERSION}"
+            exit 1
+          fi
+          echo "::notice::Release tag ${TAG} resolves to npm version ${TAG_VERSION} with dist-tag ${DIST_TAG}."
+
+          cat > release-preflight/predicate.json << EOF
+          {
+            "packageName": "@onestepat4time/aegis",
+            "version": "${TAG_VERSION}",
+            "digest": "sha256:${CHECKSUM}",
+            "registry": "registry.npmjs.org",
+            "workflow": "https://github.com/OneStepAt4time/aegis/.github/workflows/release.yml"
+          }
+          EOF
+          python3 -m json.tool release-preflight/predicate.json > /dev/null
+
+          cosign attest-blob \
+            --yes \
+            --tlog-upload=false \
+            --bundle release-preflight/package.sigstore \
+            --predicate release-preflight/predicate.json \
+            "${PACKAGE}"
+          cosign verify-blob-attestation \
+            --insecure-ignore-tlog \
+            --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release\\.yml@refs/tags/v.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --bundle release-preflight/package.sigstore \
+            "${PACKAGE}" > release-preflight/verified-attestation.log
+
+          OWNER_LOWER=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          ROOT_URL="https://${OWNER_LOWER}.github.io/${REPO_NAME}/helm"
+          AUTHENTICATED_REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          mkdir -p release-preflight/chart-artifacts
+          helm lint deploy/helm/aegis
+          helm package deploy/helm/aegis --destination release-preflight/chart-artifacts
+
+          if ! git clone --no-tags "${AUTHENTICATED_REMOTE_URL}" release-preflight/pages-repo > release-preflight/clone.log 2>&1; then
+            echo "::error::Failed to clone ${GITHUB_REPOSITORY} for Helm pages preflight."
+            sanitize_log < release-preflight/clone.log >&2
+            exit 1
+          fi
+          cd release-preflight/pages-repo
+
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git checkout -B gh-pages origin/gh-pages
+          else
+            git checkout --orphan gh-pages
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            echo "# Aegis Helm repository storage" > README.md
+          fi
+
+          mkdir -p helm
+          cp ../chart-artifacts/*.tgz helm/
+          if [ -f helm/index.yaml ]; then
+            helm repo index helm --url "${ROOT_URL}" --merge helm/index.yaml
+          else
+            helm repo index helm --url "${ROOT_URL}"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          if git diff --cached --quiet; then
+            echo "::notice::Helm gh-pages preflight produced no index changes."
+          else
+            git commit -m "chore(release): preflight Helm chart ${TAG}" > /dev/null
+            echo "::notice::Helm gh-pages preflight created a local commit only; no push was performed."
+          fi
+
   publish-npm:
-    needs: [test, fault-harness]
+    needs: attest-npm
     environment: production
     runs-on: ubuntu-latest
     steps:
@@ -170,16 +355,63 @@ jobs:
         with:
           name: package
           path: .
-      - name: Determine dist-tag
-        id: dist-tag
+      - name: Validate package version and dist-tag
+        id: release
+        shell: bash
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          if [[ "$TAG" == *-preview* ]]; then
-            echo "tag=preview" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          shopt -s nullglob
+          packages=(*.tgz)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one root npm tarball artifact, found ${#packages[@]}."
+            exit 1
           fi
-      - run: npm publish --provenance --access public --tag ${{ steps.dist-tag.outputs.tag }} *.tgz
+          PACKAGE="${packages[0]}"
+          VERSION=$(tar -xOf "${PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.version);')
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "${GITHUB_REF_NAME}" = "${TAG_VERSION}" ]; then
+            echo "::error::Release workflow must run from a v-prefixed tag; got ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+          if [ "${VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::Tarball version ${VERSION} does not match tag version ${TAG_VERSION}."
+            exit 1
+          fi
+          if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            DIST_TAG=latest
+          elif [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)([.-]?[0-9]+)?$ ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Unsupported npm release version: ${VERSION}"
+            exit 1
+          fi
+          echo "package=${PACKAGE}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Check whether root npm version already exists
+        id: npm-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PACKAGE_SPEC="@onestepat4time/aegis@${{ steps.release.outputs.version }}"
+          set +e
+          VIEW_OUTPUT=$(npm view "${PACKAGE_SPEC}" version 2>&1)
+          VIEW_STATUS=$?
+          set -e
+          if [ "${VIEW_STATUS}" -eq 0 ]; then
+            echo "::notice::${PACKAGE_SPEC} already exists on npm (${VIEW_OUTPUT}); skipping root npm publish."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif grep -Eiq '(E404|404 Not Found|No match found|not found)' <<< "${VIEW_OUTPUT}"; then
+            echo "::notice::${PACKAGE_SPEC} does not exist on npm; publishing this tarball."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::npm view failed while checking ${PACKAGE_SPEC}."
+            printf '%s\n' "${VIEW_OUTPUT}" | sed -E 's#//registry\.npmjs\.org/:_authToken=[^[:space:]]+#//registry.npmjs.org/:_authToken=***#g' >&2
+            exit 1
+          fi
+      - name: Publish root npm package
+        if: steps.npm-version.outputs.exists != 'true'
+        run: npm publish --provenance --access public --tag ${{ steps.release.outputs.dist-tag }} "${{ steps.release.outputs.package }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -206,11 +438,19 @@ jobs:
         id: release
         shell: bash
         run: |
+          set -euo pipefail
           VERSION=${GITHUB_REF_NAME#v}
-          if [[ "$VERSION" == *-preview* ]]; then
-            DIST_TAG=preview
-          else
+          if [ "${GITHUB_REF_NAME}" = "${VERSION}" ]; then
+            echo "::error::Release workflow must run from a v-prefixed tag; got ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+          if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             DIST_TAG=latest
+          elif [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)([.-]?[0-9]+)?$ ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Unsupported TypeScript SDK release version: ${VERSION}"
+            exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
@@ -222,7 +462,29 @@ jobs:
         run: npm --prefix packages/client version "${{ steps.release.outputs.version }}" --no-git-tag-version --allow-same-version
       - name: Build TypeScript SDK
         run: npm --prefix packages/client run build
+      - name: Check whether TypeScript SDK npm version already exists
+        id: ts-sdk-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PACKAGE_SPEC="@onestepat4time/aegis-client@${{ steps.release.outputs.version }}"
+          set +e
+          VIEW_OUTPUT=$(npm view "${PACKAGE_SPEC}" version 2>&1)
+          VIEW_STATUS=$?
+          set -e
+          if [ "${VIEW_STATUS}" -eq 0 ]; then
+            echo "::notice::${PACKAGE_SPEC} already exists on npm (${VIEW_OUTPUT}); skipping TypeScript SDK npm publish."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif grep -Eiq '(E404|404 Not Found|No match found|not found)' <<< "${VIEW_OUTPUT}"; then
+            echo "::notice::${PACKAGE_SPEC} does not exist on npm; publishing this package."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::npm view failed while checking ${PACKAGE_SPEC}."
+            printf '%s\n' "${VIEW_OUTPUT}" | sed -E 's#//registry\.npmjs\.org/:_authToken=[^[:space:]]+#//registry.npmjs.org/:_authToken=***#g' >&2
+            exit 1
+          fi
       - name: Publish TypeScript SDK to npm
+        if: steps.ts-sdk-version.outputs.exists != 'true'
         working-directory: packages/client
         run: npm publish --provenance --access public --tag ${{ steps.release.outputs.dist-tag }}
         env:
@@ -385,7 +647,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-predicate:
-    needs: [publish-npm, generate-checksums]
+    needs: generate-checksums
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -413,7 +675,7 @@ jobs:
           retention-days: 365
 
   attest-npm:
-    needs: [generate-predicate, ensure-github-release]
+    needs: [release-preflight, generate-predicate]
     runs-on: ubuntu-latest
     steps:
       - name: Install cosign
@@ -482,9 +744,22 @@ jobs:
           AUTHENTICATED_REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           sanitize_git_log() {
-            sed -E \
-              -e 's#https://x-access-token:[^@]+@github\.com/#https://x-access-token:***@github.com/#g' \
-              -e "s#${GITHUB_TOKEN}#***#g"
+            python3 - <<'PY'
+          import os
+          import re
+          import sys
+
+          data = sys.stdin.read()
+          data = re.sub(
+              r"https://x-access-token:[^@]+@github\.com/",
+              "https://x-access-token:***@github.com/",
+              data,
+          )
+          token = os.environ.get("GITHUB_TOKEN", "")
+          if token:
+              data = data.replace(token, "***")
+          sys.stdout.write(data)
+          PY
           }
 
           rm -rf chart-artifacts pages-repo

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -83,7 +83,12 @@ All releases are built via GitHub Actions. Verify the workflow ran successfully:
 
 ### SDK Release Automation
 
-Pushing a `v*` tag runs `.github/workflows/release.yml`. In addition to the root
+Pushing a `v*` tag runs `.github/workflows/release.yml`. Real publishing is
+production-only: the release preflight fails before publish jobs if the tag
+commit is not reachable from `origin/main`. Use `.github/workflows/release-dry-run.yml`
+on `develop` or release PRs to validate release readiness without publishing.
+
+In addition to the root
 `@onestepat4time/aegis` npm package, the workflow publishes:
 
 - `@onestepat4time/aegis-client` from `packages/client` to npm.
@@ -91,9 +96,9 @@ Pushing a `v*` tag runs `.github/workflows/release.yml`. In addition to the root
 
 The release workflow regenerates the root OpenAPI contract, regenerates each SDK
 from that contract, builds the SDK package, and then publishes it. npm packages
-use provenance and public access. Tags containing `-preview` publish npm
-packages with the `preview` dist-tag; all other release tags publish with
-`latest`.
+use provenance and public access. Stable tags publish npm packages with the
+`latest` dist-tag; prerelease tags using `preview`, `alpha`, `beta`, or `rc`
+publish with the matching npm dist-tag.
 
 The validation gates are:
 
@@ -101,6 +106,14 @@ The validation gates are:
 - `npm run sdk:ts:check`
 - `npm run sdk:py:check`
 - the normal release build and test steps
+- the release preflight job, which checks the packaged npm tarball, checksum
+  metadata, local Sigstore attestation generation/verification, release
+  version/dist-tag parsing, main-branch tag reachability, and Helm gh-pages
+  clone/index logic before npm publish jobs run
+- the release dry-run workflow on `develop` and release PRs, which packs and
+  smoke-installs local artifacts, builds SDK packages, packages Helm charts,
+  and validates Sigstore predicate generation without publishing public
+  artifacts
 
 PyPI publishing uses trusted publishing via GitHub OIDC; no PyPI token is stored
 in the repository. Maintainers must configure the `ag-client` project
@@ -122,6 +135,19 @@ package and TypeScript SDK keep the original tag version.
 
 Numeric suffixes on prerelease tags are preserved, for example `X.Y.Z-rc.1`
 becomes `X.Y.Zrc1`.
+
+### Partial Preview Release Recovery
+
+If a preview release partially publishes, first rerun the failed release
+workflow. Do not bump the preview version solely to recover a rerun until the
+idempotent rerun path has been attempted and a maintainer decides a replacement
+version is unavoidable.
+
+The root npm package and TypeScript SDK npm publish jobs are intentionally late
+and idempotent: they check whether the exact version already exists on npm and
+skip with a notice when it does. npm versions are immutable, so these jobs must
+remain guarded by the preflight checks and must never publish a new version just
+to recover an otherwise rerunnable preview release.
 
 ### Verify the Author
 


### PR DESCRIPTION
## Summary
- Add a release preflight before irreversible publish jobs.
- Add a develop/PR release dry-run workflow that packs, smoke-installs, builds SDK artifacts, packages Helm, and validates Sigstore predicate/attestation generation without publishing.
- Require publishing tags to resolve to commits reachable from origin/main, so develop can validate but cannot publish public artifacts.
- Make root npm and TypeScript SDK publishes idempotent by skipping exact versions that already exist on npm.
- Document partial preview recovery and the g-client PyPI project name.

## Validation
- YAML parse for release workflows
- npm run openapi:check
- npm run gate attempted; local PowerShell wrapper hung after early checks, so direct fallback ran hygiene/security/tokens/clickable/typecheck/build steps
- 
px vitest run --reporter=dot completed with unrelated Windows/local timeout failures; rerunning the failed files passed: audit-routes, audit, auth-key-rotation-grace, cli-init, multitenancy
- Pre-PR hygiene checks (only existing policy/checker references matched the obsolete-artifact grep)

Closes #2414