### PR TITLE
refactor: add ACP session store

### DIFF
--- a/src/__tests__/acp-postgres-session-store.test.ts
+++ b/src/__tests__/acp-postgres-session-store.test.ts
@@ -1,0 +1,450 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  PostgresAcpSessionStore,
+  type AcpSessionRecord,
+  type AcpSessionScope,
+} from '../services/acp/index.js';
+
+interface MockQueryResult {
+  rows: unknown[];
+}
+
+type MockQuery = ReturnType<
+  typeof vi.fn<(sql: string, params?: readonly unknown[]) => Promise<MockQueryResult>>
+>;
+type MockEnd = ReturnType<typeof vi.fn<() => Promise<void>>>;
+
+interface MockPool {
+  query: MockQuery;
+  end: MockEnd;
+}
+
+const pgMock = vi.hoisted(() => {
+  function makePool(): MockPool {
+    return {
+      query: vi
+        .fn<(sql: string, params?: readonly unknown[]) => Promise<MockQueryResult>>()
+        .mockResolvedValue({ rows: [] }),
+      end: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+  }
+
+  const pools: MockPool[] = [];
+  const configs: unknown[] = [];
+  const Pool = vi.fn(function MockPoolConstructor(config: unknown) {
+    configs.push(config);
+    const pool = makePool();
+    pools.push(pool);
+    return pool;
+  });
+
+  return {
+    Pool,
+    configs,
+    pools,
+    latestPool(): MockPool {
+      const pool = pools.at(-1);
+      if (!pool) throw new Error('expected a mocked pg Pool to be constructed');
+      return pool;
+    },
+    reset(): void {
+      configs.length = 0;
+      pools.length = 0;
+      Pool.mockClear();
+    },
+  };
+});
+
+vi.mock('pg', () => ({ Pool: pgMock.Pool }));
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+function makeRecord(overrides: Partial<AcpSessionRecord> = {}): AcpSessionRecord {
+  return {
+    id: 'session-1',
+    tenantId: scope.tenantId,
+    ownerKeyId: scope.ownerKeyId,
+    acpAgentSessionId: 'acp-session-1',
+    claudeSessionId: 'claude-session-1',
+    conversationId: 'conversation-1',
+    transcriptId: 'transcript-1',
+    parentSessionId: 'parent-1',
+    rootSessionId: 'root-1',
+    correlationId: 'correlation-1',
+    resumeFromSessionId: 'resume-source-1',
+    currentBackendRunId: 'backend-run-1',
+    status: 'running',
+    createdAt: 1_700_000_000_123,
+    updatedAt: 1_700_000_000_456,
+    closedAt: 1_700_000_000_789,
+    failedAt: undefined,
+    backendMetadata: {
+      runtime: 'claude-agent-acp',
+      restartCount: 2,
+      warm: true,
+      note: null,
+    },
+    ...overrides,
+  };
+}
+
+function makeRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const record = makeRecord();
+  return {
+    session_id: record.id,
+    tenant_id: record.tenantId,
+    owner_key_id: record.ownerKeyId,
+    acp_agent_session_id: record.acpAgentSessionId,
+    claude_session_id: record.claudeSessionId,
+    conversation_id: record.conversationId,
+    transcript_id: record.transcriptId,
+    parent_session_id: record.parentSessionId,
+    root_session_id: record.rootSessionId,
+    correlation_id: record.correlationId,
+    resume_from_session_id: record.resumeFromSessionId,
+    current_backend_run_id: record.currentBackendRunId,
+    status: record.status,
+    created_at: String(record.createdAt),
+    updated_at: String(record.updatedAt),
+    closed_at: String(record.closedAt),
+    failed_at: null,
+    backend_metadata: record.backendMetadata,
+    ...overrides,
+  };
+}
+
+async function createStartedStore(
+  config: {
+    schemaName?: string;
+    tableName?: string;
+    poolMax?: number;
+  } = {}
+): Promise<{ store: PostgresAcpSessionStore; pool: MockPool }> {
+  const store = new PostgresAcpSessionStore({
+    url: 'postgresql://aegis:aegis@localhost:5432/aegis_test',
+    ...config,
+  });
+  await store.start();
+  const pool = pgMock.latestPool();
+  pool.query.mockClear();
+  return { store, pool };
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+describe('PostgresAcpSessionStore constructor', () => {
+  beforeEach(() => pgMock.reset());
+
+  it('rejects unsafe schema identifiers before interpolation', () => {
+    expect(
+      () =>
+        new PostgresAcpSessionStore({
+          url: 'postgresql://localhost/test',
+          schemaName: 'public; DROP SCHEMA public; --',
+        })
+    ).toThrow('invalid schema name');
+  });
+
+  it('rejects unsafe table identifiers before interpolation', () => {
+    expect(
+      () =>
+        new PostgresAcpSessionStore({
+          url: 'postgresql://localhost/test',
+          tableName: 'acp-sessions',
+        })
+    ).toThrow('invalid table name');
+  });
+
+  it('accepts valid schema and table identifiers', () => {
+    expect(
+      () =>
+        new PostgresAcpSessionStore({
+          url: 'postgresql://localhost/test',
+          schemaName: 'tenant_1',
+          tableName: 'acp_sessions_2026',
+        })
+    ).not.toThrow();
+  });
+});
+
+describe('PostgresAcpSessionStore lifecycle', () => {
+  beforeEach(() => pgMock.reset());
+
+  it('creates a typed ACP session table and tenant-owner lookup index on start', async () => {
+    const store = new PostgresAcpSessionStore({
+      url: 'postgresql://aegis:aegis@localhost:5432/aegis_test',
+      schemaName: 'acp',
+      tableName: 'sessions',
+    });
+
+    await store.start();
+
+    expect(pgMock.configs[0]).toEqual({
+      connectionString: 'postgresql://aegis:aegis@localhost:5432/aegis_test',
+      max: 5,
+    });
+    const pool = pgMock.latestPool();
+    const sql = pool.query.mock.calls.map(call => normalizeSql(call[0]));
+    const createTableSql = sql.find(statement => statement.includes('CREATE TABLE IF NOT EXISTS'));
+    expect(createTableSql).toContain('CREATE TABLE IF NOT EXISTS "acp"."sessions"');
+    expect(createTableSql).toContain('session_id TEXT NOT NULL');
+    expect(createTableSql).toContain('tenant_id TEXT NOT NULL');
+    expect(createTableSql).toContain('owner_key_id TEXT NOT NULL');
+    expect(createTableSql).toContain('acp_agent_session_id TEXT');
+    expect(createTableSql).toContain('claude_session_id TEXT');
+    expect(createTableSql).toContain('conversation_id TEXT NOT NULL');
+    expect(createTableSql).toContain('transcript_id TEXT NOT NULL');
+    expect(createTableSql).toContain('current_backend_run_id TEXT');
+    expect(createTableSql).toContain('status TEXT NOT NULL');
+    expect(createTableSql).toContain('created_at BIGINT NOT NULL');
+    expect(createTableSql).toContain('updated_at BIGINT NOT NULL');
+    expect(createTableSql).toContain('backend_metadata JSONB');
+    expect(createTableSql).toContain(
+      'CONSTRAINT "sessions_pkey" PRIMARY KEY (tenant_id, owner_key_id, session_id)'
+    );
+    expect(createTableSql).not.toMatch(/\\bdata JSONB\\b/);
+    expect(
+      sql.some(statement =>
+        statement.includes('CREATE INDEX IF NOT EXISTS "idx_sessions_scope_session"')
+      )
+    ).toBe(true);
+    expect(
+      sql.some(statement =>
+        statement.includes('ON "acp"."sessions" (tenant_id, owner_key_id, session_id)')
+      )
+    ).toBe(true);
+  });
+
+  it('uses configured poolMax when provided', async () => {
+    const store = new PostgresAcpSessionStore({
+      url: 'postgresql://localhost/test',
+      poolMax: 9,
+    });
+
+    await store.start();
+
+    expect(pgMock.configs[0]).toEqual({
+      connectionString: 'postgresql://localhost/test',
+      max: 9,
+    });
+  });
+});
+
+describe('PostgresAcpSessionStore.create', () => {
+  beforeEach(() => pgMock.reset());
+
+  it('inserts typed ACP session columns with parameterized values', async () => {
+    const { store, pool } = await createStartedStore();
+    const record = makeRecord({
+      id: "session-1'); DROP TABLE acp_sessions; --",
+      tenantId: 'tenant-injected',
+      ownerKeyId: 'owner-injected',
+    });
+
+    await store.create(record);
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(normalizeSql(sql)).toContain('INSERT INTO "public"."acp_sessions"');
+    expect(sql).not.toContain(record.id);
+    expect(sql).not.toContain(record.tenantId);
+    expect(sql).not.toContain(record.ownerKeyId);
+    expect(params).toEqual([
+      record.id,
+      record.tenantId,
+      record.ownerKeyId,
+      record.acpAgentSessionId,
+      record.claudeSessionId,
+      record.conversationId,
+      record.transcriptId,
+      record.parentSessionId,
+      record.rootSessionId,
+      record.correlationId,
+      record.resumeFromSessionId,
+      record.currentBackendRunId,
+      record.status,
+      record.createdAt,
+      record.updatedAt,
+      record.closedAt,
+      null,
+      JSON.stringify(record.backendMetadata),
+    ]);
+  });
+});
+
+describe('PostgresAcpSessionStore.get', () => {
+  beforeEach(() => pgMock.reset());
+
+  it('reads by public session id plus tenant and owner scope', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({ rows: [makeRow()] });
+
+    const result = await store.get('session-1', scope);
+
+    expect(result).toEqual(makeRecord());
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(normalizeSql(sql)).toContain(
+      'WHERE session_id = $1 AND tenant_id = $2 AND owner_key_id = $3'
+    );
+    expect(params).toEqual(['session-1', 'tenant-a', 'owner-a']);
+  });
+
+  it('returns null when the requested tenant-owner scope has no matching row', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await store.get('session-1', {
+      tenantId: 'tenant-b',
+      ownerKeyId: 'owner-a',
+    });
+
+    expect(result).toBeNull();
+    expect(pool.query.mock.calls[0][1]).toEqual(['session-1', 'tenant-b', 'owner-a']);
+  });
+
+  it('preserves millisecond timestamps stored as BIGINT values', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          created_at: '1700000000123',
+          updated_at: '1700000000456',
+          closed_at: '1700000000789',
+          failed_at: '1700000000999',
+        }),
+      ],
+    });
+
+    const result = await store.get('session-1', scope);
+
+    expect(result?.createdAt).toBe(1_700_000_000_123);
+    expect(result?.updatedAt).toBe(1_700_000_000_456);
+    expect(result?.closedAt).toBe(1_700_000_000_789);
+    expect(result?.failedAt).toBe(1_700_000_000_999);
+  });
+
+  it('round-trips bounded backend metadata from JSONB rows', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          backend_metadata: {
+            runtime: 'claude-agent-acp',
+            restartCount: 2,
+            warm: true,
+            note: null,
+          },
+        }),
+      ],
+    });
+
+    const result = await store.get('session-1', scope);
+
+    expect(result?.backendMetadata).toEqual({
+      runtime: 'claude-agent-acp',
+      restartCount: 2,
+      warm: true,
+      note: null,
+    });
+  });
+
+  it('wraps malformed JSON metadata rows in a store-specific error', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({
+      rows: [makeRow({ backend_metadata: '{"broken"' })],
+    });
+
+    await expect(store.get('session-1', scope)).rejects.toThrow(
+      'PostgresAcpSessionStore: backend_metadata must be valid JSON'
+    );
+  });
+});
+
+describe('PostgresAcpSessionStore.update', () => {
+  beforeEach(() => pgMock.reset());
+
+  it('updates only within the requested tenant-owner scope and returns the persisted row', async () => {
+    const { store, pool } = await createStartedStore();
+    const updated = makeRecord({ status: 'paused', currentBackendRunId: 'backend-run-2' });
+    pool.query.mockResolvedValueOnce({
+      rows: [makeRow({ status: 'paused', current_backend_run_id: 'backend-run-2' })],
+    });
+
+    const result = await store.update(updated, scope);
+
+    expect(result).toEqual(updated);
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(normalizeSql(sql)).toContain('UPDATE "public"."acp_sessions"');
+    expect(normalizeSql(sql)).toContain(
+      'WHERE session_id = $1 AND tenant_id = $2 AND owner_key_id = $3'
+    );
+    expect(normalizeSql(sql)).toContain('RETURNING');
+    expect(params?.slice(0, 3)).toEqual(['session-1', 'tenant-a', 'owner-a']);
+    expect(params).toContain('backend-run-2');
+    expect(params).toContain('paused');
+  });
+
+  it('does not overwrite durable identity columns during update', async () => {
+    const { store, pool } = await createStartedStore();
+    const tampered = makeRecord({
+      conversationId: 'conversation-tampered',
+      transcriptId: 'transcript-tampered',
+      parentSessionId: 'parent-tampered',
+      rootSessionId: 'root-tampered',
+      correlationId: 'correlation-tampered',
+      resumeFromSessionId: 'resume-tampered',
+      createdAt: 9_999,
+      status: 'paused',
+    });
+    pool.query.mockResolvedValueOnce({ rows: [makeRow({ status: 'paused' })] });
+
+    const result = await store.update(tampered, scope);
+
+    const [sql, params] = pool.query.mock.calls[0];
+    const normalized = normalizeSql(sql);
+    expect(normalized).not.toContain('conversation_id =');
+    expect(normalized).not.toContain('transcript_id =');
+    expect(normalized).not.toContain('parent_session_id =');
+    expect(normalized).not.toContain('root_session_id =');
+    expect(normalized).not.toContain('correlation_id =');
+    expect(normalized).not.toContain('resume_from_session_id =');
+    expect(normalized).not.toContain('created_at =');
+    expect(params).not.toContain('conversation-tampered');
+    expect(params).not.toContain('transcript-tampered');
+    expect(params).not.toContain('parent-tampered');
+    expect(params).not.toContain('root-tampered');
+    expect(params).not.toContain('correlation-tampered');
+    expect(params).not.toContain('resume-tampered');
+    expect(params).not.toContain(9_999);
+    expect(result).toEqual(makeRecord({ status: 'paused' }));
+  });
+
+  it('returns null instead of updating when the tenant-owner scope does not match', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await store.update(makeRecord({ tenantId: 'tenant-b' }), {
+      tenantId: 'tenant-b',
+      ownerKeyId: 'owner-a',
+    });
+
+    expect(result).toBeNull();
+    expect(pool.query.mock.calls[0][1]?.slice(0, 3)).toEqual(['session-1', 'tenant-b', 'owner-a']);
+  });
+
+  it('rejects records whose tenant or owner does not match the requested scope', async () => {
+    const { store, pool } = await createStartedStore();
+
+    await expect(
+      store.update(makeRecord({ tenantId: 'tenant-b' }), scope)
+    ).rejects.toThrow('record scope does not match requested scope');
+
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -20,3 +20,7 @@ export {
   type AcpSessionServiceOptions,
   validateAcpControlActionInput,
 } from './session-service.js';
+export {
+  PostgresAcpSessionStore,
+  type PostgresAcpSessionStoreConfig,
+} from './postgres-session-store.js';

--- a/src/services/acp/postgres-session-store.ts
+++ b/src/services/acp/postgres-session-store.ts
@@ -1,0 +1,372 @@
+import { Pool } from 'pg';
+
+import type { ServiceHealth } from '../../container.js';
+import type {
+  AcpBackendMetadata,
+  AcpBackendMetadataValue,
+  AcpSessionRecord,
+  AcpSessionScope,
+  AcpSessionStatus,
+  AcpSessionStore,
+} from './types.js';
+
+export interface PostgresAcpSessionStoreConfig {
+  url: string;
+  schemaName?: string;
+  tableName?: string;
+  poolMax?: number;
+}
+
+const DEFAULT_SCHEMA = 'public';
+const DEFAULT_TABLE = 'acp_sessions';
+const DEFAULT_POOL_MAX = 5;
+const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+interface AcpSessionRow {
+  session_id: string;
+  tenant_id: string;
+  owner_key_id: string;
+  acp_agent_session_id: string | null;
+  claude_session_id: string | null;
+  conversation_id: string;
+  transcript_id: string;
+  parent_session_id: string | null;
+  root_session_id: string | null;
+  correlation_id: string | null;
+  resume_from_session_id: string | null;
+  current_backend_run_id: string | null;
+  status: string;
+  created_at: string | number;
+  updated_at: string | number;
+  closed_at: string | number | null;
+  failed_at: string | number | null;
+  backend_metadata: unknown | null;
+}
+
+const SESSION_COLUMNS = `
+  session_id,
+  tenant_id,
+  owner_key_id,
+  acp_agent_session_id,
+  claude_session_id,
+  conversation_id,
+  transcript_id,
+  parent_session_id,
+  root_session_id,
+  correlation_id,
+  resume_from_session_id,
+  current_backend_run_id,
+  status,
+  created_at,
+  updated_at,
+  closed_at,
+  failed_at,
+  backend_metadata
+`;
+
+export class PostgresAcpSessionStore implements AcpSessionStore {
+  private pool: Pool | undefined;
+  private readonly url: string;
+  private readonly schemaName: string;
+  private readonly tableName: string;
+  private readonly poolMax: number;
+
+  constructor(config: PostgresAcpSessionStoreConfig) {
+    this.url = config.url;
+    this.schemaName = config.schemaName ?? DEFAULT_SCHEMA;
+    this.tableName = config.tableName ?? DEFAULT_TABLE;
+    this.poolMax = config.poolMax ?? DEFAULT_POOL_MAX;
+
+    validateIdentifier(this.schemaName, 'schema name');
+    validateIdentifier(this.tableName, 'table name');
+  }
+
+  async start(): Promise<void> {
+    if (this.pool !== undefined) return;
+    this.pool = new Pool({
+      connectionString: this.url,
+      max: this.poolMax,
+    });
+    await this.ensureSchema();
+    await this.pool.query('SELECT 1 AS ok');
+  }
+
+  async stop(_signal?: AbortSignal): Promise<void> {
+    const pool = this.pool;
+    this.pool = undefined;
+    if (pool !== undefined) {
+      await pool.end();
+    }
+  }
+
+  async health(): Promise<ServiceHealth> {
+    const pool = this.pool;
+    if (pool === undefined) {
+      return { healthy: false, details: 'postgres acp session store not started' };
+    }
+
+    try {
+      await pool.query('SELECT 1 AS ok');
+      return { healthy: true, details: 'postgres acp session store ok' };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { healthy: false, details: `postgres acp session store: ${message}` };
+    }
+  }
+
+  async create(record: AcpSessionRecord): Promise<void> {
+    await this.requirePool().query(
+      `INSERT INTO ${this.qualifiedTable()} (${SESSION_COLUMNS})
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
+      recordToInsertParams(record)
+    );
+  }
+
+  async get(id: string, scope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    const result = await this.requirePool().query<AcpSessionRow>(
+      `SELECT ${SESSION_COLUMNS}
+       FROM ${this.qualifiedTable()}
+       WHERE session_id = $1 AND tenant_id = $2 AND owner_key_id = $3
+       LIMIT 1`,
+      [id, scope.tenantId, scope.ownerKeyId]
+    );
+    const row = result.rows[0];
+    return row === undefined ? null : rowToRecord(row);
+  }
+
+  async update(record: AcpSessionRecord, scope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    assertRecordMatchesScope(record, scope);
+    const result = await this.requirePool().query<AcpSessionRow>(
+      `UPDATE ${this.qualifiedTable()}
+       SET acp_agent_session_id = $4,
+            claude_session_id = $5,
+            current_backend_run_id = $6,
+            status = $7,
+            updated_at = $8,
+            closed_at = $9,
+            failed_at = $10,
+            backend_metadata = $11
+        WHERE session_id = $1 AND tenant_id = $2 AND owner_key_id = $3
+          AND tenant_id = $12 AND owner_key_id = $13
+        RETURNING ${SESSION_COLUMNS}`,
+      recordToUpdateParams(record, scope)
+    );
+    const row = result.rows[0];
+    return row === undefined ? null : rowToRecord(row);
+  }
+
+  private requirePool(): Pool {
+    if (this.pool === undefined) {
+      throw new Error('PostgresAcpSessionStore: store has not been started');
+    }
+    return this.pool;
+  }
+
+  private qualifiedTable(): string {
+    return `${quoteIdentifier(this.schemaName)}.${quoteIdentifier(this.tableName)}`;
+  }
+
+  private async ensureSchema(): Promise<void> {
+    const pool = this.requirePool();
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS ${quoteIdentifier(this.schemaName)}`);
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS ${this.qualifiedTable()} (
+        session_id TEXT NOT NULL,
+        tenant_id TEXT NOT NULL,
+        owner_key_id TEXT NOT NULL,
+        acp_agent_session_id TEXT,
+        claude_session_id TEXT,
+        conversation_id TEXT NOT NULL,
+        transcript_id TEXT NOT NULL,
+        parent_session_id TEXT,
+        root_session_id TEXT,
+        correlation_id TEXT,
+        resume_from_session_id TEXT,
+        current_backend_run_id TEXT,
+        status TEXT NOT NULL,
+        created_at BIGINT NOT NULL,
+        updated_at BIGINT NOT NULL,
+        closed_at BIGINT,
+        failed_at BIGINT,
+        backend_metadata JSONB,
+        CONSTRAINT ${quoteIdentifier(`${this.tableName}_pkey`)} PRIMARY KEY (tenant_id, owner_key_id, session_id),
+        CONSTRAINT ${quoteIdentifier(`${this.tableName}_status_check`)} CHECK (status IN ('initializing', 'idle', 'running', 'paused', 'intervening', 'closing', 'closed', 'failed')),
+        CONSTRAINT ${quoteIdentifier(`${this.tableName}_backend_metadata_object_check`)} CHECK (backend_metadata IS NULL OR jsonb_typeof(backend_metadata) = 'object')
+      )
+    `);
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS ${quoteIdentifier(`idx_${this.tableName}_scope_session`)}
+      ON ${this.qualifiedTable()} (tenant_id, owner_key_id, session_id)
+    `);
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS ${quoteIdentifier(`idx_${this.tableName}_updated_at`)}
+      ON ${this.qualifiedTable()} (updated_at)
+    `);
+  }
+}
+
+function assertRecordMatchesScope(record: AcpSessionRecord, scope: AcpSessionScope): void {
+  if (record.tenantId !== scope.tenantId || record.ownerKeyId !== scope.ownerKeyId) {
+    throw new Error('PostgresAcpSessionStore: record scope does not match requested scope');
+  }
+}
+
+function validateIdentifier(identifier: string, label: string): void {
+  if (!IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(
+      `PostgresAcpSessionStore: invalid ${label} "${identifier}" — must match [a-zA-Z_][a-zA-Z0-9_]*`
+    );
+  }
+}
+
+function quoteIdentifier(identifier: string): string {
+  validateIdentifier(identifier, 'identifier');
+  return `"${identifier}"`;
+}
+
+function recordToInsertParams(record: AcpSessionRecord): unknown[] {
+  return [
+    record.id,
+    record.tenantId,
+    record.ownerKeyId,
+    record.acpAgentSessionId ?? null,
+    record.claudeSessionId ?? null,
+    record.conversationId,
+    record.transcriptId,
+    record.parentSessionId ?? null,
+    record.rootSessionId ?? null,
+    record.correlationId ?? null,
+    record.resumeFromSessionId ?? null,
+    record.currentBackendRunId ?? null,
+    record.status,
+    record.createdAt,
+    record.updatedAt,
+    record.closedAt ?? null,
+    record.failedAt ?? null,
+    serializeBackendMetadata(record.backendMetadata),
+  ];
+}
+
+function recordToUpdateParams(record: AcpSessionRecord, scope: AcpSessionScope): unknown[] {
+  return [
+    record.id,
+    scope.tenantId,
+    scope.ownerKeyId,
+    record.acpAgentSessionId ?? null,
+    record.claudeSessionId ?? null,
+    record.currentBackendRunId ?? null,
+    record.status,
+    record.updatedAt,
+    record.closedAt ?? null,
+    record.failedAt ?? null,
+    serializeBackendMetadata(record.backendMetadata),
+    record.tenantId,
+    record.ownerKeyId,
+  ];
+}
+
+function serializeBackendMetadata(metadata: AcpBackendMetadata | undefined): string | null {
+  return metadata === undefined ? null : JSON.stringify(metadata);
+}
+
+function rowToRecord(row: AcpSessionRow): AcpSessionRecord {
+  const record: AcpSessionRecord = {
+    id: row.session_id,
+    tenantId: row.tenant_id,
+    ownerKeyId: row.owner_key_id,
+    conversationId: row.conversation_id,
+    transcriptId: row.transcript_id,
+    status: parseStatus(row.status),
+    createdAt: parseRequiredTimestamp(row.created_at, 'created_at'),
+    updatedAt: parseRequiredTimestamp(row.updated_at, 'updated_at'),
+  };
+
+  if (row.acp_agent_session_id !== null) record.acpAgentSessionId = row.acp_agent_session_id;
+  if (row.claude_session_id !== null) record.claudeSessionId = row.claude_session_id;
+  if (row.parent_session_id !== null) record.parentSessionId = row.parent_session_id;
+  if (row.root_session_id !== null) record.rootSessionId = row.root_session_id;
+  if (row.correlation_id !== null) record.correlationId = row.correlation_id;
+  if (row.resume_from_session_id !== null) record.resumeFromSessionId = row.resume_from_session_id;
+  if (row.current_backend_run_id !== null) record.currentBackendRunId = row.current_backend_run_id;
+
+  const closedAt = parseOptionalTimestamp(row.closed_at, 'closed_at');
+  if (closedAt !== undefined) record.closedAt = closedAt;
+  const failedAt = parseOptionalTimestamp(row.failed_at, 'failed_at');
+  if (failedAt !== undefined) record.failedAt = failedAt;
+  const backendMetadata = parseBackendMetadata(row.backend_metadata);
+  if (backendMetadata !== undefined) record.backendMetadata = backendMetadata;
+
+  return record;
+}
+
+function parseStatus(status: string): AcpSessionStatus {
+  switch (status) {
+    case 'initializing':
+    case 'idle':
+    case 'running':
+    case 'paused':
+    case 'intervening':
+    case 'closing':
+    case 'closed':
+    case 'failed':
+      return status;
+    default:
+      throw new Error(`PostgresAcpSessionStore: invalid ACP session status in row: ${status}`);
+  }
+}
+
+function parseRequiredTimestamp(value: string | number, columnName: string): number {
+  const timestamp = parseOptionalTimestamp(value, columnName);
+  if (timestamp === undefined) {
+    throw new Error(`PostgresAcpSessionStore: missing required timestamp column ${columnName}`);
+  }
+  return timestamp;
+}
+
+function parseOptionalTimestamp(
+  value: string | number | null,
+  columnName: string
+): number | undefined {
+  if (value === null) return undefined;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`PostgresAcpSessionStore: invalid millisecond timestamp in ${columnName}`);
+  }
+  return parsed;
+}
+
+function parseBackendMetadata(value: unknown | null): AcpBackendMetadata | undefined {
+  if (value === null || value === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = typeof value === 'string' ? JSON.parse(value) : value;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`PostgresAcpSessionStore: backend_metadata must be valid JSON: ${message}`);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error('PostgresAcpSessionStore: backend_metadata must be a JSON object');
+  }
+
+  const metadata: AcpBackendMetadata = {};
+  for (const [key, metadataValue] of Object.entries(parsed)) {
+    if (!isBackendMetadataValue(metadataValue)) {
+      throw new Error(`PostgresAcpSessionStore: backend_metadata value is not primitive: ${key}`);
+    }
+    metadata[key] = metadataValue;
+  }
+  return metadata;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBackendMetadataValue(value: unknown): value is AcpBackendMetadataValue {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}


### PR DESCRIPTION
## Summary
- Add a Postgres-backed ACP session store implementing the ACP session persistence contract.
- Persist ACP session identity/state fields with tenant/owner scoped reads and updates.
- Protect durable identity fields on update while preserving mutable ACP attachment, backend, status, timestamp, and metadata fields.

## Validation
- npx vitest run src\__tests__\acp-postgres-session-store.test.ts --reporter verbose
- npx tsc --noEmit
- npm run gate

Closes #2586