### PR TITLE
fix(api): add route aliases for /input, /kill, /terminate, /stop, /stream

### DIFF
--- a/src/__tests__/route-aliases-2461.test.ts
+++ b/src/__tests__/route-aliases-2461.test.ts
@@ -1,0 +1,353 @@
+/**
+ * route-aliases-2461.test.ts — Tests for Issue #2461:
+ *   POST /v1/sessions/:id/input  → alias for /send
+ *   POST /v1/sessions/:id/kill   → alias for DELETE /v1/sessions/:id
+ *   POST /v1/sessions/:id/terminate → alias for DELETE /v1/sessions/:id
+ *   POST /v1/sessions/:id/stop   → alias for DELETE /v1/sessions/:id
+ *   GET  /v1/sessions/:id/stream → alias for /events SSE
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn((_file: string, _args: string[], _options: unknown, callback?: (error: Error | null) => void) => {
+    callback?.(new Error('claude unavailable'));
+  }),
+}));
+
+import type { FastifyInstance } from 'fastify';
+import type { SessionInfo } from '../session.js';
+import type { RouteContext } from '../routes/context.js';
+import { registerSessionActionRoutes } from '../routes/session-actions.js';
+import { registerSessionDataRoutes } from '../routes/session-data.js';
+
+type RouteMethod = 'post' | 'get' | 'put' | 'delete';
+type PermissionName = 'create' | 'send' | 'approve' | 'reject' | 'kill';
+
+function makeMockApp(): FastifyInstance {
+  return {
+    post: vi.fn(),
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as FastifyInstance;
+}
+
+function makeReply() {
+  const body: { statusCode?: number; payload?: unknown } = {};
+  const send = vi.fn((payload: unknown) => {
+    body.payload = payload;
+    return payload;
+  });
+  const status = vi.fn((statusCode: number) => {
+    body.statusCode = statusCode;
+    return { send };
+  });
+  return { send, status, body };
+}
+
+function getHandler(app: FastifyInstance, method: RouteMethod, path: string) {
+  const mockMethod = app[method] as ReturnType<typeof vi.fn>;
+  const call = mockMethod.mock.calls.find((args: unknown[]) => args[0] === path);
+  if (!call) {
+    throw new Error(`Missing route registration for ${method.toUpperCase()} ${path}`);
+  }
+  const handlerOrOptions = call[1];
+  if (typeof handlerOrOptions === 'function') {
+    return handlerOrOptions as (req: unknown, reply: unknown) => Promise<unknown>;
+  }
+  return (handlerOrOptions as { handler: (req: unknown, reply: unknown) => Promise<unknown> }).handler;
+}
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    windowId: '@1',
+    windowName: 'cc-test',
+    workDir: '/home/user/repo',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ownerKeyId: 'key-owner',
+    ...overrides,
+  } as SessionInfo;
+}
+
+function makeContext(granted: Partial<Record<PermissionName, boolean>> = {}) {
+  const ownedSession = makeSession();
+  const auth = {
+    authEnabled: true,
+    hasPermission: vi.fn((_keyId: string | null | undefined, permission: PermissionName) => granted[permission] ?? false),
+    getRole: vi.fn((keyId: string | null | undefined) => (keyId === 'master' ? 'admin' : 'viewer')),
+    getAuditActor: vi.fn((keyId: string | null | undefined, fallbackActor = 'system') => {
+      if (keyId === null || keyId === undefined) return fallbackActor;
+      return keyId === 'master' ? 'master' : `actor:${keyId}`;
+    }),
+    getKey: vi.fn(() => null),
+  };
+  const sessions = {
+    getSession: vi.fn(() => ownedSession),
+    sendMessage: vi.fn(async () => ({ delivered: true, attempts: 1 })),
+    createSession: vi.fn(async () => makeSession()),
+    findIdleSessionByWorkDir: vi.fn(async () => null),
+    killSession: vi.fn(async () => {}),
+    getLatencyMetrics: vi.fn(() => ({ permission_response_ms: null })),
+    approve: vi.fn(async () => {}),
+    reject: vi.fn(async () => {}),
+    escape: vi.fn(async () => {}),
+    interrupt: vi.fn(async () => {}),
+    sendInitialPrompt: vi.fn(async () => ({ delivered: true, attempts: 1 })),
+    readMessages: vi.fn(async () => ({ messages: [] })),
+    submitAnswer: vi.fn(() => true),
+    save: vi.fn(async () => {}),
+    releaseSessionClaim: vi.fn(),
+    listSessions: vi.fn(() => [ownedSession]),
+    getHealth: vi.fn(async () => ({ alive: true, windowExists: true })),
+  };
+
+  const ctx = {
+    sessions,
+    tmux: {
+      capturePane: vi.fn(async () => ''),
+      resizePane: vi.fn(async () => {}),
+    },
+    auth,
+    quotas: {
+      checkSessionQuota: vi.fn(() => ({ allowed: true })),
+      checkSendQuota: vi.fn(() => ({ allowed: true })),
+    },
+    config: {
+      enforceSessionOwnership: true,
+      envDenylist: [],
+      envAdminAllowlist: [],
+    },
+    metrics: {
+      cleanupSession: vi.fn(),
+      sessionCreated: vi.fn(),
+      sessionFailed: vi.fn(),
+      promptSent: vi.fn(),
+      recordPermissionResponse: vi.fn(),
+      getGlobalMetrics: vi.fn(() => ({
+        sessions: { total_created: 0, completed: 0, failed: 0 },
+      })),
+      getSessionMetrics: vi.fn(() => null),
+      getSessionLatency: vi.fn(() => ({})),
+    },
+    monitor: {
+      removeSession: vi.fn(),
+      getStallInfo: vi.fn(() => ({ stalled: false })),
+    },
+    eventBus: {
+      emitEnded: vi.fn(),
+      emitStatus: vi.fn(),
+      subscribe: vi.fn(() => vi.fn()),
+    },
+    channels: {
+      message: vi.fn(async () => {}),
+      sessionEnded: vi.fn(async () => {}),
+      sessionCreated: vi.fn(async () => {}),
+      statusChange: vi.fn(async () => {}),
+    },
+    jsonlWatcher: {},
+    pipelines: {},
+    toolRegistry: {
+      cleanupSession: vi.fn(),
+      getSessionTools: vi.fn(() => []),
+      getToolDefinitions: vi.fn(() => []),
+      processEntries: vi.fn(),
+    },
+    getAuditLogger: vi.fn(() => ({ log: vi.fn(async () => {}) })),
+    alertManager: {},
+    swarmMonitor: {},
+    sseLimiter: {
+      acquire: vi.fn(() => ({ allowed: true, connectionId: 'test-conn' })),
+      release: vi.fn(),
+      unregisterWriter: vi.fn(),
+    },
+    memoryBridge: null,
+    requestKeyMap: new Map<string, string>(),
+    validateWorkDir: vi.fn(async (workDir: string) => workDir),
+    serverState: { draining: false },
+  } as unknown as RouteContext;
+
+  return { ctx, sessions, auth };
+}
+
+describe('Issue #2461: Route alias registrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST /v1/sessions/:id/input (alias for /send)', () => {
+    it('registers the /input route', () => {
+      const app = makeMockApp();
+      const { ctx } = makeContext({ send: true });
+      registerSessionActionRoutes(app, ctx);
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/input');
+      expect(handler).toBeDefined();
+    });
+
+    it('delivers message via /input just like /send', async () => {
+      const app = makeMockApp();
+      const { ctx, sessions } = makeContext({ send: true });
+      registerSessionActionRoutes(app, ctx);
+
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/input');
+      const reply = makeReply();
+      const result = await handler({
+        params: { id: '11111111-1111-1111-1111-111111111111' },
+        authKeyId: 'key-owner',
+        body: { text: 'hello from input' },
+      }, reply);
+
+      expect(sessions.sendMessage).toHaveBeenCalledWith(
+        '11111111-1111-1111-1111-111111111111',
+        'hello from input',
+      );
+      expect(result).toEqual(expect.objectContaining({ ok: true, delivered: true }));
+    });
+
+    it('rejects without send permission', async () => {
+      const app = makeMockApp();
+      const { ctx, sessions } = makeContext({ send: false });
+      registerSessionActionRoutes(app, ctx);
+
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/input');
+      const reply = makeReply();
+      await handler({
+        params: { id: '11111111-1111-1111-1111-111111111111' },
+        authKeyId: 'key-owner',
+        body: { text: 'hello' },
+      }, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(403);
+      expect(sessions.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /v1/sessions/:id/kill (alias for DELETE)', () => {
+    it('registers the /kill route', () => {
+      const app = makeMockApp();
+      const { ctx } = makeContext({ kill: true });
+      registerSessionActionRoutes(app, ctx);
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/kill');
+      expect(handler).toBeDefined();
+    });
+
+    it('kills the session', async () => {
+      const app = makeMockApp();
+      const { ctx, sessions } = makeContext({ kill: true });
+      registerSessionActionRoutes(app, ctx);
+
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/kill');
+      const reply = makeReply();
+      const result = await handler({
+        params: { id: '11111111-1111-1111-1111-111111111111' },
+        authKeyId: 'key-owner',
+      }, reply);
+
+      expect(sessions.killSession).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('rejects without kill permission', async () => {
+      const app = makeMockApp();
+      const { ctx, sessions } = makeContext({ kill: false });
+      registerSessionActionRoutes(app, ctx);
+
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/kill');
+      const reply = makeReply();
+      await handler({
+        params: { id: '11111111-1111-1111-1111-111111111111' },
+        authKeyId: 'key-owner',
+      }, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(403);
+      expect(sessions.killSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /v1/sessions/:id/terminate (alias for DELETE)', () => {
+    it('registers the /terminate route', () => {
+      const app = makeMockApp();
+      const { ctx } = makeContext({ kill: true });
+      registerSessionActionRoutes(app, ctx);
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/terminate');
+      expect(handler).toBeDefined();
+    });
+
+    it('kills the session', async () => {
+      const app = makeMockApp();
+      const { ctx, sessions } = makeContext({ kill: true });
+      registerSessionActionRoutes(app, ctx);
+
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/terminate');
+      const reply = makeReply();
+      const result = await handler({
+        params: { id: '11111111-1111-1111-1111-111111111111' },
+        authKeyId: 'key-owner',
+      }, reply);
+
+      expect(sessions.killSession).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('POST /v1/sessions/:id/stop (alias for DELETE)', () => {
+    it('registers the /stop route', () => {
+      const app = makeMockApp();
+      const { ctx } = makeContext({ kill: true });
+      registerSessionActionRoutes(app, ctx);
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/stop');
+      expect(handler).toBeDefined();
+    });
+
+    it('kills the session', async () => {
+      const app = makeMockApp();
+      const { ctx, sessions } = makeContext({ kill: true });
+      registerSessionActionRoutes(app, ctx);
+
+      const handler = getHandler(app, 'post', '/v1/sessions/:id/stop');
+      const reply = makeReply();
+      const result = await handler({
+        params: { id: '11111111-1111-1111-1111-111111111111' },
+        authKeyId: 'key-owner',
+      }, reply);
+
+      expect(sessions.killSession).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('GET /v1/sessions/:id/stream (alias for /events SSE)', () => {
+    it('registers the /stream route', () => {
+      const app = makeMockApp();
+      const { ctx } = makeContext();
+      registerSessionDataRoutes(app, ctx);
+      const handler = getHandler(app, 'get', '/v1/sessions/:id/stream');
+      expect(handler).toBeDefined();
+    });
+
+    it('registers the /events route (unchanged)', () => {
+      const app = makeMockApp();
+      const { ctx } = makeContext();
+      registerSessionDataRoutes(app, ctx);
+      const handler = getHandler(app, 'get', '/v1/sessions/:id/events');
+      expect(handler).toBeDefined();
+    });
+
+    it('uses the same handler for /stream and /events', () => {
+      const app = makeMockApp();
+      const { ctx } = makeContext();
+      registerSessionDataRoutes(app, ctx);
+      const streamHandler = getHandler(app, 'get', '/v1/sessions/:id/stream');
+      const eventsHandler = getHandler(app, 'get', '/v1/sessions/:id/events');
+      expect(streamHandler).toBe(eventsHandler);
+    });
+  });
+});

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -107,7 +107,8 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   } = ctx;
 
   // Send message (with delivery verification — Issue #1)
-  registerWithLegacy(app, 'post', '/v1/sessions/:id/send', withSessionOwnership(ctx, async (req, reply, session) => {
+  // Issue #2461: Extracted to variable so /input alias reuses the same handler.
+  const sendHandler = withSessionOwnership(ctx, async (req, reply, session) => {
     if (!requirePermission(auth, req, reply, 'send')) return;
     const parsed = sendMessageSchema.safeParse(req.body);
     if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
@@ -147,7 +148,12 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
-  }, 'send'));
+  }, 'send');
+
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/send', sendHandler);
+
+  // Issue #2461: /input alias for /send
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/input', sendHandler);
 
   // Issue #702: GET children sessions
   registerWithLegacy(app, 'get', '/v1/sessions/:id/children', withOwnership(sessions, async (_req, _reply, session) => {
@@ -291,7 +297,8 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   }, 'send'));
 
   // Kill session
-  registerWithLegacy(app, 'delete', '/v1/sessions/:id', withSessionOwnership(ctx, async (req, reply, session) => {
+  // Issue #2461: Extracted to variable so POST aliases reuse the same handler.
+  const killHandler = withSessionOwnership(ctx, async (req, reply, session) => {
     if (!requirePermission(auth, req, reply, 'kill')) return;
     try {
       await sessions.killSession(session.id);
@@ -306,7 +313,14 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
-  }, 'kill'));
+  }, 'kill');
+
+  registerWithLegacy(app, 'delete', '/v1/sessions/:id', killHandler);
+
+  // Issue #2461: POST aliases for kill
+  for (const alias of ['/v1/sessions/:id/kill', '/v1/sessions/:id/terminate', '/v1/sessions/:id/stop'] as const) {
+    registerWithLegacy(app, 'post', alias, killHandler);
+  }
 
   // Capture raw pane
   registerWithLegacy(app, 'get', '/v1/sessions/:id/pane', withOwnership(sessions, async (_req, _reply, session) => {

--- a/src/routes/session-data.ts
+++ b/src/routes/session-data.ts
@@ -156,7 +156,8 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
   }));
 
   // Per-session SSE event stream (Issue #32)
-  registerWithLegacy(app, 'get', '/v1/sessions/:id/events', withOwnership(sessions, async (req: FastifyRequest, reply: FastifyReply, session) => {
+  // Issue #2461: Extracted to variable so /stream alias reuses the same handler.
+  const sessionEventsHandler = withOwnership(sessions, async (req: FastifyRequest, reply: FastifyReply, session) => {
 
     const clientIp = req.ip;
     const acquireResult = sseLimiter.acquire(clientIp);
@@ -225,7 +226,12 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
     );
 
     await reply;
-  }));
+  });
+
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/events', sessionEventsHandler);
+
+  // Issue #2461: /stream alias for /events SSE
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/stream', sessionEventsHandler);
 
   // ── Claude Code Hook Endpoints (Issue #161) ─────────────────────
   // Permission hook — validates body with withValidation, looks up session manually

--- a/src/server.ts
+++ b/src/server.ts
@@ -427,8 +427,8 @@ function setupAuth(authManager: AuthManager): void {
     // #124/#125: Accept token from Authorization header; ?token= query param
     // only on SSE routes where EventSource cannot set headers.
     // #297: SSE routes also accept short-lived SSE tokens via ?token=.
-    // SSE routes: /v1/events and /v1/sessions/:id/events
-    const isSSERoute = /^\/v1\/events$|^\/v1\/sessions\/[^/]+\/events$/.test(urlPath);
+    // SSE routes: /v1/events, /v1/sessions/:id/events, /v1/sessions/:id/stream (#2461)
+    const isSSERoute = /^\/v1\/events$|^\/v1\/sessions\/[^/]+\/(events|stream)$/.test(urlPath);
     let token: string | undefined;
     const header = req.headers.authorization;
     if (header?.startsWith('Bearer ')) {


### PR DESCRIPTION
## Summary

- `POST /v1/sessions/:id/input` → alias for `/send` (identical handler)
- `POST /v1/sessions/:id/kill`, `/terminate`, `/stop` → aliases for `DELETE /v1/sessions/:id` (identical handler)
- `GET /v1/sessions/:id/stream` → alias for `GET /v1/sessions/:id/events` SSE (identical handler)
- Updated SSE auth middleware regex to recognize `/stream` for `?token=` query param auth

All alias handlers reference the same handler variable as the canonical route, so behavior is always identical and future changes propagate automatically.

## Aegis version

**Developed with:** v0.6.5-preview.3

## Test plan

- [x] 13 new unit tests covering all aliases (registration, behavior, permission checks)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Full test suite passes (3864/3864)
- [ ] Manual: `curl -X POST .../v1/sessions/$ID/input -d '{"text":"hello"}'` → 200
- [ ] Manual: `curl -X POST .../v1/sessions/$ID/kill` → 200
- [ ] Manual: `curl -X GET .../v1/sessions/$ID/stream` → SSE stream

Closes #2461

Generated by Hephaestus (Aegis dev agent)