### PR TITLE
chore: promote release hardening to main

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -49,11 +49,12 @@ jobs:
           fi
 
       - name: Notify — Star ⭐
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'star' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'star'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           STAR_COUNT: ${{ steps.stars.outputs.count }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           COUNT="${STAR_COUNT}"
           
           # Milestone messages
@@ -91,10 +92,11 @@ jobs:
           curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 
       - name: Notify — External Issue 🐛
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issues' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issues'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           TEAM="<@1490090121679339814> <@1490089830472880218>"
 
           PAYLOAD=$(cat <<EOF
@@ -114,10 +116,11 @@ jobs:
           curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 
       - name: Notify — External PR 🔀
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'pull_request' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'pull_request'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           TEAM="<@1490090121679339814> <@1490089830472880218>"
 
           PAYLOAD=$(cat <<EOF
@@ -137,10 +140,11 @@ jobs:
           curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
 
       - name: Notify — External Comment 💬
-        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issue_comment' && secrets.DISCORD_WEBHOOK != ''
+        if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'activity' && github.event_name == 'issue_comment'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && exit 0
           # Only notify on issues (not PRs) to reduce noise
           PAYLOAD=$(cat <<EOF
           {

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,122 @@
+name: Release Dry Run
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/release*.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'openapi.yaml'
+      - 'src/**'
+      - 'scripts/**'
+      - 'dashboard/**'
+      - 'packages/client/**'
+      - 'packages/python-client/**'
+      - 'deploy/helm/aegis/**'
+      - 'charts/aegis/**'
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/release*.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'openapi.yaml'
+      - 'src/**'
+      - 'scripts/**'
+      - 'dashboard/**'
+      - 'packages/client/**'
+      - 'packages/python-client/**'
+      - 'deploy/helm/aegis/**'
+      - 'charts/aegis/**'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release-dry-run:
+    name: Release dry run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: packages/python-client/pyproject.toml
+      - uses: azure/setup-helm@v5
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Build and validate release artifacts without publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          npm ci
+          npm run openapi:check
+          npm run sdk:ts:check
+          npm run sdk:py:check
+          AEGIS_REQUIRE_DASHBOARD_COPY=true npm run build
+
+          DRY_RUN_DIR="${RUNNER_TEMP}/release-dry-run"
+          mkdir -p "${DRY_RUN_DIR}"
+
+          npm pack --dry-run
+          npm pack --pack-destination "${DRY_RUN_DIR}"
+          ROOT_PACKAGE=$(find "${DRY_RUN_DIR}" -maxdepth 1 -name 'onestepat4time-aegis-*.tgz' -print -quit)
+          if [ -z "${ROOT_PACKAGE}" ] || [ ! -s "${ROOT_PACKAGE}" ]; then
+            echo "::error::Root npm package dry-run did not produce a tarball."
+            exit 1
+          fi
+
+          tar -tzf "${ROOT_PACKAGE}" > "${DRY_RUN_DIR}/root-package-files.txt"
+          grep -qx 'package/package.json' "${DRY_RUN_DIR}/root-package-files.txt"
+          grep -qx 'package/dist/cli.js' "${DRY_RUN_DIR}/root-package-files.txt"
+          grep -qx 'package/dist/dashboard/index.html' "${DRY_RUN_DIR}/root-package-files.txt"
+
+          INSTALL_DIR="${RUNNER_TEMP}/release-install-smoke"
+          mkdir -p "${INSTALL_DIR}"
+          npm --prefix "${INSTALL_DIR}" init -y
+          npm --prefix "${INSTALL_DIR}" install "${ROOT_PACKAGE}"
+          test -f "${INSTALL_DIR}/node_modules/@onestepat4time/aegis/dist/cli.js"
+
+          npm --prefix packages/client run generate
+          npm --prefix packages/client run build
+          (cd packages/client && npm pack --pack-destination "${DRY_RUN_DIR}")
+          test -n "$(find "${DRY_RUN_DIR}" -maxdepth 1 -name 'onestepat4time-aegis-client-*.tgz' -print -quit)"
+
+          python -m pip install --upgrade pip build
+          python -m build packages/python-client --outdir "${DRY_RUN_DIR}/python"
+          test -n "$(find "${DRY_RUN_DIR}/python" -maxdepth 1 -name 'ag_client-*.tar.gz' -print -quit)"
+          test -n "$(find "${DRY_RUN_DIR}/python" -maxdepth 1 -name 'ag_client-*-py3-none-any.whl' -print -quit)"
+
+          helm lint deploy/helm/aegis
+          helm package deploy/helm/aegis --destination "${DRY_RUN_DIR}/helm"
+
+          CHECKSUM=$(sha256sum "${ROOT_PACKAGE}" | cut -d' ' -f1)
+          ROOT_VERSION=$(tar -xOf "${ROOT_PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.version);')
+          cat > "${DRY_RUN_DIR}/predicate.json" << EOF
+          {
+            "packageName": "@onestepat4time/aegis",
+            "version": "${ROOT_VERSION}",
+            "digest": "sha256:${CHECKSUM}",
+            "registry": "registry.npmjs.org",
+            "workflow": "https://github.com/OneStepAt4time/aegis/.github/workflows/release.yml"
+          }
+          EOF
+          python3 -m json.tool "${DRY_RUN_DIR}/predicate.json" > /dev/null
+
+          cosign attest-blob \
+            --yes \
+            --tlog-upload=false \
+            --bundle "${DRY_RUN_DIR}/package.sigstore" \
+            --predicate "${DRY_RUN_DIR}/predicate.json" \
+            "${ROOT_PACKAGE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,8 +157,193 @@ jobs:
           path: /tmp/checksums.txt
           retention-days: 30
 
+  release-preflight:
+    name: Release preflight
+    needs: generate-checksums
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: azure/setup-helm@v5
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - uses: actions/download-artifact@v8
+        with:
+          name: package
+          path: release-preflight/package
+      - uses: actions/download-artifact@v8
+        with:
+          name: checksums
+          path: release-preflight/checksums
+      - name: Validate pre-publish release surfaces
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          sanitize_log() {
+            python3 -c '
+          import os
+          import re
+          import sys
+
+          data = sys.stdin.read()
+          data = re.sub(
+              r"https://x-access-token:[^@]+@github\.com/",
+              "https://x-access-token:***@github.com/",
+              data,
+          )
+          for value in (os.environ.get("GITHUB_TOKEN", ""), os.environ.get("NODE_AUTH_TOKEN", "")):
+              if value:
+                  data = data.replace(value, "***")
+          sys.stdout.write(data)
+          '
+          }
+
+          shopt -s nullglob
+          packages=(release-preflight/package/onestepat4time-aegis-*.tgz)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one root npm tarball artifact, found ${#packages[@]}."
+            exit 1
+          fi
+          PACKAGE="${packages[0]}"
+          if [ ! -s "${PACKAGE}" ]; then
+            echo "::error::Root npm tarball artifact is empty: ${PACKAGE}"
+            exit 1
+          fi
+
+          CHECKSUMS="release-preflight/checksums/checksums.txt"
+          if [ ! -s "${CHECKSUMS}" ]; then
+            echo "::error::Missing checksums artifact: ${CHECKSUMS}"
+            exit 1
+          fi
+
+          PACKAGE_BASENAME=$(basename "${PACKAGE}")
+          CHECKSUM=$(sha256sum "${PACKAGE}" | cut -d' ' -f1)
+          ARTIFACT_CHECKSUM=$(awk -v file="${PACKAGE_BASENAME}" '$2 == file { print $1 }' "${CHECKSUMS}")
+          if [ -z "${ARTIFACT_CHECKSUM}" ]; then
+            echo "::error::Checksums artifact does not contain ${PACKAGE_BASENAME}."
+            exit 1
+          fi
+          if [ "${CHECKSUM}" != "${ARTIFACT_CHECKSUM}" ]; then
+            echo "::error::Checksum mismatch for ${PACKAGE_BASENAME}."
+            exit 1
+          fi
+
+          TARBALL_NAME=$(tar -xOf "${PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.name);')
+          TARBALL_VERSION=$(tar -xOf "${PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.version);')
+          TAG="${GITHUB_REF#refs/tags/}"
+          TAG_VERSION="${TAG#v}"
+          if [ "${TAG}" = "${GITHUB_REF}" ] || [ "${TAG}" = "${TAG_VERSION}" ]; then
+            echo "::error::Release workflow must run from a v-prefixed tag; got ${GITHUB_REF}."
+            exit 1
+          fi
+
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          TAG_COMMIT=$(git rev-list -n 1 "${GITHUB_REF_NAME}")
+          if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/main; then
+            echo "::error::Real release publishing is allowed only for tags whose commit is reachable from origin/main."
+            echo "::error::Tag ${TAG} points to ${TAG_COMMIT}, which is not contained in origin/main."
+            echo "::error::Use the release dry-run workflow on develop; promote to main before pushing a publishing tag."
+            exit 1
+          fi
+
+          if [ "${TARBALL_NAME}" != "@onestepat4time/aegis" ]; then
+            echo "::error::Unexpected root package name in tarball: ${TARBALL_NAME}"
+            exit 1
+          fi
+          if [ "${TARBALL_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::Tarball version ${TARBALL_VERSION} does not match tag version ${TAG_VERSION}."
+            exit 1
+          fi
+
+          if [[ "${TAG_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            DIST_TAG=latest
+          elif [[ "${TAG_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)([.-]?[0-9]+)?$ ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Unsupported release tag version: ${TAG_VERSION}"
+            exit 1
+          fi
+          echo "::notice::Release tag ${TAG} resolves to npm version ${TAG_VERSION} with dist-tag ${DIST_TAG}."
+
+          cat > release-preflight/predicate.json << EOF
+          {
+            "packageName": "@onestepat4time/aegis",
+            "version": "${TAG_VERSION}",
+            "digest": "sha256:${CHECKSUM}",
+            "registry": "registry.npmjs.org",
+            "workflow": "https://github.com/OneStepAt4time/aegis/.github/workflows/release.yml"
+          }
+          EOF
+          python3 -m json.tool release-preflight/predicate.json > /dev/null
+
+          cosign attest-blob \
+            --yes \
+            --tlog-upload=false \
+            --bundle release-preflight/package.sigstore \
+            --predicate release-preflight/predicate.json \
+            "${PACKAGE}"
+          cosign verify-blob-attestation \
+            --insecure-ignore-tlog \
+            --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release\\.yml@refs/tags/v.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --bundle release-preflight/package.sigstore \
+            "${PACKAGE}" > release-preflight/verified-attestation.log
+
+          OWNER_LOWER=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          ROOT_URL="https://${OWNER_LOWER}.github.io/${REPO_NAME}/helm"
+          AUTHENTICATED_REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          mkdir -p release-preflight/chart-artifacts
+          helm lint deploy/helm/aegis
+          helm package deploy/helm/aegis --destination release-preflight/chart-artifacts
+
+          if ! git clone --no-tags "${AUTHENTICATED_REMOTE_URL}" release-preflight/pages-repo > release-preflight/clone.log 2>&1; then
+            echo "::error::Failed to clone ${GITHUB_REPOSITORY} for Helm pages preflight."
+            sanitize_log < release-preflight/clone.log >&2
+            exit 1
+          fi
+          cd release-preflight/pages-repo
+
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git checkout -B gh-pages origin/gh-pages
+          else
+            git checkout --orphan gh-pages
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            echo "# Aegis Helm repository storage" > README.md
+          fi
+
+          mkdir -p helm
+          cp ../chart-artifacts/*.tgz helm/
+          if [ -f helm/index.yaml ]; then
+            helm repo index helm --url "${ROOT_URL}" --merge helm/index.yaml
+          else
+            helm repo index helm --url "${ROOT_URL}"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          if git diff --cached --quiet; then
+            echo "::notice::Helm gh-pages preflight produced no index changes."
+          else
+            git commit -m "chore(release): preflight Helm chart ${TAG}" > /dev/null
+            echo "::notice::Helm gh-pages preflight created a local commit only; no push was performed."
+          fi
+
   publish-npm:
-    needs: [test, fault-harness]
+    needs: attest-npm
     environment: production
     runs-on: ubuntu-latest
     steps:
@@ -170,16 +355,63 @@ jobs:
         with:
           name: package
           path: .
-      - name: Determine dist-tag
-        id: dist-tag
+      - name: Validate package version and dist-tag
+        id: release
+        shell: bash
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          if [[ "$TAG" == *-preview* ]]; then
-            echo "tag=preview" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          shopt -s nullglob
+          packages=(*.tgz)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one root npm tarball artifact, found ${#packages[@]}."
+            exit 1
           fi
-      - run: npm publish --provenance --access public --tag ${{ steps.dist-tag.outputs.tag }} *.tgz
+          PACKAGE="${packages[0]}"
+          VERSION=$(tar -xOf "${PACKAGE}" package/package.json | node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(0, "utf8")); console.log(pkg.version);')
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "${GITHUB_REF_NAME}" = "${TAG_VERSION}" ]; then
+            echo "::error::Release workflow must run from a v-prefixed tag; got ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+          if [ "${VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::Tarball version ${VERSION} does not match tag version ${TAG_VERSION}."
+            exit 1
+          fi
+          if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            DIST_TAG=latest
+          elif [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)([.-]?[0-9]+)?$ ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Unsupported npm release version: ${VERSION}"
+            exit 1
+          fi
+          echo "package=${PACKAGE}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Check whether root npm version already exists
+        id: npm-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PACKAGE_SPEC="@onestepat4time/aegis@${{ steps.release.outputs.version }}"
+          set +e
+          VIEW_OUTPUT=$(npm view "${PACKAGE_SPEC}" version 2>&1)
+          VIEW_STATUS=$?
+          set -e
+          if [ "${VIEW_STATUS}" -eq 0 ]; then
+            echo "::notice::${PACKAGE_SPEC} already exists on npm (${VIEW_OUTPUT}); skipping root npm publish."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif grep -Eiq '(E404|404 Not Found|No match found|not found)' <<< "${VIEW_OUTPUT}"; then
+            echo "::notice::${PACKAGE_SPEC} does not exist on npm; publishing this tarball."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::npm view failed while checking ${PACKAGE_SPEC}."
+            printf '%s\n' "${VIEW_OUTPUT}" | sed -E 's#//registry\.npmjs\.org/:_authToken=[^[:space:]]+#//registry.npmjs.org/:_authToken=***#g' >&2
+            exit 1
+          fi
+      - name: Publish root npm package
+        if: steps.npm-version.outputs.exists != 'true'
+        run: npm publish --provenance --access public --tag ${{ steps.release.outputs.dist-tag }} "${{ steps.release.outputs.package }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -206,11 +438,19 @@ jobs:
         id: release
         shell: bash
         run: |
+          set -euo pipefail
           VERSION=${GITHUB_REF_NAME#v}
-          if [[ "$VERSION" == *-preview* ]]; then
-            DIST_TAG=preview
-          else
+          if [ "${GITHUB_REF_NAME}" = "${VERSION}" ]; then
+            echo "::error::Release workflow must run from a v-prefixed tag; got ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+          if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             DIST_TAG=latest
+          elif [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)([.-]?[0-9]+)?$ ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Unsupported TypeScript SDK release version: ${VERSION}"
+            exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
@@ -222,7 +462,29 @@ jobs:
         run: npm --prefix packages/client version "${{ steps.release.outputs.version }}" --no-git-tag-version --allow-same-version
       - name: Build TypeScript SDK
         run: npm --prefix packages/client run build
+      - name: Check whether TypeScript SDK npm version already exists
+        id: ts-sdk-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PACKAGE_SPEC="@onestepat4time/aegis-client@${{ steps.release.outputs.version }}"
+          set +e
+          VIEW_OUTPUT=$(npm view "${PACKAGE_SPEC}" version 2>&1)
+          VIEW_STATUS=$?
+          set -e
+          if [ "${VIEW_STATUS}" -eq 0 ]; then
+            echo "::notice::${PACKAGE_SPEC} already exists on npm (${VIEW_OUTPUT}); skipping TypeScript SDK npm publish."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif grep -Eiq '(E404|404 Not Found|No match found|not found)' <<< "${VIEW_OUTPUT}"; then
+            echo "::notice::${PACKAGE_SPEC} does not exist on npm; publishing this package."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::npm view failed while checking ${PACKAGE_SPEC}."
+            printf '%s\n' "${VIEW_OUTPUT}" | sed -E 's#//registry\.npmjs\.org/:_authToken=[^[:space:]]+#//registry.npmjs.org/:_authToken=***#g' >&2
+            exit 1
+          fi
       - name: Publish TypeScript SDK to npm
+        if: steps.ts-sdk-version.outputs.exists != 'true'
         working-directory: packages/client
         run: npm publish --provenance --access public --tag ${{ steps.release.outputs.dist-tag }}
         env:
@@ -385,7 +647,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-predicate:
-    needs: [publish-npm, generate-checksums]
+    needs: generate-checksums
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -413,7 +675,7 @@ jobs:
           retention-days: 365
 
   attest-npm:
-    needs: [generate-predicate, ensure-github-release]
+    needs: [release-preflight, generate-predicate]
     runs-on: ubuntu-latest
     steps:
       - name: Install cosign
@@ -482,9 +744,22 @@ jobs:
           AUTHENTICATED_REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           sanitize_git_log() {
-            sed -E \
-              -e 's#https://x-access-token:[^@]+@github\.com/#https://x-access-token:***@github.com/#g' \
-              -e "s#${GITHUB_TOKEN}#***#g"
+            python3 - <<'PY'
+          import os
+          import re
+          import sys
+
+          data = sys.stdin.read()
+          data = re.sub(
+              r"https://x-access-token:[^@]+@github\.com/",
+              "https://x-access-token:***@github.com/",
+              data,
+          )
+          token = os.environ.get("GITHUB_TOKEN", "")
+          if token:
+              data = data.replace(token, "***")
+          sys.stdout.write(data)
+          PY
           }
 
           rm -rf chart-artifacts pages-repo

--- a/README.md
+++ b/README.md
@@ -497,10 +497,10 @@ See [`packages/client/`](packages/client/) for the full SDK source.
 
 ## Python Client SDK
 
-Official `aegis-python-client` package generated from the OpenAPI contract — 53 methods, Pydantic v2 models, stdlib HTTP.
+Official `ag-client` package generated from the OpenAPI contract — 53 methods, Pydantic v2 models, stdlib HTTP.
 
 ```bash
-pip install aegis-python-client
+pip install ag-client
 ```
 
 ```python

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -185,6 +185,8 @@ Paginated transcript with cursor-based navigation. Use `before_id` for paginatio
 }
 ```
 
+> **Session status values:** `idle`, `working`, `compacting`, `context_warning`, `waiting_for_input`, `permission_prompt`, `plan_mode`, `ask_question`, `bash_approval`, `settings`, `error`, `rate_limit`, `unknown`. The `rate_limit` status indicates Claude Code hit a rate limit and is displaying an interactive menu — send a message or wait for the limit to reset.
+
 ### Send Message
 
 ```bash

--- a/docs/enterprise/00-gap-analysis.md
+++ b/docs/enterprise/00-gap-analysis.md
@@ -26,7 +26,7 @@ The gap to enterprise is not quality — it is **posture**: the product is singl
 
 1. **No SDK lock-in, no browser automation** — pure tmux + JSONL parsing of Claude Code's native transcript.
 2. **Unified bridge** — one server exposes the same sessions to REST, MCP tools, SSE, WebSocket, CLI, Telegram, Slack, Email, and webhooks.
-3. **Deterministic state machine** — sessions classified as `working | idle | asking | permission_prompt | stalled` via regex-based terminal parsing, not LLM-parsing.
+3. **Deterministic state machine** — sessions classified as `working | idle | asking | permission_prompt | rate_limit | stalled` via regex-based terminal parsing, not LLM-parsing.
 4. **Multi-agent orchestration primitives** — pipelines, batches, consensus, memory bridge, templates, capability handshake.
 5. **Security-first defaults** — API-key RBAC, path allowlists, SSRF blocklist, hook-secret encryption, audit trail with SHA-256 chaining.
 

--- a/docs/enterprise/06-disaster-recovery.md
+++ b/docs/enterprise/06-disaster-recovery.md
@@ -1,0 +1,328 @@
+# 06 — Disaster Recovery Runbook
+
+**Date:** 2026-05-02 | **Applies to:** Aegis ≥ 0.6.5 | **Issue:** #1950
+
+---
+
+## Overview
+
+This runbook covers backup, export, integrity verification, and restore procedures for a self-hosted Aegis deployment. It uses the **REST API** for all operations — CLI commands (`ag admin export` / `ag admin import`) are planned for a future release.
+
+> **Scope:** Single-node deployments (systemd, Docker Compose). Multi-node DR is covered in the distributed architecture ADR.
+
+---
+
+## 1. What to Back Up
+
+Aegis stores all state under the **state directory** (default `~/.aegis`, configurable via `AEGIS_STATE_DIR`):
+
+| Path | Contents | Critical? |
+|------|----------|-----------|
+| `~/.aegis/config.yaml` | Server configuration, auth token | ✅ Yes |
+| `~/.aegis/auth.json` | OIDC device-flow tokens (if SSO enabled) | ⚠️ Only with SSO |
+| `~/.aegis/audit/` | SHA-256-chained audit log (JSONL) | ✅ Yes |
+| `~/.aegis/sessions/` | Session transcripts (JSONL) | ✅ Yes |
+| `~/.aegis/memory/` | Memory Bridge persistent store | ⚠️ If used |
+
+### Filesystem Backup (Quick Method)
+
+```bash
+# Stop Aegis to get a consistent snapshot
+sudo systemctl stop aegis
+
+# Create timestamped backup
+BACKUP_DATE=$(date +%Y-%m-%d_%H%M%S)
+tar czf "aegis-backup-${BACKUP_DATE}.tar.gz" \
+  -C "$HOME" .aegis/
+
+# Restart
+sudo systemctl start aegis
+
+# Verify backup
+tar tzf "aegis-backup-${BACKUP_DATE}.tar.gz" | head -20
+```
+
+**Docker Compose variant:**
+
+```bash
+docker compose stop aegis
+BACKUP_DATE=$(date +%Y-%m-%d_%H%M%S)
+docker cp aegis:/root/.aegis "./aegis-backup-${BACKUP_DATE}"
+tar czf "aegis-backup-${BACKUP_DATE}.tar.gz" "./aegis-backup-${BACKUP_DATE}"
+rm -rf "./aegis-backup-${BACKUP_DATE}"
+docker compose start aegis
+```
+
+---
+
+## 2. Audit Chain Export
+
+The audit log is the most critical data — it is **SHA-256 hash-chained** and tamper-evident.
+
+### Full Export (JSON)
+
+```bash
+curl -s -H "Authorization: Bearer YOUR_API_KEY" \
+  "http://localhost:9100/v1/audit?limit=10000&verify=true" \
+  | jq . > audit-export-$(date +%Y-%m-%d).json
+```
+
+The `verify=true` parameter runs chain integrity validation. Response includes:
+
+```json
+{
+  "integrity": {
+    "valid": true,
+    "brokenAt": null,
+    "file": null
+  },
+  "chain": {
+    "count": 1842,
+    "firstHash": "a1b2c3...",
+    "lastHash": "d4e5f6...",
+    "badgeHash": "abc123...",
+    "firstTs": "2026-04-01T00:00:00.000Z",
+    "lastTs": "2026-05-02T07:00:00.000Z"
+  }
+}
+```
+
+### Export as CSV (for compliance archives)
+
+```bash
+curl -s -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Accept: text/csv" \
+  "http://localhost:9100/v1/audit?verify=true" \
+  > audit-export-$(date +%Y-%m-%d).csv
+```
+
+### Export as NDJSON (for tooling pipelines)
+
+```bash
+curl -s -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Accept: application/x-ndjson" \
+  "http://localhost:9100/v1/audit?verify=true" \
+  > audit-export-$(date +%Y-%m-%d).ndjson
+```
+
+### Integrity Check (Standalone)
+
+```bash
+curl -s -H "Authorization: Bearer YOUR_API_KEY" \
+  "http://localhost:9100/v1/audit?verify=true&limit=1" \
+  | jq '.integrity'
+```
+
+**If `valid` is `false`:**
+
+1. Check `brokenAt` for the sequence number where the chain breaks.
+2. Inspect the audit JSONL file at `~/.aegis/audit/` around that line.
+3. The broken hash and the expected hash are logged — compare them.
+4. Do **not** delete or modify audit files. Preserve the broken chain for forensic review.
+
+---
+
+## 3. API Key Recovery
+
+API keys are stored as SHA-256 hashes. Plaintext is returned **only at creation time** and cannot be recovered.
+
+### Before Disaster: Key Inventory
+
+```bash
+curl -s -H "Authorization: Bearer YOUR_MASTER_KEY" \
+  "http://localhost:9100/v1/auth/keys" \
+  | jq '[.[] | {id, name, role, permissions, createdAt}]'
+```
+
+Save this output regularly — it is your key registry for disaster recovery.
+
+### After Restore: Key Rotation
+
+Since key plaintext cannot be recovered from backups:
+
+1. Generate a new master key:
+   ```bash
+   curl -s -X POST -H "Authorization: Bearer YOUR_OLD_MASTER_KEY" \
+     "http://localhost:9100/v1/auth/keys" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "recovery-master", "role": "admin"}' \
+     | jq .
+   ```
+2. **Save the returned plaintext key immediately** — it will not be shown again.
+3. Update all integrations (CI pipelines, MCP clients, dashboards) with the new key.
+4. Delete old keys once all integrations are updated:
+   ```bash
+   curl -s -X DELETE -H "Authorization: Bearer YOUR_NEW_MASTER_KEY" \
+     "http://localhost:9100/v1/auth/keys/OLD_KEY_ID"
+   ```
+
+---
+
+## 4. Restore Procedure
+
+### Full Restore from Filesystem Backup
+
+```bash
+# Stop Aegis
+sudo systemctl stop aegis
+
+# Verify backup integrity
+tar tzf aegis-backup-YYYY-MM-DD_HHMMSS.tar.gz | wc -l
+
+# Restore (preserves existing as .bak)
+mv ~/.aegis ~/.aegis.pre-restore.$(date +%s)
+tar xzf aegis-backup-YYYY-MM-DD_HHMMSS.tar.gz -C "$HOME"
+
+# Verify config loaded correctly
+cat ~/.aegis/config.yaml
+
+# Start Aegis
+sudo systemctl start aegis
+
+# Health check
+curl -s http://localhost:9100/v1/health | jq .
+```
+
+### Verify Post-Restore Integrity
+
+```bash
+# 1. Server health
+curl -s http://localhost:9100/v1/health | jq .
+
+# 2. Audit chain integrity
+curl -s -H "Authorization: Bearer YOUR_API_KEY" \
+  "http://localhost:9100/v1/audit?verify=true&limit=1" \
+  | jq '.integrity'
+
+# 3. Session count matches pre-disaster
+curl -s -H "Authorization: Bearer YOUR_API_KEY" \
+  "http://localhost:9100/v1/sessions?limit=1" \
+  | jq '.total'
+```
+
+---
+
+## 5. Scheduled Backup Automation
+
+### Cron (Linux/macOS)
+
+```bash
+# Daily backup at 02:00, keep 30 days
+0 2 * * * /usr/local/bin/aegis-backup.sh >> /var/log/aegis-backup.log 2>&1
+```
+
+`/usr/local/bin/aegis-backup.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_DIR="${AEGIS_STATE_DIR:-$HOME/.aegis}"
+BACKUP_DIR="/var/backups/aegis"
+RETENTION_DAYS=30
+
+mkdir -p "$BACKUP_DIR"
+DATE=$(date +%Y-%m-%d_%H%M%S)
+FILE="${BACKUP_DIR}/aegis-${DATE}.tar.gz"
+
+# Create backup
+tar czf "$FILE" -C "$(dirname "$STATE_DIR")" "$(basename "$STATE_DIR")"
+
+# Rotate old backups
+find "$BACKUP_DIR" -name "aegis-*.tar.gz" -mtime +$RETENTION_DAYS -delete
+
+# Verify
+if ! tar tzf "$FILE" >/dev/null 2>&1; then
+  echo "ERROR: Backup verification failed for ${FILE}"
+  rm -f "$FILE"
+  exit 1
+fi
+
+echo "$(date -Iseconds) Backup created: ${FILE} ($(du -h "$FILE" | cut -f1))"
+```
+
+### Docker Compose Volume Backup
+
+```yaml
+# docker-compose.override.yml (backup service)
+services:
+  backup:
+    image: alpine:3.19
+    volumes:
+      - aegis-data:/data:ro
+      - ./backups:/backups
+    entrypoint: >
+      tar czf /backups/aegis-$(date +%Y-%m-%d).tar.gz -C /data .
+    profiles: ["backup"]
+
+volumes:
+  aegis-data:
+    external: true
+```
+
+```bash
+docker compose --profile backup run --rm backup
+```
+
+---
+
+## 6. Disaster Scenarios
+
+### Scenario A: Disk Failure (Total Data Loss)
+
+1. Provision new server with same Aegis version.
+2. Install Aegis and configure `AEGIS_STATE_DIR`.
+3. Restore from most recent filesystem backup (Section 4).
+4. Rotate all API keys (Section 3).
+5. Verify audit chain integrity.
+6. Reconnect all integrations (CI, dashboards, notification channels).
+
+### Scenario B: Audit Chain Corruption
+
+1. **Do not modify audit files.** Export the corrupted chain for forensic review:
+   ```bash
+   curl -s -H "Authorization: Bearer YOUR_API_KEY" \
+     -H "Accept: text/csv" \
+     "http://localhost:9100/v1/audit?verify=true" \
+     > audit-forensic-$(date +%Y-%m-%d).csv
+   ```
+2. Check `brokenAt` in the integrity response to identify the corruption point.
+3. If the corruption is in a single record, contact support with the forensic export.
+4. Aegis continues operating — audit queries return records before the break point.
+
+### Scenario C: Configuration Loss
+
+1. Restore `config.yaml` from backup or version control.
+2. Validate the configuration:
+   ```bash
+   # If using the CLI
+   ag init --verify 2>/dev/null || true
+   ```
+3. Restart Aegis and run health check.
+4. API keys are stored separately — they survive config-only loss if the key file is intact.
+
+### Scenario D: Accidental Key Deletion
+
+1. Keys cannot be recovered — generate a new one immediately.
+2. If the master key was deleted, use the `AEGIS_MASTER_TOKEN` environment variable (set during initial setup) to authenticate and create a replacement.
+3. Update all downstream consumers.
+
+---
+
+## 7. Acceptance Criteria Mapping
+
+| Criterion | Status | Reference |
+|-----------|--------|-----------|
+| `ag admin export` / `ag admin import` commands | 🔜 Planned | REST API equivalents documented in Sections 2–4 |
+| Audit-chain backup with integrity verification | ✅ Covered | Section 2 — `verify=true` parameter |
+| Key-material recovery procedure | ✅ Covered | Section 3 — rotation workflow |
+| Runbook validated in tabletop exercise | ⏳ Pending | Execute Scenario A–D in staging |
+
+---
+
+## References
+
+- [Audit log architecture](../enterprise/00-gap-analysis.md) — Section on SHA-256 chain design
+- [Security review](./02-security.md) — Auth model and key storage
+- [Positioning ADR-0023](../adr/0023-positioning-claude-code-control-plane.md)
+- [REST API reference](https://github.com/OneStepAt4time/aegis#api-reference)

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -42,6 +42,7 @@ It is **not yet enterprise-ready**. The following critical gaps stand between cu
 | [03 — Testing & Observability](./03-testing-observability.md) | CI/CD, coverage, metrics, logging, error handling, transcript | 20 findings |
 | [04 — MCP, Dashboard & Integrations](./04-mcp-integrations.md) | MCP tools, API contracts, dashboard, WebSocket, channels | 22 findings |
 | [05 — Enterprise Gap Roadmap](./05-enterprise-roadmap.md) | Prioritised backlog to reach enterprise grade | All findings mapped to milestones |
+| [06 — Disaster Recovery Runbook](./06-disaster-recovery.md) | Backup, audit export, key recovery, restore procedures (#1950) | 4 disaster scenarios, cron automation |
 | [00 — Gap Analysis (2026-04-16 follow-up)](./00-gap-analysis.md) | Updated P0/P1/P2 scorecard, 3-phase roadmap, ADR links | P0 ×8, P1 ×10, P2 ×12 |
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -278,7 +278,7 @@ See [`packages/client/`](../packages/client/) for source and the full README.
 ### Python SDK
 
 ```bash
-pip install aegis-python-client
+pip install ag-client
 ```
 
 ```python

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -22,7 +22,7 @@ List Aegis-managed Claude Code sessions. Optionally filter by status or workDir 
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `status` | string | no | Filter by status (`idle`, `working`, `permission_prompt`) |
+| `status` | string | no | Filter by status (`idle`, `working`, `permission_prompt`, `rate_limit`, etc.) |
 | `workDir` | string | no | Filter by workDir substring |
 
 **Example:**

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -69,13 +69,17 @@ The response includes a session ID. Save it for subsequent API calls.
 ```
 create → working → permission_prompt? → idle → done
                     ↑_______________|
+                rate_limit?
+                    |
+              (interactive menu)
 ```
 
 1. **create** — Session starts, Claude Code initializes
 2. **working** — Claude Code is processing
 3. **permission_prompt** — Waiting for approval (see Permission Modes below)
 4. **idle** — Claude Code finished, ready for next prompt
-5. **done** — Session terminated
+5. **rate_limit** — Claude Code hit a rate limit and is showing an interactive menu (choose an option or wait)
+6. **done** — Session terminated
 
 Poll for status:
 ```bash

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -83,17 +83,22 @@ All releases are built via GitHub Actions. Verify the workflow ran successfully:
 
 ### SDK Release Automation
 
-Pushing a `v*` tag runs `.github/workflows/release.yml`. In addition to the root
+Pushing a `v*` tag runs `.github/workflows/release.yml`. Real publishing is
+production-only: the release preflight fails before publish jobs if the tag
+commit is not reachable from `origin/main`. Use `.github/workflows/release-dry-run.yml`
+on `develop` or release PRs to validate release readiness without publishing.
+
+In addition to the root
 `@onestepat4time/aegis` npm package, the workflow publishes:
 
 - `@onestepat4time/aegis-client` from `packages/client` to npm.
-- `aegis-python-client` from `packages/python-client` to PyPI.
+- `ag-client` from `packages/python-client` to PyPI.
 
 The release workflow regenerates the root OpenAPI contract, regenerates each SDK
 from that contract, builds the SDK package, and then publishes it. npm packages
-use provenance and public access. Tags containing `-preview` publish npm
-packages with the `preview` dist-tag; all other release tags publish with
-`latest`.
+use provenance and public access. Stable tags publish npm packages with the
+`latest` dist-tag; prerelease tags using `preview`, `alpha`, `beta`, or `rc`
+publish with the matching npm dist-tag.
 
 The validation gates are:
 
@@ -101,9 +106,17 @@ The validation gates are:
 - `npm run sdk:ts:check`
 - `npm run sdk:py:check`
 - the normal release build and test steps
+- the release preflight job, which checks the packaged npm tarball, checksum
+  metadata, local Sigstore attestation generation/verification, release
+  version/dist-tag parsing, main-branch tag reachability, and Helm gh-pages
+  clone/index logic before npm publish jobs run
+- the release dry-run workflow on `develop` and release PRs, which packs and
+  smoke-installs local artifacts, builds SDK packages, packages Helm charts,
+  and validates Sigstore predicate generation without publishing public
+  artifacts
 
 PyPI publishing uses trusted publishing via GitHub OIDC; no PyPI token is stored
-in the repository. Maintainers must configure the `aegis-python-client` project
+in the repository. Maintainers must configure the `ag-client` project
 on PyPI with a trusted publisher for repository `OneStepAt4time/aegis`, workflow
 `.github/workflows/release.yml`, and environment `pypi`.
 
@@ -122,6 +135,19 @@ package and TypeScript SDK keep the original tag version.
 
 Numeric suffixes on prerelease tags are preserved, for example `X.Y.Z-rc.1`
 becomes `X.Y.Zrc1`.
+
+### Partial Preview Release Recovery
+
+If a preview release partially publishes, first rerun the failed release
+workflow. Do not bump the preview version solely to recover a rerun until the
+idempotent rerun path has been attempted and a maintainer decides a replacement
+version is unavoidable.
+
+The root npm package and TypeScript SDK npm publish jobs are intentionally late
+and idempotent: they check whether the exact version already exists on npm and
+skip with a notice when it does. npm versions are immutable, so these jobs must
+remain guarded by the preflight checks and must never publish a new version just
+to recover an otherwise rerunnable preview release.
 
 ### Verify the Author
 

--- a/packages/python-client/README.md
+++ b/packages/python-client/README.md
@@ -1,11 +1,11 @@
-# aegis-python-client
+# ag-client
 
 Official Python client for [Aegis](https://github.com/OneStepAt4time/aegis) — orchestration middleware for Claude Code.
 
 ## Install
 
 ```bash
-pip install aegis-python-client
+pip install ag-client
 ```
 
 ## Quick Start

--- a/packages/python-client/pyproject.toml
+++ b/packages/python-client/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "aegis-python-client"
+name = "ag-client"
 version = "0.1.0"
 description = "Official Python client for Aegis — orchestration middleware for Claude Code"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Promote current develop to main so release hardening is active for real publishing.
- Includes the g-client PyPI package-name correction, release dry-run workflow, main-only publish guard, and idempotent npm publish skips.
- Uses a single promotion commit whose final tree matches origin/develop.

## Validation
- PR #2415 checks passed and merged to develop.
- PR #2417 checks passed, including Release Dry Run, and merged to develop.
- Local promotion tree check: HEAD matches origin/develop.

Release policy after this promotion: develop validates with dry-run; real publish requires a v* tag reachable from origin/main.