### PR TITLE
fix(dashboard): harden a11y Name cell test against race condition

### DIFF
--- a/dashboard/src/__tests__/SessionHistoryPage.test.tsx
+++ b/dashboard/src/__tests__/SessionHistoryPage.test.tsx
@@ -181,6 +181,9 @@ describe('SessionHistoryPage a11y (issue #2378)', () => {
 
     renderPage();
 
+    // Wait for a data row to render (session ID cell proves data loaded)
+    await screen.findByText('sess-name-hidden');
+
     // The "—" placeholder in the Name column should be aria-hidden
     const table = await screen.findByRole('table');
     const allTd = table.querySelectorAll('td');


### PR DESCRIPTION
## Summary
Follow-up to #2495 — the `.trim()` fix addressed a whitespace symptom but the Node 20 flake persisted because the root cause is a **timing race**: `findByRole('table')` resolves before React finishes rendering data rows, so the test queries skeleton rows instead of actual data.

## Fix
Add `await screen.findByText('sess-name-hidden')` before querying the table. This guarantees data has loaded before asserting on the aria-hidden placeholder cell.

## Testing
- All 6 SessionHistoryPage tests pass locally
- TypeScript: zero errors
- Test-only change, no production code affected

## Refs
- #2495 (previous .trim() fix)
- CI run: https://github.com/OneStepAt4time/aegis/actions/runs/25274378340