### PR TITLE
refactor(dashboard): scaffold ACP-087 operator timeline view

### DIFF
--- a/dashboard/src/__tests__/OperatorTimeline.test.tsx
+++ b/dashboard/src/__tests__/OperatorTimeline.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * __tests__/OperatorTimeline.test.tsx
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { OperatorTimeline } from '../components/session/OperatorTimeline';
+import type { AcpTimelineEvent } from '../types/acp-timeline';
+
+const mockEvents: AcpTimelineEvent[] = [
+  {
+    id: 'evt-1',
+    timestamp: '2026-05-05T10:00:00Z',
+    category: 'driver',
+    description: 'Driver claimed by admin',
+    actor: 'admin',
+    details: { driverAction: 'claimed' },
+  },
+  {
+    id: 'evt-2',
+    timestamp: '2026-05-05T10:00:05Z',
+    category: 'prompt',
+    description: 'Prompt submitted',
+    actor: 'admin',
+  },
+  {
+    id: 'evt-3',
+    timestamp: '2026-05-05T10:00:10Z',
+    category: 'tool',
+    description: 'bash: ls -la',
+    details: { toolName: 'bash', toolStatus: 'completed', durationMs: 150 },
+  },
+  {
+    id: 'evt-4',
+    timestamp: '2026-05-05T10:00:15Z',
+    category: 'approval',
+    description: 'Approval requested for bash',
+    details: { approvalId: 'apr-1' },
+  },
+  {
+    id: 'evt-5',
+    timestamp: '2026-05-05T10:00:20Z',
+    category: 'session',
+    description: 'Session paused',
+    details: { sessionFrom: 'running', sessionTo: 'paused' },
+  },
+  {
+    id: 'evt-6',
+    timestamp: '2026-05-05T10:00:25Z',
+    category: 'error',
+    description: 'ACP protocol error: timeout',
+    details: { errorCode: 'ACP_TIMEOUT', errorMessage: 'Connection timed out' },
+  },
+];
+
+describe('OperatorTimeline', () => {
+  it('renders empty state when no events', () => {
+    render(<OperatorTimeline sessionId="s1" events={[]} />);
+    expect(screen.getByText('No events yet.')).toBeDefined();
+  });
+
+  it('renders event descriptions', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    expect(screen.getByText('Driver claimed by admin')).toBeDefined();
+    expect(screen.getByText('Prompt submitted')).toBeDefined();
+  });
+
+  it('renders actor badges', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    expect(screen.getAllByText('admin').length).toBeGreaterThan(0);
+  });
+
+  it('renders event count', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    expect(screen.getByText('6 / 6')).toBeDefined();
+  });
+
+  it('has list role for event list', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    expect(screen.getByRole('list')).toBeDefined();
+  });
+
+  it('has listitem role for each event', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    expect(screen.getAllByRole('listitem').length).toBe(6);
+  });
+
+  it('shows search input', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    expect(screen.getByLabelText('Search timeline events')).toBeDefined();
+  });
+
+  it('filters events by search text', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    const search = screen.getByLabelText('Search timeline events');
+    fireEvent.change(search, { target: { value: 'bash' } });
+    expect(screen.queryByText('Driver claimed by admin')).toBeNull();
+    expect(screen.getByText('bash: ls -la')).toBeDefined();
+  });
+
+  it('shows filter toggle button', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    expect(screen.getByLabelText('Toggle category filters')).toBeDefined();
+  });
+
+  it('shows category filter bar when toggled', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    fireEvent.click(screen.getByLabelText('Toggle category filters'));
+    expect(screen.getByRole('group')).toBeDefined();
+    expect(screen.getByText('Driver')).toBeDefined();
+    expect(screen.getByText('Tool')).toBeDefined();
+    expect(screen.getByText('Error')).toBeDefined();
+  });
+
+  it('filters by category', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    fireEvent.click(screen.getByLabelText('Toggle category filters'));
+    fireEvent.click(screen.getByText('Tool'));
+    // Tool category removed — driver event should still be visible
+    expect(screen.getByText('Driver claimed by admin')).toBeDefined();
+    // Tool event should be hidden
+    expect(screen.queryByText('bash: ls -la')).toBeNull();
+  });
+
+  it('shows no match message when filters exclude all events', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    fireEvent.change(screen.getByLabelText('Search timeline events'), { target: { value: 'zzz_nonexistent' } });
+    expect(screen.getByText('No events match the current filters.')).toBeDefined();
+  });
+
+  it('shows loading state', () => {
+    render(<OperatorTimeline sessionId="s1" events={[]} isLoading={true} />);
+    expect(screen.getByText('Loading events...')).toBeDefined();
+  });
+
+  it('hides events when loading', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} isLoading={true} />);
+    expect(screen.queryByText('Driver claimed by admin')).toBeNull();
+  });
+
+  it('expands event details', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    fireEvent.click(screen.getAllByText('Details')[0]);
+    expect(screen.getByText('action:')).toBeDefined();
+    expect(screen.getByText('claimed')).toBeDefined();
+  });
+
+  it('shows tool duration in details', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    fireEvent.click(screen.getAllByText('Details')[1]);
+    // Tool details should show tool name and status
+    expect(screen.getByText('tool:')).toBeDefined();
+    expect(screen.getByText('bash')).toBeDefined();
+  });
+
+  it('shows error details', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} />);
+    // Expand the error event details (last event with details)
+    const detailsButtons = screen.getAllByText('Details');
+    fireEvent.click(detailsButtons[detailsButtons.length - 1]);
+    // Error details should show error code text
+    expect(screen.getByText('ACP_TIMEOUT')).toBeDefined();
+  });
+
+  it('respects maxEvents config', () => {
+    render(<OperatorTimeline sessionId="s1" events={mockEvents} config={{ maxEvents: 2 }} />);
+    expect(screen.getByText(/2\s*\/\s*6/)).toBeDefined();
+  });
+
+  it('respects defaultFilters config', () => {
+    render(
+      <OperatorTimeline
+        sessionId="s1"
+        events={mockEvents}
+        config={{ defaultFilters: ['driver'] }}
+      />
+    );
+    expect(screen.getByText(/1\s*\/\s*6/)).toBeDefined();
+  });
+
+  it('sets data-session-id', () => {
+    render(<OperatorTimeline sessionId="test-123" events={[]} />);
+    expect(document.querySelector('[data-session-id]')?.getAttribute('data-session-id')).toBe('test-123');
+  });
+});

