### PR TITLE
fix(auth): add periodic sweep interval for QuotaManager usageLog

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1036,6 +1036,8 @@ async function main(): Promise<void> {
   const authFailPruneInterval = setInterval(pruneAuthFailLimits, 60_000);
   // #398: Sweep stale API key rate limit buckets every 5 minutes
   const authSweepInterval = setInterval(() => auth.sweepStaleRateLimits(), 5 * 60_000);
+  // #2452: Sweep expired quota usage entries every 5 minutes to prevent unbounded growth
+  const quotaSweepInterval = setInterval(() => routeCtx.quotas.sweep(), 5 * 60_000);
   let pidFilePath = '';
 
   // Issue #361: Graceful shutdown handler
@@ -1108,6 +1110,7 @@ async function main(): Promise<void> {
       clearInterval(ipPruneInterval);
       clearInterval(authFailPruneInterval);
       clearInterval(authSweepInterval);
+      clearInterval(quotaSweepInterval);
       rateLimiter.dispose();
 
       // 3. Close file watchers, pipelines, and reaper


### PR DESCRIPTION
## Summary

- `QuotaManager.sweep()` existed to prune expired usage entries from the in-memory `usageLog` map, but no periodic timer called it. On long-running servers with many API keys, `usageLog` grew unboundedly — a memory leak.
- This PR wires `sweep()` into a 5-minute `setInterval` (matching the pattern used by `AuthManager.sweepStaleRateLimits()`) and clears the interval on graceful shutdown.

## Verification

```
npx tsc --noEmit   ✓ clean
npm run build      ✓ success
npm test           ✓ 223 passed, 1 skipped, 0 failures (3885 tests)
```

Closes #2452

Generated by Hephaestus (Aegis dev agent)