### PR TITLE
fix(dashboard): use design tokens for pause controls

### DIFF
--- a/dashboard/src/components/session/DriverControlBar.tsx
+++ b/dashboard/src/components/session/DriverControlBar.tsx
@@ -66,7 +66,7 @@ export function DriverControlBar({
 
   return (
     <div
-      className="flex flex-col gap-2 rounded-lg border border-[#2a2a3a] bg-[#12121f] p-3"
+      className="flex flex-col gap-2 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3"
       role="toolbar"
       aria-label="Session driver and observer controls"
     >
@@ -91,7 +91,7 @@ export function DriverControlBar({
         <div className="flex items-center gap-2">
           <Gamepad2 className="h-4 w-4 text-blue-400" />
           {hasDriver ? (
-            <span className="text-sm text-[#e0e0e0]">
+            <span className="text-sm text-[var(--color-text-primary)]">
               Driver: <span className="font-medium">{participants!.driver!.subscriberId}</span>
               {isDriver && (
                 <span className={`ml-2 rounded px-1.5 py-0.5 text-xs ${ROLE_COLORS.driver.bg} ${ROLE_COLORS.driver.text}`}>
@@ -100,13 +100,13 @@ export function DriverControlBar({
               )}
             </span>
           ) : (
-            <span className="text-sm text-[#555]">No driver claimed</span>
+            <span className="text-sm text-[var(--color-text-muted)]">No driver claimed</span>
           )}
         </div>
 
         <div className="flex items-center gap-2">
           {participants && (
-            <span className="flex items-center gap-1 text-xs text-[#555]">
+            <span className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
               <Users className="h-3 w-3" />
               {participants.activeCount} connected
             </span>
@@ -133,7 +133,7 @@ export function DriverControlBar({
             <button
               onClick={() => onRelease?.()}
               disabled={!canAct}
-              className="flex items-center gap-2 rounded-md border border-[#2a2a3a] px-3 py-2 text-sm text-[#888] transition-colors hover:text-[#ccc] disabled:opacity-50"
+              className="flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] disabled:opacity-50"
               aria-label="Release driver role"
             >
               {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Eye className="h-4 w-4" />}
@@ -166,8 +166,8 @@ export function DriverControlBar({
 
       {/* Transfer form */}
       {showTransferForm && (
-        <div className="flex flex-col gap-2 rounded-md border border-[#2a2a3a] bg-[#0a0a0f] p-3">
-          <label htmlFor="transfer-target" className="text-xs text-[#888]">
+        <div className="flex flex-col gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] p-3">
+          <label htmlFor="transfer-target" className="text-xs text-[var(--color-text-muted)]">
             Transfer driver to (subscriber ID)
           </label>
           <input
@@ -177,10 +177,10 @@ export function DriverControlBar({
             onChange={(e) => setTransferTarget(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleTransfer()}
             placeholder="Enter subscriber ID"
-            className="w-full rounded-md border border-[#2a2a3a] bg-[#12121f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-amber-500/50 focus:outline-none"
+            className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-amber-500/50 focus:outline-none"
             autoFocus
           />
-          <label htmlFor="transfer-reason" className="text-xs text-[#888]">
+          <label htmlFor="transfer-reason" className="text-xs text-[var(--color-text-muted)]">
             Reason (optional)
           </label>
           <input
@@ -190,7 +190,7 @@ export function DriverControlBar({
             onChange={(e) => setTransferReason(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleTransfer()}
             placeholder="e.g., switching to mobile"
-            className="w-full rounded-md border border-[#2a2a3a] bg-[#12121f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-amber-500/50 focus:outline-none"
+            className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-amber-500/50 focus:outline-none"
           />
           <div className="flex items-center gap-2">
             <button
@@ -204,7 +204,7 @@ export function DriverControlBar({
             </button>
             <button
               onClick={() => { setShowTransferForm(false); setTransferTarget(''); setTransferReason(''); }}
-              className="rounded-md border border-[#2a2a3a] px-3 py-2 text-sm text-[#888] transition-colors hover:text-[#ccc]"
+              className="rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
               aria-label="Cancel transfer"
             >
               Cancel
@@ -216,7 +216,7 @@ export function DriverControlBar({
       {/* Observers list */}
       {participants && participants.observers.length > 0 && (
         <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium uppercase tracking-wider text-[#555]">
+          <span className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
             Observers ({participants.observers.length})
           </span>
           <div className="flex flex-wrap gap-1" role="list" aria-label="Session observers">

--- a/dashboard/src/components/session/InterventionHistoryPanel.tsx
+++ b/dashboard/src/components/session/InterventionHistoryPanel.tsx
@@ -110,15 +110,15 @@ export function InterventionHistoryPanel({ sessionId }: InterventionHistoryPanel
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-8" role="status" aria-label="Loading intervention history">
-        <Loader2 className="h-5 w-5 animate-spin text-[#888]" />
-        <span className="ml-2 text-sm text-[#888]">Loading intervention history...</span>
+        <Loader2 className="h-5 w-5 animate-spin text-[var(--color-text-muted)]" />
+        <span className="ml-2 text-sm text-[var(--color-text-muted)]">Loading intervention history...</span>
       </div>
     );
   }
 
   if (!record) {
     return (
-      <div className="py-8 text-center text-sm text-[#555]" role="status">
+      <div className="py-8 text-center text-sm text-[var(--color-text-muted)]" role="status">
         No intervention history for this session.
       </div>
     );
@@ -139,13 +139,13 @@ export function InterventionHistoryPanel({ sessionId }: InterventionHistoryPanel
             <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${TONE_ICON_STYLES[entry.tone]}`} />
             <div className="flex-1 min-w-0">
               <div className="flex items-center justify-between gap-2">
-                <span className="text-sm font-medium text-[#e0e0e0]">{entry.label}</span>
+                <span className="text-sm font-medium text-[var(--color-text-primary)]">{entry.label}</span>
                 {entry.timestamp && (
-                  <span className="shrink-0 text-xs text-[#555]">{entry.timestamp}</span>
+                  <span className="shrink-0 text-xs text-[var(--color-text-muted)]">{entry.timestamp}</span>
                 )}
               </div>
               {entry.detail && (
-                <p className="mt-1 text-xs text-[#888] break-words">{entry.detail}</p>
+                <p className="mt-1 text-xs text-[var(--color-text-muted)] break-words">{entry.detail}</p>
               )}
             </div>
           </div>

--- a/dashboard/src/components/session/PauseControlBar.tsx
+++ b/dashboard/src/components/session/PauseControlBar.tsx
@@ -77,7 +77,7 @@ export function PauseControlBar({
 
   return (
     <div
-      className="flex flex-col gap-2 rounded-lg border border-[#2a2a3a] bg-[#12121f] p-3"
+      className="flex flex-col gap-2 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3"
       role="toolbar"
       aria-label="Session pause and intervention controls"
     >
@@ -113,7 +113,7 @@ export function PauseControlBar({
           ) : (
             <div className="flex flex-1 items-end gap-2">
               <div className="flex-1">
-                <label htmlFor="pause-reason" className="mb-1 block text-xs text-[#888]">
+                <label htmlFor="pause-reason" className="mb-1 block text-xs text-[var(--color-text-muted)]">
                   Reason for pausing
                 </label>
                 <input
@@ -123,7 +123,7 @@ export function PauseControlBar({
                   onChange={(e) => setPauseReason(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handlePause()}
                   placeholder="e.g., security review needed"
-                  className="w-full rounded-md border border-[#2a2a3a] bg-[#0a0a0f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-amber-500/50 focus:outline-none"
+                  className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-amber-500/50 focus:outline-none"
                   autoFocus
                 />
               </div>
@@ -138,7 +138,7 @@ export function PauseControlBar({
               </button>
               <button
                 onClick={() => { setShowPauseForm(false); setPauseReason(''); }}
-                className="rounded-md border border-[#2a2a3a] px-3 py-2 text-sm text-[#888] transition-colors hover:text-[#ccc]"
+                className="rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
                 aria-label="Cancel pause"
               >
                 Cancel
@@ -197,7 +197,7 @@ export function PauseControlBar({
 
           {showGuidanceForm && (
             <div className="flex flex-col gap-2">
-              <label htmlFor="intervention-guidance" className="text-xs text-[#888]">
+              <label htmlFor="intervention-guidance" className="text-xs text-[var(--color-text-muted)]">
                 Guidance for the agent (optional)
               </label>
               <textarea
@@ -205,7 +205,7 @@ export function PauseControlBar({
                 value={guidance}
                 onChange={(e) => setGuidance(e.target.value)}
                 placeholder="Provide instructions for the agent to follow after resuming..."
-                className="w-full rounded-md border border-[#2a2a3a] bg-[#0a0a0f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-blue-500/50 focus:outline-none resize-y"
+                className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-blue-500/50 focus:outline-none resize-y"
                 rows={3}
                 autoFocus
               />
@@ -221,7 +221,7 @@ export function PauseControlBar({
                 </button>
                 <button
                   onClick={() => { setShowGuidanceForm(false); setGuidance(''); }}
-                  className="rounded-md border border-[#2a2a3a] px-3 py-2 text-sm text-[#888] transition-colors hover:text-[#ccc]"
+                  className="rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
                   aria-label="Cancel intervention completion"
                 >
                   Cancel


### PR DESCRIPTION
## Summary

- replaces raw dashboard pause/intervention color literals with existing design tokens
- restores the dashboard design-token gate on develop
- unblocks ACP runtime PR rebases that require 
pm run gate

## Validation

- 
pm run dashboard:tokens:gate
- 
pm run gate

## Aegis version

0.6.6-preview.1
