### PR TITLE
docs(2625): remove stale tmux references from Helm, onboarding, enterprise, and observability

### DIFF
--- a/charts/aegis/README.md
+++ b/charts/aegis/README.md
@@ -45,7 +45,7 @@ helm upgrade aegis ./charts/aegis \
 | `image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `aegis.host` | string | `"0.0.0.0"` | Bind address (`AEGIS_HOST`) |
 | `aegis.port` | int | `9100` | HTTP port (`AEGIS_PORT`) |
-| `aegis.tmuxSession` | string | `"aegis"` | tmux session prefix (`AEGIS_TMUX_SESSION`) |
+| `aegis.acpBin` | string | `""` | Path to the ACP binary (`AEGIS_ACP_BIN`); auto-detected if empty |
 | `aegis.stateDir` | string | `/var/lib/aegis` | State dir mounted from PVC (`AEGIS_STATE_DIR`) |
 | `aegis.extraEnv` | list | `[]` | Additional env vars (`{name, value}` or `{name, valueFrom}`) |
 | `aegis.extraEnvFrom` | list | `[]` | Additional `envFrom` entries |

--- a/charts/aegis/templates/statefulset.yaml
+++ b/charts/aegis/templates/statefulset.yaml
@@ -78,8 +78,10 @@ spec:
               value: {{ printf "%v" .Values.aegis.port | quote }}
             - name: AEGIS_STATE_DIR
               value: {{ $mountPath | quote }}
-            - name: AEGIS_TMUX_SESSION
-              value: {{ .Values.aegis.tmuxSession | quote }}
+            {{- if .Values.aegis.acpBin }}
+            - name: AEGIS_ACP_BIN
+              value: {{ .Values.aegis.acpBin | quote }}
+            {{- end }}
             {{- if or .Values.auth.token .Values.auth.existingSecret }}
             - name: AEGIS_AUTH_TOKEN
               valueFrom:

--- a/charts/aegis/values.yaml
+++ b/charts/aegis/values.yaml
@@ -23,8 +23,8 @@ aegis:
   host: "0.0.0.0"
   # -- HTTP port passed to AEGIS_PORT.
   port: 9100
-  # -- tmux session prefix passed to AEGIS_TMUX_SESSION.
-  tmuxSession: aegis
+  # -- Path to the ACP binary, auto-detected if empty (AEGIS_ACP_BIN).
+  acpBin: ""
   # -- State directory mounted from PVC and passed to AEGIS_STATE_DIR.
   stateDir: /var/lib/aegis
   # -- Override container entrypoint. Leave empty to use the image default.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -201,9 +201,8 @@ Aegis emits distributed traces via OTLP HTTP when tracing is enabled.
 | `session.create` | INTERNAL | `aegis.session.id`, `workDir` |
 | `session.send` | INTERNAL | `aegis.session.id` |
 | `session.kill` | INTERNAL | `aegis.session.id` |
-| `tmux.send-keys` | INTERNAL | `aegis.tmux.window_id` |
-| `tmux.capture-pane` | INTERNAL | `aegis.tmux.window_id` |
-| `tmux.create-window` | INTERNAL | `aegis.tmux.window_id`, `workDir` |
+| `acp.send_prompt` | INTERNAL | `aegis.session.id` |
+| `acp.respond_approval` | INTERNAL | `aegis.session.id` |
 | `monitor.poll` | INTERNAL | — |
 | `monitor.stall_check` | INTERNAL | `stall_type` |
 | HTTP spans | SERVER | Auto-instrumented |
@@ -320,7 +319,7 @@ Status values: `ok` | `degraded` | `draining`.
 curl -H "Authorization: Bearer $TOKEN" http://localhost:9100/v1/health
 ```
 
-Adds `version`, `platform`, `uptime`, `tmux` health, and `claude` CLI health.
+Adds `version`, `platform`, `uptime`, ACP backend health, and `claude` CLI health.
 
 ### Alert Stats
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -77,11 +77,9 @@ Every session tracks its `ownerKeyId` — the API key that created it. Protected
 | `DELETE /v1/sessions/:id` | Key must own session |
 | `POST /v1/sessions/:id/interrupt` | Key must own session |
 | `POST /v1/sessions/:id/escape` | Key must own session |
