### PR TITLE
fix(security): strip hookSecret from session API responses

### DIFF
--- a/src/__tests__/hooksecret-strip.test.ts
+++ b/src/__tests__/hooksecret-strip.test.ts
@@ -1,0 +1,108 @@
+/**
+ * hooksecret-strip.test.ts — Tests for Issue #2527.
+ *
+ * hookSecret must never appear in API responses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SessionManager } from '../session.js';
+import type { SessionInfo } from '../session.js';
+
+const SESSION_ID = '00000000-0000-0000-0000-000000002527';
+
+function makeSession(): SessionInfo {
+  return {
+    id: SESSION_ID,
+    windowId: '@2527',
+    windowName: 'secret-test',
+    workDir: '/tmp/secret-test',
+    claudeSessionId: 'cc-123',
+    jsonlPath: '/tmp/test.jsonl',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    hookSecret: 'deadbeef64charhexstringsecretthatshouldnotleak1234567890',
+    hookSettingsFile: '/tmp/hooks-test.json',
+    ccPid: 12345,
+    tenantId: '_system',
+  };
+}
+
+describe('hookSecret stripped from API responses (Issue #2527)', () => {
+  it('stripSensitiveFields removes hookSecret', () => {
+    const session = makeSession();
+    const public_ = SessionManager.stripSensitiveFields(session);
+    expect(public_.hookSecret).toBeUndefined();
+  });
+
+  it('stripSensitiveFields removes jsonlPath', () => {
+    const session = makeSession();
+    const public_ = SessionManager.stripSensitiveFields(session);
+    expect(public_.jsonlPath).toBeUndefined();
+  });
+
+  it('stripSensitiveFields removes hookSettingsFile', () => {
+    const session = makeSession();
+    const public_ = SessionManager.stripSensitiveFields(session);
+    expect(public_.hookSettingsFile).toBeUndefined();
+  });
+
+  it('stripSensitiveFields removes ccPid', () => {
+    const session = makeSession();
+    const public_ = SessionManager.stripSensitiveFields(session);
+    expect((public_ as any).ccPid).toBeUndefined();
+  });
+
+  it('stripSensitiveFields preserves public fields', () => {
+    const session = makeSession();
+    const public_ = SessionManager.stripSensitiveFields(session);
+    expect(public_.id).toBe(SESSION_ID);
+    expect(public_.windowId).toBe('@2527');
+    expect(public_.status).toBe('idle');
+    expect(public_.workDir).toBe('/tmp/secret-test');
+    expect(public_.createdAt).toBe(session.createdAt);
+    expect(public_.tenantId).toBe('_system');
+  });
+
+  it('stripSensitiveFieldsList strips all sessions', () => {
+    const sessions = [makeSession(), makeSession()];
+    const public_ = SessionManager.stripSensitiveFieldsList(sessions);
+    expect(public_).toHaveLength(2);
+    for (const s of public_) {
+      expect(s.hookSecret).toBeUndefined();
+      expect(s.jsonlPath).toBeUndefined();
+    }
+  });
+
+  it('original session is not mutated', () => {
+    const session = makeSession();
+    SessionManager.stripSensitiveFields(session);
+    expect(session.hookSecret).toBe('deadbeef64charhexstringsecretthatshouldnotleak1234567890');
+    expect(session.jsonlPath).toBe('/tmp/test.jsonl');
+  });
+
+  it('session without sensitive fields still works', () => {
+    const session: SessionInfo = {
+      id: SESSION_ID,
+      windowId: '@2527',
+      windowName: 'test',
+      workDir: '/tmp',
+      byteOffset: 0,
+      monitorOffset: 0,
+      status: 'idle',
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+      stallThresholdMs: 300_000,
+      permissionStallMs: 300_000,
+      permissionMode: 'default',
+    };
+    const public_ = SessionManager.stripSensitiveFields(session);
+    expect(public_.id).toBe(SESSION_ID);
+    expect(public_.status).toBe('idle');
+  });
+});

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -13,7 +13,7 @@
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { z } from 'zod';
-import type { SessionManager, SessionInfo } from '../session.js';
+import { SessionManager, type SessionInfo } from '../session.js';
 import type { TmuxManager } from '../tmux.js';
 import type { AuthManager, ApiKeyPermission, ApiKeyRole } from '../services/auth/index.js';
 import type { QuotaManager } from '../services/auth/QuotaManager.js';
@@ -288,7 +288,7 @@ export function addActionHints(
   sessions?: SessionManager,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {
-    ...session,
+    ...SessionManager.stripSensitiveFields(session),
     activeSubagents: session.activeSubagents ? [...session.activeSubagents] : undefined,
   };
   if (session.status === 'permission_prompt' || session.status === 'bash_approval') {

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -11,6 +11,7 @@ import { SYSTEM_TENANT } from '../config.js';
 import { filterByTenant } from '../utils/tenant-filter.js';
 import { validateWorkdirPath } from '../tenant-workdir.js';
 import { cleanupTerminatedSessionState } from '../session-cleanup.js';
+import { SessionManager } from '../session.js';
 import {
   type RouteContext,
   requirePermission,
@@ -218,7 +219,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     const items = all.slice(start, start + limit);
     const totalPages = Math.ceil(total / limit);
 
-    return { sessions: items, pagination: { page, limit, total: total ?? 0, totalPages: totalPages ?? 0 } };
+    return { sessions: SessionManager.stripSensitiveFieldsList(items), pagination: { page, limit, total: total ?? 0, totalPages: totalPages ?? 0 } };
   });
 
   // Issue #754: Session statistics endpoint
@@ -410,7 +411,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       metrics.promptSent(promptDelivery.delivered);
     }
 
-    return reply.status(201).send({ ...session, promptDelivery });
+    return reply.status(201).send({ ...SessionManager.stripSensitiveFields(session), promptDelivery });
   }
   registerWithLegacy(app, 'post', '/v1/sessions', {
     config: {

--- a/src/session.ts
+++ b/src/session.ts
@@ -1269,7 +1269,19 @@ export class SessionManager {
   }
 
   /** List all sessions. */
