### PR TITLE
fix(security): redact hookSecret from all session API responses

### DIFF
--- a/src/__tests__/hooksecret-redaction-2527.test.ts
+++ b/src/__tests__/hooksecret-redaction-2527.test.ts
@@ -1,0 +1,86 @@
+/**
+ * hooksecret-redaction-2527.test.ts — Verify hookSecret is never exposed in API responses.
+ *
+ * Issue #2527: hookSecret (HMAC secret for hook URL auth) must be stripped from
+ * all session API responses. Any API key holder reading session data should not
+ * be able to forge hook payloads.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { redactSession } from '../routes/context.js';
+
+describe('redactSession — Issue #2527', () => {
+  it('strips hookSecret from session object', () => {
+    const session = {
+      id: '11111111-1111-1111-1111-111111111111',
+      windowId: '@1',
+      workDir: '/home/user/repo',
+      status: 'idle',
+      hookSecret: 'dead54222855e0eeb2e60e3027423d907a755e8dff416f0b630c2c2c3eece4fd',
+      hookSettingsFile: '/tmp/aegis-hook-settings-123',
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+    };
+
+    const redacted = redactSession(session);
+    expect(redacted).not.toHaveProperty('hookSecret');
+    expect(redacted).not.toHaveProperty('hookSettingsFile');
+    // Non-sensitive fields preserved
+    expect(redacted.id).toBe(session.id);
+    expect(redacted.workDir).toBe(session.workDir);
+    expect(redacted.status).toBe(session.status);
+  });
+
+  it('preserves all non-sensitive fields', () => {
+    const session = {
+      id: '22222222-2222-2222-2222-222222222222',
+      windowName: 'test-session',
+      workDir: '/home/user/project',
+      status: 'working',
+      model: 'claude-sonnet-4-20250514',
+      ownerKeyId: 'key-abc',
+      parentId: '33333333-3333-3333-3333-333333333333',
+      children: ['44444444-4444-4444-4444-444444444444'],
+      hookSecret: 'super-secret-hex-value',
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+    };
+
+    const redacted = redactSession(session);
+    expect(redacted.id).toBe('22222222-2222-2222-2222-222222222222');
+    expect(redacted.windowName).toBe('test-session');
+    expect(redacted.model).toBe('claude-sonnet-4-20250514');
+    expect(redacted.ownerKeyId).toBe('key-abc');
+    expect(redacted.parentId).toBe('33333333-3333-3333-3333-333333333333');
+    expect(redacted.children).toEqual(['44444444-4444-4444-4444-444444444444']);
+    expect(redacted).not.toHaveProperty('hookSecret');
+  });
+
+  it('handles session without hookSecret gracefully', () => {
+    const session = {
+      id: '55555555-5555-5555-5555-555555555555',
+      status: 'idle',
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+    };
+
+    const redacted = redactSession(session);
+    expect(redacted.id).toBe('55555555-5555-5555-5555-555555555555');
+  });
+
+  it('converts activeSubagents Set to array', () => {
+    const session = {
+      id: '66666666-6666-6666-6666-666666666666',
+      status: 'idle',
+      activeSubagents: new Set(['sub-a', 'sub-b']),
+      hookSecret: 'should-be-stripped',
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+    };
+
+    const redacted = redactSession(session);
+    expect(redacted).not.toHaveProperty('hookSecret');
+    expect(Array.isArray(redacted.activeSubagents)).toBe(true);
+    expect(redacted.activeSubagents).toEqual(['sub-a', 'sub-b']);
+  });
+});

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -283,12 +283,35 @@ export function requireSessionOwnership(
 }
 
 /** Issue #20: Add actionHints to session response for interactive states. */
