### PR TITLE
docs: cover recent security and hook fixes (#2540, #2541, #2524)

### DIFF
--- a/docs/SECURITY_QUESTIONNAIRE.md
+++ b/docs/SECURITY_QUESTIONNAIRE.md
@@ -243,6 +243,7 @@ project backlog:
 | **Log integrity** | SHA-256 chained. Each log entry includes a hash of the previous entry. Tampering breaks the chain and is detectable. |
 | **Log retention** | Indefinite by default. No auto-deletion. See [RETENTION_POLICY.md](./RETENTION_POLICY.md). |
 | **Sensitive data in logs** | Auth tokens are redacted (`token=[REDACTED]`). Hook secrets are redacted (`secret=[REDACTED]`). API keys are never logged. |
+| **Sensitive data in API responses** | `hookSecret` and `hookSettingsFile` are redacted from all session API responses. Any API key holder can list sessions but cannot read hook secrets — they are encrypted at rest and stripped at serialization boundaries. |
 | **Log access control** | File permissions (`0o600` recommended). Deployer controls access. |
 
 ### 8.2 Operational Monitoring

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -730,6 +730,10 @@ Returns the status of parallel session swarm coordination.
 
 Session hooks are internal callbacks triggered by Claude Code lifecycle events. These endpoints are called by the Aegis server itself — not by external clients.
 
+> **Payload size warning:** Claude Code silently truncates hook payloads exceeding ~2KB. Aegis logs a warning and emits a `system` SSE event when any hook payload exceeds 1.5KB, so operators can detect truncated context before it causes silent failures. Keep hook payloads under 1.5KB to avoid truncation.
+
+> **hookSecret redaction:** The `hookSecret` field is never returned in session API responses (`GET /v1/sessions`, `GET /v1/sessions/:id`, `POST /v1/sessions`). It is stored encrypted at rest and used only for HMAC verification of inbound hook payloads. This prevents API key holders from reading or forging hook secrets.
+
 ### Permission Hook
 
 ```bash

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -128,12 +128,14 @@ Aegis includes built-in rate limiting at multiple levels:
 
 | Layer | Limit | Description |
 |---|---|---|
-| Per-IP | Configurable | Limits requests per IP address |
+| Per-IP (no-auth) | 120 req/min | Applied even when `AEGIS_AUTH_TOKEN` is not set |
+| Per-IP (auth) | 120 req/min | Separate bucket from no-auth traffic |
 | Auth failure | 5/min per IP | Locks out after repeated failed auth attempts |
-| Per-key | Configurable | Separate limits per API key |
+| Per-key | 100 req/min | Separate limits per API key |
+| Master token | 300 req/min | Higher limit for the master `AEGIS_AUTH_TOKEN` |
 | SSE | Configurable | Rate limiting per SSE client connection |
 
-Auth failure lockout triggers after 5 failed attempts per IP within 1 minute. Stale buckets are pruned automatically.
+Rate limiting is enforced in all modes — including unauthenticated localhost deployments. Authenticated and unauthenticated traffic are tracked in separate buckets. Auth failure lockout triggers after 5 failed attempts per IP within 1 minute. Stale buckets are pruned automatically.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents three recently-merged fixes that have user-facing implications:

- **#2541** — Rate limiting now applies even in no-auth localhost mode (was a security gap)
- **#2540** — `hookSecret` is redacted from all session API responses (P1 security fix)
- **#2524** — Hook payloads exceeding 1.5KB are logged/truncated (CC truncation upstream)

## Changes

### `docs/enterprise.md`
- Updated rate limiting table with per-mode limits (no-auth: 120/min, master token: 300/min)
- Added note that rate limiting is enforced in all modes including unauthenticated localhost

### `docs/api-reference.md`
- Added payload size warning (>1.5KB causes CC truncation, Aegis emits warning)
- Added hookSecret redaction note (never returned in session API responses)

### `docs/SECURITY_QUESTIONNAIRE.md`
- Added API response redaction entry for hookSecret and hookSettingsFile

## Verification
- [x] All changes are documentation-only
- [x] Values match PR descriptions and test expectations
- [x] No sensitive data or internal paths exposed