### PR TITLE
chore: promote release branch identity fix to main

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -90,6 +90,8 @@ jobs:
             echo "Resetting manifest from ${CURRENT_VERSION} to stable baseline ${STABLE_VERSION}"
             jq --arg v "${STABLE_VERSION}" '."." = $v' .release-please-manifest.json > .release-please-manifest.json.tmp
             mv .release-please-manifest.json.tmp .release-please-manifest.json
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add .release-please-manifest.json
             git commit -m "chore: reset release manifest to stable baseline ${STABLE_VERSION}"
           else


### PR DESCRIPTION
## Summary
- promote the Create Release Branch git identity fix to main
- required so workflow_dispatch can commit the release manifest baseline reset before dispatching Release Please

## Validation
- `actionlint .github/workflows/create-release-branch.yml`
- YAML parse for create-release-branch.yml
- `npm run gate`

No release tag was created and no publish workflow was triggered.