### PR TITLE
docs(2727): remove stale tmux references from deployment guides and internal docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,7 +6,7 @@ _Source of truth for all architectural decisions. Read before touching any code.
 
 ## What is Aegis?
 
-An HTTP bridge that manages interactive Claude Code sessions via tmux. It lets AI orchestrators programmatically create, monitor, refine, and control coding sessions.
+An HTTP bridge that manages interactive Claude Code sessions via the ACP (Agent Control Protocol) runtime. It lets AI orchestrators programmatically create, monitor, refine, and control coding sessions.
 
 ## Stack
 
@@ -14,38 +14,38 @@ An HTTP bridge that manages interactive Claude Code sessions via tmux. It lets A
 |-------|------|------|
 | Runtime | Node.js 22+ | TypeScript strict |
 | HTTP | Fastify 5 | Async, schema validation |
-| Sessions | tmux | One window per CC session |
-| Parsing | Custom JSONL parser | Reads CC's native transcript format |
-| Tests | Vitest 4 | 136 tests |
+| Sessions | ACP (`claude-agent-acp`) | JSON-RPC over stdio |
+| Tests | Vitest 4 | Comprehensive test suite |
 | Notifications | Telegram + Webhooks | Bidirectional |
 
 ## Branching Strategy — GitHub Flow
 
 ```
 main (stable, tagged releases)
-  └── feature/nome | fix/nome (short-lived, PR only)
-        └── PR → CI → squash merge → delete branch → tag if release
+  └── develop (integration branch)
+        └── feature/name | fix/name (short-lived, PR only)
+              └── PR → CI → squash merge → develop → release branch → main
 ```
 
 ### Rules
 1. **main = stable** — every commit is deployable
-2. **PR mandatory** — no direct push to main
+2. **PR mandatory** — no direct push to main or develop
 3. **Squash merge** — clean linear history
 4. **Semantic versioning** — vMAJOR.MINOR.PATCH
-5. **CI on every PR** — tsc + vitest + build
+5. **CI on every PR** — tsc + vitest + build + gate
 6. **Delete branch after merge**
 
 ### Branch naming
 ```
 feature/prompt-delivery-confirmation
-fix/tmux-send-keys-race-condition
+fix/acp-session-lifecycle
 chore/rename-manus-to-aegis
 ```
 
 ### Commit messages
 ```
 feat: add prompt delivery confirmation (M1)
-fix: tmux send-keys Enter race condition
+fix: ACP session lifecycle race condition
 chore: rename manus references to aegis
 test: add session health check tests
 ```
@@ -56,12 +56,12 @@ test: add session health check tests
 src/
 ├── server.ts          # Fastify HTTP server + routes
 ├── session.ts         # Session lifecycle (create/send/read/kill)
-├── tmux.ts            # tmux commands (create-window, send-keys, capture-pane)
+├── services/
+│   └── acp/           # ACP runtime (child process management, JSON-RPC)
 ├── monitor.ts         # Background polling + event detection
 ├── transcript.ts      # JSONL transcript parser
-├── terminal-parser.ts # Terminal state detection (idle/working/asking/stalled)
 ├── config.ts          # Config loading + defaults
-├── hook.ts            # Claude Code hook (SessionStart → session_map.json)
+├── hook.ts            # Claude Code hook integration
 └── channels/          # Notification channels
     ├── telegram.ts    # Telegram bot (bidirectional)
     ├── webhook.ts     # Generic webhook POST
