### PR TITLE
fix(dashboard): make a11y Name cell test resilient to Node 20 whitespace

### DIFF
--- a/dashboard/src/__tests__/SessionHistoryPage.test.tsx
+++ b/dashboard/src/__tests__/SessionHistoryPage.test.tsx
@@ -185,7 +185,7 @@ describe('SessionHistoryPage a11y (issue #2378)', () => {
     const table = await screen.findByRole('table');
     const allTd = table.querySelectorAll('td');
     const hiddenTd = Array.from(allTd).find(
-      (td) => td.getAttribute('aria-hidden') === 'true' && td.textContent === '—',
+      (td) => td.getAttribute('aria-hidden') === 'true' && td.textContent?.trim() === '—',
     );
     expect(hiddenTd).toBeDefined();
   });


### PR DESCRIPTION
## Summary
Fixes the `SessionHistoryPage.test.tsx` a11y test failure on Node 20 that blocks PRs #2487–#2492.

## Problem
The test `empty Name cell placeholder is hidden from assistive technology` uses strict `td.textContent === '—'` to find the aria-hidden placeholder cell. Node 20's jsdom may produce trailing whitespace in `textContent` for inline elements, causing the assertion to fail.

## Fix
Use `td.textContent?.trim() === '—'` instead — resilient across Node versions while maintaining the same semantic check.

## Testing
- All 845 dashboard tests pass locally (86 files)
- TypeScript: zero errors
- Change is test-only, no production code affected

## Unblocks
- #2487–#2492 (all 6 PRs blocked by this CI failure on Node 20)