### PR TITLE
chore(release): flip prerelease to false for stable v1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "draft": false,
-      "prerelease": true,
+      "prerelease": false,
       "prereleaseType": "preview",
       "include-sha-in-tag": false,
       "tag-separator": "-",


### PR DESCRIPTION
## Summary

Flips `prerelease` to `false` in `release-please-config.json` so release-please produces `v1.0.0` instead of `v1.0.0-preview` for the ACP cutover major release.

## ⚠️ DO NOT MERGE TO DEVELOP

This change is **release-branch only**. Merging to develop would cause the next preview release to ship as a stable version prematurely.

## When to use

1. Create the `release/1.0.0` branch from develop
2. Cherry-pick or rebase this commit onto the release branch
3. Run release-please with `--release-as=1.0.0`
4. Merge the release PR → `v1.0.0` ships as stable

## Change

```diff
-      "prerelease": true,
+      "prerelease": false,
```

1 file, -1/+1 line.