### PR TITLE
fix(sessions): detect premature termination of background agents

### DIFF
--- a/src/__tests__/premature-termination.test.ts
+++ b/src/__tests__/premature-termination.test.ts
@@ -1,0 +1,200 @@
+/**
+ * premature-termination.test.ts — Tests for Issue #2520.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import type { TmuxManager } from '../tmux.js';
+import { SessionManager } from '../session.js';
+import { mkdirSync, rmSync } from 'fs';
+
+const SESSION_ID = '00000000-0000-0000-0000-000000002520';
+const STATE_DIR = '/tmp/premature-test-2520';
+
+function makeTmux(): TmuxManager {
+  return {
+    listWindows: vi.fn().mockResolvedValue([]),
+    killWindow: vi.fn().mockResolvedValue(true),
+    createWindow: vi.fn().mockResolvedValue({ windowId: '@test', windowName: 'test' }),
+    sendKeys: vi.fn().mockResolvedValue(undefined),
+    capturePane: vi.fn().mockResolvedValue(''),
+    resizePane: vi.fn().mockResolvedValue(undefined),
+    getWindowName: vi.fn().mockResolvedValue('test'),
+    isAlive: vi.fn().mockResolvedValue(true),
+    getSessionPanes: vi.fn().mockResolvedValue([]),
+  } as unknown as TmuxManager;
+}
+
+function makeConfig(): any {
+  return {
+    stateDir: STATE_DIR,
+    maxSessions: 10,
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    hookSettingsFile: undefined,
+    hookSecret: undefined,
+    dashboardDir: '/tmp',
+  };
+}
+
+function makeManager(): SessionManager {
+  return new SessionManager(makeTmux(), makeConfig());
+}
+
+function setupSession(manager: SessionManager, now: number, createdAtOffset: number): void {
+  manager['state'].sessions[SESSION_ID] = {
+    id: SESSION_ID,
+    windowId: '@2520',
+    windowName: 'premature-test',
+    workDir: '/tmp/premature-test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: now - createdAtOffset,
+    lastActivity: now,
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    toolUseCount: 0,
+  };
+}
+
+describe('Premature termination detection (Issue #2520)', () => {
+  let manager: SessionManager;
+  let origEnv: string | undefined;
+
+  beforeAll(() => {
+    mkdirSync(STATE_DIR, { recursive: true });
+  });
+
+  beforeEach(() => {
+    origEnv = process.env.PREMATURE_TERMINATION_MIN_TOOLS;
+    delete process.env.PREMATURE_TERMINATION_MIN_TOOLS;
+    delete process.env.PREMATURE_TERMINATION_MIN_DURATION_MS;
+    manager = makeManager();
+  });
+
+  afterEach(() => {
+    if (origEnv !== undefined) {
+      process.env.PREMATURE_TERMINATION_MIN_TOOLS = origEnv;
+    } else {
+      delete process.env.PREMATURE_TERMINATION_MIN_TOOLS;
+    }
+  });
+
+  afterAll(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+  });
+
+  it('flags session as premature when tool count <= 30 and duration >= 30s', () => {
+    const now = Date.now();
+    setupSession(manager, now, 60_000);
+
+    for (let i = 0; i < 15; i++) {
+      manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    }
+
+    manager.updateStatusFromHook(SESSION_ID, 'TaskCompleted');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.toolUseCount).toBe(15);
+    expect(session.prematureTermination).toBe(true);
+  });
+
+  it('does NOT flag session when tool count > 30', () => {
+    const now = Date.now();
+    setupSession(manager, now, 60_000);
+
+    for (let i = 0; i < 40; i++) {
+      manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    }
+
+    manager.updateStatusFromHook(SESSION_ID, 'TaskCompleted');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.toolUseCount).toBe(40);
+    expect(session.prematureTermination).toBeFalsy();
+  });
+
+  it('does NOT flag session when duration < 30s', () => {
+    const now = Date.now();
+    setupSession(manager, now, 5_000);
+
+    for (let i = 0; i < 10; i++) {
+      manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    }
+
+    manager.updateStatusFromHook(SESSION_ID, 'TaskCompleted');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.toolUseCount).toBe(10);
+    expect(session.prematureTermination).toBeFalsy();
+  });
+
+  it('does NOT flag when toolUseCount is undefined', () => {
+    const now = Date.now();
+    setupSession(manager, now, 60_000);
+    manager['state'].sessions[SESSION_ID].toolUseCount = undefined;
+
+    manager.updateStatusFromHook(SESSION_ID, 'TaskCompleted');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.prematureTermination).toBeFalsy();
+  });
+
+  it('respects PREMATURE_TERMINATION_MIN_TOOLS env var', () => {
+    process.env.PREMATURE_TERMINATION_MIN_TOOLS = '5';
+
+    const now = Date.now();
+    setupSession(manager, now, 60_000);
+
+    for (let i = 0; i < 3; i++) {
+      manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    }
+
+    manager.updateStatusFromHook(SESSION_ID, 'Stop');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.prematureTermination).toBe(true);
+  });
+
+  it('flags on Stop event, not just TaskCompleted', () => {
+    const now = Date.now();
+    setupSession(manager, now, 60_000);
+
+    for (let i = 0; i < 10; i++) {
+      manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    }
+
+    manager.updateStatusFromHook(SESSION_ID, 'Stop');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.prematureTermination).toBe(true);
+  });
+
+  it('does NOT flag on non-terminal events', () => {
+    const now = Date.now();
+    setupSession(manager, now, 60_000);
+
+    for (let i = 0; i < 10; i++) {
+      manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    }
+
+    manager.updateStatusFromHook(SESSION_ID, 'PostToolUse');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.prematureTermination).toBeFalsy();
+  });
+
+  it('increments toolUseCount for each PreToolUse event', () => {
+    const now = Date.now();
+    setupSession(manager, now, 60_000);
+
+    manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+    manager.updateStatusFromHook(SESSION_ID, 'PreToolUse');
+
+    const session = manager.getSession(SESSION_ID)!;
+    expect(session.toolUseCount).toBe(3);
+  });
+});

--- a/src/session.ts
+++ b/src/session.ts
@@ -121,6 +121,9 @@ export interface SessionInfo {
   // Issue #2518: Hook failure circuit breaker
   hookFailureTimestamps?: number[];   // Sliding window of StopFailure timestamps (ms)
   circuitBreakerTripped?: boolean;    // True once the circuit breaker has fired
+  // Issue #2520: Premature termination detection for background agents
+  toolUseCount?: number;               // Count of PreToolUse hook events
+  prematureTermination?: boolean;       // True when session ended with suspiciously low tool use
 }
 
 /** Persisted session store keyed by Aegis session ID. */
