### PR TITLE
fix: implement session/load for ACP crash recovery (ACP-065)

### DIFF
--- a/src/__tests__/acp-backend.test.ts
+++ b/src/__tests__/acp-backend.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   AcpBackend,
   AcpSessionNotFoundError,
+  hasLoadSessionCapability,
   type AcpBackendClient,
   type AcpBackendClientFactoryContext,
   type AcpBackendCreateSessionInput,
+  type AcpBackendInitializeResult,
   type AcpBackendSessionService,
   type AcpCreateSessionInput,
   type AcpJsonRpcInboundRequest,
@@ -502,6 +504,95 @@ describe('AcpBackend session lifecycle', () => {
         attemptCount: 1,
       })
     ).rejects.toThrow('prompt action metadata.text');
+  });
+
+  it('loads an existing session via session/load with history replay capability', async () => {
+    const service = new FakeSessionService([
+      createSessionRecord({
+        id: 'session-load',
+        acpAgentSessionId: 'acp-agent-existing',
+        claudeSessionId: 'claude-existing',
+        status: 'idle',
+      }),
+    ]);
+    const client = new FakeBackendClient();
+    client.setResult('initialize', {
+      agentCapabilities: { loadSession: true, close: true },
+      agentInfo: { name: 'fake-acp-agent', version: '0.32.0' },
+    });
+    client.setResult('session/load', {
+      sessionId: 'acp-agent-existing',
+      claudeSessionId: 'claude-existing',
+    });
+    const rawNotifications: AcpJsonRpcNotification[] = [];
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'backend-run-load',
+      onRawNotification: notification => rawNotifications.push(notification),
+    });
+
+    const loaded = await backend.loadSession({
+      ...scope,
+      sessionId: 'session-load',
+      cwd,
+      mcpServers: { filesystem: { command: 'node', args: ['server.js'] } },
+    });
+
+    expect(loaded.session).toMatchObject({
+      id: 'session-load',
+      status: 'idle',
+      acpAgentSessionId: 'acp-agent-existing',
+      currentBackendRunId: 'backend-run-load',
+    });
+    expect(loaded.initializeResult.agentCapabilities).toEqual({ loadSession: true, close: true });
+    expect(loaded.backendRunId).toBe('backend-run-load');
+    expect(client.requests.map(request => request.method)).toEqual([
+      'initialize',
+      'session/load',
+    ]);
+    expect(client.requests[1]?.params).toEqual({
+      sessionId: 'acp-agent-existing',
+      cwd,
+      mcpServers: { filesystem: { command: 'node', args: ['server.js'] } },
+      _meta: { aegis: { sessionId: 'session-load', backendRunId: 'backend-run-load' } },
+    });
+    expect(service.attachments).toEqual([
+      {
+        sessionId: 'session-load',
+        scope,
+        attachment: {
+          acpAgentSessionId: 'acp-agent-existing',
+          claudeSessionId: 'claude-existing',
+          backendRunId: 'backend-run-load',
+        },
+      },
+    ]);
+    expect(service.transitions).toEqual([]);
+  });
+
+  it('rejects loadSession without a verified ACP agent session id', async () => {
+    const service = new FakeSessionService([
+      createSessionRecord({ id: 'session-no-agent', status: 'initializing' }),
+    ]);
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => new FakeBackendClient(),
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    await expect(
+      backend.loadSession({ ...scope, sessionId: 'session-no-agent', cwd })
+    ).rejects.toThrow('without a verified ACP agent session id');
+  });
+
+  it('detects loadSession capability from initialize result', () => {
+    expect(hasLoadSessionCapability({ agentCapabilities: { loadSession: true } })).toBe(true);
+    expect(hasLoadSessionCapability({ agentCapabilities: { loadSession: false } })).toBe(false);
+    expect(hasLoadSessionCapability({ agentCapabilities: {} })).toBe(false);
+    expect(hasLoadSessionCapability({ agentCapabilities: null })).toBe(false);
+    expect(hasLoadSessionCapability({ agentCapabilities: undefined })).toBe(false);
+    expect(hasLoadSessionCapability({})).toBe(false);
   });
 });
 

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -85,6 +85,11 @@ export interface AcpBackendResumeSessionInput extends AcpBackendScopedRuntimeInp
   cwd: string;
 }
 
+export interface AcpBackendLoadSessionInput extends AcpBackendScopedRuntimeInput {
+  cwd: string;
+  mcpServers?: AcpJsonObject;
+}
+
 export type AcpBackendCancelSessionInput = AcpBackendScopedRuntimeInput;
 
 export type AcpBackendShutdownSessionInput = AcpBackendScopedRuntimeInput;
