### PR TITLE
fix: harden numbered preview recovery releases

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -17,6 +17,21 @@ on:
         required: false
         default: false
         type: boolean
+      recovery_issue:
+        description: GitHub issue number approving a numbered preview recovery release
+        required: false
+        default: ''
+        type: string
+      recovery_reason:
+        description: Why rerun or repair cannot recover the previous published release
+        required: false
+        default: ''
+        type: string
+      recovery_confirmation:
+        description: Type RECOVERY <version> to confirm a numbered preview recovery release
+        required: false
+        default: ''
+        type: string
 
 permissions:
   actions: write
@@ -44,6 +59,9 @@ jobs:
           VERSION: ${{ inputs.version }}
           SOURCE_BRANCH: ${{ inputs.source_branch }}
           RECOVERY_RELEASE: ${{ inputs.recovery_release }}
+          RECOVERY_ISSUE: ${{ inputs.recovery_issue }}
+          RECOVERY_REASON: ${{ inputs.recovery_reason }}
+          RECOVERY_CONFIRMATION: ${{ inputs.recovery_confirmation }}
         run: |
           set -euo pipefail
 
@@ -55,10 +73,28 @@ jobs:
             exit 1
           fi
 
-          if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]] &&
-             [ "${RECOVERY_RELEASE}" != "true" ]; then
-            echo "::error::Numbered preview releases are recovery-only. Re-run with recovery_release=true if this is an approved recovery."
-            exit 1
+          if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]]; then
+            EXPECTED_CONFIRMATION="RECOVERY ${VERSION}"
+            if [ "${RECOVERY_RELEASE}" != "true" ]; then
+              echo "::error::Numbered preview releases are recovery-only. Re-run with recovery_release=true if this is an approved recovery."
+              exit 1
+            fi
+            if [[ ! "${RECOVERY_ISSUE}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Numbered preview recovery releases require recovery_issue=<GitHub issue number>."
+              exit 1
+            fi
+            if ! grep -Eq '[^[:space:]]' <<< "${RECOVERY_REASON}"; then
+              echo "::error::Numbered preview recovery releases require recovery_reason explaining why rerun or repair is insufficient."
+              exit 1
+            fi
+            if [ "${RECOVERY_CONFIRMATION}" != "${EXPECTED_CONFIRMATION}" ]; then
+              echo "::error::Numbered preview recovery releases require recovery_confirmation='${EXPECTED_CONFIRMATION}'."
+              exit 1
+            fi
+            if ! gh issue view "${RECOVERY_ISSUE}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "::error::Recovery approval issue #${RECOVERY_ISSUE} was not found."
+              exit 1
+            fi
           fi
 
           RELEASE_BRANCH="release/${VERSION}"
@@ -87,6 +123,9 @@ jobs:
             --ref "${RELEASE_BRANCH}" \
             --field "target_branch=${RELEASE_BRANCH}" \
             --field "release_as=${VERSION}" \
-            --field "recovery_release=${RECOVERY_RELEASE}"
+            --field "recovery_release=${RECOVERY_RELEASE}" \
+            --field "recovery_issue=${RECOVERY_ISSUE}" \
+            --field "recovery_reason=${RECOVERY_REASON}" \
+            --field "recovery_confirmation=${RECOVERY_CONFIRMATION}"
 
           echo "::notice::Created ${RELEASE_BRANCH} from ${SOURCE_BRANCH} and dispatched Release Please for ${VERSION}."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,21 @@ on:
         required: false
         default: false
         type: boolean
+      recovery_issue:
+        description: GitHub issue number approving a numbered preview recovery release
+        required: false
+        default: ''
+        type: string
+      recovery_reason:
+        description: Why rerun or repair cannot recover the previous published release
+        required: false
+        default: ''
+        type: string
+      recovery_confirmation:
+        description: Type RECOVERY <version> to confirm a numbered preview recovery release
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -32,6 +47,10 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target_branch }}
           RELEASE_AS: ${{ inputs.release_as }}
           RECOVERY_RELEASE: ${{ inputs.recovery_release }}
