### PR TITLE
fix(dashboard): remove tmux remnants post-ACP migration

### DIFF
--- a/dashboard/src/__tests__/HomeStatusPanel.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/HomeStatusPanel.mobile-responsive.test.tsx
@@ -23,7 +23,6 @@ function makeHealth(overrides: Partial<Record<string, unknown>> = {}) {
     platform: 'win32',
     uptime: 120,
     sessions: { active: 1, total: 3 },
-    tmux: { healthy: true, error: null },
     claude: { available: true, healthy: true, version: '2.1.90', minimumVersion: '2.1.80', error: null },
     timestamp: new Date().toISOString(),
     ...overrides,
@@ -48,7 +47,7 @@ describe('HomeStatusPanel mobile responsive', () => {
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    const card = screen.getByRole('article', { name: 'Claude CLI: Ready' });
     const iconCircle = card.querySelector('div.rounded-full');
 
     expect(iconCircle).not.toBeNull();
@@ -63,7 +62,7 @@ describe('HomeStatusPanel mobile responsive', () => {
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    const card = screen.getByRole('article', { name: 'Claude CLI: Ready' });
     // The "Ready" value element
     const valueEl = card.querySelector('.font-mono.font-bold');
     expect(valueEl).not.toBeNull();
@@ -76,7 +75,7 @@ describe('HomeStatusPanel mobile responsive', () => {
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Ready' });
+    const card = screen.getByRole('article', { name: 'Claude CLI: Ready' });
     // The row containing icon + label + value
     const row = card.querySelector('.flex.items-center');
     expect(row).not.toBeNull();
@@ -86,14 +85,14 @@ describe('HomeStatusPanel mobile responsive', () => {
 
   it('degraded status card shows action button with responsive margin', async () => {
     mockGetHealth.mockResolvedValue(makeHealth({
-      tmux: { healthy: false, error: 'tmux not running' },
+      claude: { available: true, healthy: false, version: '2.1.70', minimumVersion: '2.1.80', error: null },
     }));
 
     render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
 
     await act(async () => { await vi.runAllTicks(); });
 
-    const card = screen.getByRole('article', { name: 'Tmux status: Degraded' });
+    const card = screen.getByRole('article', { name: 'Claude CLI: Needs upgrade' });
     const actionBtn = card.querySelector('button');
     expect(actionBtn).not.toBeNull();
     expect(actionBtn!.classList.contains('ml-11')).toBe(true);

--- a/dashboard/src/__tests__/HomeStatusPanel.test.tsx
+++ b/dashboard/src/__tests__/HomeStatusPanel.test.tsx
@@ -21,10 +21,6 @@ function makeHealth(overrides: Partial<Record<string, unknown>> = {}) {
       active: 0,
       total: 0,
     },
-    tmux: {
-      healthy: true,
-      error: null,
-    },
     claude: {
       available: true,
       healthy: true,
@@ -54,14 +50,13 @@ describe('HomeStatusPanel', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders tmux, Claude CLI, and active session cards', async () => {
+  it('renders Claude CLI and active session cards', async () => {
     render(<MemoryRouter><HomeStatusPanel onCreateFirstSession={vi.fn()} /></MemoryRouter>);
 
     await act(async () => {
       await vi.runAllTicks();
     });
 
-    expect(screen.getByRole('article', { name: 'Tmux status: Ready' })).toBeDefined();
     expect(screen.getByRole('article', { name: 'Claude CLI: Ready' })).toBeDefined();
     expect(screen.getByRole('article', { name: 'Active sessions: 0' })).toBeDefined();
     expect(screen.getByText('Claude CLI 2.1.90 is available.')).toBeDefined();

--- a/dashboard/src/__tests__/__fixtures__/stream-bootstrap-user-content.txt
+++ b/dashboard/src/__tests__/__fixtures__/stream-bootstrap-user-content.txt
@@ -9,14 +9,14 @@ Claude: Here is the plan.
 ```powershell
 # This is a user-pasted code block and MUST NOT be stripped.
 Set-Location -LiteralPath 'D:\project'
-Remove-Item Env:TMUX -ErrorAction SilentlyContinue
+Install-Module -Name Pester -Force -Scope CurrentUser
 claude --session-id demo --permission-mode bypassPermissions
 ```
 
 And the Unix equivalent:
 
 ```sh
-cd /home/dev/project && unset TMUX TMUX_PANE && exec claude --session-id demo
+cd /home/dev/project && npm ci && claude --session-id demo
 ```
 
 > What is Frolicking?

--- a/dashboard/src/__tests__/sanitizeStream.test.ts
+++ b/dashboard/src/__tests__/sanitizeStream.test.ts
@@ -24,19 +24,9 @@ describe('sanitizeTerminalStream — module surface', () => {
   });
 });
 
-describe('sanitizeTerminalStream — Windows bootstrap fixture', () => {
+describe('sanitizeTerminalStream — Windows fixture', () => {
   const input = loadFixture('stream-bootstrap-win.txt');
   const output = sanitizeTerminalStream(input, 'win32');
-
-  it('strips the PowerShell prompt-only line', () => {
-    expect(output).not.toMatch(/^PS D:\\aegis>\s*$/m);
-  });
-
-  it('strips the Set-Location / Remove-Item / claude bootstrap line', () => {
-    expect(output).not.toMatch(/Set-Location\s+-LiteralPath/);
-    expect(output).not.toMatch(/Remove-Item\s+Env:TMUX/);
-    expect(output).not.toMatch(/--session-id\s+8c0b2b44/);
-  });
 
   it('strips the aegis-hooks settings path', () => {
     expect(output).not.toMatch(/aegis-hooks-[0-9a-f]{6,}/);
@@ -73,14 +63,9 @@ describe('sanitizeTerminalStream — Windows bootstrap fixture', () => {
   });
 });
 
-describe('sanitizeTerminalStream — Unix bootstrap fixture', () => {
+describe('sanitizeTerminalStream — Unix fixture', () => {
   const input = loadFixture('stream-bootstrap-unix.txt');
   const output = sanitizeTerminalStream(input, 'linux');
-
-  it('strips the unset TMUX TMUX_PANE && exec claude bootstrap line', () => {
-    expect(output).not.toMatch(/unset\s+TMUX\s+TMUX_PANE/);
-    expect(output).not.toMatch(/exec\s+claude/);
-  });
 
   it('strips the aegis-hooks settings path', () => {
     expect(output).not.toMatch(/aegis-hooks-[0-9a-f]{6,}/);
@@ -114,13 +99,8 @@ describe('sanitizeTerminalStream — user content fixture', () => {
   it('leaves user-pasted PowerShell code block contents untouched', () => {
     const output = sanitizeTerminalStream(input, 'win32');
     expect(output).toContain("Set-Location -LiteralPath 'D:\\project'");
-    expect(output).toContain('Remove-Item Env:TMUX -ErrorAction SilentlyContinue');
+    expect(output).toContain('Install-Module -Name Pester -Force -Scope CurrentUser');
     expect(output).toContain('claude --session-id demo --permission-mode bypassPermissions');
-  });
-
-  it('leaves user-pasted Unix code block contents untouched', () => {
-    const output = sanitizeTerminalStream(input, 'linux');
-    expect(output).toContain('cd /home/dev/project && unset TMUX TMUX_PANE && exec claude --session-id demo');
   });
 
   it('preserves the user question about "Frolicking"', () => {
@@ -133,33 +113,8 @@ describe('sanitizeTerminalStream — user content fixture', () => {
     const output = sanitizeTerminalStream(input, 'linux');
     expect(output).toMatch(/```powershell/);
     expect(output).toMatch(/```sh/);
-    // Three closing fences (powershell, sh) — count of ``` should be >= 4 on boundaries.
     const fenceCount = (output.match(/```/g) ?? []).length;
     expect(fenceCount).toBeGreaterThanOrEqual(4);
-  });
-});
-
-describe('sanitizeTerminalStream — cross-platform safety', () => {
-  it('also strips a Unix bootstrap when platform is win32 (defence in depth)', () => {
-    const input = "cd '/home/dev/x' && unset TMUX TMUX_PANE && exec claude --session-id demo\nhello world\n";
-    const output = sanitizeTerminalStream(input, 'win32');
-    expect(output).not.toMatch(/unset TMUX TMUX_PANE/);
-    expect(output).toContain('hello world');
-  });
-
-  it('also strips a Windows bootstrap when platform is linux (defence in depth)', () => {
-    const input =
-      "Set-Location -LiteralPath 'D:\\x'; Remove-Item Env:TMUX -ErrorAction SilentlyContinue; claude --session-id demo\nhello world\n";
-    const output = sanitizeTerminalStream(input, 'linux');
-    expect(output).not.toMatch(/Remove-Item Env:TMUX/);
-    expect(output).toContain('hello world');
-  });
-
-  it('darwin platform hint behaves like linux for Unix bootstraps', () => {
-    const input = "unset TMUX TMUX_PANE && exec claude --session-id demo\nhello\n";
-    const output = sanitizeTerminalStream(input, 'darwin');
-    expect(output).not.toMatch(/unset TMUX TMUX_PANE/);
-    expect(output).toContain('hello');
   });
 });
 

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -150,10 +150,6 @@ export const HealthResponseSchema: z.ZodType<HealthResponse> = z.object({
     active: z.number(),
     total: z.number(),
   }),
-  tmux: z.object({
-    healthy: z.boolean(),
-    error: z.string().nullable(),
-  }).optional(),
   claude: z.object({
     available: z.boolean(),
     healthy: z.boolean(),

--- a/dashboard/src/components/overview/HomeStatusPanel.tsx
+++ b/dashboard/src/components/overview/HomeStatusPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, type ReactNode } from 'react';
-import { Activity, Bot, Plus, Terminal, ExternalLink } from 'lucide-react';
+import { Activity, Bot, Plus, ExternalLink } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getHealth } from '../../api/client.js';
 import { useSseAwarePolling } from '../../hooks/useSseAwarePolling.js';
@@ -98,38 +98,6 @@ function StatusCard({ label, value, detail, tone, icon, actionButton }: StatusCa
       </div>
     </article>
   );
-}
-
-function getTmuxCard(health: HealthResponse | null, isLoading: boolean, loadError: string | null): Omit<StatusCardProps, 'icon' | 'label'> {
-  if (isLoading && !health) {
-    return {
-      value: 'Checking…',
-      detail: 'Verifying that the tmux server is responding.',
-      tone: 'blue',
-    };
-  }
-
-  if (!health?.tmux) {
-    return {
-      value: 'Unavailable',
-      detail: loadError ?? 'Tmux status has not been reported yet.',
-      tone: 'red',
-    };
-  }
-
-  if (!health.tmux.healthy) {
-    return {
-      value: 'Degraded',
-      detail: health.tmux.error ?? 'Tmux is not responding to health checks.',
-      tone: 'red',
-    };
-  }
-
-  return {
-    value: 'Ready',
-    detail: 'Tmux server is reachable and ready for new sessions.',
-    tone: 'green',
-  };
 }
 
 function getClaudeCard(health: HealthResponse | null, isLoading: boolean, loadError: string | null): Omit<StatusCardProps, 'icon' | 'label'> {
@@ -237,7 +205,6 @@ export default function HomeStatusPanel({ onCreateFirstSession }: HomeStatusPane
   const showStatusRow = Boolean(loadError) || Boolean(!sseConnected && sseError);
 
   const navigate = useNavigate();
-  const tmuxCard = getTmuxCard(health, isLoading, loadError);
   const claudeCard = getClaudeCard(health, isLoading, loadError);
   const activeSessionsCard = getActiveSessionsCard(health, isLoading, loadError);
 
@@ -256,16 +223,7 @@ export default function HomeStatusPanel({ onCreateFirstSession }: HomeStatusPane
         </div>
       )}
 
-      <div className="grid gap-3 md:grid-cols-3">
-        <StatusCard
-          label="Tmux status"
-          icon={<Terminal className="h-4 w-4" />}
-          {...tmuxCard}
-          actionButton={tmuxCard.tone === 'red' || tmuxCard.tone === 'amber' ? {
-            label: 'View Logs',
-            onClick: () => navigate('/audit'),
-          } : undefined}
-        />
+      <div className="grid gap-3 md:grid-cols-2">
         <StatusCard
           label="Claude CLI"
           icon={<Bot className="h-4 w-4" />}

--- a/dashboard/src/components/session/TerminalPassthrough.tsx
+++ b/dashboard/src/components/session/TerminalPassthrough.tsx
@@ -16,10 +16,8 @@ import { ClaudeStatusStrip, parseStatusFooter, type ClaudeStatusStripProps } fro
 import { useSessionEventsStore } from '../../store/useSessionEventsStore';
 
 /** Heuristic browser-side platform hint for the sanitizer. The server's OS
- * is not reliably known to the client — bootstraps are echoed by tmux the
- * same way regardless — so we only distinguish Windows from Unix here and
- * let the sanitizer fall back across both pattern families (see
- * `utils/sanitizeStream.ts`). */
+ * is not reliably known to the client, so we only distinguish Windows from
+ * Unix here (see `utils/sanitizeStream.ts`). */
 function detectClientPlatform(): 'win32' | 'darwin' | 'linux' {
   if (typeof navigator === 'undefined') return 'linux';
   if (/Windows/i.test(navigator.userAgent)) return 'win32';

--- a/dashboard/src/components/tour/FirstRunTour.tsx
+++ b/dashboard/src/components/tour/FirstRunTour.tsx
@@ -198,7 +198,7 @@ export function FirstRunTour({ onComplete }: FirstRunTourProps) {
     },
     killing: {
       title: 'Clean up the session',
-      description: 'Now let\'s clean up by killing the tutorial session. This stops the tmux session and removes it from the active list.',
+      description: 'Now let\'s clean up by killing the tutorial session. This stops the session and removes it from the active list.',
       icon: <Trash2 className="h-12 w-12 text-red-400" />,
       action: (
         <button

--- a/dashboard/src/utils/sanitizeStream.ts
+++ b/dashboard/src/utils/sanitizeStream.ts
@@ -1,14 +1,11 @@
 /**
- * utils/sanitizeStream.ts — Client-side sanitation of the tmux capture-pane
- * stream before it is rendered by xterm.js.
+ * utils/sanitizeStream.ts — Client-side sanitation of the terminal stream
+ * before it is rendered by xterm.js.
  *
- * The Claude Code launch command is echoed into the pane at spawn time, and
- * tmux `capture-pane` faithfully returns it. The resulting noise includes:
+ * The Claude Code session output may contain noise that should not appear in
+ * the dashboard's terminal view:
  *
- *   - PowerShell / bash bootstrap lines
- *       `Set-Location -LiteralPath '…'; Remove-Item Env:TMUX …; claude …`
- *       `cd '…' && unset TMUX TMUX_PANE && exec claude …`
- *   - A references to the random hook-settings path
+ *   - References to the random hook-settings path
  *       `…\aegis-hooks-4f3a1b\hooks-<uuid>.json`
  *   - The Claude CLI ASCII logo block
  *   - Raw Claude CLI status-footer text
@@ -39,24 +36,6 @@ export interface SanitizeOptions {
 }
 
 // ── Pattern helpers ────────────────────────────────────────────────
-
-/** PowerShell prompt prefix, e.g. `PS D:\aegis>` or `PS C:\Users\dev\foo>` */
-const WIN_PS_PROMPT = /^PS\s+[A-Za-z]:[^\n>]*>\s*/;
-
-/**
- * Windows bootstrap: optional `Set-Location -LiteralPath '…';` then one or
- * more `Remove-Item Env:TMUX…` clauses then `claude …`. May be preceded by a
- * PowerShell prompt. Matches the whole line.
- */
-const WIN_BOOTSTRAP_LINE =
-  /^(?:PS\s+[A-Za-z]:[^\n>]*>\s*)?(?:Set-Location\s+-LiteralPath\s+[^;]+;\s*)?Remove-Item\s+Env:TMUX(?:_PANE)?\b[^\n]*claude\b[^\n]*$/;
-
-/**
- * Unix bootstrap: optional `cd '…' &&` then `unset TMUX TMUX_PANE && exec
- * claude …`. Matches the whole line. Also tolerates a leading `$ ` prompt.
- */
-const UNIX_BOOTSTRAP_LINE =
-  /^(?:\$\s+)?(?:cd\s+[^\n&]+&&\s*)?unset\s+TMUX\s+TMUX_PANE\s*&&\s*(?:exec\s+)?claude\b[^\n]*$/;
 
 /**
  * Any line that contains a reference to the randomised hooks-settings path.
@@ -226,78 +205,34 @@ function findLogoBlock(
   return null;
 }
 
-// ── Platform resolution ────────────────────────────────────────────
-
-function resolvePlatform(
-  hint: SanitizeOptions['platform'],
-  explicit?: 'win32' | 'darwin' | 'linux',
-): 'win32' | 'darwin' | 'linux' {
-  if (explicit) return explicit;
-  if (hint && hint !== 'auto') {
-    // Narrow NodeJS.Platform down to the three we care about; anything else
-    // falls back to `linux`-style matching.
-    if (hint === 'win32') return 'win32';
-    if (hint === 'darwin') return 'darwin';
-    return 'linux';
-  }
-  if (typeof navigator !== 'undefined' && /Windows/i.test(navigator.userAgent)) {
-    return 'win32';
-  }
-  return 'linux';
-}
-
 // ── Main entry point ───────────────────────────────────────────────
 
 /**
- * Strip shell bootstrap, hook-settings paths, the Claude CLI ASCII logo
- * block, and status-footer noise from a pane-capture string.
+ * Strip hook-settings paths, the Claude CLI ASCII logo block, and
+ * status-footer noise from a terminal stream string.
  *
  * Pure, deterministic, side-effect-free. Same input always yields same
  * output. Safe to call on every pane delta.
  */
 export function sanitizeTerminalStream(
   text: string,
-  platform: 'win32' | 'darwin' | 'linux',
+  _platform: 'win32' | 'darwin' | 'linux',
   options: SanitizeOptions = {},
 ): string {
   if (options.preserveRaw) return text;
   if (!text) return text;
 
-  const resolved = resolvePlatform(options.platform, platform);
-
   // Preserve the trailing newline behaviour: split then rejoin with `\n`.
   const lines = text.split('\n');
   const protectedMask = markProtectedLines(lines);
 
-  // Pick the bootstrap regex for this platform. We still check both patterns
-  // as a safety net — a Windows client connected to a macOS server will see
-  // Unix bootstraps, and vice versa.
-  const bootstrapRegexes: RegExp[] = resolved === 'win32'
-    ? [WIN_BOOTSTRAP_LINE, UNIX_BOOTSTRAP_LINE]
-    : [UNIX_BOOTSTRAP_LINE, WIN_BOOTSTRAP_LINE];
-
   // Pre-compute a mask of lines to drop.
   const drop = new Array<boolean>(lines.length).fill(false);
 
-  // 1. Bootstrap + hooks-path + status lines.
+  // 1. Hooks-path + status lines.
   for (let i = 0; i < lines.length; i++) {
     if (protectedMask[i]) continue;
     const line = lines[i];
-
-    // A bare PowerShell prompt line immediately preceding a bootstrap line.
-    // We strip it only when the very next non-empty line is a bootstrap.
-    if (resolved === 'win32' && WIN_PS_PROMPT.test(line) && line.replace(WIN_PS_PROMPT, '').trim() === '') {
-      const nextIdx = nextNonEmptyIndex(lines, protectedMask, i + 1);
-      if (nextIdx !== -1 && bootstrapRegexes.some((re) => re.test(lines[nextIdx]))) {
-        drop[i] = true;
-        continue;
-      }
-    }
-
-    if (bootstrapRegexes.some((re) => re.test(line))) {
-      drop[i] = true;
-      continue;
-    }
 
     if (HOOKS_PATH_LINE.test(line)) {
       drop[i] = true;
@@ -336,18 +271,6 @@ export function sanitizeTerminalStream(
   }
 
   return out.join('\n');
-}
-
-function nextNonEmptyIndex(
-  lines: readonly string[],
-  protectedMask: readonly boolean[],
-  from: number,
-): number {
-  for (let i = from; i < lines.length; i++) {
-    if (protectedMask[i]) return -1;
-    if (lines[i].trim() !== '') return i;
-  }
-  return -1;
 }
 
 export default sanitizeTerminalStream;


### PR DESCRIPTION
## Summary
Backend tmux runtime was fully deleted in #2718/#2743. The `/v1/health` endpoint no longer returns a `tmux` field. This PR removes all dead tmux references from the dashboard.

Closes #2748

## Changes
- **schemas.ts** — Remove `tmux` field from `HealthResponse` Zod schema
- **HomeStatusPanel.tsx** — Delete `getTmuxCard()` and tmux status card from render (grid 3→2 cols)
- **sanitizeStream.ts** — Remove tmux bootstrap regex patterns (`WIN_BOOTSTRAP_LINE`, `UNIX_BOOTSTRAP_LINE`, `WIN_PS_PROMPT`, `nextNonEmptyIndex`). Keep hooks-path, Claude logo, and status-footer sanitization
- **sanitizeStream.test.ts** — Remove tmux bootstrap test cases (-49 lines)
- **HomeStatusPanel.test.tsx** — Remove tmux health mock and assertion
- **HomeStatusPanel.mobile-responsive.test.tsx** — Remove tmux mock and assertions
- **FirstRunTour.tsx** — Update "stops the tmux session" → "stops the session"
- **TerminalPassthrough.tsx** — Update comment to remove tmux reference
- **stream-bootstrap-user-content.txt** — Replace tmux content in test fixture

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — 98 files, 1044 tests pass, 2 skipped
- Zero tmux references remain in dashboard source
- All changes scoped to `dashboard/` only