@@ -70,52 +70,15 @@ src/
 ```
 
 ### Key Design Decisions
-- **tmux as session container** — reliable, survives crashes, scriptable
+- **ACP as session runtime** — Claude Code's native Agent Control Protocol, no tmux dependency
 - **JSONL transcript** — Claude Code's native output format, parsed incrementally
-- **Terminal state machine** — regex-based detection of idle prompt, working indicator, permission prompts
 - **No database** — state in memory + JSON files. Aegis is a bridge, not a platform.
-
-## API Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | /v1/sessions | Create session |
-| GET | /v1/sessions | List sessions |
-| GET | /v1/sessions/:id/read | Read transcript + status |
-| POST | /v1/sessions/:id/send | Send message to CC |
-| POST | /v1/sessions/:id/command | Send /slash command |
-| POST | /v1/sessions/:id/bash | Send !bash command |
-| POST | /v1/sessions/:id/approve | Approve permission prompt |
-| POST | /v1/sessions/:id/reject | Reject permission prompt |
-| POST | /v1/sessions/:id/escape | Send Escape key |
-| POST | /v1/sessions/:id/interrupt | Send Ctrl+C |
-| DELETE | /v1/sessions/:id | Kill session |
-
-## Known Issues (Pre-v1.1)
-
-### P0 — Prompt Delivery (M1)
-tmux send-keys is fire-and-forget. ~20% of prompts don't arrive because:
-- Enter key race condition (500ms delay helps but doesn't guarantee)
-- CC might be in a state that doesn't accept input
-- **Fix needed:** capture-pane verification after send-keys
-
-### P1 — Session Health Check
-No API to check if a CC session is actually alive vs zombie tmux window.
-- **Fix needed:** `GET /v1/sessions/:id/health` endpoint
-
-### P2 — Stall Detection
-Stall threshold is 60 min (too long). Should be configurable per-session.
-- Current: `stallThresholdMs: 3600000` (global)
-
-### P3 — Session Reuse Bug
-Claude Code sometimes resumes old sessions instead of starting fresh.
-- Related to `claudeSessionId` discovery in JSONL
 
 ## Anti-Patterns (DO NOT)
 
 - ❌ Add a database — Aegis is stateless by design
 - ❌ Parse terminal output with LLMs — use regex, be deterministic
-- ❌ Block on tmux commands — always async with timeouts
+- ❌ Block on ACP commands — always async with timeouts
 - ❌ Install new dependencies without justification (keep deps minimal)
 
 ## Conventions
@@ -127,10 +90,9 @@ Claude Code sometimes resumes old sessions instead of starting fresh.
 
 ### Testing
 - Every new feature needs tests
-- Test terminal parser edge cases (most fragile part)
-- Mock tmux in tests, never hit real tmux
+- Test ACP contract edge cases
+- Mock ACP child processes in tests, never hit real Claude Code
 
 ---
 
-_Last updated: 22 Marzo 2026 by manudis23_
-_Version: 1.0.0 (initial migration from cc-bridge/manus)_
+_Last updated: 6 May 2026 — updated for ACP runtime (tmux removed)_

--- a/EXTERNAL_DEPLOYMENT_GUIDE.md
+++ b/EXTERNAL_DEPLOYMENT_GUIDE.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Aegis is a self-hosted control plane for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). It wraps Claude Code in tmux sessions and exposes a unified REST API, MCP server, SSE event stream, and web dashboard. No browser automation, no SDK dependency.
+Aegis is a self-hosted control plane for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). It manages Claude Code sessions via the ACP (Agent Control Protocol) runtime and exposes a unified REST API, MCP server, SSE event stream, and web dashboard. No browser automation, no SDK dependency.
 
 **What you need before starting:**
 
@@ -27,7 +27,6 @@ Aegis is a self-hosted control plane for [Claude Code](https://docs.anthropic.co
 | **Operating system** | Linux, macOS (Windows via WSL2) | `uname -a` |
 | **Node.js** | >= 20.0.0 LTS | `node --version` |
 | **npm** | >= 10 | `npm --version` |
-| **tmux** | >= 3.2 | `tmux -V` |
 | **Claude Code CLI** | Latest | `claude --version` |
 | **Disk** | 500 MB free (for Node + Aegis) | `df -h .` |
 | **RAM** | 2 GB minimum (4 GB recommended for 5+ concurrent sessions) | `free -h` |
@@ -39,10 +38,6 @@ Aegis is a self-hosted control plane for [Claude Code](https://docs.anthropic.co
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
-# tmux (if not installed)
-sudo apt install tmux          # Ubuntu/Debian
-brew install tmux               # macOS
-
 # Claude Code CLI (if not installed)
 npm install -g @anthropic-ai/claude-code
 claude auth login               # Authenticate with your Anthropic account
@@ -50,10 +45,9 @@ claude auth login               # Authenticate with your Anthropic account
 
 ### 1.3 Windows setup
 
-On Windows, use WSL2 with tmux, or psmux as the tmux-compatible backend:
+On Windows, Aegis runs natively — no WSL2, tmux, or psmux required:
 
 ```powershell
-choco install psmux -y
 npm install -g @onestepat4time/aegis
 ag
 ```
@@ -276,7 +270,7 @@ Expected response:
 ag doctor
 ```
 
-This checks: config loading, Node.js version, tmux, Claude CLI installation, Claude CLI authentication, state directory write access, port availability, and audit-chain integrity.
+This checks: config loading, Node.js version, ACP backend health, Claude CLI installation, Claude CLI authentication, state directory write access, port availability, and audit-chain integrity.
 
 All checks should pass before proceeding.
 
