### PR TITLE
docs: remove stale tmux references post-ACP migration

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -1159,10 +1159,21 @@ No auth required.
 ```json
 {
   "status": "ok",
-  "tmux": "connected",
-  "claudeCli": "available",
-  "version": "0.6.1",
-  "uptime": 3600
+  "timestamp": "2026-05-06T12:00:00.000Z",
+  "version": "0.6.6-preview.1",
+  "platform": "linux",
+  "uptime": 3600,
+  "sessions": {
+    "active": 3,
+    "total": 42
+  },
+  "claude": {
+    "available": true,
+    "healthy": true,
+    "version": "1.0.33",
+    "minimumVersion": "1.0.16",
+    "error": null
+  }
 }
 ```
 

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -67,7 +67,6 @@ AEGIS_AUTH_TOKEN=secret ag
 | `AEGIS_AUTH_TOKEN` | _(none)_ | Bearer token (required for production) |
 | `AEGIS_DASHBOARD_ENABLED` | `true` | Serve the bundled dashboard |
 | `AEGIS_STATE_DIR` | `~/.aegis` | Session state directory |
-| `AEGIS_TMUX_SESSION` | `aegis` | Base tmux session name |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Max concurrent sessions |
 | `AEGIS_IDLE_TIMEOUT_MS` | `600000` | Idle timeout (10 min) |
 | `AEGIS_STALL_THRESHOLD_MS` | `120000` | Stall threshold (2 min) |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -50,7 +50,7 @@ The Phase 3.5 ACP backend cutover has an additional governance plan:
 [ACP Major Cutover Release Plan](acp-major-cutover-release-plan.md). That plan
 does not change this release process, create a tag, or bump a version. It
 defines the extra approvals and gates required before ACP public-contract and
-tmux-deletion PRs merge to `develop`.
+legacy-transport removal PRs merge to `develop`.
 
 The ACP cutover still follows the normal flow:
 `develop` → `release/<version>` → Release Please metadata PR → reviewed


### PR DESCRIPTION
## Summary
Cleans up remaining tmux references in user-facing docs after the ACP transport migration (PRs #2756, #2767, #2768).

## Changes
- **docs/integrations/cli.md**: Remove `AEGIS_TMUX_SESSION` env var (tmux transport no longer exists)
- **docs/api-examples.md**: Update health endpoint response example to match current API shape (`sessions`, `claude` object instead of `tmux`/ `claudeCli` fields)
- **docs/release-process.md**: `tmux-deletion` → `legacy-transport removal`

## Note
`AEGIS_TMUX_SESSION` still exists in `src/config.ts` — env var doc entry will be re-added once the code-side cleanup lands.