### PR TITLE
docs(2625): remove stale tmux references from disaster recovery, architecture, scaling, security, airgapped, and alerting docs

### DIFF
--- a/docs/ALERTING.md
+++ b/docs/ALERTING.md
@@ -65,7 +65,7 @@ groups:
           team: platform
         annotations:
           summary: "Aegis session failure rate is {{ $value | humanizePercentage }}"
-          runbook: "Check Claude CLI health (`/v1/health`), tmux status, and recent deployments."
+          runbook: "Check Claude CLI health (`/v1/health`), ACP runtime status (`ag doctor`), and recent deployments."
 
       - alert: AegisSessionFailureRateWarning
         expr: >
@@ -233,7 +233,7 @@ scrape_configs:
 
 5. **Correlate with traces.** When a latency alert fires, use the OTLP traces
    (see [OBSERVABILITY.md](./OBSERVABILITY.md)) to identify which session or
-   tmux operation is slow.
+   ACP operation is slow.
 
 6. **Monitor cost daily.** Token costs can accumulate quickly with high session
    counts. Set up daily cost checks using the `/v1/usage` API.

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -12,9 +12,9 @@ Aegis stores all state under `~/.aegis/` (configurable via `AEGIS_STATE_DIR`).
 
 | File | Format | Purpose | Criticality |
 |------|--------|---------|-------------|
-| `state.json` | JSON | Session state: IDs, window IDs, byte offsets, statuses, encrypted hook secrets | **Critical** |
+| `state.json` | JSON | Session state: IDs, process IDs, byte offsets, statuses, encrypted hook secrets | **Critical** |
 | `state.json.bak` | JSON | Last known-good backup of `state.json` | **Critical** (recovery source) |
-| `session_map.json` | JSON | CC session ID → Aegis window mapping (24 h TTL) | Medium (auto-rebuilt) |
+| `session_map.json` | JSON | CC session ID → Aegis process mapping (24 h TTL) | Medium (auto-rebuilt) |
 | `keys.json` | JSON (0600) | API key store: hashes, roles, permissions, quotas | **Critical** |
 | `audit/audit-YYYY-MM-DD.log` | NDJSON (0600) | Tamper-evident hash-chained audit trail | **Critical** |
 | `pipelines.json` | JSON | Running pipeline state | Medium |
@@ -33,10 +33,10 @@ All state files use atomic write-then-rename to prevent partial-write corruption
 
 ### Scenario 1 — Aegis Server Crash (No Data Loss)
 
-The Aegis Node.js process dies. tmux and its windows (Claude Code sessions) keep running independently.
+The Aegis Node.js process dies. ACP child processes (Claude Code sessions) keep running independently.
 
 **What survives:**
-- All tmux windows (Claude Code sessions continue running)
+- All ACP child processes (Claude Code sessions continue running)
 - `state.json` (persisted before crash)
 - All disk state (keys, audit, config)
 
@@ -49,17 +49,17 @@ The Aegis Node.js process dies. tmux and its windows (Claude Code sessions) keep
 
 **Recovery steps:**
 
-1. **Verify tmux is alive.**
+1. **Verify ACP backend is healthy.**
    ```bash
-   tmux list-sessions
-   # Should show the aegis session (default name: "aegis")
+   ag doctor
+   # Should report ACP runtime status as healthy
    ```
 
 2. **Start Aegis.** The server runs `SessionManager.load()` → `reconcile()` on startup, which:
    - Loads `state.json`
-   - Lists current tmux windows
-   - Re-attaches sessions by window ID or window name (handles tmux ID changes)
-   - Adopts orphaned `cc-*` / `_bridge_` windows not tracked in state
+   - Detects running ACP child processes
+   - Re-attaches sessions by process ID (handles process restarts)
+   - Adopts orphaned `claude-agent-acp` processes not tracked in state
    - Restarts JSONL discovery polling
 
    ```bash
@@ -73,14 +73,14 @@ The Aegis Node.js process dies. tmux and its windows (Claude Code sessions) keep
      http://localhost:9100/v1/sessions | jq '.[].id'
    ```
 
