### PR TITLE
fix(dashboard): prevent audit page skeleton persisting + search placeholder truncation

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -842,7 +842,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                     setSearchInput(e.target.value);
                     setPage(1);
                   }}
-                  placeholder="Search by session name or work directory"
+                  placeholder="Search sessions…"
                    className="min-h-[44px] w-full bg-transparent text-sm text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-muted)]"
                   aria-label="Search sessions"
                 />

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -501,6 +501,11 @@ export default function AuditPage() {
     setError(null);
     setEndpointMissing(false);
 
+    // #2473: Guard against indefinite loading state
+    const loadingTimeout = setTimeout(() => {
+      setLoading(false);
+    }, 15_000);
+
     const params: FetchAuditLogsParams = {
       ...buildAuditParams(appliedFilters),
       limit: pageSize,
@@ -535,6 +540,7 @@ export default function AuditPage() {
         setError(err.message ?? 'Failed to fetch audit logs');
       }
     } finally {
+      clearTimeout(loadingTimeout);
       setLoading(false);
     }
   }, [appliedFilters, page, pageSize]);


### PR DESCRIPTION
Fixes #2473, Fixes #2475

Audit page skeleton loaders could persist indefinitely when the server was slow. Added 15s loading timeout guard.

Also truncates search placeholder to prevent text truncation at 1440x900 viewport.

TypeScript clean, 845 tests pass, build clean.