### PR TITLE
fix: consolidate timingSafeEqual into shared crypto-utils (#2633, #2637)

### DIFF
--- a/src/__tests__/crypto-utils.test.ts
+++ b/src/__tests__/crypto-utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { timingSafeStringEqual } from '../crypto-utils.js';
+
+describe('timingSafeStringEqual', () => {
+  it('returns true for equal strings', () => {
+    expect(timingSafeStringEqual('secret', 'secret')).toBe(true);
+  });
+
+  it('returns false for different strings of equal length', () => {
+    expect(timingSafeStringEqual('secret1', 'secret2')).toBe(false);
+  });
+
+  it('returns false when strings differ in length', () => {
+    expect(timingSafeStringEqual('short', 'longer-string')).toBe(false);
+  });
+
+  it('returns false when a is undefined', () => {
+    expect(timingSafeStringEqual(undefined, 'secret')).toBe(false);
+  });
+
+  it('returns false when b is undefined', () => {
+    expect(timingSafeStringEqual('secret', undefined)).toBe(false);
+  });
+
+  it('returns false when both are undefined', () => {
+    expect(timingSafeStringEqual(undefined, undefined)).toBe(false);
+  });
+
+  it('returns false when a is empty string', () => {
+    expect(timingSafeStringEqual('', 'secret')).toBe(false);
+  });
+
+  it('returns false when b is empty string', () => {
+    expect(timingSafeStringEqual('secret', '')).toBe(false);
+  });
+
+  it('handles equal long hex strings (64-char hook secrets)', () => {
+    const secret = 'a'.repeat(64);
+    expect(timingSafeStringEqual(secret, secret)).toBe(true);
+  });
+
+  it('handles nearly-equal long strings differing only at the last character', () => {
+    const a = 'a'.repeat(63) + 'x';
+    const b = 'a'.repeat(63) + 'y';
+    expect(timingSafeStringEqual(a, b)).toBe(false);
+  });
+
+  it('does not throw when inputs have different lengths (no RANGE_ERROR)', () => {
+    // The vulnerable implementation threw RANGE_ERROR caught by try/catch.
+    // The correct implementation must not throw at all.
+    expect(() => timingSafeStringEqual('short', 'a-much-longer-string')).not.toThrow();
+  });
+
+  it('handles unicode characters', () => {
+    expect(timingSafeStringEqual('café', 'café')).toBe(true);
+    expect(timingSafeStringEqual('café', 'cafe')).toBe(false);
+  });
+});

--- a/src/crypto-utils.ts
+++ b/src/crypto-utils.ts
@@ -1,0 +1,17 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time equality check for secret strings.
+ * Pads both inputs to equal length before comparison so the function always
+ * runs in constant time, preventing length-leak timing attacks (#2633).
+ * Returns false when either argument is falsy.
+ */
+export function timingSafeStringEqual(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  const maxLen = Math.max(a.length, b.length);
+  const bufA = Buffer.alloc(maxLen);
+  const bufB = Buffer.alloc(maxLen);
+  bufA.write(a, 'utf8');
+  bufB.write(b, 'utf8');
+  return timingSafeEqual(bufA, bufB) && a.length === b.length;
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -22,19 +22,9 @@ import { isValidUUID, hookBodySchema, parseIntSafe } from './validation.js';
 import type { MetricsCollector } from './metrics.js';
 import type { UIState } from './terminal-parser.js';
 import { evaluatePermissionProfile } from './services/permission/index.js';
-import crypto from 'node:crypto';
+import { timingSafeStringEqual } from './crypto-utils.js';
 
 /** CC hook events that require a decision response. */
-
-/** Timing-safe string comparison to prevent timing attacks on secret values. */
-function timingSafeEqual(a: string | undefined, b: string | undefined): boolean {
-  if (!a || !b) return false;
-  try {
-    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
-  } catch {
-    return false;
-  }
-}
 
 const DECISION_EVENTS = new Set(['PreToolUse', 'PermissionRequest']);
 
@@ -234,7 +224,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
       console.warn(`Hooks: query-string hook secret is deprecated (session ${sessionId}, event ${eventName}); use X-Hook-Secret header`);
     }
     const hookSecret = headerHookSecret || queryHookSecret;
-    if (session.hookSecret && !timingSafeEqual(hookSecret, session.hookSecret)) {
+    if (session.hookSecret && !timingSafeStringEqual(hookSecret, session.hookSecret)) {
       return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import fastifyStatic from '@fastify/static';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyCors from '@fastify/cors';
 import crypto from 'node:crypto';
+import { timingSafeStringEqual } from './crypto-utils.js';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { TmuxManager } from './tmux.js';
@@ -96,15 +97,6 @@ import { authenticateDashboardSessionCookie } from './dashboard-session-auth.js'
 
 
 
-/** Timing-safe string comparison to prevent timing attacks on secret values. */
-function timingSafeEqual(a: string | undefined, b: string | undefined): boolean {
-  if (!a || !b) return false;
-  try {
-    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
-  } catch {
-    return false;
-  }
-}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -396,7 +388,7 @@ function setupAuth(authManager: AuthManager): void {
             return reply.status(401).send({ error: 'Unauthorized — hook secret must be sent via X-Hook-Secret header' });
           }
           const hookSecret = (req.headers['x-hook-secret'] as string) || queryHookSecret;
-          if (!hookSecret || !timingSafeEqual(hookSecret, session.hookSecret)) {
+          if (!hookSecret || !timingSafeStringEqual(hookSecret, session.hookSecret)) {
             return reply.status(401).send({ error: 'Unauthorized — invalid hook secret' });
           }
           return; // valid session + secret — allow
@@ -420,7 +412,7 @@ function setupAuth(authManager: AuthManager): void {
         : undefined;
       if (metricsToken) {
         // Dedicated metrics token configured — require it or the primary token
-        if (bearer && (timingSafeEqual(bearer, metricsToken) || authManager.validate(bearer).valid)) {
+        if (bearer && (timingSafeStringEqual(bearer, metricsToken) || authManager.validate(bearer).valid)) {
           return; // authenticated
         }
         return reply.status(401).send({ error: 'Unauthorized — valid Bearer token or metrics token required' });

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -6,7 +6,8 @@
  * Backward compatible with single authToken from config.
  */
 
-import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
+import { timingSafeStringEqual } from '../../crypto-utils.js';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { authStoreSchema } from '../../validation.js';
 import { existsSync } from 'node:fs';
@@ -452,7 +453,7 @@ export class AuthManager {
 
     // Check master token (backward compat) — timing-safe comparison (#402)
     // Issue #2267: master token uses SYSTEM_TENANT for cross-tenant visibility.
-    if (this.masterToken && AuthManager.timingSafeStringEqual(token, this.masterToken)) {
+    if (this.masterToken && timingSafeStringEqual(token, this.masterToken)) {
       return { valid: true, keyId: 'master', rateLimited: false, tenantId: SYSTEM_TENANT };
     }
 
@@ -570,20 +571,6 @@ export class AuthManager {
   /** Hash a key with SHA-256. */
   static hashKey(key: string): string {
     return createHash('sha256').update(key).digest('hex');
-  }
-
-  /**
-   * Constant-time equality check for secret strings.
-   * #2454: Pads shorter input so comparison always runs in constant time,
-   * preventing length-leak timing attacks.
-   */
-  private static timingSafeStringEqual(a: string, b: string): boolean {
-    const maxLen = Math.max(a.length, b.length);
-    const bufA = Buffer.alloc(maxLen);
-    const bufB = Buffer.alloc(maxLen);
-    bufA.write(a, 'utf8');
-    bufB.write(b, 'utf8');
-    return timingSafeEqual(bufA, bufB) && a.length === b.length;
   }
 
   /** #583: Check and update batch rate limit for a key. Returns true if rate-limited. */


### PR DESCRIPTION
## Summary

- Extracted the correct constant-time string comparison into `src/crypto-utils.ts` as `timingSafeStringEqual`
- Replaced the two vulnerable copies in `server.ts` and `hooks.ts` (which could leak secret length via `RANGE_ERROR` timing) with imports from the shared utility
- Removed the private `AuthManager.timingSafeStringEqual` method and replaced its call site with the shared import
- Added `src/__tests__/crypto-utils.test.ts` with 11 tests covering equal/unequal strings, length differences, undefined inputs, unicode, and the no-throw invariant

## Aegis version
**Developed with:** vunknown

Closes #2633
Closes #2637