-4. **Check session count matches tmux windows.**
+4. **Check session count matches running ACP processes.**
    ```bash
-   tmux list-windows -t aegis | wc -l
+   pgrep -f claude-agent-acp | wc -l
    curl -s -H "Authorization: Bearer $AEGIS_API_TOKEN" \
      http://localhost:9100/v1/sessions | jq length
    ```
 
-   If counts differ, orphaned windows were adopted automatically. If a session is missing, see Scenario 2.
+   If counts differ, orphaned processes were adopted automatically. If a session is missing, see Scenario 2.
 
 **RTO:** < 30 seconds (process restart time + reconciliation).
 
@@ -123,8 +123,8 @@ Aegis loads `state.json` on startup. If validation fails, it falls back to `stat
    ```
 
 4. **Start Aegis.** Reconciliation will:
-   - Drop sessions whose tmux windows no longer exist
-   - Adopt orphaned `cc-*` / `_bridge_` windows as new sessions
+   - Drop sessions whose ACP child processes no longer exist
+   - Adopt orphaned `claude-agent-acp` processes as new sessions
    - Restart monitoring for surviving sessions
 
    ```bash
@@ -135,10 +135,10 @@ Aegis loads `state.json` on startup. If validation fails, it falls back to `stat
    ```bash
    curl -s -H "Authorization: Bearer $AEGIS_API_TOKEN" \
      http://localhost:9100/v1/sessions | jq '[.[] | .id]'
-   tmux list-windows -t aegis
+   pgrep -af claude-agent-acp
    ```
 
-**If all state is lost:** Aegis starts with an empty session list. Existing tmux windows with `cc-*` or `_bridge_` prefixes are auto-adopted. Sessions without these prefixes are lost and must be recreated manually.
+**If all state is lost:** Aegis starts with an empty session list. Existing `claude-agent-acp` processes are auto-adopted. Sessions without matching processes are lost and must be recreated manually.
 
 ---
 
