### PR TITLE
chore(ci): reduce helm-smoke timeout from 40min to 15min

### DIFF
--- a/.github/workflows/helm-smoke.yml
+++ b/.github/workflows/helm-smoke.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   helm-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Reduces `helm-smoke.yml` job timeout from 40 minutes to 15 minutes.

## Justification

Post-ACP cutover, the tmux fault harness entries have been removed from the smoke tests. Recent runs (last 5 on 2026-05-06):

| Run | Started | Completed | Duration |
|-----|---------|-----------|----------|
| 1 | 09:58:35 | 10:02:39 | ~4m04s |
| 2 | 09:51:40 | 09:55:15 | ~3m35s |
| 3 | 09:45:45 | 09:49:35 | ~3m50s |
| 4 | 09:35:35 | 09:39:27 | ~3m52s |
| 5 | 09:26:27 | 09:30:15 | ~3m48s |

Average: **~3m50s**. 15 minutes provides **3.5x headroom** — more than enough for CI variability while catching genuine hangs 25 minutes earlier.

## Verification
- No change to test logic — timeout reduction only
- Will be validated by CI on this PR