### PR TITLE
chore(helm): bump chart version to 0.6.6-preview.1

### DIFF
--- a/charts/aegis/Chart.yaml
+++ b/charts/aegis/Chart.yaml
@@ -3,9 +3,9 @@ name: aegis
 description: Deploy Aegis — the control plane for Claude Code — on Kubernetes.
 type: application
 # Chart version follows SemVer 2. Bump on each chart change.
-version: 0.6.5-preview.3
+version: 0.6.6-preview.1
 # appVersion tracks the Aegis container image tag (sourced from package.json).
-appVersion: "0.6.5-preview.3"
+appVersion: "0.6.6-preview.1"
 home: https://github.com/OneStepAt4time/aegis
 sources:
   - https://github.com/OneStepAt4time/aegis

--- a/deploy/helm/aegis/Chart.yaml
+++ b/deploy/helm/aegis/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aegis
 description: Deploy Aegis on Kubernetes or k3s with persistent session state.
 type: application
-version: 0.6.5-preview.3
-appVersion: "0.6.5-preview.3"
+version: 0.6.6-preview.1
+appVersion: "0.6.6-preview.1"
 home: https://github.com/OneStepAt4time/aegis
 sources:
   - https://github.com/OneStepAt4time/aegis


### PR DESCRIPTION
## Summary

Bumps both Helm chart locations to match `package.json` version `0.6.6-preview.1`.

## Changes
- `deploy/helm/aegis/Chart.yaml`: version + appVersion `0.6.5-preview.3` → `0.6.6-preview.1`
- `charts/aegis/Chart.yaml`: version + appVersion `0.6.5-preview.3` → `0.6.6-preview.1`

## Verification
- `helm lint deploy/helm/aegis` passes
- `helm lint charts/aegis` passes
- No template rendering errors