### PR TITLE
docs: cover /v1/keys aliases and label param for session create

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -97,6 +97,9 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `DELETE` | `/v1/auth/keys/{id}` | Bearer | Revoke API key |
 | `POST` | `/v1/auth/keys/{id}/rotate` | Bearer | Rotate API key |
 | `POST` | `/v1/auth/sse-token` | Bearer | Generate SSE auth token |
+| `POST` | `/v1/keys` | Bearer | Create API key (alias) |
+| `GET` | `/v1/keys` | Bearer | List API keys (alias) |
+| `DELETE` | `/v1/keys/{id}` | Bearer | Revoke API key (alias) |
 
 ## Templates
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -108,6 +108,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | no | Session name (defaults to auto-generated) |
+| `label` | string | no | Alias for `name`. When both `name` and `label` are provided, `name` takes precedence. Accepted for backward compatibility with dashboard and CLI callers. |
 | `workDir` | string | yes | Absolute path to working directory (must exist) |
 | `prompt` | string | no | Initial prompt to send after boot |
 | `prd` | string | no | Product Requirements Document — full PRD text for the session |
@@ -815,6 +816,25 @@ curl -X POST http://127.0.0.1:9100/v1/sessions/abc123/reject \
 ---
 
 ## Auth Management Endpoints
+
+### Convenience Aliases: `/v1/keys`
+
+The following `/v1/keys` routes are convenience aliases for `/v1/auth/keys` with identical behavior, auth guards, and responses:
+
+| Alias | Canonical | Method |
+|---|---|---|
+| `/v1/keys` | `/v1/auth/keys` | `GET` (list), `POST` (create) |
+| `/v1/keys/:id` | `/v1/auth/keys/:id` | `DELETE` (revoke) |
+
+```bash
+# These are equivalent:
+curl -X POST http://localhost:9100/v1/keys -H "Content-Type: application/json" -d '{"name": "ci-bot", "role": "operator"}'
+curl -X POST http://localhost:9100/v1/auth/keys -H "Content-Type: application/json" -d '{"name": "ci-bot", "role": "operator"}'
+```
+
+> The canonical paths (`/v1/auth/keys`) remain the primary documentation reference. Use `/v1/keys` when brevity is preferred.
+
+---
 
 ### Create API Key
 


### PR DESCRIPTION
## Summary

Documents two recently merged features:

1. **`/v1/keys` convenience aliases** (#2555) — GET, POST, DELETE on `/v1/keys` now work as aliases for `/v1/auth/keys`
2. **`label` parameter** (#2554) — `POST /v1/sessions` now accepts `label` as an alias for `name`

## Changes
- **api-reference.md**: Added `/v1/keys` alias section under Auth Management; added `label` to Create Session parameters table
- **api-quick-ref.md**: Added 3 `/v1/keys` alias routes to Authentication table

## Verification
- Verified against merged code in `src/routes/auth.ts` and `src/routes/sessions.ts`
- Parameters match the actual Zod schemas and OpenAPI definitions

Closes #2555, #2554