### PR TITLE
fix: repair dashboard virtualized actions

### DIFF
--- a/dashboard/src/__tests__/AuditPage.test.tsx
+++ b/dashboard/src/__tests__/AuditPage.test.tsx
@@ -293,6 +293,60 @@ describe('AuditPage', () => {
     });
   });
 
+  it('does not restart the live-tail interval when records change', async () => {
+    mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse());
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('3 records')).toBeDefined();
+    });
+
+    // Spy AFTER initial render so we only count post-mount interval activity.
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    // Enable live tail — should subscribe one 10s interval.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Start live tail' }));
+    });
+
+    const liveTailIntervalsAfterStart = setIntervalSpy.mock.calls.filter(
+      ([, ms]) => ms === 10_000,
+    ).length;
+    expect(liveTailIntervalsAfterStart).toBe(1);
+
+    // Force the records list to change by refreshing with a new payload.
+    // Before the fix, `records` was in the live-tail effect deps so any
+    // change tore down + recreated the interval — the bug we're guarding.
+    const newRecord = {
+      ts: '2026-04-17T10:40:00.000Z',
+      actor: 'admin-key',
+      action: 'session.create',
+      sessionId: '33333333-3333-3333-3333-333333333333',
+      detail: 'Created session three',
+      prevHash: 'hash-3',
+      hash: 'hash-4',
+    };
+    mockFetchAuditLogs.mockResolvedValueOnce(
+      createAuditPageResponse({ records: [newRecord, ...mockRecords], total: 4 }),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Refresh/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('4 records')).toBeDefined();
+    });
+
+    const liveTailIntervalsAfterRefresh = setIntervalSpy.mock.calls.filter(
+      ([, ms]) => ms === 10_000,
+    ).length;
+    expect(liveTailIntervalsAfterRefresh).toBe(liveTailIntervalsAfterStart);
+
+    setIntervalSpy.mockRestore();
+  });
+
   it('exports NDJSON with the applied filters', async () => {
     // Default mock covers: initial data fetch + integrity verification + filtered fetch
     mockFetchAuditLogs.mockResolvedValue(createAuditPageResponse());

--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -384,4 +384,34 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     const emDashes = screen.getAllByText('\u2014');
     expect(emDashes.length).toBeGreaterThan(0);
   });
+
+  it('renders approve action in the virtualized desktop list for permission_prompt sessions', async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('charlie').length).toBeGreaterThan(0);
+    });
+
+    // charlie has status 'permission_prompt' so the virtualized row should
+    // expose an Approve button, matching the non-virtualized SessionTable.
+    const approveButtons = screen.getAllByLabelText('Approve session charlie');
+    expect(approveButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(approveButtons[approveButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockApprove).toHaveBeenCalledWith('s3');
+    });
+  });
+
+  it('does not render approve buttons in the virtualized list for non-approval sessions', async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+    });
+
+    expect(screen.queryByLabelText('Approve session alpha')).toBeNull();
+    expect(screen.queryByLabelText('Approve session bravo')).toBeNull();
+  });
 });

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -20,6 +20,9 @@ import type { SessionHealthState, SessionInfo } from '../../types';
 import { formatTimeAgo } from '../../utils/format';
 import StatusDot from './StatusDot';
 
