### PR TITLE
chore: remove remaining tmux references from health contracts, alerting, monitor, and tracing

### DIFF
--- a/dashboard/e2e/helpers/dashboard-fixtures.ts
+++ b/dashboard/e2e/helpers/dashboard-fixtures.ts
@@ -289,7 +289,6 @@ export async function mockDashboardFixtures(page: Page): Promise<void> {
       platform: 'win32',
       uptime: 7200,
       sessions: { active: sessions.length, total: 12 },
-      tmux: { healthy: true, error: null },
       claude: { available: true, healthy: true, version: '1.0.0', minimumVersion: '1.0.0', error: null },
       timestamp: new Date(now).toISOString(),
     }),

--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -36,7 +36,7 @@ groups:
           summary: "Aegis session failure rate exceeds 10%"
           description: >
             {{ $value | humanizePercentage }} of sessions are failing over the last 5 minutes
-            on {{ $labels.instance }}. Check Claude Code connectivity and tmux health.
+            on {{ $labels.instance }}. Check Claude Code connectivity and ACP runtime health.
           runbook_url: "https://docs.aegis.dev/disaster-recovery#scenario-2--statejson-corruption"
 
       # ── Session Health ────────────────────────────────────────────
@@ -64,7 +64,7 @@ groups:
           description: >
             {{ $value }} sessions show no activity for over 1 hour.
             Sessions may be stuck or Claude Code may be unresponsive.
-          runbook_url: "https://docs.aegis.dev/disaster-recovery#scenario-3--tmux-session-loss"
+          runbook_url: "https://docs.aegis.dev/disaster-recovery#scenario-3--session-loss"
 
       # ── Webhook Delivery ──────────────────────────────────────────
 
@@ -135,5 +135,5 @@ groups:
         annotations:
           summary: "Aegis state sync is delayed"
           description: >
-            State change detection is slow ({{ $value }}ms P95). tmux polling
+            State change detection is slow ({{ $value }}ms P95). Session polling
             may be under load. Check server resource usage.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,6 +1,6 @@
 # src/ — Aegis Server Core
 
-Module containing the HTTP server, session management, tmux integration, and all backend logic.
+Module containing the HTTP server, session management, ACP runtime integration, and all backend logic.
 
 ## Architecture
 
@@ -8,7 +8,7 @@ Module containing the HTTP server, session management, tmux integration, and all
 src/
 ├── server.ts          # Fastify HTTP server + all route registration
 ├── session.ts         # Session lifecycle (create/send/read/kill/recover)
-├── tmux.ts            # TmuxManager — tmux command wrapper (async, with timeouts)
+├── services/acp/      # ACP runtime (child process, JSON-RPC, events)
 ├── monitor.ts         # Background polling loop + event detection
 ├── mcp-server.ts      # MCP stdio transport (tool discovery for Claude Code)
 ├── config.ts          # Config loading from env + defaults
@@ -22,17 +22,17 @@ src/
 ### Key patterns
 
 - **No database** — all state in memory + JSON files on disk. Aegis is a bridge, not a platform.
-- **Tmux as session container** — one tmux window per Claude Code session. All interaction via `send-keys`/`capture-pane`.
+- **ACP as session container** — one `claude-agent-acp` child process per Claude Code session. Communication via JSON-RPC over stdio.
 - **JSONL transcript parsing** — incremental reads using byte offsets. The `transcript.ts` parser reads CC's native output format.
 - **Terminal state machine** — `terminal-parser.ts` detects idle/working/asking/stalled states via regex patterns on captured pane content.