@@ -1036,6 +1039,10 @@ export class SessionManager {
       case 'TeammateIdle':
         break;
       case 'PreToolUse':
+        // Issue #2520: Track tool use count for premature termination detection
+        session.toolUseCount = (session.toolUseCount ?? 0) + 1;
+        session.status = 'working';
+        break;
       case 'PostToolUse':
       case 'SubagentStart':
       case 'UserPromptSubmit':
@@ -1057,6 +1064,21 @@ export class SessionManager {
       default:
         // Unknown hook events: no status change
         break;
+    }
+
+    // Issue #2520: Detect premature termination. Upstream CC kills background
+    // agents at ~20-30 tool uses with no wrap-up (upstream #55707).
+    const PREMATURE_MIN_TOOLS = parseInt(process.env.PREMATURE_TERMINATION_MIN_TOOLS ?? '30', 10);
+    const PREMATURE_MIN_DURATION_MS = parseInt(process.env.PREMATURE_TERMINATION_MIN_DURATION_MS ?? '30000', 10);
+    if ((hookEvent === 'TaskCompleted' || hookEvent === 'Stop') && session.toolUseCount !== undefined) {
+      const toolCount = session.toolUseCount;
+      const duration = now - session.createdAt;
+      if (toolCount > 0 && toolCount <= PREMATURE_MIN_TOOLS && duration >= PREMATURE_MIN_DURATION_MS) {
+        session.prematureTermination = true;
+        console.warn(
+          `Session ${id.slice(0, 8)}: possible premature termination — ${toolCount} tool uses in ${Math.round(duration / 1000)}s (threshold: <=${PREMATURE_MIN_TOOLS} tools, >=${PREMATURE_MIN_DURATION_MS}ms duration)`
+        );
+      }
     }
 
     session.lastHookAt = now;


### PR DESCRIPTION
## Summary

Upstream CC issue #55707: background agents terminate at ~20-30 tool uses with no graceful wrap-up, causing silent data loss. Sessions appear `completed` when work is actually incomplete.

Add detection that flags sessions ending with suspiciously low tool use count as prematurely terminated:

1. **Tool use tracking**: `PreToolUse` hook events increment `toolUseCount` per session
2. **Premature detection**: When `TaskCompleted` or `Stop` fires with tool count <= threshold AND session duration >= minimum, sets `prematureTermination` flag
3. **Console warning**: Logs detailed message with tool count and duration for operator visibility
4. **Configurable thresholds** via env vars

## Config
- `PREMATURE_TERMINATION_MIN_TOOLS` — max tool uses before flagging (default 30)
- `PREMATURE_TERMINATION_MIN_DURATION_MS` — minimum session duration to consider (default 30000)

## Tests
- 8 tests: threshold detection, env var override, Stop vs TaskCompleted, non-terminal events, edge cases
- 227 test files, 3919 tests passing, 0 failures

## Verification
- TypeScript: 0 errors
- Build: clean
- Commit: 1a59152e0f392904d620d9e8f7a292e3e3acd146

Fixes #2520