+const needsApproval = (session: SessionInfo): boolean =>
+  session.status === 'permission_prompt' || session.status === 'bash_approval';
+
 // ── Exported Types ──────────────────────────────────────────
 
 export interface VirtualizedRowData {
@@ -92,6 +95,30 @@ interface SessionRowExtraProps {
   onToggleGroup: (key: string) => void;
 }
 
+function ApproveButton({
+  session,
+  currentAction,
+  onApprove,
+}: {
+  session: SessionInfo;
+  currentAction: string | null;
+  onApprove: (e: React.MouseEvent, id: string) => void;
+}) {
+  if (!needsApproval(session)) return null;
+  return (
+    <button
+      type="button"
+      onClick={(e) => onApprove(e, session.id)}
+      disabled={currentAction === 'approve'}
+      aria-label={`Approve session ${session.windowName || session.id}`}
+      className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-green-900/30 text-xs font-medium text-green-400 transition-colors hover:bg-green-900/50 disabled:pointer-events-none disabled:opacity-40"
+      title="Approve"
+    >
+      <Play className="h-3 w-3" />
+    </button>
+  );
+}
+
 // ── Virtualized Row Component ───────────────────────────────
 
 function VirtualizedRow(props: {
@@ -99,7 +126,7 @@ function VirtualizedRow(props: {
   index: number;
   style: CSSProperties;
 } & SessionRowExtraProps): ReactElement {
-  const { ariaAttributes, index, style, items, onToggleSelect, onInterrupt, onKill, onToggleGroup } = props;
+  const { ariaAttributes, index, style, items, onToggleSelect, onApprove, onInterrupt, onKill, onToggleGroup } = props;
   const item = items[index];
 
   if (item.type === 'group') {
@@ -199,6 +226,7 @@ function VirtualizedRow(props: {
             running
           </span>
         )}
+        <ApproveButton session={session} currentAction={currentAction} onApprove={onApprove} />
         <button
           type="button"
           onClick={(e) => onInterrupt(e, session.id)}
@@ -254,10 +282,11 @@ export function VirtualizedSessionList({
     return flat;
   }, [rowViewModels, groupedRowModels, collapsedGroups]);
 
-  const listHeight = Math.min(
-    items.length * ROW_HEIGHT,
-    maxVisibleRows * ROW_HEIGHT,
+  const totalHeight = items.reduce(
+    (sum, item) => sum + (item.type === 'group' ? GROUP_ROW_HEIGHT : ROW_HEIGHT),
+    0,
   );
+  const listHeight = Math.min(totalHeight, maxVisibleRows * ROW_HEIGHT);
 
   if (items.length === 0) return null;
 

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -494,6 +494,7 @@ export default function AuditPage() {
   // Live tail
   const [liveTail, setLiveTail] = useState(false);
   const latestHashRef = useRef<string | null>(null);
+  const recordHashesRef = useRef<Set<string>>(new Set());
 
   const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -572,6 +573,12 @@ export default function AuditPage() {
     return () => clearInterval(interval);
   }, [verifyChain]);
 
+  // Keep ref in sync with current records so live-tail can dedupe without
+  // re-subscribing the interval on every records update.
+  useEffect(() => {
+    recordHashesRef.current = new Set(records.map((r) => r.hash));
+  }, [records]);
+
   // Live tail — poll every 10s and prepend new entries
   useEffect(() => {
     if (!liveTail || page !== 1) return;
@@ -588,9 +595,7 @@ export default function AuditPage() {
         const topHash = data.records[0].hash;
         if (topHash === latestHashRef.current) return;
 
-        // Find new records by comparing against current set
-        const existingHashes = new Set(records.map((r) => r.hash));
-        const newRecords = data.records.filter((r) => !existingHashes.has(r.hash));
+        const newRecords = data.records.filter((r) => !recordHashesRef.current.has(r.hash));
         if (newRecords.length === 0) return;
 
         latestHashRef.current = topHash;
@@ -602,7 +607,7 @@ export default function AuditPage() {
     }, LIVE_TAIL_POLL_MS);
 
     return () => clearInterval(interval);
-  }, [liveTail, page, pageSize, appliedFilters, records]);
+  }, [liveTail, page, pageSize, appliedFilters]);
 
   const applyFilters = () => {
     const nextFilters = trimFilters(filters);


### PR DESCRIPTION
## Summary
- add approval controls to virtualized session rows for approval-needed sessions
- calculate virtualized grouped list height using actual group/session row heights
- keep audit live-tail interval stable while records update
- add dashboard regression coverage

## Aegis version
0.6.6-preview

## Validation
- dashboard targeted tests: `SessionTable.test.tsx`, `AuditPage.test.tsx` — 24 passed
- dashboard full test suite — 86 files passed, 845 passed / 2 skipped
- `cd dashboard && npm run build`
- `npm run gate`

Closes #2447