### PR TITLE
refactor: remove tmux fields from shared contracts

### DIFF
--- a/dashboard/e2e/helpers/dashboard-fixtures.ts
+++ b/dashboard/e2e/helpers/dashboard-fixtures.ts
@@ -22,8 +22,7 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
     overrides: Record<string, unknown> = {},
   ) => ({
     id,
-    windowId: `@${id}`,
-    windowName: id === MOBILE_SESSION_ID
+    name: id === MOBILE_SESSION_ID
       ? 'Mobile dashboard pass'
       : id === QUESTION_SESSION_ID
         ? 'Answer product question'
@@ -81,9 +80,7 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
   const sessionHealthById = {
     [MOBILE_SESSION_ID]: {
       alive: true,
-      windowExists: true,
       claudeRunning: true,
-      paneCommand: 'claude',
       status: 'permission_prompt',
       hasTranscript: true,
       lastActivity: now - 45_000,
@@ -97,9 +94,7 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
     },
     [QUESTION_SESSION_ID]: {
       alive: true,
-      windowExists: true,
       claudeRunning: true,
-      paneCommand: 'claude',
       status: 'ask_question',
       hasTranscript: true,
       lastActivity: now - 2 * 60 * 1000,
@@ -109,9 +104,7 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
     },
     'sess-idle': {
       alive: true,
-      windowExists: true,
       claudeRunning: true,
-      paneCommand: 'claude',
       status: 'idle',
       hasTranscript: true,
       lastActivity: now - 9 * 60 * 1000,
@@ -121,9 +114,7 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
     },
     [SESSION_COCKPIT_ID]: {
       alive: true,
-      windowExists: true,
       claudeRunning: true,
-      paneCommand: 'claude',
       status: 'idle',
       hasTranscript: true,
       lastActivity: now - 30_000,
@@ -289,7 +280,7 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
       platform: 'win32',
       uptime: 7200,
       sessions: { active: sessions.length, total: 12 },
-      tmux: { healthy: true, error: null },
+      backend: { driver: 'acp', healthy: true, error: null },
       claude: { available: true, healthy: true, version: '1.0.0', minimumVersion: '1.0.0', error: null },
       timestamp: new Date(now).toISOString(),
     }),

--- a/dashboard/e2e/session-cockpit.spec.ts
+++ b/dashboard/e2e/session-cockpit.spec.ts
@@ -34,13 +34,16 @@ async function mockSessionCockpit(page: import('@playwright/test').Page): Promis
     const SESSION_ID = 'sess-cockpit';
     const now = Date.now();
     const sessionDetail = {
-      id: SESSION_ID, windowId: `@${SESSION_ID}`, windowName: 'Cockpit regression',
+      id: SESSION_ID, name: 'Cockpit regression',
       workDir: 'D:\\src\\aegis', byteOffset: 0, monitorOffset: 0,
       status: 'idle', createdAt: now - 120_000, lastActivity: now - 30_000,
       stallThresholdMs: 300_000, permissionMode: 'bypassPermissions',
       ownerKeyId: `${SESSION_ID}-owner`,
     };
-    const sessionHealth = { sessionId: SESSION_ID, alive: true, status: 'idle', lastActivity: now - 30_000, details: null, windowExists: true, claudeRunning: true, paneCommand: 'claude' };
+    const sessionHealth = {
+      sessionId: SESSION_ID, alive: true, status: 'idle', lastActivity: now - 30_000, details: null, claudeRunning: true,
+      hasTranscript: true, lastActivityAgo: 30_000, sessionAge: 120_000,
+    };
     const sessionMessages = { messages: [
       { role: 'user', contentType: 'text', text: 'Review the README.', timestamp: new Date(now - 60_000).toISOString() },
       { role: 'assistant', contentType: 'text', text: 'Here is the review…', timestamp: new Date(now - 50_000).toISOString() },
@@ -80,9 +83,13 @@ async function mockSessionCockpit(page: import('@playwright/test').Page): Promis
       body: JSON.stringify({
         sessionId: SESSION_ID,
         alive: true,
+        claudeRunning: true,
         status: 'idle',
+        hasTranscript: true,
         lastActivity: Date.now() - 30_000,
-        details: null,
+        lastActivityAgo: 30_000,
+        sessionAge: 120_000,
+        details: 'Claude is idle, awaiting input.',
       }),
     }),
   );

--- a/dashboard/src/__tests__/AccessibilityIssue309.test.tsx
+++ b/dashboard/src/__tests__/AccessibilityIssue309.test.tsx
@@ -33,8 +33,7 @@ vi.mock('../hooks/useSessionPolling', () => ({
   useSessionPolling: () => ({
     session: {
       id: 'session-1',
-      windowId: 'window-1',
-      windowName: 'Alpha',
+      name: 'Alpha',
       workDir: '/tmp/alpha',
       byteOffset: 0,
       monitorOffset: 0,
@@ -46,9 +45,7 @@ vi.mock('../hooks/useSessionPolling', () => ({
     } satisfies SessionInfo,
     health: {
       alive: true,
-      windowExists: true,
       claudeRunning: true,
-      paneCommand: 'claude',
       status: 'idle',
       hasTranscript: true,
       lastActivity: Date.now(),
@@ -81,8 +78,7 @@ vi.mock('../components/session/ApprovalBanner', () => ({
 
 const baseSession: SessionInfo = {
   id: 'session-1',
-  windowId: 'window-1',
-  windowName: 'Alpha',
+  name: 'Alpha',
   workDir: '/tmp/alpha',
   byteOffset: 0,
   monitorOffset: 0,

--- a/dashboard/src/__tests__/HomeStatusPanel.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/HomeStatusPanel.mobile-responsive.test.tsx
@@ -23,7 +23,7 @@ function makeHealth(overrides: Partial<Record<string, unknown>> = {}) {
     platform: 'win32',
     uptime: 120,
     sessions: { active: 1, total: 3 },
-    tmux: { healthy: true, error: null },
+    backend: { driver: 'acp', healthy: true, error: null },
     claude: { available: true, healthy: true, version: '2.1.90', minimumVersion: '2.1.80', error: null },
     timestamp: new Date().toISOString(),
     ...overrides,
@@ -48,7 +48,7 @@ describe('HomeStatusPanel mobile responsive', () => {
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    const card = screen.getByRole('article', { name: 'Backend status: Ready' });
     const iconCircle = card.querySelector('div.rounded-full');
 
     expect(iconCircle).not.toBeNull();
@@ -63,7 +63,7 @@ describe('HomeStatusPanel mobile responsive', () => {
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    const card = screen.getByRole('article', { name: 'Backend status: Ready' });
     // The "Ready" value element
     const valueEl = card.querySelector('.font-mono.font-bold');
     expect(valueEl).not.toBeNull();
@@ -76,7 +76,7 @@ describe('HomeStatusPanel mobile responsive', () => {
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    const card = screen.getByRole('article', { name: 'Backend status: Ready' });
     // The row containing icon + label + value
     const row = card.querySelector('.flex.items-center');
     expect(row).not.toBeNull();
@@ -86,14 +86,14 @@ describe('HomeStatusPanel mobile responsive', () => {
 
   it('degraded status card shows action button with responsive margin', async () => {
     mockGetHealth.mockResolvedValue(makeHealth({
-      tmux: { healthy: false, error: 'tmux not running' },
+      backend: { driver: 'acp', healthy: false, error: 'backend not running' },
     }));
 
     render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Degraded' });
+    const card = screen.getByRole('article', { name: 'Backend status: Degraded' });
     const actionBtn = card.querySelector('button');
     expect(actionBtn).not.toBeNull();
     expect(actionBtn!.classList.contains('ml-11')).toBe(true);

--- a/dashboard/src/__tests__/HomeStatusPanel.test.tsx
+++ b/dashboard/src/__tests__/HomeStatusPanel.test.tsx
@@ -21,7 +21,8 @@ function makeHealth(overrides: Partial<Record<string, unknown>> = {}) {
       active: 0,
       total: 0,
     },
-    tmux: {
+    backend: {
+      driver: 'acp',
       healthy: true,
       error: null,
     },
@@ -54,14 +55,14 @@ describe('HomeStatusPanel', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders tmux, Claude CLI, and active session cards', async () => {
+  it('renders backend, Claude CLI, and active session cards', async () => {
     render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
 
     await act(async () => {
       await vi.runAllTicks();
     });
 
-    expect(screen.getByRole('article', { name: 'Tmux status: Ready' })).toBeDefined();
+    expect(screen.getByRole('article', { name: 'Backend status: Ready' })).toBeDefined();
     expect(screen.getByRole('article', { name: 'Claude CLI: Ready' })).toBeDefined();
     expect(screen.getByRole('article', { name: 'Active sessions: 0' })).toBeDefined();
     expect(screen.getByText('Claude CLI 2.1.90 is available.')).toBeDefined();

--- a/dashboard/src/__tests__/ScreenshotCapture319.test.tsx
+++ b/dashboard/src/__tests__/ScreenshotCapture319.test.tsx
@@ -30,8 +30,7 @@ vi.mock('../store/useToastStore', () => ({
 
 const session: SessionInfo = {
   id: 'session-1',
-  windowId: 'window-1',
-  windowName: 'Alpha',
+  name: 'Alpha',
   workDir: '/tmp/alpha',
   byteOffset: 0,
   monitorOffset: 0,
@@ -44,9 +43,7 @@ const session: SessionInfo = {
 
 const health: SessionHealth = {
   alive: true,
-  windowExists: true,
   claudeRunning: true,
-  paneCommand: 'claude',
   status: 'idle',
   hasTranscript: true,
   lastActivity: Date.now(),

--- a/dashboard/src/__tests__/SessionDetailPage.test.tsx
+++ b/dashboard/src/__tests__/SessionDetailPage.test.tsx
@@ -83,8 +83,7 @@ describe('SessionDetailPage quick actions', () => {
       notFound: false,
       session: {
         id: 'session-1',
-        windowId: '@1',
-        windowName: 'Session One',
+        name: 'Session One',
         workDir: '/repo/project',
         status: 'idle',
         createdAt: Date.now(),
@@ -96,9 +95,7 @@ describe('SessionDetailPage quick actions', () => {
       },
       health: {
         alive: true,
-        windowExists: true,
         claudeRunning: true,
-        paneCommand: 'claude',
         status: 'idle',
         hasTranscript: true,
         lastActivity: Date.now(),

--- a/dashboard/src/__tests__/SessionSummaryCard.test.tsx
+++ b/dashboard/src/__tests__/SessionSummaryCard.test.tsx
@@ -5,7 +5,7 @@ import type { SessionSummary } from '../types';
 
 const BASE_SUMMARY: SessionSummary = {
   sessionId: 'sess-1',
-  windowName: 'Test Session',
+  name: 'Test Session',
   status: 'idle',
   totalMessages: 5,
   messages: [

--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -53,8 +53,7 @@ const counts: SessionStatusCounts = {
 const sessions: SessionInfo[] = [
   {
     id: 's1',
-    windowId: 'w1',
-    windowName: 'alpha',
+    name: 'alpha',
     workDir: '/tmp/alpha',
     status: 'idle',
     createdAt: 1,
@@ -67,8 +66,7 @@ const sessions: SessionInfo[] = [
   },
   {
     id: 's2',
-    windowId: 'w2',
-    windowName: 'bravo',
+    name: 'bravo',
     workDir: '/srv/bravo',
     status: 'working',
     createdAt: 3,
@@ -80,8 +78,7 @@ const sessions: SessionInfo[] = [
   },
   {
     id: 's3',
-    windowId: 'w3',
-    windowName: 'charlie',
+    name: 'charlie',
     workDir: '/opt/project-charlie',
     status: 'permission_prompt',
     createdAt: 5,

--- a/dashboard/src/__tests__/schemas.test.ts
+++ b/dashboard/src/__tests__/schemas.test.ts
@@ -78,8 +78,7 @@ describe('SessionMessagesSchema', () => {
 describe('SessionInfoSchema', () => {
   const validPayload = {
     id: 'sess-1',
-    windowId: '@1',
-    windowName: 'Mobile dashboard pass',
+    name: 'Mobile dashboard pass',
     workDir: 'D:\\src\\aegis\\dashboard',
     byteOffset: 0,
     monitorOffset: 0,

--- a/dashboard/src/__tests__/store.test.ts
+++ b/dashboard/src/__tests__/store.test.ts
@@ -4,8 +4,7 @@ import type { SessionInfo, RowHealth, GlobalMetrics, GlobalSSEEvent } from '../t
 
 const mockSession: SessionInfo = {
   id: 's1',
-  windowId: 'w1',
-  windowName: 'test',
+  name: 'test',
   workDir: '/tmp',
   status: 'idle',
   createdAt: Date.now(),

--- a/dashboard/src/__tests__/useSessionPolling.test.ts
+++ b/dashboard/src/__tests__/useSessionPolling.test.ts
@@ -49,8 +49,7 @@ describe('useSessionPolling', () => {
 
     mockedGetSession.mockResolvedValue({
       id: 'session-a',
-      windowId: 'w1',
-      windowName: 'test',
+      name: 'test',
       workDir: '/tmp',
       status: 'idle',
       createdAt: Date.now(),
@@ -62,9 +61,7 @@ describe('useSessionPolling', () => {
     } as any);
     mockedGetSessionHealth.mockResolvedValue({
       alive: true,
-      windowExists: true,
       claudeRunning: true,
-      paneCommand: null,
       status: 'idle',
       hasTranscript: false,
       lastActivity: Date.now(),
@@ -72,7 +69,7 @@ describe('useSessionPolling', () => {
       sessionAge: 0,
       details: '',
     });
-    mockedGetSessionPane.mockResolvedValue({ pane: 'content' });
+    mockedGetSessionPane.mockResolvedValue({ content: 'content' });
     mockedGetSessionMetrics.mockResolvedValue({
       durationSec: 0,
       messages: 0,
@@ -141,8 +138,7 @@ describe('useSessionPolling', () => {
     // Change sessionId BEFORE debounce fires (debounce is 1000ms)
     mockedGetSession.mockResolvedValue({
       id: 'session-b',
-      windowId: 'w2',
-      windowName: 'test-b',
+      name: 'test-b',
       workDir: '/tmp',
       status: 'idle',
       createdAt: Date.now(),

--- a/dashboard/src/__tests__/useSessionRealtimeUpdates.test.ts
+++ b/dashboard/src/__tests__/useSessionRealtimeUpdates.test.ts
@@ -25,8 +25,7 @@ function makeActivity(event: string, sessionId: string, data: Record<string, unk
 function makeSession(id: string, status: string = 'working'): SessionInfo {
   return {
     id,
-    windowId: `window-${id}`,
-    windowName: `Session ${id}`,
+    name: `Session ${id}`,
     workDir: '/tmp',
     claudeSessionId: undefined,
     jsonlPath: undefined,

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -17,7 +17,7 @@ import type {
   MessagesResponse,
   SessionMetrics,
   SessionLatency,
-  PaneResponse,
+  TerminalSnapshotResponse,
   SessionSummary,
   OkResponse,
   SendResponse,
@@ -397,9 +397,9 @@ export function getSessionLatency(id: string): Promise<SessionLatency> {
   });
 }
 
-// ── Session Pane ────────────────────────────────────────────────
+// ── Terminal Snapshot ───────────────────────────────────────────
 
-export function getSessionPane(id: string): Promise<PaneResponse> {
+export function getSessionPane(id: string): Promise<TerminalSnapshotResponse> {
   return request(`/v1/sessions/${encodeURIComponent(id)}/pane`);
 }
 

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -150,7 +150,8 @@ export const HealthResponseSchema: z.ZodType<HealthResponse> = z.object({
     active: z.number(),
     total: z.number(),
   }),
-  tmux: z.object({
+  backend: z.object({
+    driver: z.string(),
     healthy: z.boolean(),
     error: z.string().nullable(),
   }).optional(),
@@ -184,10 +185,19 @@ const PendingQuestionInfoSchema = z.object({
 
 export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
   id: z.string(),
-  windowId: z.string(),
-  windowName: z.string(),
+  name: z.string().optional(),
   workDir: z.string(),
+  conversationId: z.string().optional(),
+  transcriptId: z.string().optional(),
+  acpAgentSessionId: z.string().optional(),
   claudeSessionId: z.string().optional(),
+  backendRunId: z.string().optional(),
+  parentSessionId: z.string().optional(),
+  rootSessionId: z.string().optional(),
+  correlationId: z.string().optional(),
+  resumeFromSessionId: z.string().optional(),
+  lifecycleState: z.enum(['initializing', 'idle', 'running', 'paused', 'intervening', 'closing', 'closed', 'failed']).optional(),
+  backendMetadata: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
   jsonlPath: z.string().optional(),
   byteOffset: z.number(),
   monitorOffset: z.number(),
@@ -236,15 +246,19 @@ export const SessionStatsSchema: z.ZodType<SessionStats> = z.object({
 
 export const SessionHealthSchema: z.ZodType<SessionHealth> = z.object({
   alive: z.boolean(),
-  windowExists: z.boolean(),
   claudeRunning: z.boolean(),
-  paneCommand: z.string().nullable(),
   status: UIState,
   hasTranscript: z.boolean(),
   lastActivity: z.number(),
   lastActivityAgo: z.number(),
   sessionAge: z.number(),
   details: z.string(),
+  backend: z.object({
+    driver: z.string(),
+    healthy: z.boolean(),
+    runId: z.string().optional(),
+    error: z.string().nullable(),
+  }).optional(),
   actionHints: z.record(z.string(), z.object({
     method: z.string(),
     url: z.string(),

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -164,7 +164,7 @@ export default function ActivityStream({
   const sessionNameMap = useMemo(() => {
     const m = new Map<string, string>();
     for (const s of sessions) {
-      m.set(s.id, s.windowName ?? s.id.slice(0, 8));
+      m.set(s.id, s.name ?? s.id.slice(0, 8));
     }
     return m;
   }, [sessions]);
@@ -191,7 +191,7 @@ export default function ActivityStream({
               <option value="">All sessions</option>
               {sessions.map((s) => (
                 <option key={s.id} value={s.id}>
-                  {s.windowName || s.id.slice(0, 8)}
+                  {s.name || s.id.slice(0, 8)}
                 </option>
               ))}
             </select>

--- a/dashboard/src/components/LiveAuditStream.tsx
+++ b/dashboard/src/components/LiveAuditStream.tsx
@@ -68,7 +68,7 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
   const sessionNameMap = useMemo(() => {
     const m = new Map<string, string>();
     for (const s of sessions) {
-      m.set(s.id, s.windowName ?? s.id.slice(0, 8));
+      m.set(s.id, s.name ?? s.id.slice(0, 8));
     }
     return m;
   }, [sessions]);

--- a/dashboard/src/components/overview/HomeStatusPanel.tsx
+++ b/dashboard/src/components/overview/HomeStatusPanel.tsx
@@ -100,34 +100,34 @@ function StatusCard({ label, value, detail, tone, icon, actionButton }: StatusCa
   );
 }
 
-function getTmuxCard(health: HealthResponse | null, isLoading: boolean, loadError: string | null): Omit<StatusCardProps, 'icon' | 'label'> {
+function getBackendCard(health: HealthResponse | null, isLoading: boolean, loadError: string | null): Omit<StatusCardProps, 'icon' | 'label'> {
   if (isLoading && !health) {
     return {
       value: 'Checking…',
-      detail: 'Verifying that the tmux server is responding.',
+      detail: 'Verifying that the session backend is responding.',
       tone: 'blue',
     };
   }
 
-  if (!health?.tmux) {
+  if (!health?.backend) {
     return {
       value: 'Unavailable',
-      detail: loadError ?? 'Tmux status has not been reported yet.',
+      detail: loadError ?? 'Backend status has not been reported yet.',
       tone: 'red',
     };
   }
 
-  if (!health.tmux.healthy) {
+  if (!health.backend.healthy) {
     return {
       value: 'Degraded',
-      detail: health.tmux.error ?? 'Tmux is not responding to health checks.',
+      detail: health.backend.error ?? 'The session backend is not responding to health checks.',
       tone: 'red',
     };
   }
 
   return {
     value: 'Ready',
-    detail: 'Tmux server is reachable and ready for new sessions.',
+    detail: `${health.backend.driver} backend is reachable and ready for new sessions.`,
     tone: 'green',
   };
 }
@@ -237,7 +237,7 @@ export default function HomeStatusPanel({ onCreateFirstSession }: HomeStatusPane
   const showStatusRow = Boolean(loadError) || Boolean(!sseConnected && sseError);
 
   const navigate = useNavigate();
-  const tmuxCard = getTmuxCard(health, isLoading, loadError);
+  const backendCard = getBackendCard(health, isLoading, loadError);
   const claudeCard = getClaudeCard(health, isLoading, loadError);
   const activeSessionsCard = getActiveSessionsCard(health, isLoading, loadError);
 
@@ -258,10 +258,10 @@ export default function HomeStatusPanel({ onCreateFirstSession }: HomeStatusPane
 
       <div className="grid gap-3 md:grid-cols-3">
         <StatusCard
-          label="Tmux status"
+          label="Backend status"
           icon={<Terminal className="h-4 w-4" />}
-          {...tmuxCard}
-          actionButton={tmuxCard.tone === 'red' || tmuxCard.tone === 'amber' ? {
+          {...backendCard}
+          actionButton={backendCard.tone === 'red' || backendCard.tone === 'amber' ? {
             label: 'View Logs',
             onClick: () => navigate('/audit'),
           } : undefined}

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -19,10 +19,10 @@ export const SessionMobileCard = memo(function SessionMobileCard({
   onInterrupt,
 }: SessionMobileCardProps) {
   const status = session.status ?? 'unknown';
-  const truncatedName = session.windowName
-    ? session.windowName.length > 30
-      ? session.windowName.slice(0, 30) + '…'
-      : session.windowName
+  const truncatedName = session.name
+    ? session.name.length > 30
+      ? session.name.slice(0, 30) + '…'
+      : session.name
     : session.id.slice(0, 8);
 
   return (

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -81,8 +81,7 @@ const DEMO_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
 const DEMO_SESSIONS: SessionInfo[] = [
   {
     id: 'demo-backend-api',
-    windowId: 'demo-win-1',
-    windowName: 'backend-api-dev',
+    name: 'backend-api-dev',
     workDir: '/tmp/demo/backend',
     status: 'working',
     createdAt: Date.now() - 3600000,
@@ -94,8 +93,7 @@ const DEMO_SESSIONS: SessionInfo[] = [
   },
   {
     id: 'demo-frontend-ui',
-    windowId: 'demo-win-2',
-    windowName: 'frontend-ui-build',
+    name: 'frontend-ui-build',
     workDir: '/tmp/demo/frontend',
     status: 'idle',
     createdAt: Date.now() - 7200000,
@@ -107,8 +105,7 @@ const DEMO_SESSIONS: SessionInfo[] = [
   },
   {
     id: 'demo-security-scan',
-    windowId: 'demo-win-3',
-    windowName: 'security-audit',
+    name: 'security-audit',
     workDir: '/tmp/demo/security',
     status: 'permission_prompt',
     createdAt: Date.now() - 1800000,
@@ -217,13 +214,13 @@ function formatStatusLabel(status: SessionStatusFilter): string {
 function matchesSearch(session: SessionInfo, query: string): boolean {
   if (!query) return true;
 
-  const haystack = `${session.windowName} ${session.id} ${session.workDir}`.toLowerCase();
+  const haystack = `${session.name} ${session.id} ${session.workDir}`.toLowerCase();
   return haystack.includes(query);
 }
 
 function isDisplayedSessionEqual(a: SessionInfo, b: SessionInfo): boolean {
   return a.id === b.id
-    && a.windowName === b.windowName
+    && a.name === b.name
     && a.workDir === b.workDir
     && a.status === b.status
     && a.createdAt === b.createdAt
@@ -258,7 +255,7 @@ const SessionMobileCard = memo(function SessionMobileCard({
         <label className="flex min-w-0 flex-1 items-center gap-3 text-sm text-gray-200">
           <input
             type="checkbox"
-            aria-label={`Select session ${session.windowName || session.id}`}
+            aria-label={`Select session ${session.name || session.id}`}
             checked={selected}
             onChange={(e) => onToggleSelect(session.id, e.target.checked)}
             className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
@@ -270,7 +267,7 @@ const SessionMobileCard = memo(function SessionMobileCard({
                 to={`/sessions/${encodeURIComponent(session.id)}`}
                 className="inline-flex min-h-[44px] items-center truncate font-medium text-gray-200 transition-colors hover:text-cyan"
               >
-                {session.windowName || session.id}
+                {session.name || session.id}
               </Link>
               {!isAlive && <XCircle className="h-3.5 w-3.5 shrink-0 text-red-400" />}
             </div>
@@ -285,7 +282,7 @@ const SessionMobileCard = memo(function SessionMobileCard({
             <button
               onClick={(e) => onApprove(e, session.id)}
               disabled={currentAction === 'approve'}
-              aria-label={`Approve session ${session.windowName || session.id}`}
+              aria-label={`Approve session ${session.name || session.id}`}
               className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-green-900/30 p-2 text-green-400 transition-colors hover:bg-green-900/50 disabled:pointer-events-none disabled:opacity-40"
               title="Approve"
             >
@@ -295,7 +292,7 @@ const SessionMobileCard = memo(function SessionMobileCard({
           <button
             onClick={(e) => onInterrupt(e, session.id)}
             disabled={currentAction === 'interrupt' || currentAction === 'kill'}
-            aria-label={`Interrupt session ${session.windowName || session.id}`}
+            aria-label={`Interrupt session ${session.name || session.id}`}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-yellow-900/30 p-2 text-yellow-400 transition-colors hover:bg-yellow-900/50 disabled:pointer-events-none disabled:opacity-40"
             title="Interrupt"
           >
@@ -304,7 +301,7 @@ const SessionMobileCard = memo(function SessionMobileCard({
           <button
             onClick={(e) => onKill(e, session.id)}
             disabled={currentAction === 'kill'}
-            aria-label={`Kill session ${session.windowName || session.id}`}
+            aria-label={`Kill session ${session.name || session.id}`}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-red-900/30 p-2 text-red-400 transition-colors hover:bg-red-900/50 disabled:pointer-events-none disabled:opacity-40"
             title="Kill"
           >
@@ -353,7 +350,7 @@ export const SessionDesktopRow = memo(function SessionDesktopRow({
       <td className="px-4 py-3">
         <input
           type="checkbox"
-          aria-label={`Select session ${session.windowName || session.id}`}
+          aria-label={`Select session ${session.name || session.id}`}
           checked={selected}
           onChange={(e) => onToggleSelect(session.id, e.target.checked)}
           className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
@@ -376,7 +373,7 @@ export const SessionDesktopRow = memo(function SessionDesktopRow({
           to={`/sessions/${encodeURIComponent(session.id)}`}
           className="font-medium text-gray-200 transition-colors hover:text-cyan"
         >
-          {session.windowName || session.id}
+          {session.name || session.id}
         </Link>
       </td>
 
@@ -417,7 +414,7 @@ export const SessionDesktopRow = memo(function SessionDesktopRow({
             <button
               onClick={(e) => onApprove(e, session.id)}
               disabled={currentAction === 'approve'}
-              aria-label={`Approve session ${session.windowName || session.id}`}
+              aria-label={`Approve session ${session.name || session.id}`}
               className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-green-900/30 text-xs font-medium text-green-400 transition-colors hover:bg-green-900/50 disabled:pointer-events-none disabled:opacity-40"
               title="Approve"
             >
@@ -427,7 +424,7 @@ export const SessionDesktopRow = memo(function SessionDesktopRow({
           <button
             onClick={(e) => onInterrupt(e, session.id)}
             disabled={currentAction === 'interrupt' || currentAction === 'kill'}
-            aria-label={`Interrupt session ${session.windowName || session.id}`}
+            aria-label={`Interrupt session ${session.name || session.id}`}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-yellow-900/30 text-xs font-medium text-yellow-400 transition-colors hover:bg-yellow-900/50 disabled:pointer-events-none disabled:opacity-40"
             title="Interrupt"
           >
@@ -436,7 +433,7 @@ export const SessionDesktopRow = memo(function SessionDesktopRow({
           <button
             onClick={(e) => onKill(e, session.id)}
             disabled={currentAction === 'kill'}
-            aria-label={`Kill session ${session.windowName || session.id}`}
+            aria-label={`Kill session ${session.name || session.id}`}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-red-900/30 text-xs font-medium text-red-400 transition-colors hover:bg-red-900/50 disabled:pointer-events-none disabled:opacity-40"
             title="Kill"
           >

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -110,7 +110,7 @@ function ApproveButton({
       type="button"
       onClick={(e) => onApprove(e, session.id)}
       disabled={currentAction === 'approve'}
-      aria-label={`Approve session ${session.windowName || session.id}`}
+      aria-label={`Approve session ${session.name || session.id}`}
       className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-green-900/30 text-xs font-medium text-green-400 transition-colors hover:bg-green-900/50 disabled:pointer-events-none disabled:opacity-40"
       title="Approve"
     >
@@ -172,7 +172,7 @@ function VirtualizedRow(props: {
       <div className="flex items-center px-3">
         <input
           type="checkbox"
-          aria-label={`Select session ${session.windowName || session.id}`}
+          aria-label={`Select session ${session.name || session.id}`}
           checked={selected}
           onChange={(e) => onToggleSelect(session.id, e.target.checked)}
           className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
@@ -192,7 +192,7 @@ function VirtualizedRow(props: {
           to={`/sessions/${encodeURIComponent(session.id)}`}
           className="inline-flex min-h-[44px] min-w-0 items-center truncate font-medium text-gray-200 transition-colors hover:text-cyan"
         >
-          {session.windowName || session.id}
+          {session.name || session.id}
         </Link>
       </div>
       <div className="flex items-center max-w-[150px] truncate px-3 font-mono text-xs text-gray-400" title={session.workDir}>
@@ -230,7 +230,7 @@ function VirtualizedRow(props: {
         <button
           type="button"
           onClick={(e) => onInterrupt(e, session.id)}
-          aria-label={`Interrupt session ${session.windowName || session.id}`}
+          aria-label={`Interrupt session ${session.name || session.id}`}
           className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-gray-500 hover:text-yellow-400 hover:bg-yellow-400/10 transition-colors"
           title="Interrupt"
         >
@@ -239,7 +239,7 @@ function VirtualizedRow(props: {
         <button
           type="button"
           onClick={(e) => onKill(e, session.id)}
-          aria-label={`Kill session ${session.windowName || session.id}`}
+          aria-label={`Kill session ${session.name || session.id}`}
           className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors"
           title="Kill"
         >

--- a/dashboard/src/components/session/OperatorTimeline.tsx
+++ b/dashboard/src/components/session/OperatorTimeline.tsx
@@ -146,7 +146,7 @@ function TimelineEventRow({
 
   return (
     <div
-      className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2 hover:bg-[var(--color-surface)] transition-colors"
+      className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2"
       role="listitem"
       aria-label={`${config.label}: ${event.description}`}
     >

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -154,7 +154,7 @@ export function SessionHeader({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="truncate text-base font-semibold text-[var(--color-text-primary)] sm:text-lg">
-              {session.windowName || 'Untitled Session'}
+              {session.name || 'Untitled Session'}
             </h1>
             <SessionStateBadge status={badgeStatus} />
           </div>

--- a/dashboard/src/components/session/SessionPreviewCard.tsx
+++ b/dashboard/src/components/session/SessionPreviewCard.tsx
@@ -107,7 +107,7 @@ export function SessionPreviewCard({ session, anchorRef, onClose }: SessionPrevi
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <StatusDot status={session.status} />
-          <span className="text-sm font-medium text-gray-200">{session.windowName || session.id}</span>
+          <span className="text-sm font-medium text-gray-200">{session.name || session.id}</span>
         </div>
         <button
           onClick={onClose}

--- a/dashboard/src/components/shared/CommandPalette.tsx
+++ b/dashboard/src/components/shared/CommandPalette.tsx
@@ -112,7 +112,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const sessionCommands: CommandItem[] = useMemo(() =>
     sessions.map((s) => ({
       id: `session-${s.id}`,
-      label: s.windowName || s.id.slice(0, 12),
+      label: s.name || s.id.slice(0, 12),
       description: s.workDir ? `📁 ${s.workDir}` : `Status: ${s.status}`,
       icon: Terminal,
       group: 'sessions' as const,

--- a/dashboard/src/hooks/useSessionPolling.ts
+++ b/dashboard/src/hooks/useSessionPolling.ts
@@ -99,7 +99,8 @@ export function useSessionPolling(sessionId: string): UseSessionPollingReturn {
     ]);
 
     if (paneRes.status === 'fulfilled') {
-      if (!cancelledRef.current) setPaneContent(paneRes.value.pane ?? '');
+      const legacyPane = (paneRes.value as { pane?: string }).pane;
+      if (!cancelledRef.current) setPaneContent(paneRes.value.content ?? legacyPane ?? '');
     } else {
       addToast('warning', 'Failed to load terminal pane', paneRes.reason instanceof Error ? paneRes.reason.message : undefined);
     }

--- a/dashboard/src/store/useStore.ts
+++ b/dashboard/src/store/useStore.ts
@@ -39,11 +39,10 @@ function areSessionsEqual(a: SessionInfo[], b: SessionInfo[]): boolean {
 
   for (let index = 0; index < a.length; index += 1) {
     const left = a[index];
-    const right = b[index];
-    if (
-      left.id !== right.id
-      || left.windowId !== right.windowId
-      || left.windowName !== right.windowName
+      const right = b[index];
+      if (
+        left.id !== right.id
+      || left.name !== right.name
       || left.workDir !== right.workDir
       || left.claudeSessionId !== right.claudeSessionId
       || left.jsonlPath !== right.jsonlPath

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -23,7 +23,7 @@ export type {
   GlobalSSEEventType,
   GlobalSSEEvent,
   CreateSessionRequest,
-  PaneResponse,
+  TerminalSnapshotResponse,
   SessionSummary,
   OkResponse,
   SendResponse,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.1.0"
 info:
   title: "Aegis API"
   version: "1.0.0"
-  description: "Orchestrate Claude Code sessions via REST API. Aegis wraps Claude Code in tmux sessions\nand exposes everything through a unified API.\n\n**Base URL:** `http://localhost:9100`\n\n**Authentication:** All endpoints except `/v1/health` and `/health` require a bearer token.\nPass `Authorization: Bearer <your-token>` header, or set `AEGIS_AUTH_TOKEN` env var.\n\n**Session lifecycle:** `working` → `idle` → `permission_prompt` → `asking` → `stalled`\n\n**API versioning:** All `/v1/` responses include `X-Aegis-API-Version: 1`.\nLegacy unversioned paths (e.g. `/health`, `/sessions`) emit `Deprecation: true`,\n`Sunset`, and `X-API-Deprecated` headers. See `docs/api-versioning.md` for the\nfull versioning policy.\n"
+  description: "Orchestrate Claude Code sessions via REST API. Aegis exposes Claude Code through a unified ACP-native control-plane API.\n\n**Base URL:** `http://localhost:9100`\n\n**Authentication:** All endpoints except `/v1/health` and `/health` require a bearer token.\nPass `Authorization: Bearer <your-token>` header, or set `AEGIS_AUTH_TOKEN` env var.\n\n**Session lifecycle:** `working` → `idle` → `permission_prompt` → `asking` → `stalled`\n\n**API versioning:** All `/v1/` responses include `X-Aegis-API-Version: 1`.\nLegacy unversioned paths (e.g. `/health`, `/sessions`) emit `Deprecation: true`,\n`Sunset`, and `X-API-Deprecated` headers. See `docs/api-versioning.md` for the\nfull versioning policy.\n"
 
 servers:
   - url: "http://localhost:9100"
@@ -92,7 +92,7 @@ paths:
   /v1/swarm:
     get:
       operationId: "getSwarmStatus"
-      summary: "Get tmux swarm status"
+      summary: "Get session swarm status"
       tags:
         - "System"
 
@@ -108,9 +108,9 @@ paths:
                     type: "integer"
                     description: "Number of active swarm monitors"
 
-                  activeWindows:
+                  activeSessions:
                     type: "integer"
-                    description: "Number of active Claude Code windows across all monitors"
+                    description: "Number of active Claude Code sessions across all monitors"
 
 
 
@@ -1402,7 +1402,7 @@ paths:
   "/v1/sessions/{id}/pane":
     get:
       operationId: "capturePane"
-      summary: "Raw terminal capture"
+      summary: "Terminal snapshot"
       tags:
         - "Sessions"
 
@@ -1412,17 +1412,20 @@ paths:
 
       responses:
         "200":
-          description: "Terminal pane content"
+          description: "Terminal snapshot content"
           content:
             application/json:
               schema:
                 type: "object"
                 properties:
-                  pane:
+                  content:
                     type: "string"
 
                   uiState:
                     type: "string"
+
+                  capturedAt:
+                    type: "number"
 
 
 
@@ -3863,6 +3866,39 @@ components:
             total:
               type: "integer"
 
+        backend:
+          type: "object"
+          properties:
+            driver:
+              type: "string"
+
+            healthy:
+              type: "boolean"
+
+            error:
+              type: "string"
+              nullable: true
+
+        claude:
+          type: "object"
+          properties:
+            available:
+              type: "boolean"
+
+            healthy:
+              type: "boolean"
+
+            version:
+              type: "string"
+              nullable: true
+
+            minimumVersion:
+              type: "string"
+
+            error:
+              type: "string"
+              nullable: true
+
 
 
 
@@ -4054,17 +4090,66 @@ components:
         id:
           type: "string"
 
-        windowId:
-          type: "string"
-
-        windowName:
+        name:
           type: "string"
 
         workDir:
           type: "string"
 
+        conversationId:
+          type: "string"
+
+        transcriptId:
+          type: "string"
+
+        acpAgentSessionId:
+          type: "string"
+
         claudeSessionId:
           type: "string"
+
+        backendRunId:
+          type: "string"
+
+        parentSessionId:
+          type: "string"
+
+        rootSessionId:
+          type: "string"
+
+        correlationId:
+          type: "string"
+
+        resumeFromSessionId:
+          type: "string"
+
+        lifecycleState:
+          type: "string"
+          enum:
+            - "initializing"
+            - "idle"
+            - "running"
+            - "paused"
+            - "intervening"
+            - "closing"
+            - "closed"
+            - "failed"
+
+
+        backendMetadata:
+          type: "object"
+          additionalProperties:
+            oneOf:
+              - type: "string"
+
+              - type: "number"
+
+              - type: "boolean"
+
+              - type: "null"
+
+
+
 
         jsonlPath:
           type: "string"
@@ -4179,11 +4264,23 @@ components:
         alive:
           type: "boolean"
 
-        windowExists:
-          type: "boolean"
-
-        paneState:
+        status:
           type: "string"
+          enum:
+            - "idle"
+            - "working"
+            - "compacting"
+            - "context_warning"
+            - "waiting_for_input"
+            - "permission_prompt"
+            - "plan_mode"
+            - "ask_question"
+            - "bash_approval"
+            - "settings"
+            - "error"
+            - "rate_limit"
+            - "unknown"
+
 
         lastSeen:
           type: "integer"

--- a/packages/client/src/generated/sdk.gen.ts
+++ b/packages/client/src/generated/sdk.gen.ts
@@ -31,7 +31,7 @@ export const getHealth = <ThrowOnError extends boolean = false>(options?: Option
 export const getHealthAlias = <ThrowOnError extends boolean = false>(options?: Options<GetHealthAliasData, ThrowOnError>) => (options?.client ?? client).get<GetHealthAliasResponses, GetHealthAliasErrors, ThrowOnError>({ url: '/health', ...options });
 
 /**
- * Get tmux swarm status
+ * Get session swarm status
  */
 export const getSwarmStatus = <ThrowOnError extends boolean = false>(options?: Options<GetSwarmStatusData, ThrowOnError>) => (options?.client ?? client).get<GetSwarmStatusResponses, unknown, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -367,7 +367,7 @@ export const verifySession = <ThrowOnError extends boolean = false>(options: Opt
 });
 
 /**
- * Raw terminal capture
+ * Terminal snapshot
  */
 export const capturePane = <ThrowOnError extends boolean = false>(options: Options<CapturePaneData, ThrowOnError>) => (options.client ?? client).get<CapturePaneResponses, CapturePaneErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -26,6 +26,18 @@ export type HealthResponse = {
         active?: number;
         total?: number;
     };
+    backend?: {
+        driver?: string;
+        healthy?: boolean;
+        error?: string;
+    };
+    claude?: {
+        available?: boolean;
+        healthy?: boolean;
+        version?: string;
+        minimumVersion?: string;
+        error?: string;
+    };
 };
 
 export type ApiKey = {
@@ -112,10 +124,21 @@ export type SessionReused = SessionCreated & {
 
 export type SessionInfo = {
     id?: string;
-    windowId?: string;
-    windowName?: string;
+    name?: string;
     workDir?: string;
+    conversationId?: string;
+    transcriptId?: string;
+    acpAgentSessionId?: string;
     claudeSessionId?: string;
+    backendRunId?: string;
+    parentSessionId?: string;
+    rootSessionId?: string;
+    correlationId?: string;
+    resumeFromSessionId?: string;
+    lifecycleState?: 'initializing' | 'idle' | 'running' | 'paused' | 'intervening' | 'closing' | 'closed' | 'failed';
+    backendMetadata?: {
+        [key: string]: string | number | boolean | null;
+    };
     jsonlPath?: string;
     byteOffset?: number;
     monitorOffset?: number;
@@ -151,8 +174,7 @@ export type SessionInfo = {
 
 export type SessionHealth = {
     alive?: boolean;
-    windowExists?: boolean;
-    paneState?: string;
+    status?: 'idle' | 'working' | 'compacting' | 'context_warning' | 'waiting_for_input' | 'permission_prompt' | 'plan_mode' | 'ask_question' | 'bash_approval' | 'settings' | 'error' | 'rate_limit' | 'unknown';
     lastSeen?: number;
     suggestion?: string;
 };
@@ -323,9 +345,9 @@ export type GetSwarmStatusResponses = {
          */
         monitors?: number;
         /**
-         * Number of active Claude Code windows across all monitors
+         * Number of active Claude Code sessions across all monitors
          */
-        activeWindows?: number;
+        activeSessions?: number;
     };
 };
 
@@ -1508,11 +1530,12 @@ export type CapturePaneError = CapturePaneErrors[keyof CapturePaneErrors];
 
 export type CapturePaneResponses = {
     /**
-     * Terminal pane content
+     * Terminal snapshot content
      */
     200: {
-        pane?: string;
+        content?: string;
         uiState?: string;
+        capturedAt?: number;
     };
 };
 

--- a/packages/python-client/src/aegis_python_client/models.py
+++ b/packages/python-client/src/aegis_python_client/models.py
@@ -36,11 +36,27 @@ class Sessions(BaseModel):
     total: int | None = None
 
 
+class Backend(BaseModel):
+    driver: str | None = None
+    healthy: bool | None = None
+    error: str | None = None
+
+
+class Claude(BaseModel):
+    available: bool | None = None
+    healthy: bool | None = None
+    version: str | None = None
+    minimumVersion: str | None = None
+    error: str | None = None
+
+
 class HealthResponse(BaseModel):
     status: Status | None = None
     version: str | None = Field(None, examples=['0.6.5-preview.3'])
     uptime: int | None = Field(None, description='Seconds since server start')
     sessions: Sessions | None = None
+    backend: Backend | None = None
+    claude: Claude | None = None
 
 
 class ApiKey(BaseModel):
@@ -125,6 +141,17 @@ class SessionReused(SessionCreated):
     reused: bool | None = Field(None, examples=[True])
 
 
+class LifecycleState(Enum):
+    initializing = 'initializing'
+    idle = 'idle'
+    running = 'running'
+    paused = 'paused'
+    intervening = 'intervening'
+    closing = 'closing'
+    closed = 'closed'
+    failed = 'failed'
+
+
 class Status1(Enum):
     idle = 'idle'
     working = 'working'
@@ -143,10 +170,19 @@ class Status1(Enum):
 
 class SessionInfo(BaseModel):
     id: str | None = None
-    windowId: str | None = None
-    windowName: str | None = None
+    name: str | None = None
     workDir: str | None = None
+    conversationId: str | None = None
+    transcriptId: str | None = None
+    acpAgentSessionId: str | None = None
     claudeSessionId: str | None = None
+    backendRunId: str | None = None
+    parentSessionId: str | None = None
+    rootSessionId: str | None = None
+    correlationId: str | None = None
+    resumeFromSessionId: str | None = None
+    lifecycleState: LifecycleState | None = None
+    backendMetadata: dict[str, str | float | bool | None] | None = None
     jsonlPath: str | None = None
     byteOffset: int | None = None
     monitorOffset: int | None = None
@@ -178,8 +214,7 @@ class SessionInfo(BaseModel):
 
 class SessionHealth(BaseModel):
     alive: bool | None = None
-    windowExists: bool | None = None
-    paneState: str | None = None
+    status: Status1 | None = None
     lastSeen: int | None = None
     suggestion: str | None = None
 

--- a/scripts/uat-smoke.mjs
+++ b/scripts/uat-smoke.mjs
@@ -103,8 +103,44 @@ function assertHealthPayload(payload) {
     throw new Error('Health payload sessions counters must be numeric');
   }
 
-  if (!payload.tmux || typeof payload.tmux !== 'object') {
-    throw new Error('Health payload is missing tmux diagnostics');
+  if (Object.hasOwn(payload, 'tmux')) {
+    throw new Error('Health payload must not expose tmux diagnostics');
+  }
+
+  if (!payload.backend || typeof payload.backend !== 'object') {
+    throw new Error('Health payload is missing backend diagnostics');
+  }
+
+  if (typeof payload.backend.driver !== 'string' || payload.backend.driver.length === 0) {
+    throw new Error('Health payload backend diagnostics are missing a driver');
+  }
+
+  if (typeof payload.backend.healthy !== 'boolean') {
+    throw new Error('Health payload backend diagnostics are missing health state');
+  }
+
+  if (payload.backend.error !== null && typeof payload.backend.error !== 'string') {
+    throw new Error('Health payload backend diagnostics error must be null or a string');
+  }
+
+  if (!payload.claude || typeof payload.claude !== 'object') {
+    throw new Error('Health payload is missing Claude diagnostics');
+  }
+
+  if (typeof payload.claude.available !== 'boolean' || typeof payload.claude.healthy !== 'boolean') {
+    throw new Error('Health payload Claude diagnostics are missing availability state');
+  }
+
+  if (payload.claude.version !== null && typeof payload.claude.version !== 'string') {
+    throw new Error('Health payload Claude diagnostics version must be null or a string');
+  }
+
+  if (typeof payload.claude.minimumVersion !== 'string' || payload.claude.minimumVersion.length === 0) {
+    throw new Error('Health payload Claude diagnostics are missing a minimum version');
+  }
+
+  if (payload.claude.error !== null && typeof payload.claude.error !== 'string') {
+    throw new Error('Health payload Claude diagnostics error must be null or a string');
   }
 
   if (typeof payload.timestamp !== 'string' || Number.isNaN(Date.parse(payload.timestamp))) {

--- a/src/__tests__/api-contract-redaction-2603.test.ts
+++ b/src/__tests__/api-contract-redaction-2603.test.ts
@@ -1,0 +1,30 @@
+/**
+ * api-contract-redaction-2603.test.ts — ACP-060 public session contract cleanup.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { redactSession } from '../routes/context.js';
+
+describe('ACP-060 public API redaction', () => {
+  it('removes tmux window identifiers while preserving the public session name', () => {
+    const redacted = redactSession({
+      id: 'session-1',
+      windowId: '@42',
+      windowName: 'review-session',
+      workDir: 'D:\\repo',
+      status: 'idle',
+      hookSecret: 'secret',
+      activeSubagents: new Set(['reviewer']),
+    });
+
+    expect(redacted).not.toHaveProperty('windowId');
+    expect(redacted).not.toHaveProperty('windowName');
+    expect(redacted).not.toHaveProperty('hookSecret');
+    expect(redacted).toMatchObject({
+      id: 'session-1',
+      name: 'review-session',
+      workDir: 'D:\\repo',
+      activeSubagents: ['reviewer'],
+    });
+  });
+});

--- a/src/__tests__/health-auth-2458.test.ts
+++ b/src/__tests__/health-auth-2458.test.ts
@@ -251,7 +251,8 @@ describe('Issue #2458: GET /v1/health auth-gated info', () => {
     expect(body.sessions).toBeDefined();
     expect((body.sessions as Record<string, unknown>).active).toBeDefined();
     expect((body.sessions as Record<string, unknown>).total).toBeDefined();
-    expect(body.tmux).toBeDefined();
+    expect(body.backend).toBeDefined();
+    expect(body.tmux).toBeUndefined();
     expect(body.claude).toBeDefined();
   });
 

--- a/src/__tests__/hooksecret-redaction-2527.test.ts
+++ b/src/__tests__/hooksecret-redaction-2527.test.ts
@@ -48,7 +48,8 @@ describe('redactSession — Issue #2527', () => {
 
     const redacted = redactSession(session);
     expect(redacted.id).toBe('22222222-2222-2222-2222-222222222222');
-    expect(redacted.windowName).toBe('test-session');
+    expect(redacted.name).toBe('test-session');
+    expect(redacted).not.toHaveProperty('windowName');
     expect(redacted.model).toBe('claude-sonnet-4-20250514');
     expect(redacted.ownerKeyId).toBe('key-abc');
     expect(redacted.parentId).toBe('33333333-3333-3333-3333-333333333333');

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -383,7 +383,8 @@ describe('MCP Integration Smoke Tests (#1898)', () => {
       expect(body.id).toBeDefined();
       expect(typeof body.id).toBe('string');
       expect(body.workDir).toBe('/tmp/my-project');
-      expect(body.windowName).toBe('smoke-test-session');
+      expect(body.name).toBe('smoke-test-session');
+      expect(body.windowName).toBeUndefined();
       expect(body.status).toBe('idle');
       expect(body).toHaveProperty('createdAt');
     });

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -320,14 +320,14 @@ describe('AegisClient', () => {
   });
 
   it('capturePane sends GET /v1/sessions/:id/pane', async () => {
-    const mockPane = { pane: 'output text here' };
+    const mockPane = { content: 'output text here' };
     (fetch as any).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockPane),
     });
 
     const result = await client.capturePane(UUID);
-    expect(result.pane).toBe('output text here');
+    expect(result.content).toBe('output text here');
     expect(fetch).toHaveBeenCalledWith(
       `http://127.0.0.1:9100/v1/sessions/${UUID}/pane`,
       expect.anything(),
@@ -1407,7 +1407,7 @@ describe('MCP Resources', () => {
     it('returns pane text for valid session ID', async () => {
       (fetch as any).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ pane: '$ ls -la\ntotal 42' }),
+        json: () => Promise.resolve({ content: '$ ls -la\ntotal 42' }),
       });
 
       const cb = getTemplateResourceCallback('session-pane');

--- a/src/__tests__/openapi.test.ts
+++ b/src/__tests__/openapi.test.ts
@@ -13,6 +13,8 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import YAML from 'yaml';
 import { z } from 'zod';
 import {
   zodToJsonSchema,
@@ -27,6 +29,21 @@ interface OpenApiTestDocument {
   openapi: string;
   info: Record<string, unknown>;
   paths: Record<string, Record<string, unknown>>;
+  components?: {
+    schemas?: Record<string, Record<string, unknown>>;
+  };
+}
+
+function loadRootOpenApiContract(): OpenApiTestDocument {
+  return YAML.parse(readFileSync('openapi.yaml', 'utf8')) as OpenApiTestDocument;
+}
+
+function componentProperties(doc: OpenApiTestDocument, schemaName: string): Record<string, unknown> {
+  const schema = doc.components?.schemas?.[schemaName];
+  expect(schema, `Missing ${schemaName} schema`).toBeDefined();
+  const properties = schema?.properties;
+  expect(properties, `${schemaName} must define properties`).toBeDefined();
+  return properties as Record<string, unknown>;
 }
 
 // ── zodToJsonSchema ─────────────────────────────────────────────────
@@ -414,6 +431,93 @@ describe('registerOpenApiSpec', () => {
         expect(Object.keys(op.responses as Record<string, unknown>).length).toBeGreaterThan(0);
       }
     }
+  });
+});
+
+describe('ACP public contract cleanup', () => {
+  it('removes tmux/window/pane fields from root session schemas while keeping ACP identity fields', () => {
+    const doc = loadRootOpenApiContract();
+
+    const sessionInfo = componentProperties(doc, 'SessionInfo');
+    expect(sessionInfo).not.toHaveProperty('windowId');
+    expect(sessionInfo).not.toHaveProperty('windowName');
+    expect(sessionInfo).toHaveProperty('id');
+    expect(sessionInfo).toHaveProperty('workDir');
+    expect(sessionInfo).toHaveProperty('status');
+    expect(sessionInfo).toHaveProperty('claudeSessionId');
+    expect(sessionInfo).toHaveProperty('conversationId');
+    expect(sessionInfo).toHaveProperty('transcriptId');
+    expect(sessionInfo).toHaveProperty('acpAgentSessionId');
+    expect(sessionInfo).toHaveProperty('backendRunId');
+    expect(sessionInfo).toHaveProperty('backendMetadata');
+
+    const sessionHealth = componentProperties(doc, 'SessionHealth');
+    expect(sessionHealth).not.toHaveProperty('windowExists');
+    expect(sessionHealth).not.toHaveProperty('paneState');
+    expect(sessionHealth).not.toHaveProperty('paneCommand');
+    expect(sessionHealth).toHaveProperty('alive');
+    expect(sessionHealth).toHaveProperty('status');
+  });
+
+  it('exposes terminal snapshots without pane-named response fields until the endpoint is removed later', () => {
+    const doc = loadRootOpenApiContract();
+    const panePath = doc.paths['/v1/sessions/{id}/pane'];
+    expect(panePath, 'ACP-062 owns removing the endpoint; ACP-060 only removes pane-shaped fields').toBeDefined();
+    const getOperation = panePath?.get as Record<string, unknown> | undefined;
+    const response = getOperation?.responses as Record<string, unknown> | undefined;
+    const okResponse = response?.['200'] as Record<string, unknown> | undefined;
+    const content = okResponse?.content as Record<string, unknown> | undefined;
+    const json = content?.['application/json'] as Record<string, unknown> | undefined;
+    const schema = json?.schema as Record<string, unknown> | undefined;
+    const properties = schema?.properties as Record<string, unknown> | undefined;
+
+    expect(properties).toBeDefined();
+    expect(properties).not.toHaveProperty('pane');
+    expect(properties).toHaveProperty('content');
+    expect(properties).toHaveProperty('uiState');
+  });
+
+  it('keeps generated route schemas aligned with terminal snapshot fields', () => {
+    registerOpenApiSpec();
+    const doc = generateOpenApiDocument() as unknown as OpenApiTestDocument;
+    const panePath = doc.paths['/v1/sessions/{id}/pane'];
+    const getOperation = panePath?.get as Record<string, unknown> | undefined;
+    const response = getOperation?.responses as Record<string, unknown> | undefined;
+    const okResponse = response?.['200'] as Record<string, unknown> | undefined;
+    const content = okResponse?.content as Record<string, unknown> | undefined;
+    const json = content?.['application/json'] as Record<string, unknown> | undefined;
+    const schema = json?.schema as Record<string, unknown> | undefined;
+    const properties = schema?.properties as Record<string, unknown> | undefined;
+
+    expect(properties).toBeDefined();
+    expect(properties).not.toHaveProperty('pane');
+    expect(properties).toHaveProperty('content');
+    expect(properties).toHaveProperty('uiState');
+    expect(properties).toHaveProperty('capturedAt');
+  });
+
+  it('exposes health backend metadata without the removed tmux field', () => {
+    const doc = loadRootOpenApiContract();
+    const healthResponse = componentProperties(doc, 'HealthResponse');
+
+    expect(healthResponse).not.toHaveProperty('tmux');
+    expect(healthResponse).toHaveProperty('backend');
+    expect(healthResponse).toHaveProperty('claude');
+  });
+
+  it('keeps generated TypeScript SDK models free of removed tmux contract fields', () => {
+    const sdkTypes = readFileSync('packages/client/src/generated/types.gen.ts', 'utf8');
+
+    expect(sdkTypes).not.toMatch(/\bwindowId\?:/);
+    expect(sdkTypes).not.toMatch(/\bwindowName\?:/);
+    expect(sdkTypes).not.toMatch(/\bwindowExists\?:/);
+    expect(sdkTypes).not.toMatch(/\bpaneState\?:/);
+    expect(sdkTypes).not.toMatch(/\bpane\?: string/);
+    expect(sdkTypes).not.toMatch(/\bactiveWindows\?:/);
+    expect(sdkTypes).toMatch(/\bconversationId\?: string/);
+    expect(sdkTypes).toMatch(/\btranscriptId\?: string/);
+    expect(sdkTypes).toMatch(/\bacpAgentSessionId\?: string/);
+    expect(sdkTypes).toMatch(/\bbackendRunId\?: string/);
   });
 });
 

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -291,7 +291,8 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     expect(body.uptime).toBeDefined();
     expect(body.sessions).toBeDefined();
     expect(body.sessions.total).toBeDefined();
-    expect(body.tmux).toBeDefined();
+    expect(body.backend).toBeDefined();
+    expect(body.tmux).toBeUndefined();
     expect(body.claude).toBeDefined();
   });
 
@@ -338,7 +339,8 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     expect(body.platform).toBe(process.platform);
     expect(body.uptime).toBeDefined();
     expect(body.sessions.total).toBeDefined();
-    expect(body.tmux).toBeDefined();
+    expect(body.backend).toBeDefined();
+    expect(body.tmux).toBeUndefined();
     expect(body.claude).toBeDefined();
   });
 
@@ -355,8 +357,9 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     const body = res.json();
     expect(body.id).toBeDefined();
     expect(body.workDir).toBe(tmpDir);
-    expect(body.windowId).toBeDefined();
-    expect(body.windowName).toBeDefined();
+    expect(body.windowId).toBeUndefined();
+    expect(body.windowName).toBeUndefined();
+    expect(body.name).toBeDefined();
     expect(typeof body.createdAt).toBe('number');
 
     // Verify session appears in listing

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ApiKeyPermission as ServiceApiKeyPermission } from './services/auth/index.js';
+import type { AcpBackendMetadata, AcpSessionStatus } from './services/acp/index.js';
 
 export type UIState =
   | 'idle'
@@ -42,10 +43,19 @@ export interface PendingQuestionInfo {
 
 export interface SessionInfo {
   id: string;
-  windowId: string;
-  windowName: string;
+  name?: string;
   workDir: string;
+  conversationId?: string;
+  transcriptId?: string;
+  acpAgentSessionId?: string;
   claudeSessionId?: string;
+  backendRunId?: string;
+  parentSessionId?: string;
+  rootSessionId?: string;
+  correlationId?: string;
+  resumeFromSessionId?: string;
+  lifecycleState?: AcpSessionStatus;
+  backendMetadata?: AcpBackendMetadata;
   jsonlPath?: string;
   byteOffset: number;
   monitorOffset: number;
@@ -72,15 +82,19 @@ export interface SessionInfo {
 
 export interface SessionHealth {
   alive: boolean;
-  windowExists: boolean;
   claudeRunning: boolean;
-  paneCommand: string | null;
   status: UIState;
   hasTranscript: boolean;
   lastActivity: number;
   lastActivityAgo: number;
   sessionAge: number;
   details: string;
+  backend?: {
+    driver: string;
+    healthy: boolean;
+    runId?: string;
+    error: string | null;
+  };
   actionHints?: Record<string, {
     method: string;
     url: string;
@@ -97,7 +111,8 @@ export interface HealthResponse {
     active: number;
     total: number;
   };
-  tmux?: {
+  backend?: {
+    driver: string;
     healthy: boolean;
     error: string | null;
   };
@@ -261,13 +276,15 @@ export interface CreateSessionRequest {
   memoryKeys?: string[];
 }
 
-export interface PaneResponse {
-  pane: string;
+export interface TerminalSnapshotResponse {
+  content: string;
+  uiState?: UIState;
+  capturedAt?: number;
 }
 
 export interface SessionSummary {
   sessionId: string;
-  windowName: string;
+  name?: string;
   status: UIState;
   totalMessages: number;
   messages: Array<{ role: string; contentType: string; text: string }>;

--- a/src/api-contracts.typecheck.ts
+++ b/src/api-contracts.typecheck.ts
@@ -6,6 +6,9 @@ import type {
 } from './events.js';
 import type {
   SessionInfo,
+  SessionHealth,
+  HealthResponse,
+  TerminalSnapshotResponse,
   MessagesResponse,
   SessionSummary,
   SessionMetrics,
@@ -16,8 +19,18 @@ import type {
 } from './api-contracts.js';
 
 type Assert<T extends true> = T;
+type NoKeys<T, K extends PropertyKey> = Extract<keyof T, K> extends never ? true : false;
+type HasKeys<T, K extends PropertyKey> = Exclude<K, keyof T> extends never ? true : false;
 
 export type SessionInfoContractCompat = Assert<InternalSessionInfo extends SessionInfo ? true : false>;
+export type SessionInfoTmuxKeysRemoved = Assert<NoKeys<SessionInfo, 'windowId' | 'windowName'>>;
+export type SessionInfoAcpIdentityKeysPresent = Assert<HasKeys<
+  SessionInfo,
+  'id' | 'workDir' | 'status' | 'claudeSessionId' | 'conversationId' | 'transcriptId' | 'acpAgentSessionId' | 'backendRunId' | 'backendMetadata'
+>>;
+export type SessionHealthTmuxKeysRemoved = Assert<NoKeys<SessionHealth, 'windowExists' | 'paneCommand' | 'paneState'>>;
+export type HealthResponseTmuxKeysRemoved = Assert<NoKeys<HealthResponse, 'tmux'>>;
+export type TerminalSnapshotPaneKeysRemoved = Assert<NoKeys<TerminalSnapshotResponse, 'pane'>>;
 export type SessionReadMessagesContractCompat = Assert<
   Awaited<ReturnType<SessionManager['readMessages']>> extends MessagesResponse ? true : false
 >;

--- a/src/mcp/embedded.ts
+++ b/src/mcp/embedded.ts
@@ -121,7 +121,7 @@ export class EmbeddedBackend implements IAegisBackend {
     }
     return {
       id: session.id,
-      windowName: session.windowName,
+      name: session.windowName,
       workDir: session.workDir,
       status: session.status,
       promptDelivery,
@@ -166,8 +166,8 @@ export class EmbeddedBackend implements IAegisBackend {
 
   async capturePane(id: string): Promise<CapturePaneResponse> {
     const session = this.requireSession(id);
-    const pane = await this.tmux.capturePane(session.windowId);
-    return { pane };
+    const content = await this.tmux.capturePane(session.windowId);
+    return { content, uiState: session.status, capturedAt: Date.now() };
   }
 
   async sendBash(id: string, command: string): Promise<OkResponse> {
@@ -219,7 +219,7 @@ export class EmbeddedBackend implements IAegisBackend {
         active: this.sessions.listSessions().length,
         total: this.metrics.getTotalSessionsCreated(),
       },
-      tmux: tmuxHealth,
+      backend: { driver: 'terminal', ...tmuxHealth },
       timestamp: new Date().toISOString(),
     };
   }

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -78,7 +78,7 @@ export function registerResources(server: McpServer, client: IAegisBackend): voi
       }
       try {
         const result = await client.capturePane(id);
-        const text = typeof result.pane === 'string' ? result.pane : JSON.stringify(result, null, 2);
+        const text = typeof result.content === 'string' ? result.content : JSON.stringify(result, null, 2);
         return {
           contents: [{ uri: uri.href, mimeType: 'text/plain', text }],
         };

--- a/src/mcp/tools/session-tools.ts
+++ b/src/mcp/tools/session-tools.ts
@@ -125,7 +125,7 @@ export function registerSessionTools(server: McpServer, client: IAegisBackend): 
             type: 'text' as const,
             text: JSON.stringify({
               id: session.id,
-              name: session.windowName,
+              name: session.name,
               status: 'created',
               workDir: session.workDir,
               promptDelivery: session.promptDelivery,

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -288,15 +288,21 @@ export function requireSessionOwnership(
  *
  * hookSecret: HMAC secret for hook URL auth — must never be exposed via API.
  * hookSettingsFile: internal temp file path — not useful to callers.
+ * windowId/windowName: terminal backend identifiers — not part of the public ACP contract.
  * activeSubagents: Set<> is not JSON-serializable; converted separately.
  */
 export function redactSession(session: Record<string, unknown>): Record<string, unknown> {
-  const { hookSecret, hookSettingsFile, activeSubagents, ...rest } = session as Record<string, unknown> & {
+  const { hookSecret, hookSettingsFile, activeSubagents, windowId, windowName, ...rest } = session as Record<string, unknown> & {
     hookSecret?: unknown;
     hookSettingsFile?: unknown;
     activeSubagents?: unknown;
+    windowId?: unknown;
+    windowName?: unknown;
   };
   const redacted = { ...rest };
+  if (typeof redacted.name !== 'string' && typeof windowName === 'string') {
+    redacted.name = windowName;
+  }
   // activeSubagents needs to be re-added as an array (if present) for JSON
   if (activeSubagents instanceof Set) {
     (redacted as Record<string, unknown>).activeSubagents = [...activeSubagents];

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -75,9 +75,9 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
     timeWindow: '1 minute',
   } as const;
 
-  // Health — Issue #397: includes tmux server health check
+  // Health — Issue #397: includes terminal backend health check
   // Issue #1911: returns 'draining' when server is shutting down
-  // Issue #2066: strip sensitive fields (version, uptime, tmux, claude) for unauthenticated requests
+  // Issue #2066: strip sensitive fields (version, uptime, backend, claude) for unauthenticated requests
   async function healthHandler(req: FastifyRequest): Promise<Record<string, unknown>> {
     const pkg = await import('../../package.json', { with: { type: 'json' } });
     const activeCount = sessions.listSessions().length;
@@ -119,7 +119,7 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
       platform: process.platform,
       uptime: process.uptime(),
       sessions: { active: activeCount, total: totalCount },
-      tmux: tmuxHealth,
+      backend: { driver: 'terminal', ...tmuxHealth },
       claude: claudeStatus,
     };
   }

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -78,6 +78,36 @@ const createSessionSchema = z.object({
   memoryKeys: z.array(z.string()).max(50).optional(),
 }).strict();
 
+const terminalSnapshotSchema = z.object({
+  content: z.string(),
+  uiState: z.string().optional(),
+  capturedAt: z.number().optional(),
+});
+
+const healthResponseSchema = z.object({
+  status: z.string(),
+  version: z.string().optional(),
+  platform: z.string().optional(),
+  uptime: z.number().optional(),
+  sessions: z.object({
+    active: z.number(),
+    total: z.number(),
+  }).optional(),
+  backend: z.object({
+    driver: z.string(),
+    healthy: z.boolean(),
+    error: z.string().nullable(),
+  }).optional(),
+  claude: z.object({
+    available: z.boolean(),
+    healthy: z.boolean(),
+    version: z.string().nullable(),
+    minimumVersion: z.string(),
+    error: z.string().nullable(),
+  }).optional(),
+  timestamp: z.string().optional(),
+});
+
 const batchDeleteSchema = z.object({
   ids: z.array(z.string().uuid()).max(100).optional(),
   status: z.enum([
@@ -298,7 +328,7 @@ export function registerOpenApiSpec(): void {
     method: 'post',
     path: '/v1/sessions',
     summary: 'Create session',
-    description: 'Create a new Claude Code session in a tmux window. Reuses an existing idle session for the same workDir if available.',
+    description: 'Create a new Claude Code session. Reuses an existing idle session for the same workDir if available.',
     tags: ['Sessions'],
     requestBody: {
       description: 'Session creation parameters',
@@ -455,10 +485,10 @@ export function registerOpenApiSpec(): void {
   registerOpenApiPath({
     method: 'get',
     path: '/v1/sessions/{id}/pane',
-    summary: 'Capture raw pane',
+    summary: 'Capture terminal snapshot',
     tags: ['Session Actions'],
     parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
-    responses: { '200': okJsonResponse(z.object({ pane: z.string() })), '404': notFoundResponse },
+    responses: { '200': okJsonResponse(terminalSnapshotSchema), '404': notFoundResponse },
   });
 
   registerOpenApiPath({
@@ -778,9 +808,9 @@ export function registerOpenApiSpec(): void {
     method: 'get',
     path: '/v1/health',
     summary: 'Health check',
-    description: 'Server health including tmux status, Claude CLI status, version, uptime.',
+    description: 'Server health including terminal backend status, Claude CLI status, version, uptime.',
     tags: ['Health'],
-    responses: { '200': okJsonResponse(z.any()) },
+    responses: { '200': okJsonResponse(healthResponseSchema) },
   });
 
   registerOpenApiPath({

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -326,10 +326,10 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     registerWithLegacy(app, 'post', alias, killHandler);
   }
 
-  // Capture raw pane
+  // Terminal snapshot endpoint. ACP-062 owns removing the legacy path.
   registerWithLegacy(app, 'get', '/v1/sessions/:id/pane', withOwnership(sessions, async (_req, _reply, session) => {
-    const pane = await tmux.capturePane(session.windowId);
-    return { pane };
+    const content = await tmux.capturePane(session.windowId);
+    return { content, uiState: session.status, capturedAt: Date.now() };
   }));
 
   // Slash command

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -385,7 +385,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           promptDelivery = await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
-        return reply.status(200).send({ ...existing, reused: true, promptDelivery });
+        return reply.status(200).send({ ...redactSession(existing as unknown as Record<string, unknown>), reused: true, promptDelivery });
       } finally {
         sessions.releaseSessionClaim(existing.id);
       }
@@ -472,25 +472,42 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
     allSessions = filterByTenant(allSessions, req.tenantId);
     const results: Record<string, {
       alive: boolean;
-      windowExists: boolean;
       claudeRunning: boolean;
-      paneCommand: string | null;
       status: string;
       hasTranscript: boolean;
       lastActivity: number;
       lastActivityAgo: number;
       sessionAge: number;
       details: string;
+      actionHints?: Record<string, { method: string; url: string; description: string }>;
+      backend?: { driver: string; healthy: boolean; error: string | null };
     }> = {};
     await Promise.all(allSessions.map(async (s) => {
       try {
-        results[s.id] = await sessions.getHealth(s.id);
+        const health = await sessions.getHealth(s.id);
+        results[s.id] = {
+          alive: health.alive,
+          claudeRunning: health.claudeRunning,
+          status: health.status,
+          hasTranscript: health.hasTranscript,
+          lastActivity: health.lastActivity,
+          lastActivityAgo: health.lastActivityAgo,
+          sessionAge: health.sessionAge,
+          details: health.details,
+          actionHints: health.actionHints,
+          backend: {
+            driver: 'terminal',
+            healthy: health.windowExists,
+            error: health.windowExists ? null : health.details,
+          },
+        };
       } catch {
         results[s.id] = {
-          alive: false, windowExists: false, claudeRunning: false,
-          paneCommand: null, status: 'unknown', hasTranscript: false,
+          alive: false, claudeRunning: false,
+          status: 'unknown', hasTranscript: false,
           lastActivity: 0, lastActivityAgo: 0, sessionAge: 0,
           details: 'Error fetching health',
+          backend: { driver: 'terminal', healthy: false, error: 'Error fetching health' },
         };
       }
     }));
@@ -500,7 +517,23 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
   // Session health check (Issue #2)
   registerWithLegacy(app, 'get', '/v1/sessions/:id/health', withOwnership(sessions, async (_req, reply, session) => {
     try {
-      return await sessions.getHealth(session.id);
+      const health = await sessions.getHealth(session.id);
+      return {
+        alive: health.alive,
+        claudeRunning: health.claudeRunning,
+        status: health.status,
+        hasTranscript: health.hasTranscript,
+        lastActivity: health.lastActivity,
+        lastActivityAgo: health.lastActivityAgo,
+        sessionAge: health.sessionAge,
+        details: health.details,
+        actionHints: health.actionHints,
+        backend: {
+          driver: 'terminal',
+          healthy: health.windowExists,
+          error: health.windowExists ? null : health.details,
+        },
+      };
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }

--- a/src/services/acp/fanout.ts
+++ b/src/services/acp/fanout.ts
@@ -353,12 +353,10 @@ export interface RedisAcpFanoutOptions {
 }
 
 export class RedisAcpFanout implements AcpFanout {
-  private readonly eventStore: AcpEventStore;
   private readonly local: LocalAcpFanout;
   private readonly redis: AcpFanoutRedisAdapter;
 
   constructor(options: RedisAcpFanoutOptions) {
-    this.eventStore = options.eventStore;
     this.local = new LocalAcpFanout({ eventStore: options.eventStore });
     this.redis = options.redis;
   }

--- a/src/services/acp/postgres-action-queue.ts
+++ b/src/services/acp/postgres-action-queue.ts
@@ -4,7 +4,6 @@ import { AcpDurableIdentityError, AcpValidationError, validateAcpControlActionIn
 import type { AcpControlActionInput, AcpControlActionType, AcpSessionScope } from './types.js';
 import {
   normalizeAcpActionMetadata,
-  type AcpActionMetadata,
   type AcpActionQueue,
   type AcpActionRecord,
   type AcpActionStatus,

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -17,13 +17,13 @@ export interface ServerHealthResponse {
   platform: NodeJS.Platform;
   uptime: number;
   sessions: { active: number; total: number };
-  tmux: { healthy: boolean; [key: string]: unknown };
+  backend: { driver: string; healthy: boolean; error: string | null };
   timestamp: string;
 }
 
 export interface CreateSessionResponse {
   id: string;
-  windowName: string;
+  name?: string;
   workDir: string;
   status: string;
   promptDelivery?: { delivered: boolean; attempts: number };
@@ -43,7 +43,9 @@ export interface OkResponse {
 }
 
 export interface CapturePaneResponse {
-  pane: string;
+  content: string;
+  uiState?: string;
+  capturedAt?: number;
 }
 
 export interface SessionLatencyResponse {


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Removes tmux/window/pane-shaped fields from shared API contracts, root OpenAPI, generated TypeScript SDK types, and dashboard consumers.
- Keeps terminal runtime internals and the legacy `/v1/sessions/{id}/pane` endpoint in place, returning ACP-neutral terminal snapshot fields until ACP-062 removes the endpoint.
- Adds contract tests covering removed fields and ACP-native replacements.

## Validation
- `npx vitest run src\__tests__\api-contract-redaction-2603.test.ts src\__tests__\openapi.test.ts src\__tests__\mcp-server.test.ts`
- `npm --prefix dashboard run test -- src\__tests__\schemas.test.ts src\__tests__\useSessionPolling.test.ts src\__tests__\SessionTable.test.ts src\__tests__\HomeStatusPanel.test.ts`
- `npm run openapi:check && npx tsc --noEmit`
- `npm run gate` (267 files passed, 2 skipped; 4363 tests passed, 22 skipped)

Closes #2603