+/**
+ * Strip sensitive internal fields from a SessionInfo before API serialization.
+ *
+ * hookSecret: HMAC secret for hook URL auth — must never be exposed via API.
+ * hookSettingsFile: internal temp file path — not useful to callers.
+ * activeSubagents: Set<> is not JSON-serializable; converted separately.
+ */
+export function redactSession(session: Record<string, unknown>): Record<string, unknown> {
+  const { hookSecret, hookSettingsFile, activeSubagents, ...rest } = session as Record<string, unknown> & {
+    hookSecret?: unknown;
+    hookSettingsFile?: unknown;
+    activeSubagents?: unknown;
+  };
+  const redacted = { ...rest };
+  // activeSubagents needs to be re-added as an array (if present) for JSON
+  if (activeSubagents instanceof Set) {
+    (redacted as Record<string, unknown>).activeSubagents = [...activeSubagents];
+  }
+  return redacted;
+}
+
 export function addActionHints(
   session: SessionInfo,
   sessions?: SessionManager,
 ): Record<string, unknown> {
+  // Issue #2527: Strip hookSecret and other internal fields before API serialization
+  const safe = redactSession(session as unknown as Record<string, unknown>);
   const result: Record<string, unknown> = {
-    ...session,
+    ...safe,
     activeSubagents: session.activeSubagents ? [...session.activeSubagents] : undefined,
   };
   if (session.status === 'permission_prompt' || session.status === 'bash_approval') {

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -18,6 +18,7 @@ import {
   resolveRequestAuditActor,
   getRequestRole,
   addActionHints,
+  redactSession,
   makePayload,
   registerWithLegacy, withOwnership, withValidation,
 } from './context.js';
@@ -218,7 +219,9 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     const items = all.slice(start, start + limit);
     const totalPages = Math.ceil(total / limit);
 
-    return { sessions: items, pagination: { page, limit, total: total ?? 0, totalPages: totalPages ?? 0 } };
+    // Issue #2527: Redact sensitive fields from session list responses
+    const safeItems = items.map(s => redactSession(s as unknown as Record<string, unknown>));
+    return { sessions: safeItems, pagination: { page, limit, total: total ?? 0, totalPages: totalPages ?? 0 } };
   });
 
   // Issue #754: Session statistics endpoint
@@ -302,7 +305,8 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     }
     // Issue #1944: Tenant scoping
     all = filterByTenant(all, req.tenantId);
-    return all;
+    // Issue #2527: Redact sensitive fields
+    return all.map(s => redactSession(s as unknown as Record<string, unknown>));
   });
 
   // Create session (Issue #607: reuse idle session for same workDir)
@@ -410,7 +414,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       metrics.promptSent(promptDelivery.delivered);
     }
 
-    return reply.status(201).send({ ...session, promptDelivery });
+    return reply.status(201).send({ ...redactSession(session as unknown as Record<string, unknown>), promptDelivery });
   }
   registerWithLegacy(app, 'post', '/v1/sessions', {
     config: {


### PR DESCRIPTION
## Summary

**P1 security fix** —  (HMAC secret for hook URL authentication, Issue #629) was returned in plaintext in session API responses. Any API key holder could read all session hook secrets and forge hook payloads, undermining the entire HMAC verification system.

### Affected endpoints
- `GET /v1/sessions` — session list
- `GET /v1/sessions/:id` — session detail
- `POST /v1/sessions` — create session response
- `GET /sessions` — legacy raw array endpoint

### Fix
- Added `redactSession()` helper in `routes/context.ts` that strips:
  - `hookSecret` — HMAC secret (critical)
  - `hookSettingsFile` — internal temp file path (defense in depth)
  - Converts `activeSubagents` Set to array for JSON serialization
- Applied at all API serialization boundaries

### Tests
- 4 new tests for `redactSession()` behavior
- All 231 existing tests pass (including server smoke + phase3 integration)
- `tsc --noEmit` clean

Closes #2527

## Test plan
- [x] New tests: redactSession strips hookSecret, hookSettingsFile, preserves other fields
- [x] New tests: handles missing hookSecret gracefully
- [x] New tests: converts activeSubagents Set to array
- [x] All 231 existing tests pass
- [x] `tsc --noEmit` clean
- [x] Manual: `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9100/v1/sessions | jq '.sessions[0].hookSecret'` → null