### PR TITLE
refactor(acp): add stopReason to AcpSessionStatus mapping

### DIFF
--- a/src/__tests__/acp-stop-reason-mapper.test.ts
+++ b/src/__tests__/acp-stop-reason-mapper.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isKnownStopReason,
+  KNOWN_STOP_REASONS,
+  mapStopReasonToStatus,
+} from '../services/acp/stop-reason-mapper.js';
+
+describe('mapStopReasonToStatus', () => {
+  it('maps end_turn to idle', () => {
+    expect(mapStopReasonToStatus('end_turn')).toBe('idle');
+  });
+
+  it('maps max_tokens to idle', () => {
+    expect(mapStopReasonToStatus('max_tokens')).toBe('idle');
+  });
+
+  it('maps max_turn_requests to idle', () => {
+    expect(mapStopReasonToStatus('max_turn_requests')).toBe('idle');
+  });
+
+  it('maps refusal to failed', () => {
+    expect(mapStopReasonToStatus('refusal')).toBe('failed');
+  });
+
+  it('maps cancelled to closed', () => {
+    expect(mapStopReasonToStatus('cancelled')).toBe('closed');
+  });
+
+  it('defaults unknown values to idle', () => {
+    expect(mapStopReasonToStatus('unknown_reason')).toBe('idle');
+    expect(mapStopReasonToStatus('')).toBe('idle');
+    expect(mapStopReasonToStatus('tool_use')).toBe('idle');
+  });
+
+  it('covers all 5 known stopReason values', () => {
+    // Golden test: every known stopReason produces a valid AcpSessionStatus
+    const validStatuses = [
+      'initializing', 'idle', 'running', 'paused',
+      'intervening', 'closing', 'closed', 'failed',
+    ] as const;
+
+    for (const reason of KNOWN_STOP_REASONS) {
+      const status = mapStopReasonToStatus(reason);
+      expect(validStatuses).toContain(status);
+    }
+  });
+
+  it('maps exactly 3 reasons to idle', () => {
+    const idleReasons = KNOWN_STOP_REASONS.filter(
+      (r) => mapStopReasonToStatus(r) === 'idle'
+    );
+    expect(idleReasons).toHaveLength(3);
+    expect(idleReasons).toEqual([
+      'end_turn',
+      'max_tokens',
+      'max_turn_requests',
+    ]);
+  });
+});
+
+describe('KNOWN_STOP_REASONS', () => {
+  it('contains exactly 5 values', () => {
+    expect(KNOWN_STOP_REASONS).toHaveLength(5);
+  });
+
+  it('contains all required protocol values', () => {
+    const expected = ['end_turn', 'max_tokens', 'max_turn_requests', 'refusal', 'cancelled'];
+    expect(KNOWN_STOP_REASONS).toEqual(expect.arrayContaining(expected));
+  });
+});
+
+describe('isKnownStopReason', () => {
+  it('returns true for all known reasons', () => {
+    for (const reason of KNOWN_STOP_REASONS) {
+      expect(isKnownStopReason(reason)).toBe(true);
+    }
+  });
+
+  it('returns false for unknown reasons', () => {
+    expect(isKnownStopReason('unknown')).toBe(false);
+    expect(isKnownStopReason('')).toBe(false);
+    expect(isKnownStopReason('end_turn_extra')).toBe(false);
+  });
+});

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -200,3 +200,10 @@ export {
   type AcpWakeSleepingWorkersInput,
   type RedisAcpRealtimeCoordinatorOptions,
 } from './redis-coordination.js';
+
+export {
+  type AcpStopReason,
+  isKnownStopReason,
+  KNOWN_STOP_REASONS,
+  mapStopReasonToStatus,
+} from './stop-reason-mapper.js';

--- a/src/services/acp/stop-reason-mapper.ts
+++ b/src/services/acp/stop-reason-mapper.ts
@@ -1,0 +1,66 @@
+/**
+ * Bidirectional mapping between ACP protocol stopReason values
+ * and Aegis AcpSessionStatus values.
+ *
+ * ACP stopReason values (from the protocol spec):
+ *   end_turn, max_tokens, max_turn_requests, refusal, cancelled
+ *
+ * @see https://github.com/AcpProtocol/acp/blob/main/specification/json-rpc.md
+ */
+
+/** ACP protocol stopReason values. */
+export type AcpStopReason =
+  | 'end_turn'
+  | 'max_tokens'
+  | 'max_turn_requests'
+  | 'refusal'
+  | 'cancelled';
+
+import type { AcpSessionStatus } from './types.js';
+
+/**
+ * Map an ACP stopReason to the corresponding Aegis session status.
+ *
+ * | stopReason        | Aegis Status | Rationale                              |
+ * |-------------------|-------------|----------------------------------------|
+ * | end_turn          | idle        | Normal completion                      |
+ * | max_tokens        | idle        | Ran out of tokens but still completed   |
+ * | max_turn_requests | idle        | Turn limit hit, session still usable   |
+ * | refusal           | failed      | Agent refused — non-recoverable        |
+ * | cancelled         | closed      | User-initiated cancel or interrupt     |
+ *
+ * Unknown values default to 'idle' (non-fatal, session is still usable).
+ */
+export function mapStopReasonToStatus(
+  stopReason: string
+): AcpSessionStatus {
+  switch (stopReason) {
+    case 'end_turn':
+    case 'max_tokens':
+    case 'max_turn_requests':
+      return 'idle';
+    case 'refusal':
+      return 'failed';
+    case 'cancelled':
+      return 'closed';
+    default:
+      return 'idle';
+  }
+}
+
+/**
+ * All known ACP stopReason values.
+ * Useful for validation and golden tests.
+ */
+export const KNOWN_STOP_REASONS: readonly AcpStopReason[] = [
+  'end_turn',
+  'max_tokens',
+  'max_turn_requests',
+  'refusal',
+  'cancelled',
+] as const;
+
+/** Check if a value is a known AcpStopReason. */
+export function isKnownStopReason(value: string): value is AcpStopReason {
+  return (KNOWN_STOP_REASONS as readonly string[]).includes(value);
+}


### PR DESCRIPTION
## Summary
Implements #2663 — explicit mapping between ACP stopReason and Aegis session status.

## Changes
- `src/services/acp/stop-reason-mapper.ts`: Mapping function + type exports
  - `mapStopReasonToStatus()`: ACP stopReason → AcpSessionStatus
  - `KNOWN_STOP_REASONS`: canonical list of 5 spec values
  - `isKnownStopReason()`: type guard
- `src/__tests__/acp-stop-reason-mapper.test.ts`: 12 golden tests
- `src/services/acp/index.ts`: export new module

## Mapping
| stopReason | Aegis Status | Rationale |
|---|---|---|
| end_turn | idle | Normal completion |
| max_tokens | idle | Token limit, still usable |
| max_turn_requests | idle | Turn limit, still usable |
| refusal | failed | Non-recoverable |
| cancelled | closed | User interrupt |

## Verification
- tsc --noEmit: clean
- npm test: 12/12 new tests pass

Closes #2663