### PR TITLE
perf(dashboard): Lazy-load recharts and xterm — save 181 KB gzip

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -21,19 +21,16 @@ export default defineConfig({
           if (id.includes('node_modules/react-router-dom/')) {
             return 'router-vendor';
           }
-          if (id.includes('node_modules/@xterm/')) {
-            return 'terminal-vendor';
-          }
           if (id.includes('node_modules/dompurify/') || id.includes('node_modules/zod/')) {
             return 'utils-vendor';
           }
           if (id.includes('node_modules/@tanstack/react-virtual/')) {
             return 'virtual-vendor';
           }
-          // recharts + d3 ecosystem (~500 KB) — lazy-loaded with AnalyticsPage
-          if (id.includes('node_modules/recharts/') || id.includes('node_modules/d3-')) {
-            return 'charts-vendor';
-          }
+          // recharts, d3, and @xterm are intentionally NOT pinned to manual chunks.
+          // Vite naturally code-splits them into the lazy-loaded page chunks that
+          // use them (AnalyticsPage, CostPage, MetricsPage, SessionDetailPage),
+          // saving ~181 KB gzip from the initial bundle (issue #2646).
           // lucide-react icons
           if (id.includes('node_modules/lucide-react/')) {
             return 'icons-vendor';


### PR DESCRIPTION
## Summary

Removes `charts-vendor` (recharts + d3) and `terminal-vendor` (xterm) from Vite `manualChunks`. These were being preloaded on every page visit despite only being needed on specific lazy-loaded pages.

## Problem

Vite's `manualChunks` extracted recharts/xterm into separate vendor chunks. Even though all pages using them are `React.lazy()`-loaded, Vite preloads all chunk dependencies eagerly — so users downloading the dashboard for the first time fetched 181 KB of unused JavaScript.

## Fix

Remove the `charts-vendor` and `terminal-vendor` entries from `manualChunks`. Rollup then naturally bundles these into the page-level chunks that import them:
- recharts/d3 → shared chunk only loaded with chart pages (Analytics, Metrics, Cost)
- xterm → SessionDetailPage chunk (only loaded when viewing a session)

## Results

| Chunk | Before | After | Saved |
|-------|--------|-------|-------|
| charts-vendor | 113 KB gzip | ❌ removed | 113 KB |
| terminal-vendor | 68 KB gzip | ❌ removed | 68 KB |
| **Total initial load savings** | | | **~181 KB gzip** |

No new chunks > 500 KB. Initial `index.js` bundle unchanged (91 KB gzip).

## Quality Gate

- ✅ `tsc --noEmit` — zero errors
- ✅ `npm run build` — success
- ✅ `npm test` — 861 tests pass (2 skipped)

## Files Changed

- `dashboard/vite.config.ts` — removed 2 manualChunks entries (net -3 lines)

Closes #2646