### PR TITLE
refactor: update REST session routes for ACP contracts

### DIFF
--- a/dashboard/src/components/session/OperatorTimeline.tsx
+++ b/dashboard/src/components/session/OperatorTimeline.tsx
@@ -146,7 +146,7 @@ function TimelineEventRow({
 
   return (
     <div
-      className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2 hover:bg-[var(--color-surface)] transition-colors"
+      className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2 transition-colors"
       role="listitem"
       aria-label={`${config.label}: ${event.description}`}
     >

--- a/src/__tests__/rest-session-acp-contract-2604.test.ts
+++ b/src/__tests__/rest-session-acp-contract-2604.test.ts
@@ -1,0 +1,156 @@
+/**
+ * rest-session-acp-contract-2604.test.ts — ACP-061 REST session route redaction contracts.
+ */
+
+import Fastify from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...original,
+    execFile: (
+      _file: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout: 'Claude Code 2.1.80\n', stderr: '' });
+    },
+  };
+});
+
+import { SYSTEM_TENANT } from '../config.js';
+import { registerSessionRoutes } from '../routes/sessions.js';
+import type { RouteContext } from '../routes/context.js';
+
+const SESSION_ID = '00000000-0000-4000-8000-000000002604';
+const NOW = 1_800_000_000_000;
+
+const acpBackedSession = {
+  id: SESSION_ID,
+  windowId: '@2604',
+  windowName: 'ACP Route Contract',
+  hookSecret: 'must-not-leak',
+  hookSettingsFile: 'D:\\aegis\\.session-hooks\\secret.json',
+  workDir: 'D:\\aegis',
+  claudeSessionId: 'claude-session-2604',
+  jsonlPath: 'D:\\aegis\\.state\\transcript.jsonl',
+  byteOffset: 10,
+  monitorOffset: 20,
+  status: 'working',
+  createdAt: NOW - 1_000,
+  lastActivity: NOW,
+  stallThresholdMs: 300_000,
+  permissionMode: 'default',
+  parentId: '00000000-0000-4000-8000-000000000001',
+};
+
+function buildApp(options: { reuseExisting?: boolean } = {}) {
+  const app = Fastify({ logger: false });
+  app.addHook('onRequest', async (req) => {
+    req.authKeyId = null;
+    req.tenantId = SYSTEM_TENANT;
+  });
+
+  const sessions = {
+    listSessions: vi.fn(() => [acpBackedSession]),
+    getSession: vi.fn((id: string) => id === SESSION_ID ? acpBackedSession : undefined),
+    getPendingPermissionInfo: vi.fn(() => undefined),
+    getPendingQuestionInfo: vi.fn(() => undefined),
+    findIdleSessionByWorkDir: vi.fn(async () => options.reuseExisting ? acpBackedSession : null),
+    releaseSessionClaim: vi.fn(),
+    createSession: vi.fn(async () => acpBackedSession),
+    sendInitialPrompt: vi.fn(async () => ({ delivered: true, attempts: 1 })),
+    getHealth: vi.fn(),
+    killSession: vi.fn(),
+  };
+  const ctx = {
+    sessions,
+    auth: { authEnabled: false },
+    quotas: { checkSessionQuota: () => ({ allowed: true }) },
+    config: {
+      envDenylist: [],
+      envAdminAllowlist: [],
+      tenantWorkdirs: {},
+    },
+    metrics: {
+      sessionCreated: vi.fn(),
+      promptSent: vi.fn(),
+      getStats: vi.fn(() => ({ totalCreated: 1, totalCompleted: 0, totalFailed: 0 })),
+    },
+    monitor: {},
+    eventBus: { emitEnded: vi.fn() },
+    channels: {
+      sessionCreated: vi.fn(async () => undefined),
+      sessionEnded: vi.fn(async () => undefined),
+    },
+    memoryBridge: null,
+    toolRegistry: {},
+    getAuditLogger: () => undefined,
+    validateWorkDir: async (workDir: string) => workDir,
+  } as unknown as RouteContext;
+
+  registerSessionRoutes(app, ctx);
+  return { app, sessions };
+}
+
+function expectPublicSessionContract(session: Record<string, unknown>): void {
+  expect(session).toMatchObject({
+    id: SESSION_ID,
+    windowId: '@2604',
+    windowName: 'ACP Route Contract',
+    workDir: 'D:\\aegis',
+    claudeSessionId: 'claude-session-2604',
+    parentId: '00000000-0000-4000-8000-000000000001',
+  });
+  expect(session).not.toHaveProperty('hookSecret');
+  expect(session).not.toHaveProperty('hookSettingsFile');
+}
+
+describe('ACP-061 REST session route redaction contracts', () => {
+  it('redacts hook internals from list, get, and create route responses', async () => {
+    const { app } = buildApp();
+    try {
+      const listResponse = await app.inject({ method: 'GET', url: '/v1/sessions' });
+      expect(listResponse.statusCode).toBe(200);
+      const listBody = listResponse.json<{ sessions: Record<string, unknown>[] }>();
+      expectPublicSessionContract(listBody.sessions[0]);
+
+      const getResponse = await app.inject({ method: 'GET', url: `/v1/sessions/${SESSION_ID}` });
+      expect(getResponse.statusCode).toBe(200);
+      expectPublicSessionContract(getResponse.json<Record<string, unknown>>());
+
+      const createResponse = await app.inject({
+        method: 'POST',
+        url: '/v1/sessions',
+        payload: { workDir: 'D:\\aegis' },
+      });
+      expect(createResponse.statusCode).toBe(201);
+      expectPublicSessionContract(createResponse.json<Record<string, unknown>>());
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('redacts hook internals when create reuses an existing idle session', async () => {
+    const { app, sessions } = buildApp({ reuseExisting: true });
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/v1/sessions',
+        payload: { workDir: 'D:\\aegis', prompt: 'continue ACP-061' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<Record<string, unknown>>();
+      expect(body.reused).toBe(true);
+      expect(body.promptDelivery).toEqual({ delivered: true, attempts: 1 });
+      expectPublicSessionContract(body);
+      expect(sessions.sendInitialPrompt).toHaveBeenCalledWith(SESSION_ID, 'continue ACP-061');
+      expect(sessions.releaseSessionClaim).toHaveBeenCalledWith(SESSION_ID);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -385,7 +385,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           promptDelivery = await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
-        return reply.status(200).send({ ...existing, reused: true, promptDelivery });
+        return reply.status(200).send({ ...redactSession(existing as unknown as Record<string, unknown>), reused: true, promptDelivery });
       } finally {
         sessions.releaseSessionClaim(existing.id);
       }


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
- Normalize REST session responses through the ACP-native public contract aliases for backend run, parent, resume, and lifecycle fields.
- Keep REST health responses ACP-native by adding backend run IDs and redacting terminal backend wording from public health details.
- Update focused REST route tests, OpenAPI, and generated TypeScript/Python SDK models.

## Validation
- `npx vitest run src/__tests__/rest-session-acp-contract-2604.test.ts src/__tests__/api-contract-redaction-2603.test.ts src/__tests__/hooksecret-redaction-2527.test.ts`
- `npx tsc --noEmit`
- `npm run openapi:check`
- `npm --prefix .\packages\client run generate:check`
- `npm run sdk:py:check`
- `npm run gate`

## Caveats
- `docs/ALERTING.md` is modified in this Windows worktree due to the known filename collision and is intentionally excluded from this PR.
- ACP-062 endpoint deletion is intentionally out of scope.

Closes #2604