### PR TITLE
test: add ACP child process lifecycle probe

### DIFF
--- a/docs/spikes/acp-010-child-process-lifecycle.md
+++ b/docs/spikes/acp-010-child-process-lifecycle.md
@@ -1,0 +1,180 @@
+# ACP-010 Child Process Lifecycle Spike
+
+Issue: [#2578](https://github.com/OneStepAt4time/aegis/issues/2578)
+
+## Verdict
+
+**Green for ACP-010.** Aegis can run `@agentclientprotocol/claude-agent-acp` as an Aegis-controlled child process on Windows, exchange ACP JSON-RPC over stdio, create/resume/close sessions, initiate a real Claude API-backed prompt turn, cancel an in-flight prompt, and shut the child process down cleanly.
+
+This is a lifecycle spike only. It does not implement `AcpBackend`, event normalization, approvals, raw terminal parity, token/cost accounting, or BYO LLM matrices.
+
+## Package and CLI shape
+
+Observed package metadata from npm:
+
+- Package: `@agentclientprotocol/claude-agent-acp`
+- Version tested: `0.32.0`
+- Binary: `claude-agent-acp` -> `dist/index.js`
+- Main export: `dist/lib.js`
+- Runtime dependencies: `@agentclientprotocol/sdk`, `@anthropic-ai/claude-agent-sdk`, `zod`
+
+The binary is an ACP stdio server by default. It does not behave like a traditional `--help` CLI; starting it without ACP input leaves it waiting for newline-delimited JSON-RPC on stdin. When invoked with `--cli`, it passes through to the underlying Claude CLI instead of starting ACP.
+
+The package redirects `console.*` output to stderr before starting ACP so stdout remains reserved for protocol frames.
+
+## Durable spike artifacts
+
+- `src/acp-lifecycle-probe.ts` — reusable NDJSON JSON-RPC lifecycle harness.
+- `scripts/acp-lifecycle-probe.mjs` — built-artifact runner for real package probes.
+- `src/__tests__/acp-lifecycle-probe.test.ts` — deterministic lifecycle tests.
+- `src/__tests__/fixtures/fake-acp-agent.mjs` — deterministic ACP child-process fixture.
+
+The harness intentionally validates that stdout contains only ACP JSON-RPC messages. Any non-JSON stdout line is a protocol error.
+
+## Operational contract for M2
+
+### Binary resolution
+
+Resolution order for Aegis should be:
+
+1. Explicit command supplied by the caller or future config.
+2. `AEGIS_ACP_BIN` override.
+3. Local package binary from `node_modules/.bin/claude-agent-acp`.
+4. Development fallback: `npm exec --yes --package=@agentclientprotocol/claude-agent-acp -- claude-agent-acp`.
+
+For shipped Aegis, the package should become a dependency in the later dependency issue, so production should normally use the local package binary. The npm-exec fallback is useful for spikes and local diagnostics, not for production startup latency.
+
+### Windows process behavior
+
+On this Windows host, spawning `npm.cmd` directly with `child_process.spawn()` failed with `spawn EINVAL`. The probe wraps `.cmd` and `.bat` commands as:
+
+```text
+cmd.exe /d /s /c "<script>.cmd" <args>
+```
+
+This is required for `npm.cmd`, `node_modules\.bin\claude-agent-acp.cmd`, and `.cmd` values supplied through `AEGIS_ACP_BIN`. Native `.exe` commands do not need wrapping.
+
+Windows paths with backslashes and spaces are preserved by quoting the command portion. Later implementation should keep shell execution disabled and use explicit argv construction as the probe does.
+
+### Spawn environment
+
+The child needs an environment close to the Aegis process environment:
+
+- `PATH` so `node`, `npm`, Claude Code, and MCP server commands resolve.
+- user home variables (`USERPROFILE` / `HOME`) for Claude credentials and settings.
+- BYO LLM and Anthropic-compatible provider variables when operators configure them.
+- `NO_COLOR=1` is safe and keeps diagnostics deterministic.
+
+Do not log raw environment variables. Redact auth headers, API keys, tokens, and local settings values in probe output and Aegis diagnostics.
+
+The package also loads Claude Code settings from the session cwd through its settings manager. This spike used the ACP worktree as `session/new.cwd`; it did not copy or print `D:\aegis\.claude\settings.local.json`.
+
+### Transport framing
+
+ACP stdio uses newline-delimited JSON-RPC, not LSP `Content-Length` framing.
+
+Contract:
+
+- client writes one JSON-RPC request or notification per line to stdin;
+- agent writes one JSON-RPC response, request, or notification per line to stdout;
+- neither side may write non-protocol text to stdout;
+- agent logs may appear on stderr and must be captured separately with byte limits.
+
+The probe treats malformed stdout as fatal because otherwise Aegis could desynchronize its protocol parser.
+
+### Initialize and session handshake
+
+Minimum startup sequence:
+
+1. Spawn child process.
+2. Send `initialize` with protocol version `1`, client capabilities, and client info.
+3. Read `agentCapabilities`, `agentInfo`, and `authMethods`.
+4. Send `session/new` with absolute `cwd` and `mcpServers`.
+5. Store the returned `sessionId`.
+6. Optionally call `session/resume` for an active session ID.
+7. Send `session/prompt` turns.
+8. On shutdown, call `session/close` when supported, close stdin, and wait for process exit.
+
+Observed capabilities from version `0.32.0` include `loadSession`, prompt image/embedded-context support, HTTP/SSE MCP support, and session `fork`, `list`, `resume`, and `close` capabilities.
+
+When `session/resume` is called, the response can contain session configuration state such as modes and model selectors. Treat those values as operational state and avoid logging them verbatim unless redacted.
+
+### Client-side method handling
+
+If Aegis advertises client capabilities such as terminal or filesystem access, it must implement the corresponding ACP client methods. For this spike, the real probes used minimal client capabilities, so the agent did not rely on terminal or filesystem callbacks.
+
+Later M2 implementation needs a real client-side request dispatcher for at least:
+
+- `session/request_permission`;
+- `terminal/*` if terminal capability is advertised;
+- `fs/*` if filesystem capability is advertised;
+- extension notifications and requests that Aegis elects to support.
+
+Unknown client requests should receive explicit JSON-RPC errors, not hang silently.
+
+### Prompt, cancellation, and close
+
+A real prompt turn completed successfully with `stopReason: "end_turn"`, proving a Claude API-backed call can be initiated from the child process.
+
+A real cancellation probe sent `session/cancel` after the first agent message update and received `stopReason: "cancelled"`. This confirms the package maps cancellation to the underlying Claude Agent SDK interrupt path for an active prompt.
+
+`session/close` completed successfully after create/resume/prompt flows. Closing stdin after `session/close` caused the package to exit with code `0`.
+
+### Exit and error handling
+
+Operational rules for M2:
+
+- Treat child `error` events as startup failures and surface the OS error code.
+- Treat JSON-RPC error responses as method failures with method name, id, and redacted error data.
+- Treat unmatched response ids as protocol errors.
+- On shutdown, call `session/close` when possible, close stdin, and wait for exit.
+- If the child does not exit after stdin closes, send `SIGTERM`; if still alive after a short grace period, send `SIGKILL`.
+- Capture stderr separately and bound memory usage.
+
+The current package exits cleanly when the ACP connection closes and also disposes sessions on `SIGTERM` / `SIGINT`.
+
+### Timeout and backoff needs
+
+Recommended initial values for M2:
+
+- spawn/initialize timeout: 15-30 seconds;
+- `session/new` and `session/resume`: 30 seconds;
+- `session/prompt`: caller-configurable, defaulting to a larger turn timeout;
+- shutdown grace after stdin close: about 2 seconds before termination;
+- restart backoff: exponential with jitter, capped, and reset after a stable run.
+
+Do not silently retry protocol errors. Restart only after classifying the child as crashed, hung, or intentionally stopped.
+
+## Validation evidence
+
+Commands run in this worktree:
+
+```text
+npm test -- src/__tests__/process-utils.test.ts
+npm test -- src/__tests__/acp-lifecycle-probe.test.ts
+npx tsc --noEmit
+npm run build
+node scripts/acp-lifecycle-probe.mjs --no-prompt --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 30000
+node scripts/acp-lifecycle-probe.mjs --prompt "Reply with exactly: AEGIS_ACP_PROBE_OK" --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 120000
+node scripts/acp-lifecycle-probe.mjs --prompt "Count from 1 to 100, one number per line." --cancel-after-first-update --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 120000
+node scripts/acp-lifecycle-probe.mjs --no-prompt --resume --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 30000
+```
+
+Results:
+
+- deterministic fixture tests passed;
+- TypeScript type-check passed;
+- build passed;
+- real package initialize/new/close passed with exit code `0`;
+- real prompt passed with `stopReason: "end_turn"`;
+- real cancellation passed with `stopReason: "cancelled"`;
+- real resume passed and returned session configuration state;
+- stderr byte count was `0` in the real successful probes.
+
+## Follow-up work unblocked
+
+- ACP-011 can use the harness to capture event stream fixtures.
+- ACP-012 can add explicit `session/request_permission` request/response handling.
+- ACP-013 can advertise and implement terminal client methods for raw terminal parity.
+- ACP-014 can run the same lifecycle probe with BYO LLM environment matrices.
+- ACP-040 should add the package as an Aegis dependency and remove production reliance on npm-exec fallback.

--- a/scripts/acp-lifecycle-probe.mjs
+++ b/scripts/acp-lifecycle-probe.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+
+const DEFAULT_PROMPT = 'Reply with exactly: AEGIS_ACP_PROBE_OK';
+
+function parseArgs(argv) {
+  const options = {
+    cwd: process.cwd(),
+    sessionCwd: process.cwd(),
+    prompt: undefined,
+    command: undefined,
+    timeoutMs: undefined,
+    resumeSession: false,
+    closeSession: true,
+    cancelAfterFirstUpdate: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      index += 1;
+      const value = argv[index];
+      if (!value) throw new Error(`${arg} requires a value`);
+      return value;
+    };
+
+    switch (arg) {
+      case '--cwd':
+        options.cwd = next();
+        break;
+      case '--session-cwd':
+        options.sessionCwd = next();
+        break;
+      case '--prompt':
+        options.prompt = next();
+        break;
+      case '--bin':
+        options.command = next();
+        break;
+      case '--timeout-ms':
+        options.timeoutMs = Number.parseInt(next(), 10);
+        if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+          throw new Error('--timeout-ms must be a positive integer');
+        }
+        break;
+      case '--no-prompt':
+        options.prompt = null;
+        break;
+      case '--resume':
+        options.resumeSession = true;
+        break;
+      case '--no-close':
+        options.closeSession = false;
+        break;
+      case '--cancel-after-first-update':
+        options.cancelAfterFirstUpdate = true;
+        break;
+      case '--help':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/acp-lifecycle-probe.mjs [options]
+
+Runs the built ACP lifecycle probe against @agentclientprotocol/claude-agent-acp.
+Build first with: npm run build
+
+Options:
+  --bin <path>                    ACP binary override. Defaults to AEGIS_ACP_BIN, local package bin, then npm exec.
+  --cwd <path>                    Child process working directory. Default: current directory.
+  --session-cwd <path>            ACP session/new cwd. Default: current directory.
+  --prompt <text>                 Prompt to send after session/new. Default: ${DEFAULT_PROMPT}
+  --no-prompt                     Stop after initialize and session/new.
+  --resume                        Call session/resume after session/new.
+  --no-close                      Do not call session/close before shutdown.
+  --cancel-after-first-update     Send session/cancel after the first agent message update.
+  --timeout-ms <number>           Per-request timeout. Default: probe module default.
+  --help                          Show this help.
+
+The summary intentionally omits environment variables and raw stderr to avoid leaking credentials.`);
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  const { resolveAcpCommand, runAcpLifecycleProbe } =
+    await import('../dist/acp-lifecycle-probe.js');
+  const resolvedCommand = parsed.command
+    ? resolveAcpCommand({ explicitCommand: parsed.command, cwd: parsed.cwd })
+    : undefined;
+  const result = await runAcpLifecycleProbe({
+    resolvedCommand,
+    cwd: parsed.cwd,
+    sessionCwd: parsed.sessionCwd,
+    timeoutMs: parsed.timeoutMs,
+    prompt: parsed.prompt === null ? undefined : (parsed.prompt ?? DEFAULT_PROMPT),
+    resumeSession: parsed.resumeSession,
+    closeSession: parsed.closeSession,
+    cancelAfterFirstUpdate: parsed.cancelAfterFirstUpdate,
+  });
+
+  const summary = {
+    command: {
+      source: result.command.source,
+      command: result.command.command,
+      args: result.command.args,
+    },
+    initialize: result.initialize.result,
+    sessionId: result.sessionId,
+    resume: result.resume
+      ? {
+          received: true,
+          resultKeys: Object.keys(result.resume.result),
+        }
+      : undefined,
+    prompt: result.prompt?.result,
+    close: result.close?.result,
+    cancelSent: result.cancelSent,
+    notificationMethods: result.notifications.map(message => message.method),
+    stderrBytes: Buffer.byteLength(result.stderr, 'utf8'),
+    exit: result.exit,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch(error => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`ACP lifecycle probe failed: ${message}`);
+  process.exit(1);
+});

--- a/src/__tests__/acp-lifecycle-probe.test.ts
+++ b/src/__tests__/acp-lifecycle-probe.test.ts
@@ -1,0 +1,140 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AcpProtocolError,
+  resolveAcpCommand,
+  runAcpLifecycleProbe,
+} from '../acp-lifecycle-probe.js';
+
+const fixturePath = path.join(process.cwd(), 'src', '__tests__', 'fixtures', 'fake-acp-agent.mjs');
+
+function nodeFixtureOptions(extraEnv: Record<string, string> = {}) {
+  return {
+    command: process.execPath,
+    args: [fixturePath],
+    cwd: process.cwd(),
+    sessionCwd: process.cwd(),
+    env: extraEnv,
+    timeoutMs: 2_000,
+  };
+}
+
+describe('acp lifecycle probe', () => {
+  it('initializes, creates, prompts, closes, and drains an NDJSON ACP child process', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'hello fixture',
+      closeSession: true,
+    });
+
+    expect(result.initialize.result.protocolVersion).toBe(1);
+    expect(result.initialize.result.agentInfo.name).toBe('@agentclientprotocol/claude-agent-acp');
+    expect(result.sessionId).toBe('fixture-session');
+    expect(result.prompt?.result.stopReason).toBe('end_turn');
+    expect(result.close?.result).toEqual({});
+    expect(result.notifications.some(message => message.method === 'session/update')).toBe(true);
+    expect(result.stderr).toContain('fake claude-agent-acp fixture ready');
+    expect(result.exit.code).toBe(0);
+  });
+
+  it('sends session/cancel and observes a cancelled prompt response', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'wait-for-cancel',
+      cancelAfterFirstUpdate: true,
+    });
+
+    expect(result.cancelSent).toBe(true);
+    expect(result.prompt?.result.stopReason).toBe('cancelled');
+    expect(result.exit.code).toBe(0);
+  });
+
+  it('can resume the created ACP session before shutdown', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      resumeSession: true,
+    });
+
+    expect(result.resume?.result).toEqual({});
+    expect(result.exit.code).toBe(0);
+  });
+
+  it('rejects non-JSON stdout because ACP stdout is reserved for framed protocol messages', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions({ FAKE_ACP_MODE: 'noisy-stdout' }),
+        prompt: 'hello fixture',
+      })
+    ).rejects.toBeInstanceOf(AcpProtocolError);
+  });
+
+  it('bounds captured stderr by UTF-8 bytes for multi-byte output', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions({ FAKE_ACP_MODE: 'unicode-stderr' }),
+    });
+
+    expect(Buffer.byteLength(result.stderr, 'utf8')).toBeLessThanOrEqual(64 * 1024);
+    expect(result.exit.code).toBe(0);
+  });
+
+  it('resolves explicit, environment, local package, and npm fallback commands', () => {
+    expect(
+      resolveAcpCommand({
+        explicitCommand: 'D:\\tools\\claude-agent-acp.cmd',
+        platform: 'win32',
+        env: {},
+        cwd: 'D:\\repo',
+        fileExists: () => false,
+      })
+    ).toEqual({
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', '"D:\\tools\\claude-agent-acp.cmd"'],
+      source: 'explicit',
+    });
+
+    expect(
+      resolveAcpCommand({
+        platform: 'win32',
+        env: { AEGIS_ACP_BIN: 'C:\\Program Files\\ACP\\claude-agent-acp.cmd' },
+        cwd: 'D:\\repo',
+        fileExists: () => false,
+      })
+    ).toEqual({
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', '"C:\\Program Files\\ACP\\claude-agent-acp.cmd"'],
+      source: 'AEGIS_ACP_BIN',
+    });
+
+    expect(
+      resolveAcpCommand({
+        platform: 'win32',
+        env: {},
+        cwd: 'D:\\repo',
+        fileExists: candidate => candidate.endsWith('node_modules\\.bin\\claude-agent-acp.cmd'),
+      })
+    ).toEqual({
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', '"D:\\repo\\node_modules\\.bin\\claude-agent-acp.cmd"'],
+      source: 'local-package-bin',
+    });
+
+    expect(
+      resolveAcpCommand({
+        platform: 'win32',
+        env: {},
+        cwd: 'D:\\repo',
+        fileExists: () => false,
+      })
+    ).toEqual({
+      command: 'cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        'npm.cmd exec --yes --package=@agentclientprotocol/claude-agent-acp -- claude-agent-acp',
+      ],
+      source: 'npm-exec',
+    });
+  });
+});

--- a/src/__tests__/acp-lifecycle-probe.test.ts
+++ b/src/__tests__/acp-lifecycle-probe.test.ts
@@ -69,6 +69,46 @@ describe('acp lifecycle probe', () => {
     ).rejects.toBeInstanceOf(AcpProtocolError);
   });
 
+  it('classifies child exit before initialize as an ACP child process exit', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions({ FAKE_ACP_MODE: 'exit-before-initialize' }),
+        timeoutMs: 1_000,
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP child process exited before response',
+      details: expect.objectContaining({
+        method: 'initialize',
+        code: 42,
+      }),
+    });
+  });
+
+  it('classifies request timeouts with method and id details', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions({ FAKE_ACP_MODE: 'hang-initialize' }),
+        timeoutMs: 50,
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP request timed out',
+      details: expect.objectContaining({
+        method: 'initialize',
+        id: 1,
+        timeoutMs: 50,
+      }),
+    });
+  });
+
+  it('preserves an explicit empty prompt instead of treating it as no prompt', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: '',
+    });
+
+    expect(result.prompt?.result.stopReason).toBe('empty_prompt_seen');
+  });
+
   it('bounds captured stderr by UTF-8 bytes for multi-byte output', async () => {
     const result = await runAcpLifecycleProbe({
       ...nodeFixtureOptions({ FAKE_ACP_MODE: 'unicode-stderr' }),

--- a/src/__tests__/fixtures/fake-acp-agent.mjs
+++ b/src/__tests__/fixtures/fake-acp-agent.mjs
@@ -9,6 +9,10 @@ if (mode === 'unicode-stderr') {
   process.stderr.write('🐉'.repeat(70_000));
 }
 process.stderr.write('fake claude-agent-acp fixture ready\n');
+if (mode === 'exit-before-initialize') {
+  process.stderr.write('fixture exiting before initialize\n');
+  process.exit(42);
+}
 
 let pendingPrompt = null;
 
@@ -31,6 +35,9 @@ rl.on('line', line => {
   const { id, method, params } = message;
 
   if (method === 'initialize') {
+    if (mode === 'hang-initialize') {
+      return;
+    }
     respond(id, {
       protocolVersion: 1,
       agentCapabilities: {
@@ -90,6 +97,10 @@ rl.on('line', line => {
       },
     });
     const firstText = params.prompt && params.prompt[0] && params.prompt[0].text;
+    if (firstText === '') {
+      respond(id, { stopReason: 'empty_prompt_seen' });
+      return;
+    }
     if (firstText === 'wait-for-cancel') {
       pendingPrompt = { id, sessionId: params.sessionId };
       return;

--- a/src/__tests__/fixtures/fake-acp-agent.mjs
+++ b/src/__tests__/fixtures/fake-acp-agent.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import readline from 'node:readline';
+
+const mode = process.env.FAKE_ACP_MODE ?? 'normal';
+if (mode === 'noisy-stdout') {
+  process.stdout.write('this is not json\n');
+}
+if (mode === 'unicode-stderr') {
+  process.stderr.write('🐉'.repeat(70_000));
+}
+process.stderr.write('fake claude-agent-acp fixture ready\n');
+
+let pendingPrompt = null;
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function respond(id, result) {
+  send({ jsonrpc: '2.0', id, result });
+}
+
+function error(id, code, message) {
+  send({ jsonrpc: '2.0', id, error: { code, message } });
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', line => {
+  if (!line.trim()) return;
+  const message = JSON.parse(line);
+  const { id, method, params } = message;
+
+  if (method === 'initialize') {
+    respond(id, {
+      protocolVersion: 1,
+      agentCapabilities: {
+        loadSession: true,
+        promptCapabilities: { image: true, embeddedContext: true },
+        mcpCapabilities: { http: true, sse: true },
+        sessionCapabilities: { close: {}, resume: {}, list: {} },
+      },
+      agentInfo: {
+        name: '@agentclientprotocol/claude-agent-acp',
+        title: 'Fake Claude Agent',
+        version: '0.0.0-fixture',
+      },
+      authMethods: [],
+    });
+    return;
+  }
+
+  if (method === 'session/new') {
+    if (!params || typeof params.cwd !== 'string') {
+      error(id, -32602, 'cwd is required');
+      return;
+    }
+    respond(id, { sessionId: 'fixture-session' });
+    setImmediate(() =>
+      send({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'fixture-session',
+          update: { sessionUpdate: 'available_commands_update', commands: [] },
+        },
+      })
+    );
+    return;
+  }
+
+  if (method === 'session/resume') {
+    if (!params || params.sessionId !== 'fixture-session') {
+      error(id, -32602, 'known sessionId is required');
+      return;
+    }
+    respond(id, {});
+    return;
+  }
+
+  if (method === 'session/prompt') {
+    send({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'fixture response' },
+        },
+      },
+    });
+    const firstText = params.prompt && params.prompt[0] && params.prompt[0].text;
+    if (firstText === 'wait-for-cancel') {
+      pendingPrompt = { id, sessionId: params.sessionId };
+      return;
+    }
+    respond(id, { stopReason: 'end_turn' });
+    return;
+  }
+
+  if (method === 'session/cancel') {
+    if (pendingPrompt) {
+      respond(pendingPrompt.id, { stopReason: 'cancelled' });
+      pendingPrompt = null;
+    }
+    return;
+  }
+
+  if (method === 'session/close') {
+    respond(id, {});
+    return;
+  }
+
+  if (id !== undefined) {
+    error(id, -32601, `Unknown method ${method}`);
+  }
+});
+
+rl.on('close', () => process.exit(0));

--- a/src/acp-lifecycle-probe.ts
+++ b/src/acp-lifecycle-probe.ts
@@ -1,0 +1,640 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const EXIT_TIMEOUT_MS = 2_000;
+const STDERR_LIMIT_BYTES = 64 * 1024;
+
+export type AcpCommandSource = 'explicit' | 'AEGIS_ACP_BIN' | 'local-package-bin' | 'npm-exec';
+
+type Platform = NodeJS.Platform;
+type JsonObject = Record<string, unknown>;
+
+type FileExists = (candidate: string) => boolean;
+
+export interface ResolvedAcpCommand {
+  command: string;
+  args: string[];
+  source: AcpCommandSource;
+}
+
+export interface ResolveAcpCommandOptions {
+  explicitCommand?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  platform?: Platform;
+  fileExists?: FileExists;
+}
+
+export interface AcpAgentInfo {
+  name: string;
+  title?: string;
+  version?: string;
+}
+
+export interface AcpInitializeResult {
+  protocolVersion: number;
+  agentCapabilities: JsonObject;
+  agentInfo: AcpAgentInfo;
+  authMethods: unknown[];
+}
+
+export interface AcpNewSessionResult {
+  sessionId: string;
+}
+
+export interface AcpPromptResult {
+  stopReason: string;
+}
+
+export interface JsonRpcSuccess<T> {
+  jsonrpc: '2.0';
+  id: number;
+  result: T;
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: JsonObject;
+}
+
+export interface AcpLifecycleProbeOptions {
+  resolvedCommand?: ResolvedAcpCommand;
+  command?: string;
+  args?: readonly string[];
+  cwd: string;
+  sessionCwd?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+  prompt?: string;
+  resumeSession?: boolean;
+  closeSession?: boolean;
+  cancelAfterFirstUpdate?: boolean;
+  clientCapabilities?: JsonObject;
+}
+
+export interface AcpLifecycleProbeResult {
+  command: ResolvedAcpCommand;
+  initialize: JsonRpcSuccess<AcpInitializeResult>;
+  newSession: JsonRpcSuccess<AcpNewSessionResult>;
+  sessionId: string;
+  resume?: JsonRpcSuccess<JsonObject>;
+  prompt?: JsonRpcSuccess<AcpPromptResult>;
+  close?: JsonRpcSuccess<JsonObject>;
+  notifications: JsonRpcNotification[];
+  stderr: string;
+  cancelSent: boolean;
+  exit: {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  };
+}
+
+interface PendingRequest {
+  method: string;
+  resolve: (message: JsonRpcSuccess<unknown>) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export class AcpProtocolError extends Error {
+  readonly details: JsonObject;
+
+  constructor(message: string, details: JsonObject = {}) {
+    super(message);
+    this.name = 'AcpProtocolError';
+    this.details = details;
+  }
+}
+
+export function resolveAcpCommand(options: ResolveAcpCommandOptions = {}): ResolvedAcpCommand {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const cwd = options.cwd ?? process.cwd();
+  const fileExists = options.fileExists ?? existsSync;
+  const pathTools = platform === 'win32' ? path.win32 : path.posix;
+
+  if (options.explicitCommand && options.explicitCommand.trim() !== '') {
+    return toSpawnableCommand(options.explicitCommand, [], 'explicit', platform);
+  }
+
+  const envCommand = env.AEGIS_ACP_BIN;
+  if (envCommand && envCommand.trim() !== '') {
+    return toSpawnableCommand(envCommand, [], 'AEGIS_ACP_BIN', platform);
+  }
+
+  const packageBinName = platform === 'win32' ? 'claude-agent-acp.cmd' : 'claude-agent-acp';
+  const packageBin = pathTools.join(cwd, 'node_modules', '.bin', packageBinName);
+  if (fileExists(packageBin)) {
+    return toSpawnableCommand(packageBin, [], 'local-package-bin', platform);
+  }
+
+  return toSpawnableCommand(
+    platform === 'win32' ? 'npm.cmd' : 'npm',
+    ['exec', '--yes', '--package=@agentclientprotocol/claude-agent-acp', '--', 'claude-agent-acp'],
+    'npm-exec',
+    platform
+  );
+}
+
+function toSpawnableCommand(
+  command: string,
+  args: string[],
+  source: AcpCommandSource,
+  platform: Platform
+): ResolvedAcpCommand {
+  if (platform !== 'win32' || !/\.(cmd|bat)$/i.test(command)) {
+    return { command, args, source };
+  }
+
+  return {
+    command: 'cmd.exe',
+    args: [
+      '/d',
+      '/s',
+      '/c',
+      [quoteWindowsCmdArg(command), ...args.map(quoteWindowsCmdArg)].join(' '),
+    ],
+    source,
+  };
+}
+
+function quoteWindowsCmdArg(value: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
+  return `"${value.replace(/(["^&|<>%])/g, '^$1')}"`;
+}
+
+export async function runAcpLifecycleProbe(
+  options: AcpLifecycleProbeOptions
+): Promise<AcpLifecycleProbeResult> {
+  let resolvedCommand: ResolvedAcpCommand;
+  if (options.resolvedCommand) {
+    resolvedCommand = options.resolvedCommand;
+  } else if (options.command) {
+    resolvedCommand = {
+      command: options.command,
+      args: [...(options.args ?? [])],
+      source: 'explicit',
+    };
+  } else {
+    resolvedCommand = resolveAcpCommand({
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+    });
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const child = spawn(resolvedCommand.command, resolvedCommand.args, {
+    cwd: options.cwd,
+    env: buildSpawnEnv(options.env),
+    stdio: 'pipe',
+    windowsHide: true,
+  });
+
+  const transport = new NdjsonRpcTransport(child, timeoutMs);
+  let sessionId = '';
+  let resumeResult: JsonRpcSuccess<JsonObject> | undefined;
+  let promptResult: JsonRpcSuccess<AcpPromptResult> | undefined;
+  let closeResult: JsonRpcSuccess<JsonObject> | undefined;
+
+  try {
+    const initialize = requireInitializeResponse(
+      await transport.request('initialize', {
+        protocolVersion: 1,
+        clientCapabilities: options.clientCapabilities ?? {},
+        clientInfo: {
+          name: 'aegis-acp-lifecycle-probe',
+          title: 'Aegis ACP Lifecycle Probe',
+          version: '0.0.0-spike',
+        },
+      })
+    );
+
+    const newSession = requireNewSessionResponse(
+      await transport.request('session/new', {
+        cwd: options.sessionCwd ?? options.cwd,
+        mcpServers: [],
+      })
+    );
+    sessionId = newSession.result.sessionId;
+
+    if (options.resumeSession) {
+      resumeResult = requireObjectResponse(
+        await transport.request('session/resume', {
+          sessionId,
+          cwd: options.sessionCwd ?? options.cwd,
+          mcpServers: [],
+        })
+      );
+    }
+
+    if (options.prompt) {
+      if (options.cancelAfterFirstUpdate) {
+        transport.cancelOnNextAgentMessage(sessionId);
+      }
+      promptResult = requirePromptResponse(
+        await transport.request('session/prompt', {
+          sessionId,
+          prompt: [{ type: 'text', text: options.prompt }],
+        })
+      );
+    }
+
+    if (options.closeSession) {
+      closeResult = requireObjectResponse(
+        await transport.request('session/close', {
+          sessionId,
+        })
+      );
+    }
+
+    child.stdin.end();
+    const exit = await transport.waitForExit(EXIT_TIMEOUT_MS);
+
+    return {
+      command: resolvedCommand,
+      initialize,
+      newSession,
+      sessionId,
+      resume: resumeResult,
+      prompt: promptResult,
+      close: closeResult,
+      notifications: transport.notifications,
+      stderr: transport.stderr,
+      cancelSent: transport.cancelSent,
+      exit,
+    };
+  } finally {
+    await transport.dispose();
+  }
+}
+
+function buildSpawnEnv(
+  overrides: Record<string, string | undefined> | undefined
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...overrides,
+    NO_COLOR: overrides?.NO_COLOR ?? process.env.NO_COLOR ?? '1',
+  };
+}
+
+class NdjsonRpcTransport {
+  readonly notifications: JsonRpcNotification[] = [];
+  stderr = '';
+  cancelSent = false;
+
+  private nextId = 1;
+  private stdoutBuffer = '';
+  private readonly pending = new Map<number, PendingRequest>();
+  private protocolFailure: AcpProtocolError | null = null;
+  private cancelOnAgentMessageSessionId: string | null = null;
+  private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+  private exited = false;
+
+  constructor(
+    private readonly child: ChildProcessWithoutNullStreams,
+    private readonly timeoutMs: number
+  ) {
+    this.exitPromise = new Promise(resolve => {
+      child.once('exit', (code, signal) => {
+        this.exited = true;
+        resolve({ code, signal });
+      });
+    });
+
+    child.once('error', error => {
+      this.fail(
+        new AcpProtocolError('ACP child process failed to start', { message: error.message })
+      );
+    });
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => this.handleStdout(chunk));
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      this.stderr = appendLimited(this.stderr, chunk, STDERR_LIMIT_BYTES);
+    });
+  }
+
+  cancelOnNextAgentMessage(sessionId: string): void {
+    this.cancelOnAgentMessageSessionId = sessionId;
+  }
+
+  async request(method: string, params: JsonObject): Promise<JsonRpcSuccess<unknown>> {
+    this.throwIfFailed();
+    const id = this.nextId;
+    this.nextId += 1;
+
+    const response = new Promise<JsonRpcSuccess<unknown>>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new AcpProtocolError('ACP request timed out', { method, id, timeoutMs: this.timeoutMs })
+        );
+      }, this.timeoutMs);
+      this.pending.set(id, { method, resolve, reject, timer });
+    });
+
+    this.write({ jsonrpc: '2.0', id, method, params });
+    return response;
+  }
+
+  async waitForExit(
+    timeoutMs: number
+  ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+    return Promise.race([
+      this.exitPromise,
+      new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((_, reject) => {
+        setTimeout(
+          () => reject(new AcpProtocolError('ACP child process did not exit after stdin closed')),
+          timeoutMs
+        );
+      }),
+    ]);
+  }
+
+  async dispose(): Promise<void> {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(
+        new AcpProtocolError('ACP transport disposed before response', {
+          method: pending.method,
+          id,
+        })
+      );
+    }
+    this.pending.clear();
+
+    if (!this.exited) {
+      if (!this.child.stdin.destroyed) {
+        this.child.stdin.end();
+      }
+      this.child.kill('SIGTERM');
+      await Promise.race([
+        this.exitPromise,
+        new Promise<void>(resolve => {
+          setTimeout(resolve, EXIT_TIMEOUT_MS);
+        }),
+      ]);
+      if (!this.exited) {
+        this.child.kill('SIGKILL');
+      }
+    }
+  }
+
+  private handleStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+
+    while (true) {
+      const newlineIndex = this.stdoutBuffer.indexOf('\n');
+      if (newlineIndex === -1) return;
+
+      const line = this.stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, '');
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line.trim() === '') continue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'unknown JSON parse error';
+        this.fail(new AcpProtocolError('ACP stdout contained a non-JSON line', { line, message }));
+        return;
+      }
+
+      this.handleMessage(parsed);
+    }
+  }
+
+  private handleMessage(message: unknown): void {
+    if (!isJsonObject(message)) {
+      this.fail(new AcpProtocolError('ACP stdout message was not a JSON object', { message }));
+      return;
+    }
+
+    const id = message.id;
+    if (
+      typeof id === 'number' &&
+      (Object.hasOwn(message, 'result') || Object.hasOwn(message, 'error'))
+    ) {
+      this.handleResponse(id, message);
+      return;
+    }
+
+    const method = message.method;
+    if (typeof method !== 'string') {
+      this.fail(
+        new AcpProtocolError('ACP message did not include a method or response id', { message })
+      );
+      return;
+    }
+
+    if (typeof id === 'number') {
+      this.write({
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32601,
+          message: `Client method not implemented by lifecycle probe: ${method}`,
+        },
+      });
+      return;
+    }
+
+    let notification: JsonRpcNotification;
+    try {
+      notification = normalizeNotification(message, method);
+    } catch (error) {
+      const protocolError =
+        error instanceof AcpProtocolError
+          ? error
+          : new AcpProtocolError('ACP notification could not be normalized');
+      this.fail(protocolError);
+      return;
+    }
+    this.notifications.push(notification);
+    if (this.shouldCancelAfterNotification(notification)) {
+      this.write({
+        jsonrpc: '2.0',
+        method: 'session/cancel',
+        params: { sessionId: this.cancelOnAgentMessageSessionId },
+      });
+      this.cancelSent = true;
+      this.cancelOnAgentMessageSessionId = null;
+    }
+  }
+
+  private handleResponse(id: number, message: JsonObject): void {
+    const pending = this.pending.get(id);
+    if (!pending) {
+      this.fail(
+        new AcpProtocolError('ACP response id did not match a pending request', { id, message })
+      );
+      return;
+    }
+
+    clearTimeout(pending.timer);
+    this.pending.delete(id);
+
+    if (Object.hasOwn(message, 'error')) {
+      pending.reject(
+        new AcpProtocolError('ACP request failed', {
+          method: pending.method,
+          id,
+          error: message.error,
+        })
+      );
+      return;
+    }
+
+    pending.resolve({ jsonrpc: '2.0', id, result: message.result });
+  }
+
+  private shouldCancelAfterNotification(notification: JsonRpcNotification): boolean {
+    if (!this.cancelOnAgentMessageSessionId || this.cancelSent) return false;
+    if (notification.method !== 'session/update') return false;
+    const params = notification.params;
+    if (!params || params.sessionId !== this.cancelOnAgentMessageSessionId) return false;
+    const update = params.update;
+    return isJsonObject(update) && update.sessionUpdate === 'agent_message_chunk';
+  }
+
+  private write(message: JsonObject): void {
+    this.throwIfFailed();
+    if (this.child.stdin.destroyed || !this.child.stdin.writable) {
+      throw new AcpProtocolError('ACP stdin is not writable', { message });
+    }
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private fail(error: AcpProtocolError): void {
+    if (this.protocolFailure) return;
+    this.protocolFailure = error;
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(
+        new AcpProtocolError(error.message, { ...error.details, method: pending.method, id })
+      );
+    }
+    this.pending.clear();
+    this.child.kill('SIGTERM');
+  }
+
+  private throwIfFailed(): void {
+    if (this.protocolFailure) throw this.protocolFailure;
+  }
+}
+
+function normalizeNotification(message: JsonObject, method: string): JsonRpcNotification {
+  const params = message.params;
+  if (params !== undefined && !isJsonObject(params)) {
+    throw new AcpProtocolError('ACP notification params must be an object when present', {
+      method,
+      params,
+    });
+  }
+  return params === undefined ? { jsonrpc: '2.0', method } : { jsonrpc: '2.0', method, params };
+}
+
+function requireInitializeResponse(
+  message: JsonRpcSuccess<unknown>
+): JsonRpcSuccess<AcpInitializeResult> {
+  const result = requireObject(message.result, 'initialize result');
+  const agentInfo = requireObject(result.agentInfo, 'initialize agentInfo');
+  return {
+    jsonrpc: '2.0',
+    id: message.id,
+    result: {
+      protocolVersion: requireNumber(result.protocolVersion, 'initialize protocolVersion'),
+      agentCapabilities: requireObject(result.agentCapabilities, 'initialize agentCapabilities'),
+      agentInfo: {
+        name: requireString(agentInfo.name, 'initialize agentInfo.name'),
+        title: optionalString(agentInfo.title, 'initialize agentInfo.title'),
+        version: optionalString(agentInfo.version, 'initialize agentInfo.version'),
+      },
+      authMethods: requireArray(result.authMethods, 'initialize authMethods'),
+    },
+  };
+}
+
+function requireNewSessionResponse(
+  message: JsonRpcSuccess<unknown>
+): JsonRpcSuccess<AcpNewSessionResult> {
+  const result = requireObject(message.result, 'session/new result');
+  return {
+    jsonrpc: '2.0',
+    id: message.id,
+    result: {
+      sessionId: requireString(result.sessionId, 'session/new sessionId'),
+    },
+  };
+}
+
+function requirePromptResponse(message: JsonRpcSuccess<unknown>): JsonRpcSuccess<AcpPromptResult> {
+  const result = requireObject(message.result, 'session/prompt result');
+  return {
+    jsonrpc: '2.0',
+    id: message.id,
+    result: {
+      stopReason: requireString(result.stopReason, 'session/prompt stopReason'),
+    },
+  };
+}
+
+function requireObjectResponse(message: JsonRpcSuccess<unknown>): JsonRpcSuccess<JsonObject> {
+  return {
+    jsonrpc: '2.0',
+    id: message.id,
+    result: requireObject(message.result, 'JSON-RPC result'),
+  };
+}
+
+function requireObject(value: unknown, label: string): JsonObject {
+  if (!isJsonObject(value)) {
+    throw new AcpProtocolError(`${label} must be an object`, { value });
+  }
+  return value;
+}
+
+function requireArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new AcpProtocolError(`${label} must be an array`, { value });
+  }
+  return value;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== 'string') {
+    throw new AcpProtocolError(`${label} must be a string`, { value });
+  }
+  return value;
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireString(value, label);
+}
+
+function requireNumber(value: unknown, label: string): number {
+  if (typeof value !== 'number') {
+    throw new AcpProtocolError(`${label} must be a number`, { value });
+  }
+  return value;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function appendLimited(current: string, chunk: string, limitBytes: number): string {
+  const combined = Buffer.from(`${current}${chunk}`, 'utf8');
+  if (combined.length <= limitBytes) return combined.toString('utf8');
+
+  let start = combined.length - limitBytes;
+  while (start < combined.length && (combined[start] & 0xc0) === 0x80) {
+    start += 1;
+  }
+  return combined.subarray(start).toString('utf8');
+}

--- a/src/acp-lifecycle-probe.ts
+++ b/src/acp-lifecycle-probe.ts
@@ -229,7 +229,7 @@ export async function runAcpLifecycleProbe(
       );
     }
 
