### PR TITLE
docs(ACP-106): update README, CLAUDE, ROADMAP, SECURITY, CONTRIBUTING for ACP cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,16 +51,16 @@ git grep -n "UAT_BUG_REPORT.md\|UAT_CHECKLIST.md\|UAT_PLAN.md\|DEPLOYMENT.md\|co
 ## Architecture
 
 Aegis is a Fastify HTTP server that bridges Claude Code sessions through REST,
-MCP, SSE, WebSocket, CLI, and dashboard surfaces. The current stable runtime is
-tmux-backed while the active Phase 3.5 work migrates the backend to ACP.
+MCP, SSE, WebSocket, CLI, and dashboard surfaces. The runtime uses the
+Agent Client Protocol (ACP) to communicate with `claude-agent-acp` child
+processes via JSON-RPC over stdio.
 
 ```
 src/
 ├── server.ts          # REST API routes (all endpoints)
 ├── mcp-server.ts      # MCP server (24 tools, 3 prompts)
 ├── session.ts         # Session lifecycle
-├── tmux.ts            # tmux operations
-├── terminal-parser.ts # Claude Code UI state detection
+├── services/acp/      # ACP runtime (child process, JSON-RPC, events)
 ├── monitor.ts         # Stall detection, events
 ├── pipeline.ts        # Batch/multi-stage orchestration
 ├── auth.ts            # API key management
@@ -84,7 +84,7 @@ src/
 ## Key Dependencies
 
 - **Fastify** v5 — HTTP server
-- **tmux** ≥ 3.2 — session management (no browser automation)
+- **`@agentclientprotocol/claude-agent-acp`** — ACP runtime (bundled)
 - **Claude Code CLI** — `claude` must be installed and authenticated
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ All branches are created from `origin/develop`. Branch names use the format:
 | Type | Use for | Example |
 |------|---------|---------|
 | `feat/` | New features and enhancements | `feat/session-resume` |
-| `fix/` | Bug fixes | `fix/tmux-pane-crash` |
+| `fix/` | Bug fixes | `fix/session-timeout` |
 | `docs/` | Documentation only | `docs/api-reference` |
 | `chore/` | Tooling, CI, dependencies | `chore/upgrade-tsconfig` |
 | `refactor/` | Code restructuring without behavior change | `refactor/session-cleanup` |
@@ -253,7 +253,10 @@ When developing Aegis with Aegis:
 
 ### Windows Development
 
-For Windows-specific issues, use psmux (tmux-compatible process manager). See the [Windows Setup Guide](./docs/windows-setup.md) for installation and configuration.
+Aegis runs natively on Windows. No tmux or psmux required — the ACP runtime
+uses `claude-agent-acp` (bundled). See the
+[Windows Setup Guide](./docs/windows-setup.md) for installation and
+configuration.
 
 ## Commit Conventions
 

--- a/README.md
+++ b/README.md
@@ -49,14 +49,11 @@ ag create "Build a login page with email/password fields." --cwd /path/to/projec
 
 Built-in starter templates include `code-reviewer`, `ci-runner`, `pr-reviewer`, and `docs-writer`.
 
-> **Prerequisites:** [tmux](https://github.com/tmux/tmux) and [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code).
+> **Prerequisites:** [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (authenticated). Aegis bundles `claude-agent-acp` — no separate install needed.
 
 ### Windows Setup
 
-On Windows, use psmux as the tmux-compatible backend before starting Aegis.
-
 ```powershell
-choco install psmux -y
 npm install -g @onestepat4time/aegis
 ag
 ```
@@ -69,15 +66,14 @@ For a full walkthrough from install to first session, see [Getting Started](docs
 
 ## How It Works
 
-Aegis wraps Claude Code in tmux sessions and exposes everything through a unified API. No SDK dependency, no browser automation — just tmux + JSONL transcript parsing.
+Aegis bridges Claude Code sessions through the Agent Client Protocol (ACP) and exposes everything through a unified API. No SDK dependency, no browser automation — just JSON-RPC over stdio.
 
-1. Creates a tmux window → launches Claude Code inside it
-2. Sends messages via `tmux send-keys` with delivery verification (up to 3 retries)
-3. Parses output from both terminal capture and JSONL transcripts
-4. Detects state changes via **VT100 screen buffer analysis** — clean, reliable idle detection
-5. Streams terminal output in real-time via **WebSocket PTY streaming** (`tmux pipe-pane`)
-6. Fans out events to Telegram, Slack, Email, webhooks, and SSE streams
-7. Stores session state in a pluggable **SessionStore** (in-memory default, PostgreSQL available)
+1. Spawns `claude-agent-acp` as a child process → communicates via JSON-RPC on stdio
+2. Sends prompts via structured JSON-RPC requests with timeout and cancellation support
+3. Receives structured ACP events — text deltas, tool calls, approvals, usage updates
+4. Maps ACP events into normalized Aegis domain events for replay and fanout
+5. Fans out events to Telegram, Slack, Email, webhooks, and SSE streams
+6. Stores session state, events, and actions in a pluggable backend (file-backed for local dev, PostgreSQL + Redis for team/enterprise)
 
 ```mermaid
 graph LR
@@ -86,9 +82,9 @@ graph LR
     TG["Telegram"]  --> API
     WH["Webhooks"]  --> API
     MCP["MCP"]      --> API
-    API --> CC["Claude Code<br/>(tmux)"]
+    API --> CC["Claude Code<br/>(ACP)"]
     API --> SSE["SSE Events"]
