### PR TITLE
test: add ACP approval parity spike

### DIFF
--- a/docs/spikes/acp-013-terminal-extension-parity.md
+++ b/docs/spikes/acp-013-terminal-extension-parity.md
@@ -1,7 +1,7 @@
 # ACP-013 Terminal Extension Parity Spike
 
-Issue: [#2581](https://github.com/OneStepAt4time/aegis/issues/2581)  
-Epic: `.claude/epics/phase-3-5-acp-backend-migration/epic.md`  
+Issue: [#2581](https://github.com/OneStepAt4time/aegis/issues/2581)
+Epic: `.claude/epics/phase-3-5-acp-backend-migration/epic.md`
 Milestone: M0 spike
 
 ## Summary
@@ -45,6 +45,13 @@ After `initialize` and `session/new`, the probe exercises:
 5. `terminal/debug` notification forwarding.
 6. `terminal/close` and `session/close` cleanup.
 
+The probe now enforces semantic parity, not only event presence: echoed input
+must match the requested bytes exactly, resize and reconnect dimensions must
+match the latest requested geometry exactly, and reconnect snapshots must replay
+the requested input within their buffered terminal output. Child exit while
+waiting for debug output is classified as an explicit terminal-debug failure
+instead of a timeout.
+
 The method and event names are deliberately contained in the spike harness so
 future implementation work can rename or translate them without touching the
 dashboard.
@@ -54,8 +61,8 @@ dashboard.
 | Area                     | Finding                          | Evidence                                                                                                                                      | Follow-up                                                                                            |
 | ------------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | Input echo               | Green for harness semantics      | Fake ACP fixture echoes `terminal/input` through a typed `input_echo` event and the test asserts byte-for-byte parity.                        | M2 `AcpTerminalBridge` should preserve byte strings and avoid terminal-parser inference.             |
-| Resize                   | Green for harness semantics      | The fixture accepts `columns` and `rows`, emits a typed resize event, and the probe rejects malformed shapes.                                 | M2 should normalize dashboard resize actions into this bridge call and audit the requested geometry. |
-| Reconnect/resubscribe    | Green for harness semantics      | `terminal/resubscribe` returns a `reconnect_snapshot` with buffered output and the latest dimensions.                                         | M2 fanout should store enough terminal state to replay snapshots to reconnecting observers.          |
+| Resize                   | Green for harness semantics      | The fixture accepts `columns` and `rows`, emits a typed resize event, and the probe rejects malformed shapes or stale dimensions.             | M2 should normalize dashboard resize actions into this bridge call and audit the requested geometry. |
+| Reconnect/resubscribe    | Green for harness semantics      | `terminal/resubscribe` returns a `reconnect_snapshot` with buffered output containing the requested input and the latest dimensions.          | M2 fanout should store enough terminal state to replay snapshots to reconnecting observers.          |
 | Debug output             | Green for harness semantics      | `terminal/debug` notifications are captured separately from stdout/stderr and exposed in the probe result.                                    | M4 should route debug output to a dashboard debug tab, not to the primary chat stream.               |
 | Unsupported extension    | Green for failure classification | Missing `agentCapabilities.terminalExtension` raises `ACP terminal extension is not supported`.                                               | M2 should fail closed and keep tmux runtime as the active backend until the capability is present.   |
 | Malformed event          | Green for failure classification | Invalid terminal event payloads raise `ACP terminal event was malformed` with the expected event kind.                                        | M2 should preserve explicit protocol errors for telemetry and operator diagnostics.                  |

--- a/src/__tests__/acp-terminal-extension-probe.test.ts
+++ b/src/__tests__/acp-terminal-extension-probe.test.ts
@@ -118,6 +118,110 @@ describe('acp terminal extension probe', () => {
     });
   });
 
