### PR TITLE
fix(ci): reset release manifest to stable baseline before branching

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -79,6 +79,23 @@ jobs:
           fi
 
           git switch --create "${RELEASE_BRANCH}" "origin/${SOURCE_BRANCH}"
+
+          # Reset .release-please-manifest.json to the last stable version
+          # (strip any prerelease suffix) so Release Please computes the
+          # correct next version from a clean baseline instead of inheriting
+          # a stale prerelease suffix like "0.6.5-preview.3".
+          CURRENT_VERSION=$(jq -r '."."' .release-please-manifest.json)
+          STABLE_VERSION=$(echo "${CURRENT_VERSION}" | sed -E 's/(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)$//')
+          if [ "${STABLE_VERSION}" != "${CURRENT_VERSION}" ]; then
+            echo "Resetting manifest from ${CURRENT_VERSION} to stable baseline ${STABLE_VERSION}"
+            jq --arg v "${STABLE_VERSION}" '."." = $v' .release-please-manifest.json > .release-please-manifest.json.tmp
+            mv .release-please-manifest.json.tmp .release-please-manifest.json
+            git add .release-please-manifest.json
+            git commit -m "chore: reset release manifest to stable baseline ${STABLE_VERSION}"
+          else
+            echo "Manifest already at stable version ${STABLE_VERSION}, no reset needed"
+          fi
+
           git push origin "HEAD:${RELEASE_BRANCH}"
 
           gh workflow run release-please.yml \


### PR DESCRIPTION
## Problem

When `create-release-branch.yml` branches off `develop`, the `.release-please-manifest.json` may contain a stale prerelease suffix (e.g. `0.6.5-preview.3`). Release Please inherits this and produces incorrect version bumps — `0.6.6-preview.3` instead of `0.6.6-preview`.

This was the root cause of PR #2426 producing the wrong version.

## Fix

Add a manifest reset step in `create-release-branch.yml` that runs **after** creating the release branch but **before** pushing:

1. Read current manifest version
2. Strip any prerelease suffix (`-preview.N`, `-alpha.N`, etc.) → stable `X.Y.Z`
3. If the version changed, commit the reset on the release branch
4. If already stable, skip (no-op)

Example: `0.6.5-preview.3` → `0.6.5` → Release Please computes `0.6.6-preview` correctly.

## Testing

- `echo "0.6.5-preview.3" | sed -E 's/(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)$//'` → `0.6.5` ✓
- `echo "0.6.6" | sed -E 's/(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)$//'` → `0.6.6` ✓
- Stable version → no-op (skip commit) ✓