### PR TITLE
fix: remove remaining tmux prerequisite checks from CLI, init, and doctor

### DIFF
--- a/src/__tests__/cli-doctor.test.ts
+++ b/src/__tests__/cli-doctor.test.ts
@@ -6,7 +6,6 @@ import {
   evaluatePortCheck,
   formatDoctorReport,
   parseDoctorArgs,
-  parseTmuxVersion,
   runDoctorChecks,
   runDoctorCommand,
   type DoctorBaseUrlResult,
@@ -15,6 +14,26 @@ import {
   type DoctorConfigContext,
   type DoctorDependencies,
 } from '../doctor.js';
+
+vi.mock('../services/acp/binary-resolver.js', () => ({
+  AcpBinaryResolutionError: class AcpBinaryResolutionError extends Error {
+    readonly code = 'AEGIS_ACP_BINARY_NOT_FOUND';
+    readonly details = {};
+    constructor(message: string) {
+      super(message);
+      this.name = 'AcpBinaryResolutionError';
+    }
+  },
+  resolveClaudeAgentAcpBinary: vi.fn(() => ({
+    command: 'node',
+    args: ['/path/to/claude-agent-acp'],
+    source: 'bundled-package-bin',
+    binName: 'claude-agent-acp',
+    binPath: '/path/to/claude-agent-acp',
+    packageName: '@agentclientprotocol/claude-agent-acp',
+    packageJsonPath: '/path/to/package.json',
+  })),
+}));
 
 function makeCommandResult(overrides: Partial<DoctorCommandResult> = {}): DoctorCommandResult {
   return {
@@ -71,9 +90,6 @@ function makeFetch(result: DoctorBaseUrlResult): typeof fetch {
 
 function makeDependencies(overrides: Partial<DoctorDependencies> = {}): DoctorDependencies {
   const runCommand = vi.fn(async (command: string, args: string[]) => {
-    if (command === 'tmux' && args[0] === '-V') {
-      return makeCommandResult({ stdout: 'tmux 3.4' });
-    }
     if (command === 'claude' && args[0] === '--version') {
       return makeCommandResult({ stdout: '2.1.111 (Claude Code)' });
     }
@@ -111,11 +127,7 @@ describe('ag doctor', () => {
     });
   });
 
-  describe('version and URL helpers', () => {
-    it('parses tmux 3.2 as a supported semver', () => {
-      expect(parseTmuxVersion('tmux 3.2')).toBe('3.2.0');
-    });
-
+  describe('URL helpers', () => {
     it('normalizes wildcard hosts for reachability probes', () => {
       expect(buildDoctorBaseUrl('0.0.0.0', 9100)).toBe('http://127.0.0.1:9100');
       expect(buildDoctorBaseUrl('::', 9100)).toBe('http://[::1]:9100');
@@ -148,7 +160,7 @@ describe('ag doctor', () => {
       expect(report.checks.map(check => check.label)).toEqual([
         'Config',
         'Node.js',
-        'tmux',
+        'ACP runtime',
         'Claude CLI',
         'Claude auth',
         'State dir',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,10 @@ import { handleInit, findStarterTemplateFiles, handleStarterTemplateDoctor } fro
 import { handleLogin } from './commands/login.js';
 import { handleLogout } from './commands/logout.js';
 import { handleWhoami } from './commands/whoami.js';
+import {
+  AcpBinaryResolutionError,
+  resolveClaudeAgentAcpBinary,
+} from './services/acp/binary-resolver.js';
 import { getErrorMessage, parseIntSafe } from './validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -38,31 +42,6 @@ const defaultCliIO: CliIO = {
   stdout: process.stdout,
   stderr: process.stderr,
 };
-
-/** Check whether a required external dependency can be executed. */
-function checkDependency(command: string, args: string[]): boolean {
-  try {
-    execFileSync(command, args, { stdio: 'ignore', timeout: 5000 });
-    return true;
-  } catch { /* command not found or exited non-zero */
-    return false;
-  }
-}
-
-/** Parse tmux -V output and enforce minimum supported version. */
-function checkTmuxVersion(minMajor: number = 3, minMinor: number = 2): { ok: boolean; version: string | null } {
-  try {
-    const out = execFileSync('tmux', ['-V'], { encoding: 'utf-8', timeout: 5000 }).trim();
-    const m = out.match(/tmux\s+(\d+)\.(\d+)/i);
-    if (!m) return { ok: false, version: null };
-    const major = parseInt(m[1]!, 10);
-    const minor = parseInt(m[2]!, 10);
-    const ok = major > minMajor || (major === minMajor && minor >= minMinor);
-    return { ok, version: `${major}.${minor}` };
-  } catch {
-    return { ok: false, version: null };
-  }
-}
 
 function write(stream: NodeJS.WritableStream, text: string): void {
   stream.write(text);
@@ -256,7 +235,6 @@ function printHelp(io: CliIO): void {
     AEGIS_PORT                     Server port (default: 9100)
     AEGIS_HOST                     Server host (default: 127.0.0.1)
     AEGIS_AUTH_TOKEN               Bearer token for API auth
-    AEGIS_TMUX_SESSION             tmux session name (default: aegis)
     AEGIS_STATE_DIR                State directory (default: ~/.aegis)
     AEGIS_DASHBOARD_ENABLED        Serve dashboard assets (default: true)
     AEGIS_TG_TOKEN                 Telegram bot token
@@ -338,32 +316,26 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
     process.env.AEGIS_PORT = argv[portIdx + 1];
   }
 
-  const acpMode = !!process.env.AEGIS_ACP_BIN;
-  const hasTmux = checkDependency('tmux', ['-V']);
-  const hasClaude = checkDependency('claude', ['--version']);
-  const tmuxVersion = hasTmux ? checkTmuxVersion(3, 2) : { ok: false, version: null };
+  let acpRuntime: { ok: boolean; label: string };
+  try {
+    const resolved = resolveClaudeAgentAcpBinary();
+    acpRuntime = { ok: true, label: resolved.source === 'AEGIS_ACP_BIN' ? `acp ✅ (${resolved.command})` : 'acp ✅' };
+  } catch (error) {
+    const message = error instanceof AcpBinaryResolutionError ? error.message : getErrorMessage(error);
+    write(io.stderr, `
+  ❌ ACP runtime not found.
 
-  if (!acpMode) {
-    if (!hasTmux) {
-      write(io.stderr, `
-  ❌ tmux not found.
-
-  Install tmux:
-    Ubuntu/Debian:  sudo apt install tmux
-    macOS:          brew install tmux
-    Windows:        winget install psmux
+  ${message}
     `);
-      return 1;
-    }
+    return 1;
+  }
 
-    if (!tmuxVersion.ok) {
-      write(io.stderr, `
-  ❌ Unsupported tmux version${tmuxVersion.version ? ` (${tmuxVersion.version})` : ''}.
-
-  Aegis requires tmux/psmux 3.2 or newer.
-  `);
-      return 1;
-    }
+  let hasClaude: boolean;
+  try {
+    execFileSync('claude', ['--version'], { stdio: 'ignore', timeout: 5000 });
+    hasClaude = true;
+  } catch {
+    hasClaude = false;
   }
 
   if (!hasClaude) {
@@ -381,11 +353,7 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
   printBanner(io, config.port);
 
   writeLine(io.stdout, '  Dependencies:');
-  if (acpMode) {
-    writeLine(io.stdout, `    runtime: acp ✅ (${process.env.AEGIS_ACP_BIN})`);
-  } else {
-    writeLine(io.stdout, `    tmux:   ${hasTmux ? '✅' : '❌'}`);
-  }
+  writeLine(io.stdout, `    runtime: ${acpRuntime.label}`);
   writeLine(io.stdout, `    claude: ${hasClaude ? '✅' : '❌'}`);
   writeLine(io.stdout);
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,12 +1,11 @@
 /**
  * commands/init.ts — Interactive project bootstrap (`ag init`).
  *
- * Detects tmux, scaffolds `.aegis/config.yaml`, generates API keys,
+ * Scaffolds `.aegis/config.yaml`, generates API keys,
  * creates the state directory, and prints next steps.
  * Also handles `--list-templates` and `--from-template`.
  */
 
-import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { copyFile, mkdir, readFile, readdir } from 'node:fs/promises';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -79,29 +78,6 @@ function write(stream: NodeJS.WritableStream, text: string): void {
 
 function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
   stream.write(`${text}\n`);
-}
-
-function checkDependency(command: string, args: string[]): boolean {
-  try {
-    execFileSync(command, args, { stdio: 'ignore', timeout: 5000 });
-    return true;
-  } catch { /* command not found or exited non-zero */
-    return false;
-  }
-}
-
-function checkTmuxVersion(minMajor: number = 3, minMinor: number = 2): { ok: boolean; version: string | null } {
-  try {
-    const out = execFileSync('tmux', ['-V'], { encoding: 'utf-8', timeout: 5000 }).trim();
-    const m = out.match(/tmux\s+(\d+)\.(\d+)/i);
-    if (!m) return { ok: false, version: null };
-    const major = parseInt(m[1]!, 10);
-    const minor = parseInt(m[2]!, 10);
-    const ok = major > minMajor || (major === minMajor && minor >= minMinor);
-    return { ok, version: `${major}.${minor}` };
-  } catch {
-    return { ok: false, version: null };
-  }
 }
 
 // --- Config path helpers ---
@@ -576,18 +552,6 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   const existingToken = resolveExistingToken(existingConfig);
   const existingByoEnv = filterByoEnv(existingConfig?.defaultSessionEnv);
   const currentConfig = await loadConfig();
-
-  // Detect tmux
-  const hasTmux = checkDependency('tmux', ['-V']);
-  const tmuxCheck = hasTmux ? checkTmuxVersion(3, 2) : { ok: false, version: null };
-  if (!hasTmux) {
-    writeLine(io.stdout, '  ⚠️  tmux not found — sessions will not start without it.');
-    writeLine(io.stdout, '     Install: sudo apt install tmux | brew install tmux');
-  } else if (!tmuxCheck.ok) {
-    writeLine(io.stdout, `  ⚠️  tmux ${tmuxCheck.version ?? 'unknown'} — Aegis requires 3.2+.`);
-  } else {
-    writeLine(io.stdout, `  ✅ tmux ${tmuxCheck.version} detected`);
-  }
 
   // Ensure state directory exists
   const stateDir = currentConfig.stateDir;

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -13,6 +13,10 @@ import {
 } from './config.js';
 import { findPidOnPort } from './process-utils.js';
 import {
+  AcpBinaryResolutionError,
+  resolveClaudeAgentAcpBinary,
+} from './services/acp/binary-resolver.js';
+import {
   compareSemver,
   extractCCVersion,
   getErrorMessage,
@@ -25,7 +29,6 @@ const HEALTH_PATH = '/v1/health';
 const STATE_DIR_PROBE_PREFIX = '.ag-doctor-';
 
 export const MIN_NODE_VERSION = '20.0.0';
-export const MIN_TMUX_VERSION = '3.2.0';
 
 export type DoctorCheckStatus = 'ok' | 'warn' | 'fail';
 
@@ -312,12 +315,6 @@ export function parseDoctorArgs(args: string[]): DoctorOptions {
   return { json, portArg };
 }
 
-export function parseTmuxVersion(output: string): string | null {
-  const match = trimCommandOutput(output).match(/tmux\s+(\d+)\.(\d+)/i);
-  if (!match) return null;
-  return `${match[1]}.${match[2]}.0`;
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -510,10 +507,7 @@ export async function runDoctorChecks(
   const baseUrl = buildDoctorBaseUrl(configContext.config.host, port);
   const auditDir = path.join(configContext.config.stateDir, 'audit');
 
-  const acpMode = !!process.env.AEGIS_ACP_BIN;
-
   const [
-    tmuxVersionResult,
     claudeVersionResult,
     claudeAuthResult,
     stateDirResult,
@@ -521,7 +515,6 @@ export async function runDoctorChecks(
     portPids,
     baseUrlResult,
   ] = await Promise.all([
-    dependencies.runCommand('tmux', ['-V']),
     dependencies.runCommand('claude', ['--version']),
     dependencies.runCommand('claude', ['auth', 'status']),
     dependencies.probeStateDirWriteAccess(configContext.config.stateDir),
@@ -544,40 +537,27 @@ export async function runDoctorChecks(
     details: { version: nodeVersion, minimum: MIN_NODE_VERSION },
   });
 
-  if (acpMode) {
-    const acpBin = process.env.AEGIS_ACP_BIN!;
+  try {
+    const resolved = resolveClaudeAgentAcpBinary();
     checks.push({
       key: 'runtime',
-      label: 'runtime',
+      label: 'ACP runtime',
       status: 'ok',
-      message: `acp (${acpBin})`,
-      details: { mode: 'acp', binary: acpBin },
+      message: resolved.source === 'AEGIS_ACP_BIN'
+        ? `acp (${resolved.command})`
+        : `acp (${resolved.binName ?? resolved.command})`,
+      details: { mode: 'acp', ...resolved },
     });
-  } else if (!tmuxVersionResult.ok) {
+  } catch (error) {
+    const message = error instanceof AcpBinaryResolutionError
+      ? error.message
+      : getErrorMessage(error);
     checks.push({
-      key: 'tmux',
-      label: 'tmux',
+      key: 'runtime',
+      label: 'ACP runtime',
       status: 'fail',
-      message: summarizeCommandFailure(tmuxVersionResult),
-      details: { minimum: MIN_TMUX_VERSION },
-    });
-  } else {
-    const tmuxVersion = parseTmuxVersion(tmuxVersionResult.stdout);
-    const supported = tmuxVersion !== null && compareSemver(tmuxVersion, MIN_TMUX_VERSION) >= 0;
-    checks.push({
-      key: 'tmux',
-      label: 'tmux',
-      status: supported ? 'ok' : 'fail',
-      message: supported
-        ? `v${tmuxVersion!.slice(0, -2)}`
-        : tmuxVersion
-          ? `v${tmuxVersion.slice(0, -2)} (requires >= ${MIN_TMUX_VERSION.slice(0, -2)})`
-          : `Could not parse version from "${tmuxVersionResult.stdout}"`,
-      details: {
-        output: tmuxVersionResult.stdout,
-        version: tmuxVersion,
-        minimum: MIN_TMUX_VERSION,
-      },
+      message,
+      details: { mode: 'acp', error: message },
     });
   }
 


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
Removes stale tmux version and dependency checks from CLI startup, `ag init`, and `ag doctor`. ACP is the only shipped backend after cutover; these checks were missed in earlier waves.

## Changes
- `src/cli.ts`: Replaces tmux prerequisite check with `resolveClaudeAgentAcpBinary`. Removes `AEGIS_TMUX_SESSION` from help text.
- `src/commands/init.ts`: Removes tmux detection during bootstrap.
- `src/doctor.ts`: Replaces tmux health check with ACP runtime check. Removes `parseTmuxVersion` and `MIN_TMUX_VERSION`.
- `src/__tests__/cli-doctor.test.ts`: Updates mocks and expectations for ACP runtime check.

## Verification
- `npm run gate` passes (251 test files, 3904 tests)
- No obsolete references to removed legacy files
- No trash/untracked artifacts

## Related issues
Closes #2627