### PR TITLE
refactor: add ACP JSON-RPC stdio client

### DIFF
--- a/src/__tests__/acp-json-rpc-client.test.ts
+++ b/src/__tests__/acp-json-rpc-client.test.ts
@@ -1,0 +1,355 @@
+import { EventEmitter } from 'node:events';
+import nodeProcess from 'node:process';
+import { PassThrough, Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+
+import { AcpChildProcess, type AcpChildProcessHandle } from '../services/acp/child-process.js';
+import {
+  AcpJsonRpcChildExitError,
+  AcpJsonRpcClient,
+  AcpJsonRpcProtocolError,
+  AcpJsonRpcRemoteError,
+  AcpJsonRpcRequestCancelledError,
+  AcpJsonRpcTimeoutError,
+} from '../services/acp/json-rpc-client.js';
+
+describe('AcpJsonRpcClient', () => {
+  it('generates namespaced ids and serializes JSON-RPC requests to ACP stdin', async () => {
+    const { client, process } = createClient({ idNamespace: 'acp-test' });
+    await client.start();
+
+    const response = client.request<{ ok: boolean }>('initialize', { clientCapabilities: {} });
+    await waitForWrites(process.stdin, 1);
+
+    expect(process.stdin.writes).toEqual([
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'acp-test-1',
+        method: 'initialize',
+        params: { clientCapabilities: {} },
+      })}\n`,
+    ]);
+
+    process.writeStdout({ jsonrpc: '2.0', id: 'acp-test-1', result: { ok: true } });
+
+    await expect(response).resolves.toEqual({
+      jsonrpc: '2.0',
+      id: 'acp-test-1',
+      result: { ok: true },
+    });
+  });
+
+  it('parses newline and Content-Length framed responses and preserves raw notifications', async () => {
+    const { client, process } = createClient({ idNamespace: 'frame-test' });
+    const notifications: unknown[] = [];
+    client.onNotification(notification => notifications.push(notification));
+    await client.start();
+
+    const first = client.request<{ sequence: number }>('first');
+    const second = client.request<{ sequence: number }>('second', { value: true });
+    await waitForWrites(process.stdin, 2);
+
+    process.stdout.write(
+      contentLengthFrame({ jsonrpc: '2.0', id: 'frame-test-2', result: { sequence: 2 } })
+    );
+    process.stdout.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { sessionId: 'fixture-session', update: { sessionUpdate: 'raw_update' } },
+      })}\n`
+    );
+    process.stdout.write(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 'frame-test-1', result: { sequence: 1 } })}\n`
+    );
+
+    await expect(first).resolves.toMatchObject({ id: 'frame-test-1', result: { sequence: 1 } });
+    await expect(second).resolves.toMatchObject({ id: 'frame-test-2', result: { sequence: 2 } });
+    expect(notifications).toEqual([
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { sessionId: 'fixture-session', update: { sessionUpdate: 'raw_update' } },
+        raw: {
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: { sessionId: 'fixture-session', update: { sessionUpdate: 'raw_update' } },
+        },
+      },
+    ]);
+  });
+
+  it('emits inbound ACP JSON-RPC requests without mapping them to Aegis domain events', async () => {
+    const { client, process } = createClient();
+    const requests: unknown[] = [];
+    client.onRequest(request => requests.push(request));
+    await client.start();
+
+    process.writeStdout({
+      jsonrpc: '2.0',
+      id: 'permission-1',
+      method: 'session/request_permission',
+      params: { sessionId: 'fixture-session', options: [] },
+    });
+
+    expect(requests).toEqual([
+      {
+        jsonrpc: '2.0',
+        id: 'permission-1',
+        method: 'session/request_permission',
+        params: { sessionId: 'fixture-session', options: [] },
+        raw: {
+          jsonrpc: '2.0',
+          id: 'permission-1',
+          method: 'session/request_permission',
+          params: { sessionId: 'fixture-session', options: [] },
+        },
+      },
+    ]);
+  });
+
+  it('rejects malformed JSON and protocol violations explicitly', async () => {
+    const { client, process } = createClient({ idNamespace: 'bad-json' });
+    const errors: Error[] = [];
+    client.onError(error => errors.push(error));
+    await client.start();
+
+    const pending = client.request('initialize');
+    await waitForWrites(process.stdin, 1);
+    process.stdout.write('not-json\n');
+
+    await expect(pending).rejects.toBeInstanceOf(AcpJsonRpcProtocolError);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      message: 'ACP JSON-RPC stdout contained malformed JSON',
+      details: expect.objectContaining({ frame: 'not-json' }),
+    });
+
+    const { client: protocolClient, process: protocolProcess } = createClient();
+    const protocolErrors: Error[] = [];
+    protocolClient.onError(error => protocolErrors.push(error));
+    await protocolClient.start();
+    protocolProcess.writeStdout({ jsonrpc: '2.0', id: 'missing-request', result: {} });
+
+    expect(protocolErrors[0]).toBeInstanceOf(AcpJsonRpcProtocolError);
+    expect(protocolErrors[0]).toMatchObject({
+      message: 'ACP JSON-RPC response id did not match a pending request',
+    });
+  });
+
+  it('rejects JSON-RPC error responses on the matching pending request only', async () => {
+    const { client, process } = createClient({ idNamespace: 'remote-error' });
+    await client.start();
+
+    const rejected = client.request('failing');
+    const fulfilled = client.request('succeeds');
+    await waitForWrites(process.stdin, 2);
+
+    process.writeStdout({
+      jsonrpc: '2.0',
+      id: 'remote-error-1',
+      error: { code: -32602, message: 'invalid params', data: { field: 'cwd' } },
+    });
+    process.writeStdout({ jsonrpc: '2.0', id: 'remote-error-2', result: { ok: true } });
+
+    await expect(rejected).rejects.toMatchObject({
+      name: 'AcpJsonRpcRemoteError',
+      message: 'ACP JSON-RPC request failed',
+      details: {
+        id: 'remote-error-1',
+        method: 'failing',
+        error: { code: -32602, message: 'invalid params', data: { field: 'cwd' } },
+      },
+    });
+    await expect(fulfilled).resolves.toMatchObject({ id: 'remote-error-2', result: { ok: true } });
+  });
+
+  it('handles request timeouts and AbortSignal cancellation without leaking pending requests', async () => {
+    const { client, process } = createClient({
+      idNamespace: 'cancel-test',
+      requestTimeoutMs: 20,
+    });
+    await client.start();
+
+    await expect(client.request('hang')).rejects.toBeInstanceOf(AcpJsonRpcTimeoutError);
+
+    const controller = new AbortController();
+    const cancelled = client.request('cancel-me', undefined, { signal: controller.signal });
+    await waitForWrites(process.stdin, 2);
+    controller.abort();
+
+    await expect(cancelled).rejects.toBeInstanceOf(AcpJsonRpcRequestCancelledError);
+    process.writeStdout({ jsonrpc: '2.0', id: 'cancel-test-2', result: { ignored: true } });
+    expect(client.pendingRequestCount).toBe(0);
+    const afterCancel = client.request('after-cancel');
+    await waitForWrites(process.stdin, 3);
+    process.writeStdout({ jsonrpc: '2.0', id: 'cancel-test-3', result: { ok: true } });
+    await expect(afterCancel).resolves.toMatchObject({
+      id: 'cancel-test-3',
+      result: { ok: true },
+    });
+  });
+
+  it('expires abandoned timeout and cancellation ids after the late-response grace window', async () => {
+    const { client, process } = createClient({
+      idNamespace: 'abandoned-test',
+      requestTimeoutMs: 10,
+      abandonedResponseGraceMs: 10,
+    });
+    const errors: Error[] = [];
+    client.onError(error => errors.push(error));
+    await client.start();
+
+    await expect(client.request('timeout-without-response')).rejects.toBeInstanceOf(
+      AcpJsonRpcTimeoutError
+    );
+    const controller = new AbortController();
+    const cancelled = client.request('cancel-without-response', undefined, {
+      signal: controller.signal,
+    });
+    await waitForWrites(process.stdin, 2);
+    controller.abort();
+    await expect(cancelled).rejects.toBeInstanceOf(AcpJsonRpcRequestCancelledError);
+
+    await waitForCondition(() => errors.length === 0);
+    await delay(25);
+    process.writeStdout({ jsonrpc: '2.0', id: 'abandoned-test-1', result: { tooLate: true } });
+
+    expect(errors[0]).toMatchObject({
+      message: 'ACP JSON-RPC response id did not match a pending request',
+      details: expect.objectContaining({ id: 'abandoned-test-1' }),
+    });
+  });
+
+  it('rejects pending requests when the ACP child exits before responding', async () => {
+    const { client, process } = createClient({ idNamespace: 'exit-test' });
+    await client.start();
+
+    const pending = client.request('initialize');
+    await waitForWrites(process.stdin, 1);
+    process.emitExit(42, null);
+
+    await expect(pending).rejects.toBeInstanceOf(AcpJsonRpcChildExitError);
+    await expect(pending).rejects.toMatchObject({
+      message: 'ACP child process exited before JSON-RPC response',
+      details: expect.objectContaining({ code: 42, id: 'exit-test-1', method: 'initialize' }),
+    });
+  });
+
+  it('performs clean shutdown and prevents further writes after closing', async () => {
+    const { client, process } = createClient();
+    await client.start();
+
+    await expect(client.shutdown({ graceMs: 50 })).resolves.toMatchObject({
+      code: 0,
+      signal: null,
+      expected: true,
+      escalated: false,
+    });
+
+    expect(process.stdin.writableEnded).toBe(true);
+    await expect(client.request('after-close')).rejects.toMatchObject({
+      message: 'ACP JSON-RPC client is closed',
+    });
+  });
+});
+
+interface TestClientOptions {
+  idNamespace?: string;
+  requestTimeoutMs?: number;
+  abandonedResponseGraceMs?: number;
+}
+
+function createClient(options: TestClientOptions = {}): {
+  client: AcpJsonRpcClient;
+  process: FakeChildProcess;
+} {
+  const process = new FakeChildProcess();
+  const child = new AcpChildProcess({
+    command: 'fake-acp',
+    cwd: nodeProcess.cwd(),
+    spawnProcess: () => process,
+  });
+  return {
+    client: new AcpJsonRpcClient({
+      child,
+      idNamespace: options.idNamespace ?? 'aegis-acp-test',
+      requestTimeoutMs: options.requestTimeoutMs ?? 1_000,
+      abandonedResponseGraceMs: options.abandonedResponseGraceMs,
+    }),
+    process,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForCondition(predicate: () => boolean): Promise<void> {
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    if (predicate()) return;
+    await delay(1);
+  }
+  throw new Error('condition was not met');
+}
+
+function contentLengthFrame(message: Record<string, unknown>): string {
+  const body = JSON.stringify(message);
+  return `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`;
+}
+
+async function waitForWrites(stdin: CapturingWritable, count: number): Promise<void> {
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    if (stdin.writes.length >= count) return;
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 1);
+    });
+  }
+  throw new Error(`Expected ${count} stdin writes, got ${stdin.writes.length}`);
+}
+
+class CapturingWritable extends Writable {
+  readonly writes: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void {
+    this.writes.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    callback();
+  }
+}
+
+class FakeChildProcess extends EventEmitter implements AcpChildProcessHandle {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdin = new CapturingWritable();
+  readonly pid = 9876;
+  readonly killedSignals: (NodeJS.Signals | number | undefined)[] = [];
+
+  constructor() {
+    super();
+    this.stdin.on('finish', () => this.emitExit(0, null));
+    queueMicrotask(() => this.emit('spawn'));
+  }
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killedSignals.push(signal);
+    this.emitExit(null, typeof signal === 'string' ? signal : null);
+    return true;
+  }
+
+  writeStdout(message: Record<string, unknown>): void {
+    this.stdout.write(`${JSON.stringify(message)}\n`);
+  }
+
+  emitExit(code: number | null, signal: NodeJS.Signals | null): void {
+    queueMicrotask(() => {
+      this.emit('exit', code, signal);
+      this.emit('close', code, signal);
+    });
+  }
+}

--- a/src/__tests__/acp-json-rpc-client.test.ts
+++ b/src/__tests__/acp-json-rpc-client.test.ts
@@ -8,7 +8,6 @@ import {
   AcpJsonRpcChildExitError,
   AcpJsonRpcClient,
   AcpJsonRpcProtocolError,
-  AcpJsonRpcRemoteError,
   AcpJsonRpcRequestCancelledError,
   AcpJsonRpcTimeoutError,
 } from '../services/acp/json-rpc-client.js';

--- a/src/services/acp/child-process.ts
+++ b/src/services/acp/child-process.ts
@@ -51,6 +51,9 @@ export interface AcpReadableProcessStream {
 
 export interface AcpWritableProcessStream {
   readonly destroyed: boolean;
+  readonly writable: boolean;
+  readonly writableEnded: boolean;
+  write(chunk: string, callback?: (error: Error | null | undefined) => void): boolean;
   end(): unknown;
   on(event: 'error', listener: (error: Error) => void): unknown;
 }
@@ -213,7 +216,9 @@ export class AcpChildProcess {
 
   async start(): Promise<AcpChildProcessStartResult> {
     if (this.statusValue !== 'idle') {
-      throw new AcpChildProcessStateError(`Cannot start ACP child process from ${this.statusValue}`);
+      throw new AcpChildProcessStateError(
+        `Cannot start ACP child process from ${this.statusValue}`
+      );
     }
 
     this.statusValue = 'starting';
@@ -284,6 +289,33 @@ export class AcpChildProcess {
       throw new AcpChildProcessStateError('Cannot wait for an ACP child process before start');
     }
     return this.exitPromise;
+  }
+
+  async writeStdin(chunk: string): Promise<void> {
+    const child = this.child;
+    if (!child || !this.exitPromise) {
+      throw new AcpChildProcessStateError('Cannot write to an ACP child process before start');
+    }
+    if (this.exitResult) {
+      throw new AcpChildProcessStateError('Cannot write to an exited ACP child process');
+    }
+    if (child.stdin.destroyed || child.stdin.writableEnded || !child.stdin.writable) {
+      throw new AcpChildProcessStateError('Cannot write to closed ACP child process stdin');
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      try {
+        child.stdin.write(chunk, error => {
+          if (error) {
+            reject(errorToError(error));
+            return;
+          }
+          resolve();
+        });
+      } catch (error) {
+        reject(errorToError(error));
+      }
+    });
   }
 
   async shutdown(options: AcpChildProcessShutdownOptions = {}): Promise<AcpChildProcessExitEvent> {

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -113,6 +113,24 @@ export {
   type AcpWritableProcessStream,
 } from './child-process.js';
 export {
+  AcpJsonRpcChildExitError,
+  AcpJsonRpcClient,
+  AcpJsonRpcClosedError,
+  AcpJsonRpcProtocolError,
+  AcpJsonRpcRemoteError,
+  AcpJsonRpcRequestCancelledError,
+  AcpJsonRpcTimeoutError,
+  type AcpJsonObject,
+  type AcpJsonRpcClientOptions,
+  type AcpJsonRpcClientRequestId,
+  type AcpJsonRpcId,
+  type AcpJsonRpcInboundRequest,
+  type AcpJsonRpcNotification,
+  type AcpJsonRpcRequestOptions,
+  type AcpJsonRpcSuccess,
+  type AcpJsonValue,
+} from './json-rpc-client.js';
+export {
   FileAcpLocalStorageProfile,
   MemoryAcpActionQueue,
   MemoryAcpEventStore,

--- a/src/services/acp/json-rpc-client.ts
+++ b/src/services/acp/json-rpc-client.ts
@@ -52,7 +52,7 @@ export interface AcpJsonRpcInboundRequest {
   raw: AcpJsonObject;
 }
 
-export interface AcpJsonRpcErrorDetails extends AcpJsonObject {}
+export type AcpJsonRpcErrorDetails = AcpJsonObject;
 
 export class AcpJsonRpcProtocolError extends Error {
   readonly details: AcpJsonRpcErrorDetails;

--- a/src/services/acp/json-rpc-client.ts
+++ b/src/services/acp/json-rpc-client.ts
@@ -1,0 +1,676 @@
+import type {
+  AcpChildProcess,
+  AcpChildProcessExitEvent,
+  AcpChildProcessShutdownOptions,
+} from './child-process.js';
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const DEFAULT_ID_NAMESPACE = 'aegis-acp';
+const DEFAULT_ABANDONED_RESPONSE_GRACE_MS = 60_000;
+
+export type AcpJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | AcpJsonValue[]
+  | { [key: string]: AcpJsonValue };
+export type AcpJsonObject = { [key: string]: AcpJsonValue };
+export type AcpJsonRpcId = string | number | null;
+export type AcpJsonRpcClientRequestId = string;
+
+export interface AcpJsonRpcClientOptions {
+  child: AcpChildProcess;
+  idNamespace?: string;
+  requestTimeoutMs?: number;
+  abandonedResponseGraceMs?: number;
+}
+
+export interface AcpJsonRpcRequestOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface AcpJsonRpcSuccess<T = AcpJsonValue> {
+  jsonrpc: '2.0';
+  id: AcpJsonRpcClientRequestId;
+  result: T;
+}
+
+export interface AcpJsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: AcpJsonValue;
+  raw: AcpJsonObject;
+}
+
+export interface AcpJsonRpcInboundRequest {
+  jsonrpc: '2.0';
+  id: AcpJsonRpcId;
+  method: string;
+  params?: AcpJsonValue;
+  raw: AcpJsonObject;
+}
+
+export interface AcpJsonRpcErrorDetails extends AcpJsonObject {}
+
+export class AcpJsonRpcProtocolError extends Error {
+  readonly details: AcpJsonRpcErrorDetails;
+
+  constructor(message: string, details: AcpJsonRpcErrorDetails = {}) {
+    super(message);
+    this.name = 'AcpJsonRpcProtocolError';
+    this.details = details;
+  }
+}
+
+export class AcpJsonRpcRemoteError extends Error {
+  readonly details: AcpJsonRpcErrorDetails;
+
+  constructor(details: AcpJsonRpcErrorDetails) {
+    super('ACP JSON-RPC request failed');
+    this.name = 'AcpJsonRpcRemoteError';
+    this.details = details;
+  }
+}
+
+export class AcpJsonRpcTimeoutError extends Error {
+  readonly details: AcpJsonRpcErrorDetails;
+
+  constructor(details: AcpJsonRpcErrorDetails) {
+    super('ACP JSON-RPC request timed out');
+    this.name = 'AcpJsonRpcTimeoutError';
+    this.details = details;
+  }
+}
+
+export class AcpJsonRpcRequestCancelledError extends Error {
+  readonly details: AcpJsonRpcErrorDetails;
+
+  constructor(details: AcpJsonRpcErrorDetails) {
+    super('ACP JSON-RPC request was cancelled');
+    this.name = 'AcpJsonRpcRequestCancelledError';
+    this.details = details;
+  }
+}
+
+export class AcpJsonRpcChildExitError extends Error {
+  readonly details: AcpJsonRpcErrorDetails;
+
+  constructor(details: AcpJsonRpcErrorDetails) {
+    super('ACP child process exited before JSON-RPC response');
+    this.name = 'AcpJsonRpcChildExitError';
+    this.details = details;
+  }
+}
+
+export class AcpJsonRpcClosedError extends Error {
+  readonly details: AcpJsonRpcErrorDetails;
+
+  constructor(details: AcpJsonRpcErrorDetails = {}) {
+    super('ACP JSON-RPC client is closed');
+    this.name = 'AcpJsonRpcClosedError';
+    this.details = details;
+  }
+}
+
+interface PendingRequest<T = AcpJsonValue> {
+  id: AcpJsonRpcClientRequestId;
+  method: string;
+  timer: NodeJS.Timeout;
+  signal?: AbortSignal;
+  abortListener?: () => void;
+  resolve: (response: AcpJsonRpcSuccess<T>) => void;
+  reject: (error: Error) => void;
+}
+
+interface FrameSeparator {
+  headerEndIndex: number;
+  bodyStartIndex: number;
+}
+
+// ACP currently uses newline-delimited JSON in local fixtures; Content-Length
+// support is intentionally limited to standard LSP-style frames for ACP agents
+// that expose framed JSON-RPC over stdio.
+export class AcpJsonRpcClient {
+  private readonly child: AcpChildProcess;
+  private readonly idNamespace: string;
+  private readonly requestTimeoutMs: number;
+  private readonly abandonedResponseGraceMs: number;
+  private readonly pending = new Map<AcpJsonRpcClientRequestId, PendingRequest<unknown>>();
+  private readonly abandonedRequestTimers = new Map<AcpJsonRpcClientRequestId, NodeJS.Timeout>();
+  private readonly notificationListeners = new Set<
+    (notification: AcpJsonRpcNotification) => void
+  >();
+  private readonly requestListeners = new Set<(request: AcpJsonRpcInboundRequest) => void>();
+  private readonly errorListeners = new Set<(error: Error) => void>();
+  private readonly exitListeners = new Set<(exit: AcpChildProcessExitEvent) => void>();
+  private stdoutBuffer = '';
+  private nextSequence = 1;
+  private started = false;
+  private closed = false;
+  private protocolFailure: AcpJsonRpcProtocolError | null = null;
+
+  constructor(options: AcpJsonRpcClientOptions) {
+    this.child = options.child;
+    this.idNamespace = normalizeIdNamespace(options.idNamespace ?? DEFAULT_ID_NAMESPACE);
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.abandonedResponseGraceMs =
+      options.abandonedResponseGraceMs ?? DEFAULT_ABANDONED_RESPONSE_GRACE_MS;
+
+    this.child.on('stdout', event => this.handleStdout(event.chunk));
+    this.child.on('exit', event => this.handleChildExit(event));
+    this.child.on('error', event => {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP child process stream error', {
+          message: event.error.message,
+        })
+      );
+    });
+  }
+
+  get pendingRequestCount(): number {
+    return this.pending.size;
+  }
+
+  onNotification(listener: (notification: AcpJsonRpcNotification) => void): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onRequest(listener: (request: AcpJsonRpcInboundRequest) => void): () => void {
+    this.requestListeners.add(listener);
+    return () => this.requestListeners.delete(listener);
+  }
+
+  onError(listener: (error: Error) => void): () => void {
+    this.errorListeners.add(listener);
+    return () => this.errorListeners.delete(listener);
+  }
+
+  onExit(listener: (exit: AcpChildProcessExitEvent) => void): () => void {
+    this.exitListeners.add(listener);
+    return () => this.exitListeners.delete(listener);
+  }
+
+  async start(): Promise<void> {
+    if (this.closed) throw new AcpJsonRpcClosedError();
+    if (this.started) return;
+    await this.child.start();
+    this.started = true;
+  }
+
+  request<T = AcpJsonValue>(
+    method: string,
+    params?: AcpJsonValue,
+    options: AcpJsonRpcRequestOptions = {}
+  ): Promise<AcpJsonRpcSuccess<T>> {
+    try {
+      this.assertWritable(method);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    const id = this.nextRequestId();
+    const timeoutMs = options.timeoutMs ?? this.requestTimeoutMs;
+    const message = buildOutboundRequest(id, method, params);
+
+    return new Promise<AcpJsonRpcSuccess<T>>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.rejectPending(id, new AcpJsonRpcTimeoutError({ id, method, timeoutMs }), true);
+      }, timeoutMs);
+
+      const pending: PendingRequest<unknown> = {
+        id,
+        method,
+        timer,
+        signal: options.signal,
+        // The transport validates JSON-RPC framing; callers bind T to the method contract.
+        resolve: response => resolve(response as AcpJsonRpcSuccess<T>),
+        reject,
+      };
+
+      if (options.signal) {
+        if (options.signal.aborted) {
+          clearTimeout(timer);
+          reject(new AcpJsonRpcRequestCancelledError({ id, method }));
+          return;
+        }
+        const abortListener = (): void => {
+          this.rejectPending(id, new AcpJsonRpcRequestCancelledError({ id, method }), true);
+        };
+        pending.abortListener = abortListener;
+        options.signal.addEventListener('abort', abortListener, { once: true });
+      }
+
+      this.pending.set(id, pending);
+      this.writeMessage(message).catch(error => {
+        this.rejectPending(id, normalizeWriteError(error, id, method));
+      });
+    });
+  }
+
+  async notify(method: string, params?: AcpJsonValue): Promise<void> {
+    this.assertWritable(method);
+    const message: AcpJsonObject = { jsonrpc: '2.0', method };
+    if (params !== undefined) message.params = params;
+    await this.writeMessage(message);
+  }
+
+  async shutdown(options: AcpChildProcessShutdownOptions = {}): Promise<AcpChildProcessExitEvent> {
+    if (this.closed) return this.child.waitForExit();
+    this.closed = true;
+    this.rejectAllPending(new AcpJsonRpcClosedError());
+    this.clearAbandonedRequestIds();
+    return this.child.shutdown(options);
+  }
+
+  private nextRequestId(): AcpJsonRpcClientRequestId {
+    const id = `${this.idNamespace}-${this.nextSequence}`;
+    this.nextSequence += 1;
+    return id;
+  }
+
+  private assertWritable(method: string): void {
+    if (this.closed) throw new AcpJsonRpcClosedError({ method });
+    if (this.protocolFailure) throw this.protocolFailure;
+    if (!this.started) {
+      throw new AcpJsonRpcProtocolError('ACP JSON-RPC client has not been started', { method });
+    }
+  }
+
+  private async writeMessage(message: AcpJsonObject): Promise<void> {
+    await this.child.writeStdin(`${JSON.stringify(message)}\n`);
+  }
+
+  private handleStdout(chunk: string): void {
+    if (this.closed || this.protocolFailure) return;
+    this.stdoutBuffer += chunk;
+    this.drainStdoutBuffer();
+  }
+
+  private drainStdoutBuffer(): void {
+    while (this.stdoutBuffer.length > 0 && !this.protocolFailure) {
+      if (startsWithContentLengthHeader(this.stdoutBuffer)) {
+        const frame = this.takeContentLengthFrame();
+        if (frame === null) return;
+        this.handleFrame(frame);
+        continue;
+      }
+
+      const newlineIndex = this.stdoutBuffer.indexOf('\n');
+      if (newlineIndex === -1) return;
+      const line = this.stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, '');
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line.trim() === '') continue;
+      this.handleFrame(line);
+    }
+  }
+
+  private takeContentLengthFrame(): string | null {
+    const separator = findHeaderSeparator(this.stdoutBuffer);
+    if (!separator) return null;
+
+    const headerText = this.stdoutBuffer.slice(0, separator.headerEndIndex);
+    const contentLength = parseContentLength(headerText);
+    if (contentLength === null) {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC framed stdout omitted Content-Length', {
+          header: headerText,
+        })
+      );
+      return null;
+    }
+
+    const headerAndSeparator = this.stdoutBuffer.slice(0, separator.bodyStartIndex);
+    const headerBytes = Buffer.byteLength(headerAndSeparator, 'utf8');
+    const bytes = Buffer.from(this.stdoutBuffer, 'utf8');
+    const frameEnd = headerBytes + contentLength;
+    if (bytes.length < frameEnd) return null;
+
+    const body = bytes.subarray(headerBytes, frameEnd).toString('utf8');
+    this.stdoutBuffer = bytes.subarray(frameEnd).toString('utf8');
+    return body;
+  }
+
+  private handleFrame(frame: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(frame);
+    } catch (error) {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC stdout contained malformed JSON', {
+          frame,
+          message: error instanceof Error ? error.message : String(error),
+        })
+      );
+      return;
+    }
+
+    if (!isJsonObject(parsed)) {
+      this.fail(new AcpJsonRpcProtocolError('ACP JSON-RPC message was not an object', { frame }));
+      return;
+    }
+
+    this.handleMessage(parsed);
+  }
+
+  private handleMessage(message: AcpJsonObject): void {
+    if (message.jsonrpc !== '2.0') {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC message used an unsupported version', { message })
+      );
+      return;
+    }
+
+    const hasId = Object.hasOwn(message, 'id');
+    const hasMethod = Object.hasOwn(message, 'method');
+    const hasResult = Object.hasOwn(message, 'result');
+    const hasError = Object.hasOwn(message, 'error');
+
+    if (hasResult || hasError) {
+      this.handleResponseMessage(message, hasResult, hasError);
+      return;
+    }
+
+    if (!hasMethod || typeof message.method !== 'string') {
+      this.fail(
+        new AcpJsonRpcProtocolError(
+          'ACP JSON-RPC message did not include a method or response payload',
+          {
+            message,
+          }
+        )
+      );
+      return;
+    }
+
+    if (hasId) {
+      this.handleInboundRequest(message);
+      return;
+    }
+
+    this.emitNotification({
+      jsonrpc: '2.0',
+      method: message.method,
+      ...(Object.hasOwn(message, 'params') ? { params: message.params } : {}),
+      raw: message,
+    });
+  }
+
+  private handleResponseMessage(
+    message: AcpJsonObject,
+    hasResult: boolean,
+    hasError: boolean
+  ): void {
+    if (hasResult === hasError) {
+      this.fail(
+        new AcpJsonRpcProtocolError(
+          'ACP JSON-RPC response must include exactly one of result or error',
+          {
+            message,
+          }
+        )
+      );
+      return;
+    }
+
+    if (typeof message.id !== 'string') {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC response id was not a client request id', {
+          message,
+        })
+      );
+      return;
+    }
+
+    const pending = this.pending.get(message.id);
+    if (!pending) {
+      if (this.clearAbandonedRequestId(message.id)) return;
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC response id did not match a pending request', {
+          id: message.id,
+          message,
+        })
+      );
+      return;
+    }
+
+    this.clearPending(pending);
+    this.pending.delete(message.id);
+
+    if (hasError) {
+      const remoteError = normalizeRemoteError(message.error);
+      if (!remoteError) {
+        pending.reject(
+          new AcpJsonRpcProtocolError('ACP JSON-RPC error response was malformed', {
+            id: message.id,
+            method: pending.method,
+            error: message.error ?? null,
+          })
+        );
+        return;
+      }
+      pending.reject(
+        new AcpJsonRpcRemoteError({
+          id: message.id,
+          method: pending.method,
+          error: remoteError,
+        })
+      );
+      return;
+    }
+
+    pending.resolve({
+      jsonrpc: '2.0',
+      id: message.id,
+      // The caller chooses T for the JSON-RPC method contract; this transport only validates framing.
+      result: message.result as unknown,
+    });
+  }
+
+  private handleInboundRequest(message: AcpJsonObject): void {
+    if (!isJsonRpcId(message.id)) {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC inbound request id was invalid', { message })
+      );
+      return;
+    }
+    if (typeof message.method !== 'string') {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC inbound request method was invalid', { message })
+      );
+      return;
+    }
+    this.emitRequest({
+      jsonrpc: '2.0',
+      id: message.id,
+      method: message.method,
+      ...(Object.hasOwn(message, 'params') ? { params: message.params } : {}),
+      raw: message,
+    });
+  }
+
+  private rejectPending(id: AcpJsonRpcClientRequestId, error: Error, abandoned = false): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    this.clearPending(pending);
+    this.pending.delete(id);
+    if (abandoned) this.trackAbandonedRequestId(id);
+    pending.reject(error);
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      this.clearPending(pending);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private clearPending(pending: PendingRequest<unknown>): void {
+    clearTimeout(pending.timer);
+    if (pending.signal && pending.abortListener) {
+      pending.signal.removeEventListener('abort', pending.abortListener);
+    }
+  }
+
+  private fail(error: AcpJsonRpcProtocolError): void {
+    if (this.protocolFailure) return;
+    this.protocolFailure = error;
+    this.rejectAllPending(error);
+    this.clearAbandonedRequestIds();
+    this.emitError(error);
+  }
+
+  private handleChildExit(exit: AcpChildProcessExitEvent): void {
+    this.clearAbandonedRequestIds();
+    if (this.stdoutBuffer.trim() !== '' && !this.protocolFailure) {
+      this.fail(
+        new AcpJsonRpcProtocolError('ACP JSON-RPC stdout ended with an unterminated frame', {
+          frame: this.stdoutBuffer,
+        })
+      );
+    }
+
+    for (const pending of this.pending.values()) {
+      this.clearPending(pending);
+      pending.reject(
+        new AcpJsonRpcChildExitError({
+          id: pending.id,
+          method: pending.method,
+          code: exit.code,
+          signal: exit.signal,
+          expected: exit.expected,
+        })
+      );
+    }
+    this.pending.clear();
+    for (const listener of this.exitListeners) listener(exit);
+  }
+
+  private emitNotification(notification: AcpJsonRpcNotification): void {
+    for (const listener of this.notificationListeners) listener(notification);
+  }
+
+  private emitRequest(request: AcpJsonRpcInboundRequest): void {
+    for (const listener of this.requestListeners) listener(request);
+  }
+
+  private emitError(error: Error): void {
+    for (const listener of this.errorListeners) listener(error);
+  }
+
+  private trackAbandonedRequestId(id: AcpJsonRpcClientRequestId): void {
+    this.clearAbandonedRequestId(id);
+    const timer = setTimeout(() => {
+      this.abandonedRequestTimers.delete(id);
+    }, this.abandonedResponseGraceMs);
+    timer.unref();
+    this.abandonedRequestTimers.set(id, timer);
+  }
+
+  private clearAbandonedRequestId(id: AcpJsonRpcClientRequestId): boolean {
+    const timer = this.abandonedRequestTimers.get(id);
+    if (!timer) return false;
+    clearTimeout(timer);
+    this.abandonedRequestTimers.delete(id);
+    return true;
+  }
+
+  private clearAbandonedRequestIds(): void {
+    for (const timer of this.abandonedRequestTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.abandonedRequestTimers.clear();
+  }
+}
+
+function buildOutboundRequest(
+  id: AcpJsonRpcClientRequestId,
+  method: string,
+  params: AcpJsonValue | undefined
+): AcpJsonObject {
+  const message: AcpJsonObject = { jsonrpc: '2.0', id, method };
+  if (params !== undefined) message.params = params;
+  return message;
+}
+
+function normalizeIdNamespace(namespace: string): string {
+  const trimmed = namespace.trim();
+  if (trimmed === '' || /[\r\n\0]/.test(trimmed)) {
+    throw new AcpJsonRpcProtocolError(
+      'ACP JSON-RPC id namespace must be a non-empty single-line string'
+    );
+  }
+  return trimmed;
+}
+
+function normalizeWriteError(
+  error: unknown,
+  id: AcpJsonRpcClientRequestId,
+  method: string
+): AcpJsonRpcProtocolError {
+  if (error instanceof AcpJsonRpcProtocolError) return error;
+  return new AcpJsonRpcProtocolError('ACP JSON-RPC request write failed', {
+    id,
+    method,
+    message: error instanceof Error ? error.message : String(error),
+  });
+}
+
+function startsWithContentLengthHeader(buffer: string): boolean {
+  return /^Content-Length:/i.test(buffer);
+}
+
+function findHeaderSeparator(buffer: string): FrameSeparator | null {
+  const crlfIndex = buffer.indexOf('\r\n\r\n');
+  if (crlfIndex !== -1) {
+    return { headerEndIndex: crlfIndex, bodyStartIndex: crlfIndex + 4 };
+  }
+
+  const lfIndex = buffer.indexOf('\n\n');
+  if (lfIndex !== -1) {
+    return { headerEndIndex: lfIndex, bodyStartIndex: lfIndex + 2 };
+  }
+
+  return null;
+}
+
+function parseContentLength(headerText: string): number | null {
+  for (const line of headerText.split(/\r?\n/)) {
+    const match = /^Content-Length:\s*(\d+)$/i.exec(line.trim());
+    if (!match) continue;
+    const length = Number(match[1]);
+    return Number.isSafeInteger(length) ? length : null;
+  }
+  return null;
+}
+
+function isJsonRpcId(value: AcpJsonValue | undefined): value is AcpJsonRpcId {
+  return value === null || typeof value === 'string' || typeof value === 'number';
+}
+
+function isJsonObject(value: unknown): value is AcpJsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && isJsonValue(value);
+}
+
+function isJsonValue(value: unknown): value is AcpJsonValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (typeof value !== 'object') return false;
+  return Object.values(value).every(isJsonValue);
+}
+
+function normalizeRemoteError(error: AcpJsonValue | undefined): AcpJsonObject | null {
+  if (!isJsonObject(error)) return null;
+  if (typeof error.code !== 'number' || typeof error.message !== 'string') return null;
+  return error;
+}


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Added `AcpJsonRpcClient` over ACP child-process stdio with namespaced request ids, request correlation, timeouts, cancellation, child-exit handling, and clean shutdown.
- Added NDJSON and standard `Content-Length` framed JSON-RPC parsing while preserving raw ACP notifications/inbound requests for ACP-043.
- Exported the typed client/errors from the ACP service barrel and added fake-process unit coverage.

## Scope
ACP-042 only: JSON-RPC request/response lifecycle over stdio on top of ACP-041 child process primitives. This intentionally does not implement ACP-043 event mapping, ACP-044 backend lifecycle, ACP-046 queue worker, or fanout.

## Tests
- `npx vitest run src\__tests__\acp-json-rpc-client.test.ts src\__tests__\acp-child-process.test.ts --reporter=dot`
- `npx tsc --noEmit`
- `powershell -NoProfile -ExecutionPolicy Bypass -Command "npm run gate"`

## Protocol notes
Existing fake ACP fixtures verify newline-delimited JSON. The client also accepts standard JSON-RPC `Content-Length` frames for agents that expose framed stdio; broader ACP wire-framing differences should be captured by future golden contract tests.

Closes #2596