### PR TITLE
fix(sessions): transition to idle on Stop/TaskCompleted/SessionEnd hooks (#2538)

### DIFF
--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -676,11 +676,31 @@ describe('SessionManager.updateStatusFromHook()', () => {
     expect(session.status).toBe('error');
   });
 
-  it('does not change status for Stop hook (idle stays idle)', () => {
+  it('sets status to idle for Stop hook (Issue #2538)', () => {
     const session = makeSession({ status: 'working' });
     const { manager } = createManagerWithSession(session);
     manager.updateStatusFromHook(session.id, 'Stop');
-    // Stop is a no-op in the switch — status unchanged
+    expect(session.status).toBe('idle');
+  });
+
+  it('sets status to idle for TaskCompleted hook (Issue #2538)', () => {
+    const session = makeSession({ status: 'working' });
+    const { manager } = createManagerWithSession(session);
+    manager.updateStatusFromHook(session.id, 'TaskCompleted');
+    expect(session.status).toBe('idle');
+  });
+
+  it('sets status to idle for SessionEnd hook (Issue #2538)', () => {
+    const session = makeSession({ status: 'working' });
+    const { manager } = createManagerWithSession(session);
+    manager.updateStatusFromHook(session.id, 'SessionEnd');
+    expect(session.status).toBe('idle');
+  });
+
+  it('does not change status for TeammateIdle hook (informational)', () => {
+    const session = makeSession({ status: 'working' });
+    const { manager } = createManagerWithSession(session);
+    manager.updateStatusFromHook(session.id, 'TeammateIdle');
     expect(session.status).toBe('working');
   });
 

--- a/src/__tests__/stop-hook-idle-2538.test.ts
+++ b/src/__tests__/stop-hook-idle-2538.test.ts
@@ -1,0 +1,187 @@
+/**
+ * stop-hook-idle-2538.test.ts — Issue #2538: session status stays "working" after CC completes.
+ *
+ * Verifies that:
+ * 1. SessionManager.updateStatusFromHook() transitions to idle on Stop/TaskCompleted/SessionEnd
+ * 2. SessionMonitor.checkStopSignals() updates session.status and monitor tracking on Stop signal
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionMonitor, DEFAULT_MONITOR_CONFIG } from '../monitor.js';
+import type { SessionManager, SessionInfo } from '../session.js';
+import type { ChannelManager } from '../channels/index.js';
+import type { SessionEventPayload } from '../channels/types.js';
+import { existsSync } from 'node:fs';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: crypto.randomUUID(),
+    windowId: '@1',
+    windowName: 'cc-test',
+    workDir: '/tmp',
+    claudeSessionId: 'cc-session-abc',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'working',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 120_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ...overrides,
+  } as SessionInfo;
+}
+
+function makeMockDeps() {
+  const sessions = new Map<string, SessionInfo>();
+
+  const mockSessions = {
+    getSession: vi.fn((id: string) => sessions.get(id) ?? null),
+    listSessions: vi.fn(() => [...sessions.values()]),
+    readMessagesForMonitor: vi.fn(async () => ({
+      messages: [],
+      status: 'idle' as const,
+      statusText: null,
+      interactiveContent: null,
+    })),
+    killSession: vi.fn(async () => {}),
+    isWindowAlive: vi.fn(async () => true),
+    reject: vi.fn(async () => {}),
+  };
+
+  const mockChannels = {
+    statusChange: vi.fn(async (_payload: SessionEventPayload) => {}),
+    message: vi.fn(async () => {}),
+  };
+
+  return { sessions, mockSessions, mockChannels };
+}
+
+function makeMonitor(
+  mockSessions: SessionManager,
+  mockChannels: ChannelManager,
+): SessionMonitor {
+  return new SessionMonitor(
+    mockSessions,
+    mockChannels,
+    { ...DEFAULT_MONITOR_CONFIG, stallCheckIntervalMs: 100 },
+  );
+}
+
+// ─── SessionMonitor.checkStopSignals — Stop signal updates status ──────────
+
+describe('Issue #2538: Stop signal transitions session to idle', () => {
+  let deps: ReturnType<typeof makeMockDeps>;
+  let monitor: SessionMonitor;
+  let session: SessionInfo;
+  let signalDir: string;
+
+  beforeEach(async () => {
+    deps = makeMockDeps();
+    session = makeSession({ claudeSessionId: 'cc-session-abc' });
+    deps.sessions.set(session.id, session);
+    monitor = makeMonitor(
+      deps.mockSessions as unknown as SessionManager,
+      deps.mockChannels as unknown as ChannelManager,
+    );
+
+    // Create a temp dir for the stop_signals.json file
+    signalDir = join(tmpdir(), `aegis-test-2538-${Date.now()}`);
+    await mkdir(signalDir, { recursive: true });
+  });
+
+  it('updates session.status to idle when Stop signal is found', async () => {
+    // Write a Stop signal
+    const signalFile = join(signalDir, 'stop_signals.json');
+    await writeFile(signalFile, JSON.stringify({
+      [session.claudeSessionId!]: {
+        event: 'Stop',
+        timestamp: Date.now(),
+      },
+    }));
+
+    // Monkey-patch the signal file path in the monitor
+    // We use a workaround: temporarily override homedir resolution
+    const origExistsSync = existsSync;
+    const origReadFile = readFile;
+
+    // The monitor reads from ~/.aegis/stop_signals.json or ~/.manus/stop_signals.json
+    // We'll override the signal file to our temp dir
+    const aegisDir = signalDir;
+
+    // Write the signal file to where the monitor looks
+    const homeDir = join(aegisDir, '.aegis');
+    await mkdir(homeDir, { recursive: true });
+    const realSignalFile = join(homeDir, 'stop_signals.json');
+    await writeFile(realSignalFile, JSON.stringify({
+      [session.claudeSessionId!]: {
+        event: 'Stop',
+        timestamp: Date.now(),
+      },
+    }));
+
+    // Use os.homedir override
+    const originalHomedir = process.env.HOME;
+    process.env.HOME = aegisDir;
+
+    try {
+      // Trigger the stop signal check via the monitor's internal method
+      await (monitor as any).checkStopSignals();
+
+      // Verify: session status should now be idle
+      expect(session.status).toBe('idle');
+
+      // Verify: monitor's internal lastStatus should be updated
+      expect((monitor as any).lastStatus.get(session.id)).toBe('idle');
+
+      // Verify: stall tracking should be cleaned up
+      expect((monitor as any).stallNotified.has(session.id)).toBe(false);
+      expect((monitor as any).stateSince.has(session.id)).toBe(false);
+
+      // Verify: idle notification should be marked
+      expect((monitor as any).idleNotified.has(session.id)).toBe(true);
+
+      // Verify: channel notification should have been sent
+      expect(deps.mockChannels.statusChange).toHaveBeenCalled();
+      const payload = deps.mockChannels.statusChange.mock.calls[0][0] as SessionEventPayload;
+      expect(payload.event).toBe('status.stopped');
+    } finally {
+      process.env.HOME = originalHomedir;
+    }
+  });
+
+  it('does not re-process the same Stop signal', async () => {
+    const aegisDir = join(signalDir, '.aegis');
+    await mkdir(aegisDir, { recursive: true });
+    const signalFile = join(aegisDir, 'stop_signals.json');
+    const timestamp = Date.now();
+
+    await writeFile(signalFile, JSON.stringify({
+      [session.claudeSessionId!]: {
+        event: 'Stop',
+        timestamp,
+      },
+    }));
+
+    const originalHomedir = process.env.HOME;
+    process.env.HOME = signalDir;
+
+    try {
+      // First check — should process the signal
+      await (monitor as any).checkStopSignals();
+      expect(session.status).toBe('idle');
+      const callCount = deps.mockChannels.statusChange.mock.calls.length;
+
+      // Second check — should NOT re-process
+      await (monitor as any).checkStopSignals();
+      expect(deps.mockChannels.statusChange.mock.calls.length).toBe(callCount);
+    } finally {
+      process.env.HOME = originalHomedir;
+    }
+  });
+});

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -582,6 +582,16 @@ export class SessionMonitor {
               signalTimestamp: signal.timestamp ?? null,
             },
           });
+          // Issue #2538: Update session status to idle so the API returns
+          // the correct state and the monitor doesn't re-broadcast stale
+          // working status on the next poll cycle.
+          session.status = 'idle';
+          this.lastStatus.set(session.id, 'idle');
+          // Clean up stall tracking so the session doesn't appear stalled
+          this.stallDeleteAll(session.id);
+          this.stateSince.delete(session.id);
+          this.idleNotified.add(session.id);
+
           await this.channels.statusChange(
             this.makePayload('status.stopped', session,
               'Claude Code session ended normally'),

--- a/src/session.ts
+++ b/src/session.ts
@@ -1036,7 +1036,12 @@ export class SessionManager {
       case 'Stop':
       case 'TaskCompleted':
       case 'SessionEnd':
+        // Issue #2538: CC finished work — transition to idle immediately
+        // so the API returns the correct status instead of staying "working".
+        session.status = 'idle';
+        break;
       case 'TeammateIdle':
+        // Informational — a teammate went idle, not this session
         break;
       case 'PreToolUse':
         // Issue #2520: Track tool use count for premature termination detection


### PR DESCRIPTION
## Summary

Fixes #2538 — Session status stays `working` indefinitely after CC completes a task and returns to the prompt.

### Root Cause

`SessionManager.updateStatusFromHook()` had a no-op fallthrough for `Stop`, `TaskCompleted`, and `SessionEnd` hook events. The stop hook fired (confirmed by `lastHookAt` timestamp) but never updated the session status, leaving it stuck at `working` until the stall timeout.

### Changes

1. **`src/session.ts`** — `updateStatusFromHook()` now explicitly sets `session.status = 'idle'` for `Stop`, `TaskCompleted`, and `SessionEnd` events
2. **`src/monitor.ts`** — `checkStopSignals()` syncs internal tracking (`lastStatus`, `stallDeleteAll`, `stateSince`, `idleNotified`) when a Stop signal is processed, preventing stale `working` status from being re-broadcast
3. **`src/__tests__/session.test.ts`** — Updated existing test + added 4 new tests covering all transition cases
4. **`src/__tests__/stop-hook-idle-2538.test.ts`** — New dedicated test file for stop signal to idle integration flow (2 tests: signal processing + idempotency)

### Verification

- **Aegis version:** 0.6.5-preview.3 (develop branch)
- **Commit:** cbbc93b20f9672676c3e9b6d8ab3ae57793fd3c8
- **Session:** f12ad17c-1671-4e94-8b12-3e03eca31bab (via Aegis, interrupted by server crash — fix verified manually)
- **TypeScript:** tsc --noEmit — zero errors
- **Build:** npm run build — success (backend + dashboard)
- **Tests:** 232 files, 3939/3939 passed (11 skipped, 1 skipped file)

```
 Test Files  232 passed | 1 skipped (233)
      Tests  3939 passed | 11 skipped (3950)
```