@@ -231,6 +236,16 @@ export class AcpBackend {
       );
     }
     return this.startResumeRuntime(session, input.cwd);
+  }
+
+  async loadSession(input: AcpBackendLoadSessionInput): Promise<AcpBackendStartResult> {
+    const session = await this.sessionService.getSession(input.sessionId, scopeFromInput(input));
+    if (!session.acpAgentSessionId) {
+      throw new AcpBackendLifecycleError(
+        `Cannot load ACP session ${session.id} without a verified ACP agent session id`
+      );
+    }
+    return this.startLoadRuntime(session, input.cwd, input.mcpServers);
   }
 
   async cancelSession(input: AcpBackendCancelSessionInput): Promise<AcpBackendCancelResult> {
@@ -414,6 +429,46 @@ export class AcpBackend {
       const response = await runtime.client.request<AcpBackendSessionResult>('session/resume', {
         sessionId: acpAgentSessionId,
         cwd,
+        _meta: this.buildAegisMetadata(session.id, backendRunId),
+      });
+      const attachment = attachmentFromResult(response.result, backendRunId);
+      const attached = await this.sessionService.attachAgentSession(
+        session.id,
+        runtime.scope,
+        attachment
+      );
+      const ready = await this.transitionIfInitializing(attached, runtime.scope, {
+        type: 'agent_ready',
+      });
+      this.runtimes.set(session.id, runtime);
+      return { session: ready, initializeResult, backendRunId };
+    } catch (error) {
+      await this.failStartup(session.id, runtime.scope, runtime, started);
+      throw error;
+    }
+  }
+
+  private async startLoadRuntime(
+    session: AcpSessionRecord,
+    cwd: string,
+    mcpServers?: AcpJsonObject
+  ): Promise<AcpBackendStartResult> {
+    const acpAgentSessionId = session.acpAgentSessionId;
+    if (!acpAgentSessionId) {
+      throw new AcpBackendLifecycleError(
+        `Cannot load ACP session ${session.id} without ACP agent session id`
+      );
+    }
+    const backendRunId = this.backendRunIdProvider();
+    const runtime = this.createRuntime(session, cwd, backendRunId);
+    let started = false;
+    try {
+      const initializeResult = await this.startAndInitialize(runtime);
+      started = true;
+      const response = await runtime.client.request<AcpBackendSessionResult>('session/load', {
+        sessionId: acpAgentSessionId,
+        cwd,
+        ...(mcpServers ? { mcpServers } : {}),
         _meta: this.buildAegisMetadata(session.id, backendRunId),
       });
       const attachment = attachmentFromResult(response.result, backendRunId);
@@ -766,4 +821,12 @@ function readPackageVersion(): string {
     return '0.0.0';
   }
   return typeof pkg.version === 'string' ? pkg.version : '0.0.0';
+}
+
+export function hasLoadSessionCapability(initializeResult: AcpBackendInitializeResult): boolean {
+  const capabilities = initializeResult.agentCapabilities;
+  if (typeof capabilities !== 'object' || capabilities === null || Array.isArray(capabilities)) {
+    return false;
+  }
+  return (capabilities as Record<string, unknown>).loadSession === true;
 }

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -183,6 +183,7 @@ export {
   type AcpBackendCreateSessionInput,
   type AcpBackendDispatchActionResult,
   type AcpBackendInitializeResult,
+  type AcpBackendLoadSessionInput,
   type AcpBackendOptions,
   type AcpBackendRestartBackoffContext,
   type AcpBackendRestartBackoffEvent,
@@ -196,6 +197,7 @@ export {
   type AcpBackendShutdownResult,
   type AcpBackendShutdownSessionInput,
   type AcpBackendStartResult,
+  hasLoadSessionCapability,
 } from './backend.js';
 export {
   ACP_TERMINAL_BRIDGE_UNVERIFIED_CASES,


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary

Implements `session/load` support for crash recovery history replay. Closes #2657.

## Changes

- `AcpBackend.loadSession()` — sends `session/load` to the ACP agent instead of `session/resume`, triggering full conversation history replay via `session/update` notifications
- `hasLoadSessionCapability()` — helper to detect `loadSession` capability from the `initialize` response `agentCapabilities`
- `AcpBackendLoadSessionInput` — new input type with optional `mcpServers`
- 3 new tests: load lifecycle, missing agent session guard, capability detection

## Test plan
- [x] `npm run gate` passes (13 acp-backend tests, 3875 total)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] New tests cover: load session happy path, missing acpAgentSessionId guard, capability detection edge cases

Closes #2657