### PR TITLE
fix(metering): make enforceMaxRecords public and parameterized

### DIFF
--- a/src/__tests__/metering.test.ts
+++ b/src/__tests__/metering.test.ts
@@ -524,6 +524,31 @@ describe('MeteringService', () => {
       vi.useRealTimers();
     });
 
+    it('enforceMaxRecords(max) evicts oldest records to cap', () => {
+      const svc = new MeteringService(
+        eventBus, () => undefined, join(tmpDir, 'enforce.json'), undefined, { maxAgeMs: 0, maxRecords: 0 },
+      );
+      for (let i = 0; i < 5; i++) {
+        svc.recordTokenUsage(`s-${i}`, { inputTokens: 100 + i, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 });
+      }
+      expect(svc.recordCount).toBe(5);
+      svc.enforceMaxRecords(2);
+      expect(svc.recordCount).toBe(2);
+      // oldest 3 evicted; remaining: s-3 (103) and s-4 (104)
+      expect(svc.getUsageSummary().totalInputTokens).toBe(103 + 104);
+    });
+
+    it('enforceMaxRecords(0) is a no-op', () => {
+      const svc = new MeteringService(
+        eventBus, () => undefined, join(tmpDir, 'enforce-noop.json'), undefined, { maxAgeMs: 0, maxRecords: 0 },
+      );
+      for (let i = 0; i < 5; i++) {
+        svc.recordTokenUsage(`s-${i}`, { inputTokens: 100, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 });
+      }
+      svc.enforceMaxRecords(0);
+      expect(svc.recordCount).toBe(5);
+    });
+
     it('does not prune when maxAgeMs is 0', () => {
       const svc = new MeteringService(
         eventBus, () => undefined, join(tmpDir, 'no-age.json'), undefined, { maxAgeMs: 0, maxRecords: 0 },

--- a/src/metering.ts
+++ b/src/metering.ts
@@ -492,7 +492,7 @@ export class MeteringService {
       const cutoff = new Date(Date.now() - this.maxAgeMs).toISOString();
       this.records = this.records.filter(r => r.timestamp >= cutoff);
     }
-    this.enforceMaxRecords();
+    this.enforceMaxRecords(this.maxRecords);
   }
 
   /** Start a periodic timer that prunes and saves every hour. */
@@ -505,10 +505,10 @@ export class MeteringService {
     if (this.pruneTimer.unref) this.pruneTimer.unref();
   }
 
-  /** Evict oldest records when the array exceeds maxRecords. */
-  private enforceMaxRecords(): void {
-    if (this.maxRecords > 0 && this.records.length > this.maxRecords) {
-      this.records = this.records.slice(this.records.length - this.maxRecords);
+  /** Evict oldest records when the array exceeds `max`. If `max` is 0 the cap is disabled. */
+  enforceMaxRecords(max: number): void {
+    if (max > 0 && this.records.length > max) {
+      this.records = this.records.slice(this.records.length - max);
     }
   }
 


### PR DESCRIPTION
## Summary

Makes `enforceMaxRecords()` public and parameterized so external callers and tests can use it directly. Auto-prune now passes `this.maxRecords` explicitly.

## Changes
- `enforceMaxRecords()` → `enforceMaxRecords(max: number)` (public, takes cap as parameter)
- `autoPrune()` passes `this.maxRecords` explicitly instead of relying on private method
- Added 2 tests: cap eviction and no-op when max=0

## Verification
- Aegis API: unknown
- Commit: 14ed5f3ec2d45b5a93d3911a9c6cd7b51cdea2e4
- TypeScript: 0 errors
- Build: clean
- Tests: 224 files, 3895 passed, 0 failed

Fixes #2453