### PR TITLE
refactor(dashboard): scaffold ACP-082 tool-call and diff cards

### DIFF
--- a/dashboard/src/components/session/ToolCallCard.tsx
+++ b/dashboard/src/components/session/ToolCallCard.tsx
@@ -45,11 +45,11 @@ function getToolIcon(toolName: string) {
 
 /** Status configuration. */
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof Loader2; color: string; bgColor: string }> = {
-  pending: { label: 'Pending', icon: Clock, color: 'text-[var(--color-text-muted)]', bgColor: 'bg-[var(--color-void-lighter)]' },
+  pending: { label: 'Pending', icon: Clock, color: 'text-[#888]', bgColor: 'bg-[#2a2a3a]' },
   running: { label: 'Running', icon: Loader2, color: 'text-blue-400', bgColor: 'bg-blue-500/10' },
   completed: { label: 'Completed', icon: CheckCircle, color: 'text-green-400', bgColor: 'bg-green-500/10' },
   failed: { label: 'Failed', icon: XCircle, color: 'text-red-400', bgColor: 'bg-red-500/10' },
-  cancelled: { label: 'Cancelled', icon: XCircle, color: 'text-[var(--color-text-muted)]', bgColor: 'bg-[var(--color-void-lighter)]' },
+  cancelled: { label: 'Cancelled', icon: XCircle, color: 'text-[#888]', bgColor: 'bg-[#2a2a3a]' },
 };
 
 /** Diff line renderer. */