+          RECOVERY_ISSUE: ${{ inputs.recovery_issue }}
+          RECOVERY_REASON: ${{ inputs.recovery_reason }}
+          RECOVERY_CONFIRMATION: ${{ inputs.recovery_confirmation }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -54,10 +73,28 @@ jobs:
             exit 1
           fi
 
-          if [[ "${RELEASE_AS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]] &&
-             [ "${RECOVERY_RELEASE}" != "true" ]; then
-            echo "::error::Numbered preview releases are recovery-only. Re-run with recovery_release=true if this is an approved recovery."
-            exit 1
+          if [[ "${RELEASE_AS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]]; then
+            EXPECTED_CONFIRMATION="RECOVERY ${RELEASE_AS}"
+            if [ "${RECOVERY_RELEASE}" != "true" ]; then
+              echo "::error::Numbered preview releases are recovery-only. Re-run with recovery_release=true if this is an approved recovery."
+              exit 1
+            fi
+            if [[ ! "${RECOVERY_ISSUE}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Numbered preview recovery releases require recovery_issue=<GitHub issue number>."
+              exit 1
+            fi
+            if ! grep -Eq '[^[:space:]]' <<< "${RECOVERY_REASON}"; then
+              echo "::error::Numbered preview recovery releases require recovery_reason explaining why rerun or repair is insufficient."
+              exit 1
+            fi
+            if [ "${RECOVERY_CONFIRMATION}" != "${EXPECTED_CONFIRMATION}" ]; then
+              echo "::error::Numbered preview recovery releases require recovery_confirmation='${EXPECTED_CONFIRMATION}'."
+              exit 1
+            fi
+            if ! gh issue view "${RECOVERY_ISSUE}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "::error::Recovery approval issue #${RECOVERY_ISSUE} was not found."
+              exit 1
+            fi
           fi
 
       - name: Generate GitHub App token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,9 +271,18 @@ jobs:
 
           if [[ "${TAG_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview[.-][0-9]+$ ]]; then
             TAG_OBJECT_TYPE=$(git cat-file -t "${GITHUB_REF_NAME}" 2>/dev/null || true)
+            TAG_MESSAGE=$(git cat-file tag "${GITHUB_REF_NAME}" 2>/dev/null || true)
             if [ "${TAG_OBJECT_TYPE}" != "tag" ] ||
-               ! git cat-file tag "${GITHUB_REF_NAME}" | grep -Fxq "recovery-release: true"; then
+               ! grep -Fxq "recovery-release: true" <<< "${TAG_MESSAGE}"; then
               echo "::error::Numbered preview tags are recovery-only and require an annotated tag containing 'recovery-release: true'."
+              exit 1
+            fi
+            if ! grep -Eq '^recovery-issue: #[0-9]+$' <<< "${TAG_MESSAGE}"; then
+              echo "::error::Numbered preview recovery tags require an annotated tag line like 'recovery-issue: #1234'."
+              exit 1
+            fi
+            if ! grep -Fxq "recovery-confirmation: RECOVERY ${TAG_VERSION}" <<< "${TAG_MESSAGE}"; then
+              echo "::error::Numbered preview recovery tags require an annotated tag line 'recovery-confirmation: RECOVERY ${TAG_VERSION}'."
               exit 1
             fi
           fi

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -501,7 +501,7 @@ export default function AuditPage() {
     setError(null);
     setEndpointMissing(false);
 
-    // #2473: Guard against indefinite loading state
+    // Issue 2473: Guard against indefinite loading state
     const loadingTimeout = setTimeout(() => {
       setLoading(false);
     }, 15_000);

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -55,12 +55,18 @@ Supported release versions are:
 - recovery preview: `X.Y.Z-preview.N`
 
 Planned previews must use `X.Y.Z-preview`. Numbered previews such as
-`X.Y.Z-preview.1` are recovery-only and require explicit maintainer approval.
-For a numbered preview tag, the annotated tag message must contain this exact
-line:
+`X.Y.Z-preview.1` are recovery-only and require explicit maintainer approval
+recorded in a GitHub issue. Creating the release branch requires
+`recovery_release=true`, a recovery issue number, a non-empty recovery reason,
+and exact typed confirmation: `RECOVERY X.Y.Z-preview.N`.
+
+For a numbered preview tag, the annotated tag message must contain these exact
+lines:
 
 ```text
 recovery-release: true
+recovery-issue: #<issue>
+recovery-confirmation: RECOVERY X.Y.Z-preview.N
 ```
 
 Do not manually edit release version files. The requested version is provided
@@ -111,9 +117,12 @@ The workflow:
 
 1. validates the version format;
 2. rejects numbered preview versions unless `recovery_release=true`;
-3. refuses to create a second active `release/*` branch for normal releases;
-4. creates `release/<version>` from `origin/develop`;
-5. dispatches **Release Please** against that release branch.
+3. requires numbered preview recovery releases to include
+   `recovery_issue=<issue-number>`, `recovery_reason=<why rerun/repair is
+   insufficient>`, and `recovery_confirmation="RECOVERY <version>"`;
+4. refuses to create a second active `release/*` branch for normal releases;
+5. creates `release/<version>` from `origin/develop`;
+6. dispatches **Release Please** against that release branch.
 
 ### 3. Review the Release Please PR
 
@@ -257,7 +266,9 @@ If it fails after one or more public artifacts are published:
 2. inspect which jobs succeeded and which failed;
 3. rerun failed jobs only if they are idempotent or have explicit
    `skip-existing`/existence checks;
-4. if a replacement artifact is required, cut an approved recovery release with
+4. open or update a GitHub issue documenting the unusable artifact, failed
+   rerun/repair path, and maintainer approval;
+5. if a replacement artifact is required, cut an approved recovery release with
    the next numbered prerelease version.
 
 npm versions are immutable. A failed run that already published
@@ -294,7 +305,16 @@ normal release branch is cut.
 
 Use a recovery tag only when a published artifact is unusable and a rerun cannot
 repair the release. For a preview recovery, use a numbered preview version such
-as `X.Y.Z-preview.1` and include `recovery-release: true` in the annotated tag.
+as `X.Y.Z-preview.1` and include the required recovery lines in the annotated
+tag:
+
+```bash
+git tag -a "vX.Y.Z-preview.N" origin/main \
+  -m "Release vX.Y.Z-preview.N" \
+  -m "recovery-release: true" \
+  -m "recovery-issue: #<issue>" \
+  -m "recovery-confirmation: RECOVERY X.Y.Z-preview.N"
+```
 
 ## Things not to do
 


### PR DESCRIPTION
## Summary

Hardens the release process so a numbered preview such as `X.Y.Z-preview.1` cannot be created with `recovery_release=true` alone.

Changes:
- require `recovery_issue`, non-empty `recovery_reason`, and exact `recovery_confirmation="RECOVERY <version>"` for numbered preview release branches;
- apply the same validation to direct Release Please dispatches;
- require numbered preview publish tags to include recovery metadata in the annotated tag message;
- update the release runbook with the stronger recovery requirements;
- fix a dashboard token-gate false positive caused by a comment that looked like a hex color.

## Aegis version

**Developed with:** v0.6.6-preview
**Tested with:** v0.6.6-preview

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring with no behavior change
- [ ] `perf` — Performance improvement
- [ ] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [x] `chore` — Build, CI, tooling
- [ ] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

Release workflows, release runbook, and one dashboard comment that blocked the token gate.

## Linked issue

Closes #2500

## Test plan

- [x] Unit tests pass (`npm test`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [x] Manually tested (workflow YAML parsed with the repo `yaml` package; recovery guard bash/tag checks smoke-tested; `npm run gate` passed non-interactively)

## Security impact

Improves release safety by requiring explicit, auditable recovery approval before numbered preview releases can be prepared or published.