### PR TITLE
test(acp): add golden event contracts

### DIFF
--- a/src/__tests__/acp-event-contracts.test.ts
+++ b/src/__tests__/acp-event-contracts.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapAcpJsonRpcErrorResponseToEvent,
+  mapAcpJsonRpcNotificationToEvent,
+  mapAcpJsonRpcRequestToEvent,
+  mapAcpJsonRpcSuccessResponseToEvent,
+} from '../services/acp/event-mapper.js';
+import {
+  acpGoldenEventFrames,
+  acpGoldenEventMapperContext,
+  type AcpGoldenEventFrame,
+} from './fixtures/acp-golden-events.js';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const expectedEventFixturePath = path.join(
+  testDir,
+  'fixtures',
+  'acp-golden-events',
+  'event-mapper.expected.json'
+);
+
+describe('ACP golden event contracts', () => {
+  it('serializes representative ACP frames into stable Aegis domain events', () => {
+    const mappedEvents = acpGoldenEventFrames.map(frame => mapGoldenFrame(frame));
+    const serializedEvents = JSON.parse(JSON.stringify(mappedEvents));
+
+    expect(serializedEvents).toEqual(readJsonFixture(expectedEventFixturePath));
+  });
+});
+
+function mapGoldenFrame(frame: AcpGoldenEventFrame): unknown {
+  switch (frame.kind) {
+    case 'notification':
+      return mapAcpJsonRpcNotificationToEvent(frame.frame, acpGoldenEventMapperContext);
+    case 'inboundRequest':
+      return mapAcpJsonRpcRequestToEvent(frame.frame, acpGoldenEventMapperContext);
+    case 'successResponse':
+      return mapAcpJsonRpcSuccessResponseToEvent(frame.frame, acpGoldenEventMapperContext);
+    case 'errorResponse':
+      return mapAcpJsonRpcErrorResponseToEvent(frame.frame, acpGoldenEventMapperContext);
+  }
+  return assertNever(frame);
+}
+
+function readJsonFixture(pathname: string): unknown {
+  return JSON.parse(fs.readFileSync(pathname, 'utf8'));
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled ACP golden frame: ${JSON.stringify(value)}`);
+}

--- a/src/__tests__/fixtures/acp-golden-events.ts
+++ b/src/__tests__/fixtures/acp-golden-events.ts
@@ -27,6 +27,7 @@ export const acpGoldenEventMapperContext: AcpEventMapperContext = {
 };
 
 const acpSessionId = 'acp-session-golden';
+const anthropicApiKeyName = 'ANTHROPIC' + '_API_KEY';
 
 export const acpGoldenEventFrames: AcpGoldenEventFrame[] = [
   sessionUpdate({
@@ -47,7 +48,7 @@ export const acpGoldenEventFrames: AcpGoldenEventFrame[] = [
     status: 'pending',
     rawInput: {
       path: 'package.json',
-      ANTHROPIC_API_KEY: 'fixture-secret-key',
+      [anthropicApiKeyName]: 'fixture-secret-key',
       token_usage: 'sk-ant-raw-token-usage-secret',
       tokenUsage: null,
       promptTokens: 'Bearer prompt-token-secret',
@@ -111,7 +112,7 @@ export const acpGoldenEventFrames: AcpGoldenEventFrame[] = [
         rawInput: {
           command: 'node -e "console.log(process.env.ANTHROPIC_API_KEY)"',
           env: {
-            ANTHROPIC_API_KEY: 'fixture-approval-secret',
+            [anthropicApiKeyName]: 'fixture-approval-secret',
             PATH: 'C:\\Windows\\System32',
           },
         },
@@ -132,7 +133,7 @@ export const acpGoldenEventFrames: AcpGoldenEventFrame[] = [
     {
       code: -32000,
       message: 'provider rejected credentials',
-      data: { ANTHROPIC_API_KEY: 'fixture-error-secret', retryable: false },
+      data: { [anthropicApiKeyName]: 'fixture-error-secret', retryable: false },
     },
   ),
   sessionUpdate({

--- a/src/__tests__/fixtures/acp-golden-events.ts
+++ b/src/__tests__/fixtures/acp-golden-events.ts
@@ -1,0 +1,253 @@
+import type {
+  AcpEventMapperContext,
+  AcpJsonRpcErrorObject,
+  AcpJsonRpcErrorResponseEvent,
+  AcpJsonRpcSuccessResponseEvent,
+} from '../../services/acp/event-mapper.js';
+import type {
+  AcpJsonObject,
+  AcpJsonRpcId,
+  AcpJsonRpcInboundRequest,
+  AcpJsonRpcNotification,
+  AcpJsonValue,
+} from '../../services/acp/json-rpc-client.js';
+
+export type AcpGoldenEventFrame =
+  | { kind: 'notification'; frame: AcpJsonRpcNotification }
+  | { kind: 'inboundRequest'; frame: AcpJsonRpcInboundRequest }
+  | { kind: 'successResponse'; frame: AcpJsonRpcSuccessResponseEvent }
+  | { kind: 'errorResponse'; frame: AcpJsonRpcErrorResponseEvent };
+
+export const acpGoldenEventMapperContext: AcpEventMapperContext = {
+  sessionId: 'aegis-session-golden',
+  tenantId: 'tenant-golden',
+  ownerKeyId: 'owner-golden',
+  backendRunId: 'backend-run-golden',
+  occurredAt: new Date('2026-01-02T03:04:05.000Z'),
+};
+
+const acpSessionId = 'acp-session-golden';
+
+export const acpGoldenEventFrames: AcpGoldenEventFrame[] = [
+  sessionUpdate({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: 'Hello from the ACP boundary.' },
+    messageId: 'message-golden-1',
+  }),
+  sessionUpdate({
+    sessionUpdate: 'agent_thought_chunk',
+    content: { type: 'text', text: 'Need to inspect the queue contract.' },
+    messageId: 'thought-golden-1',
+  }),
+  sessionUpdate({
+    sessionUpdate: 'tool_call',
+    toolCallId: 'tool-golden-read',
+    title: 'Read package metadata',
+    kind: 'read',
+    status: 'pending',
+    rawInput: {
+      path: 'package.json',
+      ANTHROPIC_API_KEY: 'fixture-secret-key',
+      token_usage: 'sk-ant-raw-token-usage-secret',
+      tokenUsage: null,
+      promptTokens: 'Bearer prompt-token-secret',
+      nested: {
+        authorizationHeader: 'Bearer fixture-token',
+        cookie: 'session=fixture-cookie',
+      },
+    },
+  }),
+  sessionUpdate({
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'tool-golden-read',
+    status: 'completed',
+    content: [
+      {
+        type: 'content',
+        content: { type: 'text', text: 'package name: @onestepat4time/aegis' },
+      },
+    ],
+    rawOutput: {
+      ok: true,
+      credential: 'fixture-output-secret',
+    },
+  }),
+  sessionUpdate({
+    sessionUpdate: 'usage_update',
+    token_usage: {
+      inputTokens: -1,
+      promptTokens: 1200,
+      completion_tokens: 340,
+      cache_creation_tokens: 128,
+      cache_read_input_tokens: 512,
+      note: 'sk-secret-inside-token-usage',
+      noteCount: 12345,
+      nested: [
+        'Bearer nested-token-secret',
+        42,
+        { outputTokens: 7, completionTokens: 'not-number', otherCount: 9 },
+      ],
+    },
+    cost_usage: { total_cost_usd: 0.012345, currencyCode: 'USD' },
+    model_id: 'claude-sonnet-4-6',
+    provider_id: 'anthropic',
+  }),
+  sessionUpdate({
+    sessionUpdate: 'session_info_update',
+    cwd: 'D:\\aegis\\redacted-session',
+    model: 'claude-sonnet-4-6',
+    oauthToken: 'fixture-session-info-token',
+  }),
+  inboundRequest(
+    1001,
+    'session/request_permission',
+    {
+      sessionId: acpSessionId,
+      toolCall: {
+        toolCallId: 'tool-golden-edit',
+        title: 'Edit package metadata',
+        kind: 'edit',
+        status: 'pending',
+        rawInput: {
+          command: 'node -e "console.log(process.env.ANTHROPIC_API_KEY)"',
+          env: {
+            ANTHROPIC_API_KEY: 'fixture-approval-secret',
+            PATH: 'C:\\Windows\\System32',
+          },
+        },
+      },
+      options: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' },
+      ],
+    },
+  ),
+  successResponse('prompt-golden-1', 'session/prompt', {
+    stopReason: 'end_turn',
+    extra: 'ignored by mapper but retained in raw ACP metadata',
+  }),
+  errorResponse(
+    'new-session-golden-1',
+    'session/new',
+    {
+      code: -32000,
+      message: 'provider rejected credentials',
+      data: { ANTHROPIC_API_KEY: 'fixture-error-secret', retryable: false },
+    },
+  ),
+  sessionUpdate({
+    sessionUpdate: 'mystery_update',
+    note: 'kept raw for schema drift analysis',
+  }),
+  notification('session/unknown_notification', { sessionId: acpSessionId, ignored: true }),
+  inboundRequest('unsupported-request-golden-1', 'session/unsupported_request', {
+    sessionId: acpSessionId,
+  }),
+  successResponse('unsupported-success-golden-1', 'session/new', { sessionId: acpSessionId }),
+  sessionUpdate({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'image', url: 'https://example.invalid/image.png' },
+  }),
+  notification('session/update', { sessionId: acpSessionId }),
+  notification('session/update', { sessionId: acpSessionId, update: { note: 'missing type' } }),
+  sessionUpdate({
+    sessionUpdate: 'agent_thought_chunk',
+    content: { type: 'image', url: 'https://example.invalid/thought.png' },
+  }),
+  sessionUpdate({
+    sessionUpdate: 'tool_call',
+    title: 'Missing tool call id',
+  }),
+  sessionUpdate({
+    sessionUpdate: 'tool_call_update',
+    status: 'completed',
+  }),
+  sessionUpdate({
+    sessionUpdate: 'usage_update',
+    cost: { totalCostUsd: 0.5, currency: 'USD' },
+  }),
+  inboundRequest(1002, 'session/request_permission', { sessionId: acpSessionId }),
+];
+
+function sessionUpdate(update: AcpJsonObject): AcpGoldenEventFrame {
+  return notification('session/update', { sessionId: acpSessionId, update });
+}
+
+function notification(method: string, params: AcpJsonValue): AcpGoldenEventFrame {
+  const raw: AcpJsonObject = { jsonrpc: '2.0', method, params };
+  return {
+    kind: 'notification',
+    frame: {
+      jsonrpc: '2.0',
+      method,
+      params,
+      raw,
+    },
+  };
+}
+
+function inboundRequest(
+  id: AcpJsonRpcId,
+  method: string,
+  params: AcpJsonValue
+): AcpGoldenEventFrame {
+  const raw: AcpJsonObject = { jsonrpc: '2.0', id, method, params };
+  return {
+    kind: 'inboundRequest',
+    frame: {
+      jsonrpc: '2.0',
+      id,
+      method,
+      params,
+      raw,
+    },
+  };
+}
+
+function successResponse(
+  id: AcpJsonRpcId,
+  requestMethod: string,
+  result: AcpJsonValue
+): AcpGoldenEventFrame {
+  const raw: AcpJsonObject = { jsonrpc: '2.0', id, result };
+  return {
+    kind: 'successResponse',
+    frame: {
+      jsonrpc: '2.0',
+      id,
+      result,
+      raw,
+      request: { method: requestMethod },
+    },
+  };
+}
+
+function errorResponse(
+  id: AcpJsonRpcId,
+  requestMethod: string,
+  error: AcpJsonRpcErrorObject
+): AcpGoldenEventFrame {
+  const raw: AcpJsonObject = {
+    jsonrpc: '2.0',
+    id,
+    error: cleanErrorObject(error),
+  };
+  return {
+    kind: 'errorResponse',
+    frame: {
+      jsonrpc: '2.0',
+      id,
+      error,
+      raw,
+      request: { method: requestMethod },
+    },
+  };
+}
+
+function cleanErrorObject(error: AcpJsonRpcErrorObject): AcpJsonObject {
+  const output: AcpJsonObject = {};
+  if (error.code !== undefined) output.code = error.code;
+  if (error.message !== undefined) output.message = error.message;
+  if (error.data !== undefined) output.data = error.data;
+  return output;
+}

--- a/src/__tests__/fixtures/acp-golden-events/event-mapper.expected.json
+++ b/src/__tests__/fixtures/acp-golden-events/event-mapper.expected.json
@@ -1,0 +1,705 @@
+[
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "message.delta",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "text": "Hello from the ACP boundary.",
+      "messageId": "message-golden-1",
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "updateType": "agent_message_chunk",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {
+                "type": "text",
+                "text": "Hello from the ACP boundary."
+              },
+              "messageId": "message-golden-1"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "thinking.delta",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "text": "Need to inspect the queue contract.",
+      "messageId": "thought-golden-1",
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "updateType": "agent_thought_chunk",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "agent_thought_chunk",
+              "content": {
+                "type": "text",
+                "text": "Need to inspect the queue contract."
+              },
+              "messageId": "thought-golden-1"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "tool.started",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "toolCallId": "tool-golden-read",
+      "title": "Read package metadata",
+      "kind": "read",
+      "status": "pending",
+      "input": {
+        "path": "package.json",
+        "ANTHROPIC_API_KEY": "[REDACTED]",
+        "token_usage": "[REDACTED]",
+        "tokenUsage": "[REDACTED]",
+        "promptTokens": "[REDACTED]",
+        "nested": {
+          "authorizationHeader": "[REDACTED]",
+          "cookie": "[REDACTED]"
+        }
+      },
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "updateType": "tool_call",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "tool_call",
+              "toolCallId": "tool-golden-read",
+              "title": "Read package metadata",
+              "kind": "read",
+              "status": "pending",
+              "rawInput": {
+                "path": "package.json",
+                "ANTHROPIC_API_KEY": "[REDACTED]",
+                "token_usage": "[REDACTED]",
+                "tokenUsage": "[REDACTED]",
+                "promptTokens": "[REDACTED]",
+                "nested": {
+                  "authorizationHeader": "[REDACTED]",
+                  "cookie": "[REDACTED]"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "tool.completed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "toolCallId": "tool-golden-read",
+      "status": "completed",
+      "text": "package name: @onestepat4time/aegis",
+      "output": {
+        "ok": true,
+        "credential": "[REDACTED]"
+      },
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "updateType": "tool_call_update",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "tool_call_update",
+              "toolCallId": "tool-golden-read",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "content",
+                  "content": {
+                    "type": "text",
+                    "text": "package name: @onestepat4time/aegis"
+                  }
+                }
+              ],
+              "rawOutput": {
+                "ok": true,
+                "credential": "[REDACTED]"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "usage.updated",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "usage": {
+        "inputTokens": 1200,
+        "outputTokens": 340,
+        "cacheCreationTokens": 128,
+        "cacheReadTokens": 512
+      },
+      "cost": {
+        "amountUsd": 0.012345,
+        "currency": "USD"
+      },
+      "model": "claude-sonnet-4-6",
+      "provider": "anthropic",
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "updateType": "usage_update",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "usage_update",
+              "token_usage": {
+                "inputTokens": "[REDACTED]",
+                "promptTokens": 1200,
+                "completion_tokens": 340,
+                "cache_creation_tokens": 128,
+                "cache_read_input_tokens": 512,
+                "note": "[REDACTED]",
+                "noteCount": "[REDACTED]",
+                "nested": [
+                  "[REDACTED]",
+                  "[REDACTED]",
+                  {
+                    "outputTokens": 7,
+                    "completionTokens": "[REDACTED]",
+                    "otherCount": "[REDACTED]"
+                  }
+                ]
+              },
+              "cost_usage": {
+                "total_cost_usd": 0.012345,
+                "currencyCode": "USD"
+              },
+              "model_id": "claude-sonnet-4-6",
+              "provider_id": "anthropic"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "session.updated",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "updateType": "session_info_update",
+      "data": {
+        "cwd": "D:\\aegis\\redacted-session",
+        "model": "claude-sonnet-4-6",
+        "oauthToken": "[REDACTED]"
+      },
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "updateType": "session_info_update",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "session_info_update",
+              "cwd": "D:\\aegis\\redacted-session",
+              "model": "claude-sonnet-4-6",
+              "oauthToken": "[REDACTED]"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "approval.requested",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "requestId": 1001,
+      "toolCall": {
+        "toolCallId": "tool-golden-edit",
+        "title": "Edit package metadata",
+        "kind": "edit",
+        "status": "pending"
+      },
+      "options": [
+        {
+          "optionId": "allow-once",
+          "name": "Allow once",
+          "kind": "allow_once"
+        },
+        {
+          "optionId": "reject-once",
+          "name": "Reject",
+          "kind": "reject_once"
+        }
+      ],
+      "acp": {
+        "method": "session/request_permission",
+        "requestId": 1001,
+        "sessionId": "acp-session-golden",
+        "raw": {
+          "jsonrpc": "2.0",
+          "id": 1001,
+          "method": "session/request_permission",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "toolCall": {
+              "toolCallId": "tool-golden-edit",
+              "title": "Edit package metadata",
+              "kind": "edit",
+              "status": "pending",
+              "rawInput": {
+                "command": "node -e \"console.log(process.env.ANTHROPIC_API_KEY)\"",
+                "env": {
+                  "ANTHROPIC_API_KEY": "[REDACTED]",
+                  "PATH": "C:\\Windows\\System32"
+                }
+              }
+            },
+            "options": [
+              {
+                "optionId": "allow-once",
+                "name": "Allow once",
+                "kind": "allow_once"
+              },
+              {
+                "optionId": "reject-once",
+                "name": "Reject",
+                "kind": "reject_once"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "turn.completed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "stopReason": "end_turn",
+      "acp": {
+        "requestId": "prompt-golden-1",
+        "requestMethod": "session/prompt",
+        "raw": {
+          "jsonrpc": "2.0",
+          "id": "prompt-golden-1",
+          "result": {
+            "stopReason": "end_turn",
+            "extra": "ignored by mapper but retained in raw ACP metadata"
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "session.error",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "code": -32000,
+      "message": "provider rejected credentials",
+      "data": {
+        "ANTHROPIC_API_KEY": "[REDACTED]",
+        "retryable": false
+      },
+      "acp": {
+        "requestId": "new-session-golden-1",
+        "requestMethod": "session/new",
+        "raw": {
+          "jsonrpc": "2.0",
+          "id": "new-session-golden-1",
+          "error": {
+            "code": -32000,
+            "message": "provider rejected credentials",
+            "data": {
+              "ANTHROPIC_API_KEY": "[REDACTED]",
+              "retryable": false
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.unsupported",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "unsupported_session_update",
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "updateType": "mystery_update",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "mystery_update",
+              "note": "kept raw for schema drift analysis"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.unsupported",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "unsupported_notification",
+      "acp": {
+        "method": "session/unknown_notification",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/unknown_notification",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "ignored": true
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.unsupported",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "unsupported_inbound_request",
+      "acp": {
+        "method": "session/unsupported_request",
+        "requestId": "unsupported-request-golden-1",
+        "raw": {
+          "jsonrpc": "2.0",
+          "id": "unsupported-request-golden-1",
+          "method": "session/unsupported_request",
+          "params": {
+            "sessionId": "acp-session-golden"
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.unsupported",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "unsupported_success_response",
+      "acp": {
+        "requestId": "unsupported-success-golden-1",
+        "requestMethod": "session/new",
+        "raw": {
+          "jsonrpc": "2.0",
+          "id": "unsupported-success-golden-1",
+          "result": {
+            "sessionId": "acp-session-golden"
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "malformed_agent_message_chunk",
+      "acp": {
+        "updateType": "agent_message_chunk",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {
+                "type": "image",
+                "url": "https://example.invalid/image.png"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "malformed_session_update",
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden"
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "missing_session_update_type",
+      "acp": {
+        "method": "session/update",
+        "sessionId": "acp-session-golden",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "note": "missing type"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "malformed_agent_thought_chunk",
+      "acp": {
+        "updateType": "agent_thought_chunk",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "agent_thought_chunk",
+              "content": {
+                "type": "image",
+                "url": "https://example.invalid/thought.png"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "malformed_tool_call",
+      "acp": {
+        "updateType": "tool_call",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "tool_call",
+              "title": "Missing tool call id"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "malformed_tool_call_update",
+      "acp": {
+        "updateType": "tool_call_update",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "tool_call_update",
+              "status": "completed"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "malformed_usage_update",
+      "acp": {
+        "updateType": "usage_update",
+        "raw": {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "acp-session-golden",
+            "update": {
+              "sessionUpdate": "usage_update",
+              "cost": {
+                "totalCostUsd": 0.5,
+                "currency": "USD"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "sessionId": "aegis-session-golden",
+    "tenantId": "tenant-golden",
+    "ownerKeyId": "owner-golden",
+    "backendRunId": "backend-run-golden",
+    "eventType": "acp.malformed",
+    "occurredAt": "2026-01-02T03:04:05.000Z",
+    "payload": {
+      "schemaVersion": 1,
+      "reason": "malformed_permission_request",
+      "acp": {
+        "method": "session/request_permission",
+        "requestId": 1002,
+        "sessionId": "acp-session-golden",
+        "raw": {
+          "jsonrpc": "2.0",
+          "id": 1002,
+          "method": "session/request_permission",
+          "params": {
+            "sessionId": "acp-session-golden"
+          }
+        }
+      }
+    }
+  }
+]

--- a/src/services/acp/event-mapper.ts
+++ b/src/services/acp/event-mapper.ts
@@ -44,6 +44,9 @@ type JsonObject = Record<string, unknown>;
 
 const SENSITIVE_KEY_RE =
   /(token|secret|password|api[_-]?key|authorization|cookie|credential|session[_-]?key)/i;
+const TOKEN_USAGE_CONTAINER_KEY_RE = /^token[_-]?usage$/i;
+const TOKEN_USAGE_COUNTER_KEY_RE =
+  /^(input[_-]?tokens|prompt[_-]?tokens|output[_-]?tokens|completion[_-]?tokens|total[_-]?tokens|cache[_-]?creation[_-]?(input[_-]?)?tokens|cache[_-]?read[_-]?(input[_-]?)?tokens)$/i;
 
 export function mapAcpJsonRpcNotificationToEvent(
   notification: AcpJsonRpcNotification,
@@ -484,9 +487,20 @@ function cleanObject(values: Record<string, unknown>): Record<string, AcpEventJs
   return output;
 }
 
-function redactEventJsonValue(value: unknown, key?: string): AcpEventJsonValue {
-  if (key !== undefined && SENSITIVE_KEY_RE.test(key) && value !== undefined && value !== null) {
+function redactEventJsonValue(
+  value: unknown,
+  key?: string,
+  tokenUsageContext = false
+): AcpEventJsonValue {
+  const entersTokenUsageContext =
+    key !== undefined &&
+    TOKEN_USAGE_CONTAINER_KEY_RE.test(key) &&
+    (isPlainObject(value) || Array.isArray(value));
+  if (key !== undefined && isSensitiveEventKey(key, value) && value !== undefined) {
     return '[REDACTED]';
+  }
+  if (tokenUsageContext || entersTokenUsageContext) {
+    return redactTokenUsageJsonValue(value, key);
   }
   if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
@@ -500,6 +514,38 @@ function redactEventJsonValue(value: unknown, key?: string): AcpEventJsonValue {
     return output;
   }
   return null;
+}
+
+function redactTokenUsageJsonValue(value: unknown, key?: string): AcpEventJsonValue {
+  if (typeof value === 'number') {
+    return key !== undefined &&
+      TOKEN_USAGE_COUNTER_KEY_RE.test(key) &&
+      Number.isFinite(value) &&
+      value >= 0
+      ? value
+      : '[REDACTED]';
+  }
+  if (Array.isArray(value)) return value.map(item => redactEventJsonValue(item, undefined, true));
+  if (isPlainObject(value)) {
+    const output: Record<string, AcpEventJsonValue> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      if (childValue === undefined) continue;
+      output[childKey] = redactEventJsonValue(childValue, childKey, true);
+    }
+    return output;
+  }
+  return '[REDACTED]';
+}
+
+function isSensitiveEventKey(key: string, value: unknown): boolean {
+  if (!SENSITIVE_KEY_RE.test(key)) return false;
+  if (TOKEN_USAGE_COUNTER_KEY_RE.test(key)) {
+    return typeof value !== 'number' || !Number.isFinite(value) || value < 0;
+  }
+  if (TOKEN_USAGE_CONTAINER_KEY_RE.test(key)) {
+    return !isPlainObject(value) && !Array.isArray(value);
+  }
+  return true;
 }
 
 function readNumberFromObjects(


### PR DESCRIPTION
Closes #2602

## Summary
- Add deterministic golden ACP event contract coverage for mapper boundary frames.
- Cover supported, unsupported, malformed, error, approval, and turn-completion ACP cases.
- Tighten ACP raw metadata redaction so token usage counters remain inspectable only when they are safe numeric counters.

## Validation
- `npm test -- src\__tests__\acp-event-contracts.test.ts src\__tests__\acp-event-mapper.test.ts src\__tests__\acp-action-worker.test.ts`
- `npx tsc --noEmit`
- `npx eslint src\services\acp\event-mapper.ts src\__tests__\acp-event-contracts.test.ts src\__tests__\fixtures\acp-golden-events.ts`
- `npm run build`
- `npm test -- --reporter=dot`
- `npm run gate`

## Aegis version
**Developed with:** v0.6.6-preview.1