### PR TITLE
fix(cli): resolve symlink before isMainModule check

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -388,7 +388,7 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
 
 const isMainModule = (() => {
   try {
-    return fileURLToPath(import.meta.url) === process.argv[1];
+    return fileURLToPath(import.meta.url) === realpathSync(process.argv[1]);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

When `ag` is invoked via npm global symlink, `process.argv[1]` is the symlink path while `import.meta.url` resolves to the real file path. The `isMainModule` check compared these directly, so it always returned `false` when invoked via symlink — causing `runCli()` to never execute.

Fix: use `realpathSync()` to dereference the symlink before comparison.

## Root Cause
```
process.argv[1]        = /home/user/.local/bin/ag (symlink)
import.meta.url path   = /home/user/.local/lib/node_modules/@onestepat4time/aegis/dist/cli.js (real)
```
These never matched, so `ag --version`, `ag --help`, and `ag` all silently did nothing when invoked via symlink.

## Verification
- Aegis API: unknown
- Commit: de7286f5037ac2c3c6150e3063d95e1d85f327ee
- TypeScript: 0 errors
- Build: clean
- Tests: 225 files, 3900 passed, 0 failed

Fixes #2463