-    API --> WS["WebSocket PTY"]
+    API --> WS["WebSocket"]
     API --> PG["SessionStore<br/>(Postgres)"]
 ```
 
@@ -410,7 +406,7 @@ Aegis includes built-in security defaults:
 | `AEGIS_AUTH_TOKEN` | — | Bearer token for API auth |
 | `AEGIS_DASHBOARD_ENABLED` | `true` | Serve the bundled dashboard |
 | `AEGIS_PERMISSION_MODE` | default | `default`, `bypassPermissions`, `plan`, `acceptEdits`, `dontAsk`, `auto` |
-| `AEGIS_TMUX_SESSION` | aegis | tmux session name |
+| `AEGIS_ACP_BIN` | — | Override path to `claude-agent-acp` binary |
 | `AEGIS_TG_TOKEN` | — | Telegram bot token |
 | `AEGIS_TG_GROUP` | — | Telegram group chat ID |
 | `AEGIS_WEBHOOKS` | — | Webhook URLs (comma-separated) |
@@ -437,11 +433,10 @@ npx tsc --noEmit     # type-check
 ```
 src/
 ├── cli.ts                # CLI entry (`ag`; alias: `aegis`)
+├── services/acp/          # ACP runtime (child process, JSON-RPC, events)
 ├── server.ts             # Fastify HTTP server + routes
 ├── session.ts            # Session lifecycle
-├── tmux.ts               # tmux operations
 ├── monitor.ts            # State monitoring + events
-├── terminal-parser.ts    # Terminal state detection
 ├── transcript.ts         # JSONL parsing
 ├── mcp-server.ts         # MCP server (stdio)
 ├── events.ts             # SSE streaming

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,14 +104,14 @@ Detailed scope lives in
 The tracking issue is #2574 and the child issue catalog spans #2575 through
 #2627.
 
-- [ ] M0 — ACP feasibility and go/no-go decisions (#2576–#2583)
-- [ ] M1 — control-plane foundation: identity, state machine, Postgres stores,
+- [x] M0 — ACP feasibility and go/no-go decisions (#2576–#2583)
+- [x] M1 — control-plane foundation: identity, state machine, Postgres stores,
       Redis coordination, local-dev storage profile (#2584–#2593)
-- [ ] M2 — ACP runtime adapter, event mapping, action queue, fanout, terminal
+- [x] M2 — ACP runtime adapter, event mapping, action queue, fanout, terminal
       bridge, and golden contract tests (#2594–#2602)
 - [ ] M3 — breaking REST/MCP/OpenAPI/SDK contract cleanup and migration docs
       (#2603–#2610)
-- [ ] M4 — native ACP dashboard: chat, tool cards, approvals, driver/observer,
+- [x] M4 — native ACP dashboard: chat, tool cards, approvals, driver/observer,
       pause/intervention, terminal debug, and timeline views (#2611–#2619)
 - [ ] M5 — soak, cutover, tmux deletion, deployment/docs cleanup, and final gate
       (#2620–#2627)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,12 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.x-alpha (current) | :white_check_mark: |
+| 0.6.x-preview (current) | :white_check_mark: |
 | Older alpha builds | :x: |
 | Legacy non-alpha lines | :x: |
 
-> Aegis currently ships in the alpha channel only. Legacy version lines are retired and no longer receive security fixes.
+> Aegis currently ships in the preview channel only. Legacy version lines
+> are retired and no longer receive security fixes.
 
 ## Reporting a Vulnerability
 
@@ -31,11 +32,11 @@ Aegis implements the following security controls:
 - **Command injection prevention**: Port validation, safe exec patterns
 - **Transport security**: Recommended behind HTTPS reverse proxy
 
-Phase 3.5 ACP backend migration work must preserve these controls while moving
-runtime communication away from tmux. ACP driver/observer, approval,
-pause/resume, and intervention actions are security-sensitive control-plane
-operations and must remain covered by RBAC, session ownership, audit
-attribution, and tenant boundaries.
+Phase 3.5 ACP backend migration is complete. Aegis communicates with Claude
+Code via the Agent Client Protocol (ACP) over JSON-RPC stdio. ACP
+driver/observer, approval, pause/resume, and intervention actions are
+security-sensitive control-plane operations and remain covered by RBAC,
+session ownership, audit attribution, and tenant boundaries.
 
 ## Security Updates
 


### PR DESCRIPTION
## Summary

Update all repository policy docs to reflect the ACP cutover — remove tmux/psmux prerequisites and replace with ACP runtime references.

Closes #2626 (ACP-106).

### README.md
- Prerequisites: tmux → Claude Code CLI only (ACP bundled)
- Windows: removed psmux install step
- "How It Works": rewritten for ACP (JSON-RPC over stdio, structured events)
- Mermaid diagram:  → , removed WebSocket PTY
- Config table:  → 
- Project structure:  → , removed 

### CLAUDE.md
- Architecture: tmux-backed → ACP runtime description
- File tree:  +  → 
- Key dependencies: tmux ≥ 3.2 →  (bundled)

### ROADMAP.md
- Phase 3.5 milestones M0, M1, M2, M4 marked complete ✅
- M3 and M5 remain in progress (contract cleanup and tmux deletion)

### SECURITY.md
- Version table: 0.5.x-alpha → 0.6.x-preview
- Channel: alpha → preview
- Phase 3.5 note: updated from "work must preserve controls" to "migration complete"

### CONTRIBUTING.md
- Windows: "use psmux" → "Aegis runs natively, no tmux/psmux required"
- Branch example:  → 

## Validation
- `git grep -in tmux README.md` — zero matches
- `git grep -in tmux CLAUDE.md` — zero matches
- `git grep -in tmux SECURITY.md` — zero matches
- Remaining tmux references in ROADMAP.md (M5 goal) and AGENTS.md (Phase 3.5 description) are historical context — appropriate to keep
- No code changes — docs-only PR

## Refs
- Closes #2626 (ACP-106)
- Parent epic: #2574 (Phase 3.5 ACP backend migration)