### PR TITLE
docs: add missing nav links for release-process, disaster-recovery, and incident-rollback runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,9 @@ See [`packages/python-client/`](packages/python-client/) for the full SDK source
 - **[Remote Access](docs/remote-access.md)** — External access configuration
 - **[BYO LLM](docs/byo-llm.md)** — OpenAI-compatible provider setup (GLM, OpenRouter, LM Studio, Ollama)
 - **[Troubleshooting](docs/troubleshooting.md)** — Common issues and fixes
+- **[Release Process](docs/release-process.md)** — Maintainer runbook for production releases
+- **[Disaster Recovery](docs/DISASTER_RECOVERY.md)** — Data loss and infrastructure failure recovery
+- **[Incident and Rollback Runbook](docs/incident-rollback-runbook.md)** — Deployment rollbacks and version pinning
 - **[TypeDoc API](https://onestepat4time.github.io/aegis/)** — Auto-generated TypeScript reference
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -302,6 +302,12 @@ See [`packages/python-client/`](../packages/python-client/) for source and the f
 - **[TypeDoc API](https://onestepat4time.github.io/aegis/)** — Auto-generated TypeScript reference
 - **[ROADMAP](../ROADMAP.md)** — What's coming next
 
+### For Maintainers
+
+- **[Release Process](./release-process.md)** — Production release flow, recovery releases, and hotfixes
+- **[Disaster Recovery](./DISASTER_RECOVERY.md)** — Data loss and infrastructure failure recovery procedures
+- **[Incident and Rollback Runbook](./incident-rollback-runbook.md)** — Deployment rollbacks and version pinning
+
 ## Contributing to Aegis
 
 See the [Contributing Guide](../CONTRIBUTING.md) for development workflow, branch conventions, and PR process.


### PR DESCRIPTION
## Summary

Closes #2464 and #2465.

Adds navigation links to three maintainer/ops-facing runbooks that existed but were only discoverable via indirect references.

## Changes

### `docs/getting-started.md`
- Added **"For Maintainers"** subsection under "Next Steps"
- Linked: release-process.md, DISASTER_RECOVERY.md, incident-rollback-runbook.md

### `README.md`
- Added all three runbooks to the Documentation section

## Why

These runbooks were added recently (release-process, DISASTER_RECOVERY via #2412) but had no navigation path from the primary onboarding flow. New contributors and maintainers couldn't find them from `getting-started.md` or the README.

## Test

- [x] All links point to existing files
- [x] `incident-rollback-runbook.md` is already cross-referenced from DISASTER_RECOVERY.md
- [x] No broken links introduced