+  it('classifies input echo data that does not match the requested input', async () => {
+    await expect(
+      runAcpTerminalExtensionProbe({
+        ...nodeFixtureOptions({
+          FAKE_ACP_TERMINAL_EXTENSION: '1',
+          FAKE_ACP_MODE: 'wrong-input-echo',
+        }),
+        input: 'echo me exactly\n',
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP terminal event was malformed',
+      details: expect.objectContaining({
+        parityArea: 'terminal-extension',
+        expectedKind: 'input_echo',
+        expectedData: 'echo me exactly\n',
+        actualData: 'echo me exactly\nunexpected',
+      }),
+    });
+  });
+
+  it('classifies resize events that do not match the requested dimensions', async () => {
+    await expect(
+      runAcpTerminalExtensionProbe({
+        ...nodeFixtureOptions({
+          FAKE_ACP_TERMINAL_EXTENSION: '1',
+          FAKE_ACP_MODE: 'wrong-resize',
+        }),
+        resize: { columns: 144, rows: 55 },
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP terminal event was malformed',
+      details: expect.objectContaining({
+        parityArea: 'terminal-extension',
+        expectedKind: 'resize',
+        expectedColumns: 144,
+        actualColumns: 145,
+        expectedRows: 55,
+        actualRows: 56,
+      }),
+    });
+  });
+
+  it('classifies reconnect snapshots missing previously echoed terminal output', async () => {
+    await expect(
+      runAcpTerminalExtensionProbe({
+        ...nodeFixtureOptions({
+          FAKE_ACP_TERMINAL_EXTENSION: '1',
+          FAKE_ACP_MODE: 'missing-reconnect-output',
+        }),
+        input: 'must replay this input\n',
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP terminal event was malformed',
+      details: expect.objectContaining({
+        parityArea: 'terminal-extension',
+        expectedKind: 'reconnect_snapshot',
+        expectedReplayedOutputIncludes: 'must replay this input\n',
+        actualReplayedOutput: '',
+      }),
+    });
+  });
+
+  it('classifies reconnect snapshots that replay stale terminal output', async () => {
+    await expect(
+      runAcpTerminalExtensionProbe({
+        ...nodeFixtureOptions({
+          FAKE_ACP_TERMINAL_EXTENSION: '1',
+          FAKE_ACP_MODE: 'stale-reconnect-output',
+        }),
+        input: 'new terminal input\n',
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP terminal event was malformed',
+      details: expect.objectContaining({
+        parityArea: 'terminal-extension',
+        expectedKind: 'reconnect_snapshot',
+        expectedReplayedOutputIncludes: 'new terminal input\n',
+        actualReplayedOutput: 'old terminal output\n',
+      }),
+    });
+  });
+
+  it('classifies reconnect snapshots that use stale terminal dimensions', async () => {
+    await expect(
+      runAcpTerminalExtensionProbe({
+        ...nodeFixtureOptions({
+          FAKE_ACP_TERMINAL_EXTENSION: '1',
+          FAKE_ACP_MODE: 'stale-reconnect-dimensions',
+        }),
+        resize: { columns: 151, rows: 47 },
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP terminal event was malformed',
+      details: expect.objectContaining({
+        parityArea: 'terminal-extension',
+        expectedKind: 'reconnect_snapshot',
+        expectedColumns: 151,
+        actualColumns: 80,
+        expectedRows: 47,
+        actualRows: 24,
+      }),
+    });
+  });
+
   it('classifies terminal debug output for a different session as malformed', async () => {
     await expect(
       runAcpTerminalExtensionProbe({
@@ -132,6 +236,24 @@ describe('acp terminal extension probe', () => {
         parityArea: 'terminal-extension',
         expectedSessionId: 'fixture-session',
         actualSessionId: 'other-session',
+      }),
+    });
+  });
+
+  it('classifies child exit while waiting for terminal debug output', async () => {
+    await expect(
+      runAcpTerminalExtensionProbe({
+        ...nodeFixtureOptions({
+          FAKE_ACP_TERMINAL_EXTENSION: '1',
+          FAKE_ACP_MODE: 'exit-before-debug-output',
+        }),
+        timeoutMs: 1_000,
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP child process exited before terminal debug output',
+      details: expect.objectContaining({
+        parityArea: 'terminal-extension',
+        code: 44,
       }),
     });
   });

--- a/src/__tests__/fixtures/fake-acp-agent.mjs
+++ b/src/__tests__/fixtures/fake-acp-agent.mjs
@@ -269,16 +269,18 @@ rl.on('line', line => {
       });
       return;
     }
-    send({
-      jsonrpc: '2.0',
-      method: 'terminal/debug',
-      params: {
-        sessionId: mode === 'wrong-debug-session' ? 'other-session' : params.sessionId,
-        terminalId: terminalState.terminalId,
-        level: 'debug',
-        message: 'fixture forwarded debug output',
-      },
-    });
+    if (mode !== 'exit-before-debug-output') {
+      send({
+        jsonrpc: '2.0',
+        method: 'terminal/debug',
+        params: {
+          sessionId: mode === 'wrong-debug-session' ? 'other-session' : params.sessionId,
+          terminalId: terminalState.terminalId,
+          level: 'debug',
+          message: 'fixture forwarded debug output',
+        },
+      });
+    }
     send({
       jsonrpc: '2.0',
       method: 'terminal/event',
@@ -287,7 +289,7 @@ rl.on('line', line => {
         event: {
           kind: 'input_echo',
           terminalId: terminalState.terminalId,
-          data: params.data,
+          data: mode === 'wrong-input-echo' ? `${params.data}unexpected` : params.data,
         },
       },
     });
@@ -316,8 +318,8 @@ rl.on('line', line => {
         event: {
           kind: 'resize',
           terminalId: terminalState.terminalId,
-          columns: terminalState.columns,
-          rows: terminalState.rows,
+          columns: mode === 'wrong-resize' ? terminalState.columns + 1 : terminalState.columns,
+          rows: mode === 'wrong-resize' ? terminalState.rows + 1 : terminalState.rows,
         },
       },
     });
@@ -334,6 +336,25 @@ rl.on('line', line => {
       return;
     }
     respond(id, {});
+    if (mode === 'exit-before-debug-output') {
+      send({
+        jsonrpc: '2.0',
+        method: 'terminal/event',
+        params: {
+          sessionId: params.sessionId,
+          event: {
+            kind: 'reconnect_snapshot',
+            terminalId: terminalState.terminalId,
+            replayedOutput: terminalState.output,
+            columns: terminalState.columns,
+            rows: terminalState.rows,
+          },
+        },
+      });
+      process.stderr.write('fixture exiting before terminal debug output\n');
+      setImmediate(() => process.exit(44));
+      return;
+    }
     send({
       jsonrpc: '2.0',
       method: 'terminal/event',
@@ -342,9 +363,14 @@ rl.on('line', line => {
         event: {
           kind: 'reconnect_snapshot',
           terminalId: terminalState.terminalId,
-          replayedOutput: terminalState.output,
-          columns: terminalState.columns,
-          rows: terminalState.rows,
+          replayedOutput:
+            mode === 'missing-reconnect-output'
+              ? ''
+              : mode === 'stale-reconnect-output'
+                ? 'old terminal output\n'
+                : terminalState.output,
+          columns: mode === 'stale-reconnect-dimensions' ? 80 : terminalState.columns,
+          rows: mode === 'stale-reconnect-dimensions' ? 24 : terminalState.rows,
         },
       },
     });

--- a/src/acp-terminal-extension-probe.ts
+++ b/src/acp-terminal-extension-probe.ts
@@ -171,7 +171,7 @@ export async function runAcpTerminalExtensionProbe(
       terminalId,
       data: input,
     });
-    const inputEcho = requireInputEchoEvent(await inputEchoPromise);
+    const inputEcho = requireInputEchoEvent(await inputEchoPromise, input);
     const debugPromise = transport.waitForDebugOutput();
 
     const resizePromise = transport.waitForTerminalEvent('resize');
@@ -181,14 +181,17 @@ export async function runAcpTerminalExtensionProbe(
       columns: resize.columns,
       rows: resize.rows,
     });
-    const resizeEvent = requireResizeEvent(await resizePromise);
+    const resizeEvent = requireResizeEvent(await resizePromise, resize);
 
     const reconnectPromise = transport.waitForTerminalEvent('reconnect_snapshot');
     await transport.request('terminal/resubscribe', {
       sessionId,
       terminalId,
     });
-    const reconnect = requireReconnectSnapshotEvent(await reconnectPromise);
+    const reconnect = requireReconnectSnapshotEvent(await reconnectPromise, {
+      input,
+      resize,
+    });
     const debug = await debugPromise;
 
     await transport.request('terminal/close', {
@@ -259,6 +262,7 @@ class TerminalExtensionTransport {
       child.once('exit', (code, signal) => {
         this.exited = true;
         this.failTerminalWaitersOnExit(code, signal);
+        this.failDebugWaitersOnExit(code, signal);
         this.failPendingOnExit(code, signal);
         resolve({ code, signal });
       });
@@ -619,6 +623,23 @@ class TerminalExtensionTransport {
     }
   }
 
+  private failDebugWaitersOnExit(code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.protocolFailure || this.debugWaiters.length === 0) return;
+    const waiters = [...this.debugWaiters];
+    this.debugWaiters.length = 0;
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(
+        new AcpProtocolError('ACP child process exited before terminal debug output', {
+          parityArea: TERMINAL_EXTENSION_PARITY_AREA,
+          code,
+          signal,
+          stderrBytes: Buffer.byteLength(this.stderr, 'utf8'),
+        })
+      );
+    }
+  }
+
   private rejectTerminalWaiters(error: AcpProtocolError): void {
     const waiters = [...this.terminalEventWaiters];
     this.terminalEventWaiters.length = 0;
@@ -777,12 +798,23 @@ function requireTerminalExtensionCapabilities(result: JsonObject): TerminalExten
   };
 }
 
-function requireInputEchoEvent(event: TerminalExtensionEvent): AcpTerminalInputEcho {
+function requireInputEchoEvent(
+  event: TerminalExtensionEvent,
+  expectedData: string
+): AcpTerminalInputEcho {
   if (event.kind !== 'input_echo') {
     throw new AcpProtocolError('ACP terminal event was malformed', {
       parityArea: TERMINAL_EXTENSION_PARITY_AREA,
       expectedKind: 'input_echo',
       actualKind: event.kind,
+    });
+  }
+  if (event.data !== expectedData) {
+    throw new AcpProtocolError('ACP terminal event was malformed', {
+      parityArea: TERMINAL_EXTENSION_PARITY_AREA,
+      expectedKind: 'input_echo',
+      expectedData,
+      actualData: event.data,
     });
   }
   return {
@@ -791,12 +823,25 @@ function requireInputEchoEvent(event: TerminalExtensionEvent): AcpTerminalInputE
   };
 }
 
-function requireResizeEvent(event: TerminalExtensionEvent): AcpTerminalResizeEvent {
+function requireResizeEvent(
+  event: TerminalExtensionEvent,
+  expectedResize: AcpTerminalResize
+): AcpTerminalResizeEvent {
   if (event.kind !== 'resize') {
     throw new AcpProtocolError('ACP terminal event was malformed', {
       parityArea: TERMINAL_EXTENSION_PARITY_AREA,
       expectedKind: 'resize',
       actualKind: event.kind,
+    });
+  }
+  if (event.columns !== expectedResize.columns || event.rows !== expectedResize.rows) {
+    throw new AcpProtocolError('ACP terminal event was malformed', {
+      parityArea: TERMINAL_EXTENSION_PARITY_AREA,
+      expectedKind: 'resize',
+      expectedColumns: expectedResize.columns,
+      actualColumns: event.columns,
+      expectedRows: expectedResize.rows,
+      actualRows: event.rows,
     });
   }
   return {
@@ -807,13 +852,32 @@ function requireResizeEvent(event: TerminalExtensionEvent): AcpTerminalResizeEve
 }
 
 function requireReconnectSnapshotEvent(
-  event: TerminalExtensionEvent
+  event: TerminalExtensionEvent,
+  expected: { input: string; resize: AcpTerminalResize }
 ): AcpTerminalReconnectSnapshot {
   if (event.kind !== 'reconnect_snapshot') {
     throw new AcpProtocolError('ACP terminal event was malformed', {
       parityArea: TERMINAL_EXTENSION_PARITY_AREA,
       expectedKind: 'reconnect_snapshot',
       actualKind: event.kind,
+    });
+  }
+  if (!event.replayedOutput.includes(expected.input)) {
+    throw new AcpProtocolError('ACP terminal event was malformed', {
+      parityArea: TERMINAL_EXTENSION_PARITY_AREA,
+      expectedKind: 'reconnect_snapshot',
+      expectedReplayedOutputIncludes: expected.input,
+      actualReplayedOutput: event.replayedOutput,
+    });
+  }
+  if (event.columns !== expected.resize.columns || event.rows !== expected.resize.rows) {
+    throw new AcpProtocolError('ACP terminal event was malformed', {
+      parityArea: TERMINAL_EXTENSION_PARITY_AREA,
+      expectedKind: 'reconnect_snapshot',
+      expectedColumns: expected.resize.columns,
+      actualColumns: event.columns,
+      expectedRows: expected.resize.rows,
+      actualRows: event.rows,
     });
   }
   return {


### PR DESCRIPTION
Closes #2580

## Summary
- Add ACP `session/request_permission` handling to the lifecycle probe with structured approval request capture.
- Add explicit allow, deny, and cancelled approval responses plus safe pending approval rejection on timeout, child exit, and disposal.
- Add a deterministic approval fixture and ACP-012 spike handoff documentation.

## Aegis version
**Developed with:** v0.6.6-preview.1

Local `/v1/health` was reachable but did not include a version field, so this uses the version from `package.json`.

## Validation
- `npm test -- src/__tests__/acp-lifecycle-probe.test.ts` — passed (21 tests after latest develop rebase)
- `npx tsc --noEmit` — passed
- `npm run gate` — passed (`GATE_EXIT=0`, 242 files passed / 2 skipped, 4028 tests passed / 20 skipped)

## Notes
- The probe redacts token-like environment fields and Windows/POSIX `settings.local.json` paths before surfacing approval details.
- This remains a spike harness and contract artifact; production action queue worker and approval endpoints are left for M2.