-  listSessions(): SessionInfo[] {
+  /** #2527: Strip sensitive fields from session objects for API responses.
+   *  Returns a new object without hookSecret, jsonlPath, and other internal fields
+   *  that should not be exposed via the public API. */
+  static stripSensitiveFields(session: SessionInfo): SessionInfo {
+    const { hookSecret, jsonlPath, hookSettingsFile, ccPid, encKey, ...public_ } = session as any;
+    return public_ as SessionInfo;
+  }
+
+  static stripSensitiveFieldsList(sessions: SessionInfo[]): SessionInfo[] {
+    return sessions.map(s => SessionManager.stripSensitiveFields(s));
+  }
+
+    listSessions(): SessionInfo[] {
     if (!this.sessionsListCache) {
       this.sessionsListCache = Object.values(this.state.sessions);
     }


### PR DESCRIPTION
## Summary

**Security fix:** `hookSecret` was exposed in `GET /v1/sessions` and `GET /v1/sessions/:id` responses. Any authenticated API key holder could read hook secrets and forge Claude Code hook payloads.

Added `SessionManager.stripSensitiveFields()` static method that removes:
- `hookSecret` — per-session HMAC secret for hook auth
- `jsonlPath` — server filesystem path
- `hookSettingsFile` — temp settings file path  
- `ccPid` — Claude Code process ID

Applied to all session API response paths (list, create, detail).

## Tests
- 8 tests: field stripping, list stripping, original immutability, public field preservation, edge cases

## Verification
- TypeScript: 0 errors
- Build: clean
- All tests passing
- Commit: 154733ae24f4941307f6138fdd51a3a66ded01fc

Fixes #2527