### PR TITLE
fix(release): promote manifest baseline fix to main

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -80,24 +80,6 @@ jobs:
 
           git switch --create "${RELEASE_BRANCH}" "origin/${SOURCE_BRANCH}"
 
-          # Reset .release-please-manifest.json to the last stable version
-          # (strip any prerelease suffix) so Release Please computes the
-          # correct next version from a clean baseline instead of inheriting
-          # a stale prerelease suffix like "0.6.5-preview.3".
-          CURRENT_VERSION=$(jq -r '."."' .release-please-manifest.json)
-          STABLE_VERSION=$(echo "${CURRENT_VERSION}" | sed -E 's/(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)$//')
-          if [ "${STABLE_VERSION}" != "${CURRENT_VERSION}" ]; then
-            echo "Resetting manifest from ${CURRENT_VERSION} to stable baseline ${STABLE_VERSION}"
-            jq --arg v "${STABLE_VERSION}" '."." = $v' .release-please-manifest.json > .release-please-manifest.json.tmp
-            mv .release-please-manifest.json.tmp .release-please-manifest.json
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add .release-please-manifest.json
-            git commit -m "chore: reset release manifest to stable baseline ${STABLE_VERSION}"
-          else
-            echo "Manifest already at stable version ${STABLE_VERSION}, no reset needed"
-          fi
-
           git push origin "HEAD:${RELEASE_BRANCH}"
 
           gh workflow run release-please.yml \


### PR DESCRIPTION
## Summary
- promote the release-branch manifest baseline fix from develop to main
- branch is based on `main` and contains only the workflow patch from #2433
- required before regenerating `release/0.6.6-preview`

## Validation
- #2433 checks passed on develop
- promotion diff is limited to `.github/workflows/create-release-branch.yml`

After this merges, I will regenerate `release/0.6.6-preview` and verify the Release Please PR before any tag/publish step.