### PR TITLE
refactor: add ACP chat cache snapshots

### DIFF
--- a/src/__tests__/acp-postgres-chat-cache.test.ts
+++ b/src/__tests__/acp-postgres-chat-cache.test.ts
@@ -1,0 +1,400 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { Pool } from 'pg';
+
+import {
+  PostgresAcpChatCache,
+  type AcpChatSnapshotRecord,
+  type AcpGetChatSnapshotInput,
+  type AcpSaveChatSnapshotInput,
+} from '../services/acp/index.js';
+
+type QueryRows = { rows: unknown[] };
+type MockQueryFn = ReturnType<typeof vi.fn<(sql: string, params?: unknown[]) => Promise<QueryRows>>>;
+
+interface MockClient {
+  query: MockQueryFn;
+  release: ReturnType<typeof vi.fn<() => void>>;
+}
+
+function makeMockPool(): {
+  query: MockQueryFn;
+  connect: ReturnType<typeof vi.fn<() => Promise<MockClient>>>;
+  end: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  client: MockClient;
+} {
+  const query = vi.fn<(sql: string, params?: unknown[]) => Promise<QueryRows>>().mockResolvedValue({ rows: [] });
+  const client: MockClient = {
+    query: vi.fn<(sql: string, params?: unknown[]) => Promise<QueryRows>>().mockResolvedValue({ rows: [] }),
+    release: vi.fn<() => void>(),
+  };
+  const connect = vi.fn<() => Promise<MockClient>>().mockResolvedValue(client);
+  const end = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  return { query, connect, end, client };
+}
+
+function createCache(config: Partial<ConstructorParameters<typeof PostgresAcpChatCache>[0]> = {}): {
+  cache: PostgresAcpChatCache;
+  mocks: ReturnType<typeof makeMockPool>;
+} {
+  const cache = new PostgresAcpChatCache({
+    url: 'postgresql://test:test@localhost:5432/aegis_test',
+    ...config,
+  });
+  const mocks = makeMockPool();
+  Object.defineProperty(cache, 'pool', {
+    value: { query: mocks.query, connect: mocks.connect, end: mocks.end },
+    writable: true,
+  });
+  return { cache, mocks };
+}
+
+async function ensureSchemaForTest(cache: PostgresAcpChatCache): Promise<void> {
+  await (cache as unknown as { ensureSchema(): Promise<void> }).ensureSchema();
+}
+
+function saveInput(overrides: Partial<AcpSaveChatSnapshotInput> = {}): AcpSaveChatSnapshotInput {
+  return {
+    sessionId: 'sess-1',
+    tenantId: 'tenant-1',
+    ownerKeyId: 'owner-1',
+    transcriptId: 'transcript-1',
+    fromEventSeq: 8,
+    toEventSeq: 12,
+    messages: [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: 'Hello from Claude',
+        eventSeq: 12,
+        createdAt: '2026-01-02T03:04:05.000Z',
+      },
+    ],
+    tokenUsage: {
+      inputTokens: 3,
+      outputTokens: 4,
+      totalTokens: 7,
+    },
+    metadata: {
+      truncatedBeforeEventSeq: 0,
+    },
+    ...overrides,
+  };
+}
+
+function unsafeSaveInput(overrides: Record<string, unknown>): AcpSaveChatSnapshotInput {
+  return { ...saveInput(), ...overrides } as unknown as AcpSaveChatSnapshotInput;
+}
+
+function unsafeGetInput(overrides: Record<string, unknown>): AcpGetChatSnapshotInput {
+  return {
+    sessionId: 'sess-1',
+    tenantId: 'tenant-1',
+    ownerKeyId: 'owner-1',
+    transcriptId: 'transcript-1',
+    ...overrides,
+  } as unknown as AcpGetChatSnapshotInput;
+}
+
+function snapshotRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: 'sess-1',
+    tenant_id: 'tenant-1',
+    owner_key_id: 'owner-1',
+    snapshot_id: '22222222-2222-4222-8222-222222222222',
+    transcript_id: 'transcript-1',
+    snapshot_seq: '2',
+    from_event_seq: '8',
+    to_event_seq: '12',
+    created_at: new Date('2026-01-02T03:04:06.000Z'),
+    messages: saveInput().messages,
+    token_usage: saveInput().tokenUsage,
+    metadata: saveInput().metadata,
+    ...overrides,
+  };
+}
+
+describe('PostgresAcpChatCache config', () => {
+  it('rejects unsafe schema and table identifiers before interpolating SQL', () => {
+    expect(() => new PostgresAcpChatCache({ url: 'postgresql://localhost/test', schemaName: 'public; DROP SCHEMA public' }))
+      .toThrow('invalid schema name');
+    expect(() => new PostgresAcpChatCache({ url: 'postgresql://localhost/test', tableName: 'chat-cache' }))
+      .toThrow('invalid table name');
+  });
+});
+
+describe('PostgresAcpChatCache schema', () => {
+  it('uses the epic table name by default', async () => {
+    const { cache, mocks } = createCache();
+
+    await ensureSchemaForTest(cache);
+
+    const sql = mocks.query.mock.calls.map(call => call[0] as string).join('\n');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "public"."acp_chat_snapshots"');
+  });
+
+  it('creates a scoped snapshot table with replay indexes and JSON shape checks', async () => {
+    const { cache, mocks } = createCache({ schemaName: 'acp', tableName: 'chat_snapshots' });
+
+    await ensureSchemaForTest(cache);
+
+    const sql = mocks.query.mock.calls.map(call => call[0] as string).join('\n');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "acp"."chat_snapshots"');
+    expect(sql).toContain('session_id TEXT NOT NULL');
+    expect(sql).toContain('tenant_id TEXT NOT NULL');
+    expect(sql).toContain('owner_key_id TEXT NOT NULL');
+    expect(sql).toContain('snapshot_id TEXT NOT NULL');
+    expect(sql).toContain('transcript_id TEXT NOT NULL');
+    expect(sql).toContain('snapshot_seq BIGINT NOT NULL');
+    expect(sql).toContain('from_event_seq BIGINT NOT NULL');
+    expect(sql).toContain('to_event_seq BIGINT NOT NULL');
+    expect(sql).toContain('messages JSONB NOT NULL');
+    expect(sql).toContain('token_usage JSONB');
+    expect(sql).toContain('metadata JSONB');
+    expect(sql).toContain('PRIMARY KEY (tenant_id, owner_key_id, session_id, snapshot_seq)');
+    expect(sql).toContain('UNIQUE (tenant_id, owner_key_id, session_id, transcript_id, from_event_seq, to_event_seq)');
+    expect(sql).toContain("jsonb_typeof(messages) = 'array'");
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS "idx_chat_snapshots_scope_latest"');
+    expect(sql).toContain('ON "acp"."chat_snapshots" (tenant_id, owner_key_id, session_id, transcript_id, to_event_seq DESC)');
+  });
+});
+
+describe('PostgresAcpChatCache.save()', () => {
+  it('assigns the next snapshot sequence inside a transaction and returns the stored snapshot', async () => {
+    const { cache, mocks } = createCache();
+    mocks.client.query.mockImplementation(async (sql: string): Promise<QueryRows> => {
+      if (sql.includes('INSERT INTO')) {
+        return { rows: [snapshotRow({ snapshot_seq: '7' })] };
+      }
+      return { rows: [] };
+    });
+
+    const saved = await cache.save(saveInput());
+
+    const queries = mocks.client.query.mock.calls.map(call => call[0] as string);
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries.some(sql => sql.includes('pg_advisory_xact_lock'))).toBe(true);
+    const lockCall = mocks.client.query.mock.calls.find(call => (call[0] as string).includes('pg_advisory_xact_lock'));
+    expect(lockCall?.[1]).toEqual(['tenant-1:owner-1:sess-1']);
+    const insertCall = mocks.client.query.mock.calls.find(call => (call[0] as string).includes('INSERT INTO'));
+    expect(insertCall).toBeDefined();
+    const insertSql = insertCall![0] as string;
+    expect(insertSql).toContain('COALESCE(MAX(snapshot_seq), 0) + 1');
+    expect(insertSql).toContain('RETURNING');
+    expect(queries.some(sql => sql.includes('COMMIT'))).toBe(true);
+    expect(saved.snapshotId).toBe('22222222-2222-4222-8222-222222222222');
+    expect(saved.snapshotSeq).toBe(7);
+    expect(saved.fromEventSeq).toBe(8);
+    expect(saved.toEventSeq).toBe(12);
+    expect(saved.messages[0]?.content).toBe('Hello from Claude');
+    expect(mocks.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('parameterizes snapshot JSON and never interpolates caller content into SQL', async () => {
+    const { cache, mocks } = createCache();
+    const maliciousContent = `'); DROP TABLE acp_chat_snapshots; --`;
+    mocks.client.query.mockImplementation(async (sql: string): Promise<QueryRows> => {
+      if (sql.includes('INSERT INTO')) {
+        return { rows: [snapshotRow({ messages: [{ ...saveInput().messages[0], content: maliciousContent }] })] };
+      }
+      return { rows: [] };
+    });
+
+    await cache.save(saveInput({
+      messages: [{ ...saveInput().messages[0]!, content: maliciousContent }],
+    }));
+
+    const insertCall = mocks.client.query.mock.calls.find(call => (call[0] as string).includes('INSERT INTO'));
+    expect(insertCall).toBeDefined();
+    const [sql, params] = insertCall as [string, unknown[]];
+    expect(sql).not.toContain(maliciousContent);
+    expect(params).toContain(JSON.stringify([{ ...saveInput().messages[0]!, content: maliciousContent }]));
+  });
+
+  it('keeps same public session ids isolated when they appear under different tenant-owner scopes', async () => {
+    const { cache, mocks } = createCache();
+    mocks.client.query.mockImplementation(async (sql: string, params?: unknown[]): Promise<QueryRows> => {
+      if (sql.includes('INSERT INTO')) {
+        return {
+          rows: [snapshotRow({
+            tenant_id: params?.[1],
+            owner_key_id: params?.[2],
+            snapshot_seq: '1',
+          })],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const saved = await cache.save(saveInput({
+      sessionId: 'shared-session-id',
+      tenantId: 'tenant-other',
+      ownerKeyId: 'owner-other',
+    }));
+
+    const queries = mocks.client.query.mock.calls.map(call => call[0] as string);
+    expect(queries.some(sql => sql.includes('tenant_id <> $2'))).toBe(false);
+    expect(queries.some(sql => sql.includes('WHERE session_id = $1') && sql.includes('tenant_id = $2'))).toBe(true);
+    expect(saved.tenantId).toBe('tenant-other');
+    expect(saved.ownerKeyId).toBe('owner-other');
+    expect(mocks.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['sessionId', { sessionId: '' }],
+    ['tenantId', { tenantId: '   ' }],
+    ['ownerKeyId', { ownerKeyId: 42 }],
+    ['transcriptId', { transcriptId: '' }],
+    ['fromEventSeq', { fromEventSeq: 0 }],
+    ['toEventSeq', { toEventSeq: 7 }],
+    ['messages', { messages: { id: 'not-an-array' } }],
+    ['tokenUsage', { tokenUsage: { totalTokens: Number.NaN } }],
+    ['metadata', { metadata: { callback: () => 'unsafe' } }],
+  ])('rejects malformed %s before opening a database client', async (_field, overrides) => {
+    const { cache, mocks } = createCache();
+
+    await expect(cache.save(unsafeSaveInput(overrides))).rejects.toThrow('PostgresAcpChatCache');
+
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+});
+
+describe('PostgresAcpChatCache.getLatest()', () => {
+  it('loads the latest scoped snapshot at or before an optional event sequence', async () => {
+    const { cache, mocks } = createCache();
+    mocks.query.mockResolvedValue({ rows: [snapshotRow({ to_event_seq: '10' })] });
+
+    const snapshot = await cache.getLatest({
+      sessionId: 'sess-1',
+      tenantId: 'tenant-1',
+      ownerKeyId: 'owner-1',
+      transcriptId: 'transcript-1',
+      atOrBeforeEventSeq: 11,
+    });
+
+    expect(snapshot?.toEventSeq).toBe(10);
+    const [sql, params] = mocks.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('WHERE session_id = $1');
+    expect(sql).toContain('tenant_id = $2');
+    expect(sql).toContain('owner_key_id = $3');
+    expect(sql).toContain('transcript_id = $4');
+    expect(sql).toContain('to_event_seq <= $5');
+    expect(sql).toContain('ORDER BY to_event_seq DESC, snapshot_seq DESC');
+    expect(sql).toContain('LIMIT 1');
+    expect(params).toEqual(['sess-1', 'tenant-1', 'owner-1', 'transcript-1', 11]);
+  });
+
+  it('returns null when no scoped snapshot exists', async () => {
+    const { cache, mocks } = createCache();
+    mocks.query.mockResolvedValue({ rows: [] });
+
+    await expect(cache.getLatest(saveInput())).resolves.toBeNull();
+  });
+
+  it.each([
+    ['sessionId', { sessionId: '' }],
+    ['tenantId', { tenantId: [] }],
+    ['ownerKeyId', { ownerKeyId: '   ' }],
+    ['transcriptId', { transcriptId: null }],
+    ['atOrBeforeEventSeq', { atOrBeforeEventSeq: -1 }],
+  ])('rejects malformed getLatest %s before querying Postgres', async (_field, overrides) => {
+    const { cache, mocks } = createCache();
+
+    await expect(cache.getLatest(unsafeGetInput(overrides))).rejects.toThrow('PostgresAcpChatCache');
+
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe BIGINT sequences returned by Postgres', async () => {
+    const { cache, mocks } = createCache();
+    mocks.query.mockResolvedValue({
+      rows: [snapshotRow({ snapshot_seq: `${Number.MAX_SAFE_INTEGER + 1}` })],
+    });
+
+    await expect(cache.getLatest({
+      sessionId: 'sess-1',
+      tenantId: 'tenant-1',
+      ownerKeyId: 'owner-1',
+      transcriptId: 'transcript-1',
+    })).rejects.toThrow('snapshot_seq');
+  });
+});
+
+describe('PostgresAcpChatCache lifecycle', () => {
+  it('reports unhealthy before the cache is started', async () => {
+    const cache = new PostgresAcpChatCache({ url: 'postgresql://localhost/test' });
+
+    await expect(cache.health()).resolves.toEqual({
+      healthy: false,
+      details: 'postgres ACP chat cache not started',
+    });
+  });
+});
+
+const postgresTestUrl = process.env.ACP_POSTGRES_TEST_URL;
+const describePostgres = postgresTestUrl === undefined ? describe.skip : describe;
+
+describePostgres('PostgresAcpChatCache integration', () => {
+  const schemaName = 'acp_chat_cache_test';
+  const tableName = `snapshots_${process.pid}`;
+  const pool = new Pool({ connectionString: postgresTestUrl });
+  const cache = new PostgresAcpChatCache({
+    url: postgresTestUrl ?? '',
+    schemaName,
+    tableName,
+  });
+
+  afterAll(async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${schemaName}"."${tableName}"`);
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}"`);
+    await pool.end();
+  });
+
+  it('stores scoped chat snapshots and loads the latest snapshot for replay warm start', async () => {
+    await cache.start();
+    try {
+      const first = await cache.save(saveInput({
+        sessionId: 'integration-session',
+        fromEventSeq: 1,
+        toEventSeq: 1,
+        messages: [{ ...saveInput().messages[0]!, id: 'msg-1', eventSeq: 1, content: 'first' }],
+      }));
+      const second = await cache.save(saveInput({
+        sessionId: 'integration-session',
+        fromEventSeq: 2,
+        toEventSeq: 3,
+        messages: [{ ...saveInput().messages[0]!, id: 'msg-2', eventSeq: 3, content: 'second' }],
+      }));
+      const otherTenant = await cache.save(saveInput({
+        tenantId: 'tenant-other',
+        ownerKeyId: 'owner-other',
+        sessionId: 'integration-session',
+        fromEventSeq: 1,
+        toEventSeq: 4,
+      }));
+
+      expect([first.snapshotSeq, second.snapshotSeq]).toEqual([1, 2]);
+      expect(otherTenant.snapshotSeq).toBe(1);
+
+      const latest = await cache.getLatest({
+        tenantId: 'tenant-1',
+        ownerKeyId: 'owner-1',
+        sessionId: 'integration-session',
+        transcriptId: 'transcript-1',
+      });
+      const replayStart = await cache.getLatest({
+        tenantId: 'tenant-1',
+        ownerKeyId: 'owner-1',
+        sessionId: 'integration-session',
+        transcriptId: 'transcript-1',
+        atOrBeforeEventSeq: 2,
+      });
+
+      expect(latest?.toEventSeq).toBe(3);
+      expect(latest?.messages[0]?.content).toBe('second');
+      expect(replayStart?.toEventSeq).toBe(1);
+      expect(replayStart?.messages[0]?.content).toBe('first');
+    } finally {
+      await cache.stop(new AbortController().signal);
+    }
+  });
+});

--- a/src/services/acp/chat-cache.ts
+++ b/src/services/acp/chat-cache.ts
@@ -1,0 +1,41 @@
+import type { AcpEventJsonValue } from './event-store.js';
+import type { AcpSessionScope } from './types.js';
+
+export type AcpChatSnapshotMessage = Record<string, AcpEventJsonValue>;
+export type AcpChatTokenUsage = Record<string, AcpEventJsonValue>;
+export type AcpChatSnapshotMetadata = Record<string, AcpEventJsonValue>;
+
+export interface AcpChatSnapshotRecord extends AcpSessionScope {
+  sessionId: string;
+  transcriptId: string;
+  snapshotId: string;
+  /** Monotonically increases within one tenant/owner/session chat cache stream. */
+  snapshotSeq: number;
+  fromEventSeq: number;
+  toEventSeq: number;
+  createdAt: Date;
+  messages: AcpChatSnapshotMessage[];
+  tokenUsage?: AcpChatTokenUsage;
+  metadata?: AcpChatSnapshotMetadata;
+}
+
+export interface AcpSaveChatSnapshotInput extends AcpSessionScope {
+  sessionId: string;
+  transcriptId: string;
+  fromEventSeq: number;
+  toEventSeq: number;
+  messages: AcpChatSnapshotMessage[];
+  tokenUsage?: AcpChatTokenUsage;
+  metadata?: AcpChatSnapshotMetadata;
+}
+
+export interface AcpGetChatSnapshotInput extends AcpSessionScope {
+  sessionId: string;
+  transcriptId: string;
+  atOrBeforeEventSeq?: number;
+}
+
+export interface AcpChatCache {
+  save(input: AcpSaveChatSnapshotInput): Promise<AcpChatSnapshotRecord>;
+  getLatest(input: AcpGetChatSnapshotInput): Promise<AcpChatSnapshotRecord | null>;
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -32,8 +32,18 @@ export type {
   AcpLeaseActionOptions,
 } from './action-queue.js';
 export { normalizeAcpActionMetadata } from './action-queue.js';
+export type {
+  AcpChatCache,
+  AcpChatSnapshotMessage,
+  AcpChatSnapshotMetadata,
+  AcpChatSnapshotRecord,
+  AcpChatTokenUsage,
+  AcpGetChatSnapshotInput,
+  AcpSaveChatSnapshotInput,
+} from './chat-cache.js';
 export { AcpInvalidStateTransitionError, transitionAcpSessionStatus } from './state-machine.js';
 export { PostgresAcpEventStore, type PostgresAcpEventStoreConfig } from './postgres-event-store.js';
+export { PostgresAcpChatCache, type PostgresAcpChatCacheConfig } from './postgres-chat-cache.js';
 export {
   AcpDurableIdentityError,
   AcpSessionNotFoundError,

--- a/src/services/acp/postgres-chat-cache.ts
+++ b/src/services/acp/postgres-chat-cache.ts
@@ -1,0 +1,474 @@
+import { randomUUID } from 'node:crypto';
+import { Pool, type PoolClient } from 'pg';
+import type { ServiceHealth } from '../../container.js';
+import type { AcpEventJsonValue } from './event-store.js';
+import type {
+  AcpChatCache,
+  AcpChatSnapshotMessage,
+  AcpChatSnapshotMetadata,
+  AcpChatSnapshotRecord,
+  AcpChatTokenUsage,
+  AcpGetChatSnapshotInput,
+  AcpSaveChatSnapshotInput,
+} from './chat-cache.js';
+
+export interface PostgresAcpChatCacheConfig {
+  url: string;
+  schemaName?: string;
+  tableName?: string;
+  poolMax?: number;
+}
+
+interface AcpChatSnapshotRow {
+  session_id: string;
+  tenant_id: string;
+  owner_key_id: string;
+  snapshot_id: string;
+  transcript_id: string;
+  snapshot_seq: string | number;
+  from_event_seq: string | number;
+  to_event_seq: string | number;
+  created_at: Date | string;
+  messages: AcpChatSnapshotMessage[];
+  token_usage: AcpChatTokenUsage | null;
+  metadata: AcpChatSnapshotMetadata | null;
+}
+
+interface ValidatedSaveInput extends Omit<AcpSaveChatSnapshotInput, 'messages' | 'tokenUsage' | 'metadata'> {
+  messagesJson: string;
+  tokenUsageJson: string | null;
+  metadataJson: string | null;
+}
+
+const DEFAULT_SCHEMA = 'public';
+const DEFAULT_TABLE = 'acp_chat_snapshots';
+const DEFAULT_POOL_MAX = 5;
+const IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export class PostgresAcpChatCache implements AcpChatCache {
+  private pool: Pool | undefined;
+  private readonly url: string;
+  private readonly schemaName: string;
+  private readonly tableName: string;
+  private readonly poolMax: number;
+
+  constructor(config: PostgresAcpChatCacheConfig) {
+    this.url = config.url;
+    this.schemaName = config.schemaName ?? DEFAULT_SCHEMA;
+    this.tableName = config.tableName ?? DEFAULT_TABLE;
+    this.poolMax = config.poolMax ?? DEFAULT_POOL_MAX;
+
+    validateIdentifier('schema name', this.schemaName);
+    validateIdentifier('table name', this.tableName);
+    validatePoolMax(this.poolMax);
+  }
+
+  async start(): Promise<void> {
+    if (this.pool !== undefined) return;
+    const pool = new Pool({
+      connectionString: this.url,
+      max: this.poolMax,
+    });
+    this.pool = pool;
+    try {
+      await this.ensureSchema();
+      const result = await pool.query('SELECT 1 AS ok');
+      if (!result.rows[0]) {
+        throw new Error('PostgresAcpChatCache: connection test failed');
+      }
+    } catch (error) {
+      this.pool = undefined;
+      await pool.end().catch(() => {});
+      throw error;
+    }
+  }
+
+  async stop(_signal?: AbortSignal): Promise<void> {
+    const pool = this.pool;
+    this.pool = undefined;
+    if (pool !== undefined) {
+      await pool.end();
+    }
+  }
+
+  async health(): Promise<ServiceHealth> {
+    const pool = this.pool;
+    if (pool === undefined) {
+      return { healthy: false, details: 'postgres ACP chat cache not started' };
+    }
+
+    try {
+      await pool.query('SELECT 1');
+      return { healthy: true, details: 'postgres ACP chat cache ok' };
+    } catch (error) {
+      return { healthy: false, details: `postgres ACP chat cache: ${toError(error).message}` };
+    }
+  }
+
+  async save(input: AcpSaveChatSnapshotInput): Promise<AcpChatSnapshotRecord> {
+    const validated = validateSaveInput(input);
+    const client = await this.requirePool().connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        "SELECT pg_advisory_xact_lock(('x' || substr(md5($1), 1, 16))::bit(64)::bigint)",
+        [`${validated.tenantId}:${validated.ownerKeyId}:${validated.sessionId}`],
+      );
+
+      const result = await client.query<AcpChatSnapshotRow>(
+        `
+          WITH next_snapshot AS (
+            SELECT COALESCE(MAX(snapshot_seq), 0) + 1 AS snapshot_seq
+            FROM ${this.qt()}
+            WHERE session_id = $1
+              AND tenant_id = $2
+              AND owner_key_id = $3
+          )
+          INSERT INTO ${this.qt()} (
+            session_id,
+            tenant_id,
+            owner_key_id,
+            snapshot_id,
+            transcript_id,
+            snapshot_seq,
+            from_event_seq,
+            to_event_seq,
+            messages,
+            token_usage,
+            metadata
+          )
+          SELECT
+            $1,
+            $2,
+            $3,
+            $4,
+            $5,
+            next_snapshot.snapshot_seq,
+            $6,
+            $7,
+            $8::jsonb,
+            $9::jsonb,
+            $10::jsonb
+          FROM next_snapshot
+          RETURNING
+            session_id,
+            tenant_id,
+            owner_key_id,
+            snapshot_id,
+            transcript_id,
+            snapshot_seq,
+            from_event_seq,
+            to_event_seq,
+            created_at,
+            messages,
+            token_usage,
+            metadata
+        `,
+        [
+          validated.sessionId,
+          validated.tenantId,
+          validated.ownerKeyId,
+          randomUUID(),
+          validated.transcriptId,
+          validated.fromEventSeq,
+          validated.toEventSeq,
+          validated.messagesJson,
+          validated.tokenUsageJson,
+          validated.metadataJson,
+        ],
+      );
+      const row = result.rows[0];
+      if (!row) {
+        throw new Error('PostgresAcpChatCache: save returned no chat snapshot row');
+      }
+      await client.query('COMMIT');
+      return mapSnapshotRow(row);
+    } catch (error) {
+      await rollback(client);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getLatest(input: AcpGetChatSnapshotInput): Promise<AcpChatSnapshotRecord | null> {
+    validateGetInput(input);
+    const params: unknown[] = [
+      input.sessionId,
+      input.tenantId,
+      input.ownerKeyId,
+      input.transcriptId,
+    ];
+    let eventPredicate = '';
+    if (input.atOrBeforeEventSeq !== undefined) {
+      eventPredicate = 'AND to_event_seq <= $5';
+      params.push(input.atOrBeforeEventSeq);
+    }
+
+    const result = await this.requirePool().query<AcpChatSnapshotRow>(
+      `
+        SELECT
+          session_id,
+          tenant_id,
+          owner_key_id,
+          snapshot_id,
+          transcript_id,
+          snapshot_seq,
+          from_event_seq,
+          to_event_seq,
+          created_at,
+          messages,
+          token_usage,
+          metadata
+        FROM ${this.qt()}
+        WHERE session_id = $1
+          AND tenant_id = $2
+          AND owner_key_id = $3
+          AND transcript_id = $4
+          ${eventPredicate}
+        ORDER BY to_event_seq DESC, snapshot_seq DESC
+        LIMIT 1
+      `,
+      params,
+    );
+    const row = result.rows[0];
+    return row === undefined ? null : mapSnapshotRow(row);
+  }
+
+  private qt(): string {
+    return `"${this.schemaName}"."${this.tableName}"`;
+  }
+
+  private requirePool(): Pool {
+    if (this.pool === undefined) {
+      throw new Error('PostgresAcpChatCache: cache has not been started');
+    }
+    return this.pool;
+  }
+
+  private async ensureSchema(): Promise<void> {
+    const pool = this.requirePool();
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${this.schemaName}"`);
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS ${this.qt()} (
+        session_id TEXT NOT NULL,
+        tenant_id TEXT NOT NULL,
+        owner_key_id TEXT NOT NULL,
+        snapshot_id TEXT NOT NULL,
+        transcript_id TEXT NOT NULL,
+        snapshot_seq BIGINT NOT NULL CHECK (snapshot_seq > 0),
+        from_event_seq BIGINT NOT NULL CHECK (from_event_seq > 0),
+        to_event_seq BIGINT NOT NULL CHECK (to_event_seq > 0),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        messages JSONB NOT NULL,
+        token_usage JSONB,
+        metadata JSONB,
+        PRIMARY KEY (tenant_id, owner_key_id, session_id, snapshot_seq),
+        UNIQUE (tenant_id, owner_key_id, snapshot_id),
+        UNIQUE (tenant_id, owner_key_id, session_id, transcript_id, from_event_seq, to_event_seq),
+        CONSTRAINT "${this.tableName}_event_range_check" CHECK (from_event_seq <= to_event_seq),
+        CONSTRAINT "${this.tableName}_messages_array_check" CHECK (jsonb_typeof(messages) = 'array'),
+        CONSTRAINT "${this.tableName}_token_usage_object_check" CHECK (token_usage IS NULL OR jsonb_typeof(token_usage) = 'object'),
+        CONSTRAINT "${this.tableName}_metadata_object_check" CHECK (metadata IS NULL OR jsonb_typeof(metadata) = 'object')
+      )
+    `);
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS "idx_${this.tableName}_scope_latest"
+      ON ${this.qt()} (tenant_id, owner_key_id, session_id, transcript_id, to_event_seq DESC)
+    `);
+  }
+}
+
+function validateSaveInput(input: AcpSaveChatSnapshotInput): ValidatedSaveInput {
+  const messages = validateMessages(input.messages);
+  return {
+    sessionId: requireNonEmptyString(input.sessionId, 'sessionId'),
+    tenantId: requireNonEmptyString(input.tenantId, 'tenantId'),
+    ownerKeyId: requireNonEmptyString(input.ownerKeyId, 'ownerKeyId'),
+    transcriptId: requireNonEmptyString(input.transcriptId, 'transcriptId'),
+    fromEventSeq: requirePositiveSafeInteger(input.fromEventSeq, 'fromEventSeq'),
+    toEventSeq: requireToEventSeq(input.fromEventSeq, input.toEventSeq),
+    messagesJson: serializeJson(messages, 'messages'),
+    tokenUsageJson: serializeOptionalObject(input.tokenUsage, 'tokenUsage'),
+    metadataJson: serializeOptionalObject(input.metadata, 'metadata'),
+  };
+}
+
+function validateGetInput(input: AcpGetChatSnapshotInput): void {
+  requireNonEmptyString(input.sessionId, 'sessionId');
+  requireNonEmptyString(input.tenantId, 'tenantId');
+  requireNonEmptyString(input.ownerKeyId, 'ownerKeyId');
+  requireNonEmptyString(input.transcriptId, 'transcriptId');
+  if (input.atOrBeforeEventSeq !== undefined) {
+    requirePositiveSafeInteger(input.atOrBeforeEventSeq, 'atOrBeforeEventSeq');
+  }
+}
+
+function validateIdentifier(label: string, value: string): void {
+  if (!IDENTIFIER_RE.test(value)) {
+    throw new Error(`PostgresAcpChatCache: invalid ${label} "${value}" — must match [a-zA-Z_][a-zA-Z0-9_]*`);
+  }
+}
+
+function validatePoolMax(value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('PostgresAcpChatCache: poolMax must be a positive safe integer');
+  }
+}
+
+function requireNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`PostgresAcpChatCache: ${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requirePositiveSafeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || typeof value !== 'number' || value <= 0) {
+    throw new Error(`PostgresAcpChatCache: ${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function requireToEventSeq(fromEventSeq: unknown, toEventSeq: unknown): number {
+  const from = requirePositiveSafeInteger(fromEventSeq, 'fromEventSeq');
+  const to = requirePositiveSafeInteger(toEventSeq, 'toEventSeq');
+  if (to < from) {
+    throw new Error('PostgresAcpChatCache: toEventSeq must be greater than or equal to fromEventSeq');
+  }
+  return to;
+}
+
+function validateMessages(value: unknown): AcpChatSnapshotMessage[] {
+  if (!Array.isArray(value)) {
+    throw new Error('PostgresAcpChatCache: messages must be an array');
+  }
+  validateJsonValue(value, 'messages', new WeakSet<object>());
+  const messages: AcpChatSnapshotMessage[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const message = value[index];
+    if (!isPlainRecord(message)) {
+      throw new Error(`PostgresAcpChatCache: messages[${index}] must be a plain JSON object`);
+    }
+    messages.push(message);
+  }
+  return messages;
+}
+
+function serializeOptionalObject(value: unknown, label: string): string | null {
+  if (value === undefined) return null;
+  if (!isPlainRecord(value)) {
+    throw new Error(`PostgresAcpChatCache: ${label} must be a plain JSON object`);
+  }
+  return serializeJson(value, label);
+}
+
+function serializeJson(value: AcpEventJsonValue, label: string): string {
+  validateJsonValue(value, label, new WeakSet<object>());
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    throw new Error(`PostgresAcpChatCache: ${label} is not serializable JSON: ${toError(error).message}`);
+  }
+}
+
+function validateJsonValue(value: unknown, path: string, seen: WeakSet<object>): asserts value is AcpEventJsonValue {
+  if (value === null) return;
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return;
+    case 'number':
+      if (!Number.isFinite(value)) {
+        throw new Error(`PostgresAcpChatCache: JSON number at ${path} must be finite`);
+      }
+      return;
+    case 'object':
+      validateJsonObjectOrArray(value, path, seen);
+      return;
+    case 'undefined':
+      throw new Error(`PostgresAcpChatCache: JSON value at ${path} must not be undefined`);
+    case 'bigint':
+    case 'function':
+    case 'symbol':
+    default:
+      throw new Error(`PostgresAcpChatCache: JSON value at ${path} has unsupported type ${typeof value}`);
+  }
+}
+
+function validateJsonObjectOrArray(value: object, path: string, seen: WeakSet<object>): void {
+  if (seen.has(value)) {
+    throw new Error(`PostgresAcpChatCache: JSON value contains a circular reference at ${path}`);
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        if (!Object.prototype.hasOwnProperty.call(value, index)) {
+          throw new Error(`PostgresAcpChatCache: JSON array at ${path} must not contain holes`);
+        }
+        validateJsonValue(value[index], `${path}[${index}]`, seen);
+      }
+      return;
+    }
+
+    if (!isPlainRecord(value)) {
+      throw new Error(`PostgresAcpChatCache: JSON object at ${path} must be a plain object`);
+    }
+
+    for (const [key, entry] of Object.entries(value)) {
+      validateJsonValue(entry, `${path}.${key}`, seen);
+    }
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, AcpEventJsonValue> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function mapSnapshotRow(row: AcpChatSnapshotRow): AcpChatSnapshotRecord {
+  const record: AcpChatSnapshotRecord = {
+    sessionId: row.session_id,
+    tenantId: row.tenant_id,
+    ownerKeyId: row.owner_key_id,
+    snapshotId: row.snapshot_id,
+    transcriptId: row.transcript_id,
+    snapshotSeq: parseSequence(row.snapshot_seq, 'snapshot_seq'),
+    fromEventSeq: parseSequence(row.from_event_seq, 'from_event_seq'),
+    toEventSeq: parseSequence(row.to_event_seq, 'to_event_seq'),
+    createdAt: toDate(row.created_at),
+    messages: row.messages,
+  };
+  if (row.token_usage !== null) record.tokenUsage = row.token_usage;
+  if (row.metadata !== null) record.metadata = row.metadata;
+  return record;
+}
+
+function parseSequence(value: string | number, label: string): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`PostgresAcpChatCache: invalid ${label} returned by Postgres`);
+  }
+  return parsed;
+}
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+async function rollback(client: PoolClient): Promise<void> {
+  try {
+    await client.query('ROLLBACK');
+  } catch {
+    // Preserve the original failure from the transaction body.
+  }
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Add ACP chat cache snapshot interfaces for transcript-aware replay anchors.
- Implement PostgresAcpChatCache with scoped snapshot persistence, validation, health, and latest-snapshot lookup.
- Cover schema, parameterization, tenant/owner isolation, replay lookup, validation, and optional Postgres integration tests.

## Test Plan
- [x] npx vitest run src/__tests__/acp-postgres-chat-cache.test.ts --reporter=dot
- [x] npx vitest run src/__tests__/acp-postgres-chat-cache.test.ts src/__tests__/acp-postgres-event-store.test.ts src/__tests__/acp-postgres-session-store.test.ts --reporter=dot
- [x] npx tsc --noEmit
- [x] npm run gate

Closes #2589