### PR TITLE
fix: resolve remaining develop gate failures

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1399,45 +1399,6 @@ paths:
 
 
 
-  "/v1/sessions/{id}/pane":
-    get:
-      operationId: "capturePane"
-      summary: "Raw terminal capture"
-      tags:
-        - "Sessions"
-
-      parameters:
-        - $ref: "#/components/parameters/sessionId"
-
-
-      responses:
-        "200":
-          description: "Terminal pane content"
-          content:
-            application/json:
-              schema:
-                type: "object"
-                properties:
-                  pane:
-                    type: "string"
-
-                  uiState:
-                    type: "string"
-
-
-
-
-
-
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-
-
-
   "/v1/sessions/{id}/command":
     post:
       operationId: "sendCommand"
@@ -1461,48 +1422,6 @@ paths:
                   description: "Shell command to execute"
 
                 workingDirectory:
-                  type: "string"
-
-
-              required:
-                - "command"
-
-
-
-
-
-      responses:
-        "202":
-          description: "Command sent"
-
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-
-
-
-  "/v1/sessions/{id}/bash":
-    post:
-      operationId: "sendBash"
-      summary: "Send a bash command (raw, no prompt wrapping)"
-      tags:
-        - "Sessions"
-
-      parameters:
-        - $ref: "#/components/parameters/sessionId"
-
-
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: "object"
-              properties:
-                command:
                   type: "string"
 
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -548,7 +548,7 @@ describe('createMcpServer', () => {
     expect(info.name).toBe('aegis');
   });
 
-  it('registers all 24 tools', () => {
+  it('registers all 36 tools', () => {
     const server = createMcpServer(9100);
     // The internal _registeredTools is private, but we can check via the server
     // We verify by checking that the tool handler setup doesn't throw
@@ -579,7 +579,7 @@ describe('createMcpServer', () => {
     expect(Object.keys(tools)).toContain('state_set');
     expect(Object.keys(tools)).toContain('state_get');
     expect(Object.keys(tools)).toContain('state_delete');
-    expect(Object.keys(tools)).toHaveLength(24);
+    expect(Object.keys(tools)).toHaveLength(36);
   });
 
   it('accepts custom auth token', () => {

--- a/src/__tests__/openapi.test.ts
+++ b/src/__tests__/openapi.test.ts
@@ -359,7 +359,6 @@ describe('registerOpenApiSpec', () => {
     // Session actions
     expect(paths).toContain('/v1/sessions/{id}/send');
     expect(paths).toContain('/v1/sessions/{id}/command');
-    expect(paths).toContain('/v1/sessions/{id}/bash');
     expect(paths).toContain('/v1/sessions/{id}/approve');
     expect(paths).toContain('/v1/sessions/{id}/reject');
 

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -21,7 +21,6 @@ import {
   authKeySchema,
   sendMessageSchema,
   commandSchema,
-  bashSchema,
   screenshotSchema,
   hookBodySchema,
   permissionHookSchema,
@@ -412,21 +411,6 @@ export function registerOpenApiSpec(): void {
 
   registerOpenApiPath({
     method: 'post',
-    path: '/v1/sessions/{id}/bash',
-    summary: 'Execute bash command',
-    description: 'Run a bash command in the session and capture output.',
-    tags: ['Session Actions'],
-    parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
-    requestBody: { content: { 'application/json': { schema: bashSchema } } },
-    responses: {
-      '200': okJsonResponse(z.object({ ok: z.boolean(), output: z.string().optional() })),
-      '400': validationErrorResponse(),
-      '404': notFoundResponse,
-    },
-  });
-
-  registerOpenApiPath({
-    method: 'post',
     path: '/v1/sessions/{id}/escape',
     summary: 'Send Escape key',
     tags: ['Session Actions'],
@@ -450,15 +434,6 @@ export function registerOpenApiSpec(): void {
     tags: ['Session Actions'],
     parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
     responses: { '200': okJsonResponse(z.object({ ok: z.boolean() })), '404': notFoundResponse },
-  });
-
-  registerOpenApiPath({
-    method: 'get',
-    path: '/v1/sessions/{id}/pane',
-    summary: 'Capture raw pane',
-    tags: ['Session Actions'],
-    parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
-    responses: { '200': okJsonResponse(z.object({ pane: z.string() })), '404': notFoundResponse },
   });
 
   registerOpenApiPath({

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -385,7 +385,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           promptDelivery = await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
-        return reply.status(200).send({ ...existing, reused: true, promptDelivery });
+        return reply.status(200).send({ ...redactSession(existing as unknown as Record<string, unknown>), reused: true, promptDelivery });
       } finally {
         sessions.releaseSessionClaim(existing.id);
       }


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
Fixes 4 test failures on develop that survived the ACP-066 merge:

1. Remove stale `/v1/sessions/{id}/bash` and `/v1/sessions/{id}/pane` OpenAPI registrations (from `openapi.ts` + root `openapi.yaml`)
2. Update MCP tool count test from 24 → 36 (ACP-065 added 12 ACP-native tools)
3. Apply `redactSession()` in session reuse path to prevent `hookSecret` leak (ACP-061 regression)
4. Remove stale `/v1/sessions/{id}/bash` assertion from `openapi.test.ts`

## Test plan
- [x] `npm test` — 253 files, 3876 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] OpenAPI spec regenerated — pane/bash absent

Closes #2740 (superseded)