### PR TITLE
docs: add link to full env var reference in getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -244,6 +244,8 @@ Aegis is configured via environment variables:
 | `AEGIS_REDIS_URL` | `redis://localhost:6379` | Redis URL (used when `AEGIS_SESSION_STORE=redis`) |
 | `AEGIS_REDIS_KEY_PREFIX` | `aegis` | Redis key prefix |
 
+See the [Enterprise Deployment Guide](enterprise.md#configuration-reference) for the complete environment variable reference (rate limiting, OIDC, hooks, notifications, alerting, and more).
+
 Or use a config file (`.aegis/config.yaml` is the preferred bootstrap path, and `aegis.config.json` remains supported):
 
 ```yaml


### PR DESCRIPTION
## Summary

Adds a link from the getting-started config table to the complete environment variable reference in enterprise.md. Found during docs accuracy dogfooding — the getting-started table lists 12 common vars but the full reference has 35+.

## Changes
- Added link text after the config table: 'See the Enterprise Deployment Guide for the complete environment variable reference (rate limiting, OIDC, hooks, notifications, alerting, and more).'