### PR TITLE
docs: add CHANGELOG entries for ACP PRs #2696, #2699–#2705

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ These changes are part of the Phase 3.5 ACP backend migration ([#2574](https://g
 - Scaffold ACP-085 pause/resume/intervention dashboard UI — frontend types, API client, React hook, `PauseControlBar`, `InterventionStatusBadge`, and `InterventionHistoryPanel` components with full a11y and dark theme; placeholder endpoints pending ACP-064 ([#2693](https://github.com/OneStepAt4time/aegis/pull/2693))
 - Drain non-runtime tmux references from CI, Helm, and package metadata — rename CI smoke step, remove tmux-kill fault harness entry, update Chart keywords and package.json keywords ([#2694](https://github.com/OneStepAt4time/aegis/pull/2694))
 - Add ACP backend session lifecycle orchestration — create, resume, cancel, shutdown, startup failure, unexpected exit, and lifecycle-scoped restart/backoff behavior over ACP child process and JSON-RPC client; fix ACP fs workdir containment for cross-platform Windows compatibility ([#2695](https://github.com/OneStepAt4time/aegis/pull/2695))
+- Add typed ACP action queue worker that leases scoped durable actions and dispatches them through injected backend dependencies — prompt, approval response, cancel, and close; leaves stale lease recovery unimplemented until ACP-024 ([#2696](https://github.com/OneStepAt4time/aegis/pull/2696))
+- Add typed `AcpFanout` contracts with local and Redis-backed implementations — persistent fanout events through `AcpEventStore`, cursor replay handoff, session/tenant/owner scoping, ordering, duplicate suppression, and disconnect cleanup; Redis fanout is volatile via adapter boundary ([#2699](https://github.com/OneStepAt4time/aegis/pull/2699))
+- Scaffold ACP-084 driver/observer controls dashboard UI ([#2700](https://github.com/OneStepAt4time/aegis/pull/2700))
+- Scaffold ACP-083 approval modal dashboard UI ([#2701](https://github.com/OneStepAt4time/aegis/pull/2701))
+- Scaffold ACP-080 session shell and control rail dashboard UI ([#2702](https://github.com/OneStepAt4time/aegis/pull/2702))
+- Scaffold ACP-081 chat view with text, thinking, and token usage dashboard UI ([#2704](https://github.com/OneStepAt4time/aegis/pull/2704))
+- Scaffold ACP-082 tool-call and diff cards dashboard UI ([#2705](https://github.com/OneStepAt4time/aegis/pull/2705))
 
 ## [0.6.6-preview.1](https://github.com/OneStepAt4time/aegis/compare/v0.6.5-preview.3...v0.6.6-preview.1) (2026-05-03)
 


### PR DESCRIPTION
## Summary\n\nAdd CHANGELOG entries for recently merged ACP Phase 3.5 PRs not yet covered:\n\n- **#2696** — ACP action queue worker (leases, dispatch, backend seams)\n- **#2699** — ACP fanout delivery (local + Redis, cursor replay, scoping)\n- **#2700** — Scaffold ACP-084 driver/observer controls (dashboard)\n- **#2701** — Scaffold ACP-083 approval modal (dashboard)\n- **#2702** — Scaffold ACP-080 session shell and control rail (dashboard)\n- **#2704** — Scaffold ACP-081 chat view (dashboard)\n- **#2705** — Scaffold ACP-082 tool-call and diff cards (dashboard)\n\nPrevious batches: #2691 (#2683–#2690), #2697 (#2692–#2695).\n\nNo functional changes — documentation only.