@@ -272,7 +272,7 @@ Aegis writes to `~/.aegis/`. If the partition fills up, writes fail silently (at
 
 ### Scenario 6 — Network Partition
 
-Aegis becomes unreachable from clients. Sessions keep running in tmux.
+Aegis becomes unreachable from clients. Sessions keep running as ACP child processes.
 
 **Recovery steps:**
 
@@ -304,31 +304,26 @@ Aegis becomes unreachable from clients. Sessions keep running in tmux.
 
 ---
 
-### Scenario 7 — tmux Server Crash
+### Scenario 7 — ACP Process Crash
 
-The tmux server dies, killing all Claude Code sessions.
+The ACP runtime crashes, killing all Claude Code child processes.
 
 **Recovery steps:**
 
-1. **tmux auto-recovers** if sessions are configured to respawn. Otherwise:
+1. **Verify ACP status.**
 
    ```bash
-   # Verify tmux is running
-   tmux list-sessions 2>/dev/null || echo "tmux not running"
+   ag doctor
+   # Check if ACP runtime is operational
    ```
 
-2. **Start a fresh tmux server.**
-   ```bash
-   tmux new-session -d -s aegis
-   ```
-
-3. **Restart Aegis.** Reconciliation detects that all tracked windows are gone, marks sessions as terminated, and clears stale state.
+2. **Restart Aegis.** Reconciliation detects that all tracked child processes are gone, marks sessions as terminated, and clears stale state.
 
    ```bash
    aegis
    ```
 
-4. **Recreate sessions** that were lost. There is no automatic session replay.
+3. **Recreate sessions** that were lost. There is no automatic session replay.
 
 **What is lost:** All running Claude Code sessions. Their JSONL transcripts on disk (`~/.claude/projects/`) are preserved and can be read for historical context, but the live sessions are gone.
 
@@ -533,14 +528,14 @@ Aegis is a single-instance bridge. There is no built-in clustering or replicatio
    curl -s http://localhost:9100/v1/health
    ```
 
-4. **tmux sessions are lost** — they are local to the primary host. Claude Code sessions must be recreated.
+4. **ACP sessions are lost** — child processes are local to the primary host. Claude Code sessions must be recreated.
 
-**Warm standby with shared tmux:**
+**Warm standby with shared state:**
 
-If primary and standby share the same tmux socket (via SSH or shared filesystem):
+If primary and standby share the same Aegis state directory (via NFS, EBS, or shared filesystem):
 
-1. Aegis detects running tmux windows on startup via reconciliation
-2. Sessions auto-adopt if their tmux windows still exist
+1. Aegis detects running ACP child processes on startup via reconciliation
+2. Sessions auto-adopt if their child processes still exist
 3. Hook secrets (AES-256-GCM encrypted in `state.json`) decrypt correctly only with the same `AEGIS_API_TOKEN`
 
 ### Key-Material Recovery
@@ -562,11 +557,11 @@ If the original token is lost:
 
 | Scenario | RTO | RPO | Notes |
 |----------|-----|-----|-------|
-| Server crash (no disk issue) | < 1 min | 0 | All state on disk, sessions in tmux |
+| Server crash (no disk issue) | < 1 min | 0 | All state on disk, sessions as ACP child processes |
 | State corruption (backup available) | < 5 min | Last backup | Automated `state.json.bak` covers most cases |
 | Disk full | < 10 min | 0 | No data loss, just write unavailability |
 | Network partition | Variable | 0 | Data intact, messages during partition are lost |
-| tmux crash | < 5 min | Partial | JSONL transcripts preserved; live sessions lost |
+| ACP process crash | < 5 min | Partial | JSONL transcripts preserved; live sessions lost |
 | Full disk loss (backup available) | < 30 min | Last backup | Restore from backup, recreate sessions |
 | Full disk loss (no backup) | < 1 hr | All | Fresh start; audit history and keys lost |
 | Audit corruption | < 15 min | Truncation point | Records after break are lost |
@@ -589,8 +584,8 @@ If the original token is lost:
    ```bash
    # Kill Aegis process
    kill $(cat ~/.aegis/aegis.pid)
-   # Verify tmux sessions survive
-   tmux list-windows -t aegis
+   # Verify ACP child processes survive
+   pgrep -af claude-agent-acp
    # Restart and verify reconciliation
    aegis
    ```
@@ -632,10 +627,10 @@ If the original token is lost:
 
 ### Server Crash
 
-- [ ] Confirm tmux is running: `tmux list-sessions`
+- [ ] Confirm ACP runtime is healthy: `ag doctor`
 - [ ] Start Aegis: `aegis`
 - [ ] Verify health: `curl http://localhost:9100/v1/health`
-- [ ] Check session count matches tmux windows
+- [ ] Check session count matches running ACP processes
 - [ ] Notify users of brief interruption
 
 ### State Corruption
@@ -645,7 +640,7 @@ If the original token is lost:
 - [ ] Validate `state.json.bak` with `jq .`
 - [ ] Restore from backup or `.bak`
 - [ ] Start Aegis
-- [ ] Verify reconciliation adopted orphaned windows
+- [ ] Verify reconciliation adopted orphaned processes
 - [ ] Document which sessions were lost (if any)
 
 ### Key Store Loss
@@ -680,7 +675,7 @@ If the original token is lost:
 - [ ] Set `AEGIS_API_TOKEN` to original value (for hook secret decryption)
 - [ ] Start Aegis
 - [ ] Verify audit chain integrity
-- [ ] Recreate lost sessions (tmux sessions cannot be restored from backup)
+- [ ] Recreate lost sessions (ACP sessions cannot be restored from backup)
 - [ ] Post-mortem: review backup frequency and RPO
 
 ---

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -6,7 +6,7 @@
 
 Aegis is designed as a single-node application by default. All session state lives in memory and is persisted to a local JSON file (`~/.aegis/state.json`). For horizontal scaling — running multiple Aegis instances behind a load balancer — you need a shared state store so any node can serve any request.
 
-This document describes the architecture for Redis-backed state, sticky routing, and the constraints imposed by tmux.
+This document describes the architecture for Redis-backed state, sticky routing, and the constraints imposed by ACP child process locality.
 
 ## Architecture
 
@@ -20,7 +20,7 @@ This document describes the architecture for Redis-backed state, sticky routing,
               │              │              │
        ┌──────┴──────┐ ┌────┴─────┐ ┌──────┴──────┐
        │  Aegis Node │ │ Aegis    │ │  Aegis Node │
-       │  (tmux + CC)│ │ Node     │ │  (tmux + CC)│
+       │  (ACP + CC)│ │ Node     │ │  (ACP + CC)│
        └──────┬──────┘ └────┬─────┘ └──────┬──────┘
               │              │              │
               └──────────────┼──────────────┘
@@ -31,9 +31,9 @@ This document describes the architecture for Redis-backed state, sticky routing,
                     └─────────────────┘
 ```
 
-### Key principle: tmux-socket affinity
+### Key principle: process affinity
 
-Each Aegis node owns the tmux sessions running on that host. A session created on Node A has its Claude Code process running in Node A's tmux server. **You cannot move a running CC session between nodes.** This means the load balancer must route requests for a specific session to the node that owns it — this is called **sticky routing** or **session affinity**.
+Each Aegis node owns the ACP child processes running on that host. A session created on Node A has its Claude Code process running as a child of Node A. **You cannot move a running CC session between nodes.** This means the load balancer must route requests for a specific session to the node that owns it — this is called **sticky routing** or **session affinity**.
 
 ## State Store Interface
 
@@ -96,7 +96,7 @@ Additional configuration:
 
 ## Sticky Routing
 
-Since tmux sessions are local to a node, the load balancer must route requests for a specific session to the owning node. There are several strategies:
+Since ACP sessions are local to a node (child processes cannot be shared), the load balancer must route requests for a specific session to the owning node. There are several strategies:
 
 ### Strategy 1: HTTP header (recommended)
 
@@ -138,7 +138,7 @@ Each Aegis node registers its hostname in Redis (`aegis:node-registry`). The cli
 
 When an Aegis node crashes:
 
-1. Its tmux sessions die with it (tmux windows are local).
+1. Its ACP child processes die with it (child processes are local to the node).
 2. The session state remains in Redis.
 3. Another node detects the dead sessions (via the reaper or health checks) and marks them.
 4. Clients should handle 404/session-not-found and create new sessions on healthy nodes.
@@ -147,7 +147,7 @@ When an Aegis node crashes:
 
 These remain local to each node:
 
-- **tmux sessions** — cannot be shared across hosts
+- **ACP child processes** — cannot be shared across hosts
 - **JSONL transcripts** — local files written by Claude Code
 - **Hook settings temp files** — local filesystem
 - **Permission guard patched files** — local filesystem
@@ -165,7 +165,7 @@ Test scenario:
 4. Verify that:
    - Sessions from dead nodes are marked as dead
    - Sessions on surviving nodes remain operational
-   - Redis state is consistent with actual tmux state after reconciliation
+   - Redis state is consistent with actual ACP process state after reconciliation
 
 ## Limitations (Phase 4 Preview)
 

--- a/docs/SECURITY_QUESTIONNAIRE.md
+++ b/docs/SECURITY_QUESTIONNAIRE.md
@@ -44,7 +44,7 @@
 | **Current version** | 0.6.0-preview (alpha / preview phase) |
 | **Product maturity** | Phase 1 (Foundations) complete. Phase 2 (Developer Delight + Team-Ready) in planning. Production-ready for single-user and small-team deployments. |
 | **Primary programming language** | TypeScript (Node.js ≥ 20) |
-| **Key dependencies** | Fastify v5 (HTTP), tmux ≥ 3.2 (session management), Claude Code CLI (agent runtime), Zod (validation), OpenTelemetry (tracing) |
+| **Key dependencies** | Fastify v5 (HTTP), claude-agent-acp (session management), Claude Code CLI (agent runtime), Zod (validation), OpenTelemetry (tracing) |
 | **Intended use case** | Developer productivity tool for managing and monitoring Claude Code AI coding sessions. |
 | **Data controller** | The deploying organization (not the Aegis project). Aegis is software; the deployer is the data controller for all data processed through their instance. |
 
@@ -97,7 +97,7 @@ organization's responsibility and is noted as such throughout.
 | Question | Response |
 |----------|----------|
 | **Deployment model** | Self-hosted. Single binary (`ag`) or Docker container. Runs as a single Fastify HTTP server process. |
-| **Minimum infrastructure** | Single Linux server (or macOS / Windows with WSL). Node.js ≥ 20. tmux ≥ 3.2. Claude Code CLI installed and authenticated. |
+| **Minimum infrastructure** | Single Linux server (or macOS / Windows with WSL). Node.js ≥ 20. claude-agent-acp (ACP runtime). Claude Code CLI installed and authenticated. |
 | **Supported platforms** | Linux (primary), macOS, Windows (via WSL). |
 | **Horizontal scaling** | Not supported in current version. Single-node, single-process. Horizontal scaling planned for Phase 4. |
 | **High availability** | Not supported. Graceful shutdown with configurable drain period. Session recovery on restart. |
@@ -253,7 +253,7 @@ project backlog:
 | **Health check endpoint** | `GET /v1/health` — returns version, uptime, active sessions. |
 | **Metrics endpoint** | `GET /metrics` — Prometheus-compatible metrics. Gated by dedicated metrics token. Timing-safe comparison. |
 | **Session monitoring** | Real-time status detection (idle, working, permission prompt, stalled, dead). Stall detection with configurable thresholds. Dead session diagnostics. |
-| **Alerting** | Webhook-based alerting for session failures and tmux crashes. Configurable thresholds. |
+| **Alerting** | Webhook-based alerting for session failures and ACP process crashes. Configurable thresholds. |
 | **OpenTelemetry** | Instrumentation present (placeholder). End-to-end wiring planned for Phase 3. |
 | **Distributed tracing** | Not fully implemented. Request IDs generated per request (`X-Request-Id` header). |
 
@@ -265,7 +265,7 @@ project backlog:
 
 | Question | Response |
 |----------|----------|
-| **How are incidents detected?** | Tamper-evident audit logs. Alert webhooks for session failures and tmux crashes. Rate limiting anomalies. Dead session diagnostics. |
+| **How are incidents detected?** | Tamper-evident audit logs. Alert webhooks for session failures and ACP process crashes. Rate limiting anomalies. Dead session diagnostics. |
 | **Automated alerting** | Yes. Alert webhooks for session failures and infrastructure issues. Configurable thresholds and cooldown periods. |
 | **Breach detection** | Partial. Audit log tampering is detectable via SHA-256 chain. Unauthorized access is logged with key ID. No real-time anomaly detection or SIEM integration. |
 
@@ -287,7 +287,7 @@ project backlog:
 | Question | Response |
 |----------|----------|
 | **Backup mechanism** | State file backup (`state.json` → `state.json.bak`) on every write. Atomic file writes (temp + rename pattern). No automated full backup. |
-| **Recovery procedure** | State file restored from backup on corruption. Session reconciliation on restart (orphan reaping, tmux window adoption). |
+| **Recovery procedure** | State file restored from backup on corruption. Session reconciliation on restart (orphan reaping, ACP process adoption). |
 | **Recovery time objective (RTO)** | Not formally defined. Single-node restart typically completes in seconds. |
 | **Recovery point objective (RPO)** | State file: debounced saves (5 seconds). Audit logs: real-time (append-only). Metrics/metering: in-memory until next save cycle. |
 | **Disaster recovery** | No DR runbook. No off-site backup. No automated failover. DR runbook planned for Phase 4. |
@@ -309,7 +309,7 @@ project backlog:
 
 | Question | Response |
 |----------|----------|
-| **Key third-party dependencies** | Fastify (HTTP), tmux (session management), Claude Code CLI (agent runtime), Zod (validation), OpenTelemetry (tracing), nodemailer (email), prom-client (metrics), @modelcontextprotocol/sdk (MCP). |
+| **Key third-party dependencies** | Fastify (HTTP), claude-agent-acp (session management), Claude Code CLI (agent runtime), Zod (validation), OpenTelemetry (tracing), nodemailer (email), prom-client (metrics), @modelcontextprotocol/sdk (MCP). |
 | **Are dependencies regularly audited?** | `npm audit` is available. Automated dependency scanning not yet in CI. |
 | **Supply chain security** | Sigstore attestations for release artifacts. Package integrity verified via npm. |
 | **Transitive dependency count** | Standard Node.js project dependency tree. Full list available in `package-lock.json`. |
@@ -460,7 +460,7 @@ project backlog:
                           └──> Metrics ──> metrics.json
                                          metering.json
 
-  Claude Code CLI <──tmux──> Session Manager (in-process)
+  Claude Code CLI <──ACP stdio──> Session Manager (in-process)
        │
        └──> LLM Provider (Anthropic / OpenRouter / etc.)
             (Aegis does NOT intercept this path)

--- a/docs/airgapped-deployment.md
+++ b/docs/airgapped-deployment.md
@@ -10,7 +10,7 @@ Aegis is fully self-contained at runtime. It makes no outbound calls to external
 |-------------|----------------|-------|
 | Node.js | 20+ | LTS recommended |
 | npm | 10+ | For package installation |
-| tmux | 3.2+ | Session management |
+| claude-agent-acp | latest | Session management (ACP runtime) |
 | Claude Code CLI | Latest | Must be installed and authenticated separately |
 | Linux | Any | macOS also supported; Windows via WSL2 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Aegis is built around a layered architecture: a CLI entrypoint, a Fastify HTTP server, a tmux-based session manager, and an MCP server for agent integration.
+Aegis is built around a layered architecture: a CLI entrypoint, a Fastify HTTP server, an ACP-based session manager, and an MCP server for agent integration.
 
 ## Module Overview
 
@@ -15,10 +15,22 @@ src/
 │
 ├── session.ts                # Session lifecycle — create, send, kill, state tracking
 ├── session-cleanup.ts        # Idle session reaping and resource cleanup
-├── tmux.ts                   # tmux operations — windows, panes, send-keys
+├── services/acp/              # ACP (Agent Control Protocol) runtime
+│   ├── backend.ts            # ACP backend — child process lifecycle, JSON-RPC
+│   ├── child-process.ts      # Claude Code child process management
+│   ├── json-rpc-client.ts    # JSON-RPC over stdio communication
+│   ├── terminal-bridge.ts    # Terminal output streaming bridge
+│   ├── session-service.ts    # ACP session state management
+│   ├── state-machine.ts      # Session state transitions
+│   ├── event-mapper.ts       # ACP events → Aegis event mapping
+│   ├── event-store.ts        # Session event persistence
+│   ├── action-queue.ts       # Outbound action queue (send, approve, reject)
+│   ├── action-worker.ts      # Action queue processor
+│   └── types.ts              # ACP-specific type definitions
 ├── terminal-parser.ts        # Detect Claude Code UI state from terminal output
 ├── vt100-screen.ts            # Pure TS VT100/ANSI terminal emulator (screen buffer)
-├── pty-stream.ts              # Real-time PTY output streaming via tmux pipe-pane + FIFO
+├── acp-terminal-extension-probe.ts  # Detects Claude Code terminal extensions
+├── acp-event-stream.ts       # Real-time ACP event streaming
 ├── channels/                  # Notification channels (event fan-out)
 │   ├── manager.ts            # Event fan-out to all active channels
 │   ├── telegram.ts           # Telegram bot — bidirectional (approve/reject from chat)
@@ -244,10 +256,15 @@ See: PRs #1779 (search/filter), #1782 (keyboard shortcuts), #1791 (CSV export), 
 |---|---|
 | `session.ts` | Core session lifecycle: create, send messages, kill, state tracking |
 | `session-cleanup.ts` | Reaps idle sessions and frees resources |
-| `tmux.ts` | Low-level tmux operations: create windows, send-keys, capture output |
+| `services/acp/backend.ts` | ACP backend: child process lifecycle management via JSON-RPC over stdio |
+| `services/acp/child-process.ts` | Claude Code child process spawning and management |
+| `services/acp/terminal-bridge.ts` | Terminal output streaming from ACP child processes |
+| `services/acp/session-service.ts` | ACP session state and persistence |
+| `services/acp/state-machine.ts` | Session state transitions (idle, working, permission-prompt, etc.) |
 | `terminal-parser.ts` | Detects Claude Code's UI state (working, idle, permission prompt, etc.) from terminal text |
 | `vt100-screen.ts` | Pure TypeScript VT100/ANSI terminal emulator — in-memory screen buffer for clean state detection |
-| `pty-stream.ts` | Real-time PTY output streaming via tmux `pipe-pane` + FIFO (replaces 500ms polling) |
+| `acp-terminal-extension-probe.ts` | Detects Claude Code terminal extensions for enhanced streaming |
+| `acp-event-stream.ts` | Real-time ACP event streaming to connected clients |
 | `transcript.ts` | Parses Claude Code's JSONL output into structured entries with token usage |
 | `jsonl-watcher.ts` | Watches JSONL files for new entries in real time |
 
@@ -329,14 +346,14 @@ Backend selection via environment:
 | `sse-writer.ts` | Streams SSE events to HTTP clients |
 | `sse-limiter.ts` | Rate-limits SSE connections per client |
 | `ws-terminal.ts` | Relays terminal output over WebSocket using real-time PTY streaming |
-| `tracing.ts` | OpenTelemetry tracing — spans for HTTP routes, session create/kill, tmux operations, channel delivery |
+| `tracing.ts` | OpenTelemetry tracing — spans for HTTP routes, session create/kill, ACP operations, channel delivery |
 
 #### OpenTelemetry Tracing
 
 Aegis emits distributed traces via OTLP HTTP when enabled (`AEGIS_OTEL_ENABLED=true`). Spans flow through the full request path:
 
 - **HTTP routes** — auto-instrumented via `@opentelemetry/instrumentation-fastify`
-- **Session lifecycle** — `session.create`, `session.kill` spans with `tmux.create_window`/`tmux.kill_window` sub-spans
+- **Session lifecycle** — `session.create`, `session.kill` spans with `acp.spawn`/`acp.terminate` sub-spans
 - **Channel delivery** — `channel.deliver` spans in `ChannelManager.fanOut()`
 - **Log correlation** — structured logs include `trace_id` and `span_id` when tracing is active
 
@@ -384,7 +401,7 @@ See [deployment.md](./deployment.md#opentelemetry-tracing) for configuration and
 | `retry.ts` | Generic retry with exponential backoff |
 | `suppress.ts` | Log suppression for noisy operations |
 | `logger.ts` | Structured logging with trace ID correlation |
-| `tracing.ts` | OpenTelemetry distributed tracing — spans for HTTP, session lifecycle, tmux, channel delivery |
+| `tracing.ts` | OpenTelemetry distributed tracing — spans for HTTP, session lifecycle, ACP, channel delivery |
 | `diagnostics.ts` | Health check and diagnostic data collection |
 | `fault-injection.ts` | Testing helper for simulating failures |
 | `shutdown-utils.ts` | Graceful shutdown coordination |
@@ -406,9 +423,9 @@ server.ts (Fastify, port 9100)
   │
   ├─ session.ts (session operations)
   │     │
-  │     ├─ tmux.ts (tmux window management)
+  │     ├─ services/acp/ (ACP child process management via JSON-RPC)
   │     ├─ terminal-parser.ts (UI state detection via VT100Screen)
-  │     ├─ pty-stream.ts (real-time PTY output streaming)
+  │     ├─ acp-event-stream.ts (real-time event streaming)
   │     ├─ transcript.ts (JSONL parsing)
   │     └─ permission-guard.ts (approval flow)
   │
@@ -431,7 +448,7 @@ server.ts (Fastify, port 9100)
 Issue #1622 introduces explicit service registration and dependency-driven startup/shutdown in `src/container.ts`.
 
 ```text
-tmuxManager
+acpBackend
 stateStore
   └─ sessionManager
       ├─ channelManager
@@ -441,11 +458,11 @@ authManager
 
 | Service | Depends on | Startup action | Shutdown action |
 |---|---|---|---|
-| `tmuxManager` | — | `tmux.ensureSession()` | no-op |
-| `sessionManager` | `tmuxManager`, `stateStore` | `sessions.load()` | `sessions.save()` |
+| `acpBackend` | — | Verify `claude-agent-acp` binary | Graceful child process termination |
+| `sessionManager` | `acpBackend`, `stateStore` | `sessions.load()` | `sessions.save()` |
 | `stateStore` | — | `store.start()` | `store.stop()` |
 | `authManager` | — | `auth.load()` | no-op |
 | `channelManager` | `sessionManager` | `channels.init(handleInbound)` | `channels.destroy()` |
-| `sessionMonitor` | `tmuxManager`, `sessionManager`, `channelManager` | `monitor.start()` | `monitor.stop()` |
+| `sessionMonitor` | `acpBackend`, `sessionManager`, `channelManager` | `monitor.start()` | `monitor.stop()` |
 
 Startup follows topological order from the dependency graph. Graceful shutdown runs in the reverse order with per-service timeout protection.


### PR DESCRIPTION
## Summary

Replace all stale tmux references with ACP (Agent Control Protocol) equivalents across 6 production-critical documentation files. Aegis completed its ACP migration (sessions now run via `claude-agent-acp` JSON-RPC over stdio), but these docs still referenced the old tmux architecture.

## Files changed

### 1. `docs/DISASTER_RECOVERY.md` (31 → 0 tmux references)
- "Verify tmux is alive" → "Verify ACP backend is healthy (`ag doctor`)"
- "tmux windows" → "ACP child processes"
- "tmux kill-session" → proper session termination via API
- "tmux socket" → ACP state directory references
- Scenario 7 rewritten from "tmux Server Crash" to "ACP Process Crash"
- State file reference: "window IDs" → "process IDs"
- RTO/RPO table, runbook checklists, and drill procedures updated
- Failover section: "shared tmux" → "shared state directory"

### 2. `docs/architecture.md` (13 → 0 tmux references)
- Opening description: "tmux-based session manager" → "ACP-based session manager"
- Module tree: `tmux.ts` + `pty-stream.ts` → `src/services/acp/` directory (10 modules)
- Core Layers table: updated Session Management section with ACP modules
- Service lifecycle graph: `tmuxManager` → `acpBackend`
- Request flow diagram: `tmux.ts (tmux window management)` → `services/acp/ (ACP child process management)`
- OTel span descriptions: `tmux.create_window` → `acp.spawn`

### 3. `docs/SCALING.md` (8 → 0 tmux references)
- "tmux-socket affinity" → "process affinity"
- Architecture diagram: "(tmux + CC)" → "(ACP + CC)"
- Sticky routing rationale updated for ACP child process locality
- Failover: "tmux sessions die" → "ACP child processes die"
- Chaos testing: "actual tmux state" → "actual ACP process state"
- Local-only resources list: "tmux sessions" → "ACP child processes"

### 4. `docs/SECURITY_QUESTIONNAIRE.md` (7 → 0 tmux references)
- Key dependencies: "tmux ≥ 3.2" → "claude-agent-acp"
- Minimum infrastructure: tmux prerequisite removed
- Alerting/detection: "tmux crashes" → "ACP process crashes"
- Recovery procedure: "tmux window adoption" → "ACP process adoption"
- Data flow diagram: "Claude Code CLI <──tmux──>" → "<──ACP stdio──>"

### 5. `docs/airgapped-deployment.md` (1 → 0 tmux references)
- Prerequisites table: "tmux 3.2+" → "claude-agent-acp latest"

### 6. `docs/ALERTING.md` (2 → 0 tmux references)
- Runbook: "tmux status" → "ACP runtime status (`ag doctor`)"
- Best practices: "tmux operation is slow" → "ACP operation is slow"

## Verification

```bash
# Zero tmux references across all 6 files
for f in docs/DISASTER_RECOVERY.md docs/architecture.md docs/SCALING.md \
         docs/SECURITY_QUESTIONNAIRE.md docs/airgapped-deployment.md docs/ALERTING.md; do
  echo "$f: $(grep -c tmux $f || echo 0)"
done
# All output: 0
```

Refs: #2625