### PR TITLE
fix: resolve pre-existing develop gate failures

### DIFF
--- a/dashboard/src/components/session/OperatorTimeline.tsx
+++ b/dashboard/src/components/session/OperatorTimeline.tsx
@@ -146,7 +146,7 @@ function TimelineEventRow({
 
   return (
     <div
-      className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2 hover:bg-[var(--color-surface)] transition-colors"
+      className="flex gap-3 border-b border-[var(--color-border)] px-3 py-2 "
       role="listitem"
       aria-label={`${config.label}: ${event.description}`}
     >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1399,45 +1399,6 @@ paths:
 
 
 
-  "/v1/sessions/{id}/pane":
-    get:
-      operationId: "capturePane"
-      summary: "Raw terminal capture"
-      tags:
-        - "Sessions"
-
-      parameters:
-        - $ref: "#/components/parameters/sessionId"
-
-
-      responses:
-        "200":
-          description: "Terminal pane content"
-          content:
-            application/json:
-              schema:
-                type: "object"
-                properties:
-                  pane:
-                    type: "string"
-
-                  uiState:
-                    type: "string"
-
-
-
-
-
-
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-
-
-
   "/v1/sessions/{id}/command":
     post:
       operationId: "sendCommand"
@@ -1480,50 +1441,6 @@ paths:
 
         "404":
           $ref: "#/components/responses/NotFound"
-
-
-
-
-  "/v1/sessions/{id}/bash":
-    post:
-      operationId: "sendBash"
-      summary: "Send a bash command (raw, no prompt wrapping)"
-      tags:
-        - "Sessions"
-
-      parameters:
-        - $ref: "#/components/parameters/sessionId"
-
-
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: "object"
-              properties:
-                command:
-                  type: "string"
-
-
-              required:
-                - "command"
-
-
-
-
-
-      responses:
-        "202":
-          description: "Command sent"
-
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-
 
 
   "/v1/sessions/{id}/summary":

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -548,7 +548,7 @@ describe('createMcpServer', () => {
     expect(info.name).toBe('aegis');
   });
 
-  it('registers all 24 tools', () => {
+  it('registers all 36 tools', () => {
     const server = createMcpServer(9100);
     // The internal _registeredTools is private, but we can check via the server
     // We verify by checking that the tool handler setup doesn't throw
@@ -579,7 +579,7 @@ describe('createMcpServer', () => {
     expect(Object.keys(tools)).toContain('state_set');
     expect(Object.keys(tools)).toContain('state_get');
     expect(Object.keys(tools)).toContain('state_delete');
-    expect(Object.keys(tools)).toHaveLength(24);
+    expect(Object.keys(tools)).toHaveLength(36);
   });
 
   it('accepts custom auth token', () => {

--- a/src/__tests__/openapi.test.ts
+++ b/src/__tests__/openapi.test.ts
@@ -359,7 +359,6 @@ describe('registerOpenApiSpec', () => {
     // Session actions
     expect(paths).toContain('/v1/sessions/{id}/send');
     expect(paths).toContain('/v1/sessions/{id}/command');
-    expect(paths).toContain('/v1/sessions/{id}/bash');
     expect(paths).toContain('/v1/sessions/{id}/approve');
     expect(paths).toContain('/v1/sessions/{id}/reject');
 

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -412,21 +412,6 @@ export function registerOpenApiSpec(): void {
 
   registerOpenApiPath({
     method: 'post',
-    path: '/v1/sessions/{id}/bash',
-    summary: 'Execute bash command',
-    description: 'Run a bash command in the session and capture output.',
-    tags: ['Session Actions'],
-    parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
-    requestBody: { content: { 'application/json': { schema: bashSchema } } },
-    responses: {
-      '200': okJsonResponse(z.object({ ok: z.boolean(), output: z.string().optional() })),
-      '400': validationErrorResponse(),
-      '404': notFoundResponse,
-    },
-  });
-
-  registerOpenApiPath({
-    method: 'post',
     path: '/v1/sessions/{id}/escape',
     summary: 'Send Escape key',
     tags: ['Session Actions'],
@@ -450,15 +435,6 @@ export function registerOpenApiSpec(): void {
     tags: ['Session Actions'],
     parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
     responses: { '200': okJsonResponse(z.object({ ok: z.boolean() })), '404': notFoundResponse },
-  });
-
-  registerOpenApiPath({
-    method: 'get',
-    path: '/v1/sessions/{id}/pane',
-    summary: 'Capture raw pane',
-    tags: ['Session Actions'],
-    parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
-    responses: { '200': okJsonResponse(z.object({ pane: z.string() })), '404': notFoundResponse },
   });
 
   registerOpenApiPath({

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -6,7 +6,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { compareSemver, extractCCVersion, MIN_CC_VERSION, buildEnvSchema, eventQuerySchema, eventReplaySchema } from '../validation.js';
+import { compareSemver, extractCCVersion, MIN_CC_VERSION, buildEnvSchema, eventReplaySchema } from '../validation.js';
 import { SYSTEM_TENANT } from '../config.js';
 import { filterByTenant } from '../utils/tenant-filter.js';
 import { validateWorkdirPath } from '../tenant-workdir.js';
@@ -385,7 +385,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           promptDelivery = await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
-        return reply.status(200).send({ ...existing, reused: true, promptDelivery });
+        return reply.status(200).send({ ...redactSession(existing as unknown as Record<string, unknown>), reused: true, promptDelivery });
       } finally {
         sessions.releaseSessionClaim(existing.id);
       }
@@ -505,27 +505,6 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
   }));
-
-  // ACP-063: GET /v1/sessions/:id/events — Retrieve stored ACP session event stream
-  registerWithLegacy(app, 'get', '/v1/sessions/:id/events', withOwnership(sessions, async (req: FastifyRequest, _reply: FastifyReply, session) => {
-    const parsed = eventQuerySchema.safeParse(req.query);
-    if (!parsed.success) {
-      return { error: 'Invalid query params', details: parsed.error.issues };
-    }
-
-    const { after, limit } = parsed.data;
-
-    // TODO (ACP-061): Once event store is added to RouteContext, retrieve events
-    // For now, return empty response as placeholder
-    return {
-      events: [],
-      pagination: {
-        hasMore: false,
-        nextAfter: undefined,
-      },
-    };
-  }));
-
   // ACP-063: POST /v1/sessions/:id/events/replay — Replay events to restore terminal state
   registerWithLegacy(app, 'post', '/v1/sessions/:id/events/replay', withValidation(eventReplaySchema, async (req: FastifyRequest, reply: FastifyReply, data) => {
     const sessionId = (req.params as Record<string, string>).id;


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
Fixes 6 pre-existing issues on develop that caused `npm run gate` to fail.

## Changes
- Remove `hover:bg-` from non-interactive OperatorTimeline div (clickable gate violation)
- Remove duplicate `GET /v1/sessions/:id/events` route registration — `session-data.ts` already owns it; ACP-063 placeholder was conflicting
- Remove `/v1/sessions/{id}/bash` and `/v1/sessions/{id}/pane` from OpenAPI spec and root `openapi.yaml` (tmux endpoints removed by ACP-062 but spec was stale)
- Update MCP tool count from 24 to 36 (ACP-065 added 12 ACP-native tools)
- Apply `redactSession()` to session reuse path in `sessions.ts` (prevented `hookSecret` leak)
- Remove bash path assertion from OpenAPI route group test

## Test plan
- [x] `npm run gate` passes (253 test files, 3876 tests)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes

Cleans up technical debt from recent ACP PRs (#2728, #2733, #2737) that left gate in failing state.