### PR TITLE
feat(2725): implement daily docs walk-through automation

### DIFF
--- a/scripts/docs-walkthrough/README.md
+++ b/scripts/docs-walkthrough/README.md
@@ -1,0 +1,50 @@
+# Docs Walk-Through
+
+Automated daily checks for Aegis documentation.
+
+## What it checks
+
+Every doc page is scanned for 5 issues:
+
+| Check | What it does |
+|-------|-------------|
+| **Dead Links** | Finds all `[text](path)` links, verifies the target file exists |
+| **Stale References** | Flags `tmux`, `psmux`, `windowId`, `windowName`, `paneCommand`, `capture-pane` without historical context |
+| **Code Block Validation** | Validates all `bash`/`shell` fenced code blocks with `bash -n` |
+| **Broken Images** | Finds all `![alt](path)` references, verifies the file exists |
+| **Heading Hierarchy** | Verifies no skipped heading levels (h1 → h3 without h2) |
+
+## Pages checked
+
+1. Getting Started
+2. ACP Migration Guide
+3. API Reference
+4. MCP Tools
+5. Deployment Guide
+6. Windows Setup
+7. Troubleshooting
+8. BYO LLM
+
+## Usage
+
+```bash
+cd scripts/docs-walkthrough
+
+# Install and run
+./run.sh
+
+# Or manually
+npm install
+npm test              # Human-readable table
+npm run test:json     # Machine-readable JSON
+npm run test:verbose  # Verbose with all findings
+```
+
+## Exit codes
+
+- **0** — All checks passed
+- **1** — One or more issues found
+
+## Integration
+
+Designed to run as a daily cron job or CI step. The `--json` output is structured for automated consumption.