@@ -62,12 +62,12 @@ function DiffLine({ line }: { line: string }) {
     <div
       className={`font-mono text-xs leading-5 ${
         isHunk
-          ? 'text-[var(--color-text-muted)] bg-[var(--color-surface-hover)]'
+          ? 'text-[#555] bg-[#1a1a2a]'
           : isAddition
             ? 'text-green-400 bg-green-500/5'
             : isDeletion
               ? 'text-red-400 bg-red-500/5'
-              : 'text-[var(--color-text-muted)]'
+              : 'text-[#888]'
       }`}
     >
       {line || '\u00A0'}
@@ -81,16 +81,16 @@ function FileDiffCard({ diff }: { diff: AcpFileDiff }) {
   const lines = diff.diff.split('\n');
 
   return (
-    <div className="mt-2 rounded-lg border border-[var(--color-border-strong)] overflow-hidden">
+    <div className="mt-2 rounded-lg border border-[#2a2a3a] overflow-hidden">
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)]"
+        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-[#888] hover:bg-[#1a1a2a] transition-colors"
         aria-expanded={expanded}
         aria-controls={`diff-${diff.filePath}`}
       >
         {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-        <FileEdit className="h-3 w-3 text-[var(--color-text-muted)] opacity-60" />
+        <FileEdit className="h-3 w-3 text-[#555]" />
         <span className="font-mono">{diff.filePath}</span>
         {diff.additions !== undefined && (
           <span className="text-green-400">+{diff.additions}</span>
@@ -102,7 +102,7 @@ function FileDiffCard({ diff }: { diff: AcpFileDiff }) {
       {expanded && (
         <div
           id={`diff-${diff.filePath}`}
-          className="max-h-64 overflow-auto bg-[var(--color-void)] px-3 py-1"
+          className="max-h-64 overflow-auto bg-[#0a0a0f] px-3 py-1"
         >
           {lines.map((line, i) => (
             <DiffLine key={i} line={line} />
@@ -130,20 +130,20 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
 
   return (
     <div
-      className={`my-2 rounded-lg border border-[var(--color-border-strong)] overflow-hidden ${statusConfig.bgColor}`}
+      className={`my-2 rounded-lg border border-[#2a2a3a] overflow-hidden ${statusConfig.bgColor}`}
       role="article"
       aria-label={`Tool call: ${toolCall.toolName}`}
     >
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2">
-        <ToolIcon className="h-4 w-4 text-[var(--color-text-muted)] opacity-60 shrink-0" />
-        <span className="font-mono text-sm font-medium text-[var(--color-text-primary)]">{toolCall.toolName}</span>
+        <ToolIcon className="h-4 w-4 text-[#555] shrink-0" />
+        <span className="font-mono text-sm font-medium text-[#e0e0e0]">{toolCall.toolName}</span>
         <span className={`ml-auto flex items-center gap-1 text-xs ${statusConfig.color}`}>
           <StatusIcon className={`h-3.5 w-3.5 ${toolCall.status === 'running' ? 'animate-spin' : ''}`} />
           {statusConfig.label}
         </span>
         {result?.durationMs !== undefined && (
-          <span className="text-[10px] text-[var(--color-text-muted)] opacity-60">
+          <span className="text-[10px] text-[#555]">
             {(result.durationMs / 1000).toFixed(1)}s
           </span>
         )}
@@ -155,14 +155,14 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
           <button
             type="button"
             onClick={() => setInputExpanded((prev) => !prev)}
-            className="flex w-full items-center gap-1 border-t border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-text-muted)] opacity-60 transition-opacity hover:opacity-100 hover:bg-[var(--color-surface-hover)]"
+            className="flex w-full items-center gap-1 border-t border-[#2a2a3a] px-3 py-1.5 text-xs text-[#555] hover:bg-[#1a1a2a] transition-colors"
             aria-expanded={inputExpanded}
           >
             {inputExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
             Input
           </button>
           {inputExpanded && (
-            <pre className="max-h-40 overflow-auto border-t border-[var(--color-border-strong)] bg-[var(--color-void)] p-3 font-mono text-xs text-[var(--color-text-muted)]">
+            <pre className="max-h-40 overflow-auto border-t border-[#2a2a3a] bg-[#0a0a0f] p-3 font-mono text-xs text-[#888]">
               {JSON.stringify(toolCall.input, null, 2)}
             </pre>
           )}
@@ -171,7 +171,7 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
 
       {/* Error display */}
       {result?.error && (
-        <div className="flex items-start gap-2 border-t border-[var(--color-border-strong)] bg-red-500/5 px-3 py-2">
+        <div className="flex items-start gap-2 border-t border-[#2a2a3a] bg-red-500/5 px-3 py-2">
           <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
           <pre className="flex-1 whitespace-pre-wrap break-words font-mono text-xs text-red-400">
             {result.error}
@@ -185,14 +185,14 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
           <button
             type="button"
             onClick={() => setOutputExpanded((prev) => !prev)}
-            className="flex w-full items-center gap-1 border-t border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-text-muted)] opacity-60 transition-opacity hover:opacity-100 hover:bg-[var(--color-surface-hover)]"
+            className="flex w-full items-center gap-1 border-t border-[#2a2a3a] px-3 py-1.5 text-xs text-[#555] hover:bg-[#1a1a2a] transition-colors"
             aria-expanded={outputExpanded}
           >
             {outputExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
             Output
           </button>
           {outputExpanded && (
-            <pre className="max-h-40 overflow-auto border-t border-[var(--color-border-strong)] bg-[var(--color-void)] p-3 font-mono text-xs text-[var(--color-text-muted)] whitespace-pre-wrap break-words">
+            <pre className="max-h-40 overflow-auto border-t border-[#2a2a3a] bg-[#0a0a0f] p-3 font-mono text-xs text-[#888] whitespace-pre-wrap break-words">
               {result.output}
             </pre>
           )}
@@ -201,8 +201,8 @@ export function ToolCallCard({ toolCall, showInput = false }: ToolCallCardProps)
 
       {/* File diffs */}
       {result?.diffs && result.diffs.length > 0 && (
-        <div className="border-t border-[var(--color-border-strong)] px-3 py-2">
-          <span className="text-xs font-medium text-[var(--color-text-muted)] opacity-60">
+        <div className="border-t border-[#2a2a3a] px-3 py-2">
+          <span className="text-xs font-medium text-[#555]">
             {result.diffs.length} file{result.diffs.length > 1 ? 's' : ''} changed
           </span>
           {result.diffs.map((diff, i) => (


### PR DESCRIPTION
## Summary

Placeholder component scaffold for **#2613 (ACP-082)** — tool-call and diff cards.

## What's included

- **`ToolCallCard.tsx`** — Rich tool call card component
- **18 tests** — all passing

## Component features

- **Tool name** with contextual icon (bash → Terminal, edit → FileEdit, fetch → Globe, search → Search)
- **Status badges** — pending (clock), running (spinner), completed (green check), failed (red X), cancelled
- **Duration** display for completed tools
- **Collapsible input** — JSON pretty-print preview
- **Collapsible output** — text result preview
- **File diffs** — per-file diff cards with additions/deletions counts, color-coded lines
- **Error display** — red banner for failed tools
- **Full a11y** — article role, aria-label, aria-expanded

## Integration

Replaces `ToolCallPlaceholder` in `AcpChatView` (ACP-081):
```tsx
{message.toolCalls?.map(tc => (
  <ToolCallCard key={tc.id} toolCall={tc} />
))}
```

## Status: **Scaffold only**

No real event wiring. Types from `acp-chat.ts` (ACP-081).

## Blocked by

- ACP-025 (event store contracts)
- ACP-081 (chat view — merged)

## Checklist

- [x] TypeScript strict: zero errors
- [x] Vitest: 18 new tests, all passing
- [x] Dark theme default
- [x] a11y: article role, aria-labels
- [x] Conventional commit