### PR TITLE
refactor: add ACP session service skeleton

### DIFF
--- a/src/__tests__/acp-session-service.test.ts
+++ b/src/__tests__/acp-session-service.test.ts
@@ -1,0 +1,504 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AcpDurableIdentityError,
+  AcpInvalidStateTransitionError,
+  AcpSessionNotFoundError,
+  AcpSessionService,
+  AcpValidationError,
+  validateAcpControlActionInput,
+  type AcpAgentSessionAttachment,
+  type AcpControlActionInput,
+  type AcpCreateSessionInput,
+  type AcpSessionRecord,
+  type AcpSessionScope,
+  type AcpSessionStore,
+} from '../services/acp/index.js';
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+function cloneRecord(record: AcpSessionRecord): AcpSessionRecord {
+  return {
+    ...record,
+    backendMetadata:
+      record.backendMetadata === undefined ? undefined : { ...record.backendMetadata },
+  };
+}
+
+class InMemoryScopedAcpSessionStore implements AcpSessionStore {
+  private readonly records = new Map<string, AcpSessionRecord>();
+
+  async create(record: AcpSessionRecord): Promise<void> {
+    if (this.records.has(record.id)) {
+      throw new Error(`session already exists: ${record.id}`);
+    }
+    this.records.set(record.id, cloneRecord(record));
+  }
+
+  async get(id: string, requestedScope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    const record = this.records.get(id);
+    if (!record) return null;
+    if (record.tenantId !== requestedScope.tenantId) return null;
+    if (record.ownerKeyId !== requestedScope.ownerKeyId) return null;
+    return cloneRecord(record);
+  }
+
+  async update(
+    record: AcpSessionRecord,
+    requestedScope: AcpSessionScope
+  ): Promise<AcpSessionRecord | null> {
+    const current = this.records.get(record.id);
+    if (!current) return null;
+    if (current.tenantId !== requestedScope.tenantId) return null;
+    if (current.ownerKeyId !== requestedScope.ownerKeyId) return null;
+    this.records.set(record.id, cloneRecord(record));
+    return cloneRecord(record);
+  }
+}
+
+class MutatingUpdateAcpSessionStore extends InMemoryScopedAcpSessionStore {
+  async update(
+    record: AcpSessionRecord,
+    requestedScope: AcpSessionScope
+  ): Promise<AcpSessionRecord | null> {
+    const persisted = await super.update(record, requestedScope);
+    if (!persisted) return null;
+    return {
+      ...persisted,
+      conversationId: 'mutated-conversation-id',
+    };
+  }
+}
+
+class UnscopedReadAcpSessionStore extends InMemoryScopedAcpSessionStore {
+  private storedRecord: AcpSessionRecord | null = null;
+
+  async create(record: AcpSessionRecord): Promise<void> {
+    await super.create(record);
+    this.storedRecord = cloneRecord(record);
+  }
+
+  async get(id: string, requestedScope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    const scoped = await super.get(id, requestedScope);
+    return scoped ?? (this.storedRecord ? cloneRecord(this.storedRecord) : null);
+  }
+}
+
+function createService(ids: string[] = ['session-1', 'conversation-1', 'transcript-1']): {
+  service: AcpSessionService;
+  store: InMemoryScopedAcpSessionStore;
+} {
+  const store = new InMemoryScopedAcpSessionStore();
+  let idIndex = 0;
+  let now = 1_700_000_000_000;
+  const service = new AcpSessionService(store, {
+    idProvider: () => {
+      const id = ids[idIndex];
+      idIndex += 1;
+      return id ?? `generated-${idIndex}`;
+    },
+    clock: () => {
+      now += 100;
+      return now;
+    },
+  });
+
+  return { service, store };
+}
+
+function isCreateSessionInput(value: unknown): value is AcpCreateSessionInput {
+  return typeof value === 'object' && value !== null;
+}
+
+function isAgentSessionAttachment(value: unknown): value is AcpAgentSessionAttachment {
+  return typeof value === 'object' && value !== null;
+}
+
+function isControlActionInput(value: unknown): value is AcpControlActionInput {
+  return typeof value === 'object' && value !== null;
+}
+
+describe('AcpSessionService', () => {
+  it('creates a scoped durable session before ACP agent attachment', async () => {
+    const { service, store } = createService();
+
+    const created = await service.createSession(scope);
+
+    expect(created).toMatchObject({
+      id: 'session-1',
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+      conversationId: 'conversation-1',
+      transcriptId: 'transcript-1',
+      status: 'initializing',
+    });
+    expect(created.id).not.toBe(created.conversationId);
+    expect(created.id).not.toBe(created.transcriptId);
+    expect(created.conversationId).not.toBe(created.transcriptId);
+    expect(created.acpAgentSessionId).toBeUndefined();
+    expect(created.claudeSessionId).toBeUndefined();
+    expect(created.currentBackendRunId).toBeUndefined();
+
+    await expect(store.get(created.id, scope)).resolves.toEqual(created);
+  });
+
+  it('rejects duplicate durable ids generated during session creation', async () => {
+    const { service } = createService(['duplicate-id', 'duplicate-id', 'transcript-1']);
+
+    await expect(service.createSession(scope)).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('rejects public session ids that collide with tenant or owner scope values', async () => {
+    const { service } = createService(['tenant-a', 'conversation-1', 'transcript-1']);
+
+    await expect(service.createSession(scope)).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('attaches and resumes ACP, Claude, and backend ids without replacing durable ids', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+
+    const attached = await service.attachAgentSession(created.id, scope, {
+      acpAgentSessionId: 'acp-session-1',
+      claudeSessionId: 'claude-session-1',
+      backendRunId: 'backend-run-1',
+    });
+    const resumed = await service.attachAgentSession(created.id, scope, {
+      acpAgentSessionId: 'acp-session-2',
+      claudeSessionId: 'claude-session-2',
+      backendRunId: 'backend-run-2',
+    });
+
+    expect(attached.id).toBe(created.id);
+    expect(resumed.id).toBe(created.id);
+    expect(resumed.conversationId).toBe(created.conversationId);
+    expect(resumed.transcriptId).toBe(created.transcriptId);
+    expect(resumed.tenantId).toBe(created.tenantId);
+    expect(resumed.ownerKeyId).toBe(created.ownerKeyId);
+    expect(resumed.createdAt).toBe(created.createdAt);
+    expect(resumed.acpAgentSessionId).toBe('acp-session-2');
+    expect(resumed.claudeSessionId).toBe('claude-session-2');
+    expect(resumed.currentBackendRunId).toBe('backend-run-2');
+    expect(resumed.updatedAt).toBeGreaterThan(created.updatedAt);
+  });
+
+  it('rejects store updates that return mutated durable identity fields', async () => {
+    const store = new MutatingUpdateAcpSessionStore();
+    let idIndex = 0;
+    const ids = ['session-1', 'conversation-1', 'transcript-1'];
+    const service = new AcpSessionService(store, {
+      idProvider: () => ids[idIndex++] ?? `generated-${idIndex}`,
+      clock: () => 1_700_000_000_000 + idIndex,
+    });
+    const created = await service.createSession(scope);
+
+    await expect(
+      service.attachAgentSession(created.id, scope, {
+        acpAgentSessionId: 'acp-session-1',
+      })
+    ).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('rejects ACP attachment ids that collide with durable identity namespaces', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+
+    await expect(
+      service.attachAgentSession(created.id, scope, {
+        acpAgentSessionId: created.id,
+      })
+    ).rejects.toBeInstanceOf(AcpDurableIdentityError);
+    await expect(
+      service.attachAgentSession(created.id, scope, {
+        claudeSessionId: created.conversationId,
+      })
+    ).rejects.toBeInstanceOf(AcpDurableIdentityError);
+    await expect(
+      service.attachAgentSession(created.id, scope, {
+        backendRunId: created.transcriptId,
+      })
+    ).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('requires tenant and owner scope for reads and updates', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+    const wrongTenant: AcpSessionScope = { tenantId: 'tenant-b', ownerKeyId: 'owner-a' };
+    const wrongOwner: AcpSessionScope = { tenantId: 'tenant-a', ownerKeyId: 'owner-b' };
+
+    await expect(service.getSession(created.id, scope)).resolves.toEqual(created);
+    await expect(service.getSession(created.id, wrongTenant)).rejects.toBeInstanceOf(
+      AcpSessionNotFoundError
+    );
+    await expect(
+      service.attachAgentSession(created.id, wrongOwner, {
+        acpAgentSessionId: 'cross-scope-acp-session',
+      })
+    ).rejects.toBeInstanceOf(AcpSessionNotFoundError);
+
+    const unchanged = await service.getSession(created.id, scope);
+    expect(unchanged.acpAgentSessionId).toBeUndefined();
+  });
+
+  it('rejects records returned by a store that ignores tenant and owner scope', async () => {
+    const store = new UnscopedReadAcpSessionStore();
+    let idIndex = 0;
+    const ids = ['session-1', 'conversation-1', 'transcript-1'];
+    const service = new AcpSessionService(store, {
+      idProvider: () => ids[idIndex++] ?? `generated-${idIndex}`,
+      clock: () => 1_700_000_000_000,
+    });
+    const created = await service.createSession({
+      ...scope,
+      parentSessionId: 'parent-1',
+    });
+
+    await expect(
+      service.getSession(created.id, { tenantId: 'tenant-b', ownerKeyId: 'owner-a' })
+    ).rejects.toBeInstanceOf(AcpSessionNotFoundError);
+  });
+
+  it('records backend restarts without altering public, conversation, or transcript ids', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+    const firstRun = await service.recordBackendRestart(created.id, scope, 'backend-run-1');
+    const secondRun = await service.recordBackendRestart(created.id, scope, 'backend-run-2');
+
+    expect(firstRun.currentBackendRunId).toBe('backend-run-1');
+    expect(secondRun.currentBackendRunId).toBe('backend-run-2');
+    expect(secondRun.id).toBe(created.id);
+    expect(secondRun.conversationId).toBe(created.conversationId);
+    expect(secondRun.transcriptId).toBe(created.transcriptId);
+    expect(secondRun.createdAt).toBe(created.createdAt);
+    expect(secondRun.updatedAt).toBeGreaterThan(firstRun.updatedAt);
+  });
+
+  it('allows valid lifecycle transitions and rejects invalid transitions', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+
+    const idle = await service.transition(created.id, scope, { type: 'agent_ready' });
+    const running = await service.transition(created.id, scope, { type: 'run_started' });
+    const paused = await service.transition(created.id, scope, { type: 'pause_requested' });
+    const resumed = await service.transition(created.id, scope, { type: 'resume_requested' });
+    const intervening = await service.transition(created.id, scope, {
+      type: 'intervention_started',
+    });
+    const closing = await service.transition(created.id, scope, { type: 'close_requested' });
+    const closed = await service.transition(created.id, scope, { type: 'close_completed' });
+
+    expect(idle.status).toBe('idle');
+    expect(running.status).toBe('running');
+    expect(paused.status).toBe('paused');
+    expect(resumed.status).toBe('running');
+    expect(intervening.status).toBe('intervening');
+    expect(closing.status).toBe('closing');
+    expect(closed.status).toBe('closed');
+
+    const { service: invalidService } = createService([
+      'invalid-session',
+      'invalid-conversation',
+      'invalid-transcript',
+    ]);
+    const invalid = await invalidService.createSession(scope);
+    await expect(
+      invalidService.transition(invalid.id, scope, { type: 'close_completed' })
+    ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
+  });
+
+  it('rejects agent_ready while a run is active', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+
+    await service.transition(created.id, scope, { type: 'agent_ready' });
+    await service.transition(created.id, scope, { type: 'run_started' });
+
+    await expect(
+      service.transition(created.id, scope, { type: 'agent_ready' })
+    ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
+  });
+
+  it('keeps paused sessions paused until an explicit resume transition', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+
+    await service.transition(created.id, scope, { type: 'agent_ready' });
+    await service.transition(created.id, scope, { type: 'run_started' });
+    const paused = await service.transition(created.id, scope, { type: 'pause_requested' });
+
+    await expect(
+      service.transition(paused.id, scope, { type: 'run_started' })
+    ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
+    await expect(
+      service.transition(paused.id, scope, { type: 'intervention_started' })
+    ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
+
+    const resumed = await service.transition(paused.id, scope, { type: 'resume_requested' });
+    expect(resumed.status).toBe('running');
+  });
+
+  it('rejects non-primitive backend metadata values before persistence', async () => {
+    const { service } = createService();
+    const decodedInput: unknown = JSON.parse(
+      JSON.stringify({
+        tenantId: 'tenant-a',
+        ownerKeyId: 'owner-a',
+        backendMetadata: { nested: { pid: 123 } },
+      })
+    );
+
+    if (!isCreateSessionInput(decodedInput)) {
+      throw new Error('test fixture must decode to an object');
+    }
+
+    await expect(service.createSession(decodedInput)).rejects.toBeInstanceOf(AcpValidationError);
+  });
+
+  it('rejects malformed decoded scope and relationship identifiers', async () => {
+    const { service } = createService();
+    const malformedInputs: unknown[] = [
+      { ownerKeyId: 'owner-a' },
+      { tenantId: 123, ownerKeyId: 'owner-a' },
+      { tenantId: 'tenant-a', ownerKeyId: null },
+      { tenantId: 'tenant-a', ownerKeyId: 'owner-a', parentSessionId: {} },
+    ];
+
+    for (const malformedInput of malformedInputs) {
+      if (!isCreateSessionInput(malformedInput)) {
+        throw new Error('test fixture must decode to an object');
+      }
+      await expect(service.createSession(malformedInput)).rejects.toBeInstanceOf(
+        AcpValidationError
+      );
+    }
+  });
+
+  it('rejects malformed decoded ACP attachment identifiers', async () => {
+    const { service } = createService();
+    const created = await service.createSession(scope);
+    const malformedAttachments: unknown[] = [
+      { acpAgentSessionId: 123 },
+      { claudeSessionId: null },
+      { backendRunId: false },
+    ];
+
+    for (const malformedAttachment of malformedAttachments) {
+      if (!isAgentSessionAttachment(malformedAttachment)) {
+        throw new Error('test fixture must decode to an object');
+      }
+      await expect(
+        service.attachAgentSession(created.id, scope, malformedAttachment)
+      ).rejects.toBeInstanceOf(AcpValidationError);
+    }
+  });
+
+  it('rejects sensitive backend metadata keys before persistence', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.createSession({
+        ...scope,
+        backendMetadata: { ANTHROPIC_API_KEY: 'secret' },
+      })
+    ).rejects.toThrow('ACP backend metadata key is sensitive');
+  });
+
+  it('rejects non-finite backend metadata numbers before persistence', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.createSession({
+        ...scope,
+        backendMetadata: { exitCode: Number.NaN },
+      })
+    ).rejects.toBeInstanceOf(AcpValidationError);
+  });
+
+  it('rejects oversized backend metadata keys before persistence', async () => {
+    const { service } = createService();
+    const oversizedKey = 'k'.repeat(129);
+
+    await expect(
+      service.createSession({
+        ...scope,
+        backendMetadata: { [oversizedKey]: 'bounded-value' },
+      })
+    ).rejects.toThrow('ACP backend metadata key exceeds 128 bytes');
+  });
+
+  it('rejects blank durable relationship identifiers', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.createSession({
+        ...scope,
+        parentSessionId: ' ',
+      })
+    ).rejects.toBeInstanceOf(AcpValidationError);
+  });
+
+  it('rejects JSON-RPC request ids as durable ACP session identity', async () => {
+    const { service } = createService();
+    const inputWithJsonRpcId = {
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+      jsonRpcRequestId: 100,
+    };
+
+    await expect(service.createSession(inputWithJsonRpcId)).rejects.toThrow(
+      'JSON-RPC request ids are transport-scoped'
+    );
+
+    const created = await service.createSession(scope);
+    const attachmentWithJsonRpcId = {
+      acpAgentSessionId: 'acp-session-1',
+      jsonRpcRequestId: 'transport-1',
+    };
+
+    await expect(
+      service.attachAgentSession(created.id, scope, attachmentWithJsonRpcId)
+    ).rejects.toThrow('JSON-RPC request ids are transport-scoped');
+
+    const persisted = await service.getSession(created.id, scope);
+    expect(Object.hasOwn(persisted, 'jsonRpcRequestId')).toBe(false);
+  });
+
+  it('validates control action ids without accepting JSON-RPC ids as durable identity', () => {
+    const decodedAction: unknown = {
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+      sessionId: 'session-1',
+      actionId: 'action-1',
+      type: 'approve',
+      approvalId: 'action-1',
+    };
+
+    if (!isControlActionInput(decodedAction)) {
+      throw new Error('test fixture must decode to an object');
+    }
+
+    expect(() => validateAcpControlActionInput(decodedAction)).toThrow(
+      'ACP identity namespaces must be distinct'
+    );
+    const actionWithJsonRpcId: unknown = {
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+      sessionId: 'session-1',
+      actionId: 'action-1',
+      type: 'approve',
+      approvalId: 'approval-1',
+      jsonRpcRequestId: 1,
+    };
+
+    if (!isControlActionInput(actionWithJsonRpcId)) {
+      throw new Error('test fixture must decode to an object');
+    }
+
+    expect(() => validateAcpControlActionInput(actionWithJsonRpcId)).toThrow(
+      'JSON-RPC request ids are transport-scoped'
+    );
+  });
+});

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -1,0 +1,22 @@
+export type {
+  AcpAgentSessionAttachment,
+  AcpBackendMetadata,
+  AcpBackendMetadataValue,
+  AcpControlActionInput,
+  AcpControlActionType,
+  AcpCreateSessionInput,
+  AcpSessionRecord,
+  AcpSessionScope,
+  AcpSessionStatus,
+  AcpSessionStore,
+  AcpSessionTransitionEvent,
+} from './types.js';
+export { AcpInvalidStateTransitionError, transitionAcpSessionStatus } from './state-machine.js';
+export {
+  AcpDurableIdentityError,
+  AcpSessionNotFoundError,
+  AcpSessionService,
+  AcpValidationError,
+  type AcpSessionServiceOptions,
+  validateAcpControlActionInput,
+} from './session-service.js';

