### PR TITLE
fix: add missing fields to persistedStateSchema (#2634)

### DIFF
--- a/src/__tests__/json-parse-validation.test.ts
+++ b/src/__tests__/json-parse-validation.test.ts
@@ -72,6 +72,64 @@ describe('persistedStateSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  // Issue #2634: circuit breaker + premature termination fields
+  it('accepts session with circuit breaker fields (Issue #2518)', () => {
+    const result = persistedStateSchema.safeParse({
+      'abc-123': {
+        ...validSession,
+        hookFailureTimestamps: [Date.now() - 1000, Date.now()],
+        circuitBreakerTripped: true,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts session with premature termination fields (Issue #2520)', () => {
+    const result = persistedStateSchema.safeParse({
+      'abc-123': {
+        ...validSession,
+        toolUseCount: 25,
+        prematureTermination: false,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('preserves circuit breaker and premature termination fields through parse', () => {
+    const input = {
+      'abc-123': {
+        ...validSession,
+        hookFailureTimestamps: [1000, 2000],
+        circuitBreakerTripped: true,
+        toolUseCount: 10,
+        prematureTermination: false,
+      },
+    };
+    const result = persistedStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const s = result.data['abc-123'];
+      expect(s.hookFailureTimestamps).toEqual([1000, 2000]);
+      expect(s.circuitBreakerTripped).toBe(true);
+      expect(s.toolUseCount).toBe(10);
+      expect(s.prematureTermination).toBe(false);
+    }
+  });
+
+  it('rejects toolUseCount with negative value', () => {
+    const result = persistedStateSchema.safeParse({
+      'abc-123': { ...validSession, toolUseCount: -1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects toolUseCount with non-integer value', () => {
+    const result = persistedStateSchema.safeParse({
+      'abc-123': { ...validSession, toolUseCount: 1.5 },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ── sessionMapSchema ─────────────────────────────────────────────

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -304,6 +304,10 @@ export const persistedStateSchema = z.record(
     permissionProfile: permissionProfileSchema.optional(),
     ownerKeyId: z.string().optional(),
     tenantId: z.string().optional(),
+    hookFailureTimestamps: z.array(z.number()).optional(),
+    circuitBreakerTripped: z.boolean().optional(),
+    toolUseCount: z.number().int().nonnegative().optional(),
+    prematureTermination: z.boolean().optional(),
   }),
 );
 


### PR DESCRIPTION
## Summary

- Add `hookFailureTimestamps` and `circuitBreakerTripped` (Issue #2518) to `persistedStateSchema`
- Add `toolUseCount` and `prematureTermination` (Issue #2520) to `persistedStateSchema`
- All four fields are optional; silently stripped on restart before this fix

## Test plan

- [x] 5 new tests in `src/__tests__/json-parse-validation.test.ts` covering accept/reject/round-trip behaviour
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes (4006 tests, 0 failures)
- [x] `npm run gate` passes

## Aegis version
**Developed with:** v0.6.6-preview.1

Closes #2634

Generated by Hephaestus (Aegis dev agent)