### PR TITLE
refactor: add ACP binary resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@onestepat4time/aegis",
-  "version": "0.6.5-preview.3",
+  "version": "0.6.6-preview.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onestepat4time/aegis",
-      "version": "0.6.5-preview.3",
+      "version": "0.6.6-preview.1",
       "license": "MIT",
       "dependencies": {
+        "@agentclientprotocol/claude-agent-acp": "^0.32.0",
         "@fastify/cors": "^11.2.0",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.0.0",
@@ -57,6 +58,179 @@
       "optionalDependencies": {
         "ioredis": "^5.10.1",
         "pg": "^8.20.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/claude-agent-acp": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/claude-agent-acp/-/claude-agent-acp-0.32.0.tgz",
+      "integrity": "sha512-3WIaD1bTmIciqHdeU97oeNajOG9H+ctloXnQ+R/T563C2CM8u1K7QsNqqgqR2F+Cn8NVBkXdHRvAMtUHglLzAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "0.21.0",
+        "@anthropic-ai/claude-agent-sdk": "0.2.126",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "bin": {
+        "claude-agent-acp": "dist/index.js"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
+      "integrity": "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.126.tgz",
+      "integrity": "sha512-4ZrVu0XUEwNG6wxvsLgppRAmSfAf3oeEMEUPhgazb0AXUUe/7W8MxwZKJWOffqSLWaNYzOt3ZCIL7NJY6toqWw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.126",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.126",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.126",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.126",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.126",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.126",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.126",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.126"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.126.tgz",
+      "integrity": "sha512-JFlJBbeAlx7Ic5s4lGUN9SppobryXk/lIqPCvhp6KrJTQIerh3MIBzxsVIJ0MaDut7jVni/oYgsvDni7NIyqHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.126.tgz",
+      "integrity": "sha512-J8BpMj16NK9FUaG3HnHSivyp4Xww9DKWHiC8QSHT9oiT8pH5IG7nl0jxyjIq/lY79evlTY+ubgDVWlMUhUAN/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.126.tgz",
+      "integrity": "sha512-LM+mnfQsgI+1i5mYZwIPDDf14NGBu5wbhzm5U8P11dCa2p8sXmKoWpkbO16BFM2NxeW44I/RXCxE5qFsbz4zcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.126.tgz",
+      "integrity": "sha512-GO0BnIUw3LQ3XAy+nipAabkN0GwQGPhHB6ITI4XLoR99fLHB3TA6WfyvTf0fnpxd25A+c/+UsAoxz4zBQaHlhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.126.tgz",
+      "integrity": "sha512-yaOTDcYCdscxC0LKg9w8IwSa5g+993WggFZJBTZpqvflA2+WMQeTarDnKlsFTCw9XUZkL8XZeBALYJGx0HutuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.126.tgz",
+      "integrity": "sha512-ByJGO0+mu7EplxSFSCIHd7QWsXdrF3qgtzQ177o/j+oSppLoqR1ot5ktf8aw5oR3CC5lFHg4tqd6TnneQpEoIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.126.tgz",
+      "integrity": "sha512-gv3MOsOBkCx3LajOOIjD7AKsOtz/qNHsS2oshGt2GVoy7JA3XbCDeCetDjM6SorV4SE+7F/IH0UJdXe5ejI/Zg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.126",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.126.tgz",
+      "integrity": "sha512-oRV75HwyoOd1/t5+kipAM2g62CaElpKGvSBx3Ys4lCwCiFUyOnmet/O+hRXENsY6ShDeQZEcJL2UWljr2d5NQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -108,6 +282,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -7194,6 +7377,19 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -9230,6 +9426,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "author": "Emanuele Santonastaso (@OneStepAt4time)",
   "license": "MIT",
   "dependencies": {
+    "@agentclientprotocol/claude-agent-acp": "^0.32.0",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",

--- a/src/__tests__/acp-binary-resolver.test.ts
+++ b/src/__tests__/acp-binary-resolver.test.ts
@@ -1,0 +1,178 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AcpBinaryResolutionError,
+  resolveClaudeAgentAcpBinary,
+} from '../services/acp/binary-resolver.js';
+
+const packageName = '@agentclientprotocol/claude-agent-acp';
+const binName = 'claude-agent-acp';
+
+describe('ACP binary resolver', () => {
+  it('uses AEGIS_ACP_BIN before inspecting the bundled dependency', () => {
+    let packageJsonResolved = false;
+
+    const resolved = resolveClaudeAgentAcpBinary({
+      env: { AEGIS_ACP_BIN: '/opt/acp/custom-agent' },
+      resolvePackageJsonPath: () => {
+        packageJsonResolved = true;
+        return '/repo/node_modules/@agentclientprotocol/claude-agent-acp/package.json';
+      },
+    });
+
+    expect(resolved).toEqual({
+      command: '/opt/acp/custom-agent',
+      args: [],
+      source: 'AEGIS_ACP_BIN',
+      binName,
+      packageName,
+    });
+    expect(packageJsonResolved).toBe(false);
+  });
+
+  it('resolves the bundled package bin through node for cross-platform spawning', () => {
+    const packageJsonPath = path.win32.join(
+      'D:\\aegis',
+      'node_modules',
+      '@agentclientprotocol',
+      'claude-agent-acp',
+      'package.json'
+    );
+    const binPath = path.win32.join(
+      'D:\\aegis',
+      'node_modules',
+      '@agentclientprotocol',
+      'claude-agent-acp',
+      'dist',
+      'index.js'
+    );
+
+    const resolved = resolveClaudeAgentAcpBinary({
+      env: { Path: 'D:\\node\\bin' },
+      platform: 'win32',
+      nodeExecPath: 'C:\\Program Files\\nodejs\\node.exe',
+      resolvePackageJsonPath: () => packageJsonPath,
+      readPackageJson: () => ({
+        name: packageName,
+        bin: { [binName]: 'dist/index.js' },
+      }),
+      fileExists: candidate => candidate === binPath,
+    });
+
+    expect(resolved).toEqual({
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      args: [binPath],
+      source: 'bundled-package-bin',
+      binName,
+      binPath,
+      packageName,
+      packageJsonPath,
+    });
+  });
+
+  it('supports package bin metadata expressed as a string', () => {
+    const packageJsonPath = path.posix.join(
+      '/repo',
+      'node_modules',
+      '@agentclientprotocol',
+      'claude-agent-acp',
+      'package.json'
+    );
+    const binPath = path.posix.join(
+      '/repo',
+      'node_modules',
+      '@agentclientprotocol',
+      'claude-agent-acp',
+      'dist',
+      'index.js'
+    );
+
+    const resolved = resolveClaudeAgentAcpBinary({
+      platform: 'linux',
+      nodeExecPath: '/usr/bin/node',
+      resolvePackageJsonPath: () => packageJsonPath,
+      readPackageJson: () => ({
+        name: packageName,
+        bin: 'dist/index.js',
+      }),
+      fileExists: candidate => candidate === binPath,
+    });
+
+    expect(resolved.command).toBe('/usr/bin/node');
+    expect(resolved.args).toEqual([binPath]);
+    expect(resolved.source).toBe('bundled-package-bin');
+  });
+
+  it('resolves the installed dependency by default without spawning a process', () => {
+    const resolved = resolveClaudeAgentAcpBinary({ env: {} });
+
+    expect(resolved.command).toBe(process.execPath);
+    expect(resolved.args).toHaveLength(1);
+    expect(resolved.args[0]).toContain(
+      path.join('node_modules', '@agentclientprotocol', 'claude-agent-acp')
+    );
+    expect(resolved.source).toBe('bundled-package-bin');
+    expect(resolved.binName).toBe(binName);
+    expect(resolved.packageName).toBe(packageName);
+  });
+
+  it('throws a structured missing-binary error when the dependency bin cannot be found', () => {
+    const packageJsonPath = path.posix.join(
+      '/repo',
+      'node_modules',
+      '@agentclientprotocol',
+      'claude-agent-acp',
+      'package.json'
+    );
+    const binPath = path.posix.join(
+      '/repo',
+      'node_modules',
+      '@agentclientprotocol',
+      'claude-agent-acp',
+      'dist',
+      'index.js'
+    );
+
+    expect(() =>
+      resolveClaudeAgentAcpBinary({
+        env: { PATH: '/usr/local/bin' },
+        platform: 'linux',
+        nodeExecPath: '/usr/bin/node',
+        resolvePackageJsonPath: () => packageJsonPath,
+        readPackageJson: () => ({
+          name: packageName,
+          bin: { [binName]: 'dist/index.js' },
+        }),
+        fileExists: () => false,
+      })
+    ).toThrow(AcpBinaryResolutionError);
+
+    try {
+      resolveClaudeAgentAcpBinary({
+        platform: 'linux',
+        nodeExecPath: '/usr/bin/node',
+        resolvePackageJsonPath: () => packageJsonPath,
+        readPackageJson: () => ({
+          name: packageName,
+          bin: { [binName]: 'dist/index.js' },
+        }),
+        fileExists: () => false,
+      });
+      throw new Error('expected resolver to throw');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AcpBinaryResolutionError);
+      expect(error).toMatchObject({
+        name: 'AcpBinaryResolutionError',
+        code: 'AEGIS_ACP_BINARY_NOT_FOUND',
+        details: {
+          attemptedPaths: [binPath],
+          binName,
+          envVar: 'AEGIS_ACP_BIN',
+          packageJsonPath,
+          packageName,
+        },
+      });
+    }
+  });
+});

--- a/src/__tests__/acp-lifecycle-probe.test.ts
+++ b/src/__tests__/acp-lifecycle-probe.test.ts
@@ -814,7 +814,9 @@ describe('acp lifecycle probe', () => {
       message,
     }));
 
-    expect(acpEventStream.normalizeAcpFrames(rawFrames)).toEqual(readJsonFixture(normalizedEventFixturePath));
+    expect(acpEventStream.normalizeAcpFrames(rawFrames)).toEqual(
+      readJsonFixture(normalizedEventFixturePath)
+    );
   });
 
   it('converts normalized ACP usage events into Claude JSONL token deltas', async () => {
@@ -823,7 +825,9 @@ describe('acp lifecycle probe', () => {
       prompt: 'emit-event-stream',
       sessionCwd: 'D:\\aegis\\redacted-session',
     });
-    expect(extractTokenDelta(acpEventStream.acpUsageEventsToClaudeJsonl(result.normalizedEvents))).toEqual({
+    expect(
+      extractTokenDelta(acpEventStream.acpUsageEventsToClaudeJsonl(result.normalizedEvents))
+    ).toEqual({
       inputTokens: 1200,
       outputTokens: 340,
       cacheCreationTokens: 128,
@@ -846,7 +850,7 @@ describe('acp lifecycle probe', () => {
     });
   });
 
-  it('resolves explicit, environment, local package, and npm fallback commands', () => {
+  it('resolves explicit, environment, and bundled package commands', () => {
     expect(
       resolveAcpCommand({
         explicitCommand: 'D:\\tools\\claude-agent-acp.cmd',
@@ -872,37 +876,34 @@ describe('acp lifecycle probe', () => {
       command: 'cmd.exe',
       args: ['/d', '/s', '/c', '"C:\\Program Files\\ACP\\claude-agent-acp.cmd"'],
       source: 'AEGIS_ACP_BIN',
+      binName: 'claude-agent-acp',
+      packageName: '@agentclientprotocol/claude-agent-acp',
     });
 
     expect(
       resolveAcpCommand({
         platform: 'win32',
         env: {},
-        cwd: 'D:\\repo',
-        fileExists: candidate => candidate.endsWith('node_modules\\.bin\\claude-agent-acp.cmd'),
+        nodeExecPath: 'C:\\Program Files\\nodejs\\node.exe',
+        resolvePackageJsonPath: () =>
+          'D:\\repo\\node_modules\\@agentclientprotocol\\claude-agent-acp\\package.json',
+        readPackageJson: () => ({
+          name: '@agentclientprotocol/claude-agent-acp',
+          bin: { 'claude-agent-acp': 'dist/index.js' },
+        }),
+        fileExists: candidate =>
+          candidate ===
+          'D:\\repo\\node_modules\\@agentclientprotocol\\claude-agent-acp\\dist\\index.js',
       })
     ).toEqual({
-      command: 'cmd.exe',
-      args: ['/d', '/s', '/c', '"D:\\repo\\node_modules\\.bin\\claude-agent-acp.cmd"'],
-      source: 'local-package-bin',
-    });
-
-    expect(
-      resolveAcpCommand({
-        platform: 'win32',
-        env: {},
-        cwd: 'D:\\repo',
-        fileExists: () => false,
-      })
-    ).toEqual({
-      command: 'cmd.exe',
-      args: [
-        '/d',
-        '/s',
-        '/c',
-        'npm.cmd exec --yes --package=@agentclientprotocol/claude-agent-acp -- claude-agent-acp',
-      ],
-      source: 'npm-exec',
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      args: ['D:\\repo\\node_modules\\@agentclientprotocol\\claude-agent-acp\\dist\\index.js'],
+      source: 'bundled-package-bin',
+      binName: 'claude-agent-acp',
+      binPath: 'D:\\repo\\node_modules\\@agentclientprotocol\\claude-agent-acp\\dist\\index.js',
+      packageName: '@agentclientprotocol/claude-agent-acp',
+      packageJsonPath:
+        'D:\\repo\\node_modules\\@agentclientprotocol\\claude-agent-acp\\package.json',
     });
   });
 });

--- a/src/acp-lifecycle-probe.ts
+++ b/src/acp-lifecycle-probe.ts
@@ -1,6 +1,4 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import path from 'node:path';
 
 import {
   type AcpCapturedFrame,
@@ -8,8 +6,21 @@ import {
   normalizeAcpFrames,
 } from './acp-event-stream.js';
 import { buildAcpResolveEnv, buildAcpSpawnEnv } from './acp-spawn-env.js';
+import {
+  resolveClaudeAgentAcpBinary,
+  type AcpCommandSource,
+  type ResolveAcpCommandOptions,
+  type ResolvedAcpCommand,
+} from './services/acp/binary-resolver.js';
 
 export type { AcpCapturedFrame, AcpNormalizedEvent } from './acp-event-stream.js';
+export {
+  AcpBinaryResolutionError,
+  resolveClaudeAgentAcpBinary as resolveAcpCommand,
+  type AcpCommandSource,
+  type ResolveAcpCommandOptions,
+  type ResolvedAcpCommand,
+} from './services/acp/binary-resolver.js';
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const EXIT_TIMEOUT_MS = 2_000;
@@ -19,7 +30,6 @@ const APPROVAL_ARRAY_LIMIT_ITEMS = 25;
 const APPROVAL_OBJECT_LIMIT_KEYS = 50;
 const APPROVAL_WRITE_EXIT_GRACE_MS = 100;
 
-export type AcpCommandSource = 'explicit' | 'AEGIS_ACP_BIN' | 'local-package-bin' | 'npm-exec';
 export type AcpModelProvider =
   | 'anthropic'
   | 'glm'
@@ -45,22 +55,6 @@ export type AcpApprovalRejectionReason =
 type Platform = NodeJS.Platform;
 export type JsonObject = Record<string, unknown>;
 type JsonRpcId = number | string | null;
-
-type FileExists = (candidate: string) => boolean;
-
-export interface ResolvedAcpCommand {
-  command: string;
-  args: string[];
-  source: AcpCommandSource;
-}
-
-export interface ResolveAcpCommandOptions {
-  explicitCommand?: string;
-  cwd?: string;
-  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
-  platform?: Platform;
-  fileExists?: FileExists;
-}
 
 export interface AcpAgentInfo {
   name: string;
@@ -229,36 +223,6 @@ export class AcpProtocolError extends Error {
     this.name = 'AcpProtocolError';
     this.details = details;
   }
-}
-
-export function resolveAcpCommand(options: ResolveAcpCommandOptions = {}): ResolvedAcpCommand {
-  const env = options.env ?? process.env;
-  const platform = options.platform ?? process.platform;
-  const cwd = options.cwd ?? process.cwd();
-  const fileExists = options.fileExists ?? existsSync;
-  const pathTools = platform === 'win32' ? path.win32 : path.posix;
-
-  if (options.explicitCommand && options.explicitCommand.trim() !== '') {
-    return toSpawnableCommand(options.explicitCommand, [], 'explicit', platform);
-  }
-
-  const envCommand = env.AEGIS_ACP_BIN;
-  if (envCommand && envCommand.trim() !== '') {
-    return toSpawnableCommand(envCommand, [], 'AEGIS_ACP_BIN', platform);
-  }
-
-  const packageBinName = platform === 'win32' ? 'claude-agent-acp.cmd' : 'claude-agent-acp';
-  const packageBin = pathTools.join(cwd, 'node_modules', '.bin', packageBinName);
-  if (fileExists(packageBin)) {
-    return toSpawnableCommand(packageBin, [], 'local-package-bin', platform);
-  }
-
-  return toSpawnableCommand(
-    platform === 'win32' ? 'npm.cmd' : 'npm',
-    ['exec', '--yes', '--package=@agentclientprotocol/claude-agent-acp', '--', 'claude-agent-acp'],
-    'npm-exec',
-    platform
-  );
 }
 
 const BYO_LLM_PROVIDER_ENV_KEYS: Record<AcpModelProvider, readonly string[]> = {
@@ -442,33 +406,6 @@ function isSensitiveKey(key: string): boolean {
   return /(?:AUTH|TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)/i.test(key);
 }
 
-function toSpawnableCommand(
-  command: string,
-  args: string[],
-  source: AcpCommandSource,
-  platform: Platform
-): ResolvedAcpCommand {
-  if (platform !== 'win32' || !/\.(cmd|bat)$/i.test(command)) {
-    return { command, args, source };
-  }
-
-  return {
-    command: 'cmd.exe',
-    args: [
-      '/d',
-      '/s',
-      '/c',
-      [quoteWindowsCmdArg(command), ...args.map(quoteWindowsCmdArg)].join(' '),
-    ],
-    source,
-  };
-}
-
-function quoteWindowsCmdArg(value: string): string {
-  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
-  return `"${value.replace(/(["^&|<>%])/g, '^$1')}"`;
-}
-
 export async function runAcpLifecycleProbe(
   options: AcpLifecycleProbeOptions
 ): Promise<AcpLifecycleProbeResult> {
@@ -483,7 +420,7 @@ export async function runAcpLifecycleProbe(
       source: 'explicit',
     };
   } else {
-    resolvedCommand = resolveAcpCommand({
+    resolvedCommand = resolveClaudeAgentAcpBinary({
       cwd: options.cwd,
       env: buildAcpResolveEnv(options.env),
     });

--- a/src/services/acp/binary-resolver.ts
+++ b/src/services/acp/binary-resolver.ts
@@ -1,0 +1,266 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const requireFromAegis = createRequire(import.meta.url);
+
+export const CLAUDE_AGENT_ACP_PACKAGE = '@agentclientprotocol/claude-agent-acp';
+export const CLAUDE_AGENT_ACP_BIN = 'claude-agent-acp';
+export const AEGIS_ACP_BIN_ENV = 'AEGIS_ACP_BIN';
+
+export type AcpCommandSource = 'explicit' | 'AEGIS_ACP_BIN' | 'bundled-package-bin';
+
+export interface ResolvedAcpCommand {
+  command: string;
+  args: string[];
+  source: AcpCommandSource;
+  binName?: string;
+  binPath?: string;
+  packageName?: string;
+  packageJsonPath?: string;
+}
+
+export interface ResolveAcpCommandOptions {
+  explicitCommand?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+  nodeExecPath?: string;
+  fileExists?: (candidate: string) => boolean;
+  resolvePackageJsonPath?: () => string | undefined;
+  readPackageJson?: (packageJsonPath: string) => unknown;
+}
+
+export interface AcpBinaryResolutionErrorDetails {
+  attemptedPaths: string[];
+  binName: string;
+  envVar: string;
+  packageName: string;
+  packageJsonPath?: string;
+  reason?: string;
+}
+
+export class AcpBinaryResolutionError extends Error {
+  readonly code = 'AEGIS_ACP_BINARY_NOT_FOUND';
+  readonly details: AcpBinaryResolutionErrorDetails;
+
+  constructor(message: string, details: AcpBinaryResolutionErrorDetails) {
+    super(message);
+    this.name = 'AcpBinaryResolutionError';
+    this.details = details;
+  }
+}
+
+export function resolveClaudeAgentAcpBinary(
+  options: ResolveAcpCommandOptions = {}
+): ResolvedAcpCommand {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+
+  if (options.explicitCommand && options.explicitCommand.trim() !== '') {
+    return toSpawnableCommand(options.explicitCommand, [], 'explicit', platform);
+  }
+
+  const envCommand = env[AEGIS_ACP_BIN_ENV];
+  if (envCommand && envCommand.trim() !== '') {
+    return {
+      ...toSpawnableCommand(envCommand, [], 'AEGIS_ACP_BIN', platform),
+      binName: CLAUDE_AGENT_ACP_BIN,
+      packageName: CLAUDE_AGENT_ACP_PACKAGE,
+    };
+  }
+
+  const packageJsonPath = resolvePackageJsonPath(options);
+  const attemptedPaths: string[] = [];
+  if (packageJsonPath !== undefined) {
+    const binPath = resolvePackageBinPath(packageJsonPath, options, platform);
+    attemptedPaths.push(binPath);
+    const fileExists = options.fileExists ?? existsSync;
+    if (fileExists(binPath)) {
+      return {
+        command: options.nodeExecPath ?? process.execPath,
+        args: [binPath],
+        source: 'bundled-package-bin',
+        binName: CLAUDE_AGENT_ACP_BIN,
+        binPath,
+        packageName: CLAUDE_AGENT_ACP_PACKAGE,
+        packageJsonPath,
+      };
+    }
+  }
+
+  throw new AcpBinaryResolutionError(
+    `Unable to resolve ${CLAUDE_AGENT_ACP_BIN}; install ${CLAUDE_AGENT_ACP_PACKAGE} or set ${AEGIS_ACP_BIN_ENV}`,
+    {
+      attemptedPaths,
+      binName: CLAUDE_AGENT_ACP_BIN,
+      envVar: AEGIS_ACP_BIN_ENV,
+      packageName: CLAUDE_AGENT_ACP_PACKAGE,
+      packageJsonPath,
+      reason: packageJsonPath === undefined ? 'package.json not found' : 'package bin not found',
+    }
+  );
+}
+
+function resolvePackageJsonPath(options: ResolveAcpCommandOptions): string | undefined {
+  if (options.resolvePackageJsonPath) {
+    return options.resolvePackageJsonPath();
+  }
+
+  try {
+    return requireFromAegis.resolve(`${CLAUDE_AGENT_ACP_PACKAGE}/package.json`);
+  } catch {
+    const packageJsonFromModuleTree = resolvePackageJsonPathFromModuleTree(options);
+    if (packageJsonFromModuleTree) return packageJsonFromModuleTree;
+
+    const packageJsonFromEntrypoint = resolvePackageJsonPathFromEntrypoint(options);
+    return (
+      packageJsonFromEntrypoint ??
+      resolvePackageJsonPathFromCwd(options.cwd ?? process.cwd(), options)
+    );
+  }
+}
+
+function resolvePackageJsonPathFromModuleTree(
+  options: ResolveAcpCommandOptions
+): string | undefined {
+  const fileExists = options.fileExists ?? existsSync;
+  let directory = path.dirname(fileURLToPath(import.meta.url));
+
+  while (true) {
+    const candidate = path.join(
+      directory,
+      'node_modules',
+      '@agentclientprotocol',
+      'claude-agent-acp',
+      'package.json'
+    );
+    if (fileExists(candidate)) return candidate;
+
+    const parent = path.dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+function resolvePackageJsonPathFromEntrypoint(
+  options: ResolveAcpCommandOptions
+): string | undefined {
+  let entrypoint: string;
+  try {
+    entrypoint = requireFromAegis.resolve(CLAUDE_AGENT_ACP_PACKAGE);
+  } catch {
+    return undefined;
+  }
+
+  const fileExists = options.fileExists ?? existsSync;
+  let directory = path.dirname(entrypoint);
+  while (true) {
+    const candidate = path.join(directory, 'package.json');
+    if (fileExists(candidate)) return candidate;
+
+    const parent = path.dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+function resolvePackageJsonPathFromCwd(
+  cwd: string,
+  options: ResolveAcpCommandOptions
+): string | undefined {
+  const platform = options.platform ?? process.platform;
+  const pathTools = platform === 'win32' ? path.win32 : path.posix;
+  const candidate = pathTools.join(
+    cwd,
+    'node_modules',
+    '@agentclientprotocol',
+    'claude-agent-acp',
+    'package.json'
+  );
+  const fileExists = options.fileExists ?? existsSync;
+  return fileExists(candidate) ? candidate : undefined;
+}
+
+function resolvePackageBinPath(
+  packageJsonPath: string,
+  options: ResolveAcpCommandOptions,
+  platform: NodeJS.Platform
+): string {
+  const packageJson = options.readPackageJson
+    ? options.readPackageJson(packageJsonPath)
+    : readPackageJson(packageJsonPath);
+  const binRelativePath = getPackageBinPath(packageJson);
+  const pathTools = platform === 'win32' ? path.win32 : path.posix;
+  return pathTools.resolve(pathTools.dirname(packageJsonPath), binRelativePath);
+}
+
+function readPackageJson(packageJsonPath: string): unknown {
+  const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  return parsed;
+}
+
+function getPackageBinPath(packageJson: unknown): string {
+  if (!isRecord(packageJson)) {
+    throw invalidPackageBin('package.json is not an object');
+  }
+
+  const bin = packageJson.bin;
+  if (typeof bin === 'string' && bin.trim() !== '') {
+    return bin;
+  }
+
+  if (isRecord(bin)) {
+    const packageBin = bin[CLAUDE_AGENT_ACP_BIN];
+    if (typeof packageBin === 'string' && packageBin.trim() !== '') {
+      return packageBin;
+    }
+  }
+
+  throw invalidPackageBin(`package.json bin does not define ${CLAUDE_AGENT_ACP_BIN}`);
+}
+
+function invalidPackageBin(reason: string): AcpBinaryResolutionError {
+  return new AcpBinaryResolutionError(
+    `Unable to resolve ${CLAUDE_AGENT_ACP_BIN}; invalid ${CLAUDE_AGENT_ACP_PACKAGE} package metadata`,
+    {
+      attemptedPaths: [],
+      binName: CLAUDE_AGENT_ACP_BIN,
+      envVar: AEGIS_ACP_BIN_ENV,
+      packageName: CLAUDE_AGENT_ACP_PACKAGE,
+      reason,
+    }
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toSpawnableCommand(
+  command: string,
+  args: string[],
+  source: AcpCommandSource,
+  platform: NodeJS.Platform
+): ResolvedAcpCommand {
+  if (platform !== 'win32' || !/\.(cmd|bat)$/i.test(command)) {
+    return { command, args, source };
+  }
+
+  return {
+    command: 'cmd.exe',
+    args: [
+      '/d',
+      '/s',
+      '/c',
+      [quoteWindowsCmdArg(command), ...args.map(quoteWindowsCmdArg)].join(' '),
+    ],
+    source,
+  };
+}
+
+function quoteWindowsCmdArg(value: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
+  return `"${value.replace(/(["^&|<>%])/g, '^$1')}"`;
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -84,6 +84,16 @@ export {
   type PostgresAcpActionQueueConfig,
 } from './postgres-action-queue.js';
 export {
+  AcpBinaryResolutionError,
+  AEGIS_ACP_BIN_ENV,
+  CLAUDE_AGENT_ACP_BIN,
+  CLAUDE_AGENT_ACP_PACKAGE,
+  resolveClaudeAgentAcpBinary,
+  type AcpCommandSource,
+  type ResolveAcpCommandOptions,
+  type ResolvedAcpCommand,
+} from './binary-resolver.js';
+export {
   FileAcpLocalStorageProfile,
   MemoryAcpActionQueue,
   MemoryAcpEventStore,


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Add @agentclientprotocol/claude-agent-acp as the bundled ACP runtime dependency.
- Add a typed ACP binary resolver with explicit command, AEGIS_ACP_BIN override, bundled package-bin resolution, and structured missing-binary errors.
- Wire existing ACP probes through the resolver while keeping tests fixture-only and avoiding real Claude/ACP process spawns.

## Test Plan
- [x] npm test -- src\__tests__\acp-binary-resolver.test.ts src\__tests__\acp-lifecycle-probe.test.ts src\__tests__\acp-terminal-extension-probe.test.ts src\__tests__\acp-spawn-env.test.ts
- [x] npx tsc --noEmit
- [x] powershell -NoProfile -ExecutionPolicy Bypass -Command "npm run gate"

Closes #2594