-    if (options.prompt) {
+    if (options.prompt !== undefined) {
       if (options.cancelAfterFirstUpdate) {
         transport.cancelOnNextAgentMessage(sessionId);
       }
@@ -300,6 +300,7 @@ class NdjsonRpcTransport {
     this.exitPromise = new Promise(resolve => {
       child.once('exit', (code, signal) => {
         this.exited = true;
+        this.failPendingOnExit(code, signal);
         resolve({ code, signal });
       });
     });
@@ -380,6 +381,7 @@ class NdjsonRpcTransport {
       ]);
       if (!this.exited) {
         this.child.kill('SIGKILL');
+        await this.waitForExit(EXIT_TIMEOUT_MS);
       }
     }
   }
@@ -520,6 +522,23 @@ class NdjsonRpcTransport {
     }
     this.pending.clear();
     this.child.kill('SIGTERM');
+  }
+
+  private failPendingOnExit(code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.protocolFailure || this.pending.size === 0) return;
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(
+        new AcpProtocolError('ACP child process exited before response', {
+          method: pending.method,
+          id,
+          code,
+          signal,
+          stderrBytes: Buffer.byteLength(this.stderr, 'utf8'),
+        })
+      );
+    }
+    this.pending.clear();
   }
 
   private throwIfFailed(): void {


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1 (local `/v1/health` returned `status: ok` but no `version` field)

## Scope
Closes #2578.

Focused ACP-010 M0 spike:
- Adds a reusable NDJSON ACP child-process lifecycle probe and deterministic fake ACP fixture.
- Documents the operational contract for later M2 `AcpBackend` work.
- Captures binary resolution, spawn environment, initialize/session handshake, stdout/stderr framing, exit/error handling, cancellation, timeout/backoff needs, Windows path behavior, and real Claude API-call feasibility.

Out of scope: full `AcpBackend`, tmux removal, approvals parity, terminal parity, BYO LLM matrix, token/cost accounting, and dependent ACP issues.

## Validation
- `npm test -- src/__tests__/process-utils.test.ts`
- `npm test -- src/__tests__/acp-lifecycle-probe.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `npm run gate`
- Real ACP package probes:
  - `node scripts/acp-lifecycle-probe.mjs --no-prompt --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 30000`
  - `node scripts/acp-lifecycle-probe.mjs --prompt "Reply with exactly: AEGIS_ACP_PROBE_OK" --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 120000`
  - `node scripts/acp-lifecycle-probe.mjs --prompt "Count from 1 to 100, one number per line." --cancel-after-first-update --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 120000`
  - `node scripts/acp-lifecycle-probe.mjs --no-prompt --resume --session-cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --cwd D:\aegis\.claude\worktrees\2578-acp-child-process-lifecycle --timeout-ms 30000`

## Review notes
- Real prompt returned `stopReason: "end_turn"`.
- Real cancellation returned `stopReason: "cancelled"`.
- Real child process exited with code `0` after `session/close` + stdin close.
- Probe output redacts raw environment, stderr contents, and resume configuration values.