### PR TITLE
fix(dashboard): Fix lucide-react tree-shaking — 152 KB gzip vendor bloat

### DIFF
--- a/dashboard/src/components/Icon.tsx
+++ b/dashboard/src/components/Icon.tsx
@@ -2,26 +2,83 @@
  * components/Icon.tsx
  * Typed wrapper over lucide-react with a fixed size scale (12/16/20/24 px).
  *
+ * Uses an explicit allowlist of imported icons to keep tree-shaking effective.
+ * If a new icon name is needed, add it to the ICON_MAP below.
+ *
  * Usage:
  *   <Icon name="Search" size={16} aria-label="Search" />
  *
- * - Renders nothing if `name` is not a valid Lucide export.
+ * - Renders nothing if `name` is not in the allowlist.
  * - Defaults to aria-hidden when no aria-label is supplied.
  * - strokeWidth default (1.75) matches the dashboard hairline token.
  */
 
-import * as Lucide from 'lucide-react';
+import {
+  Activity,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  DollarSign,
+  Download,
+  FileText,
+  Gauge,
+  Layers,
+  Link,
+  Search,
+  Shield,
+  Wifi,
+  X,
+  Zap,
+} from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
 
 export type IconSize = 12 | 16 | 20 | 24;
 
 /**
  * Names of all valid Lucide icon components.
- *
- * NOTE: `keyof typeof Lucide` is large — if compile times regress we can
- * narrow this to a curated allowlist. See issue dashboard-perfection/020.
+ * Keep in sync with the allowlist imports above.
  */
-export type IconName = keyof typeof Lucide;
+export type IconName =
+  | 'Activity'
+  | 'Check'
+  | 'ChevronDown'
+  | 'ChevronRight'
+  | 'Copy'
+  | 'DollarSign'
+  | 'Download'
+  | 'FileText'
+  | 'Gauge'
+  | 'Layers'
+  | 'Link'
+  | 'Search'
+  | 'Shield'
+  | 'Wifi'
+  | 'X'
+  | 'Zap';
+
+type LucideLike = ComponentType<
+  SVGProps<SVGSVGElement> & { size?: number | string; strokeWidth?: number }
+>;
+
+const ICON_MAP: Record<IconName, LucideLike> = {
+  Activity,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  DollarSign,
+  Download,
+  FileText,
+  Gauge,
+  Layers,
+  Link,
+  Search,
+  Shield,
+  Wifi,
+  X,
+  Zap,
+};
 
 export interface IconProps {
   name: IconName;
@@ -31,14 +88,6 @@ export interface IconProps {
   className?: string;
 }
 
-type LucideLike = ComponentType<
-  SVGProps<SVGSVGElement> & { size?: number | string; strokeWidth?: number }
->;
-
-function isLucideComponent(value: unknown): value is LucideLike {
-  return typeof value === 'function' || typeof value === 'object';
-}
-
 export function Icon({
   name,
   size = 16,
@@ -46,14 +95,13 @@ export function Icon({
   className,
   ...rest
 }: IconProps) {
-  const candidate = (Lucide as Record<string, unknown>)[name as string];
-  if (!candidate || !isLucideComponent(candidate)) {
+  const LucideIcon = ICON_MAP[name];
+  if (!LucideIcon) {
     if (typeof console !== 'undefined') {
-      console.warn(`[Icon] Unknown lucide-react icon: "${String(name)}"`);
+      console.warn(`[Icon] Unknown icon: "${name}". Add it to Icon.tsx allowlist.`);
     }
     return null;
   }
-  const LucideIcon = candidate;
   const ariaLabel = rest['aria-label'];
   const ariaHidden = ariaLabel ? undefined : true;
   return (


### PR DESCRIPTION
## Summary

Replace `import * as Lucide from 'lucide-react'` in `Icon.tsx` with 16 explicitly named imports. The barrel import pulled all ~1,500 icons into the icons-vendor chunk, defeating tree-shaking entirely.

**icons-vendor: 151.91 KB gzip → 6.43 KB gzip** (95.8% reduction, ~145 KB saved)

## Root Cause

`src/components/Icon.tsx` used `import * as Lucide from 'lucide-react'` — a barrel import of the entire icon library (~1,500 icons). Despite all 48 other import sites using named imports (which tree-shake correctly), this single wildcard import forced the bundler to include every icon.

## Changes

- Replaced wildcard import with 16 explicit named imports matching actual usage
- Narrowed `IconName` type from `keyof typeof Lucide` to a union of 16 names
- Uses an `ICON_MAP` record for O(1) lookup instead of dynamic property access
- Updated warning message to guide developers: "Add it to Icon.tsx allowlist"

## Acceptance Criteria

- [x] icons-vendor chunk drops below 20 KB gzip (actual: 6.43 KB)
- [x] All 48 import sites still resolve correctly
- [x] No visual regressions (same 16 icons rendered)
- [x] TypeScript strict: zero errors
- [x] Build completes without new warnings
- [x] 861 tests pass (87 files)

Closes #2645

Quality gate: tsc ✅ | build ✅ | 861 tests ✅