### PR TITLE
chore(deps): add reviewers and labels to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    reviewers:
+      - OneStepAt4time
 
   - package-ecosystem: npm
     directory: /dashboard
@@ -13,6 +17,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - dashboard
+    reviewers:
+      - OneStepAt4time
 
   - package-ecosystem: github-actions
     directory: /
@@ -20,3 +29,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    reviewers:
+      - OneStepAt4time


### PR DESCRIPTION
## Summary

Auto-assign human reviewer and categorize dependabot PRs with existing repo labels so they are triaged consistently.

## Changes

- Root npm: labels `dependencies`, reviewer `OneStepAt4time`
- Dashboard npm: labels `dependencies` + `dashboard`, reviewer `OneStepAt4time`
- GitHub Actions: labels `dependencies` + `ci`, reviewer `OneStepAt4time`

All labels already exist in the repo. No new labels created.