### PR TITLE
fix(security): eliminate length-leak timing side-channel in timingSafeEqual

### DIFF
--- a/src/__tests__/auth-timing-safe.test.ts
+++ b/src/__tests__/auth-timing-safe.test.ts
@@ -72,14 +72,14 @@ describe('AuthManager timing-safe token comparison (#402)', () => {
     }
   });
 
-  it('rejects tokens of different length without calling timingSafeEqual', () => {
+  it('#2454: still calls timingSafeEqual for different-length tokens (constant-time)', () => {
     const result = auth.validate('short');
     expect(result.valid).toBe(false);
 
-    // timingSafeEqual should NOT be called for length mismatch
+    // #2454: timingSafeEqual MUST be called even for length mismatch (constant-time)
     const matchCall = timingSafeEqualCalls.find(
       (c) => c.b === masterToken,
     );
-    expect(matchCall).toBeUndefined();
+    expect(matchCall).toBeDefined();
   });
 });

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -564,10 +564,18 @@ export class AuthManager {
     return createHash('sha256').update(key).digest('hex');
   }
 
-  /** Constant-time equality check for secret strings. */
+  /**
+   * Constant-time equality check for secret strings.
+   * #2454: Pads shorter input so comparison always runs in constant time,
+   * preventing length-leak timing attacks.
+   */
   private static timingSafeStringEqual(a: string, b: string): boolean {
-    if (a.length !== b.length) return false;
-    return timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+    const maxLen = Math.max(a.length, b.length);
+    const bufA = Buffer.alloc(maxLen);
+    const bufB = Buffer.alloc(maxLen);
+    bufA.write(a, 'utf8');
+    bufB.write(b, 'utf8');
+    return timingSafeEqual(bufA, bufB) && a.length === b.length;
   }
 
   /** #583: Check and update batch rate limit for a key. Returns true if rate-limited. */

--- a/src/webhook-signature.ts
+++ b/src/webhook-signature.ts
@@ -176,11 +176,14 @@ function parseSignatureHeader(header: string): ParsedSignature | null {
 
 /**
  * Constant-time string comparison to prevent timing attacks.
- * Both strings must be valid hex (same length after comparison).
+ * #2454: Pads shorter input to match longer so the comparison always runs
+ * in constant time, preventing length-leak side channels.
  */
 function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  const bufA = Buffer.from(a, 'utf8');
-  const bufB = Buffer.from(b, 'utf8');
-  return crypto.timingSafeEqual(bufA, bufB);
+  const maxLen = Math.max(a.length, b.length);
+  const bufA = Buffer.alloc(maxLen);
+  const bufB = Buffer.alloc(maxLen);
+  bufA.write(a, 'utf8');
+  bufB.write(b, 'utf8');
+  return crypto.timingSafeEqual(bufA, bufB) && a.length === b.length;
 }


### PR DESCRIPTION
## Summary

- Both `AuthManager.timingSafeStringEqual()` and `webhook-signature.ts` `timingSafeEqual()` returned `false` immediately when `a.length !== b.length`, leaking secret/HMAC length via timing side-channel
- Fix: pad shorter string to match longer one with `Buffer.alloc`, then compare equal-length buffers with `crypto.timingSafeEqual`, checking length equality after the constant-time comparison
- Updated existing test in `auth-timing-safe.test.ts` to assert `timingSafeEqual` IS called for length mismatches (constant-time requirement)

Closes #2454

## Quality Gate

```
=== tsc --noEmit ===
PASSED

=== npm run build ===
Dashboard copied to dist/dashboard/ ✓

=== npm test ===
 Test Files  219 passed | 1 skipped (220)
      Tests  3840 passed | 11 skipped (3851)
```

Generated by Hephaestus (Aegis dev agent)