### PR TITLE
fix(dashboard): restore token gate

### DIFF
--- a/dashboard/src/components/session/AcpApprovalModal.tsx
+++ b/dashboard/src/components/session/AcpApprovalModal.tsx
@@ -47,7 +47,7 @@ function ToolInputPreview({ input }: { input?: Record<string, unknown> }) {
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="flex items-center gap-1 text-xs text-[#555] hover:text-[#888] transition-colors"
+        className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] opacity-60 transition-opacity hover:opacity-100"
         aria-expanded={expanded}
         aria-controls="tool-input-preview"
       >
@@ -56,7 +56,7 @@ function ToolInputPreview({ input }: { input?: Record<string, unknown> }) {
       </button>
       <pre
         id="tool-input-preview"
-        className={`mt-1 overflow-auto rounded-md border border-[#2a2a3a] bg-[#0a0a0f] p-3 font-mono text-xs text-[#888] ${isLong && !expanded ? 'max-h-24' : 'max-h-48'}`}
+        className={`mt-1 overflow-auto rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] p-3 font-mono text-xs text-[var(--color-text-muted)] ${isLong && !expanded ? 'max-h-24' : 'max-h-48'}`}
       >
         {displayText}
       </pre>
@@ -197,7 +197,7 @@ export function AcpApprovalModal({
               <button
                 type="button"
                 onClick={() => setShowApproveReason((prev) => !prev)}
-                className="self-start text-xs text-[#555] hover:text-[#888] transition-colors"
+                className="self-start text-xs text-[var(--color-text-muted)] opacity-60 transition-opacity hover:opacity-100"
               >
                 {showApproveReason ? '▼ Hide' : '▶ Add approval reason (optional)'}
               </button>
@@ -205,7 +205,7 @@ export function AcpApprovalModal({
             {showApproveReason && (
               <div className="flex items-end gap-2">
                 <div className="flex-1">
-                  <label htmlFor="approve-reason" className="mb-1 block text-xs text-[#555]">
+                  <label htmlFor="approve-reason" className="mb-1 block text-xs text-[var(--color-text-muted)] opacity-60">
                     Approval reason (for audit log)
                   </label>
                   <input
@@ -215,7 +215,7 @@ export function AcpApprovalModal({
                     onChange={(e) => setApproveReason(e.target.value)}
                     onKeyDown={(e) => e.key === 'Enter' && handleApprove()}
                     placeholder="e.g., reviewed the command"
-                    className="w-full rounded-md border border-[#2a2a3a] bg-[#0a0a0f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-green-500/50 focus:outline-none"
+                    className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-success)]/50 focus:outline-none"
                     autoFocus
                   />
                 </div>
@@ -225,7 +225,7 @@ export function AcpApprovalModal({
             {/* Reject reason form */}
             {showRejectReason && (
               <div className="flex flex-col gap-2">
-                <label htmlFor="reject-reason" className="text-xs text-[#555]">
+                <label htmlFor="reject-reason" className="text-xs text-[var(--color-text-muted)] opacity-60">
                   Rejection reason (optional, for audit log)
                 </label>
                 <input
@@ -235,7 +235,7 @@ export function AcpApprovalModal({
                   onChange={(e) => setRejectReason(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleReject()}
                   placeholder="e.g., unsafe command"
-                  className="w-full rounded-md border border-[#2a2a3a] bg-[#0a0a0f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-red-500/50 focus:outline-none"
+                  className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-danger)]/50 focus:outline-none"
                   autoFocus
                 />
                 <div className="flex items-center gap-2">
@@ -252,7 +252,7 @@ export function AcpApprovalModal({
                   <button
                     type="button"
                     onClick={() => { setShowRejectReason(false); setRejectReason(''); }}
-                    className="rounded-md border border-[#2a2a3a] px-3 py-2 text-sm text-[#888] hover:text-[#ccc]"
+                    className="rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
                   >
                     Cancel
                   </button>

--- a/dashboard/src/components/session/AcpChatView.tsx
+++ b/dashboard/src/components/session/AcpChatView.tsx
@@ -60,7 +60,7 @@ function ThinkingBlock({ block }: { block: AcpThinkingBlock }) {
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="flex items-center gap-1 text-xs text-[#555] hover:text-[#888] transition-colors"
+        className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] opacity-60 transition-opacity hover:opacity-100"
         aria-expanded={expanded}
         aria-controls={`thinking-${block.id}`}
       >
@@ -71,7 +71,7 @@ function ThinkingBlock({ block }: { block: AcpThinkingBlock }) {
       {expanded && (
         <pre
           id={`thinking-${block.id}`}
-          className="mt-1 max-h-48 overflow-auto rounded-md border border-[#2a2a3a] bg-[#0a0a0f] p-2 font-mono text-xs text-[#666] whitespace-pre-wrap"
+          className="mt-1 max-h-48 overflow-auto rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] p-2 font-mono text-xs text-[var(--color-text-muted)] whitespace-pre-wrap"
         >
           {block.content}
         </pre>
@@ -82,7 +82,7 @@ function ThinkingBlock({ block }: { block: AcpThinkingBlock }) {
 
 function TokenUsageInline({ usage }: { usage: AcpTokenUsage }) {
   return (
-    <span className="ml-2 text-[10px] text-[#444]" title={`Input: ${usage.inputTokens} · Output: ${usage.outputTokens} · Total: ${usage.totalTokens}`}>
+    <span className="ml-2 text-[10px] text-[var(--color-text-muted)] opacity-60" title={`Input: ${usage.inputTokens} · Output: ${usage.outputTokens} · Total: ${usage.totalTokens}`}>
       {usage.totalTokens.toLocaleString()} tokens
     </span>
   );
@@ -98,7 +98,7 @@ function ToolCallPlaceholder({ toolCall }: { toolCall: import('../../types/acp-c
   };
 
   return (
-    <div className="my-1 flex items-center gap-2 rounded-md border border-[#2a2a3a] bg-[#12121f] px-3 py-1.5 text-xs text-[#888]">
+    <div className="my-1 flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)]">
       <span>{statusIcons[toolCall.status] ?? '❓'}</span>
       <span className="font-mono">{toolCall.toolName}</span>
       {toolCall.status === 'running' && <Loader2 className="h-3 w-3 animate-spin" />}
@@ -114,7 +114,7 @@ function MessageBubble({ message, showPerMessageUsage }: { message: AcpChatMessa
     <div className={`mb-4 flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div className={`max-w-[80%] ${isUser ? 'order-1' : ''}`}>
         {/* Role indicator */}
-        <div className={`mb-1 flex items-center gap-1 text-xs ${isUser ? 'justify-end text-[#555]' : 'text-[#555]'}`}>
+        <div className={`mb-1 flex items-center gap-1 text-xs text-[var(--color-text-muted)] opacity-60 ${isUser ? 'justify-end' : ''}`}>
           {isUser ? (
             <>
               <span>You</span>
@@ -126,17 +126,17 @@ function MessageBubble({ message, showPerMessageUsage }: { message: AcpChatMessa
               <span>Assistant</span>
             </>
           )}
-          {isSystem && <span className="text-[#555]">System</span>}
+          {isSystem && <span className="text-[var(--color-text-muted)]">System</span>}
         </div>
 
         {/* Message content */}
         <div
           className={`rounded-xl px-4 py-2.5 text-sm leading-relaxed ${
             isUser
-              ? 'bg-blue-500/15 text-[#e0e0e0] border border-blue-500/20'
+              ? 'bg-blue-500/15 text-[var(--color-text-primary)] border border-blue-500/20'
               : isSystem
-                ? 'bg-[#1a1a2a] text-[#888] border border-[#2a2a3a]'
-                : 'bg-[#12121f] text-[#d0d0d0] border border-[#2a2a3a]'
+                ? 'bg-[var(--color-surface-hover)] text-[var(--color-text-muted)] border border-[var(--color-border-strong)]'
+                : 'bg-[var(--color-surface)] text-[var(--color-text-primary)] border border-[var(--color-border-strong)]'
           }`}
         >
           {/* Thinking blocks */}
@@ -151,7 +151,7 @@ function MessageBubble({ message, showPerMessageUsage }: { message: AcpChatMessa
           {/* Text content */}
           <div className="whitespace-pre-wrap break-words">
             {message.content}
-            {message.isStreaming && <span className="inline-block w-1.5 h-4 ml-0.5 animate-pulse bg-[#888]" />}
+            {message.isStreaming && <span className="inline-block w-1.5 h-4 ml-0.5 animate-pulse bg-[var(--color-text-muted)]" />}
           </div>
 
           {/* Tool calls */}
@@ -177,27 +177,27 @@ function MessageBubble({ message, showPerMessageUsage }: { message: AcpChatMessa
 
 function TokenMeter({ usage }: { usage: AcpSessionTokenUsage }) {
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-[#2a2a3a] bg-[#12121f] px-3 py-2 text-xs">
-      <div className="flex items-center gap-1 text-[#555]">
+    <div className="flex items-center gap-3 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 text-xs">
+      <div className="flex items-center gap-1 text-[var(--color-text-muted)] opacity-60">
         <span>Input:</span>
-        <span className="font-mono text-[#888]">{usage.inputTokens.toLocaleString()}</span>
+        <span className="font-mono text-[var(--color-text-muted)]">{usage.inputTokens.toLocaleString()}</span>
       </div>
-      <div className="flex items-center gap-1 text-[#555]">
+      <div className="flex items-center gap-1 text-[var(--color-text-muted)] opacity-60">
         <span>Output:</span>
-        <span className="font-mono text-[#888]">{usage.outputTokens.toLocaleString()}</span>
+        <span className="font-mono text-[var(--color-text-muted)]">{usage.outputTokens.toLocaleString()}</span>
       </div>
       {usage.cacheReadTokens > 0 && (
-        <div className="flex items-center gap-1 text-[#555]">
+        <div className="flex items-center gap-1 text-[var(--color-text-muted)] opacity-60">
           <span>Cache:</span>
           <span className="font-mono text-green-400">{usage.cacheReadTokens.toLocaleString()}</span>
         </div>
       )}
       <div className="ml-auto flex items-center gap-1">
-        <span className="font-mono font-medium text-[#e0e0e0]">{usage.totalTokens.toLocaleString()}</span>
-        <span className="text-[#555]">tokens</span>
+        <span className="font-mono font-medium text-[var(--color-text-primary)]">{usage.totalTokens.toLocaleString()}</span>
+        <span className="text-[var(--color-text-muted)] opacity-60">tokens</span>
       </div>
       {usage.estimatedCostUsd !== undefined && (
-        <div className="text-[#555]">
+        <div className="text-[var(--color-text-muted)] opacity-60">
           ~${usage.estimatedCostUsd.toFixed(4)}
         </div>
       )}
@@ -253,7 +253,7 @@ export function AcpChatView({
       {/* Messages area */}
       <div className="flex-1 overflow-y-auto px-4 py-4" role="log" aria-label="Chat messages">
         {messages.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm text-[#555]">
+          <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-muted)] opacity-60">
             No messages yet. Send a prompt to start.
           </div>
         ) : (
@@ -270,7 +270,7 @@ export function AcpChatView({
 
       {/* Input area */}
       {isDriver ? (
-        <div className="border-t border-[#2a2a3a] p-3">
+        <div className="border-t border-[var(--color-border-strong)] p-3">
           <div className="flex items-end gap-2">
             <textarea
               ref={inputRef}
@@ -279,7 +279,7 @@ export function AcpChatView({
               onKeyDown={handleKeyDown}
               placeholder="Send a prompt to the agent..."
               rows={1}
-              className="flex-1 resize-none rounded-lg border border-[#2a2a3a] bg-[#0a0a0f] px-3 py-2.5 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-blue-500/50 focus:outline-none"
+              className="flex-1 resize-none rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-2.5 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-blue-500/50 focus:outline-none"
               disabled={!isDriver}
               aria-label="Message input"
             />
@@ -304,12 +304,12 @@ export function AcpChatView({
               </button>
             )}
           </div>
-          <div className="mt-1 text-right text-[10px] text-[#333]">
+          <div className="mt-1 text-right text-[10px] text-[var(--color-text-muted)] opacity-40">
             Enter to send · Shift+Enter for new line
           </div>
         </div>
       ) : (
-        <div className="border-t border-[#2a2a3a] p-3 text-center text-xs text-[#555]">
+        <div className="border-t border-[var(--color-border-strong)] p-3 text-center text-xs text-[var(--color-text-muted)] opacity-60">
           Observer mode — you cannot send prompts
         </div>
       )}

--- a/dashboard/src/components/session/AcpSessionShell.tsx
+++ b/dashboard/src/components/session/AcpSessionShell.tsx
@@ -77,13 +77,13 @@ export function AcpSessionShell({
   }, []);
 
   return (
-    <div className="flex h-full flex-col bg-[#0a0a0f]" data-session-id={sessionId}>
+    <div className="flex h-full flex-col bg-[var(--color-void)]" data-session-id={sessionId}>
       {/* Session status bar */}
-      <div className="flex items-center justify-between border-b border-[#2a2a3a] px-4 py-2">
+      <div className="flex items-center justify-between border-b border-[var(--color-border-strong)] px-4 py-2">
         <div className="flex items-center gap-2">
-          <span className="font-mono text-xs text-[#555]">{sessionId.slice(0, 8)}</span>
+          <span className="font-mono text-xs text-[var(--color-text-muted)] opacity-60">{sessionId.slice(0, 8)}</span>
           {sessionStatus && (
-            <span className="rounded bg-[#2a2a3a] px-2 py-0.5 text-xs text-[#888]">
+            <span className="rounded bg-[var(--color-void-lighter)] px-2 py-0.5 text-xs text-[var(--color-text-primary)]">
               {sessionStatus}
             </span>
           )}
@@ -92,7 +92,7 @@ export function AcpSessionShell({
           <button
             type="button"
             onClick={() => setRailOpen((prev) => !prev)}
-            className="flex items-center gap-1 rounded-md border border-[#2a2a3a] px-2 py-1 text-xs text-[#888] transition-colors hover:text-[#ccc] hover:border-[#3a3a4a]"
+            className="flex items-center gap-1 rounded-md border border-[var(--color-border-strong)] px-2 py-1 text-xs text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)]"
             aria-label={railOpen ? 'Hide control rail' : 'Show control rail'}
             aria-expanded={railOpen}
           >
@@ -114,8 +114,8 @@ export function AcpSessionShell({
       {/* Loading state */}
       {isLoading && !error && (
         <div className="flex items-center justify-center p-8" role="status">
-          <div className="h-6 w-6 animate-spin rounded-full border-2 border-[#2a2a3a] border-t-blue-500" />
-          <span className="ml-3 text-sm text-[#888]">Loading session...</span>
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-[var(--color-border-strong)] border-t-blue-500" />
+          <span className="ml-3 text-sm text-[var(--color-text-muted)]">Loading session...</span>
         </div>
       )}
 
@@ -126,7 +126,7 @@ export function AcpSessionShell({
           <div className="flex flex-1 flex-col overflow-hidden">
             {/* Tab bar */}
             <nav
-              className="flex items-center border-b border-[#2a2a3a] px-2"
+              className="flex items-center border-b border-[var(--color-border-strong)] px-2"
               role="tablist"
               aria-label="Session views"
             >
@@ -145,10 +145,10 @@ export function AcpSessionShell({
                     onClick={() => !isDisabled && handleTabChange(tab.id)}
                     className={`relative flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors ${
                       isActive
-                        ? 'text-[#e0e0e0]'
+                        ? 'text-[var(--color-text-primary)]'
                         : isDisabled
-                          ? 'text-[#333] cursor-not-allowed'
-                          : 'text-[#555] hover:text-[#888]'
+                          ? 'text-[var(--color-text-muted)] opacity-40 cursor-not-allowed'
+                          : 'text-[var(--color-text-muted)] opacity-60 hover:opacity-100'
                     }`}
                   >
                     <Icon className="h-4 w-4" />
@@ -179,7 +179,7 @@ export function AcpSessionShell({
                   className="h-full"
                 >
                   {activeTab === tab.id && (children[tab.id] ?? (
-                    <div className="flex h-full items-center justify-center text-sm text-[#555]">
+                    <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-muted)] opacity-60">
                       {tab.label} view not yet implemented
                     </div>
                   ))}
@@ -191,16 +191,16 @@ export function AcpSessionShell({
           {/* Control rail */}
           {railOpen && controlRail && (
             <aside
-              className="w-72 shrink-0 overflow-y-auto border-l border-[#2a2a3a] bg-[#12121f]"
+              className="w-72 shrink-0 overflow-y-auto border-l border-[var(--color-border-strong)] bg-[var(--color-surface)]"
               role="complementary"
               aria-label="Session controls"
             >
               {/* Rail close button (mobile) */}
-              <div className="flex items-center justify-end border-b border-[#2a2a3a] p-2 lg:hidden">
+               <div className="flex items-center justify-end border-b border-[var(--color-border-strong)] p-2 lg:hidden">
                 <button
                   type="button"
                   onClick={() => setRailOpen(false)}
-                  className="rounded-md p-1 text-[#888] hover:text-[#ccc]"
+                  className="rounded-md p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
                   aria-label="Close control rail"
                 >
                   <ChevronLeft className="h-4 w-4" />

--- a/dashboard/src/components/session/DriverControlBar.tsx
+++ b/dashboard/src/components/session/DriverControlBar.tsx
@@ -66,7 +66,7 @@ export function DriverControlBar({
 
   return (
     <div
-      className="flex flex-col gap-2 rounded-lg border border-[#2a2a3a] bg-[#12121f] p-3"
+      className="flex flex-col gap-2 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3"
       role="toolbar"
       aria-label="Session driver and observer controls"
     >
@@ -91,7 +91,7 @@ export function DriverControlBar({
         <div className="flex items-center gap-2">
           <Gamepad2 className="h-4 w-4 text-blue-400" />
           {hasDriver ? (
-            <span className="text-sm text-[#e0e0e0]">
+            <span className="text-sm text-[var(--color-text-primary)]">
               Driver: <span className="font-medium">{participants!.driver!.subscriberId}</span>
               {isDriver && (
                 <span className={`ml-2 rounded px-1.5 py-0.5 text-xs ${ROLE_COLORS.driver.bg} ${ROLE_COLORS.driver.text}`}>
@@ -100,13 +100,13 @@ export function DriverControlBar({
               )}
             </span>
           ) : (
-            <span className="text-sm text-[#555]">No driver claimed</span>
+            <span className="text-sm text-[var(--color-text-muted)] opacity-60">No driver claimed</span>
           )}
         </div>
 
         <div className="flex items-center gap-2">
           {participants && (
-            <span className="flex items-center gap-1 text-xs text-[#555]">
+            <span className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] opacity-60">
               <Users className="h-3 w-3" />
               {participants.activeCount} connected
             </span>
@@ -133,7 +133,7 @@ export function DriverControlBar({
             <button
               onClick={() => onRelease?.()}
               disabled={!canAct}
-              className="flex items-center gap-2 rounded-md border border-[#2a2a3a] px-3 py-2 text-sm text-[#888] transition-colors hover:text-[#ccc] disabled:opacity-50"
+              className="flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] disabled:opacity-50"
               aria-label="Release driver role"
             >
               {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Eye className="h-4 w-4" />}
@@ -166,8 +166,8 @@ export function DriverControlBar({
 
       {/* Transfer form */}
       {showTransferForm && (
-        <div className="flex flex-col gap-2 rounded-md border border-[#2a2a3a] bg-[#0a0a0f] p-3">
-          <label htmlFor="transfer-target" className="text-xs text-[#888]">
+        <div className="flex flex-col gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] p-3">
+          <label htmlFor="transfer-target" className="text-xs text-[var(--color-text-muted)]">
             Transfer driver to (subscriber ID)
           </label>
           <input
@@ -177,10 +177,10 @@ export function DriverControlBar({
             onChange={(e) => setTransferTarget(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleTransfer()}
             placeholder="Enter subscriber ID"
-            className="w-full rounded-md border border-[#2a2a3a] bg-[#12121f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-amber-500/50 focus:outline-none"
+            className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-warning)]/50 focus:outline-none"
             autoFocus
           />
-          <label htmlFor="transfer-reason" className="text-xs text-[#888]">
+          <label htmlFor="transfer-reason" className="text-xs text-[var(--color-text-muted)]">
             Reason (optional)
           </label>
           <input
@@ -190,7 +190,7 @@ export function DriverControlBar({
             onChange={(e) => setTransferReason(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleTransfer()}
             placeholder="e.g., switching to mobile"
-            className="w-full rounded-md border border-[#2a2a3a] bg-[#12121f] px-3 py-2 text-sm text-[#e0e0e0] placeholder-[#555] focus:border-amber-500/50 focus:outline-none"
+            className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-warning)]/50 focus:outline-none"
           />
           <div className="flex items-center gap-2">
             <button
@@ -204,7 +204,7 @@ export function DriverControlBar({
             </button>
             <button
               onClick={() => { setShowTransferForm(false); setTransferTarget(''); setTransferReason(''); }}
-              className="rounded-md border border-[#2a2a3a] px-3 py-2 text-sm text-[#888] transition-colors hover:text-[#ccc]"
+              className="rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
               aria-label="Cancel transfer"
             >
               Cancel
@@ -216,7 +216,7 @@ export function DriverControlBar({
       {/* Observers list */}
       {participants && participants.observers.length > 0 && (
         <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium uppercase tracking-wider text-[#555]">
+          <span className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)] opacity-60">
             Observers ({participants.observers.length})
           </span>
           <div className="flex flex-wrap gap-1" role="list" aria-label="Session observers">

--- a/dashboard/src/components/session/ToolCallCard.tsx
+++ b/dashboard/src/components/session/ToolCallCard.tsx
@@ -45,11 +45,11 @@ function getToolIcon(toolName: string) {
 
 /** Status configuration. */
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof Loader2; color: string; bgColor: string }> = {
-  pending: { label: 'Pending', icon: Clock, color: 'text-[#888]', bgColor: 'bg-[#2a2a3a]' },
+  pending: { label: 'Pending', icon: Clock, color: 'text-[var(--color-text-muted)]', bgColor: 'bg-[var(--color-void-lighter)]' },
   running: { label: 'Running', icon: Loader2, color: 'text-blue-400', bgColor: 'bg-blue-500/10' },
   completed: { label: 'Completed', icon: CheckCircle, color: 'text-green-400', bgColor: 'bg-green-500/10' },
   failed: { label: 'Failed', icon: XCircle, color: 'text-red-400', bgColor: 'bg-red-500/10' },
-  cancelled: { label: 'Cancelled', icon: XCircle, color: 'text-[#888]', bgColor: 'bg-[#2a2a3a]' },
+  cancelled: { label: 'Cancelled', icon: XCircle, color: 'text-[var(--color-text-muted)]', bgColor: 'bg-[var(--color-void-lighter)]' },
 };
 
 /** Diff line renderer. */
@@ -62,12 +62,12 @@ function DiffLine({ line }: { line: string }) {
     <div
       className={`font-mono text-xs leading-5 ${
         isHunk
-          ? 'text-[#555] bg-[#1a1a2a]'
+          ? 'text-[var(--color-text-muted)] bg-[var(--color-surface-hover)]'
           : isAddition
             ? 'text-green-400 bg-green-500/5'
             : isDeletion
               ? 'text-red-400 bg-red-500/5'
-              : 'text-[#888]'
+              : 'text-[var(--color-text-muted)]'
       }`}
     >
       {line || '\u00A0'}
@@ -81,16 +81,16 @@ function FileDiffCard({ diff }: { diff: AcpFileDiff }) {
   const lines = diff.diff.split('\n');
 
   return (
-    <div className="mt-2 rounded-lg border border-[#2a2a3a] overflow-hidden">
+    <div className="mt-2 rounded-lg border border-[var(--color-border-strong)] overflow-hidden">
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-[#888] hover:bg-[#1a1a2a] transition-colors"
+        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)]"
         aria-expanded={expanded}
         aria-controls={`diff-${diff.filePath}`}
       >
         {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-        <FileEdit className="h-3 w-3 text-[#555]" />
+        <FileEdit className="h-3 w-3 text-[var(--color-text-muted)] opacity-60" />
         <span className="font-mono">{diff.filePath}</span>
         {diff.additions !== undefined && (
           <span className="text-green-400">+{diff.additions}</span>
@@ -102,7 +102,7 @@ function FileDiffCard({ diff }: { diff: AcpFileDiff }) {
       {expanded && (
         <div
           id={`diff-${diff.filePath}`}
-          className="max-h-64 overflow-auto bg-[#0a0a0f] px-3 py-1"
+          className="max-h-64 overflow-auto bg-[var(--color-void)] px-3 py-1"
         >
           {lines.map((line, i) => (
             <DiffLine key={i} line={line} />
@@ -130,20 +130,20 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
 
   return (
     <div
-      className={`my-2 rounded-lg border border-[#2a2a3a] overflow-hidden ${statusConfig.bgColor}`}
+      className={`my-2 rounded-lg border border-[var(--color-border-strong)] overflow-hidden ${statusConfig.bgColor}`}
       role="article"
       aria-label={`Tool call: ${toolCall.toolName}`}
     >
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2">
-        <ToolIcon className="h-4 w-4 text-[#555] shrink-0" />
-        <span className="font-mono text-sm font-medium text-[#e0e0e0]">{toolCall.toolName}</span>
+        <ToolIcon className="h-4 w-4 text-[var(--color-text-muted)] opacity-60 shrink-0" />
+        <span className="font-mono text-sm font-medium text-[var(--color-text-primary)]">{toolCall.toolName}</span>
         <span className={`ml-auto flex items-center gap-1 text-xs ${statusConfig.color}`}>
           <StatusIcon className={`h-3.5 w-3.5 ${toolCall.status === 'running' ? 'animate-spin' : ''}`} />
           {statusConfig.label}
         </span>
         {result?.durationMs !== undefined && (
-          <span className="text-[10px] text-[#555]">
+          <span className="text-[10px] text-[var(--color-text-muted)] opacity-60">
             {(result.durationMs / 1000).toFixed(1)}s
           </span>
         )}
@@ -155,14 +155,14 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
           <button
             type="button"
             onClick={() => setInputExpanded((prev) => !prev)}
-            className="flex w-full items-center gap-1 border-t border-[#2a2a3a] px-3 py-1.5 text-xs text-[#555] hover:bg-[#1a1a2a] transition-colors"
+            className="flex w-full items-center gap-1 border-t border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-text-muted)] opacity-60 transition-opacity hover:opacity-100 hover:bg-[var(--color-surface-hover)]"
             aria-expanded={inputExpanded}
           >
             {inputExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
             Input
           </button>
           {inputExpanded && (
-            <pre className="max-h-40 overflow-auto border-t border-[#2a2a3a] bg-[#0a0a0f] p-3 font-mono text-xs text-[#888]">
+            <pre className="max-h-40 overflow-auto border-t border-[var(--color-border-strong)] bg-[var(--color-void)] p-3 font-mono text-xs text-[var(--color-text-muted)]">
               {JSON.stringify(toolCall.input, null, 2)}
             </pre>
           )}
@@ -171,7 +171,7 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
 
       {/* Error display */}
       {result?.error && (
-        <div className="flex items-start gap-2 border-t border-[#2a2a3a] bg-red-500/5 px-3 py-2">
+        <div className="flex items-start gap-2 border-t border-[var(--color-border-strong)] bg-red-500/5 px-3 py-2">
           <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
           <pre className="flex-1 whitespace-pre-wrap break-words font-mono text-xs text-red-400">
             {result.error}
@@ -185,14 +185,14 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
           <button
             type="button"
             onClick={() => setOutputExpanded((prev) => !prev)}
-            className="flex w-full items-center gap-1 border-t border-[#2a2a3a] px-3 py-1.5 text-xs text-[#555] hover:bg-[#1a1a2a] transition-colors"
+            className="flex w-full items-center gap-1 border-t border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-text-muted)] opacity-60 transition-opacity hover:opacity-100 hover:bg-[var(--color-surface-hover)]"
             aria-expanded={outputExpanded}
           >
             {outputExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
             Output
           </button>
           {outputExpanded && (
-            <pre className="max-h-40 overflow-auto border-t border-[#2a2a3a] bg-[#0a0a0f] p-3 font-mono text-xs text-[#888] whitespace-pre-wrap break-words">
+            <pre className="max-h-40 overflow-auto border-t border-[var(--color-border-strong)] bg-[var(--color-void)] p-3 font-mono text-xs text-[var(--color-text-muted)] whitespace-pre-wrap break-words">
               {result.output}
             </pre>
           )}
@@ -201,8 +201,8 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
 
       {/* File diffs */}
       {result?.diffs && result.diffs.length > 0 && (
-        <div className="border-t border-[#2a2a3a] px-3 py-2">
-          <span className="text-xs font-medium text-[#555]">
+        <div className="border-t border-[var(--color-border-strong)] px-3 py-2">
+          <span className="text-xs font-medium text-[var(--color-text-muted)] opacity-60">
             {result.diffs.length} file{result.diffs.length > 1 ? 's' : ''} changed
           </span>
           {result.diffs.map((diff, i) => (


### PR DESCRIPTION
## Summary
- Replaced raw hex Tailwind arbitrary color classes in ACP approval and driver controls with dashboard design-token CSS variables.
- Restored `npm run dashboard:tokens:gate` without using token allowlist escapes.
- Kept the change scoped to dashboard session components only.

## Aegis version
**Developed with:** v0.6.6-preview.1

## Validation
- `npm run dashboard:tokens:gate`
- `cd dashboard; npx vitest run src\__tests__\DriverControlBar.test.tsx src\__tests__\AcpApprovalModal.test.tsx`
- `npm run gate`