### PR TITLE
refactor: add ACP pause intervention persistence

### DIFF
--- a/src/__tests__/acp-postgres-pause-intervention-store.test.ts
+++ b/src/__tests__/acp-postgres-pause-intervention-store.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Pool } from 'pg';
+
+import {
+  AcpDurableIdentityError,
+  AcpValidationError,
+  type AcpSessionScope,
+} from '../services/acp/index.js';
+import { PostgresAcpPauseInterventionStore } from '../services/acp/postgres-pause-intervention-store.js';
+
+type MockQueryResult = { rows: unknown[] };
+type MockQueryFn = ReturnType<typeof vi.fn<(sql: string, params?: unknown[]) => Promise<MockQueryResult>>>;
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+function makeMockPool() {
+  const query = vi.fn<(sql: string, params?: unknown[]) => Promise<MockQueryResult>>();
+  const end = vi.fn<() => Promise<void>>();
+  query.mockResolvedValue({ rows: [] });
+  end.mockResolvedValue();
+  return { query, end };
+}
+
+function createStore(config?: { schemaName?: string; tableName?: string; poolMax?: number }): {
+  store: PostgresAcpPauseInterventionStore;
+  mocks: { query: MockQueryFn; end: ReturnType<typeof vi.fn<() => Promise<void>>> };
+} {
+  const mocks = makeMockPool();
+  const store = new PostgresAcpPauseInterventionStore({
+    url: 'postgresql://test:test@localhost:5432/aegis_test',
+    ...config,
+  });
+
+  Object.defineProperty(store, 'pool', {
+    value: {
+      query: mocks.query,
+      end: mocks.end,
+    },
+    writable: true,
+  });
+
+  return { store, mocks };
+}
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    pause_id: 'pause-1',
+    session_id: 'session-1',
+    tenant_id: 'tenant-a',
+    owner_key_id: 'owner-a',
+    status: 'paused',
+    idempotency_key: null,
+    reason: 'operator requested review',
+    requested_by: 'operator-1',
+    requested_at: new Date('2026-01-01T00:00:00.000Z'),
+    metadata: {},
+    intervention_id: null,
+    intervention_by: null,
+    intervention_started_at: null,
+    intervention_completed_by: null,
+    intervention_completed_at: null,
+    guidance: null,
+    resume_id: null,
+    resumed_by: null,
+    resumed_at: null,
+    resume_metadata: null,
+    updated_at: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function pauseInput(overrides: Partial<Parameters<PostgresAcpPauseInterventionStore['pause']>[0]> = {}) {
+  return {
+    tenantId: 'tenant-a',
+    ownerKeyId: 'owner-a',
+    sessionId: 'session-1',
+    pauseId: 'pause-1',
+    reason: 'operator requested review',
+    requestedBy: 'operator-1',
+    ...overrides,
+  };
+}
+
+describe('PostgresAcpPauseInterventionStore constructor', () => {
+  it('rejects unsafe identifiers and pool sizes before SQL interpolation', () => {
+    expect(
+      () =>
+        new PostgresAcpPauseInterventionStore({
+          url: 'postgresql://localhost/test',
+          schemaName: 'public; DROP TABLE acp_pause_interventions',
+        })
+    ).toThrow('invalid schema name');
+    expect(
+      () =>
+        new PostgresAcpPauseInterventionStore({
+          url: 'postgresql://localhost/test',
+          tableName: 'acp-pause-interventions',
+        })
+    ).toThrow('invalid table name');
+    expect(
+      () => new PostgresAcpPauseInterventionStore({ url: 'postgresql://localhost/test', poolMax: 0 })
+    ).toThrow('poolMax');
+  });
+
+  it('creates the lifecycle table with scoped active and idempotency indexes', async () => {
+    const { store, mocks } = createStore({ schemaName: 'tenant_1', tableName: 'acp_pause_interventions' });
+    mocks.query.mockResolvedValue({ rows: [{ ok: 1 }] });
+
+    await store.start();
+
+    const schemaSql = mocks.query.mock.calls.map(call => call[0]).join('\n');
+    expect(schemaSql).toContain('CREATE SCHEMA IF NOT EXISTS "tenant_1"');
+    expect(schemaSql).toContain('CREATE TABLE IF NOT EXISTS "tenant_1"."acp_pause_interventions"');
+    expect(schemaSql).toContain('pause_id');
+    expect(schemaSql).toContain('session_id');
+    expect(schemaSql).toContain('tenant_id');
+    expect(schemaSql).toContain('owner_key_id');
+    expect(schemaSql).toContain('status');
+    expect(schemaSql).toContain('intervention_id');
+    expect(schemaSql).toContain('resume_id');
+    expect(schemaSql).toContain('WHERE idempotency_key IS NOT NULL');
+    expect(schemaSql).toContain("WHERE status IN ('paused', 'intervening')");
+    expect(schemaSql).toContain('SELECT 1 AS ok');
+  });
+
+  it('clears and closes the pool when startup fails so initialization can retry', async () => {
+    const query = vi
+      .spyOn(Pool.prototype, 'query')
+      .mockRejectedValueOnce(new Error('schema unavailable'))
+      .mockResolvedValue({ rows: [{ ok: 1 }] } as never);
+    const end = vi.spyOn(Pool.prototype, 'end').mockResolvedValue(undefined as never);
+    const store = new PostgresAcpPauseInterventionStore({ url: 'postgresql://localhost/test' });
+
+    await expect(store.start()).rejects.toThrow('schema unavailable');
+    expect(end).toHaveBeenCalledTimes(1);
+    await expect(store.stop()).resolves.toBeUndefined();
+    await store.start();
+
+    expect(query.mock.calls.length).toBeGreaterThan(1);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('PostgresAcpPauseInterventionStore.pause()', () => {
+  it('validates, serializes, and parameterizes a scoped pause request', async () => {
+    const { store, mocks } = createStore();
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [makeRow({ idempotency_key: 'pause-key-1', metadata: { source: 'api' } })] });
+
+    const record = await store.pause(
+      pauseInput({ idempotencyKey: 'pause-key-1', metadata: { source: 'api' } })
+    );
+
+    expect(record).toMatchObject({
+      pauseId: 'pause-1',
+      sessionId: 'session-1',
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+      status: 'paused',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+      metadata: { source: 'api' },
+    });
+    const insertCall = mocks.query.mock.calls.find(call => call[0].includes('INSERT'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.[0]).toContain('$1');
+    expect(insertCall?.[0]).not.toContain('operator requested review');
+    expect(insertCall?.[1]).toEqual([
+      'pause-1',
+      'session-1',
+      'tenant-a',
+      'owner-a',
+      'pause-key-1',
+      'operator requested review',
+      'operator-1',
+      undefined,
+      { source: 'api' },
+    ]);
+  });
+
+  it('returns an existing scoped pause for a repeated idempotency key', async () => {
+    const { store, mocks } = createStore();
+    mocks.query.mockResolvedValueOnce({ rows: [makeRow({ pause_id: 'existing-pause', idempotency_key: 'pause-key-1' })] });
+
+    const record = await store.pause(pauseInput({ pauseId: 'new-pause', idempotencyKey: 'pause-key-1' }));
+
+    expect(record.pauseId).toBe('existing-pause');
+    expect(record.idempotencyKey).toBe('pause-key-1');
+    expect(mocks.query.mock.calls).toHaveLength(1);
+    expect(mocks.query.mock.calls[0][0]).toContain('WHERE tenant_id = $1');
+    expect(mocks.query.mock.calls[0][1]).toEqual(['tenant-a', 'owner-a', 'session-1', 'pause-key-1']);
+  });
+
+  it('rejects unsafe metadata and JSON-RPC request ids before persistence', async () => {
+    const { store, mocks } = createStore();
+    const decodedPause: unknown = {
+      ...pauseInput({ metadata: { source: 'api' } }),
+      jsonRpcRequestId: 7,
+    };
+
+    await expect(store.pause(pauseInput({ metadata: { apiToken: 'secret' } }))).rejects.toBeInstanceOf(AcpValidationError);
+    await expect(store.pause(decodedPause as Parameters<PostgresAcpPauseInterventionStore['pause']>[0])).rejects.toBeInstanceOf(AcpDurableIdentityError);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('does not treat duplicate pause ids as idempotent success', async () => {
+    const { store, mocks } = createStore();
+    mocks.query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(store.pause(pauseInput())).rejects.toThrow('pause id already exists');
+
+    const [sql] = mocks.query.mock.calls[0];
+    expect(sql).toContain('ON CONFLICT (pause_id) DO NOTHING');
+    expect(sql).not.toContain('DO UPDATE');
+  });
+});
+
+describe('PostgresAcpPauseInterventionStore lifecycle', () => {
+  it('reads only the active pause or intervention in the requested scope', async () => {
+    const { store, mocks } = createStore();
+    mocks.query.mockResolvedValueOnce({ rows: [makeRow({ status: 'intervening', intervention_id: 'intervention-1' })] });
+
+    const active = await store.getActive('session-1', scope);
+
+    expect(active?.status).toBe('intervening');
+    expect(active?.interventionId).toBe('intervention-1');
+    expect(mocks.query.mock.calls[0][0]).toContain("status IN ('paused', 'intervening')");
+    expect(mocks.query.mock.calls[0][1]).toEqual(['session-1', 'tenant-a', 'owner-a']);
+  });
+
+  it('starts intervention by transitioning the active pause and is idempotent by intervention id', async () => {
+    const { store, mocks } = createStore();
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [makeRow({ status: 'intervening', intervention_id: 'intervention-1', intervention_by: 'operator-2' })] });
+
+    const record = await store.startIntervention({
+      ...scope,
+      sessionId: 'session-1',
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+
+    expect(record?.status).toBe('intervening');
+    expect(record?.interventionId).toBe('intervention-1');
+    const updateCall = mocks.query.mock.calls.find(call => call[0].includes('UPDATE'));
+    expect(updateCall?.[0]).toContain("status = 'paused'");
+    expect(updateCall?.[1]).toEqual([
+      'session-1',
+      'tenant-a',
+      'owner-a',
+      'intervention-1',
+      'operator-2',
+      undefined,
+    ]);
+  });
+
+
+
+  it('re-reads operation ids after zero-row lifecycle updates so concurrent retries are idempotent', async () => {
+    const { store, mocks } = createStore();
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [makeRow({ status: 'intervening', intervention_id: 'intervention-1' })] });
+
+    const record = await store.startIntervention({
+      ...scope,
+      sessionId: 'session-1',
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+
+    expect(record?.status).toBe('intervening');
+    expect(record?.interventionId).toBe('intervention-1');
+    expect(mocks.query.mock.calls).toHaveLength(2);
+  });
+
+  it('does not overwrite completed intervention fields with a second intervention cycle', async () => {
+    const { store, mocks } = createStore();
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const record = await store.startIntervention({
+      ...scope,
+      sessionId: 'session-1',
+      interventionId: 'intervention-2',
+      interventionBy: 'operator-2',
+    });
+
+    expect(record).toBeNull();
+    const updateCall = mocks.query.mock.calls.find(call => call[0].includes('UPDATE'));
+    expect(updateCall?.[0]).toContain('intervention_id IS NULL');
+  });
+
+  it('returns the latest lifecycle row including resumed state for recovery', async () => {
+    const { store, mocks } = createStore();
+    mocks.query.mockResolvedValueOnce({ rows: [makeRow({ status: 'resumed', resume_id: 'resume-1' })] });
+
+    const latest = await store.getLatest('session-1', scope);
+
+    expect(latest?.status).toBe('resumed');
+    expect(latest?.resumeId).toBe('resume-1');
+    expect(mocks.query.mock.calls[0][0]).not.toContain("status IN ('paused', 'intervening')");
+    expect(mocks.query.mock.calls[0][1]).toEqual(['session-1', 'tenant-a', 'owner-a']);
+  });
+
+  it('completes intervention with durable guidance without resuming the pause', async () => {
+    const { store, mocks } = createStore();
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [makeRow({ status: 'paused', intervention_id: 'intervention-1', intervention_completed_by: 'operator-2', intervention_completed_at: new Date('2026-01-01T00:01:00.000Z'), guidance: 'Wait for approval.' })],
+      });
+
+    const record = await store.completeIntervention({
+      ...scope,
+      sessionId: 'session-1',
+      interventionId: 'intervention-1',
+      completedBy: 'operator-2',
+      guidance: 'Wait for approval.',
+      completedAt: new Date('2026-01-01T00:01:00.000Z'),
+    });
+
+    expect(record?.status).toBe('paused');
+    expect(record?.guidance).toBe('Wait for approval.');
+    expect(record?.interventionCompletedBy).toBe('operator-2');
+    const updateCall = mocks.query.mock.calls.find(call => call[0].includes('UPDATE'));
+    expect(updateCall?.[0]).toContain("status = 'paused'");
+    expect(updateCall?.[0]).toContain("AND status = 'intervening'");
+  });
+
+  it('resumes the active lifecycle once and returns an existing row for a repeated resume id', async () => {
+    const { store, mocks } = createStore();
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [makeRow({ status: 'resumed', resume_id: 'resume-1', resumed_by: 'operator-3', resume_metadata: { releaseQueuedActions: true } })] });
+
+    const record = await store.resume({
+      ...scope,
+      sessionId: 'session-1',
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+      resumeMetadata: { releaseQueuedActions: true },
+    });
+
+    expect(record?.status).toBe('resumed');
+    expect(record?.resumeId).toBe('resume-1');
+    expect(record?.resumeMetadata).toEqual({ releaseQueuedActions: true });
+    const updateCall = mocks.query.mock.calls.find(call => call[0].includes('UPDATE'));
+    expect(updateCall?.[0]).toContain("status IN ('paused', 'intervening')");
+  });
+});

--- a/src/__tests__/acp-session-service-pause-intervention.test.ts
+++ b/src/__tests__/acp-session-service-pause-intervention.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AcpInvalidStateTransitionError,
+  AcpSessionService,
+  type AcpPauseInterventionRecord,
+  type AcpPauseInterventionStore,
+  type AcpPauseSessionInput,
+  type AcpResumeSessionInput,
+  type AcpCompleteInterventionInput,
+  type AcpSessionRecord,
+  type AcpSessionScope,
+  type AcpSessionStore,
+  type AcpStartInterventionInput,
+} from '../services/acp/index.js';
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+function cloneSession(record: AcpSessionRecord): AcpSessionRecord {
+  return {
+    ...record,
+    backendMetadata: record.backendMetadata === undefined ? undefined : { ...record.backendMetadata },
+  };
+}
+
+function clonePause(record: AcpPauseInterventionRecord): AcpPauseInterventionRecord {
+  return {
+    ...record,
+    requestedAt: new Date(record.requestedAt),
+    interventionStartedAt: record.interventionStartedAt === undefined ? undefined : new Date(record.interventionStartedAt),
+    interventionCompletedAt: record.interventionCompletedAt === undefined ? undefined : new Date(record.interventionCompletedAt),
+    resumedAt: record.resumedAt === undefined ? undefined : new Date(record.resumedAt),
+    updatedAt: new Date(record.updatedAt),
+    metadata: record.metadata === undefined ? undefined : { ...record.metadata },
+    resumeMetadata: record.resumeMetadata === undefined ? undefined : { ...record.resumeMetadata },
+  };
+}
+
+class InMemoryScopedAcpSessionStore implements AcpSessionStore {
+  private readonly records = new Map<string, AcpSessionRecord>();
+
+  async create(record: AcpSessionRecord): Promise<void> {
+    this.records.set(record.id, cloneSession(record));
+  }
+
+  async get(id: string, requestedScope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    const record = this.records.get(id);
+    if (!record) return null;
+    if (record.tenantId !== requestedScope.tenantId) return null;
+    if (record.ownerKeyId !== requestedScope.ownerKeyId) return null;
+    return cloneSession(record);
+  }
+
+  async update(record: AcpSessionRecord, requestedScope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    const current = this.records.get(record.id);
+    if (!current) return null;
+    if (current.tenantId !== requestedScope.tenantId) return null;
+    if (current.ownerKeyId !== requestedScope.ownerKeyId) return null;
+    this.records.set(record.id, cloneSession(record));
+    return cloneSession(record);
+  }
+}
+
+class InMemoryPauseInterventionStore implements AcpPauseInterventionStore {
+  readonly pauses: AcpPauseSessionInput[] = [];
+  readonly interventions: AcpStartInterventionInput[] = [];
+  readonly resumes: AcpResumeSessionInput[] = [];
+  readonly completions: AcpCompleteInterventionInput[] = [];
+  private active: AcpPauseInterventionRecord | null = null;
+  private readonly records: AcpPauseInterventionRecord[] = [];
+
+  async pause(input: AcpPauseSessionInput): Promise<AcpPauseInterventionRecord> {
+    this.pauses.push(input);
+    const idempotent = this.records.find(
+      record =>
+        input.idempotencyKey !== undefined &&
+        record.sessionId === input.sessionId &&
+        record.tenantId === input.tenantId &&
+        record.ownerKeyId === input.ownerKeyId &&
+        record.idempotencyKey === input.idempotencyKey
+    );
+    if (idempotent !== undefined) {
+      return clonePause(idempotent);
+    }
+    const now = new Date('2026-01-01T00:00:00.000Z');
+    this.active = {
+      tenantId: input.tenantId,
+      ownerKeyId: input.ownerKeyId,
+      sessionId: input.sessionId,
+      pauseId: input.pauseId,
+      status: 'paused',
+      reason: input.reason,
+      requestedBy: input.requestedBy,
+      requestedAt: input.requestedAt ?? now,
+      updatedAt: input.requestedAt ?? now,
+      idempotencyKey: input.idempotencyKey,
+      metadata: input.metadata,
+    };
+    this.records.push(this.active);
+    return clonePause(this.active);
+  }
+
+  async getActive(sessionId: string, requestedScope: AcpSessionScope): Promise<AcpPauseInterventionRecord | null> {
+    if (!this.active) return null;
+    if (this.active.sessionId !== sessionId) return null;
+    if (this.active.tenantId !== requestedScope.tenantId) return null;
+    if (this.active.ownerKeyId !== requestedScope.ownerKeyId) return null;
+    if (this.active.status === 'resumed') return null;
+    return clonePause(this.active);
+  }
+
+  async startIntervention(input: AcpStartInterventionInput): Promise<AcpPauseInterventionRecord | null> {
+    this.interventions.push(input);
+    if (!this.active || this.active.sessionId !== input.sessionId) return null;
+    const idempotent = this.records.find(
+      record =>
+        record.sessionId === input.sessionId &&
+        record.tenantId === input.tenantId &&
+        record.ownerKeyId === input.ownerKeyId &&
+        record.interventionId === input.interventionId
+    );
+    if (idempotent !== undefined) {
+      return clonePause(idempotent);
+    }
+    this.active = {
+      ...this.active,
+      status: 'intervening',
+      interventionId: input.interventionId,
+      interventionBy: input.interventionBy,
+      interventionStartedAt: input.startedAt ?? new Date('2026-01-01T00:01:00.000Z'),
+      updatedAt: input.startedAt ?? new Date('2026-01-01T00:01:00.000Z'),
+    };
+    this.replaceActive();
+    return clonePause(this.active);
+  }
+
+  async completeIntervention(input: AcpCompleteInterventionInput): Promise<AcpPauseInterventionRecord | null> {
+    this.completions.push(input);
+    const idempotent = this.records.find(
+      record =>
+        record.sessionId === input.sessionId &&
+        record.tenantId === input.tenantId &&
+        record.ownerKeyId === input.ownerKeyId &&
+        record.interventionId === input.interventionId &&
+        record.interventionCompletedAt !== undefined
+    );
+    if (idempotent !== undefined) {
+      return clonePause(idempotent);
+    }
+    if (!this.active || this.active.sessionId !== input.sessionId) return null;
+    this.active = {
+      ...this.active,
+      status: 'paused',
+      interventionCompletedBy: input.completedBy,
+      interventionCompletedAt: input.completedAt ?? new Date('2026-01-01T00:01:30.000Z'),
+      guidance: input.guidance,
+      updatedAt: input.completedAt ?? new Date('2026-01-01T00:01:30.000Z'),
+    };
+    this.replaceActive();
+    return clonePause(this.active);
+  }
+
+  async getLatest(sessionId: string, requestedScope: AcpSessionScope): Promise<AcpPauseInterventionRecord | null> {
+    if (!this.active) return null;
+    if (this.active.sessionId !== sessionId) return null;
+    if (this.active.tenantId !== requestedScope.tenantId) return null;
+    if (this.active.ownerKeyId !== requestedScope.ownerKeyId) return null;
+    return clonePause(this.active);
+  }
+
+  async resume(input: AcpResumeSessionInput): Promise<AcpPauseInterventionRecord | null> {
+    this.resumes.push(input);
+    const idempotent = this.records.find(
+      record =>
+        record.sessionId === input.sessionId &&
+        record.tenantId === input.tenantId &&
+        record.ownerKeyId === input.ownerKeyId &&
+        record.resumeId === input.resumeId
+    );
+    if (idempotent !== undefined) {
+      return clonePause(idempotent);
+    }
+    if (!this.active || this.active.sessionId !== input.sessionId) return null;
+    this.active = {
+      ...this.active,
+      status: 'resumed',
+      resumeId: input.resumeId,
+      resumedBy: input.resumedBy,
+      resumedAt: input.resumedAt ?? new Date('2026-01-01T00:02:00.000Z'),
+      resumeMetadata: input.resumeMetadata,
+      updatedAt: input.resumedAt ?? new Date('2026-01-01T00:02:00.000Z'),
+    };
+    this.replaceActive();
+    return clonePause(this.active);
+  }
+
+  private replaceActive(): void {
+    if (this.active === null) return;
+    const index = this.records.findIndex(record => record.pauseId === this.active?.pauseId);
+    if (index === -1) {
+      this.records.push(this.active);
+    } else {
+      this.records[index] = this.active;
+    }
+  }
+}
+
+function createService(): { service: AcpSessionService; pauseStore: InMemoryPauseInterventionStore } {
+  const sessionStore = new InMemoryScopedAcpSessionStore();
+  const pauseStore = new InMemoryPauseInterventionStore();
+  const ids = ['session-1', 'conversation-1', 'transcript-1'];
+  let idIndex = 0;
+  let now = 1_700_000_000_000;
+  const service = new AcpSessionService(sessionStore, {
+    idProvider: () => ids[idIndex++] ?? `generated-${idIndex}`,
+    clock: () => {
+      now += 100;
+      return now;
+    },
+    pauseInterventionStore: pauseStore,
+  });
+  return { service, pauseStore };
+}
+
+async function createRunningSession(service: AcpSessionService): Promise<AcpSessionRecord> {
+  const created = await service.createSession(scope);
+  await service.transition(created.id, scope, { type: 'agent_ready' });
+  return service.transition(created.id, scope, { type: 'run_started' });
+}
+
+describe('AcpSessionService pause/intervention policy', () => {
+  it('persists a pause and transitions a running session to paused', async () => {
+    const { service, pauseStore } = createService();
+    const running = await createRunningSession(service);
+
+    const result = await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+    });
+
+    expect(result.session.status).toBe('paused');
+    expect(result.pause.status).toBe('paused');
+    expect(pauseStore.pauses).toHaveLength(1);
+    expect(pauseStore.pauses[0]).toMatchObject({
+      tenantId: 'tenant-a',
+      ownerKeyId: 'owner-a',
+      sessionId: running.id,
+      pauseId: 'pause-1',
+      idempotencyKey: 'pause-key-1',
+    });
+  });
+
+  it('does not persist a pause when the session is not running', async () => {
+    const { service, pauseStore } = createService();
+    const created = await service.createSession(scope);
+
+    await expect(
+      service.pauseSession(created.id, scope, {
+        pauseId: 'pause-1',
+        reason: 'operator requested review',
+        requestedBy: 'operator-1',
+      })
+    ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
+    expect(pauseStore.pauses).toHaveLength(0);
+  });
+
+  it('starts intervention from a paused session and keeps the runtime backend out of policy', async () => {
+    const { service, pauseStore } = createService();
+    const running = await createRunningSession(service);
+    await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+    });
+
+    const result = await service.startIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+
+    expect(result.session.status).toBe('intervening');
+    expect(result.pause.status).toBe('intervening');
+    expect(pauseStore.interventions).toEqual([
+      {
+        tenantId: 'tenant-a',
+        ownerKeyId: 'owner-a',
+        sessionId: running.id,
+        interventionId: 'intervention-1',
+        interventionBy: 'operator-2',
+      },
+    ]);
+  });
+
+
+
+  it('returns durable rows for idempotent retries after session state already advanced', async () => {
+    const { service, pauseStore } = createService();
+    const running = await createRunningSession(service);
+
+    const firstPause = await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+    });
+    const secondPause = await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1-retry',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+    });
+    const firstIntervention = await service.startIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+    const secondIntervention = await service.startIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+    const firstResume = await service.resumeSession(running.id, scope, {
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+    });
+    const secondResume = await service.resumeSession(running.id, scope, {
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+    });
+
+    expect(firstPause.session.status).toBe('paused');
+    expect(secondPause.session.status).toBe('paused');
+    expect(secondPause.pause.pauseId).toBe('pause-1');
+    expect(firstIntervention.session.status).toBe('intervening');
+    expect(secondIntervention.session.status).toBe('intervening');
+    expect(firstResume.session.status).toBe('running');
+    expect(secondResume.session.status).toBe('running');
+    expect(pauseStore.pauses).toHaveLength(2);
+  });
+
+
+
+  it('does not move a running session backward when retrying an old pause after resume', async () => {
+    const { service } = createService();
+    const running = await createRunningSession(service);
+    await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+    });
+    await service.resumeSession(running.id, scope, {
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+    });
+
+    const retry = await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1-retry',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+    });
+
+    expect(retry.pause.status).toBe('resumed');
+    expect(retry.session.status).toBe('running');
+  });
+
+
+
+  it('reconciles old pause retries from the latest lifecycle when a newer pause is active', async () => {
+    const { service } = createService();
+    const running = await createRunningSession(service);
+    await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'first pause',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+    });
+    await service.resumeSession(running.id, scope, {
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+    });
+    await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-2',
+      reason: 'second pause',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-2',
+    });
+
+    const retry = await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1-retry',
+      reason: 'first pause',
+      requestedBy: 'operator-1',
+      idempotencyKey: 'pause-key-1',
+    });
+
+    expect(retry.pause.pauseId).toBe('pause-1');
+    expect(retry.pause.status).toBe('resumed');
+    expect(retry.session.status).toBe('paused');
+  });
+
+  it('allows intervention start and completion retries after the session has resumed', async () => {
+    const { service } = createService();
+    const running = await createRunningSession(service);
+    await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+    });
+    await service.startIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+    await service.completeIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      completedBy: 'operator-2',
+    });
+    await service.resumeSession(running.id, scope, {
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+    });
+
+    const startRetry = await service.startIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+    const completeRetry = await service.completeIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      completedBy: 'operator-2',
+    });
+
+    expect(startRetry.pause.interventionId).toBe('intervention-1');
+    expect(startRetry.session.status).toBe('running');
+    expect(completeRetry.pause.interventionCompletedBy).toBe('operator-2');
+    expect(completeRetry.session.status).toBe('running');
+  });
+
+  it('completes intervention through SessionService and requires explicit resume', async () => {
+    const { service, pauseStore } = createService();
+    const running = await createRunningSession(service);
+    await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+    });
+    await service.startIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+
+    const completed = await service.completeIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      completedBy: 'operator-2',
+      guidance: 'Wait for approval.',
+    });
+
+    expect(completed.session.status).toBe('paused');
+    expect(completed.pause.status).toBe('paused');
+    expect(completed.pause.guidance).toBe('Wait for approval.');
+    expect(pauseStore.completions).toHaveLength(1);
+  });
+
+  it('reconciles session status from durable pause/intervention state after partial persistence failure', async () => {
+    const { service, pauseStore } = createService();
+    const running = await createRunningSession(service);
+    await pauseStore.pause({
+      ...scope,
+      sessionId: running.id,
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+    });
+
+    const reconciledPause = await service.getSession(running.id, scope);
+    expect(reconciledPause.status).toBe('paused');
+
+    await pauseStore.resume({
+      ...scope,
+      sessionId: running.id,
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+    });
+    const reconciledResume = await service.getSession(running.id, scope);
+    expect(reconciledResume.status).toBe('running');
+  });
+
+  it('persists resume metadata and transitions paused or intervening sessions back to running', async () => {
+    const { service, pauseStore } = createService();
+    const running = await createRunningSession(service);
+    await service.pauseSession(running.id, scope, {
+      pauseId: 'pause-1',
+      reason: 'operator requested review',
+      requestedBy: 'operator-1',
+    });
+    await service.startIntervention(running.id, scope, {
+      interventionId: 'intervention-1',
+      interventionBy: 'operator-2',
+    });
+
+    const result = await service.resumeSession(running.id, scope, {
+      resumeId: 'resume-1',
+      resumedBy: 'operator-3',
+      resumeMetadata: { releaseQueuedActions: true },
+    });
+
+    expect(result.session.status).toBe('running');
+    expect(result.pause.status).toBe('resumed');
+    expect(pauseStore.resumes).toHaveLength(1);
+    expect(pauseStore.resumes[0].resumeMetadata).toEqual({ releaseQueuedActions: true });
+  });
+});