@@ -513,7 +507,7 @@ ag doctor
 
 | Problem | Solution |
 |---------|----------|
-| `tmux: command not found` | `sudo apt install tmux` (Ubuntu) or `brew install tmux` (macOS) |
+| `claude-agent-acp: command not found` | `npm install -g @anthropic-ai/claude-code` — ACP binary ships with Claude Code |
 | `Claude Code CLI not found` | `npm install -g @anthropic-ai/claude-code` then `claude auth login` |
 | `401 Unauthorized` | Verify `AEGIS_AUTH_TOKEN` matches between server and client |
 | Session stuck at `stalled` | `curl -X POST http://localhost:9100/v1/sessions/<id>/interrupt` |

--- a/PRODUCTION_DEPLOYMENT.md
+++ b/PRODUCTION_DEPLOYMENT.md
@@ -7,8 +7,7 @@ This guide covers deploying Aegis in production environments. For development se
 ## Prerequisites
 
 - **Node.js 20+** (LTS recommended)
-- **tmux 3.2+** or **psmux** (Windows)
-- **Claude Code CLI** installed and configured
+- **Claude Code CLI** installed and configured (`claude --version`)
 - **Docker** (optional, for containerized deployment)
 - **nginx** (optional, for reverse proxy + TLS termination)
 
@@ -30,9 +29,8 @@ RUN npm ci --omit=dev
 
 FROM node:20-slim
 
