### PR TITLE
docs: add Karpathy-style coding behavior rules

### DIFF
--- a/.claude/rules/coding.md
+++ b/.claude/rules/coding.md
@@ -1,0 +1,27 @@
+# Coding Behavior
+
+## Think Before Coding
+- State assumptions explicitly before implementing. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so.
+
+## Simplicity First
+- No features beyond what was asked. No speculative abstractions.
+- No "flexibility" or "configurability" that wasn't requested.
+- If you write 200 lines and it could be 50, rewrite it.
+- No error handling for impossible scenarios.
+
+## Surgical Changes
+- Touch only what the task requires. Don't "improve" adjacent code, comments, or formatting.
+- Match existing code style — quotes, spacing, naming conventions.
+- Don't refactor things that aren't broken.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Every changed line should trace to the user's request.
+
+## Goal-Driven Execution
+- Define success criteria before starting.
+- "Fix bug X" → write a test that reproduces it, then make it pass.
+- "Refactor Y" → ensure tests pass before and after.
+- For multi-step tasks, state a plan with verification checkpoints:
+  1. [Step] → verify: [check]
+  2. [Step] → verify: [check]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ explicitly assigning the issue.
 - [.claude/rules/prs.md](./.claude/rules/prs.md) — PR body, size, review
 - [.claude/rules/positioning.md](./.claude/rules/positioning.md) — what Aegis is and what NOT to build
 - [.claude/rules/typescript.md](./.claude/rules/typescript.md) — TS conventions
+- [.claude/rules/coding.md](./.claude/rules/coding.md) — coding behavior: think-first, simplicity, surgical edits, goal-driven
 
 Authoritative strategic source: [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,4 +95,4 @@ src/
 
 ## Working with This Project
 
-See `.claude/rules/` for scoped rules on commits, branching, PRs, and TypeScript conventions.
+See `.claude/rules/` for scoped rules on commits, branching, PRs, TypeScript conventions, and coding behavior.


### PR DESCRIPTION
## Summary

Adds `.claude/rules/coding.md` with four coding-behavior principles adapted from [andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills):

- **Think Before Coding** — surface assumptions, ask when unclear, present alternatives
- **Simplicity First** — minimum code, no speculative abstractions
- **Surgical Changes** — touch only what is needed, match existing style
- **Goal-Driven Execution** — define success criteria, test-first verification

Wires the new rule into `CLAUDE.md` and `AGENTS.md` scoped-rules sections.

## Aegis version
**Developed with:** v2.4.1

## Files changed
- `.claude/rules/coding.md` (new)
- `CLAUDE.md` (scoped-rules reference)
- `AGENTS.md` (scoped-rules reference)