### PR TITLE
refactor: implement ACP Redis runtime

### DIFF
--- a/src/__tests__/acp-redis-coordination.test.ts
+++ b/src/__tests__/acp-redis-coordination.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ACP_REDIS_COORDINATION_RECOVERY_CONTRACT,
   AcpRedisCoordinationKeyError,
+  RedisAcpRealtimeCoordinator,
   createAcpRedisCoordinationKeys,
   normalizeAcpRedisCoordinationKeyPrefix,
   type AcpRealtimeDisconnectInput,
@@ -13,9 +14,7 @@ describe('ACP Redis coordination contracts', () => {
     const keys = createAcpRedisCoordinationKeys();
 
     expect(keys.presence('session-abc_123')).toBe('aegis:acp:presence:session-abc_123');
-    expect(keys.driverLock('session-abc_123')).toBe(
-      'aegis:acp:driver-lock:session-abc_123'
-    );
+    expect(keys.driverLock('session-abc_123')).toBe('aegis:acp:driver-lock:session-abc_123');
     expect(keys.driverLockFence('session-abc_123')).toBe(
       'aegis:acp:driver-lock-fence:session-abc_123'
     );
@@ -27,9 +26,7 @@ describe('ACP Redis coordination contracts', () => {
   });
 
   it('normalizes safe custom prefixes before composing keys', () => {
-    expect(normalizeAcpRedisCoordinationKeyPrefix('  team-a:aegis:  ')).toBe(
-      'team-a:aegis'
-    );
+    expect(normalizeAcpRedisCoordinationKeyPrefix('  team-a:aegis:  ')).toBe('team-a:aegis');
 
     const keys = createAcpRedisCoordinationKeys({ keyPrefix: '  team-a:aegis:  ' });
 
@@ -84,9 +81,7 @@ describe('ACP Redis coordination contracts', () => {
     expect(keys.driverLock('acp-agent-looking-id')).toBe(
       'aegis:acp:driver-lock:acp-agent-looking-id'
     );
-    expect(keys.events('json-rpc-looking-id')).toBe(
-      'aegis:acp:events:json-rpc-looking-id'
-    );
+    expect(keys.events('json-rpc-looking-id')).toBe('aegis:acp:events:json-rpc-looking-id');
   });
 
   it('documents Redis as volatile coordination recovered from durable stores', () => {
@@ -125,3 +120,711 @@ describe('ACP Redis coordination contracts', () => {
     expect(invalidDisconnect.sessionId).toBe('session-1');
   });
 });
+
+describe('RedisAcpRealtimeCoordinator runtime', () => {
+  it('records volatile presence heartbeats and prunes expired subscribers', async () => {
+    const redis = new FakeRealtimeRedis();
+    const keys = createAcpRedisCoordinationKeys();
+    const coordinator = new RedisAcpRealtimeCoordinator({
+      client: redis,
+      keyPrefix: keys.prefix,
+      now: () => redis.now,
+      tokenGenerator: () => 'unused-lock-token',
+    });
+
+    const first = await coordinator.heartbeatPresence({
+      sessionId: 'session-1',
+      subscriberId: 'observer-1',
+      role: 'observer',
+      ttlMs: 1000,
+      backendRunId: 'run-1',
+      metadata: { nodeId: 'node-a' },
+    });
+
+    expect(first).toEqual({
+      sessionId: 'session-1',
+      subscriberId: 'observer-1',
+      ttlMs: 1000,
+      expiresAt: 2000,
+      activeSubscriberCount: 1,
+    });
+    expect(redis.zscore(keys.presence('session-1'), 'observer-1')).toBe(2000);
+    expect(redis.pttl(keys.presence('session-1'))).toBe(1000);
+    expect(redis.readJsonObject(keys.subscriberState('session-1', 'observer-1'))).toMatchObject({
+      sessionId: 'session-1',
+      subscriberId: 'observer-1',
+      role: 'observer',
+      backendRunId: 'run-1',
+      expiresAt: 2000,
+    });
+
+    redis.now = 2100;
+    const second = await coordinator.heartbeatPresence({
+      sessionId: 'session-1',
+      subscriberId: 'observer-2',
+      role: 'observer',
+      ttlMs: 500,
+    });
+
+    expect(second.activeSubscriberCount).toBe(1);
+    expect(redis.zscore(keys.presence('session-1'), 'observer-1')).toBeUndefined();
+    expect(redis.zscore(keys.presence('session-1'), 'observer-2')).toBe(2600);
+  });
+
+  it('keeps the presence key alive until the longest active heartbeat expires', async () => {
+    const redis = new FakeRealtimeRedis();
+    const keys = createAcpRedisCoordinationKeys();
+    const coordinator = new RedisAcpRealtimeCoordinator({
+      client: redis,
+      now: () => redis.now,
+    });
+
+    await coordinator.heartbeatPresence({
+      sessionId: 'session-1',
+      subscriberId: 'observer-long',
+      role: 'observer',
+      ttlMs: 5000,
+    });
+    redis.now = 1100;
+    await coordinator.heartbeatPresence({
+      sessionId: 'session-1',
+      subscriberId: 'observer-short',
+      role: 'observer',
+      ttlMs: 500,
+    });
+
+    expect(redis.pttl(keys.presence('session-1'))).toBe(4900);
+  });
+
+  it('sets presence TTL atomically when concurrent heartbeats overlap', async () => {
+    const redis = new FakeRealtimeRedis();
+    const keys = createAcpRedisCoordinationKeys();
+    const coordinator = new RedisAcpRealtimeCoordinator({
+      client: redis,
+      now: () => redis.now,
+    });
+
+    redis.deferFirstPexpireUntilAfterFollowingPexpire();
+    const shorterHeartbeat = coordinator.heartbeatPresence({
+      sessionId: 'session-1',
+      subscriberId: 'observer-short',
+      role: 'observer',
+      ttlMs: 5000,
+    });
+    await redis.waitForDeferredPexpire();
+
+    const longerHeartbeat = coordinator.heartbeatPresence({
+      sessionId: 'session-1',
+      subscriberId: 'observer-long',
+      role: 'observer',
+      ttlMs: 6000,
+    });
+    await longerHeartbeat;
+    redis.releaseDeferredPexpire();
+    await shorterHeartbeat;
+
+    expect(redis.pttl(keys.presence('session-1'))).toBe(6000);
+  });
+
+  it('uses acquire-only monotonic fencing for driver locks across TTL expiry', async () => {
+    const redis = new FakeRealtimeRedis();
+    const coordinator = new RedisAcpRealtimeCoordinator({
+      client: redis,
+      now: () => redis.now,
+      tokenGenerator: () => 'token-1',
+    });
+
+    const acquired = await coordinator.acquireDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      ttlMs: 1000,
+    });
+
+    expect(acquired.acquired).toBe(true);
+    expect(acquired.lease).toMatchObject({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      lockToken: 'token-1',
+      fencingToken: 1,
+      ttlMs: 1000,
+      expiresAt: 2000,
+    });
+
+    const blocked = await coordinator.acquireDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-b',
+      ttlMs: 1000,
+    });
+
+    expect(blocked).toMatchObject({
+      acquired: false,
+      currentHolderId: 'driver-a',
+      currentFencingToken: 1,
+      expiresAt: 2000,
+    });
+    expect(redis.readCounter('aegis:acp:driver-lock-fence:session-1')).toBe(1);
+
+    const renewed = await coordinator.renewDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      lockToken: 'token-1',
+      fencingToken: 1,
+      ttlMs: 2000,
+    });
+
+    expect(renewed.renewed).toBe(true);
+    expect(renewed.lease?.fencingToken).toBe(1);
+    expect(redis.readCounter('aegis:acp:driver-lock-fence:session-1')).toBe(1);
+
+    await coordinator.releaseDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      lockToken: 'token-1',
+      fencingToken: 1,
+    });
+    expect(redis.readCounter('aegis:acp:driver-lock-fence:session-1')).toBe(1);
+
+    const reacquired = await coordinator.acquireDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-b',
+      ttlMs: 1000,
+    });
+
+    expect(reacquired.acquired).toBe(true);
+    expect(reacquired.lease?.fencingToken).toBe(2);
+  });
+
+  it('rejects stale renewals and releases without freeing a newer lease', async () => {
+    const redis = new FakeRealtimeRedis();
+    const coordinator = new RedisAcpRealtimeCoordinator({
+      client: redis,
+      now: () => redis.now,
+      tokenGenerator: redis.nextToken,
+    });
+
+    const first = await coordinator.acquireDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      ttlMs: 1000,
+    });
+    expect(first.lease).toBeDefined();
+
+    const staleRenewal = await coordinator.renewDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      lockToken: 'wrong-token',
+      fencingToken: 1,
+      ttlMs: 1000,
+    });
+    expect(staleRenewal).toEqual({ renewed: false, reason: 'token-mismatch' });
+
+    redis.now = 2500;
+    const second = await coordinator.acquireDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-b',
+      ttlMs: 1000,
+    });
+    expect(second.lease).toMatchObject({
+      holderId: 'driver-b',
+      lockToken: 'token-2',
+      fencingToken: 2,
+    });
+
+    await coordinator.releaseDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      lockToken: 'token-1',
+      fencingToken: 1,
+    });
+
+    const blocked = await coordinator.acquireDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-c',
+      ttlMs: 1000,
+    });
+
+    expect(blocked.acquired).toBe(false);
+    expect(blocked.currentHolderId).toBe('driver-b');
+    expect(blocked.currentFencingToken).toBe(2);
+  });
+
+  it('publishes event and worker wakeup messages and cleans subscriber state on close', async () => {
+    const redis = new FakeRealtimeRedis();
+    const keys = createAcpRedisCoordinationKeys();
+    const coordinator = new RedisAcpRealtimeCoordinator({
+      client: redis,
+      subscriberClient: redis,
+      now: () => redis.now,
+    });
+
+    const subscription = await coordinator.subscribeEventChannel({
+      sessionId: 'session-1',
+      subscriberId: 'observer-1',
+      subscriberTtlMs: 1000,
+      fromEventSeq: 41,
+      metadata: { nodeId: 'node-a' },
+    });
+
+    expect(subscription.channelKey).toBe(keys.events('session-1'));
+    expect(redis.subscribedChannels).toEqual([keys.events('session-1')]);
+    expect(redis.readJsonObject(keys.subscriberState('session-1', 'observer-1'))).toMatchObject({
+      sessionId: 'session-1',
+      subscriberId: 'observer-1',
+      fromEventSeq: 41,
+      expiresAt: 2000,
+    });
+
+    await coordinator.publishEventNotification({
+      sessionId: 'session-1',
+      eventId: 'evt-1',
+      eventSeq: 42,
+      eventType: 'assistant.message',
+      occurredAt: 1200,
+      backendRunId: 'run-1',
+      payload: { text: 'hello' },
+    });
+    await coordinator.wakeSleepingWorkers({
+      reason: 'new-action',
+      sessionId: 'session-1',
+      actionId: 'action-1',
+      actionType: 'prompt',
+    });
+
+    expect(redis.publishedMessages).toEqual([
+      {
+        channel: keys.events('session-1'),
+        message: JSON.stringify({
+          sessionId: 'session-1',
+          eventId: 'evt-1',
+          eventSeq: 42,
+          eventType: 'assistant.message',
+          occurredAt: 1200,
+          backendRunId: 'run-1',
+          payload: { text: 'hello' },
+        }),
+      },
+      {
+        channel: keys.wakeups(),
+        message: JSON.stringify({
+          reason: 'new-action',
+          sessionId: 'session-1',
+          actionId: 'action-1',
+          actionType: 'prompt',
+        }),
+      },
+    ]);
+
+    await subscription.close();
+
+    expect(redis.unsubscribedChannels).toEqual([keys.events('session-1')]);
+    expect(redis.getSync(keys.subscriberState('session-1', 'observer-1'))).toBeNull();
+  });
+
+  it('disconnects volatile state and only releases the matching subscriber lock', async () => {
+    const redis = new FakeRealtimeRedis();
+    const keys = createAcpRedisCoordinationKeys();
+    const coordinator = new RedisAcpRealtimeCoordinator({
+      client: redis,
+      now: () => redis.now,
+      tokenGenerator: () => 'token-1',
+    });
+
+    await coordinator.heartbeatPresence({
+      sessionId: 'session-1',
+      subscriberId: 'driver-a',
+      role: 'driver',
+      ttlMs: 1000,
+    });
+    const lease = await coordinator.acquireDriverLock({
+      sessionId: 'session-1',
+      holderId: 'driver-a',
+      ttlMs: 1000,
+    });
+    expect(lease.lease).toBeDefined();
+
+    await coordinator.disconnect({
+      sessionId: 'session-1',
+      subscriberId: 'driver-a',
+      releaseDriverLock: {
+        lockToken: 'wrong-token',
+        fencingToken: 1,
+      },
+    });
+
+    expect(redis.zscore(keys.presence('session-1'), 'driver-a')).toBeUndefined();
+    expect(redis.getSync(keys.subscriberState('session-1', 'driver-a'))).toBeNull();
+    expect(redis.getSync(keys.driverLock('session-1'))).not.toBeNull();
+
+    await coordinator.disconnect({
+      sessionId: 'session-1',
+      subscriberId: 'driver-a',
+      releaseDriverLock: {
+        lockToken: 'token-1',
+        fencingToken: 1,
+      },
+    });
+
+    expect(redis.getSync(keys.driverLock('session-1'))).toBeNull();
+  });
+});
+
+interface StoredValue {
+  value: string;
+  expiresAt?: number;
+}
+
+interface PublishedMessage {
+  channel: string;
+  message: string;
+}
+
+class FakeRealtimeRedis {
+  now = 1000;
+  readonly publishedMessages: PublishedMessage[] = [];
+  readonly subscribedChannels: string[] = [];
+  readonly unsubscribedChannels: string[] = [];
+  private readonly values = new Map<string, StoredValue>();
+  private readonly expirations = new Map<string, number>();
+  private readonly counters = new Map<string, number>();
+  private readonly sortedSets = new Map<string, Map<string, number>>();
+  private deferNextPexpire = false;
+  private deferredPexpireRelease: (() => void) | undefined;
+  private deferredPexpireStarted: Promise<void> | undefined;
+  private resolveDeferredPexpireStarted: (() => void) | undefined;
+  private tokenIndex = 0;
+
+  readonly nextToken = (): string => {
+    this.tokenIndex += 1;
+    return `token-${this.tokenIndex}`;
+  };
+
+  deferFirstPexpireUntilAfterFollowingPexpire(): void {
+    this.deferNextPexpire = true;
+    this.deferredPexpireStarted = new Promise<void>(resolve => {
+      this.resolveDeferredPexpireStarted = resolve;
+    });
+  }
+
+  async waitForDeferredPexpire(): Promise<void> {
+    if (!this.deferredPexpireStarted) {
+      throw new Error('deferred pexpire was not configured');
+    }
+    await this.deferredPexpireStarted;
+  }
+
+  releaseDeferredPexpire(): void {
+    if (this.deferredPexpireRelease) {
+      this.deferredPexpireRelease();
+    }
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.getSync(key);
+  }
+
+  getSync(key: string): string | null {
+    const entry = this.values.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt !== undefined && entry.expiresAt <= this.now) {
+      this.values.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, ...options: Array<string | number>): Promise<'OK' | null> {
+    const nx = options.some(option => option === 'NX');
+    if (nx && this.getSync(key) !== null) {
+      return null;
+    }
+
+    const pxIndex = options.findIndex(option => option === 'PX');
+    const ttlMs = pxIndex >= 0 ? Number(options[pxIndex + 1]) : undefined;
+    this.values.set(key, {
+      value,
+      expiresAt: ttlMs === undefined ? undefined : this.now + ttlMs,
+    });
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let deleted = 0;
+    for (const key of keys) {
+      if (this.values.delete(key)) {
+        deleted += 1;
+      }
+      if (this.sortedSets.delete(key)) {
+        deleted += 1;
+      }
+      this.expirations.delete(key);
+    }
+    return deleted;
+  }
+
+  async pexpire(key: string, ttlMs: number): Promise<number> {
+    if (this.deferNextPexpire) {
+      this.deferNextPexpire = false;
+      const release = new Promise<void>(resolve => {
+        this.deferredPexpireRelease = resolve;
+      });
+      this.resolveDeferredPexpireStarted?.();
+      await release;
+    }
+    return this.applyPexpire(key, ttlMs);
+  }
+
+  private applyPexpire(key: string, ttlMs: number): number {
+    const entry = this.values.get(key);
+    const sortedSet = this.sortedSets.get(key);
+    if (!entry && !sortedSet) {
+      return 0;
+    }
+    if (entry) {
+      entry.expiresAt = this.now + ttlMs;
+    }
+    if (sortedSet) {
+      this.expirations.set(key, this.now + ttlMs);
+    }
+    return 1;
+  }
+
+  pttl(key: string): number | undefined {
+    const entry = this.values.get(key);
+    if (!entry?.expiresAt) {
+      const expiresAt = this.expirations.get(key);
+      return expiresAt === undefined ? undefined : expiresAt - this.now;
+    }
+    return entry.expiresAt - this.now;
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = (this.counters.get(key) ?? 0) + 1;
+    this.counters.set(key, next);
+    return next;
+  }
+
+  readCounter(key: string): number | undefined {
+    return this.counters.get(key);
+  }
+
+  async zadd(key: string, score: number, member: string): Promise<number> {
+    let set = this.sortedSets.get(key);
+    if (!set) {
+      set = new Map<string, number>();
+      this.sortedSets.set(key, set);
+    }
+    const existed = set.has(member);
+    set.set(member, score);
+    return existed ? 0 : 1;
+  }
+
+  async zrem(key: string, ...members: string[]): Promise<number> {
+    const set = this.sortedSets.get(key);
+    if (!set) {
+      return 0;
+    }
+    let removed = 0;
+    for (const member of members) {
+      if (set.delete(member)) {
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  async zremrangebyscore(key: string, min: string | number, max: string | number): Promise<number> {
+    const set = this.sortedSets.get(key);
+    if (!set) {
+      return 0;
+    }
+    const minScore = Number(min);
+    const maxScore = Number(max);
+    let removed = 0;
+    for (const [member, score] of set) {
+      if (score >= minScore && score <= maxScore) {
+        set.delete(member);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  async zcard(key: string): Promise<number> {
+    return this.sortedSets.get(key)?.size ?? 0;
+  }
+
+  async zrange(
+    key: string,
+    start: number,
+    stop: number,
+    withScores: 'WITHSCORES'
+  ): Promise<string[]> {
+    expect(withScores).toBe('WITHSCORES');
+    const entries = [...(this.sortedSets.get(key)?.entries() ?? [])].sort(
+      ([, leftScore], [, rightScore]) => leftScore - rightScore
+    );
+    const normalizedStart = start < 0 ? entries.length + start : start;
+    const normalizedStop = stop < 0 ? entries.length + stop : stop;
+    return entries
+      .slice(normalizedStart, normalizedStop + 1)
+      .flatMap(([member, score]) => [member, String(score)]);
+  }
+
+  zscore(key: string, member: string): number | undefined {
+    return this.sortedSets.get(key)?.get(member);
+  }
+
+  async publish(channel: string, message: string): Promise<number> {
+    this.publishedMessages.push({ channel, message });
+    return 1;
+  }
+
+  async subscribe(channel: string): Promise<number> {
+    this.subscribedChannels.push(channel);
+    return this.subscribedChannels.length;
+  }
+
+  async unsubscribe(channel: string): Promise<number> {
+    this.unsubscribedChannels.push(channel);
+    return this.unsubscribedChannels.length;
+  }
+
+  async eval(
+    script: string,
+    numberOfKeys: number,
+    ...args: Array<string | number>
+  ): Promise<unknown> {
+    if (numberOfKeys !== 2 && numberOfKeys !== 1) {
+      throw new Error(`unexpected key count: ${numberOfKeys}`);
+    }
+    if (script.includes('ACP_DRIVER_LOCK_ACQUIRE')) {
+      return this.evalAcquire(args);
+    }
+    if (script.includes('ACP_PRESENCE_HEARTBEAT')) {
+      return this.evalPresenceHeartbeat(args);
+    }
+    if (script.includes('ACP_DRIVER_LOCK_RENEW')) {
+      return this.evalRenew(args);
+    }
+    if (script.includes('ACP_DRIVER_LOCK_RELEASE')) {
+      return this.evalRelease(args);
+    }
+    throw new Error('unknown script');
+  }
+
+  readJsonObject(key: string): Record<string, unknown> {
+    const raw = this.getSync(key);
+    if (raw === null) {
+      throw new Error(`missing key ${key}`);
+    }
+    return parseJsonObject(raw);
+  }
+
+  private async evalAcquire(args: Array<string | number>): Promise<unknown[]> {
+    const lockKey = String(args[0]);
+    const fenceKey = String(args[1]);
+    const basePayload = parseJsonObject(String(args[2]));
+    const ttlMs = Number(args[3]);
+    const expiresAt = Number(args[4]);
+    const existing = await this.get(lockKey);
+    if (existing !== null) {
+      return [0, existing];
+    }
+
+    const fencingToken = await this.incr(fenceKey);
+    const payload = JSON.stringify({ ...basePayload, fencingToken, ttlMs, expiresAt });
+    await this.set(lockKey, payload, 'PX', ttlMs);
+    return [1, payload];
+  }
+
+  private async evalPresenceHeartbeat(args: Array<string | number>): Promise<unknown[]> {
+    const presenceKey = String(args[0]);
+    const subscriberStateKey = String(args[1]);
+    const now = Number(args[2]);
+    const expiresAt = Number(args[3]);
+    const subscriberId = String(args[4]);
+    const subscriberPayload = String(args[5]);
+    const subscriberTtlMs = Number(args[6]);
+
+    if (this.deferNextPexpire) {
+      this.deferNextPexpire = false;
+      this.resolveDeferredPexpireStarted?.();
+    }
+
+    await this.zremrangebyscore(presenceKey, 0, now);
+    await this.zadd(presenceKey, expiresAt, subscriberId);
+    const latestPresence = await this.zrange(presenceKey, -1, -1, 'WITHSCORES');
+    const latestExpiresAt = Number(latestPresence[1]);
+    const presenceTtlMs = Number.isFinite(latestExpiresAt)
+      ? Math.max(1, Math.ceil(latestExpiresAt - now))
+      : subscriberTtlMs;
+    this.applyPexpire(presenceKey, presenceTtlMs);
+    this.values.set(subscriberStateKey, {
+      value: subscriberPayload,
+      expiresAt: this.now + subscriberTtlMs,
+    });
+    return [await this.zcard(presenceKey), presenceTtlMs];
+  }
+
+  private async evalRenew(args: Array<string | number>): Promise<unknown[]> {
+    const lockKey = String(args[0]);
+    const expectedHolderId = String(args[1]);
+    const expectedLockToken = String(args[2]);
+    const expectedFencingToken = Number(args[3]);
+    const ttlMs = Number(args[4]);
+    const expiresAt = Number(args[5]);
+    const currentRaw = await this.get(lockKey);
+    if (currentRaw === null) {
+      return [0, 'expired'];
+    }
+    const current = parseJsonObject(currentRaw);
+    if (current['holderId'] !== expectedHolderId) {
+      return [0, 'not-holder'];
+    }
+    if (
+      current['lockToken'] !== expectedLockToken ||
+      current['fencingToken'] !== expectedFencingToken
+    ) {
+      return [0, 'token-mismatch'];
+    }
+
+    const payload = JSON.stringify({ ...current, ttlMs, expiresAt });
+    await this.set(lockKey, payload, 'PX', ttlMs);
+    return [1, payload];
+  }
+
+  private async evalRelease(args: Array<string | number>): Promise<number> {
+    const lockKey = String(args[0]);
+    const expectedHolderId = String(args[1]);
+    const expectedLockToken = String(args[2]);
+    const expectedFencingToken = Number(args[3]);
+    const currentRaw = await this.get(lockKey);
+    if (currentRaw === null) {
+      return 0;
+    }
+    const current = parseJsonObject(currentRaw);
+    if (
+      current['holderId'] === expectedHolderId &&
+      current['lockToken'] === expectedLockToken &&
+      current['fencingToken'] === expectedFencingToken
+    ) {
+      await this.del(lockKey);
+      return 1;
+    }
+    return 0;
+  }
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(raw);
+  if (!isJsonRecord(parsed)) {
+    throw new Error('expected JSON object');
+  }
+  return parsed;
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -56,7 +56,10 @@ export {
   PostgresAcpSessionStore,
   type PostgresAcpSessionStoreConfig,
 } from './postgres-session-store.js';
-export { PostgresAcpActionQueue, type PostgresAcpActionQueueConfig } from './postgres-action-queue.js';
+export {
+  PostgresAcpActionQueue,
+  type PostgresAcpActionQueueConfig,
+} from './postgres-action-queue.js';
 export {
   FileAcpLocalStorageProfile,
   MemoryAcpActionQueue,
@@ -71,6 +74,8 @@ export {
 export {
   ACP_REDIS_COORDINATION_RECOVERY_CONTRACT,
   AcpRedisCoordinationKeyError,
+  AcpRedisCoordinationRuntimeError,
+  RedisAcpRealtimeCoordinator,
   createAcpRedisCoordinationKeys,
   normalizeAcpRedisCoordinationKeyPrefix,
   validateAcpPublicSessionRedisKeyId,
@@ -93,5 +98,8 @@ export {
   type AcpRedisCoordinationKeyOptions,
   type AcpRedisCoordinationKeys,
   type AcpRedisCoordinationRecoveryContract,
+  type AcpRedisRealtimeClient,
+  type AcpRedisRealtimeSubscriberClient,
   type AcpWakeSleepingWorkersInput,
+  type RedisAcpRealtimeCoordinatorOptions,
 } from './redis-coordination.js';

--- a/src/services/acp/redis-coordination.ts
+++ b/src/services/acp/redis-coordination.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import type { AcpBackendMetadata, AcpControlActionType } from './types.js';
 
 const DEFAULT_KEY_PREFIX = 'aegis';
@@ -7,6 +9,13 @@ export class AcpRedisCoordinationKeyError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'AcpRedisCoordinationKeyError';
+  }
+}
+
+export class AcpRedisCoordinationRuntimeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AcpRedisCoordinationRuntimeError';
   }
 }
 
@@ -163,11 +172,20 @@ export interface AcpDriverLockRenewInput {
   ttlMs: number;
 }
 
-export interface AcpDriverLockRenewResult {
-  renewed: boolean;
-  lease?: AcpDriverLockLease;
-  reason?: 'expired' | 'not-holder' | 'token-mismatch';
-}
+export type AcpDriverLockRenewResult =
+  | {
+      renewed: true;
+      /**
+       * The refreshed lease keeps the input fencing token unchanged.
+       * Renewing a driver lock must not advance the per-session fence.
+       */
+      lease: AcpDriverLockLease;
+    }
+  | {
+      renewed: false;
+      reason: 'expired' | 'not-holder' | 'token-mismatch';
+      lease?: never;
+    };
 
 export interface AcpDriverLockReleaseInput {
   sessionId: string;
@@ -225,16 +243,16 @@ export interface AcpRealtimeDisconnectInput {
 }
 
 /**
- * Contract for future Redis-backed realtime coordination.
+ * Contract for Redis-backed realtime coordination.
  *
  * Implementations may use Redis for presence, driver-lock leases, wakeups, and
-  * live fanout only. Redis loss is recovered through durable Postgres event
-  * replay and action queue processing, not by treating Redis as source of truth.
-  * Disconnect cleanup should clear volatile presence/subscriber state and may
-  * release only the driver lock held by the disconnecting subscriber when the
-  * supplied lock token and fencing token still match. TTL expiry remains the
-  * fallback when disconnect cleanup is missed.
-  */
+ * live fanout only. Redis loss is recovered through durable Postgres event
+ * replay and action queue processing, not by treating Redis as source of truth.
+ * Disconnect cleanup should clear volatile presence/subscriber state and may
+ * release only the driver lock held by the disconnecting subscriber when the
+ * supplied lock token and fencing token still match. TTL expiry remains the
+ * fallback when disconnect cleanup is missed.
+ */
 export interface AcpRealtimeCoordinator {
   heartbeatPresence(input: AcpPresenceHeartbeatInput): Promise<AcpPresenceHeartbeatResult>;
   acquireDriverLock(input: AcpDriverLockAcquireInput): Promise<AcpDriverLockAcquireResult>;
@@ -244,6 +262,493 @@ export interface AcpRealtimeCoordinator {
   subscribeEventChannel(input: AcpEventSubscriptionInput): Promise<AcpRealtimeSubscription>;
   wakeSleepingWorkers(input: AcpWakeSleepingWorkersInput): Promise<void>;
   disconnect(input: AcpRealtimeDisconnectInput): Promise<void>;
+}
+
+export interface AcpRedisRealtimeClient {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ...options: Array<string | number>): Promise<string | null>;
+  del(...keys: string[]): Promise<number>;
+  zrem(key: string, ...members: string[]): Promise<number>;
+  publish(channel: string, message: string): Promise<number>;
+  eval(script: string, numberOfKeys: number, ...args: Array<string | number>): Promise<unknown>;
+}
+
+export interface AcpRedisRealtimeSubscriberClient {
+  subscribe(channel: string): Promise<number>;
+  unsubscribe(channel: string): Promise<number>;
+}
+
+export interface RedisAcpRealtimeCoordinatorOptions extends AcpRedisCoordinationKeyOptions {
+  client: AcpRedisRealtimeClient;
+  subscriberClient?: AcpRedisRealtimeSubscriberClient;
+  now?: () => number;
+  tokenGenerator?: () => string;
+}
+
+const HEARTBEAT_PRESENCE_SCRIPT = `
+-- ACP_PRESENCE_HEARTBEAT
+local presenceKey = KEYS[1]
+local subscriberStateKey = KEYS[2]
+local now = tonumber(ARGV[1])
+local expiresAt = tonumber(ARGV[2])
+local subscriberId = ARGV[3]
+local subscriberPayload = ARGV[4]
+local subscriberTtlMs = tonumber(ARGV[5])
+redis.call('ZREMRANGEBYSCORE', presenceKey, 0, now)
+redis.call('ZADD', presenceKey, expiresAt, subscriberId)
+local latestPresence = redis.call('ZRANGE', presenceKey, -1, -1, 'WITHSCORES')
+local presenceTtlMs = subscriberTtlMs
+if latestPresence[2] then
+  presenceTtlMs = math.max(1, math.ceil(tonumber(latestPresence[2]) - now))
+end
+redis.call('PEXPIRE', presenceKey, presenceTtlMs)
+redis.call('SET', subscriberStateKey, subscriberPayload, 'PX', subscriberTtlMs)
+return {redis.call('ZCARD', presenceKey), presenceTtlMs}
+`;
+
+const ACQUIRE_DRIVER_LOCK_SCRIPT = `
+-- ACP_DRIVER_LOCK_ACQUIRE
+local lockKey = KEYS[1]
+local fenceKey = KEYS[2]
+local existing = redis.call('GET', lockKey)
+if existing then
+  return {0, existing}
+end
+local payload = cjson.decode(ARGV[1])
+local fencingToken = redis.call('INCR', fenceKey)
+payload['fencingToken'] = fencingToken
+payload['ttlMs'] = tonumber(ARGV[2])
+payload['expiresAt'] = tonumber(ARGV[3])
+local encoded = cjson.encode(payload)
+redis.call('PSETEX', lockKey, ARGV[2], encoded)
+return {1, encoded}
+`;
+
+const RENEW_DRIVER_LOCK_SCRIPT = `
+-- ACP_DRIVER_LOCK_RENEW
+local lockKey = KEYS[1]
+local existing = redis.call('GET', lockKey)
+if not existing then
+  return {0, 'expired'}
+end
+local payload = cjson.decode(existing)
+if payload['holderId'] ~= ARGV[1] then
+  return {0, 'not-holder'}
+end
+if payload['lockToken'] ~= ARGV[2] or tonumber(payload['fencingToken']) ~= tonumber(ARGV[3]) then
+  return {0, 'token-mismatch'}
+end
+payload['ttlMs'] = tonumber(ARGV[4])
+payload['expiresAt'] = tonumber(ARGV[5])
+local encoded = cjson.encode(payload)
+redis.call('PSETEX', lockKey, ARGV[4], encoded)
+return {1, encoded}
+`;
+
+const RELEASE_DRIVER_LOCK_SCRIPT = `
+-- ACP_DRIVER_LOCK_RELEASE
+local lockKey = KEYS[1]
+local existing = redis.call('GET', lockKey)
+if not existing then
+  return 0
+end
+local payload = cjson.decode(existing)
+if payload['holderId'] == ARGV[1]
+  and payload['lockToken'] == ARGV[2]
+  and tonumber(payload['fencingToken']) == tonumber(ARGV[3]) then
+  redis.call('DEL', lockKey)
+  return 1
+end
+return 0
+`;
+
+export class RedisAcpRealtimeCoordinator implements AcpRealtimeCoordinator {
+  private readonly client: AcpRedisRealtimeClient;
+  private readonly subscriberClient: AcpRedisRealtimeSubscriberClient | undefined;
+  private readonly keys: AcpRedisCoordinationKeys;
+  private readonly now: () => number;
+  private readonly tokenGenerator: () => string;
+
+  constructor(options: RedisAcpRealtimeCoordinatorOptions) {
+    this.client = options.client;
+    this.subscriberClient = options.subscriberClient;
+    this.keys = createAcpRedisCoordinationKeys({ keyPrefix: options.keyPrefix });
+    this.now = options.now ?? Date.now;
+    this.tokenGenerator = options.tokenGenerator ?? randomUUID;
+  }
+
+  async heartbeatPresence(input: AcpPresenceHeartbeatInput): Promise<AcpPresenceHeartbeatResult> {
+    assertPositiveTtl(input.ttlMs, 'presence heartbeat TTL');
+    const sessionId = validateAcpPublicSessionRedisKeyId(input.sessionId);
+    const subscriberId = validateAcpRedisCoordinationSubscriberId(input.subscriberId);
+    const presenceKey = this.keys.presence(sessionId);
+    const subscriberStateKey = this.keys.subscriberState(sessionId, subscriberId);
+    const now = this.now();
+    const expiresAt = now + input.ttlMs;
+    const result = toRedisEvalTuple(
+      await this.client.eval(
+        HEARTBEAT_PRESENCE_SCRIPT,
+        2,
+        presenceKey,
+        subscriberStateKey,
+        now,
+        expiresAt,
+        subscriberId,
+        JSON.stringify(buildPresencePayload(input, sessionId, subscriberId, expiresAt)),
+        input.ttlMs
+      ),
+      'presence heartbeat'
+    );
+
+    return {
+      sessionId,
+      subscriberId,
+      ttlMs: input.ttlMs,
+      expiresAt,
+      activeSubscriberCount: numberAt(result, 0, 'presence heartbeat active count'),
+    };
+  }
+
+  async acquireDriverLock(input: AcpDriverLockAcquireInput): Promise<AcpDriverLockAcquireResult> {
+    assertPositiveTtl(input.ttlMs, 'driver lock TTL');
+    const sessionId = validateAcpPublicSessionRedisKeyId(input.sessionId);
+    const holderId = validateAcpRedisCoordinationSubscriberId(input.holderId);
+    const ttlMs = input.ttlMs;
+    const expiresAt = this.now() + ttlMs;
+    const basePayload = buildDriverLockBasePayload(
+      input,
+      sessionId,
+      holderId,
+      this.tokenGenerator()
+    );
+    const result = toRedisEvalTuple(
+      await this.client.eval(
+        ACQUIRE_DRIVER_LOCK_SCRIPT,
+        2,
+        this.keys.driverLock(sessionId),
+        this.keys.driverLockFence(sessionId),
+        JSON.stringify(basePayload),
+        ttlMs,
+        expiresAt
+      ),
+      'driver lock acquire'
+    );
+
+    const payload = stringAt(result, 1, 'driver lock acquire payload');
+    const lease = parseDriverLockLease(payload);
+    if (redisFlagAt(result, 0, 'driver lock acquire flag')) {
+      return { acquired: true, lease };
+    }
+
+    return {
+      acquired: false,
+      currentHolderId: lease.holderId,
+      currentFencingToken: lease.fencingToken,
+      expiresAt: lease.expiresAt,
+    };
+  }
+
+  async renewDriverLock(input: AcpDriverLockRenewInput): Promise<AcpDriverLockRenewResult> {
+    assertPositiveTtl(input.ttlMs, 'driver lock renewal TTL');
+    const sessionId = validateAcpPublicSessionRedisKeyId(input.sessionId);
+    const holderId = validateAcpRedisCoordinationSubscriberId(input.holderId);
+    const result = toRedisEvalTuple(
+      await this.client.eval(
+        RENEW_DRIVER_LOCK_SCRIPT,
+        1,
+        this.keys.driverLock(sessionId),
+        holderId,
+        input.lockToken,
+        input.fencingToken,
+        input.ttlMs,
+        this.now() + input.ttlMs
+      ),
+      'driver lock renew'
+    );
+
+    if (redisFlagAt(result, 0, 'driver lock renew flag')) {
+      return {
+        renewed: true,
+        lease: parseDriverLockLease(stringAt(result, 1, 'driver lock renew payload')),
+      };
+    }
+
+    return {
+      renewed: false,
+      reason: renewReasonAt(result, 1),
+    };
+  }
+
+  async releaseDriverLock(input: AcpDriverLockReleaseInput): Promise<void> {
+    const sessionId = validateAcpPublicSessionRedisKeyId(input.sessionId);
+    const holderId = validateAcpRedisCoordinationSubscriberId(input.holderId);
+    await this.client.eval(
+      RELEASE_DRIVER_LOCK_SCRIPT,
+      1,
+      this.keys.driverLock(sessionId),
+      holderId,
+      input.lockToken,
+      input.fencingToken
+    );
+  }
+
+  async publishEventNotification(input: AcpRealtimeEventNotification): Promise<void> {
+    const sessionId = validateAcpPublicSessionRedisKeyId(input.sessionId);
+    await this.client.publish(this.keys.events(sessionId), JSON.stringify(input));
+  }
+
+  async subscribeEventChannel(input: AcpEventSubscriptionInput): Promise<AcpRealtimeSubscription> {
+    assertPositiveTtl(input.subscriberTtlMs, 'event subscriber TTL');
+    const subscriberClient = this.requireSubscriberClient();
+    const sessionId = validateAcpPublicSessionRedisKeyId(input.sessionId);
+    const subscriberId = validateAcpRedisCoordinationSubscriberId(input.subscriberId);
+    const channelKey = this.keys.events(sessionId);
+    const subscriberStateKey = this.keys.subscriberState(sessionId, subscriberId);
+    const expiresAt = this.now() + input.subscriberTtlMs;
+
+    await this.client.set(
+      subscriberStateKey,
+      JSON.stringify(buildSubscriberPayload(input, sessionId, subscriberId, expiresAt)),
+      'PX',
+      input.subscriberTtlMs
+    );
+    await subscriberClient.subscribe(channelKey);
+
+    let closed = false;
+    return {
+      sessionId,
+      subscriberId,
+      channelKey,
+      close: async (): Promise<void> => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        await subscriberClient.unsubscribe(channelKey);
+        await this.client.del(subscriberStateKey);
+      },
+    };
+  }
+
+  async wakeSleepingWorkers(input: AcpWakeSleepingWorkersInput): Promise<void> {
+    await this.client.publish(this.keys.wakeups(), JSON.stringify(input));
+  }
+
+  async disconnect(input: AcpRealtimeDisconnectInput): Promise<void> {
+    const sessionId = validateAcpPublicSessionRedisKeyId(input.sessionId);
+    const subscriberId = validateAcpRedisCoordinationSubscriberId(input.subscriberId);
+    await this.client.zrem(this.keys.presence(sessionId), subscriberId);
+    await this.client.del(this.keys.subscriberState(sessionId, subscriberId));
+
+    if (input.releaseDriverLock) {
+      await this.releaseDriverLock({
+        sessionId,
+        holderId: subscriberId,
+        lockToken: input.releaseDriverLock.lockToken,
+        fencingToken: input.releaseDriverLock.fencingToken,
+      });
+    }
+  }
+
+  private requireSubscriberClient(): AcpRedisRealtimeSubscriberClient {
+    if (this.subscriberClient) {
+      return this.subscriberClient;
+    }
+    if (isAcpRedisRealtimeSubscriberClient(this.client)) {
+      return this.client;
+    }
+    throw new AcpRedisCoordinationRuntimeError(
+      'ACP Redis pub/sub requires a Redis client with subscribe and unsubscribe support'
+    );
+  }
+}
+
+function buildPresencePayload(
+  input: AcpPresenceHeartbeatInput,
+  sessionId: string,
+  subscriberId: string,
+  expiresAt: number
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    sessionId,
+    subscriberId,
+    role: input.role,
+    ttlMs: input.ttlMs,
+    expiresAt,
+  };
+  addOptionalString(payload, 'backendRunId', input.backendRunId);
+  addOptionalMetadata(payload, input.metadata);
+  return payload;
+}
+
+function buildDriverLockBasePayload(
+  input: AcpDriverLockAcquireInput,
+  sessionId: string,
+  holderId: string,
+  lockToken: string
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    sessionId,
+    holderId,
+    lockToken,
+  };
+  addOptionalString(payload, 'backendRunId', input.backendRunId);
+  addOptionalMetadata(payload, input.metadata);
+  return payload;
+}
+
+function buildSubscriberPayload(
+  input: AcpEventSubscriptionInput,
+  sessionId: string,
+  subscriberId: string,
+  expiresAt: number
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    sessionId,
+    subscriberId,
+    subscriberTtlMs: input.subscriberTtlMs,
+    expiresAt,
+  };
+  if (input.fromEventSeq !== undefined) {
+    payload['fromEventSeq'] = input.fromEventSeq;
+  }
+  addOptionalMetadata(payload, input.metadata);
+  return payload;
+}
+
+function addOptionalString(
+  payload: Record<string, unknown>,
+  key: string,
+  value: string | undefined
+): void {
+  if (value !== undefined) {
+    payload[key] = value;
+  }
+}
+
+function addOptionalMetadata(
+  payload: Record<string, unknown>,
+  metadata: AcpBackendMetadata | undefined
+): void {
+  if (metadata !== undefined) {
+    payload['metadata'] = metadata;
+  }
+}
+
+function assertPositiveTtl(ttlMs: number, label: string): void {
+  if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0) {
+    throw new AcpRedisCoordinationRuntimeError(`ACP Redis ${label} must be a positive integer`);
+  }
+}
+
+function isAcpRedisRealtimeSubscriberClient(
+  client: AcpRedisRealtimeClient
+): client is AcpRedisRealtimeClient & AcpRedisRealtimeSubscriberClient {
+  return (
+    'subscribe' in client &&
+    typeof client.subscribe === 'function' &&
+    'unsubscribe' in client &&
+    typeof client.unsubscribe === 'function'
+  );
+}
+
+function parseDriverLockLease(raw: string): AcpDriverLockLease {
+  const payload = parseJsonObject(raw, 'driver lock payload');
+  return {
+    sessionId: requiredString(payload, 'sessionId', 'driver lock payload'),
+    holderId: requiredString(payload, 'holderId', 'driver lock payload'),
+    lockToken: requiredString(payload, 'lockToken', 'driver lock payload'),
+    fencingToken: requiredNumber(payload, 'fencingToken', 'driver lock payload'),
+    ttlMs: requiredNumber(payload, 'ttlMs', 'driver lock payload'),
+    expiresAt: requiredNumber(payload, 'expiresAt', 'driver lock payload'),
+  };
+}
+
+function parseJsonObject(raw: string, label: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(raw);
+  if (!isJsonRecord(parsed)) {
+    throw new AcpRedisCoordinationRuntimeError(`ACP Redis ${label} must be a JSON object`);
+  }
+  return parsed;
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requiredString(payload: Record<string, unknown>, field: string, label: string): string {
+  const value = payload[field];
+  if (typeof value !== 'string' || value === '') {
+    throw new AcpRedisCoordinationRuntimeError(
+      `ACP Redis ${label} field ${field} must be a string`
+    );
+  }
+  return value;
+}
+
+function requiredNumber(payload: Record<string, unknown>, field: string, label: string): number {
+  const value = payload[field];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new AcpRedisCoordinationRuntimeError(
+      `ACP Redis ${label} field ${field} must be a number`
+    );
+  }
+  return value;
+}
+
+function toRedisEvalTuple(value: unknown, label: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new AcpRedisCoordinationRuntimeError(
+      `ACP Redis ${label} script returned a non-array result`
+    );
+  }
+  return value;
+}
+
+function redisFlagAt(values: readonly unknown[], index: number, label: string): boolean {
+  const value = values[index];
+  if (value === 1 || value === '1') {
+    return true;
+  }
+  if (value === 0 || value === '0') {
+    return false;
+  }
+  throw new AcpRedisCoordinationRuntimeError(`ACP Redis ${label} must be 0 or 1`);
+}
+
+function stringAt(values: readonly unknown[], index: number, label: string): string {
+  const value = values[index];
+  if (typeof value !== 'string') {
+    throw new AcpRedisCoordinationRuntimeError(`ACP Redis ${label} must be a string`);
+  }
+  return value;
+}
+
+function numberAt(values: readonly unknown[], index: number, label: string): number {
+  const value = values[index];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  throw new AcpRedisCoordinationRuntimeError(`ACP Redis ${label} must be a number`);
+}
+
+function renewReasonAt(
+  values: readonly unknown[],
+  index: number
+): 'expired' | 'not-holder' | 'token-mismatch' {
+  const value = values[index];
+  if (value === 'expired' || value === 'not-holder' || value === 'token-mismatch') {
+    return value;
+  }
+  throw new AcpRedisCoordinationRuntimeError(
+    'ACP Redis driver lock renew returned an unknown reason'
+  );
 }
 
 function sessionScopedKey(prefix: string, kind: string, publicSessionId: string): string {


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Implement RedisAcpRealtimeCoordinator behind the ACP-027 realtime coordination contract.
- Add volatile Redis presence heartbeats with atomic TTL handling and subscriber cleanup.
- Add Redis driver-lock acquire/renew/release with per-session acquire-only fencing counters.
- Add Redis pub/sub event fanout, worker wakeups, and scoped disconnect cleanup.

## Testing
- npx vitest run src/__tests__/acp-redis-coordination.test.ts
- npx tsc --noEmit
- powershell -NoProfile -ExecutionPolicy Bypass -Command "npm run gate"

## Notes
Redis remains volatile coordination only. Durable recovery remains Postgres event replay and action queue state.

Closes #2592