### PR TITLE
refactor: add ACP event mapper

### DIFF
--- a/src/__tests__/acp-event-mapper.test.ts
+++ b/src/__tests__/acp-event-mapper.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapAcpJsonRpcErrorResponseToEvent,
+  mapAcpJsonRpcNotificationToEvent,
+  mapAcpJsonRpcRequestToEvent,
+  mapAcpJsonRpcSuccessResponseToEvent,
+} from '../services/acp/event-mapper.js';
+import type { AcpEventMapperContext } from '../services/acp/event-mapper.js';
+import type {
+  AcpJsonObject,
+  AcpJsonRpcInboundRequest,
+  AcpJsonRpcNotification,
+} from '../services/acp/json-rpc-client.js';
+
+const occurredAt = new Date('2026-01-02T03:04:05.000Z');
+const context: AcpEventMapperContext = {
+  sessionId: 'aegis-session-1',
+  tenantId: 'tenant-1',
+  ownerKeyId: 'owner-1',
+  backendRunId: 'backend-run-1',
+  occurredAt,
+};
+
+function notification(update: AcpJsonObject): AcpJsonRpcNotification {
+  return {
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: { sessionId: 'fixture-acp-session', update },
+    raw: {
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: { sessionId: 'fixture-acp-session', update },
+    },
+  };
+}
+
+describe('ACP event mapper', () => {
+  it('maps text, thinking, tool, approval, usage, and turn completion into store-ready Aegis events', () => {
+    const mapped = [
+      mapAcpJsonRpcNotificationToEvent(
+        notification({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'Hello from ACP.' },
+          messageId: 'message-1',
+        }),
+        context
+      ),
+      mapAcpJsonRpcNotificationToEvent(
+        notification({
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'Need a plan.' },
+          messageId: 'thought-1',
+        }),
+        context
+      ),
+      mapAcpJsonRpcNotificationToEvent(
+        notification({
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tool-read-1',
+          title: 'Read package metadata',
+          kind: 'read',
+          status: 'pending',
+          rawInput: { path: 'package.json' },
+        }),
+        context
+      ),
+      mapAcpJsonRpcNotificationToEvent(
+        notification({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tool-read-1',
+          status: 'completed',
+          content: [
+            {
+              type: 'content',
+              content: { type: 'text', text: 'package name: @onestepat4time/aegis' },
+            },
+          ],
+          rawOutput: { ok: true },
+        }),
+        context
+      ),
+      mapAcpJsonRpcNotificationToEvent(
+        notification({
+          sessionUpdate: 'usage_update',
+          usage: {
+            input_tokens: 1200,
+            outputTokens: 340,
+            cache_creation_input_tokens: 128,
+            cacheReadInputTokens: 512,
+          },
+          cost: { totalCostUsd: 0.012345, currency: 'USD' },
+          model: 'claude-sonnet-4-6',
+          provider: 'anthropic',
+        }),
+        context
+      ),
+      mapAcpJsonRpcRequestToEvent(
+        {
+          jsonrpc: '2.0',
+          id: 1001,
+          method: 'session/request_permission',
+          params: {
+            sessionId: 'fixture-acp-session',
+            toolCall: {
+              toolCallId: 'tool-edit-1',
+              title: 'Edit package metadata',
+              kind: 'edit',
+              status: 'pending',
+            },
+            options: [
+              { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+              { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' },
+            ],
+          },
+          raw: {
+            jsonrpc: '2.0',
+            id: 1001,
+            method: 'session/request_permission',
+            params: {
+              sessionId: 'fixture-acp-session',
+              toolCall: {
+                toolCallId: 'tool-edit-1',
+                title: 'Edit package metadata',
+                kind: 'edit',
+                status: 'pending',
+              },
+              options: [
+                { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+                { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' },
+              ],
+            },
+          },
+        } satisfies AcpJsonRpcInboundRequest,
+        context
+      ),
+      mapAcpJsonRpcSuccessResponseToEvent(
+        {
+          jsonrpc: '2.0',
+          id: 'prompt-1',
+          result: { stopReason: 'end_turn' },
+          raw: { jsonrpc: '2.0', id: 'prompt-1', result: { stopReason: 'end_turn' } },
+          request: { method: 'session/prompt' },
+        },
+        context
+      ),
+    ];
+
+    expect(mapped).toEqual([
+      {
+        sessionId: 'aegis-session-1',
+        tenantId: 'tenant-1',
+        ownerKeyId: 'owner-1',
+        backendRunId: 'backend-run-1',
+        eventType: 'message.delta',
+        occurredAt,
+        payload: {
+          schemaVersion: 1,
+          text: 'Hello from ACP.',
+          messageId: 'message-1',
+          acp: expect.objectContaining({
+            method: 'session/update',
+            sessionId: 'fixture-acp-session',
+            updateType: 'agent_message_chunk',
+          }),
+        },
+      },
+      expect.objectContaining({
+        eventType: 'thinking.delta',
+        payload: expect.objectContaining({ text: 'Need a plan.', messageId: 'thought-1' }),
+      }),
+      expect.objectContaining({
+        eventType: 'tool.started',
+        payload: expect.objectContaining({
+          toolCallId: 'tool-read-1',
+          title: 'Read package metadata',
+          kind: 'read',
+          status: 'pending',
+        }),
+      }),
+      expect.objectContaining({
+        eventType: 'tool.completed',
+        payload: expect.objectContaining({
+          toolCallId: 'tool-read-1',
+          status: 'completed',
+          text: 'package name: @onestepat4time/aegis',
+        }),
+      }),
+      expect.objectContaining({
+        eventType: 'usage.updated',
+        payload: expect.objectContaining({
+          usage: {
+            inputTokens: 1200,
+            outputTokens: 340,
+            cacheCreationTokens: 128,
+            cacheReadTokens: 512,
+          },
+          cost: { amountUsd: 0.012345, currency: 'USD' },
+          model: 'claude-sonnet-4-6',
+          provider: 'anthropic',
+        }),
+      }),
+      expect.objectContaining({
+        eventType: 'approval.requested',
+        payload: expect.objectContaining({
+          requestId: 1001,
+          toolCall: expect.objectContaining({
+            toolCallId: 'tool-edit-1',
+            title: 'Edit package metadata',
+          }),
+          options: [
+            { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+            { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' },
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        eventType: 'turn.completed',
+        payload: expect.objectContaining({
+          stopReason: 'end_turn',
+          acp: expect.objectContaining({ requestMethod: 'session/prompt' }),
+        }),
+      }),
+    ]);
+  });
+
+  it('stores unsupported and malformed ACP frames instead of silently dropping raw metadata', () => {
+    const unsupported = mapAcpJsonRpcNotificationToEvent(
+      notification({ sessionUpdate: 'mystery_update', note: 'kept for ACP-048' }),
+      context
+    );
+    const malformed = mapAcpJsonRpcNotificationToEvent(
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { sessionId: 'fixture-acp-session', update: { sessionUpdate: 'tool_call' } },
+        raw: {
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: { sessionId: 'fixture-acp-session', update: { sessionUpdate: 'tool_call' } },
+        },
+      },
+      context
+    );
+
+    expect(unsupported).toMatchObject({
+      eventType: 'acp.unsupported',
+      payload: {
+        schemaVersion: 1,
+        reason: 'unsupported_session_update',
+        acp: expect.objectContaining({
+          method: 'session/update',
+          updateType: 'mystery_update',
+          raw: expect.objectContaining({
+            params: expect.objectContaining({
+              update: { sessionUpdate: 'mystery_update', note: 'kept for ACP-048' },
+            }),
+          }),
+        }),
+      },
+    });
+    expect(malformed).toMatchObject({
+      eventType: 'acp.malformed',
+      payload: expect.objectContaining({
+        reason: 'malformed_tool_call',
+        acp: expect.objectContaining({ updateType: 'tool_call' }),
+      }),
+    });
+  });
+
+  it('maps session lifecycle updates and JSON-RPC error responses without storing secret values', () => {
+    const lifecycle = mapAcpJsonRpcNotificationToEvent(
+      notification({
+        sessionUpdate: 'session_info_update',
+        cwd: 'D:\\aegis\\redacted-session',
+        model: 'claude-sonnet-4-6',
+      }),
+      context
+    );
+    const error = mapAcpJsonRpcErrorResponseToEvent(
+      {
+        jsonrpc: '2.0',
+        id: 'new-session-1',
+        error: {
+          code: -32000,
+          message: 'provider rejected token',
+          data: { ANTHROPIC_API_KEY: 'secret-value', retryable: false },
+        },
+        raw: {
+          jsonrpc: '2.0',
+          id: 'new-session-1',
+          error: {
+            code: -32000,
+            message: 'provider rejected token',
+            data: { ANTHROPIC_API_KEY: 'secret-value', retryable: false },
+          },
+        },
+        request: { method: 'session/new' },
+      },
+      context
+    );
+
+    expect(lifecycle).toMatchObject({
+      eventType: 'session.updated',
+      payload: expect.objectContaining({
+        updateType: 'session_info_update',
+        data: expect.objectContaining({ model: 'claude-sonnet-4-6' }),
+      }),
+    });
+    expect(error).toMatchObject({
+      eventType: 'session.error',
+      payload: expect.objectContaining({
+        code: -32000,
+        message: 'provider rejected token',
+        data: { ANTHROPIC_API_KEY: '[REDACTED]', retryable: false },
+        acp: expect.objectContaining({
+          requestMethod: 'session/new',
+          raw: expect.objectContaining({
+            error: expect.objectContaining({
+              data: { ANTHROPIC_API_KEY: '[REDACTED]', retryable: false },
+            }),
+          }),
+        }),
+      }),
+    });
+  });
+});

--- a/src/services/acp/event-mapper.ts
+++ b/src/services/acp/event-mapper.ts
@@ -1,0 +1,545 @@
+import type { AcpAppendEventInput, AcpEventJsonValue, AcpEventPayload } from './event-store.js';
+import type {
+  AcpJsonObject,
+  AcpJsonRpcId,
+  AcpJsonRpcInboundRequest,
+  AcpJsonRpcNotification,
+  AcpJsonValue,
+} from './json-rpc-client.js';
+import type { AcpSessionScope } from './types.js';
+
+export interface AcpEventMapperContext extends AcpSessionScope {
+  sessionId: string;
+  backendRunId?: string;
+  occurredAt?: Date;
+}
+
+export interface AcpJsonRpcSuccessResponseEvent {
+  jsonrpc: '2.0';
+  id: AcpJsonRpcId;
+  result: AcpJsonValue;
+  raw: AcpJsonObject;
+  request?: AcpJsonRpcRequestContext;
+}
+
+export interface AcpJsonRpcErrorResponseEvent {
+  jsonrpc: '2.0';
+  id: AcpJsonRpcId;
+  error: AcpJsonRpcErrorObject;
+  raw: AcpJsonObject;
+  request?: AcpJsonRpcRequestContext;
+}
+
+export interface AcpJsonRpcRequestContext {
+  method: string;
+}
+
+export interface AcpJsonRpcErrorObject {
+  code?: number;
+  message?: string;
+  data?: AcpJsonValue;
+}
+
+type JsonObject = Record<string, unknown>;
+
+const SENSITIVE_KEY_RE =
+  /(token|secret|password|api[_-]?key|authorization|cookie|credential|session[_-]?key)/i;
+
+export function mapAcpJsonRpcNotificationToEvent(
+  notification: AcpJsonRpcNotification,
+  context: AcpEventMapperContext
+): AcpAppendEventInput {
+  if (notification.method !== 'session/update') {
+    return unsupportedEvent(context, 'unsupported_notification', {
+      method: notification.method,
+      raw: notification.raw,
+    });
+  }
+
+  const params = asObject(notification.params);
+  const update = asObject(params?.update);
+  const acpSessionId = readString(params?.sessionId);
+  if (params === undefined || update === undefined) {
+    return malformedEvent(context, 'malformed_session_update', {
+      method: notification.method,
+      sessionId: acpSessionId,
+      raw: notification.raw,
+    });
+  }
+
+  const updateType = readString(update.sessionUpdate);
+  if (updateType === undefined) {
+    return malformedEvent(context, 'missing_session_update_type', {
+      method: notification.method,
+      sessionId: acpSessionId,
+      raw: notification.raw,
+    });
+  }
+
+  const acp = acpMetadata({
+    method: notification.method,
+    sessionId: acpSessionId,
+    updateType,
+    raw: notification.raw,
+  });
+
+  switch (updateType) {
+    case 'agent_message_chunk':
+      return mapTextDelta(context, 'message.delta', update, acp, 'malformed_agent_message_chunk');
+    case 'agent_thought_chunk':
+      return mapTextDelta(context, 'thinking.delta', update, acp, 'malformed_agent_thought_chunk');
+    case 'tool_call':
+      return mapToolStarted(context, update, acp);
+    case 'tool_call_update':
+      return mapToolCompleted(context, update, acp);
+    case 'usage_update':
+      return mapUsageUpdated(context, update, acp);
+    case 'session_info_update':
+      return storeEvent(context, 'session.updated', {
+        schemaVersion: 1,
+        updateType,
+        data: objectWithout(update, 'sessionUpdate'),
+        acp,
+      });
+    default:
+      // ACP-043 keeps unverified runtime shapes for ACP-048 golden contract coverage.
+      return unsupportedEvent(context, 'unsupported_session_update', {
+        method: notification.method,
+        sessionId: acpSessionId,
+        updateType,
+        raw: notification.raw,
+      });
+  }
+}
+
+export function mapAcpJsonRpcRequestToEvent(
+  request: AcpJsonRpcInboundRequest,
+  context: AcpEventMapperContext
+): AcpAppendEventInput {
+  if (request.method !== 'session/request_permission') {
+    return unsupportedEvent(context, 'unsupported_inbound_request', {
+      method: request.method,
+      requestId: request.id,
+      raw: request.raw,
+    });
+  }
+
+  const params = asObject(request.params);
+  const toolCall = asObject(params?.toolCall);
+  const options = Array.isArray(params?.options) ? params.options : undefined;
+  const acpSessionId = readString(params?.sessionId);
+  if (params === undefined || toolCall === undefined || options === undefined) {
+    return malformedEvent(context, 'malformed_permission_request', {
+      method: request.method,
+      requestId: request.id,
+      sessionId: acpSessionId,
+      raw: request.raw,
+    });
+  }
+
+  return storeEvent(context, 'approval.requested', {
+    schemaVersion: 1,
+    requestId: normalizeJsonRpcId(request.id) ?? null,
+    toolCall: cleanObject({
+      toolCallId: readString(toolCall.toolCallId),
+      title: readString(toolCall.title),
+      kind: readString(toolCall.kind),
+      status: readString(toolCall.status),
+    }),
+    options: options.flatMap(option => normalizePermissionOption(option)),
+    acp: acpMetadata({
+      method: request.method,
+      requestId: request.id,
+      sessionId: acpSessionId,
+      raw: request.raw,
+    }),
+  });
+}
+
+export function mapAcpJsonRpcSuccessResponseToEvent(
+  response: AcpJsonRpcSuccessResponseEvent,
+  context: AcpEventMapperContext
+): AcpAppendEventInput {
+  const result = asObject(response.result);
+  const stopReason = readString(result?.stopReason);
+  if (response.request?.method === 'session/prompt' && stopReason !== undefined) {
+    return storeEvent(context, 'turn.completed', {
+      schemaVersion: 1,
+      stopReason,
+      acp: acpMetadata({
+        requestId: response.id,
+        requestMethod: response.request.method,
+        raw: response.raw,
+      }),
+    });
+  }
+
+  return unsupportedEvent(context, 'unsupported_success_response', {
+    requestId: response.id,
+    requestMethod: response.request?.method,
+    raw: response.raw,
+  });
+}
+
+export function mapAcpJsonRpcErrorResponseToEvent(
+  response: AcpJsonRpcErrorResponseEvent,
+  context: AcpEventMapperContext
+): AcpAppendEventInput {
+  return storeEvent(context, 'session.error', {
+    schemaVersion: 1,
+    ...cleanObject({
+      code: typeof response.error.code === 'number' ? response.error.code : undefined,
+      message: readString(response.error.message) ?? 'ACP JSON-RPC request failed',
+      data:
+        response.error.data === undefined ? undefined : redactEventJsonValue(response.error.data),
+    }),
+    acp: acpMetadata({
+      requestId: response.id,
+      requestMethod: response.request?.method,
+      raw: response.raw,
+    }),
+  });
+}
+
+function mapTextDelta(
+  context: AcpEventMapperContext,
+  eventType: 'message.delta' | 'thinking.delta',
+  update: JsonObject,
+  acp: AcpEventJsonValue,
+  malformedReason: string
+): AcpAppendEventInput {
+  const content = asObject(update.content);
+  const text = content?.type === 'text' ? readString(content.text) : undefined;
+  if (text === undefined) {
+    return malformedEvent(context, malformedReason, {
+      updateType: readString(update.sessionUpdate),
+      raw: acpRawObject(acp),
+    });
+  }
+
+  return storeEvent(context, eventType, {
+    schemaVersion: 1,
+    text,
+    ...cleanObject({ messageId: readString(update.messageId) }),
+    acp,
+  });
+}
+
+function mapToolStarted(
+  context: AcpEventMapperContext,
+  update: JsonObject,
+  acp: AcpEventJsonValue
+): AcpAppendEventInput {
+  const toolCallId = readString(update.toolCallId);
+  const title = readString(update.title);
+  if (toolCallId === undefined || title === undefined) {
+    return malformedEvent(context, 'malformed_tool_call', {
+      updateType: readString(update.sessionUpdate),
+      raw: acpRawObject(acp),
+    });
+  }
+
+  return storeEvent(context, 'tool.started', {
+    schemaVersion: 1,
+    toolCallId,
+    title,
+    ...cleanObject({
+      kind: readString(update.kind),
+      status: readString(update.status),
+      input: update.rawInput === undefined ? undefined : redactEventJsonValue(update.rawInput),
+    }),
+    acp,
+  });
+}
+
+function mapToolCompleted(
+  context: AcpEventMapperContext,
+  update: JsonObject,
+  acp: AcpEventJsonValue
+): AcpAppendEventInput {
+  const toolCallId = readString(update.toolCallId);
+  if (toolCallId === undefined) {
+    return malformedEvent(context, 'malformed_tool_call_update', {
+      updateType: readString(update.sessionUpdate),
+      raw: acpRawObject(acp),
+    });
+  }
+
+  return storeEvent(context, 'tool.completed', {
+    schemaVersion: 1,
+    toolCallId,
+    ...cleanObject({
+      status: readString(update.status),
+      text: readToolText(update.content),
+      output: update.rawOutput === undefined ? undefined : redactEventJsonValue(update.rawOutput),
+    }),
+    acp,
+  });
+}
+
+function mapUsageUpdated(
+  context: AcpEventMapperContext,
+  update: JsonObject,
+  acp: AcpEventJsonValue
+): AcpAppendEventInput {
+  const usage = normalizeTokenUsage(update);
+  if (usage === undefined) {
+    return malformedEvent(context, 'malformed_usage_update', {
+      updateType: readString(update.sessionUpdate),
+      raw: acpRawObject(acp),
+    });
+  }
+
+  return storeEvent(context, 'usage.updated', {
+    schemaVersion: 1,
+    usage,
+    ...cleanObject({
+      cost: normalizeUsageCost(update),
+      model: readStringFromObjects([update], ['model', 'modelId', 'model_id']),
+      provider: readStringFromObjects([update], ['provider', 'providerId', 'provider_id']),
+    }),
+    acp,
+  });
+}
+
+function normalizeTokenUsage(update: JsonObject): AcpEventJsonValue | undefined {
+  const sources = [
+    asObject(update.usage),
+    asObject(update.tokenUsage),
+    asObject(update.token_usage),
+    update,
+  ].filter(isDefined);
+  const inputTokens = readNumberFromObjects(sources, [
+    'inputTokens',
+    'input_tokens',
+    'promptTokens',
+    'prompt_tokens',
+  ]);
+  const outputTokens = readNumberFromObjects(sources, [
+    'outputTokens',
+    'output_tokens',
+    'completionTokens',
+    'completion_tokens',
+  ]);
+  const cacheCreationTokens = readNumberFromObjects(sources, [
+    'cacheCreationInputTokens',
+    'cache_creation_input_tokens',
+    'cacheCreationTokens',
+    'cache_creation_tokens',
+  ]);
+  const cacheReadTokens = readNumberFromObjects(sources, [
+    'cacheReadInputTokens',
+    'cache_read_input_tokens',
+    'cacheReadTokens',
+    'cache_read_tokens',
+  ]);
+
+  if (
+    inputTokens === undefined &&
+    outputTokens === undefined &&
+    cacheCreationTokens === undefined &&
+    cacheReadTokens === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    cacheCreationTokens: cacheCreationTokens ?? 0,
+    cacheReadTokens: cacheReadTokens ?? 0,
+  };
+}
+
+function normalizeUsageCost(update: JsonObject): AcpEventJsonValue | undefined {
+  const sources = [
+    asObject(update.cost),
+    asObject(update.costUsage),
+    asObject(update.cost_usage),
+    update,
+  ].filter(isDefined);
+  const amountUsd = readNumberFromObjects(sources, [
+    'amountUsd',
+    'amount_usd',
+    'costUsd',
+    'cost_usd',
+    'totalCostUsd',
+    'total_cost_usd',
+  ]);
+  const currency = readStringFromObjects(sources, ['currency', 'currencyCode', 'currency_code']);
+
+  if (amountUsd === undefined && currency === undefined) return undefined;
+  return cleanObject({ amountUsd, currency });
+}
+
+function readToolText(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  for (const item of content) {
+    const wrapper = asObject(item);
+    if (wrapper?.type !== 'content') continue;
+    const block = asObject(wrapper.content);
+    if (block?.type === 'text') {
+      const text = readString(block.text);
+      if (text !== undefined) return text;
+    }
+  }
+  return undefined;
+}
+
+function normalizePermissionOption(option: unknown): AcpEventJsonValue[] {
+  const object = asObject(option);
+  if (object === undefined) return [];
+  const optionId = readString(object.optionId);
+  const name = readString(object.name);
+  const kind = readString(object.kind);
+  if (optionId === undefined || name === undefined || kind === undefined) return [];
+  return [{ optionId, name, kind }];
+}
+
+function unsupportedEvent(
+  context: AcpEventMapperContext,
+  reason: string,
+  metadata: AcpMetadataInput
+): AcpAppendEventInput {
+  return storeEvent(context, 'acp.unsupported', {
+    schemaVersion: 1,
+    reason,
+    acp: acpMetadata(metadata),
+  });
+}
+
+function malformedEvent(
+  context: AcpEventMapperContext,
+  reason: string,
+  metadata: AcpMetadataInput
+): AcpAppendEventInput {
+  return storeEvent(context, 'acp.malformed', {
+    schemaVersion: 1,
+    reason,
+    acp: acpMetadata(metadata),
+  });
+}
+
+function storeEvent(
+  context: AcpEventMapperContext,
+  eventType: string,
+  payload: AcpEventPayload
+): AcpAppendEventInput {
+  return {
+    sessionId: context.sessionId,
+    tenantId: context.tenantId,
+    ownerKeyId: context.ownerKeyId,
+    ...(context.backendRunId !== undefined ? { backendRunId: context.backendRunId } : {}),
+    eventType,
+    ...(context.occurredAt !== undefined ? { occurredAt: context.occurredAt } : {}),
+    payload,
+  };
+}
+
+interface AcpMetadataInput {
+  method?: string;
+  requestId?: AcpJsonRpcId;
+  requestMethod?: string;
+  sessionId?: string;
+  updateType?: string;
+  raw?: unknown;
+}
+
+function acpMetadata(input: AcpMetadataInput): AcpEventJsonValue {
+  return cleanObject({
+    method: input.method,
+    requestId: normalizeJsonRpcId(input.requestId),
+    requestMethod: input.requestMethod,
+    sessionId: input.sessionId,
+    updateType: input.updateType,
+    raw: input.raw === undefined ? undefined : redactEventJsonValue(input.raw),
+  });
+}
+
+function acpRawObject(acp: AcpEventJsonValue): AcpEventJsonValue | undefined {
+  const object = asObject(acp);
+  return object?.raw === undefined ? undefined : redactEventJsonValue(object.raw);
+}
+
+function normalizeJsonRpcId(id: AcpJsonRpcId | undefined): AcpEventJsonValue | undefined {
+  if (typeof id === 'string' || typeof id === 'number' || id === null) return id;
+  return undefined;
+}
+
+function objectWithout(object: JsonObject, excludedKey: string): Record<string, AcpEventJsonValue> {
+  const output: Record<string, AcpEventJsonValue> = {};
+  for (const [key, value] of Object.entries(object)) {
+    if (key === excludedKey || value === undefined) continue;
+    output[key] = redactEventJsonValue(value, key);
+  }
+  return output;
+}
+
+function cleanObject(values: Record<string, unknown>): Record<string, AcpEventJsonValue> {
+  const output: Record<string, AcpEventJsonValue> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) continue;
+    output[key] = redactEventJsonValue(value, key);
+  }
+  return output;
+}
+
+function redactEventJsonValue(value: unknown, key?: string): AcpEventJsonValue {
+  if (key !== undefined && SENSITIVE_KEY_RE.test(key) && value !== undefined && value !== null) {
+    return '[REDACTED]';
+  }
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (Array.isArray(value)) return value.map(item => redactEventJsonValue(item));
+  if (isPlainObject(value)) {
+    const output: Record<string, AcpEventJsonValue> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      if (childValue === undefined) continue;
+      output[childKey] = redactEventJsonValue(childValue, childKey);
+    }
+    return output;
+  }
+  return null;
+}
+
+function readNumberFromObjects(
+  sources: readonly JsonObject[],
+  keys: readonly string[]
+): number | undefined {
+  for (const source of sources) {
+    for (const key of keys) {
+      const value = source[key];
+      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+    }
+  }
+  return undefined;
+}
+
+function readStringFromObjects(
+  sources: readonly JsonObject[],
+  keys: readonly string[]
+): string | undefined {
+  for (const source of sources) {
+    for (const key of keys) {
+      const value = readString(source[key]);
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function asObject(value: unknown): JsonObject | undefined {
+  return isPlainObject(value) ? value : undefined;
+}
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -19,6 +19,17 @@ export type {
   AcpEventStore,
   AcpListEventsInput,
 } from './event-store.js';
+export {
+  mapAcpJsonRpcErrorResponseToEvent,
+  mapAcpJsonRpcNotificationToEvent,
+  mapAcpJsonRpcRequestToEvent,
+  mapAcpJsonRpcSuccessResponseToEvent,
+  type AcpEventMapperContext,
+  type AcpJsonRpcErrorObject,
+  type AcpJsonRpcErrorResponseEvent,
+  type AcpJsonRpcRequestContext,
+  type AcpJsonRpcSuccessResponseEvent,
+} from './event-mapper.js';
 export type {
   AcpActionMetadata,
   AcpActionMetadataValue,


### PR DESCRIPTION
## Summary

Implements ACP-043 by adding a typed ACP JSON-RPC event mapper that converts raw ACP notifications, inbound requests, prompt completions, and error responses into AcpEventStore-ready Aegis domain events. The mapper covers verified ACP fixture shapes for message/thinking deltas, tool lifecycle, approval requests, usage updates, turn completion, session info updates, and protocol errors while preserving redacted raw ACP metadata for malformed or unsupported frames.

## Aegis version

**Developed with:** v0.6.6-preview.1
**Tested with:** v0.6.6-preview.1

## Change type

- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring with no behavior change
- [x] `test` — Adding or updating tests
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling
- [ ] `feat` — New feature (USE ONLY for user-visible features, NOT for internal changes)

## Scope

- `src/services/acp/event-mapper.ts`
- `src/services/acp/index.ts`
- `src/__tests__/acp-event-mapper.test.ts`

No REST/API contract, backend lifecycle, fanout, or action worker changes are included.

## Linked issue

Closes #2597

## Test plan

- [x] Unit tests pass (`npm test`) via `powershell -NoProfile -ExecutionPolicy Bypass -Command "npm run gate"`
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Build succeeds (`npm run build`) via `npm run gate`
- [x] Targeted ACP tests pass: `npx vitest run src\__tests__\acp-event-mapper.test.ts src\__tests__\acp-json-rpc-client.test.ts src\__tests__\acp-postgres-event-store.test.ts src\__tests__\acp-local-storage.test.ts --reporter=dot`
- [ ] Manually tested (describe below)

Manual testing not required; this PR is covered by unit/contract tests and the repository gate.

## Security impact

No new endpoints or authorization changes. Mapper redacts sensitive keys in preserved raw ACP metadata and error payloads before creating durable event-store payloads.
