### PR TITLE
fix(ci): use onestep-aegis slug for ClawHub publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -904,7 +904,7 @@ jobs:
         if: ${{ env.CLAWHUB_TOKEN != '' }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest publish skill/ --slug aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"
+          npx clawhub@latest publish skill/ --slug onestep-aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"
 
   cleanup-release-branch:
     needs:


### PR DESCRIPTION
Slug `aegis` is already claimed by `/pleasechooseusername/aegis` on ClawHub, causing the publish job to fail on every release.

Switch to `onestep-aegis`. Can be migrated back to `aegis` later if the slug becomes available.