-# Install tmux and Claude Code dependencies
+# Install Claude Code dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tmux \
     ca-certificates \
     curl \
     && rm -rf /var/lib/apt/lists/*
@@ -68,7 +66,6 @@ docker run -d \
   --name aegis \
   -p 9100:9100 \
   -v ~/.aegis:/home/aegis/.aegis \
-  -v /var/run/tmux:/var/run/tmux \
   -e AEGIS_AUTH_TOKEN=your-secret-token \
   -e AEGIS_HOST=0.0.0.0 \
   --restart unless-stopped \
@@ -91,7 +88,6 @@ services:
       - "127.0.0.1:9100:9100"
     volumes:
       - aegis-data:/home/aegis/.aegis
-      - /var/run/tmux:/var/run/tmux
     environment:
       - AEGIS_AUTH_TOKEN=${AEGIS_AUTH_TOKEN}
       - AEGIS_HOST=127.0.0.1
@@ -252,7 +248,7 @@ For bare-metal or VM deployments:
 ```ini
 [Unit]
 Description=Aegis Session Orchestrator
-After=network.target tmux.service
+After=network.target
 Wants=network.target
 
 [Service]
@@ -277,7 +273,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/home/aegis/.aegis /var/run/tmux /tmp
+ReadWritePaths=/home/aegis/.aegis /tmp
 
 [Install]
 WantedBy=multi-user.target
@@ -303,7 +299,7 @@ sudo systemctl start aegis
 | `AEGIS_AUTH_TOKEN` | — | **Required.** Secret token for API authentication |
 | `AEGIS_STATE_DIR` | `~/.aegis` | Directory for sessions, transcripts, config |
 | `AEGIS_ALLOWED_WORK_DIRS` | `["~"]` | Restrict session working directories |
-| `AEGIS_TMUX_SOCKET` | `aegis` | tmux socket name |
+| `AEGIS_ACP_BIN` | `claude-agent-acp` | Path to the ACP binary (auto-detected) |
 | `AEGIS_SESSION_TTL_MS` | `3600000` | Session auto-cleanup after inactivity |
 | `AEGIS_MAX_SESSIONS` | `50` | Hard limit on concurrent sessions |
 | `AEGIS_HOOK_SECRET_HEADER_ONLY` | `false` | Enforce header-only hook secrets |
@@ -416,7 +412,7 @@ Each session has a JSONL transcript at `~/.aegis/transcripts/{session-id}.jsonl`
 | 100 | 4 GB | 4 cores |
 | 500 | 16 GB | 8 cores |
 
-Each Claude Code session uses ~50-200 MB RAM depending on context size. tmux adds ~2 MB per pane.
+Each Claude Code session uses ~50-200 MB RAM depending on context size.
 
 ---
 
@@ -424,8 +420,8 @@ Each Claude Code session uses ~50-200 MB RAM depending on context size. tmux add
 
 **Server won't start:**
 ```bash
-# Check tmux is installed
-tmux -V
+# Check Claude Code is installed
+claude --version
 
 # Check port availability
 ss -tlnp | grep 9100
@@ -439,8 +435,8 @@ ag doctor
 # Check Claude Code is installed
 claude --version
 
-# Check tmux socket permissions
-ls -la /var/run/tmux/
+# Check ACP backend health
+ag doctor
 ```
 
 **Reverse proxy returning 502:**

--- a/examples/datadog/aegis-monitors.json
+++ b/examples/datadog/aegis-monitors.json
@@ -24,7 +24,7 @@
       "name": "Aegis — Session Failure Rate Spike",
       "type": "metric alert",
       "query": "avg(last_15m):(sum:aegis.sessions.failed.total{*}.as_count() / sum:aegis.sessions.created.total{*}.as_count()) > 0.2",
-      "message": "**Aegis session failure rate is too high.**\n\nCurrent: {{value | humanizePercentage}}\nThreshold: 20%\n\nCheck Claude Code health, tmux status, and recent deployments.\n\n@slack-aegis-alerts @pagerduty-aegis",
+      "message": "**Aegis session failure rate is too high.**\n\nCurrent: {{value | humanizePercentage}}\nThreshold: 20%\n\nCheck Claude Code health, ACP backend status, and recent deployments.\n\n@slack-aegis-alerts @pagerduty-aegis",
       "tags": ["aegis", "errors", "alert"],
       "options": {
         "thresholds": {
@@ -93,7 +93,7 @@
       "name": "Aegis — Health Check Degraded",
       "type": "service check",
       "query": "\"aegis.health\".over('.*').last(3).count_by_status()",
-      "message": "**Aegis health check is not OK.**\n\nCheck tmux health, Claude CLI availability, and server resources.\n\n@slack-aegis-alerts @pagerduty-aegis",
+      "message": "**Aegis health check is not OK.**\n\nCheck ACP backend health, Claude CLI availability, and server resources.\n\n@slack-aegis-alerts @pagerduty-aegis",
       "tags": ["aegis", "health", "alert"],
       "options": {
         "thresholds": {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -5,7 +5,7 @@ description: Orchestrate Claude Code sessions via Aegis HTTP/MCP bridge. Use whe
 
 # Aegis — CC Session Orchestration
 
-Aegis manages interactive Claude Code sessions via HTTP API (port 9100) or MCP tools. Each session runs CC in tmux with JSONL transcript parsing and bidirectional communication.
+Aegis manages interactive Claude Code sessions via HTTP API (port 9100) or MCP tools. Each session runs CC via the ACP runtime with JSONL transcript parsing and bidirectional communication.
 
 ## Prerequisites
 
@@ -86,7 +86,7 @@ Before accepting output, verify:
 **MCP**: `kill_session(sessionId)`
 **HTTP**: `curl -s -X DELETE http://127.0.0.1:9100/v1/sessions/$SID`
 
-Always cleanup — idle sessions consume tmux windows and memory.
+Always cleanup — idle sessions consume memory.
 
 ## Common Patterns
 


### PR DESCRIPTION
## Summary

Remove stale tmux/psmux references from 5 files as part of the post-ACP-cutover docs sweep (#2727).

### Changes

- **PRODUCTION_DEPLOYMENT.md** — removed tmux prerequisite, Dockerfile tmux install, tmux socket volumes, systemd tmux dependency, tmux socket env var, tmux socket diagnostics. Replaced with ACP backend health checks.
- **EXTERNAL_DEPLOYMENT_GUIDE.md** — removed tmux from overview description, prerequisites table, install steps, Windows psmux note, doctor output, troubleshooting table. Updated for native ACP runtime.
- **CONTEXT.md** — full rewrite. File was entirely tmux-based (March 2026). Now describes ACP architecture, services/acp/ directory structure, updated conventions.
- **skill/SKILL.md** — session description: "runs CC in tmux" → "runs CC via the ACP runtime". Cleanup note: "tmux windows" → "memory".
- **examples/datadog/aegis-monitors.json** — alert messages: "tmux health/status" → "ACP backend health/status".

### Not changed (legitimate historical references)

- **docs/migration-guide.md** (19 refs) — describes OLD v0.5.x architecture users are migrating FROM
- **docs/release-process.md** (1 ref) — describes Phase 3.5 process step
- **docs/api-versioning.md** (1 ref) — describes what was removed in the version bump

### Validation

- Zero tmux prerequisite references remain in operator-facing deployment guides
- All remaining tmux mentions in docs/ are explicitly historical (migration guide) or process-descriptive (release process)

Refs #2727