### PR TITLE
ci(release): move Release Please to release branches

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,91 @@
+name: Create Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact release version, for example 0.6.6-preview
+        required: true
+        type: string
+      source_branch:
+        description: Branch to cut the release from
+        required: true
+        default: develop
+        type: string
+      recovery_release:
+        description: Allow a numbered preview recovery version such as 0.6.6-preview.1
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  create-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.AEGIS_APP_ID }}
+          private-key: ${{ secrets.AEGIS_APP_PRIVATE_KEY }}
+
+      - name: Create release branch and dispatch Release Please
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          RECOVERY_RELEASE: ${{ inputs.recovery_release }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+             [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)$ ]] &&
+             [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)[.-][0-9]+$ ]] &&
+             [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]]; then
+            echo "::error::Unsupported release version ${VERSION}."
+            exit 1
+          fi
+
+          if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]] &&
+             [ "${RECOVERY_RELEASE}" != "true" ]; then
+            echo "::error::Numbered preview releases are recovery-only. Re-run with recovery_release=true if this is an approved recovery."
+            exit 1
+          fi
+
+          RELEASE_BRANCH="release/${VERSION}"
+
+          git fetch --no-tags origin "${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}"
+          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Release branch ${RELEASE_BRANCH} already exists."
+            exit 1
+          fi
+
+          if [ "${RECOVERY_RELEASE}" != "true" ]; then
+            ACTIVE_RELEASE_BRANCHES=$(git ls-remote --heads origin 'release/*' | awk '{print $2}' || true)
+            if [ -n "${ACTIVE_RELEASE_BRANCHES}" ]; then
+              echo "::error::Only one active release branch is allowed."
+              printf '%s\n' "${ACTIVE_RELEASE_BRANCHES}"
+              exit 1
+            fi
+          fi
+
+          git switch --create "${RELEASE_BRANCH}" "origin/${SOURCE_BRANCH}"
+          git push origin "HEAD:${RELEASE_BRANCH}"
+
+          gh workflow run release-please.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "${RELEASE_BRANCH}" \
+            --field "target_branch=${RELEASE_BRANCH}" \
+            --field "release_as=${VERSION}" \
+            --field "recovery_release=${RECOVERY_RELEASE}"
+
+          echo "::notice::Created ${RELEASE_BRANCH} from ${SOURCE_BRANCH} and dispatched Release Please for ${VERSION}."

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+      - 'release/**'
     paths:
       - '.github/workflows/release*.yml'
       - 'package.json'
@@ -20,6 +21,7 @@ on:
   pull_request:
     branches:
       - develop
+      - 'release/**'
     paths:
       - '.github/workflows/release*.yml'
       - 'package.json'
@@ -35,6 +37,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
   id-token: write
 
 jobs:
@@ -57,6 +60,8 @@ jobs:
         uses: sigstore/cosign-installer@v3
       - name: Build and validate release artifacts without publishing
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -64,6 +69,18 @@ jobs:
           npm run openapi:check
           npm run sdk:ts:check
           npm run sdk:py:check