-- **Async with timeouts** — all tmux commands use `execFile` with timeouts. Never block the event loop.
+- **Async with timeouts** — all ACP commands use timeouts. Never block the event loop.
 - **Fastify schema validation** — routes use Zod schemas for request/response validation.
 - **Event-driven monitoring** — `monitor.ts` polls sessions, emits events through `SessionEventBus`.
 
 ### Dependency flow
 
 ```
-server.ts → SessionManager → TmuxManager → tmux (process)
+server.ts → SessionManager → AcpRuntime → claude-agent-acp (process)
          → SessionMonitor → SessionManager
          → ChannelManager → TelegramChannel / WebhookChannel
          → PipelineManager → SessionManager
@@ -46,22 +46,21 @@ server.ts → SessionManager → TmuxManager → tmux (process)
 - **TypeScript strict mode** — no `any`. Use `unknown` + type guards.
 - **Type imports** — `import type { X }` on separate lines.
 - **Error handling** — use `normalizeApiErrorPayload()` for API responses. Never leak stack traces.
-- **Platform branching** — Windows vs Unix differences handled in `tmux.ts` and `session.ts`. Check `process.platform`.
+- **Platform branching** — Windows vs Unix differences handled in `session.ts` and ACP runtime. Check `process.platform`.
 - **Session IDs** — UUIDs generated with `crypto.randomUUID()`.
 - **Concurrency** — `async-mutex` for critical sections (e.g., session creation, permission handling).
 
 ## Testing
 
 - Tests live in `src/__tests__/`.
-- **Always mock tmux** — never hit real tmux in tests. Use `helpers/mock-tmux.ts`.
+- **Always mock ACP runtime** — never hit real Claude Code in tests.
 - **Always mock time** — use `vi.useFakeTimers()` for timeout/retry tests.
 - Integration tests go in `src/__tests__/integration/`.
 - Run: `npm test` (vitest)
 
 ## Common pitfalls
 
-- `tmux send-keys` is fire-and-forget — prompts may not arrive. Always verify via `capture-pane`.
-- `capture-pane` output includes ANSI codes — use `stripAnsi()` before parsing.
+- ACP `send_message` is async — verify delivery via transcript.
 - Session state is persisted to JSON — concurrent writes need the mutex.
 - The JSONL parser tracks byte offsets — don't reset offsets unless the file is recreated.
 - Windows paths need special handling — use `normalizeWorkDirForCompare()` for comparisons.

--- a/src/__tests__/alerting.test.ts
+++ b/src/__tests__/alerting.test.ts
@@ -146,8 +146,8 @@ describe('AlertManager', () => {
 
       manager.recordFailure('session_failure', 's1');
       manager.recordFailure('session_failure', 's2');
-      manager.recordFailure('tmux_crash', 't1');
-      manager.recordFailure('tmux_crash', 't2');
+      manager.recordFailure('acp_child_crash', 't1');
+      manager.recordFailure('acp_child_crash', 't2');
       await vi.advanceTimersByTimeAsync(0);
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -155,7 +155,7 @@ describe('AlertManager', () => {
       const calls = mockFetch.mock.calls.map(([_, opts]) => JSON.parse(opts.body));
       const types = calls.map(c => c.type);
       expect(types).toContain('session_failure');
-      expect(types).toContain('tmux_crash');
+      expect(types).toContain('acp_child_crash');
     });
 
     it('fires to multiple webhooks', async () => {

--- a/src/__tests__/dead-session.test.ts
+++ b/src/__tests__/dead-session.test.ts
@@ -153,7 +153,7 @@ describe('checkDeadSessions', () => {
 
     expect(bus.emitDead).toHaveBeenCalledTimes(1);
     expect(bus.emitDead).toHaveBeenCalledWith('emit-dead', expect.stringContaining('my-window'));
-    expect(bus.emitDead).toHaveBeenCalledWith('emit-dead', expect.stringContaining('tmux window no longer exists'));
+    expect(bus.emitDead).toHaveBeenCalledWith('emit-dead', expect.stringContaining('session process no longer alive'));
   });
 
   it('emits via channels.statusChange with "status.dead" event', async () => {
@@ -173,7 +173,7 @@ describe('checkDeadSessions', () => {
     expect(payload.event).toBe('status.dead');
     expect(payload.session.id).toBe('ch-dead');
     expect(payload.session.name).toBe('ch-win');
-    expect(payload.detail).toContain('tmux window no longer exists');
+    expect(payload.detail).toContain('session process no longer alive');
   });
 
   it('calls removeSession(sessionId) to clean up tracking state', async () => {

--- a/src/__tests__/health-auth-2458.test.ts
+++ b/src/__tests__/health-auth-2458.test.ts
@@ -234,7 +234,7 @@ describe('Issue #2458: GET /v1/health auth-gated info', () => {
     expect(Object.keys(body)).toEqual(['status']);
   });
 
-  it('unauthenticated request does not leak version, uptime, sessions, tmux, or claude', async () => {
+  it('unauthenticated request does not leak version, uptime, sessions, or claude', async () => {
     const res = await app.inject({ method: 'GET', url: '/v1/health' });
     const body = res.json() as Record<string, unknown>;
 

--- a/src/__tests__/per-action-rbac-1922.test.ts
+++ b/src/__tests__/per-action-rbac-1922.test.ts
@@ -107,10 +107,6 @@ function makeContext(granted: Partial<Record<PermissionName, boolean>> = {}) {
 
   const ctx = {
     sessions,
-    tmux: {
-      capturePane: vi.fn(async () => ''),
-      resizePane: vi.fn(async () => {}),
-    },
     auth,
     quotas: {
       checkSessionQuota: vi.fn(() => ({ allowed: true })),

--- a/src/__tests__/route-aliases-2461.test.ts
+++ b/src/__tests__/route-aliases-2461.test.ts
@@ -112,10 +112,6 @@ function makeContext(granted: Partial<Record<PermissionName, boolean>> = {}) {
 
   const ctx = {
     sessions,
-    tmux: {
-      capturePane: vi.fn(async () => ''),
-      resizePane: vi.fn(async () => {}),
-    },
     auth,
     quotas: {
       checkSessionQuota: vi.fn(() => ({ allowed: true })),

--- a/src/__tests__/tracing-e2e.test.ts
+++ b/src/__tests__/tracing-e2e.test.ts
@@ -64,15 +64,15 @@ describe('OpenTelemetry E2E trace correlation', () => {
       expect(sessionSpan.spanContext().traceId).toBe(httpSpan.spanContext().traceId);
     });
 
-    it('creates tmux spans as children of session spans', () => {
+    it('creates child spans under session spans', () => {
       const tracer = trace.getTracer('aegis-test', '0.0.0');
 
       tracer.startActiveSpan('session.create', (sessionSpan) => {
-        const tmuxSpan = tracer.startSpan('tmux.create_window', {
+        const childSpan = tracer.startSpan('acp.create_session', {
           kind: SpanKind.INTERNAL,
-          attributes: { 'aegis.tmux.window_id': '@0' },
+          attributes: { 'aegis.session.window_id': '@0' },
         });
-        tmuxSpan.end();
+        childSpan.end();
         sessionSpan.end();
       });
 
@@ -80,10 +80,10 @@ describe('OpenTelemetry E2E trace correlation', () => {
       expect(spans).toHaveLength(2);
 
       const sessionSpan = spans.find(s => s.name === 'session.create')!;
-      const tmuxSpan = spans.find(s => s.name === 'tmux.create_window')!;
+      const childSpan = spans.find(s => s.name === 'acp.create_session')!;
 
-      expect(tmuxSpan.parentSpanContext?.spanId).toBe(sessionSpan.spanContext().spanId);
-      expect(tmuxSpan.spanContext().traceId).toBe(sessionSpan.spanContext().traceId);
+      expect(childSpan.parentSpanContext?.spanId).toBe(sessionSpan.spanContext().spanId);
+      expect(childSpan.spanContext().traceId).toBe(sessionSpan.spanContext().traceId);
     });
 
     it('creates channel spans as children of the active span', () => {
@@ -161,16 +161,16 @@ describe('OpenTelemetry E2E trace correlation', () => {
       expect(exported.attributes['workDir']).toBe('/tmp/project');
     });
 
-    it('tmux spans include window ID', () => {
+    it('child spans include custom attributes', () => {
       const tracer = trace.getTracer('aegis-test', '0.0.0');
 
-      const span = tracer.startSpan('tmux.create_window', {
-        attributes: { 'aegis.tmux.window_id': '@5' },
+      const span = tracer.startSpan('acp.create_session', {
+        attributes: { 'aegis.session.window_id': '@5' },
       });
       span.end();
 
       const [exported] = memoryExporter.getFinishedSpans();
-      expect(exported.attributes['aegis.tmux.window_id']).toBe('@5');
+      expect(exported.attributes['aegis.session.window_id']).toBe('@5');
     });
 
     it('channel spans include event name', () => {

--- a/src/__tests__/tracing.test.ts
+++ b/src/__tests__/tracing.test.ts
@@ -118,14 +118,6 @@ describe('tracing', () => {
       span.end();
     });
 
-    it('startTmuxSpan creates non-recording span when tracing is off', async () => {
-      const { initTracing, startTmuxSpan } = await import('../tracing.js');
-      await initTracing({ enabled: false, serviceName: 'test', otlpEndpoint: 'http://localhost:4318', sampleRate: 1.0 });
-      const span = startTmuxSpan('send-keys', '@0');
-      expect(span.isRecording()).toBe(false);
-      span.end();
-    });
-
     it('startMonitorSpan creates non-recording span when tracing is off', async () => {
       const { initTracing, startMonitorSpan } = await import('../tracing.js');
       await initTracing({ enabled: false, serviceName: 'test', otlpEndpoint: 'http://localhost:4318', sampleRate: 1.0 });

--- a/src/alerting.ts
+++ b/src/alerting.ts
@@ -1,5 +1,5 @@
 /**
- * alerting.ts — Production alerting for session failures, tmux crashes, and API errors.
+ * alerting.ts — Production alerting for session failures, ACP child crashes, and API errors.
  *
  * Issue #1418: Tracks failure events and fires alert webhooks when configurable
  * thresholds are exceeded. Uses a cooldown window to prevent alert fatigue.
@@ -10,7 +10,7 @@ import { logger } from './logger.js';
 import { validateWebhookUrl, resolveAndCheckIp } from './ssrf.js';
 
 /** Supported alert types. */
-export type AlertType = 'session_failure' | 'tmux_crash' | 'api_error_rate';
+export type AlertType = 'session_failure' | 'acp_child_crash' | 'api_error_rate';
 
 /** An alert event ready for delivery. */
 export interface AlertEvent {

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -97,10 +97,6 @@ export interface HealthResponse {
     active: number;
     total: number;
   };
-  tmux?: {
-    healthy: boolean;
-    error: string | null;
-  };
   claude?: {
     available: boolean;
     healthy: boolean;

--- a/src/mcp/embedded.ts
+++ b/src/mcp/embedded.ts
@@ -209,7 +209,6 @@ export class EmbeddedBackend implements IAegisBackend {
         active: this.sessions.listSessions().length,
         total: this.metrics.getTotalSessionsCreated(),
       },
-      tmux: { healthy: true },
       timestamp: new Date().toISOString(),
     };
   }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -35,7 +35,7 @@ export interface MonitorConfig {
   hookQuietMs: number;          // If no hook received for this long, switch to fast polling (default: 60000)
   stallThresholdMs: number;     // Emit stall event after this long without new JSONL bytes while "working" (default: 5min)
   stallCheckIntervalMs: number; // How often to run stall checks (default: 30000)
-  deadCheckIntervalMs: number;  // How often to check for dead tmux windows (default: 10000)
+  deadCheckIntervalMs: number;  // How often to check for dead sessions (default: 10000)
   permissionStallMs: number;    // Permission prompt stall threshold (default: 5min)
   unknownStallMs: number;       // Unknown state stall threshold (default: 3min)
   permissionTimeoutMs: number;  // Auto-reject permission after this long (default: 10min)
@@ -55,23 +55,6 @@ export const DEFAULT_MONITOR_CONFIG: MonitorConfig = {
   unknownStallMs: 3 * 60 * 1000,          // 3 min in unknown state = stalled
   permissionTimeoutMs: 10 * 60 * 1000,    // 10 min → auto-reject permission
 };
-
-const SIGNAL_BY_NUMBER: Record<number, string> = {
-  1: 'SIGHUP',
-  2: 'SIGINT',
-  3: 'SIGQUIT',
-  6: 'SIGABRT',
-  9: 'SIGKILL',
-  11: 'SIGSEGV',
-  13: 'SIGPIPE',
-  14: 'SIGALRM',
-  15: 'SIGTERM',
-};
-
-function signalFromExitCode(exitCode: number | null): string | null {
-  if (exitCode === null || exitCode < 129) return null;
-  return SIGNAL_BY_NUMBER[exitCode - 128] ?? `SIG${exitCode - 128}`;
-}
 
 export class SessionMonitor {
   private running = false;
@@ -149,7 +132,6 @@ export class SessionMonitor {
     this.eventBus = bus;
   }
 
-  private tmux?: unknown;
   /** Issue #1418: Alert manager for production alerting. */
   private alertManager?: AlertManager;
   /** Issue #2067: MetricsCollector for completed/failed session counters. */
@@ -804,9 +786,6 @@ export class SessionMonitor {
           attributes: { windowName: session.windowName },
         });
         try {
-          if (this.tmux) {
-            await (this.tmux as any).sendKeys(session.windowId, '/compact');
-          }
           await this.channels.statusChange(
             this.makePayload('status.context_warning', session,
               'Context window nearing limit — auto-injected /compact to prevent overflow'),
@@ -847,7 +826,7 @@ export class SessionMonitor {
     };
   }
 
-  /** Check for dead tmux windows and notify via channels. */
+  /** Check for dead sessions and notify via channels. */
   private async checkDeadSessions(): Promise<void> {
 
     const sessions = this.sessions.listSessions();
@@ -857,35 +836,7 @@ export class SessionMonitor {
       await maybeInjectFault('monitor.checkDeadSessions.isWindowAlive');
       const alive = await this.sessions.isWindowAlive(session.id);
       if (!alive) {
-        let windowExists: boolean | null = null;
-        let paneDead: boolean | null = null;
-        let paneCommand: string | null = null;
-        let exitCode: number | null = null;
-
-        try {
-          if (this.tmux) {
-            const health = await (this.tmux as any).getWindowHealth(session.windowId);
-            windowExists = health.windowExists;
-            paneDead = health.paneDead;
-            paneCommand = health.paneCommand;
-            if (health.windowExists && health.paneDead) {
-              const paneText = await (this.tmux as any).capturePane(session.windowId);
-              const statusMatch = paneText.match(/Pane is dead \(status\s+(\d+)\)/i);
-              if (statusMatch) {
-                const parsed = parseInt(statusMatch[1] ?? '', 10);
-                exitCode = Number.isFinite(parsed) ? parsed : null;
-              }
-            }
-          }
-        } catch {
-          // best-effort diagnostics only
-        }
-
-        const cause = windowExists === false
-          ? 'window_missing'
-          : paneDead
-            ? 'pane_dead'
-            : 'process_not_alive_or_unknown';
+        const cause = 'process_not_alive_or_unknown';
 
         logger.warn({
           component: 'monitor',
@@ -898,12 +849,6 @@ export class SessionMonitor {
             windowId: session.windowId,
             claudeSessionId: session.claudeSessionId,
             ccPid: session.ccPid ?? null,
-            paneCommand,
-            windowExists,
-            paneDead,
-            paneAlive: paneDead === null ? null : !paneDead,
-            exitCode,
-            signal: signalFromExitCode(exitCode),
             uptimeMs: Date.now() - session.createdAt,
             lastActivityAt: new Date(session.lastActivity).toISOString(),
             detectedAt: new Date().toISOString(),
@@ -913,7 +858,7 @@ export class SessionMonitor {
         this.deadNotified.add(session.id);
         // Track when the session died so the zombie reaper can clean it up
         session.lastDeadAt = Date.now();
-        const detail = `Session "${session.windowName}" died — tmux window no longer exists. ` +
+        const detail = `Session "${session.windowName}" died — session process no longer alive. ` +
             `Last activity: ${new Date(session.lastActivity).toISOString()}`;
         this.eventBus?.emitDead(session.id, detail);
         await this.channels.statusChange(

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -75,9 +75,9 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
     timeWindow: '1 minute',
   } as const;
 
-  // Health — Issue #397: includes tmux server health check
+  // Health — Issue #397: includes ACP runtime health check
   // Issue #1911: returns 'draining' when server is shutting down
-  // Issue #2066: strip sensitive fields (version, uptime, tmux, claude) for unauthenticated requests
+  // Issue #2066: strip sensitive fields (version, uptime, claude) for unauthenticated requests
   async function healthHandler(req: FastifyRequest): Promise<Record<string, unknown>> {
     const pkg = await import('../../package.json', { with: { type: 'json' } });
     const activeCount = sessions.listSessions().length;

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -298,7 +298,7 @@ export function registerOpenApiSpec(): void {
     method: 'post',
     path: '/v1/sessions',
     summary: 'Create session',
-    description: 'Create a new Claude Code session in a tmux window. Reuses an existing idle session for the same workDir if available.',
+    description: 'Create a new Claude Code session. Reuses an existing idle session for the same workDir if available.',
     tags: ['Sessions'],
     requestBody: {
       description: 'Session creation parameters',
@@ -754,7 +754,7 @@ export function registerOpenApiSpec(): void {
     method: 'get',
     path: '/v1/health',
     summary: 'Health check',
-    description: 'Server health including tmux status, Claude CLI status, version, uptime.',
+    description: 'Server health including Claude CLI status, version, uptime.',
     tags: ['Health'],
     responses: { '200': okJsonResponse(z.any()) },
   });

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -17,7 +17,6 @@ export interface ServerHealthResponse {
   platform: NodeJS.Platform;
   uptime: number;
   sessions: { active: number; total: number };
-  tmux: { healthy: boolean; [key: string]: unknown };
   timestamp: string;
 }
 

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -1,7 +1,7 @@
 /**
  * tracing.ts — OpenTelemetry distributed tracing for Aegis.
  *
- * Provides request-scoped tracing across the Fastify → session → tmux → monitor flow.
+ * Provides request-scoped tracing across the Fastify → session → monitor flow.
  * Configured via AEGIS_OTEL_* environment variables (all optional).
  *
  * When AEGIS_OTEL_ENABLED is not set (or "false"), tracing is a no-op —
@@ -211,23 +211,6 @@ export function startSessionSpan(
     kind: SpanKind.INTERNAL,
     attributes: {
       'aegis.session.id': sessionId,
-      ...attributes,
-    },
-  });
-}
-
-/**
- * Create a child span for a tmux operation.
- */
-export function startTmuxSpan(
-  operation: string,
-  windowId: string,
-  attributes?: Record<string, string | number | boolean>,
-): Span {
-  return _tracer.startSpan(`tmux.${operation}`, {
-    kind: SpanKind.INTERNAL,
-    attributes: {
-      'aegis.tmux.window_id': windowId,
       ...attributes,
     },
   });


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6-preview.1

## Summary
Second wave of ACP backend migration cleanup. Removes dead tmux code paths and updates contracts after cutover:

- **alerting.ts**: `tmux_crash` → `acp_child_crash` alert type
- **api-contracts.ts + services/interfaces.ts**: remove `tmux` field from `HealthResponse` / `ServerHealthResponse`
- **monitor.ts**: remove unused `this.tmux`, `signalFromExitCode`, and tmux-specific diagnostics in `checkDeadSessions`
- **tracing.ts**: remove `startTmuxSpan` helper and update header comment
- **routes/health.ts + openapi.ts**: update comments/descriptions to reference ACP instead of tmux
- **src/CLAUDE.md**: rewrite for ACP architecture
- **deploy/prometheus/alerts.yml + dashboard fixtures**: update tmux references
- **Tests**: align with new alert type, detail strings, and removed mocks

## Scope
This PR targets the remaining runtime tmux references in production code and tests, separate from the CLI/init/doctor prerequisite cleanup in #2767.

## Test plan
- [x] `npm run gate` passes (type check, build, 3905 tests)
- [x] No untracked artifacts
- [x] No obsolete legacy file references

Epic: #2574

Generated by Hephaestus (Aegis dev agent)