### PR TITLE
docs: add CHANGELOG for dashboard PRs and update doctor/Helm/Windows/Getting Started for ACP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ These changes are part of the Phase 3.5 ACP backend migration ([#2574](https://g
 - Scaffold ACP-080 session shell and control rail dashboard UI ([#2702](https://github.com/OneStepAt4time/aegis/pull/2702))
 - Scaffold ACP-081 chat view with text, thinking, and token usage dashboard UI ([#2704](https://github.com/OneStepAt4time/aegis/pull/2704))
 - Scaffold ACP-082 tool-call and diff cards dashboard UI ([#2705](https://github.com/OneStepAt4time/aegis/pull/2705))
+- Add ACP control action types, unified API client, and wiring layer for pause/resume/intervention UI — session control state machine, action availability derivation, and control action client ([#2713](https://github.com/OneStepAt4time/aegis/pull/2713))
+- Scaffold ACP-082 tool-call and diff cards dashboard UI (v2) with CSS design tokens ([#2714](https://github.com/OneStepAt4time/aegis/pull/2714))
+- Scaffold ACP-087 operator timeline view — timeline event types, categories, filters, and search with 20 tests ([#2717](https://github.com/OneStepAt4time/aegis/pull/2717))
+- Scaffold ACP-086 terminal debug tab — terminal config, theme, size, mode types with 21 tests ([#2719](https://github.com/OneStepAt4time/aegis/pull/2719))
+- Restore dashboard token gate — replace hardcoded hex Tailwind values with design-token CSS variables in ACP approval and driver controls ([#2707](https://github.com/OneStepAt4time/aegis/pull/2707))
+- Update README, CLAUDE, ROADMAP, SECURITY, and CONTRIBUTING for ACP cutover — remove tmux/psmux prerequisites, rewrite How It Works, update project structure, mark Phase 3.5 milestones M0/M1/M2/M4 complete ([#2715](https://github.com/OneStepAt4time/aegis/pull/2715))
 
 ## [0.6.6-preview.1](https://github.com/OneStepAt4time/aegis/compare/v0.6.5-preview.3...v0.6.6-preview.1) (2026-05-03)
 

--- a/charts/aegis/Chart.yaml
+++ b/charts/aegis/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - aegis
   - claude-code
   - mcp
-  - tmux
+  - acp
   - ai
 maintainers:
   - name: OneStepAt4time

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -300,8 +300,8 @@ storage:
 | `GET /v1/...` | SERVER | Auto-instrumented Fastify HTTP routes |
 | `session.create` | INTERNAL | Session creation lifecycle |
 | `session.kill` | INTERNAL | Session termination |
-| `tmux.create_window` | INTERNAL | tmux window creation |
-| `tmux.kill_window` | INTERNAL | tmux window destruction |
+| `acp.child_process.spawn` | INTERNAL | ACP child process lifecycle |
+| `acp.json_rpc.request` | INTERNAL | JSON-RPC communication with ACP child |
 | `channel.<name>.<event>` | INTERNAL | Notification channel delivery |
 
 ### Log–trace correlation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,9 +8,8 @@ Get from zero to orchestrating Claude Code sessions in under 5 minutes.
 |---|---|---|
 | Node.js | ≥ 20 | `node --version` |
 | Claude Code CLI | Latest | `claude --version` |
-| tmux | ≥ 3.2 | `tmux -V` |
 
-> **Windows users:** Install [psmux](https://github.com/nicknisi/psmux) instead of tmux. See [Windows Setup](./windows-setup.md) for details.
+Aegis bundles `claude-agent-acp` — no tmux installation required.
 
 ## 1. Bootstrap and Start Aegis
 
@@ -46,7 +45,7 @@ npx --package=@onestepat4time/aegis ag
 docker run -it --rm \
   -v $(pwd):/workspace \
   -p 9100:9100 \
-  node:20-slim bash -c "apt-get update && apt-get install -y tmux > /dev/null 2>&1 && npm install -g @anthropic-ai/claude-code @onestepat4time/aegis && ag"
+  node:20-slim bash -c "npm install -g @anthropic-ai/claude-code @onestepat4time/aegis && ag"
 ```
 
 > Docker requires Claude Code CLI to be installed and authenticated inside the container.
@@ -187,7 +186,7 @@ You can also set `permissionMode` when creating a session to control approval be
 
 ## 9. Run Multiple Sessions in Parallel
 
-Aegis is designed for parallel orchestration. Each session runs in its own tmux window:
+Aegis is designed for parallel orchestration. Each session runs as an independent ACP child process:
 
 ```bash
 # Backend fix
@@ -330,7 +329,7 @@ See the [Worktree Guide](./worktree-guide.md) for detailed setup instructions.
 
 | Problem | Solution |
 |---|---|
-| `tmux: command not found` | Install tmux: `sudo apt install tmux` (Ubuntu) or `brew install tmux` (macOS) |
+| `claude: command not found` | Install Claude Code: `npm install -g @anthropic-ai/claude-code` and run `claude` to authenticate |
 | `Claude Code CLI not found` | Install Claude Code: `npm install -g @anthropic-ai/claude-code` and run `claude` to authenticate |
 | `401 Unauthorized` | Set `AEGIS_AUTH_TOKEN` or include `Authorization: Bearer <token>` header |
 | Session stuck on `stalled` | Send an interrupt: `curl -X POST http://localhost:9100/v1/sessions/:id/interrupt` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,22 +26,24 @@ AEGIS_PORT=9200 ag
 
 ---
 
-### Server starts but tmux reports unhealthy
+### Server starts but ACP backend reports unhealthy
 
 ```json
-{ "status": "ok", "tmux": { "healthy": false, "error": "no tmux" } }
+{ "status": "ok", "backend": "acp", "acp": { "status": "error" } }
 ```
 
-**Cause:** tmux is not installed or not in PATH.
+**Cause:** `claude-agent-acp` binary not found. Aegis bundles this dependency but it may be missing if installed from an incomplete build.
 
 **Fix:**
 ```bash
-# Install tmux
-sudo apt install tmux  # Ubuntu/Debian
-brew install tmux       # macOS
+# Reinstall Aegis to restore bundled claude-agent-acp
+npm install -g @onestepat4time/aegis
 
-# Verify tmux is available
-tmux -V
+# Or set an explicit binary path
+export AEGIS_ACP_BIN=/path/to/claude-agent-acp
+
+# Verify Aegis can resolve the binary
+ag doctor
 ```
 
 ---
@@ -284,7 +286,7 @@ ag doctor --json
 `ag doctor` checks:
 - config loading
 - Node.js version
-- tmux / psmux version (`>= 3.2`)
+- ACP binary resolution (`claude-agent-acp`)
 - Claude CLI installation
 - Claude CLI authentication (`claude auth status`)
 - write access to the configured state directory
@@ -358,9 +360,9 @@ AEGIS_MAX_SESSIONS=10 ag
 
 ### Docker container exits immediately
 
-**Cause:** tmux not available inside container.
+**Cause:** Claude Code CLI not installed or not authenticated inside the container.
 
-**Fix:** Run container with tmux installed, or use host networking:
+**Fix:** Ensure Claude Code is available in the container image:
 ```bash
 docker run --network=host \
   -v /var/run/docker.sock:/var/run/docker.sock \

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -1,35 +1,17 @@
 # Windows Setup
 
-This guide covers running Aegis natively on Windows for local development and CI-like verification.
+This guide covers running Aegis natively on Windows for local development and
+CI-like verification.
 
 ## Prerequisites
 
 - Node.js 20+ (Node.js 22 recommended)
 - npm 10+
 - Claude Code CLI installed and authenticated
-- psmux installed (tmux-compatible process manager for Windows)
 
-## Install Options
+Aegis bundles `claude-agent-acp` — no tmux or psmux required on any platform.
 
-Choose one package manager for psmux:
-
-### Option A: Chocolatey
-
-```powershell
-choco install psmux -y
-```
-
-### Option B: winget
-
-```powershell
-winget install psmux
-```
-
-### Option C: Scoop
-
-```powershell
-scoop install psmux
-```
+## Install
 
 Install Aegis dependencies:
 
@@ -70,14 +52,12 @@ Expected health payload includes platform:
 
 ## Troubleshooting
 
-- If Aegis exits at startup with tmux not found, verify psmux is installed and available in PATH.
 - If health checks time out, ensure port 9100 is not blocked by local firewall software.
-- If Claude sessions fail to launch, run claude --version and confirm CLI auth status.
+- If Claude sessions fail to launch, run `claude --version` and confirm CLI auth status.
 - If npm install or build fails due to antivirus locks, retry after excluding the repo temp/build folders.
 
-## Known Limitations and psmux Caveats
+## Notes
 
-- psmux is tmux-compatible but not a byte-for-byte replacement; subtle behavior differences can surface in pane timing and process metadata.
 - Path handling differs on Windows (drive letters, backslashes); prefer normalized paths in tests and scripts.
 - Some shell snippets written for POSIX tools (grep, awk, find) are not portable; use PowerShell alternatives in Windows-specific scripts/workflows.
-- CI and local verification should always include a real /v1/health smoke check to catch platform drift early.
+- CI and local verification should always include a real `/v1/health` smoke check to catch platform drift early.


### PR DESCRIPTION
## Summary

Two changes in one PR:

### 1. CHANGELOG entries for dashboard PRs

Add missing CHANGELOG entries for recently merged dashboard scaffolds:
- #2713: ACP control action types, client, and wiring layer
- #2714: ACP-082 tool-call and diff cards v2 (CSS design tokens)
- #2717: ACP-087 operator timeline view
- #2719: ACP-086 terminal debug tab
- #2707: Restore dashboard token gate
- #2715: ACP-106 README/CLAUDE/ROADMAP/SECURITY/CONTRIBUTING update

### 2. ACP-025: Update doctor/Helm/Windows/Getting Started for ACP

Remove tmux/psmux references from operator-facing docs:
- **windows-setup.md**: Remove psmux install steps (Chocolatey/winget/Scoop), remove psmux caveats section, add ACP note
- **getting-started.md**: Remove tmux from prerequisites table, remove psmux Windows note, update Docker command (no tmux install), update parallel sessions description, update troubleshooting
- **troubleshooting.md**: tmux health check → ACP backend health, doctor check tmux → ACP binary resolution, Docker tmux issue → Claude Code CLI issue
- **deployment.md**: tmux audit spans → ACP child process spans
- **charts/aegis/Chart.yaml**: keyword tmux → acp

## Refs
- Partial #2625 (ACP-025: update doctor/Helm/Windows for ACP)
- Partial #2626 (ACP-106: docs overhaul)

## Validation
- All tmux/psmux prerequisite references removed from windows-setup.md, getting-started.md, troubleshooting.md, deployment.md
- Remaining tmux mentions explicitly say "no tmux required"
- No code changes — docs-only PR