### PR TITLE
refactor: add ACP event store

### DIFF
--- a/src/__tests__/acp-postgres-event-store.test.ts
+++ b/src/__tests__/acp-postgres-event-store.test.ts
@@ -1,0 +1,462 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Pool } from 'pg';
+import { PostgresAcpEventStore } from '../services/acp/postgres-event-store.js';
+import type { AcpAppendEventInput, AcpListEventsInput } from '../services/acp/event-store.js';
+
+type QueryRows = { rows: unknown[] };
+type MockQueryFn = ReturnType<typeof vi.fn<(sql: string, params?: unknown[]) => Promise<QueryRows>>>;
+
+interface MockClient {
+  query: MockQueryFn;
+  release: ReturnType<typeof vi.fn<() => void>>;
+}
+
+function makeMockPool(): { query: MockQueryFn; connect: ReturnType<typeof vi.fn<() => Promise<MockClient>>>; end: ReturnType<typeof vi.fn<() => Promise<void>>>; client: MockClient } {
+  const query = vi.fn<(sql: string, params?: unknown[]) => Promise<QueryRows>>().mockResolvedValue({ rows: [] });
+  const client: MockClient = {
+    query: vi.fn<(sql: string, params?: unknown[]) => Promise<QueryRows>>().mockResolvedValue({ rows: [] }),
+    release: vi.fn<() => void>(),
+  };
+  const connect = vi.fn<() => Promise<MockClient>>().mockResolvedValue(client);
+  const end = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  return { query, connect, end, client };
+}
+
+function createStore(config: Partial<ConstructorParameters<typeof PostgresAcpEventStore>[0]> = {}): {
+  store: PostgresAcpEventStore;
+  mocks: ReturnType<typeof makeMockPool>;
+} {
+  const store = new PostgresAcpEventStore({
+    url: 'postgresql://test:test@localhost:5432/aegis_test',
+    ...config,
+  });
+  const mocks = makeMockPool();
+  Object.defineProperty(store, 'pool', {
+    value: { query: mocks.query, connect: mocks.connect, end: mocks.end },
+    writable: true,
+  });
+  return { store, mocks };
+}
+
+async function ensureSchemaForTest(store: PostgresAcpEventStore): Promise<void> {
+  // Validate DDL emitted by the private startup helper without opening a real database connection.
+  await (store as unknown as { ensureSchema(): Promise<void> }).ensureSchema();
+}
+
+function appendInput(overrides: Partial<AcpAppendEventInput> = {}): AcpAppendEventInput {
+  return {
+    sessionId: 'sess-1',
+    tenantId: 'tenant-1',
+    ownerKeyId: 'owner-1',
+    backendRunId: 'run-1',
+    eventType: 'message.delta',
+    occurredAt: new Date('2026-01-02T03:04:05.000Z'),
+    payload: { text: 'hello', tokenCount: 3 },
+    payloadRef: 'blob://payloads/sess-1/1',
+    ...overrides,
+  };
+}
+
+function unsafeAppendInput(overrides: Record<string, unknown>): AcpAppendEventInput {
+  return { ...appendInput(), ...overrides } as unknown as AcpAppendEventInput;
+}
+
+function unsafeListInput(overrides: Record<string, unknown>): AcpListEventsInput {
+  return {
+    sessionId: 'sess-1',
+    tenantId: 'tenant-1',
+    ownerKeyId: 'owner-1',
+    ...overrides,
+  } as unknown as AcpListEventsInput;
+}
+
+function eventRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: 'sess-1',
+    tenant_id: 'tenant-1',
+    owner_key_id: 'owner-1',
+    event_seq: '1',
+    event_id: '11111111-1111-4111-8111-111111111111',
+    backend_run_id: 'run-1',
+    event_type: 'message.delta',
+    occurred_at: new Date('2026-01-02T03:04:05.000Z'),
+    ingested_at: new Date('2026-01-02T03:04:06.000Z'),
+    payload: { text: 'hello', tokenCount: 3 },
+    payload_ref: 'blob://payloads/sess-1/1',
+    ...overrides,
+  };
+}
+
+describe('PostgresAcpEventStore config', () => {
+  it('rejects unsafe schema and table identifiers before interpolating SQL', () => {
+    expect(() => new PostgresAcpEventStore({ url: 'postgresql://localhost/test', schemaName: 'public; DROP SCHEMA public' }))
+      .toThrow('invalid schema name');
+    expect(() => new PostgresAcpEventStore({ url: 'postgresql://localhost/test', tableName: 'events-table' }))
+      .toThrow('invalid table name');
+  });
+
+  it('rejects invalid pool sizes before creating a Postgres pool', () => {
+    expect(() => new PostgresAcpEventStore({ url: 'postgresql://localhost/test', poolMax: 0 }))
+      .toThrow('poolMax');
+    expect(() => new PostgresAcpEventStore({ url: 'postgresql://localhost/test', poolMax: 1.5 }))
+      .toThrow('poolMax');
+    expect(() => new PostgresAcpEventStore({ url: 'postgresql://localhost/test', poolMax: Number.MAX_SAFE_INTEGER + 1 }))
+      .toThrow('poolMax');
+  });
+
+  it('accepts valid custom schema and table identifiers', () => {
+    expect(() => new PostgresAcpEventStore({
+      url: 'postgresql://localhost/test',
+      schemaName: 'tenant_events',
+      tableName: 'acp_events_2026',
+      poolMax: 8,
+    })).not.toThrow();
+  });
+});
+
+describe('PostgresAcpEventStore schema', () => {
+  it('creates a typed ACP event table with uniqueness constraints and scoped replay index', async () => {
+    const { store, mocks } = createStore({ schemaName: 'acp', tableName: 'events' });
+
+    await ensureSchemaForTest(store);
+
+    const sql = mocks.query.mock.calls.map(call => call[0] as string).join('\n');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "acp"."events"');
+    expect(sql).toContain('session_id TEXT NOT NULL');
+    expect(sql).toContain('tenant_id TEXT NOT NULL');
+    expect(sql).toContain('owner_key_id TEXT NOT NULL');
+    expect(sql).toContain('event_seq BIGINT NOT NULL');
+    expect(sql).toContain('event_id TEXT NOT NULL');
+    expect(sql).toContain('backend_run_id TEXT');
+    expect(sql).toContain('event_type TEXT NOT NULL');
+    expect(sql).toContain('occurred_at TIMESTAMPTZ NOT NULL');
+    expect(sql).toContain('ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW()');
+    expect(sql).toContain('payload JSONB NOT NULL');
+    expect(sql).toContain('payload_ref TEXT');
+    expect(sql).toContain('PRIMARY KEY (session_id, event_seq)');
+    expect(sql).toContain('UNIQUE (event_id)');
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS "idx_events_scope_replay"');
+    expect(sql).toContain('ON "acp"."events" (tenant_id, owner_key_id, session_id, event_seq)');
+  });
+});
+
+describe('PostgresAcpEventStore.append()', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('assigns the next event sequence inside a transaction and returns the stored record', async () => {
+    const { store, mocks } = createStore();
+    mocks.client.query.mockImplementation(async (sql: string): Promise<QueryRows> => {
+      if (sql.includes('INSERT INTO')) {
+        return { rows: [eventRow({ event_seq: '7' })] };
+      }
+      return { rows: [] };
+    });
+
+    const stored = await store.append(appendInput());
+
+    const queries = mocks.client.query.mock.calls.map(call => call[0] as string);
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries.some(sql => sql.includes('pg_advisory_xact_lock'))).toBe(true);
+    expect(queries.some(sql => sql.includes('hashtextextended'))).toBe(false);
+    expect(queries.some(sql => sql.includes('md5($1)'))).toBe(true);
+    const insertCall = mocks.client.query.mock.calls.find(call => (call[0] as string).includes('INSERT INTO'));
+    expect(insertCall).toBeDefined();
+    const insertSql = insertCall![0] as string;
+    expect(insertSql).toContain('COALESCE(MAX(event_seq), 0) + 1');
+    expect(insertSql).toContain('RETURNING');
+    expect(queries.some(sql => sql.includes('COMMIT'))).toBe(true);
+    expect(stored.eventSeq).toBe(7);
+    expect(stored.eventId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(mocks.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('parameterizes append values and never interpolates caller input into SQL', async () => {
+    const { store, mocks } = createStore();
+    const maliciousSessionId = `sess'; DROP TABLE acp_events; --`;
+    mocks.client.query.mockImplementation(async (sql: string): Promise<QueryRows> => {
+      if (sql.includes('INSERT INTO')) {
+        return { rows: [eventRow({ session_id: maliciousSessionId })] };
+      }
+      return { rows: [] };
+    });
+
+    await store.append(appendInput({ sessionId: maliciousSessionId, payload: { text: `'); DROP TABLE x; --` } }));
+
+    const insertCall = mocks.client.query.mock.calls.find(call => (call[0] as string).includes('INSERT INTO'));
+    expect(insertCall).toBeDefined();
+    const [sql, params] = insertCall as [string, unknown[]];
+    expect(sql).not.toContain(maliciousSessionId);
+    expect(params[0]).toBe(maliciousSessionId);
+    expect(params[7]).toBe(JSON.stringify({ text: `'); DROP TABLE x; --` }));
+  });
+
+  it('rolls back and releases the client when the database rejects a duplicate event id', async () => {
+    const { store, mocks } = createStore();
+    const duplicate = new Error('duplicate key value violates unique constraint "aegis_acp_events_event_id_key"');
+    mocks.client.query.mockImplementation(async (sql: string): Promise<QueryRows> => {
+      if (sql.includes('INSERT INTO')) {
+        throw duplicate;
+      }
+      return { rows: [] };
+    });
+
+    await expect(store.append(appendInput())).rejects.toThrow('duplicate key value');
+
+    const queries = mocks.client.query.mock.calls.map(call => call[0] as string);
+    expect(queries).toContain('BEGIN');
+    expect(queries.some(sql => sql.includes('ROLLBACK'))).toBe(true);
+    expect(mocks.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('round-trips timestamps, payload, and optional payload references from the returned row', async () => {
+    const { store, mocks } = createStore();
+    const occurredAt = '2026-02-03T04:05:06.000Z';
+    const ingestedAt = '2026-02-03T04:05:07.000Z';
+    mocks.client.query.mockImplementation(async (sql: string): Promise<QueryRows> => {
+      if (sql.includes('INSERT INTO')) {
+        return { rows: [eventRow({ occurred_at: occurredAt, ingested_at: ingestedAt, payload: { nested: { ok: true } }, payload_ref: null })] };
+      }
+      return { rows: [] };
+    });
+
+    const stored = await store.append(appendInput({ payload: { nested: { ok: true } }, payloadRef: undefined }));
+
+    expect(stored.occurredAt.toISOString()).toBe(occurredAt);
+    expect(stored.ingestedAt.toISOString()).toBe(ingestedAt);
+    expect(stored.payload).toEqual({ nested: { ok: true } });
+    expect(stored.payloadRef).toBeUndefined();
+  });
+
+  it('rejects an append when the public session id already belongs to another tenant-owner scope', async () => {
+    const { store, mocks } = createStore();
+    mocks.client.query.mockImplementation(async (sql: string): Promise<QueryRows> => {
+      if (sql.includes('tenant_id <> $2')) {
+        return { rows: [{ tenant_id: 'tenant-other', owner_key_id: 'owner-other' }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(store.append(appendInput())).rejects.toThrow('session scope');
+
+    const queries = mocks.client.query.mock.calls.map(call => call[0] as string);
+    expect(queries.some(sql => sql.includes('ROLLBACK'))).toBe(true);
+    expect(queries.some(sql => sql.includes('INSERT INTO'))).toBe(false);
+    expect(mocks.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['sessionId', { sessionId: '' }],
+    ['tenantId', { tenantId: '   ' }],
+    ['ownerKeyId', { ownerKeyId: 42 }],
+    ['eventType', { eventType: '' }],
+    ['backendRunId', { backendRunId: '' }],
+    ['payloadRef', { payloadRef: 123 }],
+  ])('rejects malformed %s before opening a database client', async (_field, overrides) => {
+    const { store, mocks } = createStore();
+
+    await expect(store.append(unsafeAppendInput(overrides))).rejects.toThrow('PostgresAcpEventStore');
+
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['top-level undefined', undefined],
+    ['function property', { callback: () => 'unsafe' }],
+    ['symbol in array', [Symbol('unsafe')]],
+    ['bigint value', { count: 1n }],
+    ['NaN number', { value: Number.NaN }],
+    ['Infinity number', { value: Infinity }],
+    ['undefined object property', { omitted: undefined }],
+    ['sparse array', Object.assign([], { 1: 'x' })],
+  ])('rejects payloads that cannot be losslessly persisted as JSON: %s', async (_label, payload) => {
+    const { store, mocks } = createStore();
+
+    await expect(store.append(unsafeAppendInput({ payload }))).rejects.toThrow('payload');
+
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects circular payloads instead of surfacing a JSON.stringify TypeError', async () => {
+    const { store, mocks } = createStore();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await expect(store.append(unsafeAppendInput({ payload: circular }))).rejects.toThrow('payload');
+
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+});
+
+describe('PostgresAcpEventStore.list()', () => {
+  it('replays events for one scoped session after an optional event sequence in ascending order with a limit', async () => {
+    const { store, mocks } = createStore();
+    mocks.query.mockResolvedValue({
+      rows: [eventRow({ event_seq: '2' }), eventRow({ event_seq: '3', event_id: '33333333-3333-4333-8333-333333333333' })],
+    });
+
+    const events = await store.list({
+      sessionId: 'sess-1',
+      tenantId: 'tenant-1',
+      ownerKeyId: 'owner-1',
+      afterEventSeq: 1,
+      limit: 2,
+    });
+
+    expect(events.map(event => event.eventSeq)).toEqual([2, 3]);
+    const [sql, params] = mocks.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('WHERE session_id = $1');
+    expect(sql).toContain('tenant_id = $2');
+    expect(sql).toContain('owner_key_id = $3');
+    expect(sql).toContain('event_seq > $4');
+    expect(sql).toContain('ORDER BY event_seq ASC');
+    expect(sql).toContain('LIMIT $5');
+    expect(params).toEqual(['sess-1', 'tenant-1', 'owner-1', 1, 2]);
+  });
+
+  it('keeps cross-scope replay isolated by tenant and owner predicates', async () => {
+    const { store, mocks } = createStore();
+    mocks.query.mockResolvedValue({ rows: [] });
+
+    const events = await store.list({
+      sessionId: 'shared-session-id',
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+    });
+
+    expect(events).toEqual([]);
+    const [sql, params] = mocks.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('tenant_id = $2');
+    expect(sql).toContain('owner_key_id = $3');
+    expect(params.slice(0, 3)).toEqual(['shared-session-id', 'tenant-a', 'owner-a']);
+  });
+
+  it.each([
+    ['sessionId', { sessionId: '' }],
+    ['tenantId', { tenantId: [] }],
+    ['ownerKeyId', { ownerKeyId: '   ' }],
+  ])('rejects malformed list %s before querying Postgres', async (_field, overrides) => {
+    const { store, mocks } = createStore();
+
+    await expect(store.list(unsafeListInput(overrides))).rejects.toThrow('PostgresAcpEventStore');
+
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe BIGINT event sequences returned by Postgres', async () => {
+    const { store, mocks } = createStore();
+    mocks.query.mockResolvedValue({
+      rows: [eventRow({ event_seq: `${Number.MAX_SAFE_INTEGER + 1}` })],
+    });
+
+    await expect(store.list({
+      sessionId: 'sess-1',
+      tenantId: 'tenant-1',
+      ownerKeyId: 'owner-1',
+    })).rejects.toThrow('event_seq');
+  });
+});
+
+describe('PostgresAcpEventStore health', () => {
+  it('reports unhealthy before the store is started', async () => {
+    const store = new PostgresAcpEventStore({ url: 'postgresql://localhost/test' });
+
+    await expect(store.health()).resolves.toEqual({
+      healthy: false,
+      details: 'postgres ACP event store not started',
+    });
+  });
+});
+
+describe('PostgresAcpEventStore lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clears and closes the pool when startup fails so a later start can retry', async () => {
+    const query = vi
+      .spyOn(Pool.prototype, 'query')
+      .mockRejectedValueOnce(new Error('schema unavailable'))
+      .mockResolvedValue({ rows: [{ ok: 1 }] } as never);
+    const end = vi.spyOn(Pool.prototype, 'end').mockResolvedValue(undefined as never);
+    const store = new PostgresAcpEventStore({ url: 'postgresql://localhost/test' });
+
+    await expect(store.start()).rejects.toThrow('schema unavailable');
+    await expect(store.health()).resolves.toEqual({
+      healthy: false,
+      details: 'postgres ACP event store not started',
+    });
+
+    await store.start();
+
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls.length).toBeGreaterThan(1);
+  });
+});
+
+const postgresTestUrl = process.env.ACP_POSTGRES_TEST_URL;
+const describePostgres = postgresTestUrl === undefined ? describe.skip : describe;
+
+describePostgres('PostgresAcpEventStore integration', () => {
+  const schemaName = 'acp_event_store_test';
+  const tableName = `events_${process.pid}`;
+  const pool = new Pool({ connectionString: postgresTestUrl });
+  const store = new PostgresAcpEventStore({
+    url: postgresTestUrl ?? '',
+    schemaName,
+    tableName,
+  });
+
+  afterAll(async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${schemaName}"."${tableName}"`);
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}"`);
+    await pool.end();
+  });
+
+  it('serializes concurrent appends into contiguous per-session event sequences and scoped replay', async () => {
+    await store.start();
+    try {
+      const append = () => store.append(appendInput({
+        tenantId: 'tenant-a',
+        ownerKeyId: 'owner-a',
+        sessionId: 'integration-session',
+        payload: { tenantId: 'tenant-a', ownerKeyId: 'owner-a' },
+      }));
+
+      const events = await Promise.all([
+        append(),
+        append(),
+        append(),
+      ]);
+      await expect(store.append(appendInput({
+        tenantId: 'tenant-b',
+        ownerKeyId: 'owner-b',
+        sessionId: 'integration-session',
+      }))).rejects.toThrow('session scope');
+
+      expect(events.map(event => event.eventSeq).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+
+      const tenantAReplay = await store.list({
+        tenantId: 'tenant-a',
+        ownerKeyId: 'owner-a',
+        sessionId: 'integration-session',
+      });
+      const tenantBReplay = await store.list({
+        tenantId: 'tenant-b',
+        ownerKeyId: 'owner-b',
+        sessionId: 'integration-session',
+      });
+
+      expect(tenantAReplay).toHaveLength(3);
+      expect(tenantAReplay.map(event => event.eventSeq)).toEqual([1, 2, 3]);
+      expect(tenantBReplay).toHaveLength(0);
+    } finally {
+      await store.stop(new AbortController().signal);
+    }
+  });
+});

--- a/src/services/acp/event-store.ts
+++ b/src/services/acp/event-store.ts
@@ -1,0 +1,50 @@
+import type { AcpSessionScope } from './types.js';
+
+export type AcpEventJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | AcpEventJsonValue[]
+  | { [key: string]: AcpEventJsonValue };
+
+/**
+ * JSON payload stored with an ACP event.
+ *
+ * Callers must provide payloads that are already redacted and bounded. The event
+ * store preserves the payload as durable history; it does not inspect or redact
+ * protocol-specific content.
+ */
+export type AcpEventPayload = AcpEventJsonValue;
+
+export interface AcpEventRecord extends AcpSessionScope {
+  sessionId: string;
+  eventSeq: number;
+  eventId: string;
+  backendRunId?: string;
+  eventType: string;
+  occurredAt: Date;
+  ingestedAt: Date;
+  payload: AcpEventPayload;
+  payloadRef?: string;
+}
+
+export interface AcpAppendEventInput extends AcpSessionScope {
+  sessionId: string;
+  backendRunId?: string;
+  eventType: string;
+  occurredAt?: Date;
+  payload: AcpEventPayload;
+  payloadRef?: string;
+}
+
+export interface AcpListEventsInput extends AcpSessionScope {
+  sessionId: string;
+  afterEventSeq?: number;
+  limit?: number;
+}
+
+export interface AcpEventStore {
+  append(input: AcpAppendEventInput): Promise<AcpEventRecord>;
+  list(input: AcpListEventsInput): Promise<AcpEventRecord[]>;
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -11,7 +11,16 @@ export type {
   AcpSessionStore,
   AcpSessionTransitionEvent,
 } from './types.js';
+export type {
+  AcpAppendEventInput,
+  AcpEventJsonValue,
+  AcpEventPayload,
+  AcpEventRecord,
+  AcpEventStore,
+  AcpListEventsInput,
+} from './event-store.js';
 export { AcpInvalidStateTransitionError, transitionAcpSessionStatus } from './state-machine.js';
+export { PostgresAcpEventStore, type PostgresAcpEventStoreConfig } from './postgres-event-store.js';
 export {
   AcpDurableIdentityError,
   AcpSessionNotFoundError,

--- a/src/services/acp/postgres-event-store.ts
+++ b/src/services/acp/postgres-event-store.ts
@@ -1,0 +1,437 @@
+import { randomUUID } from 'node:crypto';
+import { Pool, type PoolClient } from 'pg';
+import type { ServiceHealth } from '../../container.js';
+import type {
+  AcpAppendEventInput,
+  AcpEventPayload,
+  AcpEventRecord,
+  AcpEventStore,
+  AcpListEventsInput,
+} from './event-store.js';
+
+export interface PostgresAcpEventStoreConfig {
+  url: string;
+  schemaName?: string;
+  tableName?: string;
+  poolMax?: number;
+}
+
+interface AcpEventRow {
+  session_id: string;
+  tenant_id: string;
+  owner_key_id: string;
+  event_seq: string | number;
+  event_id: string;
+  backend_run_id: string | null;
+  event_type: string;
+  occurred_at: Date | string;
+  ingested_at: Date | string;
+  payload: AcpEventPayload;
+  payload_ref: string | null;
+}
+
+const DEFAULT_SCHEMA = 'public';
+const DEFAULT_TABLE = 'aegis_acp_events';
+const DEFAULT_POOL_MAX = 5;
+const DEFAULT_LIST_LIMIT = 100;
+const MAX_LIST_LIMIT = 1_000;
+const IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export class PostgresAcpEventStore implements AcpEventStore {
+  private pool: Pool | undefined;
+  private readonly url: string;
+  private readonly schemaName: string;
+  private readonly tableName: string;
+  private readonly poolMax: number;
+
+  constructor(config: PostgresAcpEventStoreConfig) {
+    this.url = config.url;
+    this.schemaName = config.schemaName ?? DEFAULT_SCHEMA;
+    this.tableName = config.tableName ?? DEFAULT_TABLE;
+    this.poolMax = config.poolMax ?? DEFAULT_POOL_MAX;
+
+    validateIdentifier('schema name', this.schemaName);
+    validateIdentifier('table name', this.tableName);
+    validatePoolMax(this.poolMax);
+  }
+
+  async start(): Promise<void> {
+    if (this.pool !== undefined) return;
+    const pool = new Pool({
+      connectionString: this.url,
+      max: this.poolMax,
+    });
+    this.pool = pool;
+    try {
+      await this.ensureSchema();
+      const result = await pool.query('SELECT 1 AS ok');
+      if (!result.rows[0]) {
+        throw new Error('PostgresAcpEventStore: connection test failed');
+      }
+    } catch (error) {
+      this.pool = undefined;
+      await pool.end().catch(() => {});
+      throw error;
+    }
+  }
+
+  async stop(_signal: AbortSignal): Promise<void> {
+    const pool = this.pool;
+    this.pool = undefined;
+    if (pool !== undefined) {
+      await pool.end();
+    }
+  }
+
+  async health(): Promise<ServiceHealth> {
+    const pool = this.pool;
+    if (pool === undefined) {
+      return { healthy: false, details: 'postgres ACP event store not started' };
+    }
+
+    try {
+      await pool.query('SELECT 1');
+      return { healthy: true, details: 'postgres ACP event store ok' };
+    } catch (error) {
+      return { healthy: false, details: `postgres ACP event store: ${toError(error).message}` };
+    }
+  }
+
+  async append(input: AcpAppendEventInput): Promise<AcpEventRecord> {
+    const validated = validateAppendInput(input);
+    const client = await this.requirePool().connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        "SELECT pg_advisory_xact_lock(('x' || substr(md5($1), 1, 16))::bit(64)::bigint)",
+        [validated.sessionId],
+      );
+      const scopeConflict = await client.query<{ tenant_id: string; owner_key_id: string }>(
+        `
+          SELECT tenant_id, owner_key_id
+          FROM ${this.qt()}
+          WHERE session_id = $1
+            AND (tenant_id <> $2 OR owner_key_id <> $3)
+          LIMIT 1
+        `,
+        [validated.sessionId, validated.tenantId, validated.ownerKeyId],
+      );
+      if (scopeConflict.rows[0] !== undefined) {
+        throw new Error('PostgresAcpEventStore: session scope does not match existing event stream');
+      }
+      const result = await client.query<AcpEventRow>(
+        `
+          WITH next_event AS (
+            SELECT COALESCE(MAX(event_seq), 0) + 1 AS event_seq
+            FROM ${this.qt()}
+            WHERE session_id = $1
+          )
+          INSERT INTO ${this.qt()} (
+            session_id,
+            tenant_id,
+            owner_key_id,
+            event_seq,
+            event_id,
+            backend_run_id,
+            event_type,
+            occurred_at,
+            payload,
+            payload_ref
+          )
+          SELECT
+            $1,
+            $2,
+            $3,
+            next_event.event_seq,
+            $4,
+            $5,
+            $6,
+            $7,
+            $8::jsonb,
+            $9
+          FROM next_event
+          RETURNING
+            session_id,
+            tenant_id,
+            owner_key_id,
+            event_seq,
+            event_id,
+            backend_run_id,
+            event_type,
+            occurred_at,
+            ingested_at,
+            payload,
+            payload_ref
+        `,
+        [
+          validated.sessionId,
+          validated.tenantId,
+          validated.ownerKeyId,
+          randomUUID(),
+          validated.backendRunId ?? null,
+          validated.eventType,
+          validated.occurredAt,
+          validated.payloadJson,
+          validated.payloadRef ?? null,
+        ],
+      );
+      const row = result.rows[0];
+      if (!row) {
+        throw new Error('PostgresAcpEventStore: append returned no event row');
+      }
+      await client.query('COMMIT');
+      return mapEventRow(row);
+    } catch (error) {
+      await rollback(client);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async list(input: AcpListEventsInput): Promise<AcpEventRecord[]> {
+    validateListInput(input);
+    const afterEventSeq = resolveAfterEventSeq(input.afterEventSeq);
+    const limit = resolveLimit(input.limit);
+    const result = await this.requirePool().query<AcpEventRow>(
+      `
+        SELECT
+          session_id,
+          tenant_id,
+          owner_key_id,
+          event_seq,
+          event_id,
+          backend_run_id,
+          event_type,
+          occurred_at,
+          ingested_at,
+          payload,
+          payload_ref
+        FROM ${this.qt()}
+        WHERE session_id = $1
+          AND tenant_id = $2
+          AND owner_key_id = $3
+          AND event_seq > $4
+        ORDER BY event_seq ASC
+        LIMIT $5
+      `,
+      [
+        input.sessionId,
+        input.tenantId,
+        input.ownerKeyId,
+        afterEventSeq,
+        limit,
+      ],
+    );
+    return result.rows.map(mapEventRow);
+  }
+
+  private qt(): string {
+    return `"${this.schemaName}"."${this.tableName}"`;
+  }
+
+  private requirePool(): Pool {
+    if (this.pool === undefined) {
+      throw new Error('PostgresAcpEventStore: store has not been started');
+    }
+    return this.pool;
+  }
+
+  private async ensureSchema(): Promise<void> {
+    const pool = this.requirePool();
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${this.schemaName}"`);
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS ${this.qt()} (
+        session_id TEXT NOT NULL,
+        tenant_id TEXT NOT NULL,
+        owner_key_id TEXT NOT NULL,
+        event_seq BIGINT NOT NULL CHECK (event_seq > 0),
+        event_id TEXT NOT NULL,
+        backend_run_id TEXT,
+        event_type TEXT NOT NULL,
+        occurred_at TIMESTAMPTZ NOT NULL,
+        ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        payload JSONB NOT NULL,
+        payload_ref TEXT,
+        PRIMARY KEY (session_id, event_seq),
+        UNIQUE (event_id)
+      )
+    `);
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS "idx_${this.tableName}_scope_replay"
+      ON ${this.qt()} (tenant_id, owner_key_id, session_id, event_seq)
+    `);
+  }
+}
+
+function validateIdentifier(label: string, value: string): void {
+  if (!IDENTIFIER_RE.test(value)) {
+    throw new Error(`PostgresAcpEventStore: invalid ${label} "${value}" — must match [a-zA-Z_][a-zA-Z0-9_]*`);
+  }
+}
+
+function validatePoolMax(value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('PostgresAcpEventStore: poolMax must be a positive safe integer');
+  }
+}
+
+interface ValidatedAppendInput extends Omit<AcpAppendEventInput, 'payload' | 'occurredAt'> {
+  occurredAt: Date;
+  payloadJson: string;
+}
+
+function validateAppendInput(input: AcpAppendEventInput): ValidatedAppendInput {
+  return {
+    sessionId: requireNonEmptyString(input.sessionId, 'sessionId'),
+    tenantId: requireNonEmptyString(input.tenantId, 'tenantId'),
+    ownerKeyId: requireNonEmptyString(input.ownerKeyId, 'ownerKeyId'),
+    backendRunId: requireOptionalNonEmptyString(input.backendRunId, 'backendRunId'),
+    eventType: requireNonEmptyString(input.eventType, 'eventType'),
+    occurredAt: resolveOccurredAt(input.occurredAt),
+    payloadJson: serializePayload(input.payload),
+    payloadRef: requireOptionalNonEmptyString(input.payloadRef, 'payloadRef'),
+  };
+}
+
+function validateListInput(input: AcpListEventsInput): void {
+  requireNonEmptyString(input.sessionId, 'sessionId');
+  requireNonEmptyString(input.tenantId, 'tenantId');
+  requireNonEmptyString(input.ownerKeyId, 'ownerKeyId');
+}
+
+function requireNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`PostgresAcpEventStore: ${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireOptionalNonEmptyString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireNonEmptyString(value, label);
+}
+
+function resolveOccurredAt(value: unknown): Date {
+  if (value === undefined) return new Date();
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new Error('PostgresAcpEventStore: occurredAt must be a valid Date');
+  }
+  return value;
+}
+
+function serializePayload(payload: unknown): string {
+  validateJsonValue(payload, 'payload', new WeakSet<object>());
+  try {
+    return JSON.stringify(payload);
+  } catch (error) {
+    throw new Error(`PostgresAcpEventStore: payload is not serializable JSON: ${toError(error).message}`);
+  }
+}
+
+function validateJsonValue(value: unknown, path: string, seen: WeakSet<object>): asserts value is AcpEventPayload {
+  if (value === null) return;
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return;
+    case 'number':
+      if (!Number.isFinite(value)) {
+        throw new Error(`PostgresAcpEventStore: payload number at ${path} must be finite`);
+      }
+      return;
+    case 'object':
+      validateJsonObjectOrArray(value, path, seen);
+      return;
+    case 'undefined':
+      throw new Error(`PostgresAcpEventStore: payload value at ${path} must not be undefined`);
+    case 'bigint':
+    case 'function':
+    case 'symbol':
+    default:
+      throw new Error(`PostgresAcpEventStore: payload value at ${path} has unsupported type ${typeof value}`);
+  }
+}
+
+function validateJsonObjectOrArray(value: object, path: string, seen: WeakSet<object>): void {
+  if (seen.has(value)) {
+    throw new Error(`PostgresAcpEventStore: payload contains a circular reference at ${path}`);
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        if (!Object.prototype.hasOwnProperty.call(value, index)) {
+          throw new Error(`PostgresAcpEventStore: payload array at ${path} must not contain holes`);
+        }
+        validateJsonValue(value[index], `${path}[${index}]`, seen);
+      }
+      return;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error(`PostgresAcpEventStore: payload object at ${path} must be a plain JSON object`);
+    }
+
+    for (const [key, entry] of Object.entries(value)) {
+      validateJsonValue(entry, `${path}.${key}`, seen);
+    }
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function mapEventRow(row: AcpEventRow): AcpEventRecord {
+  return {
+    sessionId: row.session_id,
+    tenantId: row.tenant_id,
+    ownerKeyId: row.owner_key_id,
+    eventSeq: parseEventSeq(row.event_seq),
+    eventId: row.event_id,
+    backendRunId: row.backend_run_id ?? undefined,
+    eventType: row.event_type,
+    occurredAt: toDate(row.occurred_at),
+    ingestedAt: toDate(row.ingested_at),
+    payload: row.payload,
+    payloadRef: row.payload_ref ?? undefined,
+  };
+}
+
+function parseEventSeq(value: string | number): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error('PostgresAcpEventStore: invalid event_seq returned by Postgres');
+  }
+  return parsed;
+}
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function resolveAfterEventSeq(value: number | undefined): number {
+  if (value === undefined) return 0;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('PostgresAcpEventStore: afterEventSeq must be a non-negative safe integer');
+  }
+  return value;
+}
+
+function resolveLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('PostgresAcpEventStore: limit must be a positive safe integer');
+  }
+  return Math.min(value, MAX_LIST_LIMIT);
+}
+
+async function rollback(client: PoolClient): Promise<void> {
+  await client.query('ROLLBACK').catch(() => {});
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
+}


### PR DESCRIPTION
## Summary
- Add ACP event store contracts and a Postgres-backed event store implementation.
- Persist append-only ACP event history with monotonic per-session replay cursors and scoped replay.
- Validate runtime input, reject non-lossless JSON payloads, guard cross-scope stream writes, and clean up failed startup state.

## Aegis version

**Developed with:** v0.6.6-preview.1
**Tested with:** v0.6.6-preview.1

## Change type

- [ ] ix — Bug fix
- [x] efactor — Code restructuring with no behavior change
- [x] 	est — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, tooling
- [ ] eat — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

ACP event store infrastructure. No production route/runtime wiring.

## Linked issue

Closes #2587

## Test plan

- [x] Targeted tests pass ($test)
- [x] Type-check passes (
px tsc --noEmit)
- [x] Build succeeds (
pm run gate includes 
pm run build)
- [x] Unit tests pass (
pm run gate)

## Security impact

No new public endpoint or auth surface. Changes add ACP persistence/coordination infrastructure with tenant/owner scoping and validation guardrails.