### PR TITLE
refactor: add ACP child process supervision

### DIFF
--- a/src/__tests__/acp-child-process.test.ts
+++ b/src/__tests__/acp-child-process.test.ts
@@ -1,0 +1,190 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough, Writable } from 'node:stream';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { AcpBinaryResolutionError } from '../services/acp/binary-resolver.js';
+import {
+  AcpChildProcess,
+  type AcpChildProcessHandle,
+} from '../services/acp/child-process.js';
+
+const fixturePath = path.join(process.cwd(), 'src', '__tests__', 'fixtures', 'fake-acp-child-process.mjs');
+
+describe('AcpChildProcess supervision', () => {
+  it('spawns the resolved command with explicit args, cwd, and BYO provider environment passthrough', async () => {
+    const child = new AcpChildProcess({
+      command: process.execPath,
+      args: [fixturePath, '--fixture-arg'],
+      cwd: process.cwd(),
+      env: {
+        FAKE_ACP_CHILD_MODE: 'print-env',
+        ACP_CHILD_TEST_VALUE: 'custom-value',
+      },
+      providerEnv: {
+        ANTHROPIC_AUTH_TOKEN: 'synthetic-token',
+      },
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    child.on('stdout', event => stdout.push(event.chunk));
+    child.on('stderr', event => stderr.push(event.chunk));
+
+    const started = await child.start();
+    const exit = await child.waitForExit();
+
+    expect(started.pid).toEqual(expect.any(Number));
+    expect(started.command).toMatchObject({
+      command: process.execPath,
+      args: [fixturePath, '--fixture-arg'],
+      source: 'explicit',
+    });
+    expect(exit).toMatchObject({ code: 0, signal: null, expected: false, escalated: false });
+    const payload = JSON.parse(stdout.join('').trim()) as {
+      argv: string[];
+      cwd: string;
+      customEnv?: string;
+      providerEnv: boolean;
+      noColor?: string;
+    };
+    expect(payload.argv).toEqual(['--fixture-arg']);
+    expect(payload.cwd).toBe(process.cwd());
+    expect(payload.customEnv).toBe('custom-value');
+    expect(payload.providerEnv).toBe(true);
+    expect(payload.noColor).toBe('1');
+    expect(stderr.join('')).toContain('fixture stderr ready');
+  });
+
+  it('propagates structured binary resolver failures without spawning', async () => {
+    const resolverError = new AcpBinaryResolutionError('missing test binary', {
+      attemptedPaths: ['D:\\missing\\claude-agent-acp.mjs'],
+      binName: 'claude-agent-acp',
+      envVar: 'AEGIS_ACP_BIN',
+      packageName: '@agentclientprotocol/claude-agent-acp',
+      reason: 'package bin not found',
+    });
+    const child = new AcpChildProcess({
+      cwd: process.cwd(),
+      resolveCommand: () => {
+        throw resolverError;
+      },
+    });
+
+    await expect(child.start()).rejects.toBe(resolverError);
+    expect(child.status).toBe('failed');
+  });
+
+  it('surfaces missing explicit command startup failures and emits an error event', async () => {
+    const child = new AcpChildProcess({
+      command: 'definitely-missing-acp-command-for-aegis-tests',
+      cwd: process.cwd(),
+      env: { AEGIS_ACP_BIN: undefined },
+    });
+    const errors: Error[] = [];
+    child.on('error', event => errors.push(event.error));
+
+    await expect(child.start()).rejects.toMatchObject({
+      name: 'AcpChildProcessStartError',
+      code: 'AEGIS_ACP_CHILD_PROCESS_START_FAILED',
+      details: expect.objectContaining({ command: 'definitely-missing-acp-command-for-aegis-tests' }),
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain('failed to start');
+  });
+
+  it('forwards stdout and stderr as raw chunks without JSON-RPC parsing', async () => {
+    const child = new AcpChildProcess({
+      command: process.execPath,
+      args: [fixturePath],
+      cwd: process.cwd(),
+      env: { FAKE_ACP_CHILD_MODE: 'stream' },
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    child.on('stdout', event => stdout.push(event.chunk));
+    child.on('stderr', event => stderr.push(event.chunk));
+
+    await child.start();
+    await child.waitForExit();
+
+    expect(stdout.join('')).toContain('stdout-one\n');
+    expect(stdout.join('')).toContain('stdout-two\n');
+    expect(stderr.join('')).toContain('stderr-one\n');
+    expect(stderr.join('')).toContain('stderr-two\n');
+  });
+
+  it('marks graceful shutdown exits as expected when stdin close lets the child exit', async () => {
+    const child = new AcpChildProcess({
+      command: process.execPath,
+      args: [fixturePath],
+      cwd: process.cwd(),
+      env: { FAKE_ACP_CHILD_MODE: 'wait-for-stdin-close' },
+    });
+    const exits: unknown[] = [];
+    child.on('exit', event => exits.push(event));
+
+    await child.start();
+    const exit = await child.shutdown({ graceMs: 1_000 });
+
+    expect(exit).toMatchObject({ code: 0, signal: null, expected: true, escalated: false });
+    expect(exits).toEqual([exit]);
+  });
+
+  it('escalates shutdown when the supervised child ignores graceful termination', async () => {
+    const fake = new FakeChildProcess();
+    const child = new AcpChildProcess({
+      command: 'fake-acp',
+      cwd: process.cwd(),
+      spawnProcess: () => fake,
+    });
+
+    await child.start();
+    const exit = await child.shutdown({ graceMs: 5 });
+
+    expect(fake.killedSignals).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(exit).toMatchObject({ code: null, signal: 'SIGKILL', expected: true, escalated: true });
+  });
+
+  it('emits an unexpected exit event for non-zero child termination', async () => {
+    const child = new AcpChildProcess({
+      command: process.execPath,
+      args: [fixturePath],
+      cwd: process.cwd(),
+      env: { FAKE_ACP_CHILD_MODE: 'exit-nonzero' },
+    });
+    const exits: unknown[] = [];
+    child.on('exit', event => exits.push(event));
+
+    await child.start();
+    const exit = await child.waitForExit();
+
+    expect(exit).toMatchObject({ code: 7, signal: null, expected: false, escalated: false });
+    expect(exits).toEqual([exit]);
+  });
+});
+
+class FakeChildProcess extends EventEmitter implements AcpChildProcessHandle {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdin = new Writable({ write(_chunk, _encoding, callback): void { callback(); } });
+  readonly killedSignals: NodeJS.Signals[] = [];
+  readonly pid = 12345;
+
+  constructor() {
+    super();
+    queueMicrotask(() => this.emit('spawn'));
+  }
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    if (typeof signal === 'string') {
+      this.killedSignals.push(signal);
+      if (signal === 'SIGKILL') {
+        queueMicrotask(() => {
+          this.emit('exit', null, 'SIGKILL');
+          this.emit('close', null, 'SIGKILL');
+        });
+      }
+    }
+    return true;
+  }
+}

--- a/src/__tests__/fixtures/fake-acp-child-process.mjs
+++ b/src/__tests__/fixtures/fake-acp-child-process.mjs
@@ -1,0 +1,43 @@
+import process from 'node:process';
+
+const mode = process.env.FAKE_ACP_CHILD_MODE ?? 'echo';
+
+if (mode === 'print-env') {
+  const payload = {
+    argv: process.argv.slice(2),
+    cwd: process.cwd(),
+    customEnv: process.env.ACP_CHILD_TEST_VALUE,
+    providerEnv: process.env.ANTHROPIC_AUTH_TOKEN === 'synthetic-token',
+    noColor: process.env.NO_COLOR,
+  };
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+  process.stderr.write('fixture stderr ready\n');
+  process.exit(0);
+}
+
+if (mode === 'stream') {
+  process.stdout.write('stdout-one\n');
+  setTimeout(() => process.stdout.write('stdout-two\n'), 10);
+  process.stderr.write('stderr-one\n');
+  setTimeout(() => process.stderr.write('stderr-two\n'), 20);
+  setTimeout(() => process.exit(0), 40);
+}
+
+if (mode === 'exit-nonzero') {
+  process.stderr.write('fatal fixture exit\n');
+  setTimeout(() => process.exit(7), 20);
+}
+
+if (mode === 'wait-for-stdin-close') {
+  process.stdout.write('ready\n');
+  process.stdin.resume();
+  process.stdin.on('end', () => {
+    process.stdout.write('stdin closed\n');
+    process.exit(0);
+  });
+}
+
+if (mode === 'long-running') {
+  process.stdout.write('ready\n');
+  setInterval(() => undefined, 1_000);
+}

--- a/src/services/acp/child-process.ts
+++ b/src/services/acp/child-process.ts
@@ -1,0 +1,441 @@
+import { spawn } from 'node:child_process';
+
+import { buildAcpResolveEnv, buildAcpSpawnEnv } from '../../acp-spawn-env.js';
+import {
+  resolveClaudeAgentAcpBinary,
+  type ResolveAcpCommandOptions,
+  type ResolvedAcpCommand,
+} from './binary-resolver.js';
+
+const DEFAULT_SHUTDOWN_GRACE_MS = 2_000;
+
+export type AcpChildProcessStatus = 'idle' | 'starting' | 'running' | 'exited' | 'failed';
+
+export interface AcpChildProcessStartResult {
+  pid?: number;
+  command: ResolvedAcpCommand;
+}
+
+export interface AcpChildProcessOutputEvent {
+  chunk: string;
+}
+
+export type AcpChildProcessSpawnedEvent = AcpChildProcessStartResult;
+
+export interface AcpChildProcessExitEvent {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  expected: boolean;
+  escalated: boolean;
+}
+
+export interface AcpChildProcessErrorEvent {
+  error: Error;
+}
+
+export interface AcpChildProcessShutdownOptions {
+  graceMs?: number;
+}
+
+export interface AcpChildProcessSpawnOptions {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  stdio: 'pipe';
+  windowsHide: true;
+}
+
+export interface AcpReadableProcessStream {
+  setEncoding(encoding: BufferEncoding): unknown;
+  on(event: 'data', listener: (chunk: string) => void): unknown;
+}
+
+export interface AcpWritableProcessStream {
+  readonly destroyed: boolean;
+  end(): unknown;
+  on(event: 'error', listener: (error: Error) => void): unknown;
+}
+
+export interface AcpChildProcessHandle {
+  readonly pid?: number;
+  readonly stdout: AcpReadableProcessStream;
+  readonly stderr: AcpReadableProcessStream;
+  readonly stdin: AcpWritableProcessStream;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  once(event: 'spawn', listener: () => void): unknown;
+  once(event: 'error', listener: (error: Error) => void): unknown;
+  once(
+    event: 'exit' | 'close',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void
+  ): unknown;
+}
+
+export type AcpChildProcessSpawner = (
+  command: string,
+  args: readonly string[],
+  options: AcpChildProcessSpawnOptions
+) => AcpChildProcessHandle;
+
+export interface AcpChildProcessOptions {
+  resolvedCommand?: ResolvedAcpCommand;
+  command?: string;
+  args?: readonly string[];
+  cwd: string;
+  env?: Record<string, string | undefined>;
+  providerEnv?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+  resolveCommand?: (options: ResolveAcpCommandOptions) => ResolvedAcpCommand;
+  spawnProcess?: AcpChildProcessSpawner;
+}
+
+export interface AcpChildProcessErrorDetails {
+  command: string;
+  args: string[];
+  cwd: string;
+  message: string;
+}
+
+export class AcpChildProcessStartError extends Error {
+  readonly code = 'AEGIS_ACP_CHILD_PROCESS_START_FAILED';
+  readonly details: AcpChildProcessErrorDetails;
+
+  constructor(details: AcpChildProcessErrorDetails) {
+    super(`ACP child process failed to start: ${details.message}`);
+    this.name = 'AcpChildProcessStartError';
+    this.details = details;
+  }
+}
+
+export class AcpChildProcessStateError extends Error {
+  readonly code = 'AEGIS_ACP_CHILD_PROCESS_INVALID_STATE';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'AcpChildProcessStateError';
+  }
+}
+
+// Process-boundary supervision only; JSON-RPC framing and backend lifecycle restart policy are downstream ACP modules.
+export class AcpChildProcess {
+  private statusValue: AcpChildProcessStatus = 'idle';
+  private resolvedCommand?: ResolvedAcpCommand;
+  private child?: AcpChildProcessHandle;
+  private exitPromise?: Promise<AcpChildProcessExitEvent>;
+  private exitResult?: AcpChildProcessExitEvent;
+  private shutdownRequested = false;
+  private shutdownEscalated = false;
+  private exitObserved: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+
+  private readonly stdoutListeners = new Set<(event: AcpChildProcessOutputEvent) => void>();
+  private readonly stderrListeners = new Set<(event: AcpChildProcessOutputEvent) => void>();
+  private readonly spawnedListeners = new Set<(event: AcpChildProcessSpawnedEvent) => void>();
+  private readonly exitListeners = new Set<(event: AcpChildProcessExitEvent) => void>();
+  private readonly errorListeners = new Set<(event: AcpChildProcessErrorEvent) => void>();
+
+  constructor(private readonly options: AcpChildProcessOptions) {}
+
+  get status(): AcpChildProcessStatus {
+    return this.statusValue;
+  }
+
+  get command(): ResolvedAcpCommand | undefined {
+    return this.resolvedCommand;
+  }
+
+  on(event: 'stdout', listener: (event: AcpChildProcessOutputEvent) => void): this;
+  on(event: 'stderr', listener: (event: AcpChildProcessOutputEvent) => void): this;
+  on(event: 'spawned', listener: (event: AcpChildProcessSpawnedEvent) => void): this;
+  on(event: 'exit', listener: (event: AcpChildProcessExitEvent) => void): this;
+  on(event: 'error', listener: (event: AcpChildProcessErrorEvent) => void): this;
+  on(
+    event: 'stdout' | 'stderr' | 'spawned' | 'exit' | 'error',
+    listener:
+      | ((event: AcpChildProcessOutputEvent) => void)
+      | ((event: AcpChildProcessSpawnedEvent) => void)
+      | ((event: AcpChildProcessExitEvent) => void)
+      | ((event: AcpChildProcessErrorEvent) => void)
+  ): this {
+    // The overload signatures bind each event name to its listener payload type.
+    // TypeScript does not carry that relationship into the shared implementation.
+    switch (event) {
+      case 'stdout':
+        this.stdoutListeners.add(listener as (event: AcpChildProcessOutputEvent) => void);
+        break;
+      case 'stderr':
+        this.stderrListeners.add(listener as (event: AcpChildProcessOutputEvent) => void);
+        break;
+      case 'spawned':
+        this.spawnedListeners.add(listener as (event: AcpChildProcessSpawnedEvent) => void);
+        break;
+      case 'exit':
+        this.exitListeners.add(listener as (event: AcpChildProcessExitEvent) => void);
+        break;
+      case 'error':
+        this.errorListeners.add(listener as (event: AcpChildProcessErrorEvent) => void);
+        break;
+    }
+    return this;
+  }
+
+  off(event: 'stdout', listener: (event: AcpChildProcessOutputEvent) => void): this;
+  off(event: 'stderr', listener: (event: AcpChildProcessOutputEvent) => void): this;
+  off(event: 'spawned', listener: (event: AcpChildProcessSpawnedEvent) => void): this;
+  off(event: 'exit', listener: (event: AcpChildProcessExitEvent) => void): this;
+  off(event: 'error', listener: (event: AcpChildProcessErrorEvent) => void): this;
+  off(
+    event: 'stdout' | 'stderr' | 'spawned' | 'exit' | 'error',
+    listener:
+      | ((event: AcpChildProcessOutputEvent) => void)
+      | ((event: AcpChildProcessSpawnedEvent) => void)
+      | ((event: AcpChildProcessExitEvent) => void)
+      | ((event: AcpChildProcessErrorEvent) => void)
+  ): this {
+    // The overload signatures bind each event name to its listener payload type.
+    // TypeScript does not carry that relationship into the shared implementation.
+    switch (event) {
+      case 'stdout':
+        this.stdoutListeners.delete(listener as (event: AcpChildProcessOutputEvent) => void);
+        break;
+      case 'stderr':
+        this.stderrListeners.delete(listener as (event: AcpChildProcessOutputEvent) => void);
+        break;
+      case 'spawned':
+        this.spawnedListeners.delete(listener as (event: AcpChildProcessSpawnedEvent) => void);
+        break;
+      case 'exit':
+        this.exitListeners.delete(listener as (event: AcpChildProcessExitEvent) => void);
+        break;
+      case 'error':
+        this.errorListeners.delete(listener as (event: AcpChildProcessErrorEvent) => void);
+        break;
+    }
+    return this;
+  }
+
+  async start(): Promise<AcpChildProcessStartResult> {
+    if (this.statusValue !== 'idle') {
+      throw new AcpChildProcessStateError(`Cannot start ACP child process from ${this.statusValue}`);
+    }
+
+    this.statusValue = 'starting';
+    let resolvedCommand: ResolvedAcpCommand;
+    try {
+      resolvedCommand = this.resolveCommand();
+    } catch (error) {
+      this.statusValue = 'failed';
+      throw error;
+    }
+    this.resolvedCommand = resolvedCommand;
+
+    const spawnOptions: AcpChildProcessSpawnOptions = {
+      cwd: this.options.cwd,
+      env: buildAcpSpawnEnv(
+        this.options.env,
+        definedEnv(this.options.providerEnv),
+        process.env,
+        this.options.platform ?? process.platform
+      ),
+      stdio: 'pipe',
+      windowsHide: true,
+    };
+
+    let child: AcpChildProcessHandle;
+    try {
+      child = this.spawnProcess(resolvedCommand, spawnOptions);
+    } catch (error) {
+      const startError = this.toStartError(error, resolvedCommand);
+      this.statusValue = 'failed';
+      this.emitError(startError);
+      throw startError;
+    }
+
+    this.child = child;
+    this.attachStreams(child);
+    this.exitPromise = this.createExitPromise(child);
+
+    return new Promise<AcpChildProcessStartResult>((resolve, reject) => {
+      let settled = false;
+      child.once('spawn', () => {
+        settled = true;
+        this.statusValue = 'running';
+        const result: AcpChildProcessStartResult = {
+          pid: child.pid,
+          command: resolvedCommand,
+        };
+        this.emitSpawned(result);
+        resolve(result);
+      });
+      child.once('error', error => {
+        const startError = this.toStartError(error, resolvedCommand);
+        if (!settled) {
+          settled = true;
+          this.statusValue = 'failed';
+          this.emitError(startError);
+          reject(startError);
+          return;
+        }
+        this.emitError(startError);
+      });
+    });
+  }
+
+  async waitForExit(): Promise<AcpChildProcessExitEvent> {
+    if (this.exitResult) return this.exitResult;
+    if (!this.exitPromise) {
+      throw new AcpChildProcessStateError('Cannot wait for an ACP child process before start');
+    }
+    return this.exitPromise;
+  }
+
+  async shutdown(options: AcpChildProcessShutdownOptions = {}): Promise<AcpChildProcessExitEvent> {
+    if (this.exitResult) return this.exitResult;
+    if (!this.child || !this.exitPromise) {
+      throw new AcpChildProcessStateError('Cannot shut down an ACP child process before start');
+    }
+
+    this.shutdownRequested = true;
+    const graceMs = options.graceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
+    this.endStdin();
+    const gracefulExit = await this.waitForExitWithin(graceMs);
+    if (gracefulExit) return gracefulExit;
+
+    this.child.kill('SIGTERM');
+    const terminatedExit = await this.waitForExitWithin(graceMs);
+    if (terminatedExit) return terminatedExit;
+
+    this.shutdownEscalated = true;
+    this.child.kill('SIGKILL');
+    return this.waitForExit();
+  }
+
+  private resolveCommand(): ResolvedAcpCommand {
+    if (this.options.resolvedCommand) {
+      return {
+        ...this.options.resolvedCommand,
+        args: [...this.options.resolvedCommand.args],
+      };
+    }
+
+    if (this.options.command && this.options.command.trim() !== '') {
+      return {
+        command: this.options.command,
+        args: [...(this.options.args ?? [])],
+        source: 'explicit',
+      };
+    }
+
+    const resolver = this.options.resolveCommand ?? resolveClaudeAgentAcpBinary;
+    return resolver({
+      cwd: this.options.cwd,
+      env: buildAcpResolveEnv(this.options.env),
+      platform: this.options.platform,
+    });
+  }
+
+  private spawnProcess(
+    resolvedCommand: ResolvedAcpCommand,
+    options: AcpChildProcessSpawnOptions
+  ): AcpChildProcessHandle {
+    const spawner = this.options.spawnProcess ?? defaultSpawner;
+    return spawner(resolvedCommand.command, resolvedCommand.args, options);
+  }
+
+  private attachStreams(child: AcpChildProcessHandle): void {
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', chunk => this.emitStdout({ chunk }));
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', chunk => this.emitStderr({ chunk }));
+    child.stdin.on('error', error => this.emitError(error));
+  }
+
+  private createExitPromise(child: AcpChildProcessHandle): Promise<AcpChildProcessExitEvent> {
+    return new Promise(resolve => {
+      child.once('exit', (code, signal) => {
+        this.exitObserved = { code, signal };
+      });
+      child.once('close', (code, signal) => {
+        const finalCode = code ?? this.exitObserved?.code ?? null;
+        const finalSignal = signal ?? this.exitObserved?.signal ?? null;
+        const result: AcpChildProcessExitEvent = {
+          code: finalCode,
+          signal: finalSignal,
+          expected: this.shutdownRequested,
+          escalated: this.shutdownEscalated,
+        };
+        this.exitResult = result;
+        this.statusValue = this.statusValue === 'failed' ? 'failed' : 'exited';
+        this.emitExit(result);
+        resolve(result);
+      });
+    });
+  }
+
+  private async waitForExitWithin(timeoutMs: number): Promise<AcpChildProcessExitEvent | null> {
+    if (this.exitResult) return this.exitResult;
+    if (!this.exitPromise) return null;
+    return Promise.race([
+      this.exitPromise,
+      new Promise<null>(resolve => {
+        setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  }
+
+  private endStdin(): void {
+    if (!this.child || this.child.stdin.destroyed) return;
+    try {
+      this.child.stdin.end();
+    } catch (error) {
+      this.emitError(errorToError(error));
+    }
+  }
+
+  private toStartError(error: unknown, command: ResolvedAcpCommand): AcpChildProcessStartError {
+    const normalizedError = errorToError(error);
+    return new AcpChildProcessStartError({
+      command: command.command,
+      args: [...command.args],
+      cwd: this.options.cwd,
+      message: normalizedError.message,
+    });
+  }
+
+  private emitStdout(event: AcpChildProcessOutputEvent): void {
+    for (const listener of this.stdoutListeners) listener(event);
+  }
+
+  private emitStderr(event: AcpChildProcessOutputEvent): void {
+    for (const listener of this.stderrListeners) listener(event);
+  }
+
+  private emitSpawned(event: AcpChildProcessSpawnedEvent): void {
+    for (const listener of this.spawnedListeners) listener(event);
+  }
+
+  private emitExit(event: AcpChildProcessExitEvent): void {
+    for (const listener of this.exitListeners) listener(event);
+  }
+
+  private emitError(error: Error): void {
+    const event: AcpChildProcessErrorEvent = { error };
+    for (const listener of this.errorListeners) listener(event);
+  }
+}
+
+const defaultSpawner: AcpChildProcessSpawner = (command, args, options) =>
+  spawn(command, [...args], options);
+
+function errorToError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
+}
+
+function definedEnv(env: Record<string, string | undefined> | undefined): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!env) return result;
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -94,6 +94,25 @@ export {
   type ResolvedAcpCommand,
 } from './binary-resolver.js';
 export {
+  AcpChildProcess,
+  AcpChildProcessStartError,
+  AcpChildProcessStateError,
+  type AcpChildProcessErrorDetails,
+  type AcpChildProcessErrorEvent,
+  type AcpChildProcessExitEvent,
+  type AcpChildProcessHandle,
+  type AcpChildProcessOptions,
+  type AcpChildProcessOutputEvent,
+  type AcpChildProcessShutdownOptions,
+  type AcpChildProcessSpawnOptions,
+  type AcpChildProcessSpawnedEvent,
+  type AcpChildProcessSpawner,
+  type AcpChildProcessStartResult,
+  type AcpChildProcessStatus,
+  type AcpReadableProcessStream,
+  type AcpWritableProcessStream,
+} from './child-process.js';
+export {
   FileAcpLocalStorageProfile,
   MemoryAcpActionQueue,
   MemoryAcpEventStore,


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Add `AcpChildProcess` as the typed ACP child-process supervision boundary.
- Preserve ACP binary resolution behavior for explicit commands, `AEGIS_ACP_BIN`, and bundled package resolution.
- Preserve BYO/custom model environment passthrough by reusing ACP spawn env helpers.
- Forward stdout/stderr as raw chunks only; JSON-RPC parsing remains out of scope for ACP-042.

## Scope
ACP-041 only: process spawn, startup errors, raw stream forwarding, exit/error events, and graceful shutdown with escalation. Restart/backoff policy is intentionally left for ACP-044 backend lifecycle wiring.

## Tests
- `npx vitest run src\__tests__\acp-child-process.test.ts src\__tests__\acp-binary-resolver.test.ts src\__tests__\acp-spawn-env.test.ts --reporter=dot`
- `npx tsc --noEmit`
- `powershell -NoProfile -ExecutionPolicy Bypass -Command "npm run gate"`

Closes #2595