### PR TITLE
fix(dashboard): wire ACP control client from mock to real API calls

### DIFF
--- a/dashboard/src/__tests__/acp-control.test.ts
+++ b/dashboard/src/__tests__/acp-control.test.ts
@@ -2,7 +2,7 @@
  * __tests__/acp-control.test.ts
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   sendControlAction,
   pauseSession,
@@ -15,6 +15,38 @@ import {
 } from '../api/acp-control-client';
 import type { ControlActionRequest } from '../api/acp-control-client';
 import { deriveControlAvailability } from '../types/acp-control';
+
+// Mock the acp-pause-client module
+const mockPauseSessionApi = vi.fn();
+const mockResumeSessionApi = vi.fn();
+const mockStartInterventionApi = vi.fn();
+const mockCompleteInterventionApi = vi.fn();
+const mockGetSessionInterventionApi = vi.fn();
+
+vi.mock('../api/acp-pause-client.js', () => ({
+  pauseSession: (...args: unknown[]) => mockPauseSessionApi(...args),
+  resumeSession: (...args: unknown[]) => mockResumeSessionApi(...args),
+  startIntervention: (...args: unknown[]) => mockStartInterventionApi(...args),
+  completeIntervention: (...args: unknown[]) => mockCompleteInterventionApi(...args),
+  getSessionIntervention: (...args: unknown[]) => mockGetSessionInterventionApi(...args),
+}));
+
+const mockPolicyResult = (sessionId: string) => ({
+  session: { id: sessionId, status: 'paused', updatedAt: '2026-05-06T07:00:00.000Z' },
+  pause: {
+    pauseId: 'pause-1',
+    sessionId,
+    status: 'paused' as const,
+    reason: 'test',
+    requestedBy: 'test-user',
+    requestedAt: '2026-05-06T07:00:00.000Z',
+    updatedAt: '2026-05-06T07:00:00.000Z',
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('generateActionId', () => {
   it('returns a string starting with ctrl-', () => {
@@ -29,25 +61,87 @@ describe('generateActionId', () => {
 });
 
 describe('sendControlAction', () => {
-  it('returns completed mock response', async () => {
+  it('delegates pause to the real API', async () => {
+    mockPauseSessionApi.mockResolvedValue(mockPolicyResult('sess-1'));
     const request: ControlActionRequest = {
       actionId: 'test-1',
       sessionId: 'sess-1',
       type: 'pause',
-      reason: 'test',
+      reason: 'security review',
     };
     const result = await sendControlAction(request);
+    expect(mockPauseSessionApi).toHaveBeenCalledWith('sess-1', {
+      reason: 'security review',
+      idempotencyKey: 'test-1',
+    }, undefined);
     expect(result.actionId).toBe('test-1');
-    expect(result.sessionId).toBe('sess-1');
-    expect(result.type).toBe('pause');
     expect(result.status).toBe('completed');
-    expect(result.timestamp).toBeDefined();
+    expect(result.timestamp).toBe('2026-05-06T07:00:00.000Z');
+  });
+
+  it('delegates resume to the real API', async () => {
+    mockResumeSessionApi.mockResolvedValue(mockPolicyResult('sess-2'));
+    const result = await sendControlAction({
+      actionId: 'test-2',
+      sessionId: 'sess-2',
+      type: 'resume',
+    });
+    expect(mockResumeSessionApi).toHaveBeenCalledWith('sess-2', {
+      resumedBy: 'test-2',
+    }, undefined);
+    expect(result.status).toBe('completed');
+  });
+
+  it('delegates intervene without guidance to startIntervention', async () => {
+    mockStartInterventionApi.mockResolvedValue(mockPolicyResult('sess-3'));
+    const result = await sendControlAction({
+      actionId: 'test-3',
+      sessionId: 'sess-3',
+      type: 'intervene',
+    });
+    expect(mockStartInterventionApi).toHaveBeenCalledWith('sess-3', {
+      interventionBy: 'test-3',
+    }, undefined);
+    expect(result.status).toBe('completed');
+  });
+
+  it('delegates intervene with guidance to completeIntervention', async () => {
+    mockCompleteInterventionApi.mockResolvedValue(mockPolicyResult('sess-4'));
+    const result = await sendControlAction({
+      actionId: 'test-4',
+      sessionId: 'sess-4',
+      type: 'intervene',
+      guidance: 'follow these steps',
+    });
+    expect(mockCompleteInterventionApi).toHaveBeenCalledWith('sess-4', {
+      completedBy: 'test-4',
+      guidance: 'follow these steps',
+    }, undefined);
+    expect(result.status).toBe('completed');
+  });
+
+  it('throws for cancel type', async () => {
+    await expect(sendControlAction({
+      actionId: 'test-5',
+      sessionId: 'sess-5',
+      type: 'cancel',
+    })).rejects.toThrow('Cancel not yet implemented');
+  });
+
+  it('throws for unknown type', async () => {
+    await expect(sendControlAction({
+      actionId: 'test-6',
+      sessionId: 'sess-6',
+      type: 'prompt' as ControlActionRequest['type'],
+    })).rejects.toThrow('Unknown control action type');
   });
 });
 
 describe('pauseSession', () => {
-  it('sends pause action with reason', async () => {
+  it('sends pause action with reason via delegation', async () => {
+    mockPauseSessionApi.mockResolvedValue(mockPolicyResult('sess-1'));
     const result = await pauseSession('sess-1', 'security review');
+    expect(mockPauseSessionApi).toHaveBeenCalled();
     expect(result.type).toBe('pause');
     expect(result.sessionId).toBe('sess-1');
     expect(result.actionId).toMatch(/^ctrl-/);
@@ -55,26 +149,33 @@ describe('pauseSession', () => {
 });
 
 describe('resumeSession', () => {
-  it('sends resume action', async () => {
+  it('sends resume action via delegation', async () => {
+    mockResumeSessionApi.mockResolvedValue(mockPolicyResult('sess-1'));
     const result = await resumeSession('sess-1');
+    expect(mockResumeSessionApi).toHaveBeenCalled();
     expect(result.type).toBe('resume');
   });
 });
 
 describe('startIntervention', () => {
-  it('sends intervene action', async () => {
+  it('sends intervene action via delegation', async () => {
+    mockStartInterventionApi.mockResolvedValue(mockPolicyResult('sess-1'));
     const result = await startIntervention('sess-1');
+    expect(mockStartInterventionApi).toHaveBeenCalled();
     expect(result.type).toBe('intervene');
   });
 });
 
 describe('completeIntervention', () => {
-  it('sends intervene action with guidance', async () => {
+  it('sends intervene action with guidance via delegation', async () => {
+    mockCompleteInterventionApi.mockResolvedValue(mockPolicyResult('sess-1'));
     const result = await completeIntervention('sess-1', 'follow these steps');
+    expect(mockCompleteInterventionApi).toHaveBeenCalled();
     expect(result.type).toBe('intervene');
   });
 
-  it('works without guidance', async () => {
+  it('works without guidance via delegation', async () => {
+    mockStartInterventionApi.mockResolvedValue(mockPolicyResult('sess-1'));
     const result = await completeIntervention('sess-1');
     expect(result.type).toBe('intervene');
     expect(result.status).toBe('completed');
@@ -82,16 +183,51 @@ describe('completeIntervention', () => {
 });
 
 describe('cancelSession', () => {
-  it('sends cancel action', async () => {
-    const result = await cancelSession('sess-1');
-    expect(result.type).toBe('cancel');
+  it('throws because cancel is not yet implemented', async () => {
+    await expect(cancelSession('sess-1')).rejects.toThrow('Cancel not yet implemented');
   });
 });
 
 describe('getIntervention', () => {
-  it('returns null in mock mode', async () => {
+  it('returns mapped record from real API', async () => {
+    mockGetSessionInterventionApi.mockResolvedValue({
+      pauseId: 'pause-1',
+      sessionId: 'sess-1',
+      status: 'paused',
+      reason: 'test reason',
+      requestedBy: 'test-user',
+      requestedAt: '2026-05-06T07:00:00.000Z',
+      updatedAt: '2026-05-06T07:00:00.000Z',
+    });
+    const result = await getIntervention('sess-1');
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('pause-1');
+    expect(result!.sessionId).toBe('sess-1');
+    expect(result!.reason).toBe('test reason');
+    expect(result!.actor).toBe('test-user');
+    expect(result!.status).toBe('active');
+  });
+
+  it('returns null when no intervention exists', async () => {
+    mockGetSessionInterventionApi.mockResolvedValue(null);
     const result = await getIntervention('sess-1');
     expect(result).toBeNull();
+  });
+
+  it('maps resumed status to completed', async () => {
+    mockGetSessionInterventionApi.mockResolvedValue({
+      pauseId: 'pause-2',
+      sessionId: 'sess-2',
+      status: 'resumed',
+      reason: 'test',
+      requestedBy: 'user',
+      requestedAt: '2026-05-06T07:00:00.000Z',
+      interventionCompletedAt: '2026-05-06T07:05:00.000Z',
+      updatedAt: '2026-05-06T07:05:00.000Z',
+    });
+    const result = await getIntervention('sess-2');
+    expect(result!.status).toBe('completed');
+    expect(result!.completedAt).toBe('2026-05-06T07:05:00.000Z');
   });
 });
 

--- a/dashboard/src/api/acp-approval-client.ts
+++ b/dashboard/src/api/acp-approval-client.ts
@@ -1,23 +1,25 @@
 /**
  * api/acp-approval-client.ts — API client for ACP approval actions.
  *
- * Placeholder functions aligned with ACP-064 (control action endpoints).
- * Approve/reject go through the control action API with type=approve/reject.
+ * Wired to real endpoints from ACP-064 (control action endpoints).
  *
- * Assumed endpoints:
+ * Endpoints:
  *   POST /v1/sessions/:id/approval/approve
  *   POST /v1/sessions/:id/approval/reject
  *   GET  /v1/sessions/:id/approval/pending
  */
 
-const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
-
+import { getAuthHeaders } from './client.js';
 import type {
   AcpApprovalRequest,
   AcpApproveRequest,
   AcpRejectRequest,
   AcpApprovalActionResult,
 } from '../types/acp-approval';
+
+const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
+
+const JSON_HEADERS = getAuthHeaders({ 'Content-Type': 'application/json' });
 
 /** Approve a pending tool approval. */
 export async function approveTool(
@@ -27,8 +29,9 @@ export async function approveTool(
 ): Promise<AcpApprovalActionResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/approval/approve`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to approve tool: ${res.status}`);
@@ -43,8 +46,9 @@ export async function rejectTool(
 ): Promise<AcpApprovalActionResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/approval/reject`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to reject tool: ${res.status}`);
@@ -57,6 +61,8 @@ export async function getPendingApproval(
   signal?: AbortSignal,
 ): Promise<AcpApprovalRequest | null> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/approval/pending`, {
+    headers: getAuthHeaders(),
+    credentials: 'include',
     signal,
   });
   if (res.status === 404) return null;

--- a/dashboard/src/api/acp-control-client.ts
+++ b/dashboard/src/api/acp-control-client.ts
@@ -1,17 +1,21 @@
 /**
  * api/acp-control-client.ts — ACP control action API client.
  *
- * Handles pause, resume, intervention, and cancel actions for sessions.
- * All mutating control actions are idempotent (actionId-based).
+ * High-level wrapper that delegates to the real ACP sub-clients:
+ *   - acp-pause-client.ts (pause, resume, intervention)
+ *   - acp-driver-client.ts (driver claim/release/transfer)
  *
- * Planned contract (from ACP-064 / #2607):
- *   POST /v1/sessions/:sessionId/actions
- *   Body: { actionId, type, sessionId, ...typeSpecificFields }
- *
- * TODO: Swap mock implementation for real fetch calls once #2607 lands.
+ * All mutating control actions use actionId-based idempotency.
  */
 
 import type { AcpControlActionType } from '../types/acp-control';
+import {
+  pauseSession as pauseSessionApi,
+  resumeSession as resumeSessionApi,
+  startIntervention as startInterventionApi,
+  completeIntervention as completeInterventionApi,
+  getSessionIntervention as getSessionInterventionApi,
+} from './acp-pause-client.js';
 
 /** Control action request payload. */
 export interface ControlActionRequest {
@@ -53,46 +57,95 @@ export function generateActionId(): string {
 
 /**
  * Send a control action to a session.
- *
- * TODO: Replace with real fetch once #2607 lands.
+ * Delegates to the real ACP pause/intervention endpoints.
  */
 export async function sendControlAction(
   request: ControlActionRequest,
+  signal?: AbortSignal,
 ): Promise<ControlActionResponse> {
-  // TODO: Real implementation
-  // const res = await fetch(`/v1/sessions/${encodeURIComponent(request.sessionId)}/actions`, {
-  //   method: 'POST',
-  //   headers: { 'Content-Type': 'application/json' },
-  //   body: JSON.stringify(request),
-  // });
-  // if (!res.ok) throw new Error(`Control action failed: ${res.status}`);
-  // return res.json();
+  try {
+    let result;
 
-  // Mock implementation for scaffold phase
-  return {
-    actionId: request.actionId,
-    sessionId: request.sessionId,
-    type: request.type,
-    status: 'completed',
-    timestamp: new Date().toISOString(),
-  };
+    switch (request.type) {
+      case 'pause':
+        result = await pauseSessionApi(request.sessionId, {
+          reason: request.reason ?? '',
+          idempotencyKey: request.actionId,
+        }, signal);
+        break;
+
+      case 'resume':
+        result = await resumeSessionApi(request.sessionId, {
+          resumedBy: request.actionId,
+        }, signal);
+        break;
+
+      case 'intervene':
+        if (request.guidance) {
+          result = await completeInterventionApi(request.sessionId, {
+            completedBy: request.actionId,
+            guidance: request.guidance,
+          }, signal);
+        } else {
+          result = await startInterventionApi(request.sessionId, {
+            interventionBy: request.actionId,
+          }, signal);
+        }
+        break;
+
+      case 'cancel':
+        throw new Error('Cancel not yet implemented via ACP control endpoints');
+
+      default:
+        throw new Error(`Unknown control action type: ${request.type}`);
+    }
+
+    return {
+      actionId: request.actionId,
+      sessionId: request.sessionId,
+      type: request.type,
+      status: 'completed',
+      timestamp: result.session.updatedAt,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      // Map known error codes from the backend
+      if (error.message.includes('409')) {
+        return {
+          actionId: request.actionId,
+          sessionId: request.sessionId,
+          type: request.type,
+          status: 'failed',
+          error: error.message,
+          timestamp: new Date().toISOString(),
+        };
+      }
+      throw error;
+    }
+    throw new Error(String(error));
+  }
 }
 
 /**
  * Get the current intervention record for a session (if any).
- *
- * TODO: Replace with real fetch once #2607 lands.
  */
 export async function getIntervention(
-  _sessionId: string,
+  sessionId: string,
+  signal?: AbortSignal,
 ): Promise<InterventionRecord | null> {
-  // TODO: Real implementation
-  // const res = await fetch(`/v1/sessions/${encodeURIComponent(sessionId)}/intervention`);
-  // if (res.status === 404) return null;
-  // if (!res.ok) throw new Error(`Failed to get intervention: ${res.status}`);
-  // return res.json();
+  const record = await getSessionInterventionApi(sessionId, signal);
+  if (!record) return null;
 
-  return null;
+  return {
+    id: record.pauseId,
+    sessionId: record.sessionId,
+    reason: record.reason,
+    guidance: record.guidance,
+    actor: record.requestedBy,
+    startedAt: record.requestedAt,
+    completedAt: record.interventionCompletedAt,
+    status: record.status === 'paused' ? 'active' : 'completed',
+  };
 }
 
 /** Pause a session with a reason. */

--- a/dashboard/src/api/acp-driver-client.ts
+++ b/dashboard/src/api/acp-driver-client.ts
@@ -1,18 +1,17 @@
 /**
  * api/acp-driver-client.ts — API client for ACP driver/observer controls.
  *
- * Placeholder functions aligned with ACP-028 (Redis presence, driver locks)
+ * Wired to real endpoints from ACP-028 (Redis presence, driver locks)
  * and ACP-064 (control action endpoints).
  *
- * Assumed endpoints:
+ * Endpoints:
  *   POST /v1/sessions/:id/driver/claim
  *   POST /v1/sessions/:id/driver/release
  *   POST /v1/sessions/:id/driver/transfer
  *   GET  /v1/sessions/:id/participants
  */
 
-const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
-
+import { getAuthHeaders } from './client.js';
 import type {
   AcpClaimDriverRequest,
   AcpReleaseDriverRequest,
@@ -20,6 +19,10 @@ import type {
   AcpDriverActionResult,
   AcpSessionParticipants,
 } from '../types/acp-driver-observer';
+
+const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
+
+const JSON_HEADERS = getAuthHeaders({ 'Content-Type': 'application/json' });
 
 /** Claim the driver role for a session. */
 export async function claimDriver(
@@ -29,8 +32,9 @@ export async function claimDriver(
 ): Promise<AcpDriverActionResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/driver/claim`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to claim driver: ${res.status}`);
@@ -45,8 +49,9 @@ export async function releaseDriver(
 ): Promise<AcpDriverActionResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/driver/release`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to release driver: ${res.status}`);
@@ -61,8 +66,9 @@ export async function transferDriver(
 ): Promise<AcpDriverActionResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/driver/transfer`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to transfer driver: ${res.status}`);
@@ -75,6 +81,8 @@ export async function getSessionParticipants(
   signal?: AbortSignal,
 ): Promise<AcpSessionParticipants> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/participants`, {
+    headers: getAuthHeaders(),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to get participants: ${res.status}`);

--- a/dashboard/src/api/acp-pause-client.ts
+++ b/dashboard/src/api/acp-pause-client.ts
@@ -1,10 +1,7 @@
 /**
  * api/acp-pause-client.ts — API client for ACP pause/resume/intervention.
  *
- * Placeholder functions aligned with the ACP-064 control action endpoints.
- * Once the backend routes are defined, these will be wired to the real endpoints.
- *
- * Current assumption: endpoints follow the pattern
+ * Wired to real endpoints from ACP-064 (#2607):
  *   POST /v1/sessions/:id/pause
  *   POST /v1/sessions/:id/intervention/start
  *   POST /v1/sessions/:id/intervention/complete
@@ -12,7 +9,7 @@
  *   GET  /v1/sessions/:id/intervention
  */
 
-const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
+import { getAuthHeaders } from './client.js';
 import type {
   AcpPauseInterventionRecord,
   AcpPauseSessionRequest,
@@ -22,6 +19,10 @@ import type {
   AcpPauseInterventionPolicyResult,
 } from '../types/acp-pause';
 
+const BASE_URL = import.meta.env.VITE_AEGIS_URL ?? '';
+
+const JSON_HEADERS = getAuthHeaders({ 'Content-Type': 'application/json' });
+
 /** Pause a running session. */
 export async function pauseSession(
   sessionId: string,
@@ -30,8 +31,9 @@ export async function pauseSession(
 ): Promise<AcpPauseInterventionPolicyResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/pause`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to pause session: ${res.status}`);
@@ -46,8 +48,9 @@ export async function startIntervention(
 ): Promise<AcpPauseInterventionPolicyResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/intervention/start`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to start intervention: ${res.status}`);
@@ -62,8 +65,9 @@ export async function completeIntervention(
 ): Promise<AcpPauseInterventionPolicyResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/intervention/complete`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to complete intervention: ${res.status}`);
@@ -78,8 +82,9 @@ export async function resumeSession(
 ): Promise<AcpPauseInterventionPolicyResult> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/resume`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: JSON_HEADERS,
     body: JSON.stringify(request),
+    credentials: 'include',
     signal,
   });
   if (!res.ok) throw new Error(`Failed to resume session: ${res.status}`);
@@ -92,6 +97,8 @@ export async function getSessionIntervention(
   signal?: AbortSignal,
 ): Promise<AcpPauseInterventionRecord | null> {
   const res = await fetch(`${BASE_URL}/v1/sessions/${encodeURIComponent(sessionId)}/intervention`, {
+    headers: getAuthHeaders(),
+    credentials: 'include',
     signal,
   });
   if (res.status === 404) return null;

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -92,6 +92,15 @@ export function setTokenAccessor(fn: () => string | null): void {
 
 // ── Helpers ──────────────────────────────────────────────────────
 
+/** Build auth headers using the in-memory token accessor. Used by ACP sub-clients. */
+export function getAuthHeaders(extra?: Record<string, string>): Record<string, string> {
+  const token = tokenAccessor();
+  return {
+    ...(extra ?? {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
 function headersToObject(h: HeadersInit | undefined): Record<string, string> {
   if (!h) return {};
   if (h instanceof Headers) {


### PR DESCRIPTION
## Summary
ACP-064 (#2607) endpoints are live. `acp-control-client.ts` was returning mock responses while `acp-pause-client.ts` already had real fetch calls. This PR wires the wrapper to delegate to real endpoints and adds missing Bearer auth headers across all ACP clients.

Closes #2750

## Changes
- **client.ts** — Export `getAuthHeaders()` helper using the existing `tokenAccessor()` pattern
- **acp-control-client.ts** — `sendControlAction()` delegates to `acp-pause-client.ts` for pause/resume/intervene. `getIntervention()` maps real records. `cancelSession()` throws (not yet implemented on backend).
- **acp-pause-client.ts** — Add `getAuthHeaders` + `credentials: 'include'` to all fetch calls
- **acp-driver-client.ts** — Add `getAuthHeaders` + `credentials: 'include'` to all fetch calls
- **acp-approval-client.ts** — Add `getAuthHeaders` + `credentials: 'include'` to all fetch calls
- **acp-control.test.ts** — Mock `acp-pause-client` module, test delegation logic with 24 tests (up from 17)

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — 98 files, 1058 tests pass, 2 skipped
- All changes scoped to `dashboard/` only