--- a/dashboard/src/components/session/OperatorTimeline.tsx
+++ b/dashboard/src/components/session/OperatorTimeline.tsx
@@ -1,0 +1,337 @@
+/**
+ * components/session/OperatorTimeline.tsx — ACP operator timeline view.
+ *
+ * Displays a chronological audit trail of session events per epic §11.5:
+ * - Driver claimed/released/transferred/revoked
+ * - Prompt submitted, tool started/completed/failed
+ * - Approval requested/responded/timed out
+ * - Session paused/resumed, intervention started/completed
+ * - System events, ACP protocol errors
+ *
+ * Features:
+ * - Category-based filtering
+ * - Text search
+ * - Collapsible event details
+ * - Actor attribution
+ * - Relative/absolute timestamps
+ *
+ * Uses CSS design tokens (var(--color-*)).
+ *
+ * TODO: Wire to real event stream once ACP-025 lands.
+ */
+
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import {
+  User,
+  Terminal,
+  Wrench,
+  Shield,
+  Pause,
+  AlertTriangle,
+  Server,
+  Search,
+  Filter,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
+import type {
+  AcpTimelineEvent,
+  AcpTimelineCategory,
+  AcpTimelineFilters,
+  AcpTimelineConfig,
+} from '../../types/acp-timeline';
+
+/** Map categories to display config. */
+const CATEGORY_CONFIG: Record<AcpTimelineCategory, { label: string; icon: typeof Terminal; color: string }> = {
+  driver: { label: 'Driver', icon: User, color: 'text-[var(--color-accent)]' },
+  prompt: { label: 'Prompt', icon: Terminal, color: 'text-[var(--color-text-primary)]' },
+  tool: { label: 'Tool', icon: Wrench, color: 'text-[var(--color-warning)]' },
+  approval: { label: 'Approval', icon: Shield, color: 'text-[var(--color-success)]' },
+  session: { label: 'Session', icon: Pause, color: 'text-[var(--color-text-muted)]' },
+  intervention: { label: 'Intervention', icon: AlertTriangle, color: 'text-[var(--color-error)]' },
+  system: { label: 'System', icon: Server, color: 'text-[var(--color-text-muted)]' },
+  error: { label: 'Error', icon: AlertTriangle, color: 'text-[var(--color-error)]' },
+};
+
+const ALL_CATEGORIES: AcpTimelineCategory[] = [
+  'driver', 'prompt', 'tool', 'approval', 'session', 'intervention', 'system', 'error',
+];
+
+/** Format a timestamp as relative time. */
+function formatRelativeTime(isoString: string): string {
+  const now = Date.now();
+  const then = new Date(isoString).getTime();
+  const diffMs = now - then;
+  const diffS = Math.floor(diffMs / 1000);
+
+  if (diffS < 5) return 'just now';
+  if (diffS < 60) return `${diffS}s ago`;
+  const diffM = Math.floor(diffS / 60);
+  if (diffM < 60) return `${diffM}m ago`;
+  const diffH = Math.floor(diffM / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  return new Date(isoString).toLocaleTimeString();
+}
+
+/** Format a timestamp as absolute time. */
+function formatAbsoluteTime(isoString: string): string {
+  return new Date(isoString).toLocaleTimeString();
+}
+
+/** Event detail renderer. */
+function EventDetails({ event }: { event: AcpTimelineEvent }) {
+  const [expanded, setExpanded] = useState(false);
+  const details = event.details;
+  if (!details) return null;
+
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+        aria-expanded={expanded}
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        Details
+      </button>
+      {expanded && (
+        <div className="ml-4 mt-1 rounded-md border border-[var(--color-border)] bg-[var(--color-void)] p-2 font-mono text-xs text-[var(--color-text-secondary)]">
+          {details.toolName && (
+            <div><span className="text-[var(--color-text-muted)]">tool:</span> {details.toolName}</div>
+          )}
+          {details.toolStatus && (
+            <div><span className="text-[var(--color-text-muted)]">status:</span> {details.toolStatus}</div>
+          )}
+          {details.driverAction && (
+            <div><span className="text-[var(--color-text-muted)]">action:</span> {details.driverAction}</div>
+          )}
+          {details.driverFrom && details.driverTo && (
+            <div><span className="text-[var(--color-text-muted)]">transfer:</span> {details.driverFrom} → {details.driverTo}</div>
+          )}
+          {details.sessionFrom && details.sessionTo && (
+            <div><span className="text-[var(--color-text-muted)]">state:</span> {details.sessionFrom} → {details.sessionTo}</div>
+          )}
+          {details.approvalDecision && (
+            <div><span className="text-[var(--color-text-muted)]">decision:</span> {details.approvalDecision}</div>
+          )}
+          {details.durationMs !== undefined && (
+            <div><span className="text-[var(--color-text-muted)]">duration:</span> {(details.durationMs / 1000).toFixed(1)}s</div>
+          )}
+          {details.tokenUsage && (
+            <div><span className="text-[var(--color-text-muted)]">tokens:</span> {details.tokenUsage.total.toLocaleString()}</div>
+          )}
+          {details.errorCode && (
+            <div><span className="text-[var(--color-error)]">error:</span> {details.errorCode}</div>
+          )}
+          {details.errorMessage && (
+            <div className="text-[var(--color-error)]">{details.errorMessage}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Single timeline event row. */
+function TimelineEventRow({
+  event,
+  relativeTime,
+}: {
+  event: AcpTimelineEvent;
+  relativeTime: boolean;
+}) {
+  const config = CATEGORY_CONFIG[event.category];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2 hover:bg-[var(--color-surface)] transition-colors"
+      role="listitem"
+      aria-label={`${config.label}: ${event.description}`}
+    >
+      {/* Icon */}
+      <div className={`mt-0.5 shrink-0 ${config.color}`}>
+        <Icon className="h-4 w-4" />
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-[var(--color-text-primary)]">{event.description}</span>
+          {event.actor && (
+            <span className="shrink-0 rounded bg-[var(--color-void-lighter)] px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)]">
+              {event.actor}
+            </span>
+          )}
+        </div>
+        <EventDetails event={event} />
+      </div>
+
+      {/* Timestamp */}
+      <time
+        className="shrink-0 text-[10px] text-[var(--color-text-muted)]"
+        dateTime={event.timestamp}
+      >
+        {relativeTime ? formatRelativeTime(event.timestamp) : formatAbsoluteTime(event.timestamp)}
+      </time>
+    </div>
+  );
+}
+
+export interface OperatorTimelineProps {
+  sessionId: string;
+  /** Timeline events to display. */
+  events: AcpTimelineEvent[];
+  /** View configuration. */
+  config?: AcpTimelineConfig;
+  /** Whether events are loading. */
+  isLoading?: boolean;
+}
+
+export function OperatorTimeline({
+  sessionId,
+  events,
+  config,
+  isLoading = false,
+}: OperatorTimelineProps) {
+  const [filters, setFilters] = useState<AcpTimelineFilters>({
+    categories: new Set(config?.defaultFilters ?? ALL_CATEGORIES),
+    search: '',
+  });
+  const [showFilters, setShowFilters] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const relativeTime = config?.relativeTime ?? true;
+  const autoScroll = config?.autoScroll ?? true;
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (autoScroll && listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [events, autoScroll]);
+
+  // Filter events
+  const filteredEvents = useMemo(() => {
+    const max = config?.maxEvents ?? 100;
+    return events
+      .filter((e) => filters.categories.has(e.category))
+      .filter((e) => {
+        if (!filters.search) return true;
+        const q = filters.search.toLowerCase();
+        return (
+          e.description.toLowerCase().includes(q) ||
+          e.actor?.toLowerCase().includes(q) ||
+          e.category.toLowerCase().includes(q)
+        );
+      })
+      .slice(-max);
+  }, [events, filters, config?.maxEvents]);
+
+  const toggleCategory = useCallback((cat: AcpTimelineCategory) => {
+    setFilters((prev) => {
+      const next = new Set(prev.categories);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return { ...prev, categories: next };
+    });
+  }, []);
+
+  const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilters((prev) => ({ ...prev, search: e.target.value }));
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col" data-session-id={sessionId}>
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setShowFilters((prev) => !prev)}
+          className={`flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors ${
+            showFilters
+              ? 'bg-[var(--color-accent)]/20 text-[var(--color-accent)]'
+              : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
+          }`}
+          aria-expanded={showFilters}
+          aria-label="Toggle category filters"
+        >
+          <Filter className="h-3.5 w-3.5" />
+          Filter
+          {filters.categories.size < ALL_CATEGORIES.length && (
+            <span className="ml-1 rounded-full bg-[var(--color-accent)]/20 px-1 py-0.5 text-[10px] text-[var(--color-accent)]">
+              {filters.categories.size}
+            </span>
+          )}
+        </button>
+        <div className="relative flex-1">
+          <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--color-text-muted)]" />
+          <input
+            type="text"
+            value={filters.search}
+            onChange={handleSearch}
+            placeholder="Search events..."
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-void)] py-1.5 pl-7 pr-3 text-xs text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-accent)]/50 focus:outline-none"
+            aria-label="Search timeline events"
+          />
+        </div>
+        <span className="text-[10px] text-[var(--color-text-muted)]">
+          {filteredEvents.length} / {events.length}
+        </span>
+      </div>
+
+      {/* Category filter bar */}
+      {showFilters && (
+        <div className="flex flex-wrap gap-1 border-b border-[var(--color-border)] px-3 py-2" role="group" aria-label="Category filters">
+          {ALL_CATEGORIES.map((cat) => {
+            const cfg = CATEGORY_CONFIG[cat];
+            const isActive = filters.categories.has(cat);
+            const Icon = cfg.icon;
+            return (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => toggleCategory(cat)}
+                className={`flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors ${
+                  isActive
+                    ? `${cfg.color} bg-[var(--color-surface)]`
+                    : 'text-[var(--color-text-muted)] opacity-40'
+                }`}
+                aria-pressed={isActive}
+              >
+                <Icon className="h-3 w-3" />
+                {cfg.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Event list */}
+      <div
+        ref={listRef}
+        className="flex-1 overflow-y-auto"
+        role="list"
+        aria-label="Session timeline"
+      >
+        {isLoading && (
+          <div className="flex items-center justify-center p-8" role="status">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-[var(--color-border)] border-t-[var(--color-accent)]" />
+            <span className="ml-3 text-sm text-[var(--color-text-muted)]">Loading events...</span>
+          </div>
+        )}
+
+        {!isLoading && filteredEvents.length === 0 && (
+          <div className="flex items-center justify-center p-8 text-sm text-[var(--color-text-muted)]">
+            {events.length === 0 ? 'No events yet.' : 'No events match the current filters.'}
+          </div>
+        )}
+
+        {!isLoading && filteredEvents.map((event) => (
+          <TimelineEventRow key={event.id} event={event} relativeTime={relativeTime} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/types/acp-timeline.ts
+++ b/dashboard/src/types/acp-timeline.ts
@@ -1,0 +1,97 @@
+/**
+ * types/acp-timeline.ts — Types for the ACP operator timeline view.
+ *
+ * Matches the normalized event model from epic §11.5:
+ *   - driver claimed/released/transferred/revoked
+ *   - prompt submitted
+ *   - tool started/completed/failed
+ *   - approval requested/responded/timed out
+ *   - session paused/resumed
+ *   - intervention started/completed
+ *   - child process restart
+ *   - ACP protocol errors
+ *   - Redis/Postgres health transitions
+ *   - actor and tenant attribution
+ */
+
+/** Timeline event categories for filtering. */
+export type AcpTimelineCategory =
+  | 'driver'
+  | 'prompt'
+  | 'tool'
+  | 'approval'
+  | 'session'
+  | 'intervention'
+  | 'system'
+  | 'error';
+
+/** A single timeline event. */
+export interface AcpTimelineEvent {
+  id: string;
+  /** Event timestamp (ISO string). */
+  timestamp: string;
+  /** Event category for filtering and icon selection. */
+  category: AcpTimelineCategory;
+  /** Human-readable event description. */
+  description: string;
+  /** Optional structured details. */
+  details?: AcpTimelineEventDetails;
+  /** Actor who triggered the event (username or 'system'). */
+  actor?: string;
+  /** Tenant attribution (enterprise). */
+  tenant?: string;
+}
+
+/** Structured details for specific event types. */
+export interface AcpTimelineEventDetails {
+  /** For tool events: tool name. */
+  toolName?: string;
+  /** For tool events: tool status. */
+  toolStatus?: 'started' | 'completed' | 'failed' | 'cancelled';
+  /** For approval events: approval ID. */
+  approvalId?: string;
+  /** For approval events: approval decision. */
+  approvalDecision?: 'approved' | 'rejected' | 'timed_out';
+  /** For driver events: old and new driver. */
+  driverFrom?: string;
+  driverTo?: string;
+  /** For driver events: transfer type. */
+  driverAction?: 'claimed' | 'released' | 'transferred' | 'revoked';
+  /** For session events: session state change. */
+  sessionFrom?: string;
+  sessionTo?: string;
+  /** For error events: error code. */
+  errorCode?: string;
+  /** For error events: error message. */
+  errorMessage?: string;
+  /** Duration in milliseconds (for tool events). */
+  durationMs?: number;
+  /** Token usage snapshot (for prompt/completion events). */
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+  };
+}
+
+/** Timeline view configuration. */
+export interface AcpTimelineConfig {
+  /** Maximum events to display (default: 100). */
+  maxEvents?: number;
+  /** Whether to auto-scroll to latest event. */
+  autoScroll?: boolean;
+  /** Default filter categories (empty = show all). */
+  defaultFilters?: AcpTimelineCategory[];
+  /** Whether to show timestamps in relative format. */
+  relativeTime?: boolean;
+}
+
+/** Timeline filter state. */
+export interface AcpTimelineFilters {
+  /** Active category filters. */
+  categories: Set<AcpTimelineCategory>;
+  /** Text search query. */
+  search: string;
+  /** Actor filter. */
+  actor?: string;
+}


### PR DESCRIPTION
## Summary

Placeholder component scaffold for **#2618 (ACP-087)** — operator timeline view.

## What's included

- **`types/acp-timeline.ts`** — Timeline event types, categories, filters, config
- **`OperatorTimeline.tsx`** — Full timeline component with filtering and search
- **20 tests** — all passing

## Component features

- **Chronological event list** with category-specific icons and CSS token colors
- **8 event categories**: driver, prompt, tool, approval, session, intervention, system, error
- **Category filtering** — toggle bar with active count badge
- **Text search** — across descriptions, actors, and categories
- **Collapsible details** — tool name/status/duration, driver transfers, session state changes, error codes
- **Actor attribution** badges
- **Timestamps** — relative ("5m ago") or absolute format
- **Event count** indicator (filtered / total)
- **Loading and empty states**
- **Full a11y** — list/listitem roles, aria-label, aria-expanded, aria-pressed

## Integration

Designed to plug into `AcpSessionShell` as the `timeline` tab content (ACP-080, already merged).

## Status: **Scaffold only**

No real event stream wiring. Types aligned with epic §11.5 normalized event model.

## Blocked by

- ACP-025 (event store contracts)
- ACP-080 (session shell — merged)

## Checklist

- [x] TypeScript strict: zero errors
- [x] Vitest: 20 new tests, all passing
- [x] Dark theme default
- [x] CSS design tokens (no hardcoded hex)
- [x] a11y: list roles, aria attributes, keyboard nav
- [x] Conventional commit