--- a/src/services/acp/session-service.ts
+++ b/src/services/acp/session-service.ts
@@ -1,0 +1,419 @@
+import { randomUUID } from 'node:crypto';
+
+import { transitionAcpSessionStatus } from './state-machine.js';
+import type {
+  AcpAgentSessionAttachment,
+  AcpBackendMetadata,
+  AcpBackendMetadataValue,
+  AcpControlActionInput,
+  AcpCreateSessionInput,
+  AcpSessionRecord,
+  AcpSessionScope,
+  AcpSessionStore,
+  AcpSessionTransitionEvent,
+} from './types.js';
+
+const MAX_BACKEND_METADATA_KEYS = 20;
+const MAX_BACKEND_METADATA_KEY_BYTES = 128;
+const MAX_BACKEND_METADATA_STRING_BYTES = 1024;
+const BLOCKED_BACKEND_METADATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const SENSITIVE_BACKEND_METADATA_KEY_PATTERN =
+  /(token|secret|password|api[_-]?key|authorization|cookie|prompt|payload|tool.*arg)/i;
+const CONTROL_ACTION_TYPES = new Set([
+  'prompt',
+  'approve',
+  'reject',
+  'pause',
+  'resume',
+  'cancel',
+  'driver_transfer',
+  'intervene',
+  'close',
+]);
+
+export interface AcpSessionServiceOptions {
+  idProvider?: () => string;
+  clock?: () => number;
+}
+
+export class AcpSessionNotFoundError extends Error {
+  constructor(readonly sessionId: string) {
+    super(`ACP session not found in the requested tenant and owner scope: ${sessionId}`);
+    this.name = 'AcpSessionNotFoundError';
+  }
+}
+
+export class AcpDurableIdentityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AcpDurableIdentityError';
+  }
+}
+
+export class AcpValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AcpValidationError';
+  }
+}
+
+export class AcpSessionService {
+  private readonly idProvider: () => string;
+  private readonly clock: () => number;
+
+  constructor(
+    private readonly store: AcpSessionStore,
+    options: AcpSessionServiceOptions = {}
+  ) {
+    this.idProvider = options.idProvider ?? randomUUID;
+    this.clock = options.clock ?? Date.now;
+  }
+
+  async createSession(input: AcpCreateSessionInput): Promise<AcpSessionRecord> {
+    assertNoJsonRpcRequestId(input);
+    assertScope(input);
+    assertOptionalNonEmptyString(input.parentSessionId, 'parent session id');
+    assertOptionalNonEmptyString(input.rootSessionId, 'root session id');
+    assertOptionalNonEmptyString(input.correlationId, 'correlation id');
+    assertOptionalNonEmptyString(input.resumeFromSessionId, 'resume-from session id');
+    const now = this.clock();
+    const id = this.createId('session id');
+    const conversationId = this.createId('conversation id');
+    const transcriptId = this.createId('transcript id');
+    assertDistinctIdentityNamespaces([
+      ['session id', id],
+      ['tenant id', input.tenantId],
+      ['owner key id', input.ownerKeyId],
+      ['conversation id', conversationId],
+      ['transcript id', transcriptId],
+      ['parent session id', input.parentSessionId],
+      ['root session id', input.rootSessionId],
+      ['correlation id', input.correlationId],
+      ['resume-from session id', input.resumeFromSessionId],
+    ]);
+    const record: AcpSessionRecord = {
+      id,
+      tenantId: input.tenantId,
+      ownerKeyId: input.ownerKeyId,
+      conversationId,
+      transcriptId,
+      status: 'initializing',
+      createdAt: now,
+      updatedAt: now,
+      parentSessionId: input.parentSessionId,
+      rootSessionId: input.rootSessionId,
+      correlationId: input.correlationId,
+      resumeFromSessionId: input.resumeFromSessionId,
+      backendMetadata: normalizeBackendMetadata(input.backendMetadata),
+    };
+
+    await this.store.create(record);
+    return cloneRecord(record);
+  }
+
+  async getSession(sessionId: string, scope: AcpSessionScope): Promise<AcpSessionRecord> {
+    assertNonEmptyString(sessionId, 'session id');
+    assertScope(scope);
+    return this.requireSession(sessionId, scope);
+  }
+
+  async attachAgentSession(
+    sessionId: string,
+    scope: AcpSessionScope,
+    attachment: AcpAgentSessionAttachment
+  ): Promise<AcpSessionRecord> {
+    assertNoJsonRpcRequestId(attachment);
+    const record = await this.requireSession(sessionId, scope);
+    const updated: AcpSessionRecord = {
+      ...record,
+      updatedAt: this.clock(),
+    };
+
+    if (attachment.acpAgentSessionId !== undefined) {
+      assertNonEmptyString(attachment.acpAgentSessionId, 'ACP agent session id');
+      updated.acpAgentSessionId = attachment.acpAgentSessionId;
+    }
+    if (attachment.claudeSessionId !== undefined) {
+      assertNonEmptyString(attachment.claudeSessionId, 'Claude session id');
+      updated.claudeSessionId = attachment.claudeSessionId;
+    }
+    if (attachment.backendRunId !== undefined) {
+      assertNonEmptyString(attachment.backendRunId, 'backend run id');
+      updated.currentBackendRunId = attachment.backendRunId;
+    }
+    if (attachment.backendMetadata !== undefined) {
+      updated.backendMetadata = normalizeBackendMetadata(attachment.backendMetadata);
+    }
+
+    assertSessionIdentityNamespaces(updated);
+    return this.persistUpdate(record, updated, scope);
+  }
+
+  async recordBackendRestart(
+    sessionId: string,
+    scope: AcpSessionScope,
+    backendRunId = this.createId('backend run id')
+  ): Promise<AcpSessionRecord> {
+    assertNonEmptyString(backendRunId, 'backend run id');
+    const record = await this.requireSession(sessionId, scope);
+    const updated: AcpSessionRecord = {
+      ...record,
+      currentBackendRunId: backendRunId,
+      updatedAt: this.clock(),
+    };
+    assertSessionIdentityNamespaces(updated);
+    return this.persistUpdate(record, updated, scope);
+  }
+
+  async transition(
+    sessionId: string,
+    scope: AcpSessionScope,
+    event: AcpSessionTransitionEvent
+  ): Promise<AcpSessionRecord> {
+    assertNoJsonRpcRequestId(event);
+    const record = await this.requireSession(sessionId, scope);
+    const nextStatus = transitionAcpSessionStatus(record.status, event);
+    const now = this.clock();
+    const updated: AcpSessionRecord = {
+      ...record,
+      status: nextStatus,
+      updatedAt: now,
+      closedAt: nextStatus === 'closed' ? record.closedAt ?? now : record.closedAt,
+      failedAt: nextStatus === 'failed' ? record.failedAt ?? now : record.failedAt,
+    };
+    return this.persistUpdate(record, updated, scope);
+  }
+
+  private createId(label: string): string {
+    const id = this.idProvider();
+    assertNonEmptyString(id, label);
+    return id;
+  }
+
+  private async requireSession(
+    sessionId: string,
+    scope: AcpSessionScope
+  ): Promise<AcpSessionRecord> {
+    assertNonEmptyString(sessionId, 'session id');
+    assertScope(scope);
+    const record = await this.store.get(sessionId, scope);
+    if (!record) {
+      throw new AcpSessionNotFoundError(sessionId);
+    }
+    assertRecordMatchesScope(record, scope);
+    return cloneRecord(record);
+  }
+
+  private async persistUpdate(
+    previous: AcpSessionRecord,
+    updated: AcpSessionRecord,
+    scope: AcpSessionScope
+  ): Promise<AcpSessionRecord> {
+    assertDurableIdentityPreserved(previous, updated);
+    assertSessionIdentityNamespaces(updated);
+    const persisted = await this.store.update(updated, scope);
+    if (!persisted) {
+      throw new AcpSessionNotFoundError(previous.id);
+    }
+    assertDurableIdentityPreserved(previous, persisted);
+    assertRecordMatchesScope(persisted, scope);
+    assertSessionIdentityNamespaces(persisted);
+    return cloneRecord(persisted);
+  }
+}
+
+export function validateAcpControlActionInput(input: AcpControlActionInput): void {
+  assertNoJsonRpcRequestId(input);
+  assertScope(input);
+  assertNonEmptyString(input.sessionId, 'control action session id');
+  assertNonEmptyString(input.actionId, 'control action id');
+  assertControlActionType(input.type);
+  assertOptionalNonEmptyString(input.idempotencyKey, 'control action idempotency key');
+  assertOptionalNonEmptyString(input.approvalId, 'approval id');
+  assertOptionalNonEmptyString(input.controlRequestId, 'control request id');
+  normalizeBackendMetadata(input.metadata);
+  assertDistinctIdentityNamespaces([
+    ['tenant id', input.tenantId],
+    ['owner key id', input.ownerKeyId],
+    ['session id', input.sessionId],
+    ['action id', input.actionId],
+    ['approval id', input.approvalId],
+    ['control request id', input.controlRequestId],
+  ]);
+}
+
+function assertScope(scope: AcpSessionScope): void {
+  assertNonEmptyString(scope.tenantId, 'tenant id');
+  assertNonEmptyString(scope.ownerKeyId, 'owner key id');
+}
+
+function assertRecordMatchesScope(record: AcpSessionRecord, scope: AcpSessionScope): void {
+  if (record.tenantId !== scope.tenantId || record.ownerKeyId !== scope.ownerKeyId) {
+    throw new AcpSessionNotFoundError(record.id);
+  }
+}
+
+function assertNoJsonRpcRequestId(input: object): void {
+  if (Object.hasOwn(input, 'jsonRpcRequestId')) {
+    throw new AcpDurableIdentityError(
+      'JSON-RPC request ids are transport-scoped and cannot be stored as durable ACP identity'
+    );
+  }
+}
+
+function assertNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AcpValidationError(`ACP ${label} must be a non-empty string`);
+  }
+}
+
+function assertOptionalNonEmptyString(
+  value: unknown,
+  label: string
+): asserts value is string | undefined {
+  if (value !== undefined) {
+    assertNonEmptyString(value, label);
+  }
+}
+
+function assertControlActionType(value: unknown): void {
+  if (typeof value !== 'string' || !CONTROL_ACTION_TYPES.has(value)) {
+    throw new AcpValidationError('ACP control action type is not supported');
+  }
+}
+
+function assertDurableIdentityPreserved(
+  previous: AcpSessionRecord,
+  updated: AcpSessionRecord
+): void {
+  const changedField =
+    firstChangedField(previous, updated, [
+      'id',
+      'tenantId',
+      'ownerKeyId',
+      'conversationId',
+      'transcriptId',
+      'createdAt',
+      'parentSessionId',
+      'rootSessionId',
+      'correlationId',
+      'resumeFromSessionId',
+    ]) ?? null;
+
+  if (changedField) {
+    throw new AcpDurableIdentityError(`ACP durable identity field cannot change: ${changedField}`);
+  }
+}
+
+function assertSessionIdentityNamespaces(record: AcpSessionRecord): void {
+  assertDistinctIdentityNamespaces([
+    ['session id', record.id],
+    ['tenant id', record.tenantId],
+    ['owner key id', record.ownerKeyId],
+    ['conversation id', record.conversationId],
+    ['transcript id', record.transcriptId],
+    ['ACP agent session id', record.acpAgentSessionId],
+    ['Claude session id', record.claudeSessionId],
+    ['backend run id', record.currentBackendRunId],
+    ['parent session id', record.parentSessionId],
+    ['root session id', record.rootSessionId],
+    ['correlation id', record.correlationId],
+    ['resume-from session id', record.resumeFromSessionId],
+  ]);
+}
+
+function assertDistinctIdentityNamespaces(
+  ids: readonly (readonly [string, string | undefined])[]
+): void {
+  const seen = new Map<string, string>();
+  for (const [label, id] of ids) {
+    if (id === undefined) continue;
+    const firstLabel = seen.get(id);
+    if (firstLabel) {
+      throw new AcpDurableIdentityError(
+        `ACP identity namespaces must be distinct: ${firstLabel} and ${label}`
+      );
+    }
+    seen.set(id, label);
+  }
+}
+
+function firstChangedField(
+  previous: AcpSessionRecord,
+  updated: AcpSessionRecord,
+  fields: readonly (keyof AcpSessionRecord)[]
+): keyof AcpSessionRecord | undefined {
+  return fields.find(field => previous[field] !== updated[field]);
+}
+
+function normalizeBackendMetadata(
+  metadata: Record<string, unknown> | undefined
+): AcpBackendMetadata | undefined {
+  if (metadata === undefined) return undefined;
+  const entries = Object.entries(metadata);
+  if (entries.length > MAX_BACKEND_METADATA_KEYS) {
+    throw new AcpValidationError(
+      `ACP backend metadata cannot contain more than ${MAX_BACKEND_METADATA_KEYS} keys`
+    );
+  }
+
+  const normalized: AcpBackendMetadata = {};
+  for (const [key, value] of entries) {
+    assertNonEmptyString(key, 'backend metadata key');
+    assertBackendMetadataKey(key);
+    assertBackendMetadataValue(key, value);
+    normalized[key] = value;
+  }
+  return normalized;
+}
+
+function assertBackendMetadataKey(key: string): void {
+  if (BLOCKED_BACKEND_METADATA_KEYS.has(key)) {
+    throw new AcpValidationError(`ACP backend metadata key is not allowed: ${key}`);
+  }
+
+  if (SENSITIVE_BACKEND_METADATA_KEY_PATTERN.test(key)) {
+    throw new AcpValidationError(`ACP backend metadata key is sensitive: ${key}`);
+  }
+
+  if (Buffer.byteLength(key, 'utf8') > MAX_BACKEND_METADATA_KEY_BYTES) {
+    throw new AcpValidationError(
+      `ACP backend metadata key exceeds ${MAX_BACKEND_METADATA_KEY_BYTES} bytes`
+    );
+  }
+}
+
+function assertBackendMetadataValue(
+  key: string,
+  value: unknown
+): asserts value is AcpBackendMetadataValue {
+  if (
+    value !== null &&
+    typeof value !== 'string' &&
+    typeof value !== 'number' &&
+    typeof value !== 'boolean'
+  ) {
+    throw new AcpValidationError(`ACP backend metadata value must be primitive: ${key}`);
+  }
+
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new AcpValidationError(`ACP backend metadata number must be finite: ${key}`);
+  }
+
+  if (
+    typeof value === 'string' &&
+    Buffer.byteLength(value, 'utf8') > MAX_BACKEND_METADATA_STRING_BYTES
+  ) {
+    throw new AcpValidationError(
+      `ACP backend metadata value exceeds ${MAX_BACKEND_METADATA_STRING_BYTES} bytes: ${key}`
+    );
+  }
+}
+
+function cloneRecord(record: AcpSessionRecord): AcpSessionRecord {
+  return {
+    ...record,
+    backendMetadata:
+      record.backendMetadata === undefined ? undefined : { ...record.backendMetadata },
+  };
+}

