### PR TITLE
fix: harden ACP approval classifications

### DIFF
--- a/src/__tests__/acp-lifecycle-probe.test.ts
+++ b/src/__tests__/acp-lifecycle-probe.test.ts
@@ -162,6 +162,21 @@ describe('acp lifecycle probe', () => {
     ).rejects.toBeInstanceOf(AcpProtocolError);
   });
 
+  it('rejects unterminated non-JSON stdout when the child exits', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions({ FAKE_ACP_MODE: 'unterminated-stdout-before-exit' }),
+        timeoutMs: 1_000,
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP stdout ended with an unterminated line',
+      details: expect.objectContaining({
+        line: 'this is not terminated json',
+        method: 'initialize',
+      }),
+    });
+  });
+
   it('classifies child exit before initialize as an ACP child process exit', async () => {
     await expect(
       runAcpLifecycleProbe({
@@ -175,6 +190,28 @@ describe('acp lifecycle probe', () => {
         code: 42,
       }),
     });
+  });
+
+  it('does not expose raw initialize payloads when request writes fail', async () => {
+    const secretMarker = 'fixture-request-write-secret';
+
+    let caught: unknown;
+    try {
+      await runAcpLifecycleProbe({
+        ...nodeFixtureOptions({ FAKE_ACP_MODE: 'exit-before-initialize' }),
+        clientCapabilities: {
+          secretMarker,
+          padding: 'x'.repeat(1_000_000),
+        },
+        timeoutMs: 1_000,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AcpProtocolError);
+    expect(JSON.stringify(caught)).not.toContain(secretMarker);
+    expect(JSON.stringify(caught)).not.toContain('padding');
   });
 
   it('classifies request timeouts with method and id details', async () => {
@@ -438,9 +475,9 @@ describe('acp lifecycle probe', () => {
         },
       })
     ).rejects.toThrow(`Provider env ${anthDefaultModelKey} must be a non-empty string`);
-
   });
-it('surfaces ACP approval requests as structured data and sends an explicit allow response', async () => {
+
+  it('surfaces ACP approval requests as structured data and sends an explicit allow response', async () => {
     const result = await runAcpLifecycleProbe({
       ...nodeFixtureOptions(),
       prompt: 'request-permission',
@@ -512,11 +549,59 @@ it('surfaces ACP approval requests as structured data and sends an explicit allo
         ANTHROPIC_API_KEY: '[REDACTED]',
       },
     });
-    const command = rawInput && typeof rawInput === 'object' && 'command' in rawInput ? rawInput.command : '';
-    expect(typeof command === 'string' ? Buffer.byteLength(command, 'utf8') : 0).toBeLessThanOrEqual(
+    const command =
+      rawInput && typeof rawInput === 'object' && 'command' in rawInput ? rawInput.command : '';
+    expect(
+      typeof command === 'string' ? Buffer.byteLength(command, 'utf8') : 0
+    ).toBeLessThanOrEqual(2_048);
+    expect(typeof command === 'string' ? command : '').not.toContain('fixture-command-token');
+  });
+
+  it('bounds and redacts ACP approval metadata before surfacing structured requests', async () => {
+    const result = await runAcpLifecycleProbe({
+      ...nodeFixtureOptions(),
+      prompt: 'request-metadata-permission',
+      approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
+    });
+
+    const request = result.approvalRequests[0];
+    expect(request?.options).toHaveLength(25);
+    expect(Buffer.byteLength(request?.sessionId ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.toolCall.toolCallId ?? '', 'utf8')).toBeLessThanOrEqual(
       2_048
     );
-    expect(typeof command === 'string' ? command : '').not.toContain('fixture-command-token');
+    expect(Buffer.byteLength(request?.toolCall.title ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.toolCall.kind ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.toolCall.status ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(Buffer.byteLength(request?.options[0]?.optionId ?? '', 'utf8')).toBeLessThanOrEqual(
+      2_048
+    );
+    expect(Buffer.byteLength(request?.options[0]?.name ?? '', 'utf8')).toBeLessThanOrEqual(2_048);
+    expect(JSON.stringify(request)).not.toContain('fixture-session-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-tool-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-title-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-kind-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-status-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-option-id-secret');
+    expect(JSON.stringify(request)).not.toContain('fixture-option-secret');
+    expect(JSON.stringify(request)).not.toContain('settings.local.json');
+    expect(request?.sessionId).toContain('[REDACTED]');
+    expect(request?.toolCall.toolCallId).toContain('[REDACTED]');
+    expect(request?.toolCall.title).toContain('[REDACTED]');
+    expect(request?.toolCall.kind).toContain('[REDACTED]');
+    expect(request?.toolCall.status).toContain('[REDACTED]');
+    expect(request?.options[0]?.optionId).toContain('[REDACTED]');
+    expect(request?.options[0]?.name).toContain('[REDACTED]');
+    const rawInput = request?.toolCall.rawInput;
+    expect(isJsonObject(rawInput)).toBe(true);
+    const rawInputKeys = isJsonObject(rawInput) ? Object.keys(rawInput) : [];
+    expect(rawInputKeys.some(key => key.includes('Bearer [REDACTED]'))).toBe(true);
+    expect(rawInputKeys.some(key => key.includes('[REDACTED_PATH]'))).toBe(true);
+    expect(rawInputKeys.some(key => key.includes('api_key=[REDACTED]'))).toBe(true);
+    expect(rawInputKeys.some(key => key.includes('[TRUNCATED]'))).toBe(true);
+    expect(JSON.stringify(rawInputKeys)).not.toContain('sk-ant-fixture-key-secret');
+    expect(JSON.stringify(rawInputKeys)).not.toContain('fixture-key-secret');
+    expect(JSON.stringify(rawInputKeys)).not.toContain('settings.local.json');
   });
 
   it('redacts POSIX settings.local.json paths in ACP approval command details', async () => {
@@ -551,11 +636,63 @@ it('surfaces ACP approval requests as structured data and sends an explicit allo
     });
   });
 
+  it('rejects ACP approval requests when the child exits before the response write is accepted', async () => {
+    let rejection: unknown;
+    try {
+      await runAcpLifecycleProbe({
+        ...nodeFixtureOptions(),
+        prompt: 'request-permission-exit-large-option',
+        approvalDecision: { outcome: 'selected', optionKind: 'allow_once' },
+        timeoutMs: 1_000,
+      });
+    } catch (error) {
+      rejection = error;
+    }
+
+    expect(rejection).toBeInstanceOf(AcpProtocolError);
+    const details = rejection instanceof AcpProtocolError ? rejection.details : {};
+    const approvalRequest =
+      isJsonObject(details.approvalRequest) && details.approvalRequest.requestId === 'permission-1'
+        ? details.approvalRequest
+        : Array.isArray(details.pendingApprovals)
+          ? details.pendingApprovals.find(
+              approval => isJsonObject(approval) && approval.requestId === 'permission-1'
+            )
+          : undefined;
+    expect(approvalRequest).toMatchObject({
+      requestId: 'permission-1',
+      state: 'rejected',
+      rejectionReason: 'child_exit',
+    });
+  });
+
   it('rejects pending ACP approval requests when the child exits before a response', async () => {
     await expect(
       runAcpLifecycleProbe({
         ...nodeFixtureOptions(),
         prompt: 'request-permission-exit',
+      })
+    ).rejects.toMatchObject({
+      message: 'ACP child process exited before response',
+      details: expect.objectContaining({
+        method: 'session/prompt',
+        code: 43,
+        pendingApprovals: [
+          expect.objectContaining({
+            requestId: 'permission-1',
+            state: 'rejected',
+            rejectionReason: 'child_exit',
+          }),
+        ],
+      }),
+    });
+  });
+
+  it('keeps pending approval child_exit classification when residual stdout is also present', async () => {
+    await expect(
+      runAcpLifecycleProbe({
+        ...nodeFixtureOptions(),
+        prompt: 'request-permission-exit-unterminated',
       })
     ).rejects.toMatchObject({
       message: 'ACP child process exited before response',
@@ -605,11 +742,12 @@ it('surfaces ACP approval requests as structured data and sends an explicit allo
     ).rejects.toMatchObject({
       message: 'ACP permission option kind is unsupported',
       details: expect.objectContaining({
-        method: 'session/prompt',
+        method: 'session/request_permission',
         optionId: 'allow-once',
         kind: 'bogus',
       }),
-    });  });
+    });
+  });
 
   it('bounds captured stderr by UTF-8 bytes for multi-byte output', async () => {
     const result = await runAcpLifecycleProbe({

--- a/src/__tests__/fixtures/fake-acp-agent.mjs
+++ b/src/__tests__/fixtures/fake-acp-agent.mjs
@@ -16,6 +16,10 @@ if (mode === 'unicode-stderr') {
   process.stderr.write('🐉'.repeat(70_000));
 }
 process.stderr.write('fake claude-agent-acp fixture ready\n');
+if (mode === 'unterminated-stdout-before-exit') {
+  process.stdout.write('this is not terminated json');
+  process.exit(45);
+}
 if (mode === 'exit-before-initialize') {
   process.stderr.write('fixture exiting before initialize\n');
   process.exit(42);
@@ -37,6 +41,13 @@ const terminalState = {
 
 function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function sendBeforeExit(message, exitCode, afterSend) {
+  process.stdout.write(`${JSON.stringify(message)}\n`, () => {
+    afterSend?.();
+    setImmediate(() => process.exit(exitCode));
+  });
 }
 
 function respond(id, result) {
@@ -225,7 +236,10 @@ rl.on('line', line => {
     if (
       firstText === 'request-permission' ||
       firstText === 'request-permission-exit' ||
+      firstText === 'request-permission-exit-unterminated' ||
+      firstText === 'request-permission-exit-large-option' ||
       firstText === 'request-large-permission' ||
+      firstText === 'request-metadata-permission' ||
       firstText === 'request-posix-settings-permission'
     ) {
       const permissionId = 'permission-1';
@@ -243,30 +257,87 @@ rl.on('line', line => {
                 },
               },
             }
-          : firstText === 'request-posix-settings-permission'
+          : firstText === 'request-metadata-permission'
             ? {
                 ...approvalFixture,
                 toolCall: {
                   ...approvalFixture.toolCall,
+                  toolCallId: `tool-call secret fixture-tool-secret ${'z'.repeat(5_000)}`,
+                  title: `Run secret fixture-title-secret ${'x'.repeat(5_000)} C:\\Users\\fixture\\.claude\\settings.local.json`,
+                  kind: `execute secret fixture-kind-secret ${'k'.repeat(5_000)}`,
+                  status: `pending secret fixture-status-secret ${'s'.repeat(5_000)}`,
                   rawInput: {
-                    command: 'cat /Users/fixture/project/.claude/settings.local.json',
+                    [`${['Bearer', ['sk', 'ant', 'fixture', 'key', 'secret'].join('-')].join(' ')} ${'b'.repeat(5_000)}`]:
+                      'header value',
+                    [`C:\\Users\\fixture\\.claude\\settings.local.json ${'p'.repeat(5_000)}`]:
+                      'settings value',
+                    [`api_key=fixture-key-secret ${'a'.repeat(5_000)}`]: 'api key value',
+                    [`long-key-${'l'.repeat(5_000)}`]: 'long key value',
                   },
                 },
+                options: Array.from({ length: 30 }, (_, index) =>
+                  index === 0
+                    ? {
+                        optionId: `allow-once secret fixture-option-id-secret ${'i'.repeat(5_000)}`,
+                        name: `Allow api_key fixture-option-secret ${'n'.repeat(5_000)} C:\\Users\\fixture\\.claude\\settings.local.json`,
+                        kind: 'allow_once',
+                      }
+                    : {
+                        optionId: `option-${index}`,
+                        name: `Option ${index}`,
+                        kind: index % 2 === 0 ? 'allow_once' : 'reject_once',
+                      }
+                ),
               }
-            : approvalFixture;
+            : firstText === 'request-permission-exit-large-option'
+              ? {
+                  ...approvalFixture,
+                  options: [
+                    {
+                      optionId: `allow-once-${'x'.repeat(1_000_000)}`,
+                      name: 'Allow once with large id',
+                      kind: 'allow_once',
+                    },
+                    ...approvalFixture.options.slice(1),
+                  ],
+                }
+              : firstText === 'request-posix-settings-permission'
+                ? {
+                    ...approvalFixture,
+                    toolCall: {
+                      ...approvalFixture.toolCall,
+                      rawInput: {
+                        command: 'cat /Users/fixture/project/.claude/settings.local.json',
+                      },
+                    },
+                  }
+                : approvalFixture;
       pendingPermissionPrompts.set(permissionId, { promptId: id, sessionId: params.sessionId });
-      send({
+      const permissionMessage = {
         jsonrpc: '2.0',
         id: permissionId,
         method: 'session/request_permission',
         params: {
           ...approvalParams,
-          sessionId: params.sessionId,
+          sessionId:
+            firstText === 'request-metadata-permission'
+              ? `fixture-session secret fixture-session-secret ${'q'.repeat(5_000)}`
+              : params.sessionId,
         },
-      });
-      if (firstText === 'request-permission-exit') {
-        setImmediate(() => process.exit(43));
+      };
+      if (
+        firstText === 'request-permission-exit' ||
+        firstText === 'request-permission-exit-unterminated' ||
+        firstText === 'request-permission-exit-large-option'
+      ) {
+        sendBeforeExit(permissionMessage, 43, () => {
+          if (firstText === 'request-permission-exit-unterminated') {
+            process.stdout.write('unterminated residual approval output');
+          }
+        });
+        return;
       }
+      send(permissionMessage);
       return;
     }
     if (firstText === 'request-invalid-permission') {

--- a/src/acp-lifecycle-probe.ts
+++ b/src/acp-lifecycle-probe.ts
@@ -17,6 +17,7 @@ const STDERR_LIMIT_BYTES = 64 * 1024;
 const APPROVAL_STRING_LIMIT_BYTES = 2 * 1024;
 const APPROVAL_ARRAY_LIMIT_ITEMS = 25;
 const APPROVAL_OBJECT_LIMIT_KEYS = 50;
+const APPROVAL_WRITE_EXIT_GRACE_MS = 100;
 
 export type AcpCommandSource = 'explicit' | 'AEGIS_ACP_BIN' | 'local-package-bin' | 'npm-exec';
 export type AcpModelProvider =
@@ -35,7 +36,11 @@ export type AcpPermissionOptionKind =
   | 'reject_once'
   | 'reject_always';
 export type AcpApprovalState = 'pending' | 'responded' | 'rejected';
-export type AcpApprovalRejectionReason = 'child_exit' | 'request_timeout' | 'transport_disposed';
+export type AcpApprovalRejectionReason =
+  | 'child_exit'
+  | 'request_timeout'
+  | 'transport_disposed'
+  | 'write_failed';
 
 type Platform = NodeJS.Platform;
 export type JsonObject = Record<string, unknown>;
@@ -201,6 +206,14 @@ interface AcpModelPassthrough {
 
 interface PendingApprovalRequest {
   request: AcpApprovalRequest;
+  rawSessionId: string;
+  responseOptions: AcpPermissionOption[];
+}
+
+interface NormalizedApprovalRequest {
+  request: AcpApprovalRequest;
+  rawSessionId: string;
+  responseOptions: AcpPermissionOption[];
 }
 
 interface ApprovalHandlingOptions {
@@ -598,6 +611,8 @@ class NdjsonRpcTransport {
   private cancelOnAgentMessageSessionId: string | null = null;
   private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
   private exited = false;
+  private activeWrites = 0;
+  private approvalWriteClassifications = 0;
 
   constructor(
     private readonly child: ChildProcessWithoutNullStreams,
@@ -606,10 +621,23 @@ class NdjsonRpcTransport {
     private readonly approvalHandling: ApprovalHandlingOptions = {}
   ) {
     this.exitPromise = new Promise(resolve => {
+      let exitResult: { code: number | null; signal: NodeJS.Signals | null } | undefined;
       child.once('exit', (code, signal) => {
         this.exited = true;
-        this.failPendingOnExit(code, signal);
-        resolve({ code, signal });
+        exitResult = { code, signal };
+      });
+      child.once('close', (code, signal) => {
+        this.exited = true;
+        const finalCode = code ?? exitResult?.code ?? null;
+        const finalSignal = signal ?? exitResult?.signal ?? null;
+        if (this.pendingApprovals.size > 0) {
+          this.failPendingOnExit(finalCode, finalSignal);
+          this.failOnResidualStdoutBuffer();
+        } else {
+          this.failOnResidualStdoutBuffer();
+          this.failPendingOnExit(finalCode, finalSignal);
+        }
+        resolve({ code: finalCode, signal: finalSignal });
       });
     });
 
@@ -624,6 +652,16 @@ class NdjsonRpcTransport {
     child.stderr.setEncoding('utf8');
     child.stderr.on('data', (chunk: string) => {
       this.stderr = appendLimited(this.stderr, chunk, STDERR_LIMIT_BYTES);
+    });
+    child.stdin.on('error', error => {
+      const activeWritesAtError = this.activeWrites;
+      setImmediate(() => {
+        if (activeWritesAtError > 0) return;
+        if (this.approvalWriteClassifications > 0) return;
+        if (!this.protocolFailure) {
+          this.fail(new AcpProtocolError('ACP stdin write failed', { message: error.message }));
+        }
+      });
     });
   }
 
@@ -652,14 +690,25 @@ class NdjsonRpcTransport {
       this.pending.set(id, { method, resolve, reject, timer });
     });
 
-    this.write({ jsonrpc: '2.0', id, method, params });
+    try {
+      await this.write({ jsonrpc: '2.0', id, method, params });
+    } catch (error) {
+      const pending = this.pending.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+      }
+      const protocolError = toAcpProtocolError(error, 'ACP request write failed', { method, id });
+      this.fail(protocolError);
+      throw protocolError;
+    }
     return response;
   }
 
   async waitForExit(
     timeoutMs: number
   ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-    return Promise.race([
+    const exit = await Promise.race([
       this.exitPromise,
       new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((_, reject) => {
         setTimeout(
@@ -668,9 +717,12 @@ class NdjsonRpcTransport {
         );
       }),
     ]);
+    this.throwIfFailed();
+    return exit;
   }
 
   async dispose(): Promise<void> {
+    this.failOnResidualStdoutBuffer();
     this.rejectPendingApprovals('transport_disposed', true);
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer);
@@ -726,11 +778,13 @@ class NdjsonRpcTransport {
         return;
       }
 
-      this.handleMessage(parsed);
+      void this.handleMessage(parsed).catch(error => {
+        this.fail(toAcpProtocolError(error, 'ACP stdout message handling failed'));
+      });
     }
   }
 
-  private handleMessage(message: unknown): void {
+  private async handleMessage(message: unknown): Promise<void> {
     if (!isJsonObject(message)) {
       this.fail(new AcpProtocolError('ACP stdout message was not a JSON object', { message }));
       return;
@@ -759,7 +813,7 @@ class NdjsonRpcTransport {
         this.fail(new AcpProtocolError('ACP request id was not a JSON-RPC id', { id, method }));
         return;
       }
-      this.handleClientRequest(id, method, message.params);
+      await this.handleClientRequest(id, method, message.params);
       return;
     }
 
@@ -776,10 +830,11 @@ class NdjsonRpcTransport {
     }
     this.notifications.push(notification);
     if (this.shouldCancelAfterNotification(notification)) {
-      this.write({
+      const sessionId = this.cancelOnAgentMessageSessionId;
+      await this.write({
         jsonrpc: '2.0',
         method: 'session/cancel',
-        params: { sessionId: this.cancelOnAgentMessageSessionId },
+        params: { sessionId },
       });
       this.cancelSent = true;
       this.cancelOnAgentMessageSessionId = null;
@@ -821,34 +876,39 @@ class NdjsonRpcTransport {
     return isJsonObject(update) && update.sessionUpdate === 'agent_message_chunk';
   }
 
-  private handleClientRequest(id: JsonRpcId, method: string, params: unknown): void {
+  private async handleClientRequest(id: JsonRpcId, method: string, params: unknown): Promise<void> {
     if (method !== 'session/request_permission') {
-      this.writeJsonRpcError(id, -32601, `Client method not implemented by lifecycle probe: ${method}`);
+      await this.writeJsonRpcError(
+        id,
+        -32601,
+        `Client method not implemented by lifecycle probe: ${method}`
+      );
       return;
     }
 
-    let request: AcpApprovalRequest;
+    let normalized: NormalizedApprovalRequest;
     try {
-      request = normalizeApprovalRequest(id, params);
+      normalized = normalizeApprovalRequest(id, params);
     } catch (error) {
       const protocolError =
         error instanceof AcpProtocolError
           ? error
           : new AcpProtocolError('ACP permission request could not be normalized', { method });
-      this.writeJsonRpcError(id, -32602, protocolError.message);
+      await this.writeJsonRpcError(id, -32602, protocolError.message);
       this.fail(protocolError);
       return;
     }
+    const { request, rawSessionId, responseOptions } = normalized;
 
     this.approvalRequests.push(request);
-    this.pendingApprovals.set(id, { request });
+    this.pendingApprovals.set(id, { request, rawSessionId, responseOptions });
 
     if (this.approvalHandling.cancelAfterApprovalRequest) {
-      this.respondToApproval(id, request, { outcome: { outcome: 'cancelled' } });
-      this.write({
+      await this.respondToApproval(id, request, { outcome: { outcome: 'cancelled' } });
+      await this.write({
         jsonrpc: '2.0',
         method: 'session/cancel',
-        params: { sessionId: request.sessionId },
+        params: { sessionId: rawSessionId },
       });
       this.cancelSent = true;
       return;
@@ -862,7 +922,7 @@ class NdjsonRpcTransport {
 
     let response: AcpApprovalResponse;
     try {
-      response = approvalResponseFromDecision(request, decision);
+      response = approvalResponseFromDecision(request, decision, responseOptions);
     } catch (error) {
       const protocolError =
         error instanceof AcpProtocolError
@@ -870,36 +930,163 @@ class NdjsonRpcTransport {
           : new AcpProtocolError('ACP permission decision could not be applied', {
               method: 'session/request_permission',
             });
-      this.writeJsonRpcError(id, -32602, protocolError.message);
+      await this.writeJsonRpcError(id, -32602, protocolError.message);
       this.fail(protocolError);
       return;
     }
 
-    this.respondToApproval(id, request, response);
+    await this.respondToApproval(id, request, response);
   }
 
-  private respondToApproval(
+  private async respondToApproval(
     id: JsonRpcId,
     request: AcpApprovalRequest,
     response: AcpApprovalResponse
-  ): void {
+  ): Promise<void> {
+    try {
+      await this.write({
+        jsonrpc: '2.0',
+        id,
+        result: response,
+      });
+    } catch (error) {
+      this.approvalWriteClassifications += 1;
+      let rejectionReason: AcpApprovalRejectionReason;
+      try {
+        rejectionReason = await this.approvalRejectionReasonFromWriteError(error);
+      } finally {
+        this.approvalWriteClassifications -= 1;
+      }
+      request.state = 'rejected';
+      request.rejectionReason = rejectionReason;
+      delete request.response;
+      this.pendingApprovals.delete(id);
+      const protocolError = new AcpProtocolError(
+        rejectionReason === 'child_exit'
+          ? 'ACP child process exited before approval response write'
+          : 'ACP approval response write failed',
+        {
+          method: 'session/request_permission',
+          requestId: id,
+          rejectionReason,
+          writeError: error instanceof Error ? error.message : String(error),
+          approvalRequest: { ...request },
+        }
+      );
+      this.fail(protocolError);
+      throw protocolError;
+    }
     request.state = 'responded';
-    request.response = response;
+    request.response = surfaceApprovalResponse(response);
     this.pendingApprovals.delete(id);
-    this.write({
-      jsonrpc: '2.0',
-      id,
-      result: response,
-    });
   }
 
-  private write(message: JsonObject): void {
+  private async write(message: JsonObject): Promise<void> {
     this.throwIfFailed();
-    if (this.child.stdin.destroyed || !this.child.stdin.writable) {
-      throw new AcpProtocolError('ACP stdin is not writable', { message });
+    if (this.hasChildExited()) {
+      throw new AcpProtocolError('ACP child process exited before write', {
+        ...summarizeOutboundMessage(message),
+        approvalRejectionReason: 'child_exit',
+      });
+    }
+    if (
+      this.child.stdin.destroyed ||
+      this.child.stdin.writableEnded ||
+      !this.child.stdin.writable
+    ) {
+      throw new AcpProtocolError('ACP stdin is not writable', summarizeOutboundMessage(message));
+    }
+    const payload = `${JSON.stringify(message)}\n`;
+    this.activeWrites += 1;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const settle = (error: Error | null): void => {
+          if (settled) return;
+          settled = true;
+          this.child.stdin.off('error', onError);
+          this.child.off('exit', onExit);
+          if (error) {
+            if (error instanceof AcpProtocolError) {
+              reject(error);
+              return;
+            }
+            reject(
+              new AcpProtocolError('ACP stdin write failed', {
+                ...summarizeOutboundMessage(message),
+                approvalRejectionReason: this.hasChildExited() ? 'child_exit' : 'write_failed',
+                writeError: error.message,
+              })
+            );
+            return;
+          }
+          if (this.hasChildExited()) {
+            reject(
+              new AcpProtocolError('ACP child process exited before write completed', {
+                ...summarizeOutboundMessage(message),
+                approvalRejectionReason: 'child_exit',
+              })
+            );
+            return;
+          }
+          if (this.child.stdin.destroyed || this.child.stdin.writableEnded) {
+            reject(
+              new AcpProtocolError(
+                'ACP stdin closed before write completed',
+                summarizeOutboundMessage(message)
+              )
+            );
+            return;
+          }
+          resolve();
+        };
+        const onError = (error: Error): void => settle(error);
+        const onExit = (): void => {
+          settle(
+            new AcpProtocolError('ACP child process exited before write completed', {
+              ...summarizeOutboundMessage(message),
+              approvalRejectionReason: 'child_exit',
+            })
+          );
+        };
+        this.child.stdin.once('error', onError);
+        this.child.once('exit', onExit);
+        try {
+          this.child.stdin.write(payload, error => settle(error ?? null));
+        } catch (error) {
+          settle(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+    } finally {
+      this.activeWrites -= 1;
     }
     this.frames.push({ direction: 'client_to_agent', message });
-    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private hasChildExited(): boolean {
+    return this.exited || this.child.exitCode !== null || this.child.signalCode !== null;
+  }
+
+  private async approvalRejectionReasonFromWriteError(
+    error: unknown
+  ): Promise<AcpApprovalRejectionReason> {
+    if (
+      error instanceof AcpProtocolError &&
+      error.details.approvalRejectionReason === 'child_exit'
+    ) {
+      return 'child_exit';
+    }
+
+    if (this.hasChildExited()) return 'child_exit';
+
+    await Promise.race([
+      this.exitPromise.then(() => undefined),
+      new Promise<void>(resolve => {
+        setTimeout(resolve, APPROVAL_WRITE_EXIT_GRACE_MS);
+      }),
+    ]);
+
+    return this.hasChildExited() ? 'child_exit' : 'write_failed';
   }
 
   private fail(error: AcpProtocolError): void {
@@ -910,7 +1097,12 @@ class NdjsonRpcTransport {
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer);
       pending.reject(
-        new AcpProtocolError(error.message, { ...redactedDetails, method: pending.method, id })
+        new AcpProtocolError(error.message, {
+          ...redactedDetails,
+          method:
+            typeof redactedDetails.method === 'string' ? redactedDetails.method : pending.method,
+          id,
+        })
       );
     }
     this.pending.clear();
@@ -941,8 +1133,8 @@ class NdjsonRpcTransport {
     if (this.protocolFailure) throw this.protocolFailure;
   }
 
-  private writeJsonRpcError(id: JsonRpcId, code: number, message: string): void {
-    this.write({
+  private async writeJsonRpcError(id: JsonRpcId, code: number, message: string): Promise<void> {
+    await this.write({
       jsonrpc: '2.0',
       id,
       error: {
@@ -962,19 +1154,26 @@ class NdjsonRpcTransport {
       pending.request.rejectionReason = reason;
       rejected.push({ ...pending.request });
       if (notifyAgent && !this.exited) {
-        this.tryWriteJsonRpcError(id, -32000, `ACP approval request rejected: ${reason}`);
+        void this.tryWriteJsonRpcError(id, -32000, `ACP approval request rejected: ${reason}`);
       }
     }
     this.pendingApprovals.clear();
     return rejected;
   }
 
-  private tryWriteJsonRpcError(id: JsonRpcId, code: number, message: string): void {
+  private async tryWriteJsonRpcError(id: JsonRpcId, code: number, message: string): Promise<void> {
     try {
-      this.writeJsonRpcError(id, code, message);
+      await this.writeJsonRpcError(id, code, message);
     } catch {
       // Best-effort cleanup: the original timeout/exit/dispose error is reported to the caller.
     }
+  }
+
+  private failOnResidualStdoutBuffer(): void {
+    if (this.protocolFailure || this.stdoutBuffer.trim() === '') return;
+    const line = this.stdoutBuffer.replace(/\r$/, '');
+    this.stdoutBuffer = '';
+    this.fail(new AcpProtocolError('ACP stdout ended with an unterminated line', { line }));
   }
 }
 
@@ -1079,7 +1278,7 @@ function requireObject(value: unknown, label: string): JsonObject {
   return value;
 }
 
-function normalizeApprovalRequest(id: JsonRpcId, params: unknown): AcpApprovalRequest {
+function normalizeApprovalRequest(id: JsonRpcId, params: unknown): NormalizedApprovalRequest {
   const request = requireObject(params, 'session/request_permission params');
   const optionsValue = request.options;
   if (!Array.isArray(optionsValue)) {
@@ -1087,17 +1286,26 @@ function normalizeApprovalRequest(id: JsonRpcId, params: unknown): AcpApprovalRe
       method: 'session/request_permission',
     });
   }
+  const rawSessionId = requireString(request.sessionId, 'session/request_permission sessionId');
+  const normalizedOptions = optionsValue.map(normalizePermissionOption);
 
   return {
-    requestId: id,
-    sessionId: requireString(request.sessionId, 'session/request_permission sessionId'),
-    toolCall: normalizeApprovalToolCall(request.toolCall),
-    options: optionsValue.map(normalizePermissionOption),
-    state: 'pending',
+    request: {
+      requestId: id,
+      sessionId: redactApprovalString(rawSessionId),
+      toolCall: normalizeApprovalToolCall(request.toolCall),
+      options: normalizedOptions.slice(0, APPROVAL_ARRAY_LIMIT_ITEMS).map(option => option.surface),
+      state: 'pending',
+    },
+    rawSessionId,
+    responseOptions: normalizedOptions.map(option => option.response),
   };
 }
 
-function normalizePermissionOption(value: unknown): AcpPermissionOption {
+function normalizePermissionOption(value: unknown): {
+  surface: AcpPermissionOption;
+  response: AcpPermissionOption;
+} {
   const option = requireObject(value, 'session/request_permission option');
   const optionId = requireString(option.optionId, 'session/request_permission option.optionId');
   const kind = requireString(option.kind, 'session/request_permission option.kind');
@@ -1109,21 +1317,40 @@ function normalizePermissionOption(value: unknown): AcpPermissionOption {
     });
   }
   return {
-    optionId,
-    name: requireString(option.name, 'session/request_permission option.name'),
-    kind,
+    surface: {
+      optionId: redactApprovalString(optionId),
+      name: redactApprovalString(
+        requireString(option.name, 'session/request_permission option.name')
+      ),
+      kind,
+    },
+    response: {
+      optionId,
+      name: requireString(option.name, 'session/request_permission option.name'),
+      kind,
+    },
   };
 }
 
 function normalizeApprovalToolCall(value: unknown): AcpApprovalToolCall {
   const toolCall = requireObject(value, 'session/request_permission toolCall');
   return {
-    toolCallId: requireString(toolCall.toolCallId, 'session/request_permission toolCall.toolCallId'),
-    title: optionalStringOrNull(toolCall.title, 'session/request_permission toolCall.title'),
-    kind: optionalStringOrNull(toolCall.kind, 'session/request_permission toolCall.kind'),
-    status: optionalStringOrNull(toolCall.status, 'session/request_permission toolCall.status'),
+    toolCallId: redactApprovalString(
+      requireString(toolCall.toolCallId, 'session/request_permission toolCall.toolCallId')
+    ),
+    title: optionalRedactedStringOrNull(
+      toolCall.title,
+      'session/request_permission toolCall.title'
+    ),
+    kind: optionalRedactedStringOrNull(toolCall.kind, 'session/request_permission toolCall.kind'),
+    status: optionalRedactedStringOrNull(
+      toolCall.status,
+      'session/request_permission toolCall.status'
+    ),
     rawInput:
-      toolCall.rawInput === undefined ? undefined : sanitizeAcpApprovalValue(toolCall.rawInput, undefined),
+      toolCall.rawInput === undefined
+        ? undefined
+        : sanitizeAcpApprovalValue(toolCall.rawInput, undefined),
     rawOutput:
       toolCall.rawOutput === undefined
         ? undefined
@@ -1133,21 +1360,24 @@ function normalizeApprovalToolCall(value: unknown): AcpApprovalToolCall {
         ? undefined
         : sanitizeAcpApprovalValue(toolCall.locations, undefined),
     content:
-      toolCall.content === undefined ? undefined : sanitizeAcpApprovalValue(toolCall.content, undefined),
+      toolCall.content === undefined
+        ? undefined
+        : sanitizeAcpApprovalValue(toolCall.content, undefined),
   };
 }
 
 function approvalResponseFromDecision(
   request: AcpApprovalRequest,
-  decision: AcpApprovalDecision
+  decision: AcpApprovalDecision,
+  responseOptions: readonly AcpPermissionOption[] = request.options
 ): AcpApprovalResponse {
   if (decision.outcome === 'cancelled') return { outcome: { outcome: 'cancelled' } };
 
-  const optionId =
+  const selectedOption =
     'optionId' in decision
-      ? decision.optionId
-      : request.options.find(option => option.kind === decision.optionKind)?.optionId;
-  if (!optionId || !request.options.some(option => option.optionId === optionId)) {
+      ? findResponseOptionById(request.options, responseOptions, decision.optionId)
+      : responseOptions.find(option => option.kind === decision.optionKind);
+  if (!selectedOption) {
     throw new AcpProtocolError('ACP permission decision did not match an available option', {
       method: 'session/request_permission',
       requestId: request.requestId,
@@ -1155,7 +1385,38 @@ function approvalResponseFromDecision(
     });
   }
 
-  return { outcome: { outcome: 'selected', optionId } };
+  return { outcome: { outcome: 'selected', optionId: selectedOption.optionId } };
+}
+
+function findResponseOptionById(
+  surfaceOptions: readonly AcpPermissionOption[],
+  responseOptions: readonly AcpPermissionOption[],
+  optionId: string
+): AcpPermissionOption | undefined {
+  const directMatch = responseOptions.find(option => option.optionId === optionId);
+  if (directMatch) return directMatch;
+  const surfaceIndex = surfaceOptions.findIndex(option => option.optionId === optionId);
+  return surfaceIndex === -1 ? undefined : responseOptions[surfaceIndex];
+}
+
+function surfaceApprovalResponse(response: AcpApprovalResponse): AcpApprovalResponse {
+  if (response.outcome.outcome === 'cancelled') return response;
+  return {
+    outcome: {
+      outcome: 'selected',
+      optionId: redactApprovalString(response.outcome.optionId),
+    },
+  };
+}
+
+function summarizeOutboundMessage(message: JsonObject): JsonObject {
+  return {
+    jsonrpc: message.jsonrpc === '2.0' ? '2.0' : undefined,
+    id: isJsonRpcId(message.id) ? message.id : undefined,
+    method: typeof message.method === 'string' ? message.method : undefined,
+    hasResult: Object.hasOwn(message, 'result'),
+    hasError: Object.hasOwn(message, 'error'),
+  };
 }
 
 function requireArray(value: unknown, label: string): unknown[] {
@@ -1180,6 +1441,11 @@ function optionalString(value: unknown, label: string): string | undefined {
 function optionalStringOrNull(value: unknown, label: string): string | undefined {
   if (value === undefined || value === null) return undefined;
   return requireString(value, label);
+}
+
+function optionalRedactedStringOrNull(value: unknown, label: string): string | undefined {
+  const stringValue = optionalStringOrNull(value, label);
+  return stringValue === undefined ? undefined : redactApprovalString(stringValue);
 }
 
 function requireNumber(value: unknown, label: string): number {
@@ -1220,8 +1486,10 @@ function sanitizeAcpApprovalValue(value: unknown, key: string | undefined): unkn
   if (isJsonObject(value)) {
     const entries = Object.entries(value).slice(0, APPROVAL_OBJECT_LIMIT_KEYS);
     const sanitized: JsonObject = {};
+    const usedKeys = new Set<string>();
     for (const [entryKey, entryValue] of entries) {
-      sanitized[entryKey] = sanitizeAcpApprovalValue(entryValue, entryKey);
+      const sanitizedKey = uniqueJsonObjectKey(redactApprovalString(entryKey), usedKeys);
+      sanitized[sanitizedKey] = sanitizeAcpApprovalValue(entryValue, entryKey);
     }
     if (Object.keys(value).length > APPROVAL_OBJECT_LIMIT_KEYS) {
       sanitized.__truncatedKeys = Object.keys(value).length - APPROVAL_OBJECT_LIMIT_KEYS;
@@ -1231,23 +1499,64 @@ function sanitizeAcpApprovalValue(value: unknown, key: string | undefined): unkn
   return String(value);
 }
 
+function toAcpProtocolError(
+  error: unknown,
+  message: string,
+  details: JsonObject = {}
+): AcpProtocolError {
+  if (error instanceof AcpProtocolError) {
+    return new AcpProtocolError(error.message, { ...details, ...error.details });
+  }
+  return new AcpProtocolError(message, {
+    ...details,
+    message: error instanceof Error ? error.message : String(error),
+  });
+}
+
 function isSensitiveApprovalKey(key: string): boolean {
-  return /(authorization|cookie|api[_-]?key|auth[_-]?token|token|secret|password|credential)/i.test(key);
+  return /(authorization|cookie|api[_-]?key|auth[_-]?token|token|secret|password|credential)/i.test(
+    key
+  );
 }
 
 function redactApprovalString(value: string): string {
-  const withoutSettingsPath = value
-    .replace(/[A-Za-z]:\\(?:[^\\\r\n"]+\\)*settings\.local\.json/gi, '[REDACTED_PATH]')
-    .replace(/(?:~|(?:\/[^\s'"\\/]+)+)\/settings\.local\.json/gi, '[REDACTED_PATH]');
+  const boundedValue = truncateUtf8(value, APPROVAL_STRING_LIMIT_BYTES);
+  const withoutSettingsPath = boundedValue.replace(
+    /[^\s'"]*settings\.local\.json/gi,
+    '[REDACTED_PATH]'
+  );
   const withoutSecretTokens = withoutSettingsPath.replace(
     /\bsk-(?:ant|live|test|proj)-[A-Za-z0-9_-]+\b/g,
     '[REDACTED]'
   );
   const withoutBearer = withoutSecretTokens.replace(
-    /(?<![A-Za-z0-9_-])(Bearer|token|api[_-]?key|secret)\s+['"]?[^'",\s]+/gi,
+    /\b(Bearer|token|api[_-]?key|secret)\s+['"]?[^'",\s]+/gi,
     '$1 [REDACTED]'
   );
-  return truncateUtf8(withoutBearer, APPROVAL_STRING_LIMIT_BYTES);
+  const withoutAssignments = withoutBearer.replace(
+    /\b((?:authorization|token|api[_-]?key|secret)\s*[:=]\s*)['"]?[^'",\s]+/gi,
+    '$1[REDACTED]'
+  );
+  return truncateUtf8(withoutAssignments, APPROVAL_STRING_LIMIT_BYTES);
+}
+
+function uniqueJsonObjectKey(candidate: string, usedKeys: Set<string>): string {
+  if (!usedKeys.has(candidate)) {
+    usedKeys.add(candidate);
+    return candidate;
+  }
+
+  let index = 2;
+  while (true) {
+    const suffix = `#${index}`;
+    const key = truncateUtf8(candidate, APPROVAL_STRING_LIMIT_BYTES - Buffer.byteLength(suffix));
+    const uniqueKey = `${key}${suffix}`;
+    if (!usedKeys.has(uniqueKey)) {
+      usedKeys.add(uniqueKey);
+      return uniqueKey;
+    }
+    index += 1;
+  }
 }
 
 function appendLimited(current: string, chunk: string, limitBytes: number): string {


### PR DESCRIPTION
## Summary
- Harden ACP approval child-exit classification on top of the ACP-012 v2 spike already merged to `develop`.
- Keep pending approval `child_exit` classification from being masked by residual unterminated stdout.
- Route approval response write races through approval-specific classification instead of generic stdin failure handling.
- Sanitize approval metadata object keys before surfacing captured permission request data.

## Aegis version
0.6.6-preview.1

## Validation
- `npm run gate`
- `npx tsc --noEmit`
- `npx vitest run src/__tests__/acp-lifecycle-probe.test.ts -t "child exits before the response write" --reporter dot --testTimeout 5000`
- `npm test -- src/__tests__/acp-lifecycle-probe.test.ts`
- `npm test -- src/__tests__/acp-terminal-extension-probe.test.ts`
- Independent code review: no Critical or Important blockers.

Follow-up to ACP-012 / #2580. Supersedes #2671.