### PR TITLE
ci: add CODEOWNERS requiring review for workflow and release config changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS — Required reviewers for path-based changes
+#
+# These rules require review from listed owners before PRs targeting
+# the specified paths can be merged. Works with GitHub's CODEOWNERS
+# feature and branch protection "require code owner review" option.
+
+# CI/CD workflows — require review from Ema (repo owner) + Hermes
+# before any workflow changes can land on develop.
+# Hermes handles release/DevOps; Ema is the human gate for infra changes.
+.github/workflows/ @OneStepAt4time
+
+# Release configuration — version manifests, release-please config
+.release-please-manifest.json @OneStepAt4time
+release-please-config.json @OneStepAt4time
+
+# Helm chart versioning
+deploy/helm/aegis/Chart.yaml @OneStepAt4time
+
+# Security and access configuration
+ SECURITY.md @OneStepAt4time


### PR DESCRIPTION
## What

Add `CODEOWNERS` file requiring review from `@OneStepAt4time` (Ema) for changes to:

- `.github/workflows/` — all CI/CD pipelines
- `.release-please-manifest.json` + `release-please-config.json` — release config
- `deploy/helm/aegis/Chart.yaml` — Helm chart versioning
- `SECURITY.md` — security policy

## Why

Per Themis audit S7 — prevents unauthorized workflow modifications before the first release under the new release process.

## Note

`@OneStepAt4time` is used as the required reviewer since they are the repo owner and only direct collaborator with write access. To enable "require code owner review" in branch protection, this must be paired with enabling that setting in the repo's branch protection rules for `develop` and `main`.