--- a/scripts/docs-walkthrough/checks.ts
+++ b/scripts/docs-walkthrough/checks.ts
@@ -1,0 +1,269 @@
+/**
+ * Automated checks for Aegis documentation markdown files.
+ *
+ * Each check receives the file's absolute path, its content, and the docs
+ * directory root.  It returns an array of findings — an empty array means pass.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { resolve, dirname, basename, join } from "node:path";
+import { execSync } from "node:child_process";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface Finding {
+  line: number;
+  column: number;
+  message: string;
+}
+
+export interface CheckResult {
+  check: string;
+  status: "pass" | "fail";
+  findings: Finding[];
+}
+
+export type CheckFn = (params: {
+  filePath: string;
+  content: string;
+  docsDir: string;
+  lines: string[];
+}) => CheckResult;
+
+// ── 1. Dead Links ───────────────────────────────────────────────────
+
+const MARKDOWN_LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
+
+export const deadLinks: CheckFn = ({ filePath, content, docsDir }) => {
+  const findings: Finding[] = [];
+  const fileDir = dirname(filePath);
+
+  for (const match of content.matchAll(MARKDOWN_LINK_RE)) {
+    const raw = match[2] as string;
+    const startIdx = match.index as number;
+    const line = content.slice(0, startIdx).split("\n").length;
+
+    // Skip external URLs, anchors-only, and section headings
+    if (
+      raw.startsWith("http://") ||
+      raw.startsWith("https://") ||
+      raw.startsWith("#") ||
+      raw.startsWith("mailto:")
+    ) {
+      continue;
+    }
+
+    // Strip trailing anchor (#section)
+    const pathPart = raw.replace(/#.*$/, "");
+
+    // Resolve relative to the markdown file's directory
+    const resolved = resolve(fileDir, pathPart);
+
+    if (!existsSync(resolved)) {
+      findings.push({
+        line,
+        column: 0,
+        message: `Dead link: [${match[1]}](${raw}) → ${resolved} does not exist`,
+      });
+    }
+  }
+
+  return {
+    check: "dead-links",
+    status: findings.length === 0 ? "pass" : "fail",
+    findings,
+  };
+};
+
+// ── 2. Stale References ─────────────────────────────────────────────
+
+const STALE_TERMS = [
+  "tmux",
+  "psmux",
+  "windowId",
+  "windowName",
+  "paneCommand",
+  "capture-pane",
+];
+
+// Contexts where stale terms are acceptable (historical / migration docs)
+const HISTORICAL_KEYWORDS = [
+  "no longer",
+  "deprecated",
+  "legacy",
+  "removed",
+  "replaced by",
+  "pre-ACP",
+  "before ACP",
+  "pre-ACP-cutover",
+  "migration",
+  "was replaced",
+  "no longer required",
+];
+
+export const staleReferences: CheckFn = ({ content, lines }) => {
+  const findings: Finding[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+
+    // Skip code fences (lines inside ``` blocks)
+    // We check this loosely — if the line contains a stale term inside a
+    // code block that's showing "how things used to be", it may still be
+    // intentional.  But we flag it unless it's clearly historical prose.
+    for (const term of STALE_TERMS) {
+      const idx = line.toLowerCase().indexOf(term.toLowerCase());
+      if (idx === -1) continue;
+
+      // Check if the surrounding context (same line) has a historical keyword
+      const lineLower = line.toLowerCase();
+      const hasHistoricalContext = HISTORICAL_KEYWORDS.some((kw) =>
+        lineLower.includes(kw)
+      );
+
+      // Also check previous and next line for context
+      const prevLine = (lines[i - 1] || "").toLowerCase();
+      const nextLine = (lines[i + 1] || "").toLowerCase();
+      const nearbyHistorical = [...HISTORICAL_KEYWORDS].some(
+        (kw) => prevLine.includes(kw) || nextLine.includes(kw)
+      );
+
+      if (!hasHistoricalContext && !nearbyHistorical) {
+        findings.push({
+          line: i + 1,
+          column: idx,
+          message: `Stale reference: "${term}" found without historical context`,
+        });
+      }
+    }
+  }
+
+  return {
+    check: "stale-references",
+    status: findings.length === 0 ? "pass" : "fail",
+    findings,
+  };
+};
+
+// ── 3. Code Block Validation ────────────────────────────────────────
+
+const FENCED_CODE_RE = /```(bash|shell)\n([\s\S]*?)```/g;
+
+export const codeBlockValidation: CheckFn = ({ content }) => {
+  const findings: Finding[] = [];
+
+  for (const match of content.matchAll(FENCED_CODE_RE)) {
+    const lang = match[1] as string;
+    const code = match[2] as string;
+    const startIdx = match.index as number;
+    const startLine = content.slice(0, startIdx).split("\n").length;
+
+    // Validate with bash -n (syntax check, no execution)
+    try {
+      execSync(`bash -n -c ${JSON.stringify(code)}`, {
+        timeout: 5000,
+        stdio: "pipe",
+      });
+    } catch (err: unknown) {
+      const stderr = (err as { stderr?: Buffer })?.stderr
+        ?.toString()
+        .trim();
+      findings.push({
+        line: startLine + 1,
+        column: 0,
+        message: `Invalid ${lang} syntax in code block: ${stderr || "syntax error"}`,
+      });
+    }
+  }
+
+  return {
+    check: "code-block-validation",
+    status: findings.length === 0 ? "pass" : "fail",
+    findings,
+  };
+};
+
+// ── 4. Broken Images ────────────────────────────────────────────────
+
+const IMAGE_RE = /!\[([^\]]*)\]\(([^)]+)\)/g;
+
+export const brokenImages: CheckFn = ({ filePath, content, docsDir }) => {
+  const findings: Finding[] = [];
+  const fileDir = dirname(filePath);
+
+  for (const match of content.matchAll(IMAGE_RE)) {
+    const raw = match[2] as string;
+    const startIdx = match.index as number;
+    const line = content.slice(0, startIdx).split("\n").length;
+
+    // Skip external URLs
+    if (raw.startsWith("http://") || raw.startsWith("https://")) {
+      continue;
+    }
+
+    const resolved = resolve(fileDir, raw);
+
+    if (!existsSync(resolved)) {
+      findings.push({
+        line,
+        column: 0,
+        message: `Broken image: [${match[1]}](${raw}) → ${resolved} does not exist`,
+      });
+    }
+  }
+
+  return {
+    check: "broken-images",
+    status: findings.length === 0 ? "pass" : "fail",
+    findings,
+  };
+};
+
+// ── 5. Heading Hierarchy ────────────────────────────────────────────
+
+const HEADING_RE = /^(#{1,6})\s+/;
+
+export const headingHierarchy: CheckFn = ({ lines }) => {
+  const findings: Finding[] = [];
+  let lastLevel = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i]!.match(HEADING_RE);
+    if (!match) continue;
+
+    const level = match[1]!.length;
+
+    // H1 is allowed at the top of a file (first heading)
+    if (i === 0 && level === 1) {
+      lastLevel = level;
+      continue;
+    }
+
+    // A heading should not skip levels (e.g., h1 → h3)
+    if (level > lastLevel + 1 && lastLevel > 0) {
+      findings.push({
+        line: i + 1,
+        column: 0,
+        message: `Heading hierarchy: h${level} follows h${lastLevel} (skipped level)`,
+      });
+    }
+
+    lastLevel = level;
+  }
+
+  return {
+    check: "heading-hierarchy",
+    status: findings.length === 0 ? "pass" : "fail",
+    findings,
+  };
+};
+
+// ── Registry ─────────────────────────────────────────────────────────
+
+export const ALL_CHECKS: { name: string; fn: CheckFn }[] = [
+  { name: "Dead Links", fn: deadLinks },
+  { name: "Stale References", fn: staleReferences },
+  { name: "Code Block Validation", fn: codeBlockValidation },
+  { name: "Broken Images", fn: brokenImages },
+  { name: "Heading Hierarchy", fn: headingHierarchy },
+];

--- a/scripts/docs-walkthrough/package-lock.json
+++ b/scripts/docs-walkthrough/package-lock.json
@@ -1,0 +1,572 @@
+{
+  "name": "aegis-docs-walkthrough",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aegis-docs-walkthrough",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/scripts/docs-walkthrough/package.json
+++ b/scripts/docs-walkthrough/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "aegis-docs-walkthrough",
+  "version": "1.0.0",
+  "description": "Daily automated docs walk-through — dead links, stale refs, code blocks, images, heading hierarchy",
+  "type": "module",
+  "scripts": {
+    "test": "tsx walkthrough.ts",
+    "test:json": "tsx walkthrough.ts --json",
+    "test:verbose": "tsx walkthrough.ts --verbose"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/scripts/docs-walkthrough/run.sh
+++ b/scripts/docs-walkthrough/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "🔧 Installing dependencies..."
+cd "$SCRIPT_DIR"
+npm install
+
+echo ""
+echo "🏃 Running docs walk-through..."
+echo ""
+
+npm test

--- a/scripts/docs-walkthrough/tsconfig.json
+++ b/scripts/docs-walkthrough/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["*.ts"]
+}

--- a/scripts/docs-walkthrough/walkthrough.ts
+++ b/scripts/docs-walkthrough/walkthrough.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env tsx
+/**
+ * Aegis Docs Walk-Through Runner
+ *
+ * Walks through all configured doc pages and runs automated checks.
+ * Usage:
+ *   npm test                  # human-readable table
+ *   npm run test:json         # machine-readable JSON
+ *   npm run test:verbose      # verbose output with all findings
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, join, relative } from "node:path";
+import { ALL_CHECKS, type CheckResult } from "./checks.js";
+
+// ── Configuration ───────────────────────────────────────────────────
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+const DOCS_DIR = join(REPO_ROOT, "docs");
+
+const PAGES: { name: string; file: string }[] = [
+  { name: "Getting Started", file: "getting-started.md" },
+  { name: "ACP Migration Guide", file: "acp-migration-guide.md" },
+  { name: "API Reference", file: "api-reference.md" },
+  { name: "MCP Tools", file: "mcp-tools.md" },
+  { name: "Deployment Guide", file: "deployment.md" },
+  { name: "Windows Setup", file: "windows-setup.md" },
+  { name: "Troubleshooting", file: "troubleshooting.md" },
+  { name: "BYO LLM", file: "byo-llm.md" },
+];
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface PageResult {
+  page: string;
+  file: string;
+  skipped: boolean;
+  checks: CheckResult[];
+}
+
+// ── Runner ──────────────────────────────────────────────────────────
+
+function runWalkthrough(): PageResult[] {
+  const results: PageResult[] = [];
+
+  for (const page of PAGES) {
+    const filePath = join(DOCS_DIR, page.file);
+
+    if (!existsSync(filePath)) {
+      console.log(`⏭️  ${page.name}: skipped (file not found)`);
+      results.push({
+        page: page.name,
+        file: page.file,
+        skipped: true,
+        checks: [],
+      });
+      continue;
+    }
+
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.split("\n");
+    const checks: CheckResult[] = [];
+
+    for (const { name, fn } of ALL_CHECKS) {
+      try {
+        const result = fn({ filePath, content, docsDir: DOCS_DIR, lines });
+        checks.push(result);
+      } catch (err: unknown) {
+        checks.push({
+          check: name.toLowerCase().replace(/\s+/g, "-"),
+          status: "fail",
+          findings: [
+            {
+              line: 0,
+              column: 0,
+              message: `Check crashed: ${(err as Error).message}`,
+            },
+          ],
+        });
+      }
+    }
+
+    results.push({
+      page: page.name,
+      file: page.file,
+      skipped: false,
+      checks,
+    });
+  }
+
+  return results;
+}
+
+// ── Formatters ──────────────────────────────────────────────────────
+
+function formatTable(results: PageResult[]): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("╔════════════════════════════════════════════════════════════════════════════════╗");
+  lines.push("║                        AEGIS DOCS WALK-THROUGH REPORT                         ║");
+  lines.push("╚════════════════════════════════════════════════════════════════════════════════╝");
+  lines.push("");
+
+  let totalChecks = 0;
+  let totalFails = 0;
+  let totalFindings = 0;
+
+  for (const result of results) {
+    if (result.skipped) {
+      lines.push(`  ⏭️  ${result.page.padEnd(24)} SKIPPED (file not found)`);
+      lines.push("");
+      continue;
+    }
+
+    lines.push(`  📄 ${result.page}`);
+    lines.push(`     ${"─".repeat(50)}`);
+
+    for (const check of result.checks) {
+      totalChecks++;
+      const icon = check.status === "pass" ? "✅" : "❌";
+      const detail =
+        check.status === "pass"
+          ? ""
+          : ` — ${check.findings.length} finding(s)`;
+      lines.push(
+        `     ${icon} ${check.check.padEnd(26)} ${check.status.toUpperCase()}${detail}`
+      );
+
+      if (check.status === "fail") {
+        totalFails++;
+        totalFindings += check.findings.length;
+      }
+    }
+
+    lines.push("");
+  }
+
+  // Summary
+  lines.push("  ──────────────────────────────────────────────────────");
+  const summaryIcon = totalFails === 0 ? "✅" : "❌";
+  lines.push(
+    `  ${summaryIcon} Summary: ${totalChecks} checks, ${totalFails} failed, ${totalFindings} total findings`
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function formatJson(results: PageResult[]): string {
+  const output = {
+    timestamp: new Date().toISOString(),
+    pages: results.map((r) => ({
+      page: r.page,
+      file: r.file,
+      skipped: r.skipped,
+      checks: r.checks.map((c) => ({
+        check: c.check,
+        status: c.status,
+        findingCount: c.findings.length,
+        findings: c.findings.map((f) => ({
+          line: f.line,
+          column: f.column,
+          message: f.message,
+        })),
+      })),
+    })),
+    summary: {
+      totalChecks: results.reduce((n, r) => n + r.checks.length, 0),
+      failedChecks: results.reduce(
+        (n, r) => n + r.checks.filter((c) => c.status === "fail").length,
+        0
+      ),
+      totalFindings: results.reduce(
+        (n, r) => n + r.checks.reduce((n2, c) => n2 + c.findings.length, 0),
+        0
+      ),
+    },
+  };
+  return JSON.stringify(output, null, 2);
+}
+
+function formatVerbose(results: PageResult[]): string {
+  const lines: string[] = [];
+  lines.push(formatTable(results));
+
+  for (const result of results) {
+    if (result.skipped) continue;
+
+    const failedChecks = result.checks.filter((c) => c.status === "fail");
+    if (failedChecks.length === 0) continue;
+
+    lines.push(`  📄 ${result.page} — ${result.file}`);
+    lines.push("");
+
+    for (const check of failedChecks) {
+      lines.push(`     ❌ ${check.check}:`);
+      for (const f of check.findings) {
+        lines.push(`        L${f.line}:${f.column}  ${f.message}`);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const jsonMode = args.includes("--json");
+const verboseMode = args.includes("--verbose");
+
+console.error(`Docs dir: ${DOCS_DIR}`);
+
+const results = runWalkthrough();
+
+if (jsonMode) {
+  console.log(formatJson(results));
+} else {
+  console.log(verboseMode ? formatVerbose(results) : formatTable(results));
+}
+
+// Exit code: 0 if all clean, 1 if any issues
+const hasFailures = results.some((r) =>
+  r.checks.some((c) => c.status === "fail")
+);
+process.exit(hasFailures ? 1 : 0);


### PR DESCRIPTION
## What

Automated docs walk-through that runs 5 checks across 8 doc pages.

## Checks

| Check | What it does |
|-------|-------------|
| Dead Links | Verifies all `[text](path)` targets exist on disk |
| Stale References | Flags `tmux`, `psmux`, `windowId`, `windowName`, `paneCommand`, `capture-pane` without historical context |
| Code Block Validation | Validates all `bash`/`shell` code blocks with `bash -n` |
| Broken Images | Verifies all `![alt](path)` targets exist on disk |
| Heading Hierarchy | Detects skipped heading levels (h1 → h3 without h2) |

## Pages covered

Getting Started, ACP Migration Guide, API Reference, MCP Tools, Deployment Guide, Windows Setup, Troubleshooting, BYO LLM

## How to run

```bash
cd scripts/docs-walkthrough
npm install
npm test              # human-readable table
npm run test:json     # machine-readable JSON
npm run test:verbose  # verbose with all findings
```

## Design decisions

- **No web server** — reads markdown files directly from disk, so it works in CI without a Vite build
- **`bash -n`** for syntax validation — catches syntax errors without executing anything
- **Stale reference context** — only flags tmux/etc terms when there is no nearby "deprecated", "no longer", "legacy" etc. keyword
- **Exit code 1 on any failure** — suitable for CI gating

## Future (not in this PR)

- OpenClaw cron job for daily runs
- GitHub issue filing on failure
- Screenshot baseline diffing
- cspell integration

Closes #2725