### PR TITLE
fix(security): apply rate limiting in no-auth localhost mode

### DIFF
--- a/src/__tests__/rate-limit-localhost-noauth.test.ts
+++ b/src/__tests__/rate-limit-localhost-noauth.test.ts
@@ -1,0 +1,85 @@
+/**
+ * rate-limit-localhost-noauth.test.ts — Tests for Issue #2532.
+ *
+ * When Aegis runs on localhost with no auth configured, all requests
+ * previously bypassed rate limiting entirely. Now per-IP rate limiting
+ * is applied even in no-auth localhost mode.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Fastify from 'fastify';
+import { RateLimiter } from '../services/auth/RateLimiter.js';
+
+describe('Rate limiting in no-auth localhost mode (Issue #2532)', () => {
+  it('RateLimiter.checkIpRateLimit returns false under threshold', () => {
+    const limiter = new RateLimiter();
+    const ip = '127.0.0.1';
+
+    // Normal limit is 120/min — 50 requests should be fine
+    for (let i = 0; i < 50; i++) {
+      expect(limiter.checkIpRateLimit(ip, false)).toBe(false);
+    }
+  });
+
+  it('RateLimiter.checkIpRateLimit returns true over threshold', () => {
+    const limiter = new RateLimiter();
+    const ip = '192.168.1.1';
+
+    // Normal limit is 120/min — send 121 requests
+    let exceeded = false;
+    for (let i = 0; i < 130; i++) {
+      if (limiter.checkIpRateLimit(ip, false)) {
+        exceeded = true;
+        break;
+      }
+    }
+    expect(exceeded).toBe(true);
+  });
+
+  it('RateLimiter.checkIpRateLimitUnauth returns true over threshold', () => {
+    const limiter = new RateLimiter();
+    const ip = '10.0.0.1';
+
+    // Unauth limit is 30/min — send 31 requests
+    let exceeded = false;
+    for (let i = 0; i < 35; i++) {
+      if (limiter.checkIpRateLimitUnauth(ip)) {
+        exceeded = true;
+        break;
+      }
+    }
+    expect(exceeded).toBe(true);
+  });
+
+  it('RateLimiter isolates authenticated and unauthenticated buckets', () => {
+    const limiter = new RateLimiter();
+    const ip = '127.0.0.1';
+
+    // Exhaust unauthenticated bucket (30/min)
+    for (let i = 0; i < 35; i++) {
+      limiter.checkIpRateLimitUnauth(ip);
+    }
+    // Unauthenticated should be blocked
+    expect(limiter.checkIpRateLimitUnauth(ip)).toBe(true);
+
+    // Authenticated should still work (separate bucket)
+    expect(limiter.checkIpRateLimit(ip, false, 'key-1')).toBe(false);
+  });
+
+  it('master token gets higher IP rate limit (300/min)', () => {
+    const limiter = new RateLimiter();
+    const ip = '127.0.0.1';
+
+    // Normal limit is 120 — exhaust it
+    for (let i = 0; i < 125; i++) {
+      limiter.checkIpRateLimit(ip, false);
+    }
+    expect(limiter.checkIpRateLimit(ip, false)).toBe(true);
+
+    // Master should still be under its 300 limit
+    const masterIp = '127.0.0.2';
+    for (let i = 0; i < 125; i++) {
+      expect(limiter.checkIpRateLimit(masterIp, true)).toBe(false);
+    }
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -474,7 +474,14 @@ function setupAuth(authManager: AuthManager): void {
     // #1080: Only bypass auth if no credentials are configured AND server is bound to localhost.
     // When binding to a non-localhost interface (0.0.0.0, public IP) with no auth configured,
     // do NOT bypass — let validate() reject the request (it returns valid:false in this case).
-    if (!authManager.authEnabled && authManager.isLocalhostBinding) return;
+    // #2532: Even in localhost no-auth mode, apply per-IP rate limiting to prevent flooding.
+    const isNoAuthLocalhost = !authManager.authEnabled && authManager.isLocalhostBinding;
+    if (isNoAuthLocalhost) {
+      if (checkIpRateLimit(clientIp, false)) {
+        return reply.status(429).send({ error: 'Rate limit exceeded — IP throttled' });
+      }
+      return;
+    }
 
     if (!token) {
       // #2456: Rate-limit no-token requests via the IP-only (unauth) bucket so they


### PR DESCRIPTION
## Summary

Issue #2532 reported that authenticated requests had no rate limit. Investigation showed rate limiting IS working for authenticated requests (120 req/min per-IP, 100/min per-key), but the report's 15-request test was below threshold.

The **real bug**: when Aegis runs on localhost with no auth configured, the `onRequest` hook returned early before any rate limit check, allowing unlimited requests from any local process.

## Fix

Apply per-IP rate limiting (120 req/min) even in no-auth localhost mode. Authenticated and unauthenticated traffic remain in separate buckets.

## Tests
- 5 tests: threshold enforcement, unauth bucket isolation, master token higher limit (300/min)
- All existing tests pass (228 files)

## Verification
- TypeScript: 0 errors
- Build: clean
- Commit: c75de46e70bc474544cacc5db836d87ac544b564

Fixes #2532