### PR TITLE
refactor: add ACP action queue

### DIFF
--- a/src/__tests__/acp-postgres-action-queue.test.ts
+++ b/src/__tests__/acp-postgres-action-queue.test.ts
@@ -1,0 +1,538 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Pool } from 'pg';
+
+import {
+  AcpDurableIdentityError,
+  AcpValidationError,
+  type AcpActionRecord,
+  type AcpSessionScope,
+} from '../services/acp/index.js';
+import { PostgresAcpActionQueue } from '../services/acp/postgres-action-queue.js';
+
+type MockQueryResult = { rows: unknown[] };
+type MockQueryFn = ReturnType<
+  typeof vi.fn<(sql: string, params?: unknown[]) => Promise<MockQueryResult>>
+>;
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+function makeMockPool() {
+  const query = vi.fn<(sql: string, params?: unknown[]) => Promise<MockQueryResult>>();
+  const end = vi.fn<() => Promise<void>>();
+
+  query.mockResolvedValue({ rows: [] });
+  end.mockResolvedValue();
+
+  return { query, end };
+}
+
+function createQueue(config?: {
+  schemaName?: string;
+  tableName?: string;
+  poolMax?: number;
+}): {
+  queue: PostgresAcpActionQueue;
+  mocks: { query: MockQueryFn; end: ReturnType<typeof vi.fn<() => Promise<void>>> };
+} {
+  const mocks = makeMockPool();
+  const queue = new PostgresAcpActionQueue({
+    url: 'postgresql://test:test@localhost:5432/aegis_test',
+    ...config,
+  });
+
+  Object.defineProperty(queue, 'pool', {
+    value: {
+      query: mocks.query,
+      end: mocks.end,
+    },
+    writable: true,
+  });
+
+  return { queue, mocks };
+}
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    action_id: 'action-1',
+    session_id: 'session-1',
+    tenant_id: 'tenant-a',
+    owner_key_id: 'owner-a',
+    action_type: 'prompt',
+    idempotency_key: null,
+    status: 'queued',
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    available_at: new Date('2026-01-01T00:00:00.000Z'),
+    leased_until: null,
+    attempt_count: 0,
+    approval_id: null,
+    control_request_id: null,
+    metadata: null,
+    result_metadata: null,
+    error_metadata: null,
+    completed_at: null,
+    failed_at: null,
+    cancelled_at: null,
+    ...overrides,
+  };
+}
+
+function baseActionInput(overrides: Partial<Parameters<PostgresAcpActionQueue['enqueue']>[0]> = {}) {
+  return {
+    tenantId: 'tenant-a',
+    ownerKeyId: 'owner-a',
+    sessionId: 'session-1',
+    actionId: 'action-1',
+    type: 'prompt' as const,
+    ...overrides,
+  };
+}
+
+describe('PostgresAcpActionQueue constructor', () => {
+  it('rejects invalid schema and table identifiers before SQL interpolation', () => {
+    expect(
+      () =>
+        new PostgresAcpActionQueue({
+          url: 'postgresql://localhost/test',
+          schemaName: 'public; DROP TABLE acp_actions',
+        })
+    ).toThrow('invalid schema name');
+    expect(
+      () =>
+        new PostgresAcpActionQueue({
+          url: 'postgresql://localhost/test',
+          tableName: 'acp-actions',
+        })
+      ).toThrow('invalid table name');
+  });
+
+  it('rejects invalid pool sizes before creating a Postgres pool', () => {
+    expect(() => new PostgresAcpActionQueue({ url: 'postgresql://localhost/test', poolMax: 0 }))
+      .toThrow('poolMax');
+    expect(() => new PostgresAcpActionQueue({ url: 'postgresql://localhost/test', poolMax: 1.5 }))
+      .toThrow('poolMax');
+  });
+
+  it('creates the typed action table and scoped idempotency index on start', async () => {
+    const { queue, mocks } = createQueue({ schemaName: 'tenant_1', tableName: 'acp_actions' });
+    mocks.query.mockResolvedValue({ rows: [{ ok: 1 }] });
+
+    await queue.start();
+
+    const schemaSql = mocks.query.mock.calls.map(call => call[0] as string).join('\n');
+    expect(schemaSql).toContain('CREATE SCHEMA IF NOT EXISTS "tenant_1"');
+    expect(schemaSql).toContain('CREATE TABLE IF NOT EXISTS "tenant_1"."acp_actions"');
+    expect(schemaSql).toContain('action_id');
+    expect(schemaSql).toContain('session_id');
+    expect(schemaSql).toContain('tenant_id');
+    expect(schemaSql).toContain('owner_key_id');
+    expect(schemaSql).toContain('action_type');
+    expect(schemaSql).toContain('idempotency_key');
+    expect(schemaSql).toContain('status');
+    expect(schemaSql).toContain('metadata');
+    expect(schemaSql).toContain('result_metadata');
+    expect(schemaSql).toContain('error_metadata');
+    expect(schemaSql).toContain('WHERE idempotency_key IS NOT NULL');
+    expect(schemaSql).toContain('SELECT 1 AS ok');
+  });
+
+  it('clears and closes the pool when startup fails so initialization can retry', async () => {
+    const query = vi
+      .spyOn(Pool.prototype, 'query')
+      .mockRejectedValueOnce(new Error('schema unavailable'))
+      .mockResolvedValue({ rows: [{ ok: 1 }] } as never);
+    const end = vi.spyOn(Pool.prototype, 'end').mockResolvedValue(undefined as never);
+    const queue = new PostgresAcpActionQueue({ url: 'postgresql://localhost/test' });
+
+    await expect(queue.start()).rejects.toThrow('schema unavailable');
+    expect(end).toHaveBeenCalledTimes(1);
+    await expect(queue.stop()).resolves.toBeUndefined();
+    await queue.start();
+
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls.length).toBeGreaterThan(1);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('PostgresAcpActionQueue.enqueue()', () => {
+  it('validates action input and parameterizes values when inserting', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          makeRow({
+            action_id: 'action-1',
+            idempotency_key: 'client-key-1',
+            metadata: { source: 'api' },
+          }),
+        ],
+      });
+
+    const record = await queue.enqueue(
+      baseActionInput({
+        idempotencyKey: 'client-key-1',
+        metadata: { source: 'api' },
+      }),
+      { availableAt: new Date('2026-01-01T00:00:00.000Z') }
+    );
+
+    expect(record).toMatchObject<AcpActionRecord>({
+      actionId: 'action-1',
+      sessionId: 'session-1',
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+      actionType: 'prompt',
+      idempotencyKey: 'client-key-1',
+      status: 'queued',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      availableAt: new Date('2026-01-01T00:00:00.000Z'),
+      attemptCount: 0,
+      metadata: { source: 'api' },
+    });
+    const insertCall = mocks.query.mock.calls.find(call => (call[0] as string).includes('INSERT'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.[0]).toContain('"public"."acp_actions"');
+    expect(insertCall?.[0]).toContain('$1');
+    expect(insertCall?.[0]).not.toContain('client-key-1');
+    expect(insertCall?.[1]).toEqual([
+      'action-1',
+      'session-1',
+      'tenant-a',
+      'owner-a',
+      'prompt',
+      'client-key-1',
+      new Date('2026-01-01T00:00:00.000Z'),
+      { source: 'api' },
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it('returns an existing scoped action for a repeated explicit idempotency key', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          action_id: 'existing-action',
+          idempotency_key: 'client-key-1',
+        }),
+      ],
+    });
+
+    const record = await queue.enqueue(
+      baseActionInput({
+        actionId: 'new-action',
+        idempotencyKey: 'client-key-1',
+      })
+    );
+
+    expect(record.actionId).toBe('existing-action');
+    expect(record.idempotencyKey).toBe('client-key-1');
+    expect(mocks.query.mock.calls).toHaveLength(1);
+    expect(mocks.query.mock.calls[0][0]).toContain('WHERE tenant_id = $1');
+    expect(mocks.query.mock.calls[0][1]).toEqual([
+      'tenant-a',
+      'owner-a',
+      'session-1',
+      'client-key-1',
+    ]);
+  });
+
+  it('rejects an idempotency row that does not match the requested scope', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          tenant_id: 'tenant-b',
+          idempotency_key: 'client-key-1',
+        }),
+      ],
+    });
+
+    await expect(
+      queue.enqueue(
+        baseActionInput({
+          idempotencyKey: 'client-key-1',
+        })
+      )
+    ).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('stores an empty metadata object when action metadata is omitted', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({ rows: [makeRow({ metadata: {} })] });
+
+    await queue.enqueue(baseActionInput());
+
+    const insertCall = mocks.query.mock.calls.find(call => (call[0] as string).includes('INSERT'));
+    expect(insertCall?.[1]?.[7]).toEqual({});
+  });
+
+  it('rejects JSON-RPC request ids instead of using them for idempotency', async () => {
+    const { queue, mocks } = createQueue();
+    const decodedAction: unknown = {
+      ...baseActionInput(),
+      jsonRpcRequestId: 99,
+    };
+
+    await expect(queue.enqueue(decodedAction as Parameters<PostgresAcpActionQueue['enqueue']>[0]))
+      .rejects.toBeInstanceOf(AcpDurableIdentityError);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('does not use action ids as an idempotency return-existing path', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(queue.enqueue(baseActionInput())).rejects.toThrow('action id already exists');
+
+    const [sql] = mocks.query.mock.calls[0];
+    expect(sql).toContain('ON CONFLICT (action_id) DO NOTHING');
+    expect(sql).not.toContain('DO UPDATE');
+  });
+
+  it('rejects a returned action row that does not match the requested scope', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          tenant_id: 'tenant-b',
+          owner_key_id: 'owner-b',
+        }),
+      ],
+    });
+
+    await expect(queue.enqueue(baseActionInput())).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('rejects unsafe action metadata before persistence', async () => {
+    const { queue, mocks } = createQueue();
+
+    await expect(
+      queue.enqueue(
+        baseActionInput({
+          metadata: { nested: JSON.parse('{"value":1}') } as Parameters<
+            PostgresAcpActionQueue['enqueue']
+          >[0]['metadata'],
+        })
+      )
+    ).rejects.toBeInstanceOf(AcpValidationError);
+    await expect(
+      queue.enqueue(baseActionInput({ metadata: { authToken: 'secret' } }))
+    ).rejects.toThrow('metadata key is sensitive');
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid availability timestamps before persistence', async () => {
+    const { queue, mocks } = createQueue();
+
+    await expect(
+      queue.enqueue(baseActionInput(), { availableAt: new Date(Number.NaN) })
+    ).rejects.toBeInstanceOf(AcpValidationError);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('PostgresAcpActionQueue.leaseNext()', () => {
+  it('claims only queued available actions in the requested scope with SKIP LOCKED', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          status: 'leased',
+          leased_until: new Date('2026-01-01T00:05:00.000Z'),
+          attempt_count: 1,
+        }),
+      ],
+    });
+
+    const leased = await queue.leaseNext(scope, {
+      now: new Date('2026-01-01T00:00:00.000Z'),
+      leaseUntil: new Date('2026-01-01T00:05:00.000Z'),
+    });
+
+    expect(leased?.status).toBe('leased');
+    expect(leased?.attemptCount).toBe(1);
+    const [sql, params] = mocks.query.mock.calls[0];
+    expect(sql).toContain('FOR UPDATE SKIP LOCKED');
+    expect(sql).toContain("status = 'queued'");
+    expect(sql).toContain('available_at <= $3');
+    expect(sql).toContain('attempt_count = attempt_count + 1');
+    expect(params).toEqual([
+      'tenant-a',
+      'owner-a',
+      new Date('2026-01-01T00:00:00.000Z'),
+      new Date('2026-01-01T00:05:00.000Z'),
+    ]);
+  });
+
+  it('rejects a leased row that does not match the requested scope', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          tenant_id: 'tenant-b',
+          status: 'leased',
+          leased_until: new Date('2026-01-01T00:05:00.000Z'),
+          attempt_count: 1,
+        }),
+      ],
+    });
+
+    await expect(queue.leaseNext(scope, {
+      now: new Date('2026-01-01T00:00:00.000Z'),
+      leaseUntil: new Date('2026-01-01T00:05:00.000Z'),
+    })).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('rejects invalid or expired lease windows before querying', async () => {
+    const { queue, mocks } = createQueue();
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    await expect(
+      queue.leaseNext(scope, {
+        now,
+        leaseUntil: now,
+      })
+    ).rejects.toThrow('leaseUntil must be after now');
+    await expect(
+      queue.leaseNext(scope, {
+        now: new Date(Number.NaN),
+        leaseUntil: new Date('2026-01-01T00:05:00.000Z'),
+      })
+    ).rejects.toBeInstanceOf(AcpValidationError);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('PostgresAcpActionQueue status updates', () => {
+  it('completes only leased actions in the requested scope', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          status: 'completed',
+          result_metadata: { delivered: true },
+          completed_at: new Date('2026-01-01T00:06:00.000Z'),
+        }),
+      ],
+    });
+
+    const completed = await queue.complete('action-1', scope, {
+      resultMetadata: { delivered: true },
+      now: new Date('2026-01-01T00:06:00.000Z'),
+    });
+
+    expect(completed?.status).toBe('completed');
+    expect(completed?.resultMetadata).toEqual({ delivered: true });
+    const [sql, params] = mocks.query.mock.calls[0];
+    expect(sql).toContain('WHERE action_id = $1');
+    expect(sql).toContain('tenant_id = $2');
+    expect(sql).toContain('owner_key_id = $3');
+    expect(sql).toContain("status = 'leased'");
+    expect(params).toEqual([
+      'action-1',
+      'tenant-a',
+      'owner-a',
+      { delivered: true },
+      new Date('2026-01-01T00:06:00.000Z'),
+    ]);
+  });
+
+  it('marks leased actions failed with validated error metadata', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          status: 'failed',
+          error_metadata: { reason: 'agent-exit' },
+          failed_at: new Date('2026-01-01T00:07:00.000Z'),
+        }),
+      ],
+    });
+
+    const failed = await queue.fail('action-1', scope, {
+      errorMetadata: { reason: 'agent-exit' },
+      now: new Date('2026-01-01T00:07:00.000Z'),
+    });
+
+    expect(failed?.status).toBe('failed');
+    expect(failed?.errorMetadata).toEqual({ reason: 'agent-exit' });
+    expect(mocks.query.mock.calls[0][0]).toContain("status = 'leased'");
+  });
+
+  it('cancels only queued or leased actions in the requested scope', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          status: 'cancelled',
+          error_metadata: { reason: 'client-cancelled' },
+          cancelled_at: new Date('2026-01-01T00:08:00.000Z'),
+        }),
+      ],
+    });
+
+    const cancelled = await queue.cancel('action-1', scope, {
+      errorMetadata: { reason: 'client-cancelled' },
+      now: new Date('2026-01-01T00:08:00.000Z'),
+    });
+
+    expect(cancelled?.status).toBe('cancelled');
+    expect(cancelled?.errorMetadata).toEqual({ reason: 'client-cancelled' });
+    expect(mocks.query.mock.calls[0][0]).toContain("status IN ('queued', 'leased')");
+  });
+
+  it('returns null without mutating cross-scope actions', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await queue.complete(
+      'action-1',
+      { tenantId: 'tenant-b', ownerKeyId: 'owner-a' },
+      { now: new Date('2026-01-01T00:09:00.000Z') }
+    );
+
+    expect(result).toBeNull();
+    const [sql, params] = mocks.query.mock.calls[0];
+    expect(sql).toContain('tenant_id = $2');
+    expect(sql).toContain('owner_key_id = $3');
+    expect(params?.slice(0, 3)).toEqual(['action-1', 'tenant-b', 'owner-a']);
+  });
+
+  it('rejects a completed row that does not match the requested action scope', async () => {
+    const { queue, mocks } = createQueue();
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          action_id: 'action-other',
+          status: 'completed',
+          completed_at: new Date('2026-01-01T00:06:00.000Z'),
+        }),
+      ],
+    });
+
+    await expect(queue.complete('action-1', scope, {
+      now: new Date('2026-01-01T00:06:00.000Z'),
+    })).rejects.toBeInstanceOf(AcpDurableIdentityError);
+  });
+
+  it('rejects invalid completion timestamps before querying', async () => {
+    const { queue, mocks } = createQueue();
+
+    await expect(
+      queue.complete('action-1', scope, { now: new Date(Number.NaN) })
+    ).rejects.toBeInstanceOf(AcpValidationError);
+    await expect(
+      queue.fail('action-1', scope, { now: new Date(Number.NaN) })
+    ).rejects.toBeInstanceOf(AcpValidationError);
+    await expect(
+      queue.cancel('action-1', scope, { now: new Date(Number.NaN) })
+    ).rejects.toBeInstanceOf(AcpValidationError);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/acp/action-queue.ts
+++ b/src/services/acp/action-queue.ts
@@ -1,0 +1,163 @@
+import { Buffer } from 'node:buffer';
+
+import { AcpValidationError } from './session-service.js';
+import type {
+  AcpBackendMetadata,
+  AcpBackendMetadataValue,
+  AcpControlActionInput,
+  AcpControlActionType,
+  AcpSessionScope,
+} from './types.js';
+
+export type AcpActionStatus = 'queued' | 'leased' | 'completed' | 'failed' | 'cancelled';
+
+export type AcpActionMetadataValue = AcpBackendMetadataValue;
+export type AcpActionMetadata = AcpBackendMetadata;
+
+export interface AcpActionRecord extends AcpSessionScope {
+  actionId: string;
+  sessionId: string;
+  actionType: AcpControlActionType;
+  idempotencyKey?: string;
+  status: AcpActionStatus;
+  createdAt: Date;
+  availableAt: Date;
+  leasedUntil?: Date;
+  attemptCount: number;
+  approvalId?: string;
+  controlRequestId?: string;
+  metadata?: AcpActionMetadata;
+  resultMetadata?: AcpActionMetadata;
+  errorMetadata?: AcpActionMetadata;
+  completedAt?: Date;
+  failedAt?: Date;
+  cancelledAt?: Date;
+}
+
+export interface AcpEnqueueActionOptions {
+  availableAt?: Date;
+}
+
+export interface AcpLeaseActionOptions {
+  now?: Date;
+  leaseUntil: Date;
+}
+
+export interface AcpCompleteActionOptions {
+  now?: Date;
+  resultMetadata?: AcpActionMetadata;
+}
+
+export interface AcpFailActionOptions {
+  now?: Date;
+  errorMetadata?: AcpActionMetadata;
+}
+
+export interface AcpCancelActionOptions {
+  now?: Date;
+  errorMetadata?: AcpActionMetadata;
+}
+
+export interface AcpActionQueue {
+  enqueue(
+    input: AcpControlActionInput,
+    options?: AcpEnqueueActionOptions
+  ): Promise<AcpActionRecord>;
+  leaseNext(scope: AcpSessionScope, options: AcpLeaseActionOptions): Promise<AcpActionRecord | null>;
+  complete(
+    actionId: string,
+    scope: AcpSessionScope,
+    options?: AcpCompleteActionOptions
+  ): Promise<AcpActionRecord | null>;
+  fail(
+    actionId: string,
+    scope: AcpSessionScope,
+    options?: AcpFailActionOptions
+  ): Promise<AcpActionRecord | null>;
+  cancel(
+    actionId: string,
+    scope: AcpSessionScope,
+    options?: AcpCancelActionOptions
+  ): Promise<AcpActionRecord | null>;
+}
+
+const MAX_ACTION_METADATA_KEYS = 20;
+const MAX_ACTION_METADATA_KEY_BYTES = 128;
+const MAX_ACTION_METADATA_STRING_BYTES = 1024;
+const BLOCKED_ACTION_METADATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const SENSITIVE_ACTION_METADATA_KEY_PATTERN =
+  /(token|secret|password|api[_-]?key|authorization|cookie|prompt|payload|tool.*arg)/i;
+
+export function normalizeAcpActionMetadata(
+  metadata: unknown,
+  label = 'action metadata'
+): AcpActionMetadata | undefined {
+  if (metadata === undefined || metadata === null) return undefined;
+  if (!isMetadataRecord(metadata)) {
+    throw new AcpValidationError(`ACP ${label} must be an object with primitive values`);
+  }
+
+  const entries = Object.entries(metadata);
+  if (entries.length > MAX_ACTION_METADATA_KEYS) {
+    throw new AcpValidationError(
+      `ACP ${label} cannot contain more than ${MAX_ACTION_METADATA_KEYS} keys`
+    );
+  }
+
+  const normalized: AcpActionMetadata = {};
+  for (const [key, value] of entries) {
+    validateActionMetadataKey(key, label);
+    validateActionMetadataValue(key, value, label);
+    normalized[key] = value;
+  }
+  return normalized;
+}
+
+function isMetadataRecord(value: unknown): value is Record<string, AcpActionMetadataValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateActionMetadataKey(key: string, label: string): void {
+  if (key.trim() === '') {
+    throw new AcpValidationError(`ACP ${label} key must be a non-empty string`);
+  }
+  if (BLOCKED_ACTION_METADATA_KEYS.has(key)) {
+    throw new AcpValidationError(`ACP ${label} key is not allowed: ${key}`);
+  }
+  if (SENSITIVE_ACTION_METADATA_KEY_PATTERN.test(key)) {
+    throw new AcpValidationError(`ACP ${label} key is sensitive: ${key}`);
+  }
+  if (Buffer.byteLength(key, 'utf8') > MAX_ACTION_METADATA_KEY_BYTES) {
+    throw new AcpValidationError(
+      `ACP ${label} key exceeds ${MAX_ACTION_METADATA_KEY_BYTES} bytes`
+    );
+  }
+}
+
+function validateActionMetadataValue(
+  key: string,
+  value: unknown,
+  label: string
+): asserts value is AcpActionMetadataValue {
+  if (
+    value !== null &&
+    typeof value !== 'string' &&
+    typeof value !== 'number' &&
+    typeof value !== 'boolean'
+  ) {
+    throw new AcpValidationError(`ACP ${label} value must be primitive: ${key}`);
+  }
+
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new AcpValidationError(`ACP ${label} number must be finite: ${key}`);
+  }
+
+  if (
+    typeof value === 'string' &&
+    Buffer.byteLength(value, 'utf8') > MAX_ACTION_METADATA_STRING_BYTES
+  ) {
+    throw new AcpValidationError(
+      `ACP ${label} value exceeds ${MAX_ACTION_METADATA_STRING_BYTES} bytes: ${key}`
+    );
+  }
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -19,6 +19,19 @@ export type {
   AcpEventStore,
   AcpListEventsInput,
 } from './event-store.js';
+export type {
+  AcpActionMetadata,
+  AcpActionMetadataValue,
+  AcpActionQueue,
+  AcpActionRecord,
+  AcpActionStatus,
+  AcpCancelActionOptions,
+  AcpCompleteActionOptions,
+  AcpEnqueueActionOptions,
+  AcpFailActionOptions,
+  AcpLeaseActionOptions,
+} from './action-queue.js';
+export { normalizeAcpActionMetadata } from './action-queue.js';
 export { AcpInvalidStateTransitionError, transitionAcpSessionStatus } from './state-machine.js';
 export { PostgresAcpEventStore, type PostgresAcpEventStoreConfig } from './postgres-event-store.js';
 export {
@@ -33,3 +46,4 @@ export {
   PostgresAcpSessionStore,
   type PostgresAcpSessionStoreConfig,
 } from './postgres-session-store.js';
+export { PostgresAcpActionQueue, type PostgresAcpActionQueueConfig } from './postgres-action-queue.js';

--- a/src/services/acp/postgres-action-queue.ts
+++ b/src/services/acp/postgres-action-queue.ts
@@ -1,0 +1,559 @@
+import { Pool, type QueryResultRow } from 'pg';
+
+import { AcpDurableIdentityError, AcpValidationError, validateAcpControlActionInput } from './session-service.js';
+import type { AcpControlActionInput, AcpControlActionType, AcpSessionScope } from './types.js';
+import {
+  normalizeAcpActionMetadata,
+  type AcpActionMetadata,
+  type AcpActionQueue,
+  type AcpActionRecord,
+  type AcpActionStatus,
+  type AcpCancelActionOptions,
+  type AcpCompleteActionOptions,
+  type AcpEnqueueActionOptions,
+  type AcpFailActionOptions,
+  type AcpLeaseActionOptions,
+} from './action-queue.js';
+
+export interface PostgresAcpActionQueueConfig {
+  url: string;
+  schemaName?: string;
+  tableName?: string;
+  poolMax?: number;
+}
+
+interface AcpActionRow extends QueryResultRow {
+  action_id: string;
+  session_id: string;
+  tenant_id: string;
+  owner_key_id: string;
+  action_type: string;
+  idempotency_key: string | null;
+  status: string;
+  created_at: Date | string;
+  available_at: Date | string;
+  leased_until: Date | string | null;
+  attempt_count: number;
+  approval_id: string | null;
+  control_request_id: string | null;
+  metadata: unknown;
+  result_metadata: unknown;
+  error_metadata: unknown;
+  completed_at: Date | string | null;
+  failed_at: Date | string | null;
+  cancelled_at: Date | string | null;
+}
+
+const DEFAULT_SCHEMA = 'public';
+const DEFAULT_TABLE = 'acp_actions';
+const DEFAULT_POOL_MAX = 5;
+const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export class PostgresAcpActionQueue implements AcpActionQueue {
+  private pool?: Pool;
+  private readonly url: string;
+  private readonly schemaName: string;
+  private readonly tableName: string;
+  private readonly poolMax: number;
+
+  constructor(config: PostgresAcpActionQueueConfig) {
+    this.url = config.url;
+    this.schemaName = config.schemaName ?? DEFAULT_SCHEMA;
+    this.tableName = config.tableName ?? DEFAULT_TABLE;
+    this.poolMax = config.poolMax ?? DEFAULT_POOL_MAX;
+
+    validateIdentifier(this.schemaName, 'schema name');
+    validateIdentifier(this.tableName, 'table name');
+    validatePoolMax(this.poolMax);
+  }
+
+  async start(): Promise<void> {
+    const pool = this.pool ?? new Pool({
+      connectionString: this.url,
+      max: this.poolMax,
+    });
+    this.pool = pool;
+    try {
+      await this.ensureSchema();
+      const result = await pool.query<{ ok: number }>('SELECT 1 AS ok');
+      if (!result.rows[0]) {
+        throw new Error('PostgresAcpActionQueue: connection test failed');
+      }
+    } catch (error) {
+      this.pool = undefined;
+      await pool.end().catch(() => {});
+      throw error;
+    }
+  }
+
+  async stop(_signal?: AbortSignal): Promise<void> {
+    const pool = this.pool;
+    this.pool = undefined;
+    if (pool !== undefined) {
+      await pool.end();
+    }
+  }
+
+  async enqueue(
+    input: AcpControlActionInput,
+    options: AcpEnqueueActionOptions = {}
+  ): Promise<AcpActionRecord> {
+    validateAcpControlActionInput(input);
+    const metadata = normalizeAcpActionMetadata(input.metadata) ?? {};
+    const availableAt = options.availableAt ?? new Date();
+    assertValidDate(availableAt, 'action availableAt');
+    const pool = this.requirePool();
+
+    if (input.idempotencyKey !== undefined) {
+      const existing = await this.findByIdempotencyKey(
+        input.tenantId,
+        input.ownerKeyId,
+        input.sessionId,
+        input.idempotencyKey
+      );
+      if (existing) return existing;
+    }
+
+    try {
+      const result = await pool.query<AcpActionRow>(
+        `INSERT INTO ${this.qt()} (
+           action_id,
+           session_id,
+           tenant_id,
+           owner_key_id,
+           action_type,
+           idempotency_key,
+           available_at,
+           metadata,
+           approval_id,
+           control_request_id
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         ON CONFLICT (action_id) DO NOTHING
+         RETURNING ${returningColumns()}`,
+        [
+          input.actionId,
+          input.sessionId,
+          input.tenantId,
+          input.ownerKeyId,
+          input.type,
+          input.idempotencyKey,
+          availableAt,
+          metadata,
+          input.approvalId,
+          input.controlRequestId,
+        ]
+      );
+      if (!result.rows[0]) {
+        throw new AcpDurableIdentityError(`ACP action id already exists: ${input.actionId}`);
+      }
+      const record = rowToRecord(result.rows[0]);
+      assertReturnedActionMatchesInput(record, input);
+      return record;
+    } catch (error) {
+      if (input.idempotencyKey !== undefined && isPgUniqueViolation(error)) {
+        const existing = await this.findByIdempotencyKey(
+          input.tenantId,
+          input.ownerKeyId,
+          input.sessionId,
+          input.idempotencyKey
+        );
+        if (existing) return existing;
+      }
+      throw error;
+    }
+  }
+
+  async leaseNext(
+    scope: AcpSessionScope,
+    options: AcpLeaseActionOptions
+  ): Promise<AcpActionRecord | null> {
+    validateScope(scope);
+    const now = options.now ?? new Date();
+    assertValidDate(now, 'action lease now');
+    assertValidDate(options.leaseUntil, 'action leaseUntil');
+    if (options.leaseUntil.getTime() <= now.getTime()) {
+      throw new AcpValidationError('ACP action leaseUntil must be after now');
+    }
+    const result = await this.requirePool().query<AcpActionRow>(
+      `WITH candidate AS (
+         SELECT action_id
+         FROM ${this.qt()}
+         WHERE tenant_id = $1
+           AND owner_key_id = $2
+           AND status = 'queued'
+           AND available_at <= $3
+         ORDER BY available_at ASC, created_at ASC
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1
+       )
+       UPDATE ${this.qt()} AS actions
+       SET status = 'leased',
+           leased_until = $4,
+           attempt_count = attempt_count + 1
+       FROM candidate
+       WHERE actions.action_id = candidate.action_id
+       RETURNING ${returningColumns('actions')}`,
+      [scope.tenantId, scope.ownerKeyId, now, options.leaseUntil]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertReturnedActionMatchesScope(record, scope);
+    return record;
+  }
+
+  async complete(
+    actionId: string,
+    scope: AcpSessionScope,
+    options: AcpCompleteActionOptions = {}
+  ): Promise<AcpActionRecord | null> {
+    validateActionIdAndScope(actionId, scope);
+    const now = options.now ?? new Date();
+    assertValidDate(now, 'action completion time');
+    const resultMetadata = normalizeAcpActionMetadata(
+      options.resultMetadata,
+      'action result metadata'
+    );
+    const result = await this.requirePool().query<AcpActionRow>(
+      `UPDATE ${this.qt()}
+       SET status = 'completed',
+           result_metadata = $4,
+           completed_at = $5,
+           leased_until = NULL
+       WHERE action_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+         AND status = 'leased'
+       RETURNING ${returningColumns()}`,
+      [actionId, scope.tenantId, scope.ownerKeyId, resultMetadata, now]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertReturnedActionMatchesActionScope(record, actionId, scope);
+    return record;
+  }
+
+  async fail(
+    actionId: string,
+    scope: AcpSessionScope,
+    options: AcpFailActionOptions = {}
+  ): Promise<AcpActionRecord | null> {
+    validateActionIdAndScope(actionId, scope);
+    const now = options.now ?? new Date();
+    assertValidDate(now, 'action failure time');
+    const errorMetadata = normalizeAcpActionMetadata(options.errorMetadata, 'action error metadata');
+    const result = await this.requirePool().query<AcpActionRow>(
+      `UPDATE ${this.qt()}
+       SET status = 'failed',
+           error_metadata = $4,
+           failed_at = $5,
+           leased_until = NULL
+       WHERE action_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+         AND status = 'leased'
+       RETURNING ${returningColumns()}`,
+      [actionId, scope.tenantId, scope.ownerKeyId, errorMetadata, now]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertReturnedActionMatchesActionScope(record, actionId, scope);
+    return record;
+  }
+
+  async cancel(
+    actionId: string,
+    scope: AcpSessionScope,
+    options: AcpCancelActionOptions = {}
+  ): Promise<AcpActionRecord | null> {
+    validateActionIdAndScope(actionId, scope);
+    const now = options.now ?? new Date();
+    assertValidDate(now, 'action cancellation time');
+    const errorMetadata = normalizeAcpActionMetadata(options.errorMetadata, 'action error metadata');
+    const result = await this.requirePool().query<AcpActionRow>(
+      `UPDATE ${this.qt()}
+       SET status = 'cancelled',
+           error_metadata = $4,
+           cancelled_at = $5,
+           leased_until = NULL
+       WHERE action_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+         AND status IN ('queued', 'leased')
+       RETURNING ${returningColumns()}`,
+      [actionId, scope.tenantId, scope.ownerKeyId, errorMetadata, now]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertReturnedActionMatchesActionScope(record, actionId, scope);
+    return record;
+  }
+
+  private async findByIdempotencyKey(
+    tenantId: string,
+    ownerKeyId: string,
+    sessionId: string,
+    idempotencyKey: string
+  ): Promise<AcpActionRecord | null> {
+    const result = await this.requirePool().query<AcpActionRow>(
+      `SELECT ${returningColumns()}
+       FROM ${this.qt()}
+       WHERE tenant_id = $1
+         AND owner_key_id = $2
+         AND session_id = $3
+         AND idempotency_key = $4
+       ORDER BY created_at ASC
+       LIMIT 1`,
+      [tenantId, ownerKeyId, sessionId, idempotencyKey]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertReturnedActionMatchesIdempotencyLookup(record, {
+      tenantId,
+      ownerKeyId,
+      sessionId,
+      idempotencyKey,
+    });
+    return record;
+  }
+
+  private requirePool(): Pool {
+    if (!this.pool) {
+      throw new Error('PostgresAcpActionQueue: start() must be called before use');
+    }
+    return this.pool;
+  }
+
+  private qt(): string {
+    return `"${this.schemaName}"."${this.tableName}"`;
+  }
+
+  private async ensureSchema(): Promise<void> {
+    await this.requirePool().query(`
+      CREATE SCHEMA IF NOT EXISTS "${this.schemaName}"
+    `);
+    await this.requirePool().query(`
+      CREATE TABLE IF NOT EXISTS ${this.qt()} (
+        action_id          TEXT PRIMARY KEY,
+        session_id         TEXT NOT NULL,
+        tenant_id          TEXT NOT NULL,
+        owner_key_id       TEXT NOT NULL,
+        action_type        TEXT NOT NULL,
+        idempotency_key    TEXT,
+        status             TEXT NOT NULL DEFAULT 'queued'
+          CHECK (status IN ('queued', 'leased', 'completed', 'failed', 'cancelled')),
+        created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        available_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        leased_until       TIMESTAMPTZ,
+        attempt_count      INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+        approval_id        TEXT,
+        control_request_id TEXT,
+        metadata           JSONB NOT NULL DEFAULT '{}',
+        result_metadata    JSONB,
+        error_metadata     JSONB,
+        completed_at       TIMESTAMPTZ,
+        failed_at          TIMESTAMPTZ,
+        cancelled_at       TIMESTAMPTZ
+      )
+    `);
+    await this.requirePool().query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "uniq_${this.tableName}_scoped_idempotency"
+      ON ${this.qt()} (tenant_id, owner_key_id, session_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL
+    `);
+    await this.requirePool().query(`
+      CREATE INDEX IF NOT EXISTS "idx_${this.tableName}_lease"
+      ON ${this.qt()} (tenant_id, owner_key_id, status, available_at, created_at)
+    `);
+  }
+}
+
+function validateIdentifier(identifier: string, label: string): void {
+  if (!IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(
+      `PostgresAcpActionQueue: invalid ${label} "${identifier}" — must match [a-zA-Z_][a-zA-Z0-9_]*`
+    );
+  }
+}
+
+function validatePoolMax(value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('PostgresAcpActionQueue: poolMax must be a positive safe integer');
+  }
+}
+
+function returningColumns(alias?: string): string {
+  const prefix = alias ? `${alias}.` : '';
+  return [
+    'action_id',
+    'session_id',
+    'tenant_id',
+    'owner_key_id',
+    'action_type',
+    'idempotency_key',
+    'status',
+    'created_at',
+    'available_at',
+    'leased_until',
+    'attempt_count',
+    'approval_id',
+    'control_request_id',
+    'metadata',
+    'result_metadata',
+    'error_metadata',
+    'completed_at',
+    'failed_at',
+    'cancelled_at',
+  ]
+    .map(column => `${prefix}${column}`)
+    .join(', ');
+}
+
+function rowToRecord(row: AcpActionRow): AcpActionRecord {
+  return {
+    actionId: row.action_id,
+    sessionId: row.session_id,
+    tenantId: row.tenant_id,
+    ownerKeyId: row.owner_key_id,
+    actionType: parseActionType(row.action_type),
+    idempotencyKey: nullableString(row.idempotency_key),
+    status: parseActionStatus(row.status),
+    createdAt: toDate(row.created_at, 'created_at'),
+    availableAt: toDate(row.available_at, 'available_at'),
+    leasedUntil: nullableDate(row.leased_until, 'leased_until'),
+    attemptCount: row.attempt_count,
+    approvalId: nullableString(row.approval_id),
+    controlRequestId: nullableString(row.control_request_id),
+    metadata: normalizeAcpActionMetadata(row.metadata),
+    resultMetadata: normalizeAcpActionMetadata(row.result_metadata, 'action result metadata'),
+    errorMetadata: normalizeAcpActionMetadata(row.error_metadata, 'action error metadata'),
+    completedAt: nullableDate(row.completed_at, 'completed_at'),
+    failedAt: nullableDate(row.failed_at, 'failed_at'),
+    cancelledAt: nullableDate(row.cancelled_at, 'cancelled_at'),
+  };
+}
+
+function assertReturnedActionMatchesInput(
+  record: AcpActionRecord,
+  input: AcpControlActionInput
+): void {
+  if (
+    record.actionId !== input.actionId ||
+    record.sessionId !== input.sessionId ||
+    record.tenantId !== input.tenantId ||
+    record.ownerKeyId !== input.ownerKeyId ||
+    record.actionType !== input.type
+  ) {
+    throw new AcpDurableIdentityError('ACP action row does not match requested action scope');
+  }
+}
+
+function assertReturnedActionMatchesIdempotencyLookup(
+  record: AcpActionRecord,
+  lookup: AcpSessionScope & { sessionId: string; idempotencyKey: string }
+): void {
+  if (
+    record.tenantId !== lookup.tenantId ||
+    record.ownerKeyId !== lookup.ownerKeyId ||
+    record.sessionId !== lookup.sessionId ||
+    record.idempotencyKey !== lookup.idempotencyKey
+  ) {
+    throw new AcpDurableIdentityError('ACP idempotency row does not match requested action scope');
+  }
+}
+
+function assertReturnedActionMatchesScope(
+  record: AcpActionRecord,
+  scope: AcpSessionScope
+): void {
+  if (record.tenantId !== scope.tenantId || record.ownerKeyId !== scope.ownerKeyId) {
+    throw new AcpDurableIdentityError('ACP action row does not match requested action scope');
+  }
+}
+
+function assertReturnedActionMatchesActionScope(
+  record: AcpActionRecord,
+  actionId: string,
+  scope: AcpSessionScope
+): void {
+  if (record.actionId !== actionId) {
+    throw new AcpDurableIdentityError('ACP action row does not match requested action scope');
+  }
+  assertReturnedActionMatchesScope(record, scope);
+}
+
+function parseActionStatus(status: string): AcpActionStatus {
+  switch (status) {
+    case 'queued':
+    case 'leased':
+    case 'completed':
+    case 'failed':
+    case 'cancelled':
+      return status;
+    default:
+      throw new AcpValidationError(`ACP action status is not supported: ${status}`);
+  }
+}
+
+function parseActionType(actionType: string): AcpControlActionType {
+  switch (actionType) {
+    case 'prompt':
+    case 'approve':
+    case 'reject':
+    case 'pause':
+    case 'resume':
+    case 'cancel':
+    case 'driver_transfer':
+    case 'intervene':
+    case 'close':
+      return actionType;
+    default:
+      throw new AcpValidationError(`ACP action type is not supported: ${actionType}`);
+  }
+}
+
+function nullableString(value: string | null): string | undefined {
+  return value === null ? undefined : value;
+}
+
+function nullableDate(value: Date | string | null, label: string): Date | undefined {
+  return value === null ? undefined : toDate(value, label);
+}
+
+function toDate(value: Date | string, label: string): Date {
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new AcpValidationError(`ACP action timestamp is invalid: ${label}`);
+  }
+  return date;
+}
+
+function validateActionIdAndScope(actionId: string, scope: AcpSessionScope): void {
+  assertNonEmptyString(actionId, 'action id');
+  validateScope(scope);
+}
+
+function validateScope(scope: AcpSessionScope): void {
+  assertNonEmptyString(scope.tenantId, 'tenant id');
+  assertNonEmptyString(scope.ownerKeyId, 'owner key id');
+}
+
+function assertNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AcpValidationError(`ACP ${label} must be a non-empty string`);
+  }
+}
+
+function assertValidDate(value: Date, label: string): void {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new AcpValidationError(`ACP ${label} must be a valid Date`);
+  }
+}
+
+function isPgUniqueViolation(error: unknown): boolean {
+  return hasErrorCode(error) && error.code === '23505';
+}
+
+function hasErrorCode(error: unknown): error is { code: unknown } {
+  return typeof error === 'object' && error !== null && 'code' in error;
+}


### PR DESCRIPTION
## Summary
- Add ACP action queue contracts and a Postgres-backed durable queue implementation.
- Support scoped enqueue/idempotency, leasing with `FOR UPDATE SKIP LOCKED`, and complete/fail/cancel state transitions.
- Validate action metadata, durable action identity boundaries, row scope, pool lifecycle, and startup cleanup.

## Aegis version

**Developed with:** v0.6.6-preview.1
**Tested with:** v0.6.6-preview.1

## Change type

- [ ] ix — Bug fix
- [x] efactor — Code restructuring with no behavior change
- [x] 	est — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, tooling
- [ ] eat — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

ACP action queue infrastructure. No production route/runtime wiring.

## Linked issue

Closes #2588

## Test plan

- [x] Targeted tests pass ($test)
- [x] Type-check passes (
px tsc --noEmit)
- [x] Build succeeds (
pm run gate includes 
pm run build)
- [x] Unit tests pass (
pm run gate)

## Security impact

No new public endpoint or auth surface. Changes add ACP persistence/coordination infrastructure with tenant/owner scoping and validation guardrails.