--- a/src/services/acp/state-machine.ts
+++ b/src/services/acp/state-machine.ts
@@ -1,0 +1,70 @@
+import type { AcpSessionStatus, AcpSessionTransitionEvent } from './types.js';
+
+const ACTIVE_STATUSES: readonly AcpSessionStatus[] = [
+  'initializing',
+  'idle',
+  'running',
+  'paused',
+  'intervening',
+];
+
+export class AcpInvalidStateTransitionError extends Error {
+  constructor(
+    readonly currentStatus: AcpSessionStatus,
+    readonly eventType: AcpSessionTransitionEvent['type']
+  ) {
+    super(`Invalid ACP session transition from ${currentStatus} via ${eventType}`);
+    this.name = 'AcpInvalidStateTransitionError';
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled ACP session transition event: ${JSON.stringify(value)}`);
+}
+
+function canTransitionFrom(
+  currentStatus: AcpSessionStatus,
+  eventType: AcpSessionTransitionEvent['type'],
+  allowedStatuses: readonly AcpSessionStatus[],
+  nextStatus: AcpSessionStatus
+): AcpSessionStatus {
+  if (!allowedStatuses.includes(currentStatus)) {
+    throw new AcpInvalidStateTransitionError(currentStatus, eventType);
+  }
+  return nextStatus;
+}
+
+export function transitionAcpSessionStatus(
+  currentStatus: AcpSessionStatus,
+  event: AcpSessionTransitionEvent
+): AcpSessionStatus {
+  switch (event.type) {
+    case 'agent_ready':
+      return canTransitionFrom(currentStatus, event.type, ['initializing'], 'idle');
+    case 'run_started':
+      return canTransitionFrom(
+        currentStatus,
+        event.type,
+        ['initializing', 'idle', 'intervening'],
+        'running'
+      );
+    case 'run_completed':
+      return canTransitionFrom(currentStatus, event.type, ['running', 'intervening'], 'idle');
+    case 'pause_requested':
+      return canTransitionFrom(currentStatus, event.type, ['running'], 'paused');
+    case 'resume_requested':
+      return canTransitionFrom(currentStatus, event.type, ['paused', 'intervening'], 'running');
+    case 'intervention_started':
+      return canTransitionFrom(currentStatus, event.type, ['running'], 'intervening');
+    case 'intervention_completed':
+      return canTransitionFrom(currentStatus, event.type, ['intervening'], 'running');
+    case 'close_requested':
+      return canTransitionFrom(currentStatus, event.type, ACTIVE_STATUSES, 'closing');
+    case 'close_completed':
+      return canTransitionFrom(currentStatus, event.type, ['closing'], 'closed');
+    case 'runtime_failed':
+      return canTransitionFrom(currentStatus, event.type, [...ACTIVE_STATUSES, 'closing'], 'failed');
+    default:
+      return assertNever(event);
+  }
+}

--- a/src/services/acp/types.ts
+++ b/src/services/acp/types.ts
@@ -1,0 +1,90 @@
+export type AcpSessionStatus =
+  | 'initializing'
+  | 'idle'
+  | 'running'
+  | 'paused'
+  | 'intervening'
+  | 'closing'
+  | 'closed'
+  | 'failed';
+
+export interface AcpSessionScope {
+  tenantId: string;
+  ownerKeyId: string;
+}
+
+export type AcpBackendMetadataValue = string | number | boolean | null;
+export type AcpBackendMetadata = Record<string, AcpBackendMetadataValue>;
+
+export interface AcpSessionRecord extends AcpSessionScope {
+  id: string;
+  conversationId: string;
+  transcriptId: string;
+  acpAgentSessionId?: string;
+  claudeSessionId?: string;
+  currentBackendRunId?: string;
+  parentSessionId?: string;
+  rootSessionId?: string;
+  correlationId?: string;
+  resumeFromSessionId?: string;
+  status: AcpSessionStatus;
+  createdAt: number;
+  updatedAt: number;
+  closedAt?: number;
+  failedAt?: number;
+  backendMetadata?: AcpBackendMetadata;
+}
+
+export interface AcpCreateSessionInput extends AcpSessionScope {
+  parentSessionId?: string;
+  rootSessionId?: string;
+  correlationId?: string;
+  resumeFromSessionId?: string;
+  backendMetadata?: AcpBackendMetadata;
+}
+
+export interface AcpAgentSessionAttachment {
+  acpAgentSessionId?: string;
+  claudeSessionId?: string;
+  backendRunId?: string;
+  backendMetadata?: AcpBackendMetadata;
+}
+
+export type AcpSessionTransitionEvent =
+  | { type: 'agent_ready' }
+  | { type: 'run_started' }
+  | { type: 'run_completed' }
+  | { type: 'pause_requested' }
+  | { type: 'resume_requested' }
+  | { type: 'intervention_started' }
+  | { type: 'intervention_completed' }
+  | { type: 'close_requested' }
+  | { type: 'close_completed' }
+  | { type: 'runtime_failed' };
+
+export type AcpControlActionType =
+  | 'prompt'
+  | 'approve'
+  | 'reject'
+  | 'pause'
+  | 'resume'
+  | 'cancel'
+  | 'driver_transfer'
+  | 'intervene'
+  | 'close';
+
+export interface AcpControlActionInput extends AcpSessionScope {
+  actionId: string;
+  sessionId: string;
+  type: AcpControlActionType;
+  idempotencyKey?: string;
+  approvalId?: string;
+  controlRequestId?: string;
+  metadata?: AcpBackendMetadata;
+}
+
+export interface AcpSessionStore {
+  create(record: AcpSessionRecord): Promise<void>;
+  get(id: string, scope: AcpSessionScope): Promise<AcpSessionRecord | null>;
+  update(record: AcpSessionRecord, scope: AcpSessionScope): Promise<AcpSessionRecord | null>;
+}


### PR DESCRIPTION
## Summary
- Add an isolated ACP SessionService skeleton under `src/services/acp`.
- Add ACP-native identity/state/action types aligned with ADR-0028.
- Add state-machine transition guards, tenant/owner scoped store access, durable identity preservation, JSON-RPC id rejection, sensitive metadata key rejection, and control-action validation.
- Keep ACP disconnected from production tmux-backed routes for this milestone.

## Validation
- `npx vitest run src\__tests__\acp-session-service.test.ts`
- `npx tsc --noEmit`
- `npm run gate`

Closes #2585