### PR TITLE
fix(release): configure release branch git identity

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -90,6 +90,8 @@ jobs:
             echo "Resetting manifest from ${CURRENT_VERSION} to stable baseline ${STABLE_VERSION}"
             jq --arg v "${STABLE_VERSION}" '."." = $v' .release-please-manifest.json > .release-please-manifest.json.tmp
             mv .release-please-manifest.json.tmp .release-please-manifest.json
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add .release-please-manifest.json
             git commit -m "chore: reset release manifest to stable baseline ${STABLE_VERSION}"
           else


### PR DESCRIPTION
## Summary
- configure git author identity before Create Release Branch commits the manifest baseline reset
- fixes the failed 0.6.6-preview branch creation run that stopped with "Author identity unknown"

## Validation
- `npx --yes js-yaml .github/workflows/create-release-branch.yml`
- `actionlint .github/workflows/create-release-branch.yml`
- `npm run gate`