--- a/src/__tests__/acp-session-service.test.ts
+++ b/src/__tests__/acp-session-service.test.ts
@@ -283,18 +283,22 @@ describe('AcpSessionService', () => {
     const idle = await service.transition(created.id, scope, { type: 'agent_ready' });
     const running = await service.transition(created.id, scope, { type: 'run_started' });
     const paused = await service.transition(created.id, scope, { type: 'pause_requested' });
-    const resumed = await service.transition(created.id, scope, { type: 'resume_requested' });
     const intervening = await service.transition(created.id, scope, {
       type: 'intervention_started',
     });
+    const interventionCompleted = await service.transition(created.id, scope, {
+      type: 'intervention_completed',
+    });
+    const resumed = await service.transition(created.id, scope, { type: 'resume_requested' });
     const closing = await service.transition(created.id, scope, { type: 'close_requested' });
     const closed = await service.transition(created.id, scope, { type: 'close_completed' });
 
     expect(idle.status).toBe('idle');
     expect(running.status).toBe('running');
     expect(paused.status).toBe('paused');
-    expect(resumed.status).toBe('running');
     expect(intervening.status).toBe('intervening');
+    expect(interventionCompleted.status).toBe('paused');
+    expect(resumed.status).toBe('running');
     expect(closing.status).toBe('closing');
     expect(closed.status).toBe('closed');
 
@@ -321,7 +325,7 @@ describe('AcpSessionService', () => {
     ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
   });
 
-  it('keeps paused sessions paused until an explicit resume transition', async () => {
+  it('keeps paused sessions paused until intervention or explicit resume transition', async () => {
     const { service } = createService();
     const created = await service.createSession(scope);
 
@@ -332,9 +336,8 @@ describe('AcpSessionService', () => {
     await expect(
       service.transition(paused.id, scope, { type: 'run_started' })
     ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
-    await expect(
-      service.transition(paused.id, scope, { type: 'intervention_started' })
-    ).rejects.toBeInstanceOf(AcpInvalidStateTransitionError);
+    const intervening = await service.transition(paused.id, scope, { type: 'intervention_started' });
+    expect(intervening.status).toBe('intervening');
 
     const resumed = await service.transition(paused.id, scope, { type: 'resume_requested' });
     expect(resumed.status).toBe('running');

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -41,6 +41,24 @@ export type {
   AcpGetChatSnapshotInput,
   AcpSaveChatSnapshotInput,
 } from './chat-cache.js';
+export type {
+  AcpCompleteInterventionInput,
+  AcpPauseInterventionMetadata,
+  AcpPauseInterventionMetadataValue,
+  AcpPauseInterventionRecord,
+  AcpPauseInterventionStatus,
+  AcpPauseInterventionStore,
+  AcpPauseSessionInput,
+  AcpResumeSessionInput,
+  AcpStartInterventionInput,
+} from './pause-intervention.js';
+export {
+  normalizeAcpPauseInterventionMetadata,
+  validateAcpCompleteInterventionInput,
+  validateAcpPauseSessionInput,
+  validateAcpResumeSessionInput,
+  validateAcpStartInterventionInput,
+} from './pause-intervention.js';
 export { AcpInvalidStateTransitionError, transitionAcpSessionStatus } from './state-machine.js';
 export { PostgresAcpEventStore, type PostgresAcpEventStoreConfig } from './postgres-event-store.js';
 export { PostgresAcpChatCache, type PostgresAcpChatCacheConfig } from './postgres-chat-cache.js';
@@ -49,7 +67,12 @@ export {
   AcpSessionNotFoundError,
   AcpSessionService,
   AcpValidationError,
+  type AcpCompleteInterventionRequest,
+  type AcpPauseInterventionPolicyResult,
+  type AcpPauseSessionRequest,
+  type AcpResumeSessionRequest,
   type AcpSessionServiceOptions,
+  type AcpStartInterventionRequest,
   validateAcpControlActionInput,
 } from './session-service.js';
 export {
@@ -71,6 +94,10 @@ export {
   type AcpLocalStorageProfile,
   type FileAcpLocalStorageProfileConfig,
 } from './local-storage.js';
+export {
+  PostgresAcpPauseInterventionStore,
+  type PostgresAcpPauseInterventionStoreConfig,
+} from './postgres-pause-intervention-store.js';
 export {
   ACP_REDIS_COORDINATION_RECOVERY_CONTRACT,
   AcpRedisCoordinationKeyError,

--- a/src/services/acp/pause-intervention.ts
+++ b/src/services/acp/pause-intervention.ts
@@ -1,0 +1,217 @@
+import { Buffer } from 'node:buffer';
+
+import { AcpDurableIdentityError, AcpValidationError } from './session-service.js';
+import type { AcpBackendMetadataValue, AcpSessionScope } from './types.js';
+
+export type AcpPauseInterventionStatus = 'paused' | 'intervening' | 'resumed';
+export type AcpPauseInterventionMetadataValue = AcpBackendMetadataValue;
+export type AcpPauseInterventionMetadata = Record<string, AcpPauseInterventionMetadataValue>;
+
+export interface AcpPauseInterventionRecord extends AcpSessionScope {
+  pauseId: string;
+  sessionId: string;
+  status: AcpPauseInterventionStatus;
+  idempotencyKey?: string;
+  reason: string;
+  requestedBy: string;
+  requestedAt: Date;
+  metadata?: AcpPauseInterventionMetadata;
+  interventionId?: string;
+  interventionBy?: string;
+  interventionStartedAt?: Date;
+  interventionCompletedBy?: string;
+  interventionCompletedAt?: Date;
+  guidance?: string;
+  resumeId?: string;
+  resumedBy?: string;
+  resumedAt?: Date;
+  resumeMetadata?: AcpPauseInterventionMetadata;
+  updatedAt: Date;
+}
+
+export interface AcpPauseSessionInput extends AcpSessionScope {
+  pauseId: string;
+  sessionId: string;
+  reason: string;
+  requestedBy: string;
+  requestedAt?: Date;
+  idempotencyKey?: string;
+  metadata?: AcpPauseInterventionMetadata;
+}
+
+export interface AcpStartInterventionInput extends AcpSessionScope {
+  sessionId: string;
+  interventionId: string;
+  interventionBy: string;
+  startedAt?: Date;
+}
+
+export interface AcpCompleteInterventionInput extends AcpSessionScope {
+  sessionId: string;
+  interventionId: string;
+  completedBy: string;
+  completedAt?: Date;
+  guidance?: string;
+}
+
+export interface AcpResumeSessionInput extends AcpSessionScope {
+  sessionId: string;
+  resumeId: string;
+  resumedBy: string;
+  resumedAt?: Date;
+  resumeMetadata?: AcpPauseInterventionMetadata;
+}
+
+export interface AcpPauseInterventionStore {
+  pause(input: AcpPauseSessionInput): Promise<AcpPauseInterventionRecord>;
+  getActive(sessionId: string, scope: AcpSessionScope): Promise<AcpPauseInterventionRecord | null>;
+  getLatest(sessionId: string, scope: AcpSessionScope): Promise<AcpPauseInterventionRecord | null>;
+  startIntervention(input: AcpStartInterventionInput): Promise<AcpPauseInterventionRecord | null>;
+  completeIntervention(input: AcpCompleteInterventionInput): Promise<AcpPauseInterventionRecord | null>;
+  resume(input: AcpResumeSessionInput): Promise<AcpPauseInterventionRecord | null>;
+}
+
+const MAX_METADATA_KEYS = 20;
+const MAX_METADATA_KEY_BYTES = 128;
+const MAX_METADATA_STRING_BYTES = 1024;
+const MAX_REASON_BYTES = 2048;
+const MAX_GUIDANCE_BYTES = 8192;
+const BLOCKED_METADATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const SENSITIVE_METADATA_KEY_PATTERN =
+  /(token|secret|password|api[_-]?key|authorization|cookie|prompt|payload|tool.*arg)/i;
+
+export function validateAcpPauseSessionInput(input: AcpPauseSessionInput): void {
+  assertNoJsonRpcRequestId(input);
+  validateScope(input);
+  assertNonEmptyString(input.sessionId, 'session id');
+  assertNonEmptyString(input.pauseId, 'pause id');
+  assertNonEmptyString(input.requestedBy, 'pause requestedBy');
+  assertBoundedString(input.reason, 'pause reason', MAX_REASON_BYTES);
+  assertOptionalNonEmptyString(input.idempotencyKey, 'pause idempotency key');
+  assertOptionalDate(input.requestedAt, 'pause requestedAt');
+  normalizeAcpPauseInterventionMetadata(input.metadata);
+}
+
+export function validateAcpStartInterventionInput(input: AcpStartInterventionInput): void {
+  assertNoJsonRpcRequestId(input);
+  validateScope(input);
+  assertNonEmptyString(input.sessionId, 'session id');
+  assertNonEmptyString(input.interventionId, 'intervention id');
+  assertNonEmptyString(input.interventionBy, 'interventionBy');
+  assertOptionalDate(input.startedAt, 'intervention startedAt');
+}
+
+export function validateAcpCompleteInterventionInput(input: AcpCompleteInterventionInput): void {
+  assertNoJsonRpcRequestId(input);
+  validateScope(input);
+  assertNonEmptyString(input.sessionId, 'session id');
+  assertNonEmptyString(input.interventionId, 'intervention id');
+  assertNonEmptyString(input.completedBy, 'intervention completedBy');
+  assertOptionalDate(input.completedAt, 'intervention completedAt');
+  if (input.guidance !== undefined) {
+    assertBoundedString(input.guidance, 'intervention guidance', MAX_GUIDANCE_BYTES);
+  }
+}
+
+export function validateAcpResumeSessionInput(input: AcpResumeSessionInput): void {
+  assertNoJsonRpcRequestId(input);
+  validateScope(input);
+  assertNonEmptyString(input.sessionId, 'session id');
+  assertNonEmptyString(input.resumeId, 'resume id');
+  assertNonEmptyString(input.resumedBy, 'resume resumedBy');
+  assertOptionalDate(input.resumedAt, 'resume resumedAt');
+  normalizeAcpPauseInterventionMetadata(input.resumeMetadata, 'resume metadata');
+}
+
+export function normalizeAcpPauseInterventionMetadata(
+  metadata: unknown,
+  label = 'pause/intervention metadata'
+): AcpPauseInterventionMetadata | undefined {
+  if (metadata === undefined || metadata === null) return undefined;
+  if (!isMetadataRecord(metadata)) {
+    throw new AcpValidationError(`ACP ${label} must be an object with primitive values`);
+  }
+
+  const entries = Object.entries(metadata);
+  if (entries.length > MAX_METADATA_KEYS) {
+    throw new AcpValidationError(`ACP ${label} cannot contain more than ${MAX_METADATA_KEYS} keys`);
+  }
+
+  const normalized: AcpPauseInterventionMetadata = {};
+  for (const [key, value] of entries) {
+    validateMetadataKey(key, label);
+    validateMetadataValue(key, value, label);
+    normalized[key] = value;
+  }
+  return normalized;
+}
+
+function validateScope(scope: AcpSessionScope): void {
+  assertNonEmptyString(scope.tenantId, 'tenant id');
+  assertNonEmptyString(scope.ownerKeyId, 'owner key id');
+}
+
+function assertNoJsonRpcRequestId(input: object): void {
+  if (Object.hasOwn(input, 'jsonRpcRequestId')) {
+    throw new AcpDurableIdentityError(
+      'JSON-RPC request ids are transport-scoped and cannot be stored as durable ACP pause/intervention identity'
+    );
+  }
+}
+
+function assertNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AcpValidationError(`ACP ${label} must be a non-empty string`);
+  }
+}
+
+function assertOptionalNonEmptyString(
+  value: unknown,
+  label: string
+): asserts value is string | undefined {
+  if (value !== undefined) assertNonEmptyString(value, label);
+}
+
+function assertBoundedString(value: unknown, label: string, maxBytes: number): asserts value is string {
+  assertNonEmptyString(value, label);
+  if (Buffer.byteLength(value, 'utf8') > maxBytes) {
+    throw new AcpValidationError(`ACP ${label} exceeds ${maxBytes} bytes`);
+  }
+}
+
+function assertOptionalDate(value: unknown, label: string): void {
+  if (value !== undefined && (!(value instanceof Date) || Number.isNaN(value.getTime()))) {
+    throw new AcpValidationError(`ACP ${label} must be a valid Date`);
+  }
+}
+
+function isMetadataRecord(value: unknown): value is Record<string, AcpPauseInterventionMetadataValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateMetadataKey(key: string, label: string): void {
+  if (key.trim() === '') {
+    throw new AcpValidationError(`ACP ${label} key must be a non-empty string`);
+  }
+  if (BLOCKED_METADATA_KEYS.has(key)) {
+    throw new AcpValidationError(`ACP ${label} key is not allowed: ${key}`);
+  }
+  if (SENSITIVE_METADATA_KEY_PATTERN.test(key)) {
+    throw new AcpValidationError(`ACP ${label} key is sensitive: ${key}`);
+  }
+  if (Buffer.byteLength(key, 'utf8') > MAX_METADATA_KEY_BYTES) {
+    throw new AcpValidationError(`ACP ${label} key exceeds ${MAX_METADATA_KEY_BYTES} bytes`);
+  }
+}
+
+function validateMetadataValue(key: string, value: unknown, label: string): asserts value is AcpPauseInterventionMetadataValue {
+  if (value !== null && typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+    throw new AcpValidationError(`ACP ${label} value must be primitive: ${key}`);
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new AcpValidationError(`ACP ${label} number must be finite: ${key}`);
+  }
+  if (typeof value === 'string' && Buffer.byteLength(value, 'utf8') > MAX_METADATA_STRING_BYTES) {
+    throw new AcpValidationError(`ACP ${label} value exceeds ${MAX_METADATA_STRING_BYTES} bytes: ${key}`);
+  }
+}

--- a/src/services/acp/postgres-pause-intervention-store.ts
+++ b/src/services/acp/postgres-pause-intervention-store.ts
@@ -1,0 +1,559 @@
+import { Pool, type QueryResultRow } from 'pg';
+
+import type { ServiceHealth } from '../../container.js';
+import { AcpDurableIdentityError, AcpValidationError } from './session-service.js';
+import type { AcpSessionScope } from './types.js';
+import {
+  normalizeAcpPauseInterventionMetadata,
+  validateAcpCompleteInterventionInput,
+  validateAcpPauseSessionInput,
+  validateAcpResumeSessionInput,
+  validateAcpStartInterventionInput,
+  type AcpCompleteInterventionInput,
+  type AcpPauseInterventionRecord,
+  type AcpPauseInterventionStatus,
+  type AcpPauseInterventionStore,
+  type AcpPauseSessionInput,
+  type AcpResumeSessionInput,
+  type AcpStartInterventionInput,
+} from './pause-intervention.js';
+
+export interface PostgresAcpPauseInterventionStoreConfig {
+  url: string;
+  schemaName?: string;
+  tableName?: string;
+  poolMax?: number;
+}
+
+interface AcpPauseInterventionRow extends QueryResultRow {
+  pause_id: string;
+  session_id: string;
+  tenant_id: string;
+  owner_key_id: string;
+  status: string;
+  idempotency_key: string | null;
+  reason: string;
+  requested_by: string;
+  requested_at: Date | string;
+  metadata: unknown;
+  intervention_id: string | null;
+  intervention_by: string | null;
+  intervention_started_at: Date | string | null;
+  intervention_completed_by: string | null;
+  intervention_completed_at: Date | string | null;
+  guidance: string | null;
+  resume_id: string | null;
+  resumed_by: string | null;
+  resumed_at: Date | string | null;
+  resume_metadata: unknown;
+  updated_at: Date | string;
+}
+
+const DEFAULT_SCHEMA = 'public';
+const DEFAULT_TABLE = 'acp_pause_interventions';
+const DEFAULT_POOL_MAX = 5;
+const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export class PostgresAcpPauseInterventionStore implements AcpPauseInterventionStore {
+  private pool?: Pool;
+  private readonly url: string;
+  private readonly schemaName: string;
+  private readonly tableName: string;
+  private readonly poolMax: number;
+
+  constructor(config: PostgresAcpPauseInterventionStoreConfig) {
+    this.url = config.url;
+    this.schemaName = config.schemaName ?? DEFAULT_SCHEMA;
+    this.tableName = config.tableName ?? DEFAULT_TABLE;
+    this.poolMax = config.poolMax ?? DEFAULT_POOL_MAX;
+
+    validateIdentifier(this.schemaName, 'schema name');
+    validateIdentifier(this.tableName, 'table name');
+    validatePoolMax(this.poolMax);
+  }
+
+  async start(): Promise<void> {
+    const pool = this.pool ?? new Pool({ connectionString: this.url, max: this.poolMax });
+    this.pool = pool;
+    try {
+      await this.ensureSchema();
+      const result = await pool.query<{ ok: number }>('SELECT 1 AS ok');
+      if (!result.rows[0]) {
+        throw new Error('PostgresAcpPauseInterventionStore: connection test failed');
+      }
+    } catch (error) {
+      this.pool = undefined;
+      await pool.end().catch(() => {});
+      throw error;
+    }
+  }
+
+  async stop(_signal?: AbortSignal): Promise<void> {
+    const pool = this.pool;
+    this.pool = undefined;
+    if (pool !== undefined) await pool.end();
+  }
+
+  async health(): Promise<ServiceHealth> {
+    const pool = this.pool;
+    if (pool === undefined) {
+      return { healthy: false, details: 'postgres ACP pause/intervention store not started' };
+    }
+    try {
+      await pool.query('SELECT 1');
+      return { healthy: true, details: 'postgres ACP pause/intervention store ok' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { healthy: false, details: `postgres ACP pause/intervention store: ${message}` };
+    }
+  }
+
+  async pause(input: AcpPauseSessionInput): Promise<AcpPauseInterventionRecord> {
+    validateAcpPauseSessionInput(input);
+    const metadata = normalizeAcpPauseInterventionMetadata(input.metadata) ?? {};
+    if (input.idempotencyKey !== undefined) {
+      const existing = await this.findByIdempotencyKey(input);
+      if (existing) return existing;
+    }
+
+    try {
+      const result = await this.requirePool().query<AcpPauseInterventionRow>(
+        `INSERT INTO ${this.qt()} (
+           pause_id,
+           session_id,
+           tenant_id,
+           owner_key_id,
+           idempotency_key,
+           reason,
+           requested_by,
+           requested_at,
+           metadata
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, NOW()), $9)
+         ON CONFLICT (pause_id) DO NOTHING
+         RETURNING ${returningColumns()}`,
+        [
+          input.pauseId,
+          input.sessionId,
+          input.tenantId,
+          input.ownerKeyId,
+          input.idempotencyKey,
+          input.reason,
+          input.requestedBy,
+          input.requestedAt,
+          metadata,
+        ]
+      );
+      if (!result.rows[0]) {
+        throw new AcpDurableIdentityError(`ACP pause id already exists: ${input.pauseId}`);
+      }
+      const record = rowToRecord(result.rows[0]);
+      assertRecordMatchesPauseInput(record, input);
+      return record;
+    } catch (error) {
+      if (input.idempotencyKey !== undefined && isPgUniqueViolation(error)) {
+        const existing = await this.findByIdempotencyKey(input);
+        if (existing) return existing;
+      }
+      throw error;
+    }
+  }
+
+  async getActive(sessionId: string, scope: AcpSessionScope): Promise<AcpPauseInterventionRecord | null> {
+    validateSessionIdAndScope(sessionId, scope);
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `SELECT ${returningColumns()}
+       FROM ${this.qt()}
+       WHERE session_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+         AND status IN ('paused', 'intervening')
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      [sessionId, scope.tenantId, scope.ownerKeyId]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, sessionId, scope);
+    return record;
+  }
+
+  async getLatest(sessionId: string, scope: AcpSessionScope): Promise<AcpPauseInterventionRecord | null> {
+    validateSessionIdAndScope(sessionId, scope);
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `SELECT ${returningColumns()}
+       FROM ${this.qt()}
+       WHERE session_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      [sessionId, scope.tenantId, scope.ownerKeyId]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, sessionId, scope);
+    return record;
+  }
+
+  async startIntervention(input: AcpStartInterventionInput): Promise<AcpPauseInterventionRecord | null> {
+    validateAcpStartInterventionInput(input);
+    const existing = await this.findByInterventionId(input.interventionId, input);
+    if (existing) return existing;
+
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `UPDATE ${this.qt()}
+       SET status = 'intervening',
+           intervention_id = $4,
+           intervention_by = $5,
+           intervention_started_at = COALESCE($6, NOW()),
+           intervention_completed_by = NULL,
+           intervention_completed_at = NULL,
+           guidance = NULL,
+           updated_at = COALESCE($6, NOW())
+       WHERE session_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+         AND status = 'paused'
+         AND intervention_id IS NULL
+       RETURNING ${returningColumns()}`,
+      [input.sessionId, input.tenantId, input.ownerKeyId, input.interventionId, input.interventionBy, input.startedAt]
+    );
+    if (!result.rows[0]) return this.findByInterventionId(input.interventionId, input);
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, input.sessionId, input);
+    return record;
+  }
+
+  async completeIntervention(input: AcpCompleteInterventionInput): Promise<AcpPauseInterventionRecord | null> {
+    validateAcpCompleteInterventionInput(input);
+    const existing = await this.findByInterventionId(input.interventionId, input);
+    if (existing?.interventionCompletedAt !== undefined) return existing;
+
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `UPDATE ${this.qt()}
+       SET status = 'paused',
+           intervention_completed_by = $5,
+           intervention_completed_at = COALESCE($6, NOW()),
+           guidance = $7,
+           updated_at = COALESCE($6, NOW())
+       WHERE session_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+         AND intervention_id = $4
+         AND status = 'intervening'
+       RETURNING ${returningColumns()}`,
+      [
+        input.sessionId,
+        input.tenantId,
+        input.ownerKeyId,
+        input.interventionId,
+        input.completedBy,
+        input.completedAt,
+        input.guidance,
+      ]
+    );
+    if (!result.rows[0]) return this.findByInterventionId(input.interventionId, input);
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, input.sessionId, input);
+    return record;
+  }
+
+  async resume(input: AcpResumeSessionInput): Promise<AcpPauseInterventionRecord | null> {
+    validateAcpResumeSessionInput(input);
+    const existing = await this.findByResumeId(input.resumeId, input);
+    if (existing) return existing;
+    const resumeMetadata = normalizeAcpPauseInterventionMetadata(input.resumeMetadata, 'resume metadata') ?? {};
+
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `UPDATE ${this.qt()}
+       SET status = 'resumed',
+           resume_id = $4,
+           resumed_by = $5,
+           resumed_at = COALESCE($6, NOW()),
+           resume_metadata = $7,
+           updated_at = COALESCE($6, NOW())
+       WHERE session_id = $1
+         AND tenant_id = $2
+         AND owner_key_id = $3
+         AND status IN ('paused', 'intervening')
+       RETURNING ${returningColumns()}`,
+      [
+        input.sessionId,
+        input.tenantId,
+        input.ownerKeyId,
+        input.resumeId,
+        input.resumedBy,
+        input.resumedAt,
+        resumeMetadata,
+      ]
+    );
+    if (!result.rows[0]) return this.findByResumeId(input.resumeId, input);
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, input.sessionId, input);
+    return record;
+  }
+
+  private async findByIdempotencyKey(input: AcpPauseSessionInput): Promise<AcpPauseInterventionRecord | null> {
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `SELECT ${returningColumns()}
+       FROM ${this.qt()}
+       WHERE tenant_id = $1
+         AND owner_key_id = $2
+         AND session_id = $3
+         AND idempotency_key = $4
+       ORDER BY requested_at ASC
+       LIMIT 1`,
+      [input.tenantId, input.ownerKeyId, input.sessionId, input.idempotencyKey]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, input.sessionId, input);
+    return record;
+  }
+
+  private async findByInterventionId(
+    interventionId: string,
+    scope: AcpSessionScope & { sessionId: string }
+  ): Promise<AcpPauseInterventionRecord | null> {
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `SELECT ${returningColumns()}
+       FROM ${this.qt()}
+       WHERE tenant_id = $1
+         AND owner_key_id = $2
+         AND session_id = $3
+         AND intervention_id = $4
+       LIMIT 1`,
+      [scope.tenantId, scope.ownerKeyId, scope.sessionId, interventionId]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, scope.sessionId, scope);
+    return record;
+  }
+
+  private async findByResumeId(
+    resumeId: string,
+    scope: AcpSessionScope & { sessionId: string }
+  ): Promise<AcpPauseInterventionRecord | null> {
+    const result = await this.requirePool().query<AcpPauseInterventionRow>(
+      `SELECT ${returningColumns()}
+       FROM ${this.qt()}
+       WHERE tenant_id = $1
+         AND owner_key_id = $2
+         AND session_id = $3
+         AND resume_id = $4
+       LIMIT 1`,
+      [scope.tenantId, scope.ownerKeyId, scope.sessionId, resumeId]
+    );
+    if (!result.rows[0]) return null;
+    const record = rowToRecord(result.rows[0]);
+    assertRecordMatchesSessionScope(record, scope.sessionId, scope);
+    return record;
+  }
+
+  private requirePool(): Pool {
+    if (!this.pool) {
+      throw new Error('PostgresAcpPauseInterventionStore: start() must be called before use');
+    }
+    return this.pool;
+  }
+
+  private qt(): string {
+    return `"${this.schemaName}"."${this.tableName}"`;
+  }
+
+  private async ensureSchema(): Promise<void> {
+    await this.requirePool().query(`CREATE SCHEMA IF NOT EXISTS "${this.schemaName}"`);
+    await this.requirePool().query(`
+      CREATE TABLE IF NOT EXISTS ${this.qt()} (
+        pause_id                  TEXT PRIMARY KEY,
+        session_id                TEXT NOT NULL,
+        tenant_id                 TEXT NOT NULL,
+        owner_key_id              TEXT NOT NULL,
+        status                    TEXT NOT NULL DEFAULT 'paused'
+          CHECK (status IN ('paused', 'intervening', 'resumed')),
+        idempotency_key           TEXT,
+        reason                    TEXT NOT NULL,
+        requested_by              TEXT NOT NULL,
+        requested_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        metadata                  JSONB NOT NULL DEFAULT '{}',
+        intervention_id           TEXT,
+        intervention_by           TEXT,
+        intervention_started_at   TIMESTAMPTZ,
+        intervention_completed_by TEXT,
+        intervention_completed_at TIMESTAMPTZ,
+        guidance                  TEXT,
+        resume_id                 TEXT,
+        resumed_by                TEXT,
+        resumed_at                TIMESTAMPTZ,
+        resume_metadata           JSONB,
+        updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    await this.requirePool().query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "uniq_${this.tableName}_scoped_idempotency"
+      ON ${this.qt()} (tenant_id, owner_key_id, session_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL
+    `);
+    await this.requirePool().query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "uniq_${this.tableName}_active_session"
+      ON ${this.qt()} (tenant_id, owner_key_id, session_id)
+      WHERE status IN ('paused', 'intervening')
+    `);
+    await this.requirePool().query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "uniq_${this.tableName}_intervention_id"
+      ON ${this.qt()} (tenant_id, owner_key_id, session_id, intervention_id)
+      WHERE intervention_id IS NOT NULL
+    `);
+    await this.requirePool().query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "uniq_${this.tableName}_resume_id"
+      ON ${this.qt()} (tenant_id, owner_key_id, session_id, resume_id)
+      WHERE resume_id IS NOT NULL
+    `);
+  }
+}
+
+function returningColumns(alias?: string): string {
+  const prefix = alias ? `${alias}.` : '';
+  return [
+    'pause_id',
+    'session_id',
+    'tenant_id',
+    'owner_key_id',
+    'status',
+    'idempotency_key',
+    'reason',
+    'requested_by',
+    'requested_at',
+    'metadata',
+    'intervention_id',
+    'intervention_by',
+    'intervention_started_at',
+    'intervention_completed_by',
+    'intervention_completed_at',
+    'guidance',
+    'resume_id',
+    'resumed_by',
+    'resumed_at',
+    'resume_metadata',
+    'updated_at',
+  ]
+    .map(column => `${prefix}${column}`)
+    .join(', ');
+}
+
+function rowToRecord(row: AcpPauseInterventionRow): AcpPauseInterventionRecord {
+  return {
+    pauseId: row.pause_id,
+    sessionId: row.session_id,
+    tenantId: row.tenant_id,
+    ownerKeyId: row.owner_key_id,
+    status: parseStatus(row.status),
+    idempotencyKey: nullableString(row.idempotency_key),
+    reason: row.reason,
+    requestedBy: row.requested_by,
+    requestedAt: toDate(row.requested_at, 'requested_at'),
+    metadata: normalizeAcpPauseInterventionMetadata(row.metadata),
+    interventionId: nullableString(row.intervention_id),
+    interventionBy: nullableString(row.intervention_by),
+    interventionStartedAt: nullableDate(row.intervention_started_at, 'intervention_started_at'),
+    interventionCompletedBy: nullableString(row.intervention_completed_by),
+    interventionCompletedAt: nullableDate(row.intervention_completed_at, 'intervention_completed_at'),
+    guidance: nullableString(row.guidance),
+    resumeId: nullableString(row.resume_id),
+    resumedBy: nullableString(row.resumed_by),
+    resumedAt: nullableDate(row.resumed_at, 'resumed_at'),
+    resumeMetadata: normalizeAcpPauseInterventionMetadata(row.resume_metadata, 'resume metadata'),
+    updatedAt: toDate(row.updated_at, 'updated_at'),
+  };
+}
+
+function parseStatus(status: string): AcpPauseInterventionStatus {
+  switch (status) {
+    case 'paused':
+    case 'intervening':
+    case 'resumed':
+      return status;
+    default:
+      throw new AcpValidationError(`ACP pause/intervention status is not supported: ${status}`);
+  }
+}
+
+function assertRecordMatchesPauseInput(
+  record: AcpPauseInterventionRecord,
+  input: AcpPauseSessionInput
+): void {
+  if (
+    record.pauseId !== input.pauseId ||
+    record.sessionId !== input.sessionId ||
+    record.tenantId !== input.tenantId ||
+    record.ownerKeyId !== input.ownerKeyId
+  ) {
+    throw new AcpDurableIdentityError('ACP pause/intervention row does not match requested scope');
+  }
+}
+
+function assertRecordMatchesSessionScope(
+  record: AcpPauseInterventionRecord,
+  sessionId: string,
+  scope: AcpSessionScope
+): void {
+  if (
+    record.sessionId !== sessionId ||
+    record.tenantId !== scope.tenantId ||
+    record.ownerKeyId !== scope.ownerKeyId
+  ) {
+    throw new AcpDurableIdentityError('ACP pause/intervention row does not match requested scope');
+  }
+}
+
+function nullableString(value: string | null): string | undefined {
+  return value === null ? undefined : value;
+}
+
+function nullableDate(value: Date | string | null, label: string): Date | undefined {
+  return value === null ? undefined : toDate(value, label);
+}
+
+function toDate(value: Date | string, label: string): Date {
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new AcpValidationError(`ACP pause/intervention timestamp is invalid: ${label}`);
+  }
+  return date;
+}
+
+function validateSessionIdAndScope(sessionId: string, scope: AcpSessionScope): void {
+  assertNonEmptyString(sessionId, 'session id');
+  assertNonEmptyString(scope.tenantId, 'tenant id');
+  assertNonEmptyString(scope.ownerKeyId, 'owner key id');
+}
+
+function assertNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AcpValidationError(`ACP ${label} must be a non-empty string`);
+  }
+}
+
+function validateIdentifier(identifier: string, label: string): void {
+  if (!IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(
+      `PostgresAcpPauseInterventionStore: invalid ${label} "${identifier}" — must match [a-zA-Z_][a-zA-Z0-9_]*`
+    );
+  }
+}
+
+function validatePoolMax(value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('PostgresAcpPauseInterventionStore: poolMax must be a positive safe integer');
+  }
+}
+
+function isPgUniqueViolation(error: unknown): boolean {
+  return hasErrorCode(error) && error.code === '23505';
+}
+
+function hasErrorCode(error: unknown): error is { code: unknown } {
+  return typeof error === 'object' && error !== null && 'code' in error;
+}

--- a/src/services/acp/session-service.ts
+++ b/src/services/acp/session-service.ts
@@ -1,5 +1,13 @@
 import { randomUUID } from 'node:crypto';
 
+import type {
+  AcpPauseInterventionRecord,
+  AcpPauseInterventionStore,
+  AcpCompleteInterventionInput,
+  AcpPauseSessionInput,
+  AcpResumeSessionInput,
+  AcpStartInterventionInput,
+} from './pause-intervention.js';
 import { transitionAcpSessionStatus } from './state-machine.js';
 import type {
   AcpAgentSessionAttachment,
@@ -34,6 +42,26 @@ const CONTROL_ACTION_TYPES = new Set([
 export interface AcpSessionServiceOptions {
   idProvider?: () => string;
   clock?: () => number;
+  pauseInterventionStore?: AcpPauseInterventionStore;
+}
+
+export type AcpPauseSessionRequest = Omit<AcpPauseSessionInput, keyof AcpSessionScope | 'sessionId'>;
+
+export type AcpStartInterventionRequest = Omit<
+  AcpStartInterventionInput,
+  keyof AcpSessionScope | 'sessionId'
+>;
+
+export type AcpResumeSessionRequest = Omit<AcpResumeSessionInput, keyof AcpSessionScope | 'sessionId'>;
+
+export type AcpCompleteInterventionRequest = Omit<
+  AcpCompleteInterventionInput,
+  keyof AcpSessionScope | 'sessionId'
+>;
+
+export interface AcpPauseInterventionPolicyResult {
+  session: AcpSessionRecord;
+  pause: AcpPauseInterventionRecord;
 }
 
 export class AcpSessionNotFoundError extends Error {
@@ -60,6 +88,7 @@ export class AcpValidationError extends Error {
 export class AcpSessionService {
   private readonly idProvider: () => string;
   private readonly clock: () => number;
+  private readonly pauseInterventionStore: AcpPauseInterventionStore | undefined;
 
   constructor(
     private readonly store: AcpSessionStore,
@@ -67,6 +96,7 @@ export class AcpSessionService {
   ) {
     this.idProvider = options.idProvider ?? randomUUID;
     this.clock = options.clock ?? Date.now;
+    this.pauseInterventionStore = options.pauseInterventionStore;
   }
 
   async createSession(input: AcpCreateSessionInput): Promise<AcpSessionRecord> {
@@ -184,6 +214,93 @@ export class AcpSessionService {
     return this.persistUpdate(record, updated, scope);
   }
 
+  async pauseSession(
+    sessionId: string,
+    scope: AcpSessionScope,
+    request: AcpPauseSessionRequest
+  ): Promise<AcpPauseInterventionPolicyResult> {
+    const pauseStore = this.requirePauseInterventionStore();
+    const record = await this.requireSession(sessionId, scope);
+    if (!isPauseSatisfied(record.status)) {
+      transitionAcpSessionStatus(record.status, { type: 'pause_requested' });
+    }
+    const pause = await pauseStore.pause({
+      ...request,
+      sessionId,
+      tenantId: scope.tenantId,
+      ownerKeyId: scope.ownerKeyId,
+    });
+    assertPauseRecordMatchesScope(pause, sessionId, scope);
+    const session = await this.reconcilePauseInterventionStatus(record, scope);
+    return { session, pause: clonePauseInterventionRecord(pause) };
+  }
+
+  async startIntervention(
+    sessionId: string,
+    scope: AcpSessionScope,
+    request: AcpStartInterventionRequest
+  ): Promise<AcpPauseInterventionPolicyResult> {
+    const pauseStore = this.requirePauseInterventionStore();
+    const record = await this.requireSession(sessionId, scope);
+    const pause = await pauseStore.startIntervention({
+      ...request,
+      sessionId,
+      tenantId: scope.tenantId,
+      ownerKeyId: scope.ownerKeyId,
+    });
+    if (!pause) {
+      transitionAcpSessionStatus(record.status, { type: 'intervention_started' });
+      throw new AcpSessionNotFoundError(sessionId);
+    }
+    assertPauseRecordMatchesScope(pause, sessionId, scope);
+    const session = await this.reconcilePauseInterventionStatus(record, scope);
+    return { session, pause: clonePauseInterventionRecord(pause) };
+  }
+
+  async completeIntervention(
+    sessionId: string,
+    scope: AcpSessionScope,
+    request: AcpCompleteInterventionRequest
+  ): Promise<AcpPauseInterventionPolicyResult> {
+    const pauseStore = this.requirePauseInterventionStore();
+    const record = await this.requireSession(sessionId, scope);
+    const pause = await pauseStore.completeIntervention({
+      ...request,
+      sessionId,
+      tenantId: scope.tenantId,
+      ownerKeyId: scope.ownerKeyId,
+    });
+    if (!pause) {
+      transitionAcpSessionStatus(record.status, { type: 'intervention_completed' });
+      throw new AcpSessionNotFoundError(sessionId);
+    }
+    assertPauseRecordMatchesScope(pause, sessionId, scope);
+    const session = await this.reconcilePauseInterventionStatus(record, scope);
+    return { session, pause: clonePauseInterventionRecord(pause) };
+  }
+
+  async resumeSession(
+    sessionId: string,
+    scope: AcpSessionScope,
+    request: AcpResumeSessionRequest
+  ): Promise<AcpPauseInterventionPolicyResult> {
+    const pauseStore = this.requirePauseInterventionStore();
+    const record = await this.requireSession(sessionId, scope);
+    const pause = await pauseStore.resume({
+      ...request,
+      sessionId,
+      tenantId: scope.tenantId,
+      ownerKeyId: scope.ownerKeyId,
+    });
+    if (!pause) {
+      transitionAcpSessionStatus(record.status, { type: 'resume_requested' });
+      throw new AcpSessionNotFoundError(sessionId);
+    }
+    assertPauseRecordMatchesScope(pause, sessionId, scope);
+    const session = await this.reconcilePauseInterventionStatus(record, scope);
+    return { session, pause: clonePauseInterventionRecord(pause) };
+  }
+
   private createId(label: string): string {
     const id = this.idProvider();
     assertNonEmptyString(id, label);
@@ -201,7 +318,7 @@ export class AcpSessionService {
       throw new AcpSessionNotFoundError(sessionId);
     }
     assertRecordMatchesScope(record, scope);
-    return cloneRecord(record);
+    return this.reconcilePauseInterventionStatus(record, scope);
   }
 
   private async persistUpdate(
@@ -219,6 +336,51 @@ export class AcpSessionService {
     assertRecordMatchesScope(persisted, scope);
     assertSessionIdentityNamespaces(persisted);
     return cloneRecord(persisted);
+  }
+
+  private requirePauseInterventionStore(): AcpPauseInterventionStore {
+    if (this.pauseInterventionStore === undefined) {
+      throw new AcpValidationError('ACP pause/intervention store is required for pause policy');
+    }
+    return this.pauseInterventionStore;
+  }
+
+  private async persistSessionStatus(
+    record: AcpSessionRecord,
+    status: AcpSessionRecord['status'],
+    scope: AcpSessionScope
+  ): Promise<AcpSessionRecord> {
+    const now = this.clock();
+    return this.persistUpdate(
+      record,
+      {
+        ...record,
+        status,
+        updatedAt: now,
+        closedAt: status === 'closed' ? record.closedAt ?? now : record.closedAt,
+        failedAt: status === 'failed' ? record.failedAt ?? now : record.failedAt,
+      },
+      scope
+    );
+  }
+
+  private async reconcilePauseInterventionStatus(
+    record: AcpSessionRecord,
+    scope: AcpSessionScope
+  ): Promise<AcpSessionRecord> {
+    if (this.pauseInterventionStore === undefined || isTerminalStatus(record.status)) {
+      return cloneRecord(record);
+    }
+    const lifecycle = await this.pauseInterventionStore.getLatest(record.id, scope);
+    if (lifecycle === null) {
+      return cloneRecord(record);
+    }
+    assertPauseRecordMatchesScope(lifecycle, record.id, scope);
+    const reconciledStatus = sessionStatusFromPauseIntervention(lifecycle.status);
+    if (record.status === reconciledStatus) {
+      return cloneRecord(record);
+    }
+    return this.persistSessionStatus(record, reconciledStatus, scope);
   }
 }
 
@@ -416,4 +578,61 @@ function cloneRecord(record: AcpSessionRecord): AcpSessionRecord {
     backendMetadata:
       record.backendMetadata === undefined ? undefined : { ...record.backendMetadata },
   };
+}
+
+function assertPauseRecordMatchesScope(
+  record: AcpPauseInterventionRecord,
+  sessionId: string,
+  scope: AcpSessionScope
+): void {
+  if (
+    record.sessionId !== sessionId ||
+    record.tenantId !== scope.tenantId ||
+    record.ownerKeyId !== scope.ownerKeyId
+  ) {
+    throw new AcpDurableIdentityError('ACP pause/intervention row does not match session scope');
+  }
+}
+
+function clonePauseInterventionRecord(
+  record: AcpPauseInterventionRecord
+): AcpPauseInterventionRecord {
+  return {
+    ...record,
+    requestedAt: new Date(record.requestedAt.getTime()),
+    interventionStartedAt:
+      record.interventionStartedAt === undefined
+        ? undefined
+        : new Date(record.interventionStartedAt.getTime()),
+    interventionCompletedAt:
+      record.interventionCompletedAt === undefined
+        ? undefined
+        : new Date(record.interventionCompletedAt.getTime()),
+    resumedAt: record.resumedAt === undefined ? undefined : new Date(record.resumedAt.getTime()),
+    updatedAt: new Date(record.updatedAt.getTime()),
+    metadata: record.metadata === undefined ? undefined : { ...record.metadata },
+    resumeMetadata:
+      record.resumeMetadata === undefined ? undefined : { ...record.resumeMetadata },
+  };
+}
+
+function isPauseSatisfied(status: AcpSessionRecord['status']): boolean {
+  return status === 'paused' || status === 'intervening';
+}
+
+function isTerminalStatus(status: AcpSessionRecord['status']): boolean {
+  return status === 'closing' || status === 'closed' || status === 'failed';
+}
+
+function sessionStatusFromPauseIntervention(
+  status: AcpPauseInterventionRecord['status']
+): AcpSessionRecord['status'] {
+  switch (status) {
+    case 'paused':
+      return 'paused';
+    case 'intervening':
+      return 'intervening';
+    case 'resumed':
+      return 'running';
+  }
 }

--- a/src/services/acp/state-machine.ts
+++ b/src/services/acp/state-machine.ts
@@ -55,9 +55,9 @@ export function transitionAcpSessionStatus(
     case 'resume_requested':
       return canTransitionFrom(currentStatus, event.type, ['paused', 'intervening'], 'running');
     case 'intervention_started':
-      return canTransitionFrom(currentStatus, event.type, ['running'], 'intervening');
+      return canTransitionFrom(currentStatus, event.type, ['paused'], 'intervening');
     case 'intervention_completed':
-      return canTransitionFrom(currentStatus, event.type, ['intervening'], 'running');
+      return canTransitionFrom(currentStatus, event.type, ['intervening'], 'paused');
     case 'close_requested':
       return canTransitionFrom(currentStatus, event.type, ACTIVE_STATUSES, 'closing');
     case 'close_completed':


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Add a typed ACP pause/intervention persistence contract.
- Add `PostgresAcpPauseInterventionStore` for durable pause, intervention, completion, resume, idempotency, and recovery state.
- Extend `AcpSessionService` so pause/resume/intervention policy remains service-owned and reconciles from the latest durable lifecycle row.

## Testing
- `npm test -- --run src/__tests__/acp-session-service-pause-intervention.test.ts src/__tests__/acp-postgres-pause-intervention-store.test.ts src/__tests__/acp-session-service.test.ts src/__tests__/acp-postgres-action-queue.test.ts` — 67 tests passed
- `npx tsc --noEmit` — passed
- `powershell -NoProfile -ExecutionPolicy Bypass -Command "npm run gate"` — passed

## Review notes
- Intervention requires a prior pause.
- Completing an intervention returns the session to paused; an explicit resume releases it back to running.
- Idempotent retries return the operation row but canonical session state reconciles from the latest durable lifecycle row.

Closes #2590