### PR TITLE
fix(dashboard): remove console.log/info from production code

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -142,7 +142,7 @@ function getDemoSessions(): SessionInfo[] {
 function setDemoSessions(): void {
   try {
     localStorage.setItem(DEMO_SESSIONS_KEY, JSON.stringify({ timestamp: Date.now() }));
-    console.info('[aegis] Demo sessions created (auto-expire in 24h)');
+    if (import.meta.env.DEV) console.info('[aegis] Demo sessions created (auto-expire in 24h)');
   } catch {
     // Ignore storage errors
   }

--- a/dashboard/src/components/session/TerminalPassthrough.tsx
+++ b/dashboard/src/components/session/TerminalPassthrough.tsx
@@ -100,8 +100,7 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
   const sanitationCtx = useMemo(() => {
     const preserveRaw = isRawStreamOptOut();
     if (preserveRaw) {
-      // eslint-disable-next-line no-console
-      console.info('[aegis] terminal stream sanitation disabled via ?raw=1');
+      if (import.meta.env.DEV) console.info('[aegis] terminal stream sanitation disabled via ?raw=1');
     }
     return { platform: detectClientPlatform(), preserveRaw };
   }, []);

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -11,10 +11,10 @@ if ('serviceWorker' in navigator) {
     navigator.serviceWorker
       .register('/dashboard/sw.js')
       .then((registration) => {
-        console.log('SW registered:', registration);
+        if (import.meta.env.DEV) console.log('SW registered:', registration);
       })
       .catch((error) => {
-        console.log('SW registration failed:', error);
+        if (import.meta.env.DEV) console.log('SW registration failed:', error);
       });
   });
 }

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -80,7 +80,7 @@ function getDemoPipelines(): PipelineInfo[] {
 function setDemoPipelines(): void {
   try {
     localStorage.setItem(DEMO_TAG_KEY, JSON.stringify({ timestamp: Date.now() }));
-    console.info('[aegis] Demo pipelines created (auto-expire in 24h)');
+    if (import.meta.env.DEV) console.info('[aegis] Demo pipelines created (auto-expire in 24h)');
   } catch {
     // Ignore storage errors
   }


### PR DESCRIPTION
## Summary
Gate all `console.log` and `console.info` calls behind `import.meta.env.DEV` so they only execute in development builds.

## Changes
- **main.tsx**: Service worker registration logs gated
- **PipelinesPage.tsx**: Demo pipeline creation log gated
- **TerminalPassthrough.tsx**: Stream sanitation debug log gated (removed eslint-disable comment)
- **SessionTable.tsx**: Demo session creation log gated

## Quality Gate
- ✅ `tsc --noEmit` — zero errors
- ✅ `npm run build` — production build successful
- ✅ `npm test` — 845 tests passed (86 files), 2 skipped

Closes #2511