### PR TITLE
fix(ci): add --previous flag to helm-smoke kubectl logs for crash diagnosis

### DIFF
--- a/.github/workflows/helm-smoke.yml
+++ b/.github/workflows/helm-smoke.yml
@@ -132,4 +132,5 @@ jobs:
           kubectl get all,pvc -n aegis || true
           kubectl describe statefulset -n aegis aegis || true
           kubectl describe pod -n aegis aegis-0 || true
+          kubectl logs -n aegis aegis-0 --previous || true
           kubectl logs -n aegis aegis-0 || true


### PR DESCRIPTION
## Summary
When the smoke container crashes before producing logs, the current diagnostic step returns empty. This adds `kubectl logs --previous` to capture the crash output from the terminated container.

## Context
Root cause of helm-smoke failures identified in #2730: `cli.ts` has a hard tmux dependency check that exits with code 1 when tmux is absent. The smoke Dockerfile no longer installs tmux (removed by #2711). This PR is a diagnostic improvement only — the actual fix in `cli.ts` needs Hephaestus.

## Test Plan
- [x] Workflow YAML is valid
- [ ] CI will validate on push