### PR TITLE
refactor(acp): add list() and listSessions() to AcpSessionStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased](https://github.com/OneStepAt4time/aegis/compare/v0.6.6-preview.1...HEAD)
+
+### Internal — ACP Runtime Layer
+
+These changes are part of the Phase 3.5 ACP backend migration ([#2574](https://github.com/OneStepAt4time/aegis/issues/2574)). They add the internal ACP service modules that will replace the tmux runtime. No public API changes in this batch — all modules are under `src/services/acp/` and are not yet wired into REST or MCP routes.
+
+- Add ACP local-dev storage profile with file-backed and in-memory adapters for `AcpSessionStore`, `AcpEventStore`, and `AcpActionQueue` — enables Redis-free and Postgres-free local development ([#2683](https://github.com/OneStepAt4time/aegis/pull/2683))
+- Implement `RedisAcpRealtimeCoordinator` — volatile Redis presence heartbeats, driver-lock acquire/renew/release with fencing counters, pub/sub event fanout, worker wakeups, and scoped disconnect cleanup ([#2684](https://github.com/OneStepAt4time/aegis/pull/2684))
+- Add `@agentclientprotocol/claude-agent-acp` as bundled ACP runtime dependency with typed binary resolver supporting explicit command, `AEGIS_ACP_BIN` override, and bundled package-bin resolution ([#2685](https://github.com/OneStepAt4time/aegis/pull/2685))
+- Add ACP pause/intervention persistence — `PostgresAcpPauseInterventionStore` for durable pause, intervention, completion, resume, idempotency, and recovery state; extend `AcpSessionService` with pause/resume/intervention policy reconciliation ([#2686](https://github.com/OneStepAt4time/aegis/pull/2686))
+- Add `AcpChildProcess` supervision boundary — typed child process spawn, startup errors, raw stream forwarding, exit/error events, graceful shutdown with escalation, and BYO/custom model environment passthrough ([#2687](https://github.com/OneStepAt4time/aegis/pull/2687))
+- Add `AcpJsonRpcClient` over ACP child-process stdio — namespaced request IDs, request correlation, timeouts, cancellation, child-exit handling, NDJSON and `Content-Length` framed JSON-RPC parsing ([#2688](https://github.com/OneStepAt4time/aegis/pull/2688))
+- Add ACP event mapper — converts raw ACP JSON-RPC notifications, inbound requests, prompt completions, and error responses into `AcpEventStore`-ready Aegis domain events (message/thinking deltas, tool lifecycle, approval requests, usage updates, turn completion, session info) ([#2689](https://github.com/OneStepAt4time/aegis/pull/2689))
+- Add ACP fs client methods — `fs/read_text_file` and `fs/write_text_file` with workdir boundary enforcement, path traversal protection, and typed error responses; adds `respond()`/`respondWithError()` to `AcpJsonRpcClient` for inbound request replies ([#2690](https://github.com/OneStepAt4time/aegis/pull/2690))
+
 ## [0.6.6-preview.1](https://github.com/OneStepAt4time/aegis/compare/v0.6.5-preview.3...v0.6.6-preview.1) (2026-05-03)
 
 

--- a/src/__tests__/acp-session-list.test.ts
+++ b/src/__tests__/acp-session-list.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AcpSessionService,
+  AcpValidationError,
+  MemoryAcpSessionStore,
+  PostgresAcpSessionStore,
+  type AcpListSessionsInput,
+  type AcpSessionRecord,
+  type AcpSessionScope,
+  type AcpSessionStore,
+} from '../services/acp/index.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const scope: AcpSessionScope = { tenantId: 'tenant-a', ownerKeyId: 'owner-a' };
+const otherScope: AcpSessionScope = { tenantId: 'tenant-b', ownerKeyId: 'owner-b' };
+
+function makeRecord(overrides: Partial<AcpSessionRecord> = {}): AcpSessionRecord {
+  return {
+    id: 'session-1',
+    tenantId: scope.tenantId,
+    ownerKeyId: scope.ownerKeyId,
+    conversationId: 'conversation-1',
+    transcriptId: 'transcript-1',
+    status: 'running',
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MemoryAcpSessionStore.list
+// ---------------------------------------------------------------------------
+
+describe('MemoryAcpSessionStore.list', () => {
+  it('returns all sessions in scope', async () => {
+    const store = new MemoryAcpSessionStore();
+    const a = makeRecord({ id: 'session-a', updatedAt: 1_000 });
+    const b = makeRecord({ id: 'session-b', updatedAt: 2_000 });
+    await store.create(a);
+    await store.create(b);
+
+    const result = await store.list({ ...scope });
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.id)).toContain('session-a');
+    expect(result.map(r => r.id)).toContain('session-b');
+  });
+
+  it('excludes sessions outside the requested tenant-owner scope', async () => {
+    const store = new MemoryAcpSessionStore();
+    await store.create(makeRecord({ id: 'mine' }));
+    await store.create(makeRecord({ id: 'theirs', ...otherScope }));
+
+    const result = await store.list({ ...scope });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('mine');
+  });
+
+  it('returns an empty array when no sessions match the scope', async () => {
+    const store = new MemoryAcpSessionStore();
+
+    const result = await store.list({ ...scope });
+
+    expect(result).toEqual([]);
+  });
+
+  it('filters by status when statuses are provided', async () => {
+    const store = new MemoryAcpSessionStore();
+    await store.create(makeRecord({ id: 'running-1', status: 'running' }));
+    await store.create(makeRecord({ id: 'idle-1', status: 'idle' }));
+    await store.create(makeRecord({ id: 'closed-1', status: 'closed' }));
+
+    const result = await store.list({ ...scope, statuses: ['running', 'idle'] });
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.id).sort()).toEqual(['idle-1', 'running-1']);
+  });
+
+  it('filters by updatedAfter when provided', async () => {
+    const store = new MemoryAcpSessionStore();
+    await store.create(makeRecord({ id: 'old', updatedAt: 1_000 }));
+    await store.create(makeRecord({ id: 'new', updatedAt: 3_000 }));
+
+    const result = await store.list({ ...scope, updatedAfter: 2_000 });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('new');
+  });
+
+  it('respects the limit option', async () => {
+    const store = new MemoryAcpSessionStore();
+    for (let i = 0; i < 5; i++) {
+      await store.create(makeRecord({ id: `session-${i}`, updatedAt: i * 1_000 }));
+    }
+
+    const result = await store.list({ ...scope, limit: 3 });
+
+    expect(result).toHaveLength(3);
+  });
+
+  it('sorts results by updatedAt descending', async () => {
+    const store = new MemoryAcpSessionStore();
+    await store.create(makeRecord({ id: 'first', updatedAt: 1_000 }));
+    await store.create(makeRecord({ id: 'third', updatedAt: 3_000 }));
+    await store.create(makeRecord({ id: 'second', updatedAt: 2_000 }));
+
+    const result = await store.list({ ...scope });
+
+    expect(result.map(r => r.id)).toEqual(['third', 'second', 'first']);
+  });
+
+  it('returns cloned records so mutations do not affect stored state', async () => {
+    const store = new MemoryAcpSessionStore();
+    await store.create(makeRecord({ id: 'session-a' }));
+
+    const [record] = await store.list({ ...scope });
+    record!.status = 'closed';
+
+    const [unchanged] = await store.list({ ...scope });
+    expect(unchanged!.status).toBe('running');
+  });
+
+  it('throws AcpValidationError when tenantId is empty', async () => {
+    const store = new MemoryAcpSessionStore();
+
+    await expect(
+      store.list({ tenantId: '', ownerKeyId: 'owner-a' })
+    ).rejects.toThrow(AcpValidationError);
+  });
+
+  it('throws AcpValidationError when ownerKeyId is empty', async () => {
+    const store = new MemoryAcpSessionStore();
+
+    await expect(
+      store.list({ tenantId: 'tenant-a', ownerKeyId: '' })
+    ).rejects.toThrow(AcpValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PostgresAcpSessionStore.list
+// ---------------------------------------------------------------------------
+
+interface MockQueryResult {
+  rows: unknown[];
+}
+
+type MockQuery = ReturnType<
+  typeof vi.fn<(sql: string, params?: readonly unknown[]) => Promise<MockQueryResult>>
+>;
+
+interface MockPool {
+  query: MockQuery;
+  end: ReturnType<typeof vi.fn<() => Promise<void>>>;
+}
+
+const pgMock = vi.hoisted(() => {
+  function makePool(): MockPool {
+    return {
+      query: vi
+        .fn<(sql: string, params?: readonly unknown[]) => Promise<MockQueryResult>>()
+        .mockResolvedValue({ rows: [] }),
+      end: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+  }
+
+  const pools: MockPool[] = [];
+  const Pool = vi.fn(function MockPoolConstructor() {
+    const pool = makePool();
+    pools.push(pool);
+    return pool;
+  });
+
+  return {
+    Pool,
+    pools,
+    latestPool(): MockPool {
+      const pool = pools.at(-1);
+      if (!pool) throw new Error('expected a mocked pg Pool to be constructed');
+      return pool;
+    },
+    reset(): void {
+      pools.length = 0;
+      Pool.mockClear();
+    },
+  };
+});
+
+vi.mock('pg', () => ({ Pool: pgMock.Pool }));
+
+function makeRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: 'session-1',
+    tenant_id: 'tenant-a',
+    owner_key_id: 'owner-a',
+    acp_agent_session_id: null,
+    claude_session_id: null,
+    conversation_id: 'conversation-1',
+    transcript_id: 'transcript-1',
+    parent_session_id: null,
+    root_session_id: null,
+    correlation_id: null,
+    resume_from_session_id: null,
+    current_backend_run_id: null,
+    status: 'running',
+    created_at: '1700000000000',
+    updated_at: '1700000000000',
+    closed_at: null,
+    failed_at: null,
+    backend_metadata: null,
+    ...overrides,
+  };
+}
+
+async function createStartedStore(): Promise<{ store: PostgresAcpSessionStore; pool: MockPool }> {
+  const store = new PostgresAcpSessionStore({
+    url: 'postgresql://aegis:aegis@localhost:5432/aegis_test',
+  });
+  await store.start();
+  const pool = pgMock.latestPool();
+  pool.query.mockClear();
+  return { store, pool };
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+describe('PostgresAcpSessionStore.list', () => {
+  beforeEach(() => pgMock.reset());
+
+  it('queries within tenant-owner scope using parameterized values', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({ rows: [makeRow()] });
+
+    await store.list({ ...scope });
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = pool.query.mock.calls[0]!;
+    expect(normalizeSql(sql)).toContain('WHERE tenant_id = $1 AND owner_key_id = $2');
+    expect(params).toContain('tenant-a');
+    expect(params).toContain('owner-a');
+  });
+
+  it('returns rows mapped to session records', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({
+      rows: [makeRow({ session_id: 'session-x', status: 'idle' })],
+    });
+
+    const result = await store.list({ ...scope });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('session-x');
+    expect(result[0]!.status).toBe('idle');
+  });
+
+  it('returns an empty array when no rows are found', async () => {
+    const { store, pool } = await createStartedStore();
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await store.list({ ...scope });
+
+    expect(result).toEqual([]);
+  });
+
+  it('includes a status IN filter when statuses are provided', async () => {
+    const { store, pool } = await createStartedStore();
+
+    await store.list({ ...scope, statuses: ['running', 'paused'] });
+
+    const [sql, params] = pool.query.mock.calls[0]!;
+    expect(normalizeSql(sql)).toMatch(/status = ANY\(\$/);
+    expect(params).toContainEqual(['running', 'paused']);
+  });
+
+  it('includes an updatedAfter filter when provided', async () => {
+    const { store, pool } = await createStartedStore();
+
+    await store.list({ ...scope, updatedAfter: 1_700_000_000_000 });
+
+    const [sql, params] = pool.query.mock.calls[0]!;
+    expect(normalizeSql(sql)).toContain('updated_at >');
+    expect(params).toContain(1_700_000_000_000);
+  });
+
+  it('applies a default LIMIT to the query', async () => {
+    const { store, pool } = await createStartedStore();
+
+    await store.list({ ...scope });
+
+    const [sql] = pool.query.mock.calls[0]!;
+    expect(normalizeSql(sql)).toContain('LIMIT');
+  });
+
+  it('applies the caller-supplied limit when provided', async () => {
+    const { store, pool } = await createStartedStore();
+
+    await store.list({ ...scope, limit: 7 });
+
+    const [, params] = pool.query.mock.calls[0]!;
+    expect(params).toContain(7);
+  });
+
+  it('orders results by updated_at descending', async () => {
+    const { store, pool } = await createStartedStore();
+
+    await store.list({ ...scope });
+
+    const [sql] = pool.query.mock.calls[0]!;
+    expect(normalizeSql(sql)).toContain('ORDER BY updated_at DESC');
+  });
+
+  it('throws when not started', async () => {
+    const store = new PostgresAcpSessionStore({
+      url: 'postgresql://localhost/test',
+    });
+
+    await expect(store.list({ ...scope })).rejects.toThrow('not been started');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AcpSessionService.listSessions
+// ---------------------------------------------------------------------------
+
+class StubAcpSessionStore implements AcpSessionStore {
+  readonly created: AcpSessionRecord[] = [];
+
+  async create(record: AcpSessionRecord): Promise<void> {
+    this.created.push({ ...record });
+  }
+
+  async get(_id: string, _scope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    return null;
+  }
+
+  async update(_record: AcpSessionRecord, _scope: AcpSessionScope): Promise<AcpSessionRecord | null> {
+    return null;
+  }
+
+  async list(input: AcpListSessionsInput): Promise<AcpSessionRecord[]> {
+    return this.created.filter(
+      r => r.tenantId === input.tenantId && r.ownerKeyId === input.ownerKeyId
+    );
+  }
+}
+
+describe('AcpSessionService.listSessions', () => {
+  it('returns sessions from the underlying store', async () => {
+    const store = new StubAcpSessionStore();
+    store.created.push(
+      makeRecord({ id: 'session-a' }),
+      makeRecord({ id: 'session-b' })
+    );
+    const service = new AcpSessionService(store);
+
+    const result = await service.listSessions(scope);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.id).sort()).toEqual(['session-a', 'session-b']);
+  });
+
+  it('rejects an empty tenantId', async () => {
+    const service = new AcpSessionService(new StubAcpSessionStore());
+
+    await expect(
+      service.listSessions({ tenantId: '', ownerKeyId: 'owner-a' })
+    ).rejects.toThrow(AcpValidationError);
+  });
+
+  it('rejects an empty ownerKeyId', async () => {
+    const service = new AcpSessionService(new StubAcpSessionStore());
+
+    await expect(
+      service.listSessions({ tenantId: 'tenant-a', ownerKeyId: '' })
+    ).rejects.toThrow(AcpValidationError);
+  });
+
+  it('passes status filter through to the store', async () => {
+    const store = new StubAcpSessionStore();
+    store.created.push(
+      makeRecord({ id: 'running-1', status: 'running' }),
+      makeRecord({ id: 'idle-1', status: 'idle' })
+    );
+
+    // Override list to capture the input
+    let capturedInput: AcpListSessionsInput | undefined;
+    store.list = async (input: AcpListSessionsInput) => {
+      capturedInput = input;
+      return [];
+    };
+
+    const service = new AcpSessionService(store);
+    await service.listSessions(scope, { statuses: ['running'] });
+
+    expect(capturedInput?.statuses).toEqual(['running']);
+  });
+
+  it('passes limit through to the store', async () => {
+    const store = new StubAcpSessionStore();
+    let capturedInput: AcpListSessionsInput | undefined;
+    store.list = async (input: AcpListSessionsInput) => {
+      capturedInput = input;
+      return [];
+    };
+
+    const service = new AcpSessionService(store);
+    await service.listSessions(scope, { limit: 10 });
+
+    expect(capturedInput?.limit).toBe(10);
+  });
+});

--- a/src/__tests__/acp-session-service-pause-intervention.test.ts
+++ b/src/__tests__/acp-session-service-pause-intervention.test.ts
@@ -62,6 +62,12 @@ class InMemoryScopedAcpSessionStore implements AcpSessionStore {
     this.records.set(record.id, cloneSession(record));
     return cloneSession(record);
   }
+
+  async list(input: { tenantId: string; ownerKeyId: string }): Promise<AcpSessionRecord[]> {
+    return [...this.records.values()]
+      .filter(r => r.tenantId === input.tenantId && r.ownerKeyId === input.ownerKeyId)
+      .map(cloneSession);
+  }
 }
 
 class InMemoryPauseInterventionStore implements AcpPauseInterventionStore {

--- a/src/__tests__/acp-session-service.test.ts
+++ b/src/__tests__/acp-session-service.test.ts
@@ -57,6 +57,12 @@ class InMemoryScopedAcpSessionStore implements AcpSessionStore {
     this.records.set(record.id, cloneRecord(record));
     return cloneRecord(record);
   }
+
+  async list(input: { tenantId: string; ownerKeyId: string }): Promise<AcpSessionRecord[]> {
+    return [...this.records.values()]
+      .filter(r => r.tenantId === input.tenantId && r.ownerKeyId === input.ownerKeyId)
+      .map(cloneRecord);
+  }
 }
 
 class MutatingUpdateAcpSessionStore extends InMemoryScopedAcpSessionStore {

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -5,6 +5,7 @@ export type {
   AcpControlActionInput,
   AcpControlActionType,
   AcpCreateSessionInput,
+  AcpListSessionsInput,
   AcpSessionRecord,
   AcpSessionScope,
   AcpSessionStatus,

--- a/src/services/acp/local-storage.ts
+++ b/src/services/acp/local-storage.ts
@@ -27,6 +27,7 @@ import type {
 } from './event-store.js';
 import type {
   AcpControlActionInput,
+  AcpListSessionsInput,
   AcpSessionRecord,
   AcpSessionScope,
   AcpSessionStore,
@@ -205,6 +206,22 @@ export class MemoryAcpSessionStore implements AcpSessionStore {
     this.state.sessions[index] = cloneSession(persisted);
     await this.onMutation();
     return cloneSession(persisted);
+  }
+
+  async list(input: AcpListSessionsInput): Promise<AcpSessionRecord[]> {
+    validateScope(input);
+    const limit = resolveSessionListLimit(input.limit);
+    return this.state.sessions
+      .filter(
+        session =>
+          session.tenantId === input.tenantId &&
+          session.ownerKeyId === input.ownerKeyId &&
+          (input.statuses === undefined || input.statuses.includes(session.status)) &&
+          (input.updatedAfter === undefined || session.updatedAt > input.updatedAfter)
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, limit)
+      .map(cloneSession);
   }
 
   replaceState(state: LocalState): void {
@@ -565,6 +582,14 @@ function resolveAfterEventSeq(value: number | undefined): number {
   if (value === undefined) return 0;
   if (!Number.isSafeInteger(value) || value < 0) {
     throw new AcpValidationError('ACP afterEventSeq must be a non-negative safe integer');
+  }
+  return value;
+}
+
+function resolveSessionListLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_LIST_LIMIT) {
+    throw new AcpValidationError(`ACP session list limit must be between 1 and ${MAX_LIST_LIMIT}`);
   }
   return value;
 }

--- a/src/services/acp/postgres-session-store.ts
+++ b/src/services/acp/postgres-session-store.ts
@@ -4,6 +4,7 @@ import type { ServiceHealth } from '../../container.js';
 import type {
   AcpBackendMetadata,
   AcpBackendMetadataValue,
+  AcpListSessionsInput,
   AcpSessionRecord,
   AcpSessionScope,
   AcpSessionStatus,
@@ -20,6 +21,7 @@ export interface PostgresAcpSessionStoreConfig {
 const DEFAULT_SCHEMA = 'public';
 const DEFAULT_TABLE = 'acp_sessions';
 const DEFAULT_POOL_MAX = 5;
+const DEFAULT_SESSION_LIST_LIMIT = 100;
 const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 interface AcpSessionRow {
@@ -153,6 +155,34 @@ export class PostgresAcpSessionStore implements AcpSessionStore {
     );
     const row = result.rows[0];
     return row === undefined ? null : rowToRecord(row);
+  }
+
+  async list(input: AcpListSessionsInput): Promise<AcpSessionRecord[]> {
+    const params: unknown[] = [input.tenantId, input.ownerKeyId];
+    const conditions: string[] = ['tenant_id = $1 AND owner_key_id = $2'];
+
+    if (input.statuses !== undefined && input.statuses.length > 0) {
+      params.push(input.statuses);
+      conditions.push(`status = ANY($${params.length})`);
+    }
+
+    if (input.updatedAfter !== undefined) {
+      params.push(input.updatedAfter);
+      conditions.push(`updated_at > $${params.length}`);
+    }
+
+    const limit = input.limit ?? DEFAULT_SESSION_LIST_LIMIT;
+    params.push(limit);
+
+    const result = await this.requirePool().query<AcpSessionRow>(
+      `SELECT ${SESSION_COLUMNS}
+       FROM ${this.qualifiedTable()}
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY updated_at DESC
+       LIMIT $${params.length}`,
+      params
+    );
+    return result.rows.map(rowToRecord);
   }
 
   private requirePool(): Pool {

--- a/src/services/acp/session-service.ts
+++ b/src/services/acp/session-service.ts
@@ -15,8 +15,10 @@ import type {
   AcpBackendMetadataValue,
   AcpControlActionInput,
   AcpCreateSessionInput,
+  AcpListSessionsInput,
   AcpSessionRecord,
   AcpSessionScope,
+  AcpSessionStatus,
   AcpSessionStore,
   AcpSessionTransitionEvent,
 } from './types.js';
@@ -145,6 +147,15 @@ export class AcpSessionService {
     assertNonEmptyString(sessionId, 'session id');
     assertScope(scope);
     return this.requireSession(sessionId, scope);
+  }
+
+  async listSessions(
+    scope: AcpSessionScope,
+    options: { statuses?: AcpSessionStatus[]; limit?: number; updatedAfter?: number } = {}
+  ): Promise<AcpSessionRecord[]> {
+    assertScope(scope);
+    const input: AcpListSessionsInput = { ...scope, ...options };
+    return this.store.list(input);
   }
 
   async attachAgentSession(

--- a/src/services/acp/types.ts
+++ b/src/services/acp/types.ts
@@ -83,8 +83,15 @@ export interface AcpControlActionInput extends AcpSessionScope {
   metadata?: AcpBackendMetadata;
 }
 
+export interface AcpListSessionsInput extends AcpSessionScope {
+  statuses?: AcpSessionStatus[];
+  limit?: number;
+  updatedAfter?: number;
+}
+
 export interface AcpSessionStore {
   create(record: AcpSessionRecord): Promise<void>;
   get(id: string, scope: AcpSessionScope): Promise<AcpSessionRecord | null>;
   update(record: AcpSessionRecord, scope: AcpSessionScope): Promise<AcpSessionRecord | null>;
+  list(input: AcpListSessionsInput): Promise<AcpSessionRecord[]>;
 }


### PR DESCRIPTION
## Summary
Implements #2658 — ACP session/list support for active session discovery.

Adds `list()` method to `AcpSessionStore` interface with scope enforcement and optional status filtering. Implemented across memory store, file store, and Postgres store.

## Changes
- `src/services/acp/types.ts`: Added `AcpListSessionsFilter` type and `list()` to `AcpSessionStore` interface
- `src/services/acp/session-service.ts`: Added `listSessions()` method with scope validation
- `src/services/acp/local-storage.ts`: Implemented `list()` in `MemoryAcpSessionStore`
- `src/services/acp/postgres-session-store.ts`: Implemented `list()` in `PostgresAcpSessionStore`
- `src/services/acp/index.ts`: Exported new types
- `src/__tests__/acp-session-list.test.ts`: 24 tests covering filtering, scope isolation, pagination, empty results

## Verification
- tsc --noEmit: clean
- npm run build: success
- npm test: 4302 passed, 1 pre-existing failure (acp-binary-resolver unrelated)
- New tests: 24/24 passed

Closes #2658