### PR TITLE
chore(acp): remove tmux from Helm env vars and smoke Dockerfile (ACP-101 follow-up)

### DIFF
--- a/.github/workflows/helm-smoke.yml
+++ b/.github/workflows/helm-smoke.yml
@@ -91,7 +91,7 @@ jobs:
           COPY package*.json ./
           RUN npm ci --omit=dev \
             && apt-get update \
-            && apt-get install -y --no-install-recommends tmux ca-certificates \
+            && apt-get install -y --no-install-recommends ca-certificates \
             && rm -rf /var/lib/apt/lists/*
           COPY --from=build /app/dist ./dist
           COPY .helm-smoke/claude /usr/local/bin/claude

--- a/deploy/helm/aegis/templates/statefulset.yaml
+++ b/deploy/helm/aegis/templates/statefulset.yaml
@@ -75,8 +75,6 @@ spec:
               value: {{ printf "%v" .Values.aegis.port | quote }}
             - name: AEGIS_STATE_DIR
               value: {{ $mountPath | quote }}
-            - name: AEGIS_TMUX_SESSION
-              value: {{ .Values.aegis.tmuxSession | quote }}
             {{- if or .Values.auth.token .Values.auth.existingSecret }}
             - name: AEGIS_AUTH_TOKEN
               valueFrom:

--- a/deploy/helm/aegis/values.yaml
+++ b/deploy/helm/aegis/values.yaml
@@ -23,8 +23,6 @@ aegis:
   host: 0.0.0.0
   # -- HTTP port passed to `AEGIS_PORT`.
   port: 9100
-  # -- tmux session prefix passed to `AEGIS_TMUX_SESSION`.
-  tmuxSession: aegis
   # -- Stateful data directory mounted from the PVC and passed to `AEGIS_STATE_DIR`.
   stateDir: /var/lib/aegis
   # -- Override the container entrypoint. Leave empty to use the image default.


### PR DESCRIPTION
## Summary

Follow-up to #2694. Removes remaining tmux runtime references from Helm chart and CI smoke test Dockerfile.

## Context

#2718 (delete tmux runtime) merged — `server.ts` no longer imports or spawns tmux. This PR cleans up the infra that depended on tmux at runtime.

Note: #2718 already removed the CI tmux install steps, so this PR only covers the Helm/Dockerfile surfaces.

## Changes

| File | Change |
|------|--------|
| `statefulset.yaml` | Remove `AEGIS_TMUX_SESSION` env var (ACP manages sessions by PID/run ID) |
| `values.yaml` | Remove `tmuxSession` key |
| `helm-smoke.yml` | Remove `tmux` from Dockerfile apt-get install |

3 files, -5/+1 lines. Zero tmux references remain in changed files.

## Verification

- Rebased on latest develop (post #2718 merge)
- CI install steps already removed by #2718
- No src/ or test files touched