+          TARGET_BRANCH="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
+          if [[ "${TARGET_BRANCH}" == release/* ]]; then
+            RELEASE_AS="${TARGET_BRANCH#release/}"
+            npx --yes release-please release-pr \
+              --dry-run \
+              --token="${GITHUB_TOKEN}" \
+              --repo-url="${GITHUB_REPOSITORY}" \
+              --target-branch="${TARGET_BRANCH}" \
+              --release-as="${RELEASE_AS}" \
+              --config-file=release-please-config.json \
+              --manifest-file=.release-please-manifest.json
+          fi
           AEGIS_REQUIRE_DASHBOARD_COPY=true npm run build
 
           DRY_RUN_DIR="${RUNNER_TEMP}/release-dry-run"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,38 +1,86 @@
 name: Release Please
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Release branch to prepare, for example release/0.6.6-preview
+        required: true
+        type: string
+      release_as:
+        description: Exact version Release Please should prepare, for example 0.6.6-preview
+        required: true
+        type: string
+      recovery_release:
+        description: Allow a numbered preview recovery version such as 0.6.6-preview.1
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
   release-please:
-    # Skip runs triggered by release-please's own commits or promotion merges
-    if: |
-      !startsWith(github.event.head_commit.message, 'chore(main): release') &&
-      !startsWith(github.event.head_commit.message, 'chore: promote')
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release request
+        shell: bash
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          RELEASE_AS: ${{ inputs.release_as }}
+          RECOVERY_RELEASE: ${{ inputs.recovery_release }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${TARGET_BRANCH}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-]?[0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error::Release Please target must be a release/<version> branch; got ${TARGET_BRANCH}."
+            exit 1
+          fi
+
+          BRANCH_VERSION="${TARGET_BRANCH#release/}"
+          if [ "${BRANCH_VERSION}" != "${RELEASE_AS}" ]; then
+            echo "::error::target_branch version ${BRANCH_VERSION} must match release_as ${RELEASE_AS}."
+            exit 1
+          fi
+
+          if [[ ! "${RELEASE_AS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+             [[ ! "${RELEASE_AS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(preview|alpha|beta|rc)$ ]] &&
+             [[ ! "${RELEASE_AS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)[.-][0-9]+$ ]] &&
+             [[ ! "${RELEASE_AS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]]; then
+            echo "::error::Unsupported release version ${RELEASE_AS}."
+            exit 1
+          fi
+
+          if [[ "${RELEASE_AS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]] &&
+             [ "${RECOVERY_RELEASE}" != "true" ]; then
+            echo "::error::Numbered preview releases are recovery-only. Re-run with recovery_release=true if this is an approved recovery."
+            exit 1
+          fi
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.AEGIS_APP_ID }}
           private-key: ${{ secrets.AEGIS_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5
         id: release
         with:
           # Use GitHub App token for separate rate limit (15K/h)
           # and to trigger CI workflows on release PRs.
           token: ${{ steps.app-token.outputs.token }}
+          target-branch: ${{ inputs.target_branch }}
+          release-as: ${{ inputs.release_as }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           # GitHub Releases are created by release.yml on tag pushes.
-          # This avoids hard failures when historical tags already exist.
+          # This keeps version/changelog preparation separate from publishing.
           skip-github-release: true
+
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,15 @@ jobs:
             exit 1
           fi
 
+          if [[ "${TAG_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]]; then
+            TAG_OBJECT_TYPE=$(git cat-file -t "${GITHUB_REF_NAME}" 2>/dev/null || true)
+            if [ "${TAG_OBJECT_TYPE}" != "tag" ] ||
+               ! git cat-file tag "${GITHUB_REF_NAME}" | grep -Fxq "recovery-release: true"; then
+              echo "::error::Numbered preview tags are recovery-only and require an annotated tag containing 'recovery-release: true'."
+              exit 1
+            fi
+          fi
+
           git fetch --no-tags origin main:refs/remotes/origin/main
           TAG_COMMIT=$(git rev-list -n 1 "${GITHUB_REF_NAME}")
           if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/main; then
@@ -896,3 +905,33 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           npx clawhub@latest publish skill/ --slug aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"
+
+  cleanup-release-branch:
+    needs:
+      - attach-checksums
+      - attach-sbom
+      - attach-attestation
+      - publish-helm-chart
+      - publish-typescript-sdk
+      - publish-python-sdk
+      - publish-clawhub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete completed release branch when present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${GITHUB_REF_NAME#v}"
+          RELEASE_BRANCH="release/${VERSION}"
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${RELEASE_BRANCH}"
+            echo "::notice::Deleted completed release branch ${RELEASE_BRANCH}."
+          else
+            echo "::notice::No release branch ${RELEASE_BRANCH} exists; nothing to delete."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,11 @@ If the gate fails:
 ## Branch and PR Rules
 
 1. Standard PRs target `develop`.
-2. `main` is release/promotion only, unless maintainers explicitly declare an emergency hotfix.
-3. Never push directly to protected branches.
+2. `release/<version>` branches are short-lived release preparation branches created by the Create Release Branch workflow from `origin/develop`.
+3. `main` is release/promotion only, unless maintainers explicitly declare an emergency hotfix.
+4. Never push directly to protected branches.
+5. Planned releases use `develop` → `release/<version>` → `main` → `v*` tag. Release Please prepares version/changelog state on `release/<version>`; `.github/workflows/release.yml` publishes only from tags reachable from `origin/main`.
+6. Do not create release tags without a real user-facing payload and explicit go/no-go. Planned preview releases use `X.Y.Z-preview`; numbered `X.Y.Z-preview.N` tags are recovery-only and require an annotated tag containing `recovery-release: true`.
 
 ## Security-First Defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 - **Security check:** `npm run security-check`
 - **Quality gate:** `npm run gate` must pass before any push/PR
 - **Branch model:** all standard PRs target `develop` (not `main`)
+- **Release model:** `develop` → `release/<version>` → `main` → `v*` tag; Release Please prepares release branches, `release.yml` publishes tags from `main`
 - **Docs alignment:** keep policy docs synchronized in the same PR
 
 ## Non-Negotiable Hygiene Rules
@@ -19,6 +20,7 @@
 2. Do not place deployment documentation in repository root; keep it under `docs/`.
 3. Do not keep obsolete UAT or one-off audit artifacts in tracked files.
 4. Keep alpha lifecycle language consistent; do not reference retired legacy version lines.
+5. Do not create release tags or preview bumps without a real user-facing payload and explicit go/no-go; planned previews use `X.Y.Z-preview`, not `X.Y.Z-preview.N`.
 
 ## Mandatory Pre-PR Alignment Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,14 +144,16 @@ All branches are created from `origin/develop`. Branch names use the format:
 ### Aegis team conventions
 
 - **Scribe documentation PRs**: always `docs/<topic>` — targeted at `develop`, reviewed by Argus
-- **Release promotion**: `release/<version>` (e.g., `release/0.3.2`) — created by Ema only
+- **Release branches**: `release/<version>` (e.g., `release/0.6.6-preview`) — created only by the Create Release Branch workflow from `origin/develop`
 - **Hotfixes**: `hotfix/<description>` — targets `main` directly with Argus emergency review
 
 ### Branching rules (6 April 2026)
 
 - **ALL PRs target `develop`**, not `main`
-- `main` = release-ready only; Ema promotes `develop → main`
+- `main` = production release only; normal releases flow `develop → release/<version> → main → v* tag`
 - `origin/develop` must exist before branching — run `git fetch origin develop:develop` first
+- Release Please prepares version and changelog state on `release/<version>` branches. Public publishing is owned by `.github/workflows/release.yml` and starts only from a `v*` tag reachable from `origin/main`.
+- Planned preview releases use `X.Y.Z-preview`; numbered `X.Y.Z-preview.N` releases are recovery-only and require explicit maintainer approval plus the release workflow recovery annotation.
 
 ### Development Workflow: Git Worktrees
 
@@ -193,6 +195,7 @@ Every change to the codebase must follow this path:
 - **Always run `gh pr list` before starting work** — verify the issue isn't already resolved
 - **Always run `gh pr list --state merged` after closing a PR** — confirm the merge completed
 - **Never skip CI** — all checks must pass before merge
+- **Never tag a release without a real user-facing payload and go/no-go approval** — CI/release workflow changes alone do not justify publishing an npm/PyPI package.
 - **Never push or open/update a PR with a failing local gate** — stop, fix, or escalate with `needs-human`
 - **`feat:` commits require the `approved-minor-bump` label** — without it, the CI gate blocks merge
 - **Zero test coverage bypasses** — never add files to `coverage.exclude` to hide untested code

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,5 +141,6 @@ All remaining P2 items from the gap analysis:
 3. **Deterministic gates** — local + CI checks are non-optional.
 4. **Docs as contract** — behaviour and policy must match documentation.
 5. **Same pattern at every scale** — no fork, no edition split, no rewrite.
-6. **Sustainable pace** — this is a part-time maintainer project; the roadmap
+6. **Release discipline** — planned releases require a real user-facing payload, a short-lived `release/<version>` branch, Release Please version/changelog preparation, dry-run validation, and a tag on `main`.
+7. **Sustainable pace** — this is a part-time maintainer project; the roadmap
    is calibrated to that reality.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,4 +33,6 @@ Aegis implements the following security controls:
 
 ## Security Updates
 
-Security patches are released through the active alpha line. We recommend upgrading to the latest published alpha immediately.
+Security patches are released through the active preview line. We recommend upgrading to the latest published preview immediately.
+
+Security hotfixes may target `main` directly with maintainer approval, but normal releases follow `develop` → `release/<version>` → `main` → `v*` tag. Public publishing is performed only by the tag-triggered release workflow after its preflight, SBOM, checksum, Sigstore, npm, PyPI, and Helm gates pass.

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -83,10 +83,17 @@ All releases are built via GitHub Actions. Verify the workflow ran successfully:
 
 ### SDK Release Automation
 
+Normal releases follow `develop` → `release/<version>` → `main` → `v*` tag.
+Release Please prepares version and changelog state on the short-lived
+`release/<version>` branch. It does not create GitHub Releases or publish
+artifacts; `.github/workflows/release.yml` owns all public publishing at tag
+time.
+
 Pushing a `v*` tag runs `.github/workflows/release.yml`. Real publishing is
 production-only: the release preflight fails before publish jobs if the tag
 commit is not reachable from `origin/main`. Use `.github/workflows/release-dry-run.yml`
-on `develop` or release PRs to validate release readiness without publishing.
+on `develop`, `release/**`, and release PRs to validate release readiness
+without publishing.
 
 In addition to the root
 `@onestepat4time/aegis` npm package, the workflow publishes:
@@ -114,6 +121,8 @@ The validation gates are:
   smoke-installs local artifacts, builds SDK packages, packages Helm charts,
   and validates Sigstore predicate generation without publishing public
   artifacts
+- the Release Please dry-run path on `release/**`, which verifies that the
+  requested release branch can produce the expected version/changelog update
 
 PyPI publishing uses trusted publishing via GitHub OIDC; no PyPI token is stored
 in the repository. Maintainers must configure the `ag-client` project
@@ -133,8 +142,39 @@ package and TypeScript SDK keep the original tag version.
 | `X.Y.Z-beta` | `X.Y.Zb0` |
 | `X.Y.Z-rc` | `X.Y.Zrc0` |
 
-Numeric suffixes on prerelease tags are preserved, for example `X.Y.Z-rc.1`
-becomes `X.Y.Zrc1`.
+Numeric suffixes on `alpha`, `beta`, and `rc` prerelease tags are preserved,
+for example `X.Y.Z-rc.1` becomes `X.Y.Zrc1`.
+
+Planned preview releases use `X.Y.Z-preview`. Numbered preview releases such as
+`X.Y.Z-preview.1` are recovery-only. The release workflow rejects numbered
+preview tags unless the tag is annotated and the annotation contains:
+
+```text
+recovery-release: true
+```
+
+### Release Branch Lifecycle
+
+Release branches are created by the Create Release Branch workflow, not by
+manual local git commands. The workflow creates `release/<version>` from
+`origin/develop` and dispatches Release Please with an explicit `release-as`
+version so planned previews remain `X.Y.Z-preview`.
+
+Only one active release branch is allowed for normal releases. Release branches
+must be promoted or abandoned within 48 hours; if stabilization takes longer,
+delete the branch and cut a fresh one from `develop`. After a successful tag
+release, the release workflow deletes the matching release branch when present;
+then sync `main` back to `develop` so changelog, manifest, and version files
+remain aligned.
+
+### Hotfix Releases
+
+Emergency hotfixes may target `main` directly only with maintainer approval.
+After a hotfix tag publishes successfully, backport the fix to `develop` so the
+next normal release branch includes it. If a preview artifact was already
+published and is unusable, use the recovery path: fix the issue, create an
+approved annotated recovery tag with a numbered preview suffix, and include
+`recovery-release: true` in the tag annotation.
 
 ### Partial Preview Release Recovery
 


### PR DESCRIPTION
## Summary
- move Release Please from automatic `main` pushes to explicit release branch dispatch
- add a Create Release Branch workflow that cuts `release/<version>` from `develop` and dispatches Release Please with explicit `release-as`
- extend Release Dry Run to `release/**`, block numbered preview tags unless annotated as recovery releases, and clean up completed release branches after a successful tag release
- document the agreed `develop -> release/<version> -> main -> v* tag` release model across policy docs

## Validation
- `npm run gate`
- `actionlint .github/workflows/release-please.yml .github/workflows/create-release-branch.yml .github/workflows/release-dry-run.yml .github/workflows/release.yml`
- Release Please CLI dry-run with `--release-as=0.6.6-preview` confirmed it prepares `0.6.6-preview` instead of `preview.N`