### PR TITLE
fix(metrics): count messages and tool calls from JSONL events

### DIFF
--- a/src/__tests__/metrics-message-toolcall-2536.test.ts
+++ b/src/__tests__/metrics-message-toolcall-2536.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Issue #2536: Verify per-session metrics track message and toolCall counts
+ * from JSONL watcher events.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MetricsCollector } from '../metrics.js';
+
+describe('Issue #2536: per-session message/toolCall counting', () => {
+  it('messageReceived increments per-session message count', () => {
+    const metrics = new MetricsCollector('/tmp/test-metrics-2536.json');
+    metrics.sessionCreated('sess-1');
+    metrics.messageReceived('sess-1');
+    metrics.messageReceived('sess-1');
+    metrics.messageReceived('sess-1');
+
+    const m = metrics.getSessionMetrics('sess-1');
+    expect(m).not.toBeNull();
+    expect(m!.messages).toBe(3);
+    expect(m!.toolCalls).toBe(0);
+  });
+
+  it('toolCallReceived increments per-session toolCall count', () => {
+    const metrics = new MetricsCollector('/tmp/test-metrics-2536.json');
+    metrics.sessionCreated('sess-1');
+    metrics.messageReceived('sess-1');
+    metrics.messageReceived('sess-1');
+    metrics.toolCallReceived('sess-1');
+    metrics.toolCallReceived('sess-1');
+
+    const m = metrics.getSessionMetrics('sess-1');
+    expect(m).not.toBeNull();
+    expect(m!.messages).toBe(2);
+    expect(m!.toolCalls).toBe(2);
+  });
+
+  it('counts are independent across sessions', () => {
+    const metrics = new MetricsCollector('/tmp/test-metrics-2536.json');
+    metrics.sessionCreated('s1');
+    metrics.sessionCreated('s2');
+
+    metrics.messageReceived('s1');
+    metrics.messageReceived('s1');
+    metrics.toolCallReceived('s1');
+
+    metrics.messageReceived('s2');
+    metrics.toolCallReceived('s2');
+    metrics.toolCallReceived('s2');
+    metrics.toolCallReceived('s2');
+
+    const m1 = metrics.getSessionMetrics('s1');
+    const m2 = metrics.getSessionMetrics('s2');
+
+    expect(m1!.messages).toBe(2);
+    expect(m1!.toolCalls).toBe(1);
+    expect(m2!.messages).toBe(1);
+    expect(m2!.toolCalls).toBe(3);
+  });
+
+  it('getSessionMetrics returns null for unknown session', () => {
+    const metrics = new MetricsCollector('/tmp/test-metrics-2536.json');
+    expect(metrics.getSessionMetrics('nonexistent')).toBeNull();
+  });
+
+  it('messageReceived/toolCallReceived are no-ops for unknown session', () => {
+    const metrics = new MetricsCollector('/tmp/test-metrics-2536.json');
+    // Should not throw
+    metrics.messageReceived('unknown');
+    metrics.toolCallReceived('unknown');
+    expect(metrics.getSessionMetrics('unknown')).toBeNull();
+  });
+
+  it('global counters also increment alongside per-session', () => {
+    const metrics = new MetricsCollector('/tmp/test-metrics-2536.json');
+    metrics.sessionCreated('s1');
+
+    metrics.messageReceived('s1');
+    metrics.messageReceived('s1');
+    metrics.toolCallReceived('s1');
+
+    const global = metrics.getGlobalMetrics(1);
+    // getGlobalMetrics returns avg_messages_per_session
+    expect(global.sessions.avg_messages_per_session).toBe(2);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -934,12 +934,20 @@ async function main(): Promise<void> {
   await container.start(['tmuxManager', 'sessionManager', 'authManager', 'channelManager']);
 
   // Issue #488: Accumulate token usage from JSONL events into per-session metrics.
+  // Issue #2536: Also count messages and tool calls from JSONL events.
   jsonlWatcher.onEntries((event) => {
-    const { tokenUsageDelta } = event;
-    if (tokenUsageDelta.inputTokens > 0 || tokenUsageDelta.outputTokens > 0) {
-      if (metrics) {
+    if (metrics) {
+      const { tokenUsageDelta } = event;
+      if (tokenUsageDelta.inputTokens > 0 || tokenUsageDelta.outputTokens > 0) {
         const model = sessions.getSession(event.sessionId)?.model;
         metrics.recordTokenUsage(event.sessionId, tokenUsageDelta, model);
+      }
+      // Issue #2536: Count messages and tool calls from parsed entries.
+      for (const msg of event.messages) {
+        metrics.messageReceived(event.sessionId);
+        if (msg.contentType === 'tool_use') {
+          metrics.toolCallReceived(event.sessionId);
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary

- Per-session `/v1/sessions/:id/metrics` endpoint returned `messages: 0` and `toolCalls: 0` even when the session had transcript entries with messages and tool calls
- Root cause: `MetricsCollector.messageReceived()` and `toolCallReceived()` were never called in the runtime code path — only in tests
- Fix: count messages and tool calls in the `jsonlWatcher.onEntries` callback alongside the existing token usage recording

## Changes

- **`src/server.ts`**: In the JSONL watcher `onEntries` callback, iterate `event.messages` and call `metrics.messageReceived()` for each entry + `metrics.toolCallReceived()` for `tool_use` entries
- **`src/__tests__/metrics-message-toolcall-2536.test.ts`**: 6 new tests verifying per-session message/toolCall counting, cross-session independence, unknown session handling, and global counter increments

## Aegis version
**Developed with:** v0.6.5-preview.3

## Verification

```
$ npx tsc --noEmit  # pass (no output)
$ npm run build     # pass
$ npx vitest run src/__tests__/metrics-message-toolcall-2536.test.ts
  Test Files  1 passed (1)
       Tests  6 passed (6)
$ npx vitest run src/__tests__/metrics.test.ts src/__tests__/session-created-metric-625.test.ts
  Test Files  2 passed (2)
       Tests  38 passed (38)
```

Closes #2536

Generated by Hephaestus (Aegis dev agent)