-| `GET /v1/sessions/:id/pane` | Key must own session |
 | `GET /v1/sessions/:id/read` | Key must own session |
 | `GET /v1/sessions/:id/summary` | Key must own session |
 | `POST /v1/sessions/:id/command` | Key must own session |
-| `POST /v1/sessions/:id/bash` | Key must own session |
 | `POST /v1/sessions/batch` | Each session stamped with caller's key |
 | `DELETE /v1/sessions` | Key can only delete its own sessions |
 
@@ -226,7 +224,6 @@ server {
 
 ```dockerfile
 FROM node:20-slim
-RUN apt-get update && apt-get install -y tmux && rm -rf /var/lib/apt/lists/*
 RUN npm install -g @anthropic-ai/claude-code
 ENV AEGIS_PORT=9100
 EXPOSE 9100
@@ -245,7 +242,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_HOST` | `127.0.0.1` | HTTP server bind address |
 | `AEGIS_AUTH_TOKEN` | _(empty)_ | Master bearer token (empty = no auth) |
 | `AEGIS_STATE_DIR` | `~/.aegis` | State directory (sessions, PID file) |
-| `AEGIS_TMUX_SESSION` | `aegis` | Base tmux session name |
+| `AEGIS_ACP_BIN` | _(auto)_ | Path to the ACP binary (auto-detected if empty) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Maximum concurrent sessions |
@@ -310,7 +307,7 @@ Create `aegis.config.json` in the working directory or set `AEGIS_CONFIG`:
 curl http://localhost:9100/v1/health
 ```
 
-Returns server status, version, uptime, active session count, and tmux health. **No auth required** — safe for load balancer health checks.
+Returns server status, version, uptime, and active session count. **No auth required** — safe for load balancer health checks.
 
 ```json
 {
@@ -423,7 +420,7 @@ curl http://localhost:9100/v1/diagnostics \
 Returns system-level diagnostics for troubleshooting. Use when the health endpoint shows degraded state but cause is unclear.
 
 **Response includes:**
-- Tmux health (session count, window state)
+- ACP backend health (process state, session count)
 - Resource usage (memory, CPU via Node.js `process.resourceUsage()`)
 - Active SSE connection count
 - Config state (auth enabled, max sessions, stall threshold)
@@ -477,8 +474,7 @@ curl -X GET http://localhost:9100/v1/alerts/stats \
 
 **AlertManager monitors:**
 - Session failures (crashes, unexpected exits)
-- Dead sessions (tmux process gone)
-- Tmux crashes
+- Dead sessions (ACP process gone)
 - API error rate threshold breaches
 
 **Authorization Requirements:**
@@ -563,6 +559,6 @@ curl -sf http://localhost:9100/v1/metrics | \
 | 401 on all endpoints | Check `AEGIS_AUTH_TOKEN` matches the `Authorization` header |
 | Sessions stuck on `stalled` | Send interrupt: `POST /v1/sessions/:id/interrupt` |
 | High memory usage | Reduce `AEGIS_MAX_SESSIONS` or increase `AEGIS_IDLE_TIMEOUT_MS` |
-| tmux errors | Verify tmux is installed: `tmux -V` (requires ≥ 3.2) |
+| Claude Code not found | `claude --version` — verify installation and auth |
 | Rate limited (429) | Wait for the rate limit window to reset or increase limits |
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -4,7 +4,7 @@ Welcome to Aegis. This guide gets you from zero to running your first session in
 
 ## What is Aegis?
 
-Aegis is a **Claude Code control plane** — a self-hosted server that wraps Claude Code sessions in tmux and exposes them via REST API, MCP tools, CLI, and a web dashboard. You orchestrate AI coding work programmatically or visually.
+Aegis is a **Claude Code control plane** — a self-hosted server that manages Claude Code sessions via the ACP (Agent Control Protocol) runtime and exposes them via REST API, MCP tools, CLI, and a web dashboard. You orchestrate AI coding work programmatically or visually.
 
 **Use cases:**
 - Run multiple Claude Code sessions in parallel, monitored from one dashboard
@@ -15,20 +15,9 @@ Aegis is a **Claude Code control plane** — a self-hosted server that wraps Cla
 ## Prerequisites
 
 - **Node.js 20+**
-- **tmux 3.2+** (or psmux on Windows)
 - **Claude Code CLI** installed and configured (`claude --version`)
 
-Install tmux:
-```bash
-# Linux
-sudo apt install tmux
-
-# macOS
-brew install tmux
-
-# Windows (WSL2)
-sudo apt install tmux
-```
+Aegis bundles `claude-agent-acp` — no tmux or psmux required on any platform.
 
 ## Quick Start
 
@@ -49,7 +38,7 @@ The server starts on `http://localhost:9100`. Open `http://localhost:9100/dashbo
 
 ### Sessions
 
-A **session** is one Claude Code process running in a tmux window. Each session has:
+A **session** is one Claude Code process managed by Aegis via the ACP runtime. Each session has:
 - A unique ID (UUID)
 - A display name (e.g., `cc-my-task`)
 - A working directory
@@ -246,10 +235,7 @@ Config file: `~/.aegis/config.json`
   "host": "127.0.0.1",
   "port": 9100,
   "authToken": "your-secret-token",
-  "allowedWorkDirs": ["~/projects", "/tmp"],
-  "tmux": {
-    "socketName": "aegis"
-  }
+  "allowedWorkDirs": ["~/projects", "/tmp"]
 }
 ```
 
@@ -263,7 +249,7 @@ See [Configuration Reference](getting-started.md#configuration) for all options.
 **Server won't start:**
 ```bash
 ag doctor   # Run diagnostics
-# Check: tmux installed? port 9100 free? Claude Code available?
+# Check: ACP backend healthy? port 9100 free? Claude Code available?
 ```
 
 **Session stuck on `permission_prompt`:**
@@ -277,12 +263,6 @@ curl -X POST http://localhost:9100/v1/sessions/{id}/reject
 ```bash
 claude --version   # Verify installation
 export PATH="$PATH:$(which claude)"   # Add to PATH
-```
-
-**tmux not found:**
-```bash
-tmux -V   # Should print tmux version
-# If not: sudo apt install tmux (Linux) or brew install tmux (macOS)
 ```
 
 See the [Troubleshooting](troubleshooting.md) guide for more.


### PR DESCRIPTION
## Summary

Completes ACP-105 (#2625) — removes remaining tmux references from Helm chart, onboarding guide, enterprise deployment guide, and observability docs. Partial work was done in #2721; this PR covers the remaining files.

## Changes

### Helm Chart
- **values.yaml** — replace  with  (, auto-detected if empty)
- **statefulset.yaml** — conditionally set  only when configured
- **README.md** — update configuration table

### docs/onboarding.md
- Remove tmux from prerequisites and install steps
- Update session description: "tmux window" → "ACP runtime"
- Remove tmux config block from example config.json
- Replace "tmux installed?" doctor check with "ACP backend healthy?"
- Add note: "no tmux or psmux required on any platform"

### docs/enterprise.md
- Remove tmux from Dockerfile ()
- Replace  with  in config reference
- Remove "tmux health" from health endpoint description
- Replace tmux spans with ACP process spans in diagnostics
- Remove  and  from RBAC operation table (endpoints removed)
- Replace "tmux process gone" with "ACP process gone" in alerting
- Replace "tmux errors" troubleshooting with "Claude Code not found"

### docs/OBSERVABILITY.md
- Replace tmux span attributes (, , ) with ACP spans (, )
- Update authenticated health check description

## Validation
- Zero tmux references remain in Helm chart, onboarding, enterprise, or observability docs
- Remaining tmux mentions in the repo are explicitly historical (migration guide) or process-descriptive (release process, spikes)

## Refs
- Closes #2625 (ACP-105)
- Follows #2721 (partial ACP-105 work)