### PR TITLE
test: add ACP approval parity spike

### DIFF
--- a/docs/spikes/acp-012-approval-parity.md
+++ b/docs/spikes/acp-012-approval-parity.md
@@ -1,0 +1,172 @@
+# ACP-012 Approval Request/Response Parity Spike
+
+Issue: [#2580](https://github.com/OneStepAt4time/aegis/issues/2580)
+
+## Verdict
+
+**Green for ACP-012.** The ACP lifecycle probe can now receive
+`session/request_permission` JSON-RPC requests from an ACP child process, surface
+them as structured approval data, and send explicit allow, deny, or cancelled
+JSON-RPC responses without terminal keypress emulation.
+
+This is a spike harness and approval contract artifact. It does not implement
+the production `AcpBackend`, REST approval endpoints, or the M2 action queue
+worker.
+
+## Durable spike artifacts
+
+- `src/acp-lifecycle-probe.ts` — reusable NDJSON JSON-RPC probe with
+  `session/request_permission` handling, structured approval capture, explicit
+  approval decisions, and pending-request cleanup.
+- `src/__tests__/fixtures/fake-acp-agent.mjs` — deterministic fake ACP child
+  process that can request approval, observe allow/deny/cancel responses, emit
+  malformed approval requests, and exit while approval is pending.
+- `src/__tests__/fixtures/acp-approval-request.json` — deterministic approval
+  fixture suitable for future golden tests.
+- `src/__tests__/acp-lifecycle-probe.test.ts` — parity coverage for approval
+  surfacing, allow/deny responses, cancellation, child exit, timeout, malformed
+  approval protocol errors, and redaction/bounding.
+
+## Observed approval contract
+
+The ACP child sends a client request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "permission-1",
+  "method": "session/request_permission",
+  "params": {
+    "sessionId": "fixture-session",
+    "toolCall": {
+      "toolCallId": "tool-call-approval-1",
+      "title": "Run shell command",
+      "kind": "execute",
+      "status": "pending",
+      "rawInput": {}
+    },
+    "options": [
+      { "optionId": "allow-once", "name": "Allow once", "kind": "allow_once" },
+      { "optionId": "reject-once", "name": "Deny", "kind": "reject_once" }
+    ]
+  }
+}
+```
+
+Aegis must answer the same JSON-RPC id. Selecting an option returns:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "permission-1",
+  "result": {
+    "outcome": {
+      "outcome": "selected",
+      "optionId": "allow-once"
+    }
+  }
+}
+```
+
+Cancelling approval returns:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "permission-1",
+  "result": {
+    "outcome": {
+      "outcome": "cancelled"
+    }
+  }
+}
+```
+
+The probe validates permission option shape and rejects unsupported option
+kinds as ACP protocol errors. Unknown client requests still receive explicit
+JSON-RPC errors rather than hanging silently.
+
+## Security considerations
+
+Approval requests can contain sensitive command, environment, header, or file
+path details in `toolCall.rawInput`, `rawOutput`, `locations`, or content.
+The spike therefore treats surfaced approval data as operator-facing diagnostic
+data and applies conservative controls:
+
+- secret-like field names such as `authorization`, `cookie`, `apiKey`, `token`,
+  `secret`, `password`, and `credential` are replaced with `[REDACTED]`;
+- local `settings.local.json` paths are replaced with `[REDACTED_PATH]`;
+- surfaced strings are bounded to 2 KiB, arrays to 25 items, and objects to 50
+  keys before they are stored in the probe result;
+- stderr remains separately bounded by the ACP-010 64 KiB limit;
+- raw environment variables are not printed by the probe or fixture.
+
+The production backend should preserve these redaction and bounding rules before
+persisting approval events, returning pending approval API responses, emitting
+SSE/WebSocket updates, or writing logs.
+
+## Pending request safety
+
+The probe now tracks inbound approval requests separately from outbound
+client-to-agent requests. Pending approval requests are not left dangling:
+
+- prompt cancellation can respond with an ACP `cancelled` approval outcome and
+  send `session/cancel`;
+- child exit marks pending approvals as rejected with `child_exit` and includes
+  those rejected approvals in the surfaced protocol error;
+- request timeout marks pending approvals as rejected with `request_timeout` and
+  sends a best-effort JSON-RPC error to the child;
+- transport disposal marks pending approvals as rejected with
+  `transport_disposed`.
+
+These states are intentionally explicit because the M2 worker must be able to
+resolve a pending approval exactly once and make terminal states visible to API
+clients.
+
+## Limitations
+
+- The spike uses a deterministic fake ACP child. It does not prove every
+  production `@agentclientprotocol/claude-agent-acp` approval option shape.
+- The probe supports one immediate approval decision policy per run. It is not a
+  multi-user approval queue.
+- Redaction is intentionally conservative and may hide benign fields with
+  sensitive names. That is acceptable for the spike and safer than leaking
+  credentials.
+- The spike does not persist approval state, expose HTTP endpoints, emit public
+  events, or map ACP approvals to the existing tmux-backed permission API.
+
+## Handoff requirements for M2
+
+M2 action queue worker and approval endpoints should:
+
+1. register a first-class client request dispatcher for
+   `session/request_permission`;
+2. normalize approval requests into a stored `pending` record with
+   `sessionId`, JSON-RPC request id, sanitized `toolCall`, available options,
+   and creation time;
+3. expose pending approvals through the existing Aegis approval surfaces without
+   terminal keypress emulation;
+4. accept explicit allow, deny, and cancel decisions, map them to ACP
+   `selected` or `cancelled` outcomes, and write exactly one JSON-RPC response;
+5. mark pending approvals rejected on child exit, prompt timeout, session
+   cancellation, and backend disposal;
+6. apply redaction and bounding before logging, persistence, REST responses, and
+   realtime event emission;
+7. keep malformed ACP approval requests as protocol errors with structured
+   method/id/details so operators can diagnose incompatible agents.
+
+## Validation evidence
+
+Commands run in this worktree:
+
+```text
+npm test -- src/__tests__/acp-lifecycle-probe.test.ts
+npx tsc --noEmit
+npm run gate
+```
+
+Results:
+
+- targeted ACP lifecycle probe fixture suite passed;
+- TypeScript type-check passed;
+- full repository gate passed.

--- a/src/__tests__/acp-lifecycle-probe.test.ts
+++ b/src/__tests__/acp-lifecycle-probe.test.ts
@@ -162,6 +162,21 @@ describe('acp lifecycle probe', () => {
     ).rejects.toBeInstanceOf(AcpProtocolError);
   });
 
+  it('rejects unterminated non-JSON stdout when the child exits', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions({ FAKE_ACP_MODE: 'unterminated-stdout-before-exit' }),
+        timeoutMs: 1_000,
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP stdout ended with an unterminated line',
+      details: expect.objectContaining({
+        line: 'this is not terminated json',
+        method: 'initialize',
+      }),
+    });
+  });
+
   it('classifies child exit before initialize as an ACP child process exit', async () => {
     await expect(
       runAcpLifecycleProbe({
@@ -175,6 +190,28 @@ describe('acp lifecycle probe', () => {
         code: 42,
       }),
     });
+  });
+
+  it('does not expose raw initialize payloads when request writes fail', async () => {
+    const secretMarker = 'fixture-request-write-secret';
+
+    let caught: unknown;
+    try {
+      await runAcpLifecycleProbe({
+        ...nodeFixtureOptions({ FAKE_ACP_MODE: 'exit-before-initialize' }),
+        clientCapabilities: {
+          secretMarker,
+          padding: 'x'.repeat(1_000_000),
+        },
+        timeoutMs: 1_000,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AcpProtocolError);
+    expect(JSON.stringify(caught)).not.toContain(secretMarker);
+    expect(JSON.stringify(caught)).not.toContain('padding');
   });
 
   it('classifies request timeouts with method and id details', async () => {
@@ -512,11 +549,49 @@ describe('acp lifecycle probe', () => {
         ANTHROPIC_API_KEY: '[REDACTED]',
       },
     });
-    const command = rawInput && typeof rawInput === 'object' && 'command' in rawInput ? rawInput.command : '';
-    expect(typeof command === 'string' ? Buffer.byteLength(command, 'utf8') : 0).toBeLessThanOrEqual(
+    const command =
+      rawInput && typeof rawInput === 'object' && 'command' in rawInput ? rawInput.command : '';
+    expect(
+      typeof command === 'string' ? Buffer.byteLength(command, 'utf8') : 0
+    ).toBeLessThanOrEqual(2_048);
+    expect(typeof command === 'string' ? command : '').not.toContain('fixture-command-token');
+  });
+
+  it('bounds and redacts ACP approval metadata before surfacing structured requests', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'request-metadata-permission',
+      approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
+    });
+
+    const request = result.approvalRequests[0];
+    expect(request?.options).toHaveLength(25);
+    expect(Buffer.byteLength(request?.sessionId ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.toolCall.toolCallId ?? '', 'utf8')).toBeLessThanOrEqual(
       2_048
     );
-    expect(typeof command === 'string' ? command : '').not.toContain('fixture-command-token');
+    expect(Buffer.byteLength(request?.toolCall.title ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.toolCall.kind ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.toolCall.status ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.options[0]?.optionId ?? '', 'utf8')).toBeLessThanOrEqual(
+      2_048
+    );
+    expect(Buffer.byteLength(request?.options[0]?.name ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(JSON.stringify(request)).not.toContain('fixture-session-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-tool-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-title-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-kind-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-status-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-option-id-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-option-secret');
+    expect(JSON.stringify(request)).not.toContain('settings.local.json');
+    expect(request?.sessionId).toContain('[REDACTED]');
+    expect(request?.toolCall.toolCallId).toContain('[REDACTED]');
+    expect(request?.toolCall.title).toContain('[REDACTED]');
+    expect(request?.toolCall.kind).toContain('[REDACTED]');
+    expect(request?.toolCall.status).toContain('[REDACTED]');
+    expect(request?.options[0]?.optionId).toContain('[REDACTED]');
+    expect(request?.options[0]?.name).toContain('[REDACTED]');
   });
 
   it('redacts POSIX settings.local.json paths in ACP approval command details', async () => {
@@ -548,6 +623,28 @@ describe('acp lifecycle probe', () => {
           outcome: 'cancelled',
         },
       },
+    });
+  });
+
+  it('rejects ACP approval requests when the child exits before the response write is accepted', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions(),
+        prompt: 'request-permission-exit-large-option',
+        approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
+        timeoutMs: 1_000,
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP approval response write failed',
+      details: expect.objectContaining({
+        method: 'session/request_permission',
+        requestId: 'permission-1',
+        approvalRequest: expect.objectContaining({
+          requestId: 'permission-1',
+          state: 'rejected',
+          rejectionReason: 'write_failed',
+        }),
+      }),
     });
   });
 

--- a/src/__tests__/acp-lifecycle-probe.test.ts
+++ b/src/__tests__/acp-lifecycle-probe.test.ts
@@ -440,6 +440,178 @@ describe('acp lifecycle probe', () => {
     ).rejects.toThrow(`Provider env ${anthDefaultModelKey} must be a non-empty string`);
   });
 
+  it('surfaces ACP approval requests as structured data and sends an explicit allow response', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'request-permission',
+      approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
+    });
+
+    expect(result.prompt?.result.stopReason).toBe('permission_allowed');
+    expect(result.approvalRequests).toHaveLength(1);
+    expect(result.approvalRequests[0]).toMatchObject({
+      requestId: 'permission-1',
+      sessionId: 'fixture-session',
+      state: 'responded',
+      toolCall: {
+        toolCallId: 'tool-call-approval-1',
+        title: 'Run shell command',
+        kind: 'execute',
+        rawInput: {
+          command: expect.stringContaining('[REDACTED_PATH]'),
+          env: {
+            ANTHROPIC_API_KEY: '[REDACTED]',
+            AEGIS_AUTH_TOKEN: '[REDACTED]',
+            PATH: 'C:\\Windows\\System32',
+          },
+        },
+      },
+      options: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Deny', kind: 'reject_once' },
+      ],
+      response: {
+        outcome: {
+          outcome: 'selected',
+          optionId: 'allow-once',
+        },
+      },
+    });
+    expect(JSON.stringify(result.approvalRequests)).not.toContain('placeholder-anthropic-key');
+    expect(JSON.stringify(result.approvalRequests)).not.toContain('fixture-token');
+    expect(JSON.stringify(result.approvalRequests)).not.toContain('settings.local.json');
+  });
+
+  it('sends an explicit deny response for ACP approval requests', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'request-permission',
+      approvalDecision: { outcome: 'selected', optionKind: 'reject_once' },
+    });
+
+    expect(result.prompt?.result.stopReason).toBe('permission_denied');
+    expect(result.approvalRequests[0]?.response).toEqual({
+      outcome: {
+        outcome: 'selected',
+        optionId: 'reject-once',
+      },
+    });
+  });
+
+  it('bounds long ACP approval command details before surfacing structured requests', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'request-large-permission',
+      approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
+    });
+
+    const rawInput = result.approvalRequests[0]?.toolCall.rawInput;
+    expect(rawInput).toMatchObject({
+      command: expect.stringContaining('[TRUNCATED]'),
+      env: {
+        ANTHROPIC_API_KEY: '[REDACTED]',
+      },
+    });
+    const command = rawInput && typeof rawInput === 'object' && 'command' in rawInput ? rawInput.command : '';
+    expect(typeof command === 'string' ? Buffer.byteLength(command, 'utf8') : 0).toBeLessThanOrEqual(
+      2_048
+    );
+    expect(typeof command === 'string' ? command : '').not.toContain('fixture-command-token');
+  });
+
+  it('redacts POSIX settings.local.json paths in ACP approval command details', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'request-posix-settings-permission',
+      approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
+    });
+
+    expect(result.approvalRequests[0]?.toolCall.rawInput).toMatchObject({
+      command: 'cat [REDACTED_PATH]',
+    });
+    expect(JSON.stringify(result.approvalRequests)).not.toContain('settings.local.json');
+  });
+
+  it('resolves a pending ACP approval request with cancelled outcome when the prompt is cancelled', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'request-permission',
+      cancelAfterApprovalRequest: true,
+    });
+
+    expect(result.cancelSent).toBe(true);
+    expect(result.prompt?.result.stopReason).toBe('permission_cancelled');
+    expect(result.approvalRequests[0]).toMatchObject({
+      state: 'responded',
+      response: {
+        outcome: {
+          outcome: 'cancelled',
+        },
+      },
+    });
+  });
+
+  it('rejects pending ACP approval requests when the child exits before a response', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions(),
+        prompt: 'request-permission-exit',
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP child process exited before response',
+      details: expect.objectContaining({
+        method: 'session/prompt',
+        code: 43,
+        pendingApprovals: [
+          expect.objectContaining({
+            requestId: 'permission-1',
+            state: 'rejected',
+            rejectionReason: 'child_exit',
+          }),
+        ],
+      }),
+    });
+  });
+
+  it('rejects pending ACP approval requests when the waiting prompt times out', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions(),
+        prompt: 'request-permission',
+        timeoutMs: 500,
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP request timed out',
+      details: expect.objectContaining({
+        method: 'session/prompt',
+        timeoutMs: 500,
+        pendingApprovals: [
+          expect.objectContaining({
+            requestId: 'permission-1',
+            state: 'rejected',
+            rejectionReason: 'request_timeout',
+          }),
+        ],
+      }),
+    });
+  });
+
+  it('surfaces malformed ACP approval requests as protocol errors', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions(),
+        prompt: 'request-invalid-permission',
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP permission option kind is unsupported',
+      details: expect.objectContaining({
+        method: 'session/request_permission',
+        optionId: 'allow-once',
+        kind: 'bogus',
+      }),
+    });
+  });
+
   it('bounds captured stderr by UTF-8 bytes for multi-byte output', async () => {
     const result = await runAcpLifecycleProbe({
       ...nodeFixtureOptions({ FAKE_ACP_MODE: 'unicode-stderr' }),

--- a/src/__tests__/acp-lifecycle-probe.test.ts
+++ b/src/__tests__/acp-lifecycle-probe.test.ts
@@ -592,6 +592,16 @@ describe('acp lifecycle probe', () => {
     expect(request?.toolCall.status).toContain('[REDACTED]');
     expect(request?.options[0]?.optionId).toContain('[REDACTED]');
     expect(request?.options[0]?.name).toContain('[REDACTED]');
+    const rawInput = request?.toolCall.rawInput;
+    expect(isJsonObject(rawInput)).toBe(true);
+    const rawInputKeys = isJsonObject(rawInput) ? Object.keys(rawInput) : [];
+    expect(rawInputKeys.some(key => key.includes('Bearer [REDACTED]'))).toBe(true);
+    expect(rawInputKeys.some(key => key.includes('[REDACTED_PATH]'))).toBe(true);
+    expect(rawInputKeys.some(key => key.includes('api_key=[REDACTED]'))).toBe(true);
+    expect(rawInputKeys.some(key => key.includes('[TRUNCATED]'))).toBe(true);
+    expect(JSON.stringify(rawInputKeys)).not.toContain('sk-ant-fixture-key-secret');
+    expect(JSON.stringify(rawInputKeys)).not.toContain('fixture-key-secret');
+    expect(JSON.stringify(rawInputKeys)).not.toContain('settings.local.json');
   });
 
   it('redacts POSIX settings.local.json paths in ACP approval command details', async () => {
@@ -627,24 +637,32 @@ describe('acp lifecycle probe', () => {
   });
 
   it('rejects ACP approval requests when the child exits before the response write is accepted', async () => {
-    await expect(
-      runAcpLifecycleProbe({
+    let rejection: unknown;
+    try {
+      await runAcpLifecycleProbe({
         ...nodeFixtureOptions(),
         prompt: 'request-permission-exit-large-option',
         approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
         timeoutMs: 1_000,
-      })
-    ).rejects.toMatchObject({
-      message: 'ACP approval response write failed',
-      details: expect.objectContaining({
-        method: 'session/request_permission',
-        requestId: 'permission-1',
-        approvalRequest: expect.objectContaining({
-          requestId: 'permission-1',
-          state: 'rejected',
-          rejectionReason: 'write_failed',
-        }),
-      }),
+      });
+    } catch (error) {
+      rejection = error;
+    }
+
+    expect(rejection).toBeInstanceOf(AcpProtocolError);
+    const details = rejection instanceof AcpProtocolError ? rejection.details : {};
+    const approvalRequest =
+      isJsonObject(details.approvalRequest) && details.approvalRequest.requestId === 'permission-1'
+        ? details.approvalRequest
+        : Array.isArray(details.pendingApprovals)
+          ? details.pendingApprovals.find(
+              approval => isJsonObject(approval) && approval.requestId === 'permission-1'
+            )
+          : undefined;
+    expect(approvalRequest).toMatchObject({
+      requestId: 'permission-1',
+      state: 'rejected',
+      rejectionReason: 'child_exit',
     });
   });
 
@@ -653,6 +671,28 @@ describe('acp lifecycle probe', () => {
       runAcpLifecycleProbe({
         ...nodeFixtureOptions(),
         prompt: 'request-permission-exit',
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP child process exited before response',
+      details: expect.objectContaining({
+        method: 'session/prompt',
+        code: 43,
+        pendingApprovals: [
+          expect.objectContaining({
+            requestId: 'permission-1',
+            state: 'rejected',
+            rejectionReason: 'child_exit',
+          }),
+        ],
+      }),
+    });
+  });
+
+  it('keeps pending approval child_exit classification when residual stdout is also present', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions(),
+        prompt: 'request-permission-exit-unterminated',
       })
     ).rejects.toMatchObject({
       message: 'ACP child process exited before response',

--- a/src/__tests__/fixtures/acp-approval-request.json
+++ b/src/__tests__/fixtures/acp-approval-request.json
@@ -1,0 +1,35 @@
+{
+  "sessionId": "fixture-session",
+  "toolCall": {
+    "toolCallId": "tool-call-approval-1",
+    "title": "Run shell command",
+    "kind": "execute",
+    "status": "pending",
+    "rawInput": {
+      "command": "node -e \"console.log(process.env.ANTHROPIC_API_KEY)\" && type C:\\Users\\fixture\\.claude\\settings.local.json",
+      "env": {
+        "ANTHROPIC_API_KEY": "placeholder-anthropic-key",
+        "AEGIS_AUTH_TOKEN": "fixture-token",
+        "PATH": "C:\\Windows\\System32"
+      }
+    },
+    "locations": [
+      {
+        "path": "src\\server.ts",
+        "line": 42
+      }
+    ]
+  },
+  "options": [
+    {
+      "optionId": "allow-once",
+      "name": "Allow once",
+      "kind": "allow_once"
+    },
+    {
+      "optionId": "reject-once",
+      "name": "Deny",
+      "kind": "reject_once"
+    }
+  ]
+}

--- a/src/__tests__/fixtures/fake-acp-agent.mjs
+++ b/src/__tests__/fixtures/fake-acp-agent.mjs
@@ -229,6 +229,7 @@ rl.on('line', line => {
     if (
       firstText === 'request-permission' ||
       firstText === 'request-permission-exit' ||
+      firstText === 'request-permission-exit-unterminated' ||
       firstText === 'request-permission-exit-large-option' ||
       firstText === 'request-large-permission' ||
       firstText === 'request-metadata-permission' ||
@@ -258,6 +259,14 @@ rl.on('line', line => {
                   title: `Run secret fixture-title-secret ${'x'.repeat(5_000)} C:\\Users\\fixture\\.claude\\settings.local.json`,
                   kind: `execute secret fixture-kind-secret ${'k'.repeat(5_000)}`,
                   status: `pending secret fixture-status-secret ${'s'.repeat(5_000)}`,
+                  rawInput: {
+                    [`${['Bearer', ['sk', 'ant', 'fixture', 'key', 'secret'].join('-')].join(' ')} ${'b'.repeat(5_000)}`]:
+                      'header value',
+                    [`C:\\Users\\fixture\\.claude\\settings.local.json ${'p'.repeat(5_000)}`]:
+                      'settings value',
+                    [`api_key=fixture-key-secret ${'a'.repeat(5_000)}`]: 'api key value',
+                    [`long-key-${'l'.repeat(5_000)}`]: 'long key value',
+                  },
                 },
                 options: Array.from({ length: 30 }, (_, index) =>
                   index === 0
@@ -297,7 +306,7 @@ rl.on('line', line => {
                   }
                 : approvalFixture;
       pendingPermissionPrompts.set(permissionId, { promptId: id, sessionId: params.sessionId });
-      send({
+      const permissionMessage = {
         jsonrpc: '2.0',
         id: permissionId,
         method: 'session/request_permission',
@@ -308,11 +317,16 @@ rl.on('line', line => {
               ? `fixture-session secret fixture-session-secret ${'q'.repeat(5_000)}`
               : params.sessionId,
         },
-      });
+      };
+      send(permissionMessage);
       if (
         firstText === 'request-permission-exit' ||
+        firstText === 'request-permission-exit-unterminated' ||
         firstText === 'request-permission-exit-large-option'
       ) {
+        if (firstText === 'request-permission-exit-unterminated') {
+          process.stdout.write('unterminated residual approval output');
+        }
         setImmediate(() => process.exit(43));
       }
       return;

--- a/src/__tests__/fixtures/fake-acp-agent.mjs
+++ b/src/__tests__/fixtures/fake-acp-agent.mjs
@@ -16,6 +16,10 @@ if (mode === 'unicode-stderr') {
   process.stderr.write('🐉'.repeat(70_000));
 }
 process.stderr.write('fake claude-agent-acp fixture ready\n');
+if (mode === 'unterminated-stdout-before-exit') {
+  process.stdout.write('this is not terminated json');
+  process.exit(45);
+}
 if (mode === 'exit-before-initialize') {
   process.stderr.write('fixture exiting before initialize\n');
   process.exit(42);
@@ -225,7 +229,9 @@ rl.on('line', line => {
     if (
       firstText === 'request-permission' ||
       firstText === 'request-permission-exit' ||
+      firstText === 'request-permission-exit-large-option' ||
       firstText === 'request-large-permission' ||
+      firstText === 'request-metadata-permission' ||
       firstText === 'request-posix-settings-permission'
     ) {
       const permissionId = 'permission-1';
@@ -243,17 +249,53 @@ rl.on('line', line => {
                 },
               },
             }
-          : firstText === 'request-posix-settings-permission'
+          : firstText === 'request-metadata-permission'
             ? {
                 ...approvalFixture,
                 toolCall: {
                   ...approvalFixture.toolCall,
-                  rawInput: {
-                    command: 'cat /Users/fixture/project/.claude/settings.local.json',
-                  },
+                  toolCallId: `tool-call secret fixture-tool-secret ${'z'.repeat(5_000)}`,
+                  title: `Run secret fixture-title-secret ${'x'.repeat(5_000)} C:\\Users\\fixture\\.claude\\settings.local.json`,
+                  kind: `execute secret fixture-kind-secret ${'k'.repeat(5_000)}`,
+                  status: `pending secret fixture-status-secret ${'s'.repeat(5_000)}`,
                 },
+                options: Array.from({ length: 30 }, (_, index) =>
+                  index === 0
+                    ? {
+                        optionId: `allow-once secret fixture-option-id-secret ${'i'.repeat(5_000)}`,
+                        name: `Allow api_key fixture-option-secret ${'n'.repeat(5_000)} C:\\Users\\fixture\\.claude\\settings.local.json`,
+                        kind: 'allow_once',
+                      }
+                    : {
+                        optionId: `option-${index}`,
+                        name: `Option ${index}`,
+                        kind: index % 2 === 0 ? 'allow_once' : 'reject_once',
+                      }
+                ),
               }
-            : approvalFixture;
+            : firstText === 'request-permission-exit-large-option'
+              ? {
+                  ...approvalFixture,
+                  options: [
+                    {
+                      optionId: `allow-once-${'x'.repeat(1_000_000)}`,
+                      name: 'Allow once with large id',
+                      kind: 'allow_once',
+                    },
+                    ...approvalFixture.options.slice(1),
+                  ],
+                }
+              : firstText === 'request-posix-settings-permission'
+                ? {
+                    ...approvalFixture,
+                    toolCall: {
+                      ...approvalFixture.toolCall,
+                      rawInput: {
+                        command: 'cat /Users/fixture/project/.claude/settings.local.json',
+                      },
+                    },
+                  }
+                : approvalFixture;
       pendingPermissionPrompts.set(permissionId, { promptId: id, sessionId: params.sessionId });
       send({
         jsonrpc: '2.0',
@@ -261,10 +303,16 @@ rl.on('line', line => {
         method: 'session/request_permission',
         params: {
           ...approvalParams,
-          sessionId: params.sessionId,
+          sessionId:
+            firstText === 'request-metadata-permission'
+              ? `fixture-session secret fixture-session-secret ${'q'.repeat(5_000)}`
+              : params.sessionId,
         },
       });
-      if (firstText === 'request-permission-exit') {
+      if (
+        firstText === 'request-permission-exit' ||
+        firstText === 'request-permission-exit-large-option'
+      ) {
         setImmediate(() => process.exit(43));
       }
       return;

--- a/src/__tests__/fixtures/fake-acp-agent.mjs
+++ b/src/__tests__/fixtures/fake-acp-agent.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
 import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
 
 const mode = process.env.FAKE_ACP_MODE ?? 'normal';
 const anthAuthTokenKey = ['ANTHROPIC', 'AUTH', 'TOKEN'].join('_');
@@ -19,6 +22,12 @@ if (mode === 'exit-before-initialize') {
 }
 
 let pendingPrompt = null;
+const pendingPermissionPrompts = new Map();
+const approvalFixturePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'acp-approval-request.json'
+);
+const approvalFixture = JSON.parse(fs.readFileSync(approvalFixturePath, 'utf8'));
 const terminalState = {
   terminalId: 'fixture-terminal',
   output: '',
@@ -51,6 +60,10 @@ const rl = readline.createInterface({ input: process.stdin });
 rl.on('line', line => {
   if (!line.trim()) return;
   const message = JSON.parse(line);
+  if (Object.hasOwn(message, 'result') || Object.hasOwn(message, 'error')) {
+    handlePermissionResponse(message);
+    return;
+  }
   const { id, method, params } = message;
   if (method === undefined && id !== undefined) {
     return;
@@ -207,6 +220,66 @@ rl.on('line', line => {
     }
     if (firstText === 'wait-for-cancel') {
       pendingPrompt = { id, sessionId: params.sessionId };
+      return;
+    }
+    if (
+      firstText === 'request-permission' ||
+      firstText === 'request-permission-exit' ||
+      firstText === 'request-large-permission' ||
+      firstText === 'request-posix-settings-permission'
+    ) {
+      const permissionId = 'permission-1';
+      const approvalParams =
+        firstText === 'request-large-permission'
+          ? {
+              ...approvalFixture,
+              toolCall: {
+                ...approvalFixture.toolCall,
+                rawInput: {
+                  command: `echo secret fixture-command-token ${'x'.repeat(5_000)}`,
+                  env: {
+                    ANTHROPIC_API_KEY: 'placeholder-anthropic-key',
+                  },
+                },
+              },
+            }
+          : firstText === 'request-posix-settings-permission'
+            ? {
+                ...approvalFixture,
+                toolCall: {
+                  ...approvalFixture.toolCall,
+                  rawInput: {
+                    command: 'cat /Users/fixture/project/.claude/settings.local.json',
+                  },
+                },
+              }
+            : approvalFixture;
+      pendingPermissionPrompts.set(permissionId, { promptId: id, sessionId: params.sessionId });
+      send({
+        jsonrpc: '2.0',
+        id: permissionId,
+        method: 'session/request_permission',
+        params: {
+          ...approvalParams,
+          sessionId: params.sessionId,
+        },
+      });
+      if (firstText === 'request-permission-exit') {
+        setImmediate(() => process.exit(43));
+      }
+      return;
+    }
+    if (firstText === 'request-invalid-permission') {
+      send({
+        jsonrpc: '2.0',
+        id: 'permission-1',
+        method: 'session/request_permission',
+        params: {
+          sessionId: params.sessionId,
+          toolCall: { toolCallId: 'tool-call-approval-1' },
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'bogus' }],
+        },
+      });
       return;
     }
     respond(id, { stopReason: 'end_turn' });
@@ -407,6 +480,35 @@ rl.on('line', line => {
     error(id, -32601, `Unknown method ${method}`);
   }
 });
+
+function handlePermissionResponse(message) {
+  const pending = pendingPermissionPrompts.get(message.id);
+  if (!pending) return;
+  pendingPermissionPrompts.delete(message.id);
+
+  if (Object.hasOwn(message, 'error')) {
+    respond(pending.promptId, { stopReason: 'permission_error' });
+    return;
+  }
+
+  const outcome = message.result?.outcome;
+  if (outcome?.outcome === 'cancelled') {
+    respond(pending.promptId, { stopReason: 'permission_cancelled' });
+    return;
+  }
+
+  if (outcome?.outcome === 'selected' && outcome.optionId === 'allow-once') {
+    respond(pending.promptId, { stopReason: 'permission_allowed' });
+    return;
+  }
+
+  if (outcome?.outcome === 'selected' && outcome.optionId === 'reject-once') {
+    respond(pending.promptId, { stopReason: 'permission_denied' });
+    return;
+  }
+
+  respond(pending.promptId, { stopReason: 'permission_unknown' });
+}
 
 rl.on('close', () => process.exit(0));
 

--- a/src/acp-lifecycle-probe.ts
+++ b/src/acp-lifecycle-probe.ts
@@ -17,6 +17,7 @@ const STDERR_LIMIT_BYTES = 64 * 1024;
 const APPROVAL_STRING_LIMIT_BYTES = 2 * 1024;
 const APPROVAL_ARRAY_LIMIT_ITEMS = 25;
 const APPROVAL_OBJECT_LIMIT_KEYS = 50;
+const APPROVAL_WRITE_EXIT_GRACE_MS = 100;
 
 export type AcpCommandSource = 'explicit' | 'AEGIS_ACP_BIN' | 'local-package-bin' | 'npm-exec';
 export type AcpModelProvider =
@@ -610,6 +611,7 @@ class NdjsonRpcTransport {
   private cancelOnAgentMessageSessionId: string | null = null;
   private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
   private exited = false;
+  private activeWrites = 0;
 
   constructor(
     private readonly child: ChildProcessWithoutNullStreams,
@@ -620,8 +622,13 @@ class NdjsonRpcTransport {
     this.exitPromise = new Promise(resolve => {
       child.once('exit', (code, signal) => {
         this.exited = true;
-        this.failOnResidualStdoutBuffer();
-        this.failPendingOnExit(code, signal);
+        if (this.pendingApprovals.size > 0) {
+          this.failPendingOnExit(code, signal);
+          this.failOnResidualStdoutBuffer();
+        } else {
+          this.failOnResidualStdoutBuffer();
+          this.failPendingOnExit(code, signal);
+        }
         resolve({ code, signal });
       });
     });
@@ -639,7 +646,9 @@ class NdjsonRpcTransport {
       this.stderr = appendLimited(this.stderr, chunk, STDERR_LIMIT_BYTES);
     });
     child.stdin.on('error', error => {
+      const activeWritesAtError = this.activeWrites;
       setImmediate(() => {
+        if (activeWritesAtError > 0) return;
         if (!this.protocolFailure) {
           this.fail(new AcpProtocolError('ACP stdin write failed', { message: error.message }));
         }
@@ -932,16 +941,23 @@ class NdjsonRpcTransport {
         result: response,
       });
     } catch (error) {
+      const rejectionReason = await this.approvalRejectionReasonFromWriteError(error);
       request.state = 'rejected';
-      request.rejectionReason = 'write_failed';
+      request.rejectionReason = rejectionReason;
       delete request.response;
       this.pendingApprovals.delete(id);
-      const protocolError = new AcpProtocolError('ACP approval response write failed', {
-        method: 'session/request_permission',
-        requestId: id,
-        writeError: error instanceof Error ? error.message : String(error),
-        approvalRequest: { ...request },
-      });
+      const protocolError = new AcpProtocolError(
+        rejectionReason === 'child_exit'
+          ? 'ACP child process exited before approval response write'
+          : 'ACP approval response write failed',
+        {
+          method: 'session/request_permission',
+          requestId: id,
+          rejectionReason,
+          writeError: error instanceof Error ? error.message : String(error),
+          approvalRequest: { ...request },
+        }
+      );
       this.fail(protocolError);
       throw protocolError;
     }
@@ -952,6 +968,12 @@ class NdjsonRpcTransport {
 
   private async write(message: JsonObject): Promise<void> {
     this.throwIfFailed();
+    if (this.hasChildExited()) {
+      throw new AcpProtocolError('ACP child process exited before write', {
+        ...summarizeOutboundMessage(message),
+        approvalRejectionReason: 'child_exit',
+      });
+    }
     if (
       this.child.stdin.destroyed ||
       this.child.stdin.writableEnded ||
@@ -960,41 +982,96 @@ class NdjsonRpcTransport {
       throw new AcpProtocolError('ACP stdin is not writable', summarizeOutboundMessage(message));
     }
     const payload = `${JSON.stringify(message)}\n`;
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      const settle = (error: Error | null): void => {
-        if (settled) return;
-        settled = true;
-        this.child.stdin.off('error', onError);
-        if (error) {
-          reject(
-            new AcpProtocolError('ACP stdin write failed', {
+    this.activeWrites += 1;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const settle = (error: Error | null): void => {
+          if (settled) return;
+          settled = true;
+          this.child.stdin.off('error', onError);
+          this.child.off('exit', onExit);
+          if (error) {
+            if (error instanceof AcpProtocolError) {
+              reject(error);
+              return;
+            }
+            reject(
+              new AcpProtocolError('ACP stdin write failed', {
+                ...summarizeOutboundMessage(message),
+                approvalRejectionReason: this.hasChildExited() ? 'child_exit' : 'write_failed',
+                writeError: error.message,
+              })
+            );
+            return;
+          }
+          if (this.hasChildExited()) {
+            reject(
+              new AcpProtocolError('ACP child process exited before write completed', {
+                ...summarizeOutboundMessage(message),
+                approvalRejectionReason: 'child_exit',
+              })
+            );
+            return;
+          }
+          if (this.child.stdin.destroyed || this.child.stdin.writableEnded) {
+            reject(
+              new AcpProtocolError(
+                'ACP stdin closed before write completed',
+                summarizeOutboundMessage(message)
+              )
+            );
+            return;
+          }
+          resolve();
+        };
+        const onError = (error: Error): void => settle(error);
+        const onExit = (): void => {
+          settle(
+            new AcpProtocolError('ACP child process exited before write completed', {
               ...summarizeOutboundMessage(message),
-              writeError: error.message,
+              approvalRejectionReason: 'child_exit',
             })
           );
-          return;
+        };
+        this.child.stdin.once('error', onError);
+        this.child.once('exit', onExit);
+        try {
+          this.child.stdin.write(payload, error => settle(error ?? null));
+        } catch (error) {
+          settle(error instanceof Error ? error : new Error(String(error)));
         }
-        if (this.exited || this.child.stdin.destroyed || this.child.stdin.writableEnded) {
-          reject(
-            new AcpProtocolError(
-              'ACP stdin closed before write completed',
-              summarizeOutboundMessage(message)
-            )
-          );
-          return;
-        }
-        resolve();
-      };
-      const onError = (error: Error): void => settle(error);
-      this.child.stdin.once('error', onError);
-      try {
-        this.child.stdin.write(payload, error => settle(error ?? null));
-      } catch (error) {
-        settle(error instanceof Error ? error : new Error(String(error)));
-      }
-    });
+      });
+    } finally {
+      this.activeWrites -= 1;
+    }
     this.frames.push({ direction: 'client_to_agent', message });
+  }
+
+  private hasChildExited(): boolean {
+    return this.exited || this.child.exitCode !== null || this.child.signalCode !== null;
+  }
+
+  private async approvalRejectionReasonFromWriteError(
+    error: unknown
+  ): Promise<AcpApprovalRejectionReason> {
+    if (
+      error instanceof AcpProtocolError &&
+      error.details.approvalRejectionReason === 'child_exit'
+    ) {
+      return 'child_exit';
+    }
+
+    if (this.hasChildExited()) return 'child_exit';
+
+    await Promise.race([
+      this.exitPromise.then(() => undefined),
+      new Promise<void>(resolve => {
+        setTimeout(resolve, APPROVAL_WRITE_EXIT_GRACE_MS);
+      }),
+    ]);
+
+    return this.hasChildExited() ? 'child_exit' : 'write_failed';
   }
 
   private fail(error: AcpProtocolError): void {
@@ -1394,8 +1471,10 @@ function sanitizeAcpApprovalValue(value: unknown, key: string | undefined): unkn
   if (isJsonObject(value)) {
     const entries = Object.entries(value).slice(0, APPROVAL_OBJECT_LIMIT_KEYS);
     const sanitized: JsonObject = {};
+    const usedKeys = new Set<string>();
     for (const [entryKey, entryValue] of entries) {
-      sanitized[entryKey] = sanitizeAcpApprovalValue(entryValue, entryKey);
+      const sanitizedKey = uniqueJsonObjectKey(redactApprovalString(entryKey), usedKeys);
+      sanitized[sanitizedKey] = sanitizeAcpApprovalValue(entryValue, entryKey);
     }
     if (Object.keys(value).length > APPROVAL_OBJECT_LIMIT_KEYS) {
       sanitized.__truncatedKeys = Object.keys(value).length - APPROVAL_OBJECT_LIMIT_KEYS;
@@ -1426,18 +1505,43 @@ function isSensitiveApprovalKey(key: string): boolean {
 }
 
 function redactApprovalString(value: string): string {
-  const withoutSettingsPath = value
-    .replace(/[A-Za-z]:\\(?:[^\\\r\n"]+\\)*settings\.local\.json/gi, '[REDACTED_PATH]')
-    .replace(/(?:~|\/[^\s'"\\]+)(?:\/[^\s'"\\]+)*\/settings\.local\.json/gi, '[REDACTED_PATH]');
+  const boundedValue = truncateUtf8(value, APPROVAL_STRING_LIMIT_BYTES);
+  const withoutSettingsPath = boundedValue.replace(
+    /[^\s'"]*settings\.local\.json/gi,
+    '[REDACTED_PATH]'
+  );
   const withoutSecretTokens = withoutSettingsPath.replace(
     /\bsk-(?:ant|live|test|proj)-[A-Za-z0-9_-]+\b/g,
     '[REDACTED]'
   );
   const withoutBearer = withoutSecretTokens.replace(
-    /(?<![A-Za-z0-9_-])(Bearer|token|api[_-]?key|secret)\s+['"]?[^'",\s]+/gi,
+    /\b(Bearer|token|api[_-]?key|secret)\s+['"]?[^'",\s]+/gi,
     '$1 [REDACTED]'
   );
-  return truncateUtf8(withoutBearer, APPROVAL_STRING_LIMIT_BYTES);
+  const withoutAssignments = withoutBearer.replace(
+    /\b((?:authorization|token|api[_-]?key|secret)\s*[:=]\s*)['"]?[^'",\s]+/gi,
+    '$1[REDACTED]'
+  );
+  return truncateUtf8(withoutAssignments, APPROVAL_STRING_LIMIT_BYTES);
+}
+
+function uniqueJsonObjectKey(candidate: string, usedKeys: Set<string>): string {
+  if (!usedKeys.has(candidate)) {
+    usedKeys.add(candidate);
+    return candidate;
+  }
+
+  let index = 2;
+  while (true) {
+    const suffix = `#${index}`;
+    const key = truncateUtf8(candidate, APPROVAL_STRING_LIMIT_BYTES - Buffer.byteLength(suffix));
+    const uniqueKey = `${key}${suffix}`;
+    if (!usedKeys.has(uniqueKey)) {
+      usedKeys.add(uniqueKey);
+      return uniqueKey;
+    }
+    index += 1;
+  }
 }
 
 function appendLimited(current: string, chunk: string, limitBytes: number): string {

--- a/src/acp-lifecycle-probe.ts
+++ b/src/acp-lifecycle-probe.ts
@@ -205,6 +205,14 @@ interface AcpModelPassthrough {
 
 interface PendingApprovalRequest {
   request: AcpApprovalRequest;
+  rawSessionId: string;
+  responseOptions: AcpPermissionOption[];
+}
+
+interface NormalizedApprovalRequest {
+  request: AcpApprovalRequest;
+  rawSessionId: string;
+  responseOptions: AcpPermissionOption[];
 }
 
 interface ApprovalHandlingOptions {
@@ -612,6 +620,7 @@ class NdjsonRpcTransport {
     this.exitPromise = new Promise(resolve => {
       child.once('exit', (code, signal) => {
         this.exited = true;
+        this.failOnResidualStdoutBuffer();
         this.failPendingOnExit(code, signal);
         resolve({ code, signal });
       });
@@ -628,6 +637,13 @@ class NdjsonRpcTransport {
     child.stderr.setEncoding('utf8');
     child.stderr.on('data', (chunk: string) => {
       this.stderr = appendLimited(this.stderr, chunk, STDERR_LIMIT_BYTES);
+    });
+    child.stdin.on('error', error => {
+      setImmediate(() => {
+        if (!this.protocolFailure) {
+          this.fail(new AcpProtocolError('ACP stdin write failed', { message: error.message }));
+        }
+      });
     });
   }
 
@@ -656,14 +672,25 @@ class NdjsonRpcTransport {
       this.pending.set(id, { method, resolve, reject, timer });
     });
 
-    this.write({ jsonrpc: '2.0', id, method, params });
+    try {
+      await this.write({ jsonrpc: '2.0', id, method, params });
+    } catch (error) {
+      const pending = this.pending.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+      }
+      const protocolError = toAcpProtocolError(error, 'ACP request write failed', { method, id });
+      this.fail(protocolError);
+      throw protocolError;
+    }
     return response;
   }
 
   async waitForExit(
     timeoutMs: number
   ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-    return Promise.race([
+    const exit = await Promise.race([
       this.exitPromise,
       new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((_, reject) => {
         setTimeout(
@@ -672,9 +699,12 @@ class NdjsonRpcTransport {
         );
       }),
     ]);
+    this.throwIfFailed();
+    return exit;
   }
 
   async dispose(): Promise<void> {
+    this.failOnResidualStdoutBuffer();
     this.rejectPendingApprovals('transport_disposed', true);
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer);
@@ -730,11 +760,13 @@ class NdjsonRpcTransport {
         return;
       }
 
-      this.handleMessage(parsed);
+      void this.handleMessage(parsed).catch(error => {
+        this.fail(toAcpProtocolError(error, 'ACP stdout message handling failed'));
+      });
     }
   }
 
-  private handleMessage(message: unknown): void {
+  private async handleMessage(message: unknown): Promise<void> {
     if (!isJsonObject(message)) {
       this.fail(new AcpProtocolError('ACP stdout message was not a JSON object', { message }));
       return;
@@ -763,7 +795,7 @@ class NdjsonRpcTransport {
         this.fail(new AcpProtocolError('ACP request id was not a JSON-RPC id', { id, method }));
         return;
       }
-      this.handleClientRequest(id, method, message.params);
+      await this.handleClientRequest(id, method, message.params);
       return;
     }
 
@@ -780,10 +812,11 @@ class NdjsonRpcTransport {
     }
     this.notifications.push(notification);
     if (this.shouldCancelAfterNotification(notification)) {
-      this.write({
+      const sessionId = this.cancelOnAgentMessageSessionId;
+      await this.write({
         jsonrpc: '2.0',
         method: 'session/cancel',
-        params: { sessionId: this.cancelOnAgentMessageSessionId },
+        params: { sessionId },
       });
       this.cancelSent = true;
       this.cancelOnAgentMessageSessionId = null;
@@ -825,34 +858,39 @@ class NdjsonRpcTransport {
     return isJsonObject(update) && update.sessionUpdate === 'agent_message_chunk';
   }
 
-  private handleClientRequest(id: JsonRpcId, method: string, params: unknown): void {
+  private async handleClientRequest(id: JsonRpcId, method: string, params: unknown): Promise<void> {
     if (method !== 'session/request_permission') {
-      this.writeJsonRpcError(id, -32601, `Client method not implemented by lifecycle probe: ${method}`);
+      await this.writeJsonRpcError(
+        id,
+        -32601,
+        `Client method not implemented by lifecycle probe: ${method}`
+      );
       return;
     }
 
-    let request: AcpApprovalRequest;
+    let normalized: NormalizedApprovalRequest;
     try {
-      request = normalizeApprovalRequest(id, params);
+      normalized = normalizeApprovalRequest(id, params);
     } catch (error) {
       const protocolError =
         error instanceof AcpProtocolError
           ? error
           : new AcpProtocolError('ACP permission request could not be normalized', { method });
-      this.writeJsonRpcError(id, -32602, protocolError.message);
+      await this.writeJsonRpcError(id, -32602, protocolError.message);
       this.fail(protocolError);
       return;
     }
+    const { request, rawSessionId, responseOptions } = normalized;
 
     this.approvalRequests.push(request);
-    this.pendingApprovals.set(id, { request });
+    this.pendingApprovals.set(id, { request, rawSessionId, responseOptions });
 
     if (this.approvalHandling.cancelAfterApprovalRequest) {
-      this.respondToApproval(id, request, { outcome: { outcome: 'cancelled' } });
-      this.write({
+      await this.respondToApproval(id, request, { outcome: { outcome: 'cancelled' } });
+      await this.write({
         jsonrpc: '2.0',
         method: 'session/cancel',
-        params: { sessionId: request.sessionId },
+        params: { sessionId: rawSessionId },
       });
       this.cancelSent = true;
       return;
@@ -866,7 +904,7 @@ class NdjsonRpcTransport {
 
     let response: AcpApprovalResponse;
     try {
-      response = approvalResponseFromDecision(request, decision);
+      response = approvalResponseFromDecision(request, decision, responseOptions);
     } catch (error) {
       const protocolError =
         error instanceof AcpProtocolError
@@ -874,36 +912,89 @@ class NdjsonRpcTransport {
           : new AcpProtocolError('ACP permission decision could not be applied', {
               method: 'session/request_permission',
             });
-      this.writeJsonRpcError(id, -32602, protocolError.message);
+      await this.writeJsonRpcError(id, -32602, protocolError.message);
       this.fail(protocolError);
       return;
     }
 
-    this.respondToApproval(id, request, response);
+    await this.respondToApproval(id, request, response);
   }
 
-  private respondToApproval(
+  private async respondToApproval(
     id: JsonRpcId,
     request: AcpApprovalRequest,
     response: AcpApprovalResponse
-  ): void {
+  ): Promise<void> {
+    try {
+      await this.write({
+        jsonrpc: '2.0',
+        id,
+        result: response,
+      });
+    } catch (error) {
+      request.state = 'rejected';
+      request.rejectionReason = 'write_failed';
+      delete request.response;
+      this.pendingApprovals.delete(id);
+      const protocolError = new AcpProtocolError('ACP approval response write failed', {
+        method: 'session/request_permission',
+        requestId: id,
+        writeError: error instanceof Error ? error.message : String(error),
+        approvalRequest: { ...request },
+      });
+      this.fail(protocolError);
+      throw protocolError;
+    }
     request.state = 'responded';
-    request.response = response;
+    request.response = surfaceApprovalResponse(response);
     this.pendingApprovals.delete(id);
-    this.write({
-      jsonrpc: '2.0',
-      id,
-      result: response,
-    });
   }
 
-  private write(message: JsonObject): void {
+  private async write(message: JsonObject): Promise<void> {
     this.throwIfFailed();
-    if (this.child.stdin.destroyed || !this.child.stdin.writable) {
-      throw new AcpProtocolError('ACP stdin is not writable', { message });
+    if (
+      this.child.stdin.destroyed ||
+      this.child.stdin.writableEnded ||
+      !this.child.stdin.writable
+    ) {
+      throw new AcpProtocolError('ACP stdin is not writable', summarizeOutboundMessage(message));
     }
+    const payload = `${JSON.stringify(message)}\n`;
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const settle = (error: Error | null): void => {
+        if (settled) return;
+        settled = true;
+        this.child.stdin.off('error', onError);
+        if (error) {
+          reject(
+            new AcpProtocolError('ACP stdin write failed', {
+              ...summarizeOutboundMessage(message),
+              writeError: error.message,
+            })
+          );
+          return;
+        }
+        if (this.exited || this.child.stdin.destroyed || this.child.stdin.writableEnded) {
+          reject(
+            new AcpProtocolError(
+              'ACP stdin closed before write completed',
+              summarizeOutboundMessage(message)
+            )
+          );
+          return;
+        }
+        resolve();
+      };
+      const onError = (error: Error): void => settle(error);
+      this.child.stdin.once('error', onError);
+      try {
+        this.child.stdin.write(payload, error => settle(error ?? null));
+      } catch (error) {
+        settle(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
     this.frames.push({ direction: 'client_to_agent', message });
-    this.child.stdin.write(`${JSON.stringify(message)}\n`);
   }
 
   private fail(error: AcpProtocolError): void {
@@ -950,8 +1041,8 @@ class NdjsonRpcTransport {
     if (this.protocolFailure) throw this.protocolFailure;
   }
 
-  private writeJsonRpcError(id: JsonRpcId, code: number, message: string): void {
-    this.write({
+  private async writeJsonRpcError(id: JsonRpcId, code: number, message: string): Promise<void> {
+    await this.write({
       jsonrpc: '2.0',
       id,
       error: {
@@ -971,19 +1062,26 @@ class NdjsonRpcTransport {
       pending.request.rejectionReason = reason;
       rejected.push({ ...pending.request });
       if (notifyAgent && !this.exited) {
-        this.tryWriteJsonRpcError(id, -32000, `ACP approval request rejected: ${reason}`);
+        void this.tryWriteJsonRpcError(id, -32000, `ACP approval request rejected: ${reason}`);
       }
     }
     this.pendingApprovals.clear();
     return rejected;
   }
 
-  private tryWriteJsonRpcError(id: JsonRpcId, code: number, message: string): void {
+  private async tryWriteJsonRpcError(id: JsonRpcId, code: number, message: string): Promise<void> {
     try {
-      this.writeJsonRpcError(id, code, message);
+      await this.writeJsonRpcError(id, code, message);
     } catch {
       // Best-effort cleanup: the original timeout/exit/dispose error is reported to the caller.
     }
+  }
+
+  private failOnResidualStdoutBuffer(): void {
+    if (this.protocolFailure || this.stdoutBuffer.trim() === '') return;
+    const line = this.stdoutBuffer.replace(/\r$/, '');
+    this.stdoutBuffer = '';
+    this.fail(new AcpProtocolError('ACP stdout ended with an unterminated line', { line }));
   }
 }
 
@@ -1088,7 +1186,7 @@ function requireObject(value: unknown, label: string): JsonObject {
   return value;
 }
 
-function normalizeApprovalRequest(id: JsonRpcId, params: unknown): AcpApprovalRequest {
+function normalizeApprovalRequest(id: JsonRpcId, params: unknown): NormalizedApprovalRequest {
   const request = requireObject(params, 'session/request_permission params');
   const optionsValue = request.options;
   if (!Array.isArray(optionsValue)) {
@@ -1096,17 +1194,26 @@ function normalizeApprovalRequest(id: JsonRpcId, params: unknown): AcpApprovalRe
       method: 'session/request_permission',
     });
   }
+  const rawSessionId = requireString(request.sessionId, 'session/request_permission sessionId');
+  const normalizedOptions = optionsValue.map(normalizePermissionOption);
 
   return {
-    requestId: id,
-    sessionId: requireString(request.sessionId, 'session/request_permission sessionId'),
-    toolCall: normalizeApprovalToolCall(request.toolCall),
-    options: optionsValue.map(normalizePermissionOption),
-    state: 'pending',
+    request: {
+      requestId: id,
+      sessionId: redactApprovalString(rawSessionId),
+      toolCall: normalizeApprovalToolCall(request.toolCall),
+      options: normalizedOptions.slice(0, APPROVAL_ARRAY_LIMIT_ITEMS).map(option => option.surface),
+      state: 'pending',
+    },
+    rawSessionId,
+    responseOptions: normalizedOptions.map(option => option.response),
   };
 }
 
-function normalizePermissionOption(value: unknown): AcpPermissionOption {
+function normalizePermissionOption(value: unknown): {
+  surface: AcpPermissionOption;
+  response: AcpPermissionOption;
+} {
   const option = requireObject(value, 'session/request_permission option');
   const optionId = requireString(option.optionId, 'session/request_permission option.optionId');
   const kind = requireString(option.kind, 'session/request_permission option.kind');
@@ -1118,21 +1225,40 @@ function normalizePermissionOption(value: unknown): AcpPermissionOption {
     });
   }
   return {
-    optionId,
-    name: requireString(option.name, 'session/request_permission option.name'),
-    kind,
+    surface: {
+      optionId: redactApprovalString(optionId),
+      name: redactApprovalString(
+        requireString(option.name, 'session/request_permission option.name')
+      ),
+      kind,
+    },
+    response: {
+      optionId,
+      name: requireString(option.name, 'session/request_permission option.name'),
+      kind,
+    },
   };
 }
 
 function normalizeApprovalToolCall(value: unknown): AcpApprovalToolCall {
   const toolCall = requireObject(value, 'session/request_permission toolCall');
   return {
-    toolCallId: requireString(toolCall.toolCallId, 'session/request_permission toolCall.toolCallId'),
-    title: optionalStringOrNull(toolCall.title, 'session/request_permission toolCall.title'),
-    kind: optionalStringOrNull(toolCall.kind, 'session/request_permission toolCall.kind'),
-    status: optionalStringOrNull(toolCall.status, 'session/request_permission toolCall.status'),
+    toolCallId: redactApprovalString(
+      requireString(toolCall.toolCallId, 'session/request_permission toolCall.toolCallId')
+    ),
+    title: optionalRedactedStringOrNull(
+      toolCall.title,
+      'session/request_permission toolCall.title'
+    ),
+    kind: optionalRedactedStringOrNull(toolCall.kind, 'session/request_permission toolCall.kind'),
+    status: optionalRedactedStringOrNull(
+      toolCall.status,
+      'session/request_permission toolCall.status'
+    ),
     rawInput:
-      toolCall.rawInput === undefined ? undefined : sanitizeAcpApprovalValue(toolCall.rawInput, undefined),
+      toolCall.rawInput === undefined
+        ? undefined
+        : sanitizeAcpApprovalValue(toolCall.rawInput, undefined),
     rawOutput:
       toolCall.rawOutput === undefined
         ? undefined
@@ -1142,21 +1268,24 @@ function normalizeApprovalToolCall(value: unknown): AcpApprovalToolCall {
         ? undefined
         : sanitizeAcpApprovalValue(toolCall.locations, undefined),
     content:
-      toolCall.content === undefined ? undefined : sanitizeAcpApprovalValue(toolCall.content, undefined),
+      toolCall.content === undefined
+        ? undefined
+        : sanitizeAcpApprovalValue(toolCall.content, undefined),
   };
 }
 
 function approvalResponseFromDecision(
   request: AcpApprovalRequest,
-  decision: AcpApprovalDecision
+  decision: AcpApprovalDecision,
+  responseOptions: readonly AcpPermissionOption[] = request.options
 ): AcpApprovalResponse {
   if (decision.outcome === 'cancelled') return { outcome: { outcome: 'cancelled' } };
 
-  const optionId =
+  const selectedOption =
     'optionId' in decision
-      ? decision.optionId
-      : request.options.find(option => option.kind === decision.optionKind)?.optionId;
-  if (!optionId || !request.options.some(option => option.optionId === optionId)) {
+      ? findResponseOptionById(request.options, responseOptions, decision.optionId)
+      : responseOptions.find(option => option.kind === decision.optionKind);
+  if (!selectedOption) {
     throw new AcpProtocolError('ACP permission decision did not match an available option', {
       method: 'session/request_permission',
       requestId: request.requestId,
@@ -1164,7 +1293,38 @@ function approvalResponseFromDecision(
     });
   }
 
-  return { outcome: { outcome: 'selected', optionId } };
+  return { outcome: { outcome: 'selected', optionId: selectedOption.optionId } };
+}
+
+function findResponseOptionById(
+  surfaceOptions: readonly AcpPermissionOption[],
+  responseOptions: readonly AcpPermissionOption[],
+  optionId: string
+): AcpPermissionOption | undefined {
+  const directMatch = responseOptions.find(option => option.optionId === optionId);
+  if (directMatch) return directMatch;
+  const surfaceIndex = surfaceOptions.findIndex(option => option.optionId === optionId);
+  return surfaceIndex === -1 ? undefined : responseOptions[surfaceIndex];
+}
+
+function surfaceApprovalResponse(response: AcpApprovalResponse): AcpApprovalResponse {
+  if (response.outcome.outcome === 'cancelled') return response;
+  return {
+    outcome: {
+      outcome: 'selected',
+      optionId: redactApprovalString(response.outcome.optionId),
+    },
+  };
+}
+
+function summarizeOutboundMessage(message: JsonObject): JsonObject {
+  return {
+    jsonrpc: message.jsonrpc === '2.0' ? '2.0' : undefined,
+    id: isJsonRpcId(message.id) ? message.id : undefined,
+    method: typeof message.method === 'string' ? message.method : undefined,
+    hasResult: Object.hasOwn(message, 'result'),
+    hasError: Object.hasOwn(message, 'error'),
+  };
 }
 
 function requireArray(value: unknown, label: string): unknown[] {
@@ -1189,6 +1349,11 @@ function optionalString(value: unknown, label: string): string | undefined {
 function optionalStringOrNull(value: unknown, label: string): string | undefined {
   if (value === undefined || value === null) return undefined;
   return requireString(value, label);
+}
+
+function optionalRedactedStringOrNull(value: unknown, label: string): string | undefined {
+  const stringValue = optionalStringOrNull(value, label);
+  return stringValue === undefined ? undefined : redactApprovalString(stringValue);
 }
 
 function requireNumber(value: unknown, label: string): number {
@@ -1240,8 +1405,24 @@ function sanitizeAcpApprovalValue(value: unknown, key: string | undefined): unkn
   return String(value);
 }
 
+function toAcpProtocolError(
+  error: unknown,
+  message: string,
+  details: JsonObject = {}
+): AcpProtocolError {
+  if (error instanceof AcpProtocolError) {
+    return new AcpProtocolError(error.message, { ...details, ...error.details });
+  }
+  return new AcpProtocolError(message, {
+    ...details,
+    message: error instanceof Error ? error.message : String(error),
+  });
+}
+
 function isSensitiveApprovalKey(key: string): boolean {
-  return /(authorization|cookie|api[_-]?key|auth[_-]?token|token|secret|password|credential)/i.test(key);
+  return /(authorization|cookie|api[_-]?key|auth[_-]?token|token|secret|password|credential)/i.test(
+    key
+  );
 }
 
 function redactApprovalString(value: string): string {

--- a/src/acp-lifecycle-probe.ts
+++ b/src/acp-lifecycle-probe.ts
@@ -14,6 +14,9 @@ export type { AcpCapturedFrame, AcpNormalizedEvent } from './acp-event-stream.js
 const DEFAULT_TIMEOUT_MS = 15_000;
 const EXIT_TIMEOUT_MS = 2_000;
 const STDERR_LIMIT_BYTES = 64 * 1024;
+const APPROVAL_STRING_LIMIT_BYTES = 2 * 1024;
+const APPROVAL_ARRAY_LIMIT_ITEMS = 25;
+const APPROVAL_OBJECT_LIMIT_KEYS = 50;
 
 export type AcpCommandSource = 'explicit' | 'AEGIS_ACP_BIN' | 'local-package-bin' | 'npm-exec';
 export type AcpModelProvider =
@@ -26,8 +29,21 @@ export type AcpModelProvider =
 
 export const REDACTED_ACP_VALUE = '[REDACTED]';
 
+export type AcpPermissionOptionKind =
+  | 'allow_once'
+  | 'allow_always'
+  | 'reject_once'
+  | 'reject_always';
+export type AcpApprovalState = 'pending' | 'responded' | 'rejected';
+export type AcpApprovalRejectionReason =
+  | 'child_exit'
+  | 'request_timeout'
+  | 'transport_disposed'
+  | 'write_failed';
+
 type Platform = NodeJS.Platform;
 export type JsonObject = Record<string, unknown>;
+type JsonRpcId = number | string | null;
 
 type FileExists = (candidate: string) => boolean;
 
@@ -78,6 +94,53 @@ export interface JsonRpcNotification {
   params?: JsonObject;
 }
 
+export interface AcpPermissionOption {
+  optionId: string;
+  name: string;
+  kind: AcpPermissionOptionKind;
+}
+
+export interface AcpApprovalToolCall {
+  toolCallId: string;
+  title?: string;
+  kind?: string;
+  status?: string;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  locations?: unknown;
+  content?: unknown;
+}
+
+export interface AcpSelectedApprovalOutcome {
+  outcome: 'selected';
+  optionId: string;
+}
+
+export interface AcpCancelledApprovalOutcome {
+  outcome: 'cancelled';
+}
+
+export type AcpApprovalOutcome = AcpSelectedApprovalOutcome | AcpCancelledApprovalOutcome;
+
+export interface AcpApprovalResponse {
+  outcome: AcpApprovalOutcome;
+}
+
+export type AcpApprovalDecision =
+  | { outcome: 'selected'; optionId: string }
+  | { outcome: 'selected'; optionKind: AcpPermissionOptionKind }
+  | { outcome: 'cancelled' };
+
+export interface AcpApprovalRequest {
+  requestId: JsonRpcId;
+  sessionId: string;
+  toolCall: AcpApprovalToolCall;
+  options: AcpPermissionOption[];
+  state: AcpApprovalState;
+  response?: AcpApprovalResponse;
+  rejectionReason?: AcpApprovalRejectionReason;
+}
+
 export interface AcpLifecycleProbeOptions {
   resolvedCommand?: ResolvedAcpCommand;
   command?: string;
@@ -93,6 +156,8 @@ export interface AcpLifecycleProbeOptions {
   resumeSession?: boolean;
   closeSession?: boolean;
   cancelAfterFirstUpdate?: boolean;
+  cancelAfterApprovalRequest?: boolean;
+  approvalDecision?: AcpApprovalDecision | ((request: AcpApprovalRequest) => AcpApprovalDecision);
   clientCapabilities?: JsonObject;
 }
 
@@ -114,6 +179,7 @@ export interface AcpLifecycleProbeResult {
   frames: AcpCapturedFrame[];
   normalizedEvents: AcpNormalizedEvent[];
   notifications: JsonRpcNotification[];
+  approvalRequests: AcpApprovalRequest[];
   stderr: string;
   modelPassthrough: AcpModelPassthroughSummary;
   cancelSent: boolean;
@@ -135,6 +201,15 @@ interface AcpModelPassthrough {
   env: Record<string, string>;
   sessionMeta?: JsonObject;
   sensitiveValues: string[];
+}
+
+interface PendingApprovalRequest {
+  request: AcpApprovalRequest;
+}
+
+interface ApprovalHandlingOptions {
+  cancelAfterApprovalRequest?: boolean;
+  decision?: AcpApprovalDecision | ((request: AcpApprovalRequest) => AcpApprovalDecision);
 }
 
 export class AcpProtocolError extends Error {
@@ -412,7 +487,10 @@ export async function runAcpLifecycleProbe(
     windowsHide: true,
   });
 
-  const transport = new NdjsonRpcTransport(child, timeoutMs, modelPassthrough.sensitiveValues);
+  const transport = new NdjsonRpcTransport(child, timeoutMs, modelPassthrough.sensitiveValues, {
+    cancelAfterApprovalRequest: options.cancelAfterApprovalRequest,
+    decision: options.approvalDecision,
+  });
   let sessionId = '';
   let resumeResult: JsonRpcSuccess<JsonObject> | undefined;
   let promptResult: JsonRpcSuccess<AcpPromptResult> | undefined;
@@ -487,6 +565,7 @@ export async function runAcpLifecycleProbe(
       frames: transport.frames,
       normalizedEvents: normalizeAcpFrames(transport.frames),
       notifications: transport.notifications,
+      approvalRequests: transport.approvalRequests,
       stderr: transport.stderr,
       modelPassthrough: modelPassthrough.summary,
       cancelSent: transport.cancelSent,
@@ -511,12 +590,14 @@ function buildSessionRequestParams(cwd: string, sessionMeta: JsonObject | undefi
 class NdjsonRpcTransport {
   readonly frames: AcpCapturedFrame[] = [];
   readonly notifications: JsonRpcNotification[] = [];
+  readonly approvalRequests: AcpApprovalRequest[] = [];
   stderr = '';
   cancelSent = false;
 
   private nextId = 1;
   private stdoutBuffer = '';
   private readonly pending = new Map<number, PendingRequest>();
+  private readonly pendingApprovals = new Map<JsonRpcId, PendingApprovalRequest>();
   private protocolFailure: AcpProtocolError | null = null;
   private cancelOnAgentMessageSessionId: string | null = null;
   private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
@@ -525,7 +606,8 @@ class NdjsonRpcTransport {
   constructor(
     private readonly child: ChildProcessWithoutNullStreams,
     private readonly timeoutMs: number,
-    private readonly sensitiveValues: readonly string[]
+    private readonly sensitiveValues: readonly string[],
+    private readonly approvalHandling: ApprovalHandlingOptions = {}
   ) {
     this.exitPromise = new Promise(resolve => {
       child.once('exit', (code, signal) => {
@@ -561,8 +643,14 @@ class NdjsonRpcTransport {
     const response = new Promise<JsonRpcSuccess<unknown>>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
+        const pendingApprovals = this.rejectPendingApprovals('request_timeout', true);
         reject(
-          new AcpProtocolError('ACP request timed out', { method, id, timeoutMs: this.timeoutMs })
+          new AcpProtocolError('ACP request timed out', {
+            method,
+            id,
+            timeoutMs: this.timeoutMs,
+            pendingApprovals,
+          })
         );
       }, this.timeoutMs);
       this.pending.set(id, { method, resolve, reject, timer });
@@ -587,6 +675,7 @@ class NdjsonRpcTransport {
   }
 
   async dispose(): Promise<void> {
+    this.rejectPendingApprovals('transport_disposed', true);
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer);
       pending.reject(
@@ -669,15 +758,12 @@ class NdjsonRpcTransport {
       return;
     }
 
-    if (typeof id === 'number') {
-      this.write({
-        jsonrpc: '2.0',
-        id,
-        error: {
-          code: -32601,
-          message: `Client method not implemented by lifecycle probe: ${method}`,
-        },
-      });
+    if (Object.hasOwn(message, 'id')) {
+      if (!isJsonRpcId(id)) {
+        this.fail(new AcpProtocolError('ACP request id was not a JSON-RPC id', { id, method }));
+        return;
+      }
+      this.handleClientRequest(id, method, message.params);
       return;
     }
 
@@ -739,6 +825,78 @@ class NdjsonRpcTransport {
     return isJsonObject(update) && update.sessionUpdate === 'agent_message_chunk';
   }
 
+  private handleClientRequest(id: JsonRpcId, method: string, params: unknown): void {
+    if (method !== 'session/request_permission') {
+      this.writeJsonRpcError(id, -32601, `Client method not implemented by lifecycle probe: ${method}`);
+      return;
+    }
+
+    let request: AcpApprovalRequest;
+    try {
+      request = normalizeApprovalRequest(id, params);
+    } catch (error) {
+      const protocolError =
+        error instanceof AcpProtocolError
+          ? error
+          : new AcpProtocolError('ACP permission request could not be normalized', { method });
+      this.writeJsonRpcError(id, -32602, protocolError.message);
+      this.fail(protocolError);
+      return;
+    }
+
+    this.approvalRequests.push(request);
+    this.pendingApprovals.set(id, { request });
+
+    if (this.approvalHandling.cancelAfterApprovalRequest) {
+      this.respondToApproval(id, request, { outcome: { outcome: 'cancelled' } });
+      this.write({
+        jsonrpc: '2.0',
+        method: 'session/cancel',
+        params: { sessionId: request.sessionId },
+      });
+      this.cancelSent = true;
+      return;
+    }
+
+    const decision =
+      typeof this.approvalHandling.decision === 'function'
+        ? this.approvalHandling.decision(request)
+        : this.approvalHandling.decision;
+    if (!decision) return;
+
+    let response: AcpApprovalResponse;
+    try {
+      response = approvalResponseFromDecision(request, decision);
+    } catch (error) {
+      const protocolError =
+        error instanceof AcpProtocolError
+          ? error
+          : new AcpProtocolError('ACP permission decision could not be applied', {
+              method: 'session/request_permission',
+            });
+      this.writeJsonRpcError(id, -32602, protocolError.message);
+      this.fail(protocolError);
+      return;
+    }
+
+    this.respondToApproval(id, request, response);
+  }
+
+  private respondToApproval(
+    id: JsonRpcId,
+    request: AcpApprovalRequest,
+    response: AcpApprovalResponse
+  ): void {
+    request.state = 'responded';
+    request.response = response;
+    this.pendingApprovals.delete(id);
+    this.write({
+      jsonrpc: '2.0',
+      id,
+      result: response,
+    });
+  }
+
   private write(message: JsonObject): void {
     this.throwIfFailed();
     if (this.child.stdin.destroyed || !this.child.stdin.writable) {
@@ -752,10 +910,16 @@ class NdjsonRpcTransport {
     if (this.protocolFailure) return;
     const redactedDetails = redactJsonObject(error.details, this.sensitiveValues);
     this.protocolFailure = new AcpProtocolError(error.message, redactedDetails);
+    this.rejectPendingApprovals('transport_disposed', false);
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer);
       pending.reject(
-        new AcpProtocolError(error.message, { ...redactedDetails, method: pending.method, id })
+        new AcpProtocolError(error.message, {
+          ...redactedDetails,
+          method:
+            typeof redactedDetails.method === 'string' ? redactedDetails.method : pending.method,
+          id,
+        })
       );
     }
     this.pending.clear();
@@ -763,7 +927,9 @@ class NdjsonRpcTransport {
   }
 
   private failPendingOnExit(code: number | null, signal: NodeJS.Signals | null): void {
-    if (this.protocolFailure || this.pending.size === 0) return;
+    if (this.protocolFailure) return;
+    const pendingApprovals = this.rejectPendingApprovals('child_exit', false);
+    if (this.pending.size === 0) return;
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer);
       pending.reject(
@@ -773,6 +939,7 @@ class NdjsonRpcTransport {
           code,
           signal,
           stderrBytes: Buffer.byteLength(this.stderr, 'utf8'),
+          pendingApprovals,
         })
       );
     }
@@ -781,6 +948,42 @@ class NdjsonRpcTransport {
 
   private throwIfFailed(): void {
     if (this.protocolFailure) throw this.protocolFailure;
+  }
+
+  private writeJsonRpcError(id: JsonRpcId, code: number, message: string): void {
+    this.write({
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code,
+        message,
+      },
+    });
+  }
+
+  private rejectPendingApprovals(
+    reason: AcpApprovalRejectionReason,
+    notifyAgent: boolean
+  ): AcpApprovalRequest[] {
+    const rejected: AcpApprovalRequest[] = [];
+    for (const [id, pending] of this.pendingApprovals) {
+      pending.request.state = 'rejected';
+      pending.request.rejectionReason = reason;
+      rejected.push({ ...pending.request });
+      if (notifyAgent && !this.exited) {
+        this.tryWriteJsonRpcError(id, -32000, `ACP approval request rejected: ${reason}`);
+      }
+    }
+    this.pendingApprovals.clear();
+    return rejected;
+  }
+
+  private tryWriteJsonRpcError(id: JsonRpcId, code: number, message: string): void {
+    try {
+      this.writeJsonRpcError(id, code, message);
+    } catch {
+      // Best-effort cleanup: the original timeout/exit/dispose error is reported to the caller.
+    }
   }
 }
 
@@ -885,6 +1088,85 @@ function requireObject(value: unknown, label: string): JsonObject {
   return value;
 }
 
+function normalizeApprovalRequest(id: JsonRpcId, params: unknown): AcpApprovalRequest {
+  const request = requireObject(params, 'session/request_permission params');
+  const optionsValue = request.options;
+  if (!Array.isArray(optionsValue)) {
+    throw new AcpProtocolError('ACP permission request options must be an array', {
+      method: 'session/request_permission',
+    });
+  }
+
+  return {
+    requestId: id,
+    sessionId: requireString(request.sessionId, 'session/request_permission sessionId'),
+    toolCall: normalizeApprovalToolCall(request.toolCall),
+    options: optionsValue.map(normalizePermissionOption),
+    state: 'pending',
+  };
+}
+
+function normalizePermissionOption(value: unknown): AcpPermissionOption {
+  const option = requireObject(value, 'session/request_permission option');
+  const optionId = requireString(option.optionId, 'session/request_permission option.optionId');
+  const kind = requireString(option.kind, 'session/request_permission option.kind');
+  if (!isPermissionOptionKind(kind)) {
+    throw new AcpProtocolError('ACP permission option kind is unsupported', {
+      method: 'session/request_permission',
+      optionId,
+      kind,
+    });
+  }
+  return {
+    optionId,
+    name: requireString(option.name, 'session/request_permission option.name'),
+    kind,
+  };
+}
+
+function normalizeApprovalToolCall(value: unknown): AcpApprovalToolCall {
+  const toolCall = requireObject(value, 'session/request_permission toolCall');
+  return {
+    toolCallId: requireString(toolCall.toolCallId, 'session/request_permission toolCall.toolCallId'),
+    title: optionalStringOrNull(toolCall.title, 'session/request_permission toolCall.title'),
+    kind: optionalStringOrNull(toolCall.kind, 'session/request_permission toolCall.kind'),
+    status: optionalStringOrNull(toolCall.status, 'session/request_permission toolCall.status'),
+    rawInput:
+      toolCall.rawInput === undefined ? undefined : sanitizeAcpApprovalValue(toolCall.rawInput, undefined),
+    rawOutput:
+      toolCall.rawOutput === undefined
+        ? undefined
+        : sanitizeAcpApprovalValue(toolCall.rawOutput, undefined),
+    locations:
+      toolCall.locations === undefined
+        ? undefined
+        : sanitizeAcpApprovalValue(toolCall.locations, undefined),
+    content:
+      toolCall.content === undefined ? undefined : sanitizeAcpApprovalValue(toolCall.content, undefined),
+  };
+}
+
+function approvalResponseFromDecision(
+  request: AcpApprovalRequest,
+  decision: AcpApprovalDecision
+): AcpApprovalResponse {
+  if (decision.outcome === 'cancelled') return { outcome: { outcome: 'cancelled' } };
+
+  const optionId =
+    'optionId' in decision
+      ? decision.optionId
+      : request.options.find(option => option.kind === decision.optionKind)?.optionId;
+  if (!optionId || !request.options.some(option => option.optionId === optionId)) {
+    throw new AcpProtocolError('ACP permission decision did not match an available option', {
+      method: 'session/request_permission',
+      requestId: request.requestId,
+      decision,
+    });
+  }
+
+  return { outcome: { outcome: 'selected', optionId } };
+}
+
 function requireArray(value: unknown, label: string): unknown[] {
   if (!Array.isArray(value)) {
     throw new AcpProtocolError(`${label} must be an array`, { value });
@@ -904,6 +1186,11 @@ function optionalString(value: unknown, label: string): string | undefined {
   return requireString(value, label);
 }
 
+function optionalStringOrNull(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return requireString(value, label);
+}
+
 function requireNumber(value: unknown, label: string): number {
   if (typeof value !== 'number') {
     throw new AcpProtocolError(`${label} must be a number`, { value });
@@ -915,6 +1202,63 @@ function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+  return typeof value === 'number' || typeof value === 'string' || value === null;
+}
+
+function isPermissionOptionKind(value: string): value is AcpPermissionOptionKind {
+  return (
+    value === 'allow_once' ||
+    value === 'allow_always' ||
+    value === 'reject_once' ||
+    value === 'reject_always'
+  );
+}
+
+function sanitizeAcpApprovalValue(value: unknown, key: string | undefined): unknown {
+  if (key && isSensitiveApprovalKey(key)) return '[REDACTED]';
+  if (typeof value === 'string') return redactApprovalString(value);
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) return value;
+  if (Array.isArray(value)) {
+    const sanitized = value
+      .slice(0, APPROVAL_ARRAY_LIMIT_ITEMS)
+      .map(item => sanitizeAcpApprovalValue(item, undefined));
+    if (value.length > APPROVAL_ARRAY_LIMIT_ITEMS) sanitized.push('[TRUNCATED_ITEMS]');
+    return sanitized;
+  }
+  if (isJsonObject(value)) {
+    const entries = Object.entries(value).slice(0, APPROVAL_OBJECT_LIMIT_KEYS);
+    const sanitized: JsonObject = {};
+    for (const [entryKey, entryValue] of entries) {
+      sanitized[entryKey] = sanitizeAcpApprovalValue(entryValue, entryKey);
+    }
+    if (Object.keys(value).length > APPROVAL_OBJECT_LIMIT_KEYS) {
+      sanitized.__truncatedKeys = Object.keys(value).length - APPROVAL_OBJECT_LIMIT_KEYS;
+    }
+    return sanitized;
+  }
+  return String(value);
+}
+
+function isSensitiveApprovalKey(key: string): boolean {
+  return /(authorization|cookie|api[_-]?key|auth[_-]?token|token|secret|password|credential)/i.test(key);
+}
+
+function redactApprovalString(value: string): string {
+  const withoutSettingsPath = value
+    .replace(/[A-Za-z]:\\(?:[^\\\r\n"]+\\)*settings\.local\.json/gi, '[REDACTED_PATH]')
+    .replace(/(?:~|\/[^\s'"\\]+)(?:\/[^\s'"\\]+)*\/settings\.local\.json/gi, '[REDACTED_PATH]');
+  const withoutSecretTokens = withoutSettingsPath.replace(
+    /\bsk-(?:ant|live|test|proj)-[A-Za-z0-9_-]+\b/g,
+    '[REDACTED]'
+  );
+  const withoutBearer = withoutSecretTokens.replace(
+    /(?<![A-Za-z0-9_-])(Bearer|token|api[_-]?key|secret)\s+['"]?[^'",\s]+/gi,
+    '$1 [REDACTED]'
+  );
+  return truncateUtf8(withoutBearer, APPROVAL_STRING_LIMIT_BYTES);
+}
+
 function appendLimited(current: string, chunk: string, limitBytes: number): string {
   const combined = Buffer.from(`${current}${chunk}`, 'utf8');
   if (combined.length <= limitBytes) return combined.toString('utf8');
@@ -924,4 +1268,17 @@ function appendLimited(current: string, chunk: string, limitBytes: number): stri
     start += 1;
   }
   return combined.subarray(start).toString('utf8');
+}
+
+function truncateUtf8(value: string, limitBytes: number): string {
+  const encoded = Buffer.from(value, 'utf8');
+  if (encoded.length <= limitBytes) return value;
+
+  const suffix = '…[TRUNCATED]';
+  const suffixBytes = Buffer.byteLength(suffix, 'utf8');
+  let end = Math.max(0, limitBytes - suffixBytes);
+  while (end > 0 && (encoded[end] & 0xc0) === 0x80) {
+    end -= 1;
+  }
+  return `${encoded.subarray(0, end).toString('utf8')}${suffix}`;
 }


### PR DESCRIPTION
## Summary
- Add the ACP-012 approval parity lifecycle probe spike as a clean replacement for the closed/corrupted #2668 branch.
- Capture ACP `session/request_permission` requests as structured, bounded, redacted data and exercise explicit allow/deny/cancel responses.
- Harden approval response writes so approval state is only marked responded after the response write is accepted, and child-exit/write failures are classified explicitly.
- Preserve ACP-011 event stream fixtures, ACP-013 terminal parity behavior, and ACP-014 minimal ACP spawn env / BYO model passthrough behavior.

## Aegis version
0.6.6-preview.1

## Validation
- `npm run gate`
- Independent code review: no Critical or Important blockers after final re-review.

Replaces closed corrupted PR #2668.

Closes #2580.