### PR TITLE
fix(security): serialize audit writes with file lock to prevent hash chain breaks (#2781)

### DIFF
--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -10,10 +10,12 @@ import {
   auditRecordsToNdjson,
   buildAuditChainMetadata,
   type AuditAction,
+  type AuditRecord,
 } from '../audit.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { rm, readdir, readFile, writeFile, mkdir, symlink } from 'node:fs/promises';
+import { rm, readdir, readFile, writeFile, mkdir, symlink, utimes } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 
 describe('AuditLogger (Issue #1419)', () => {
   let audit: AuditLogger;
@@ -381,6 +383,123 @@ describe('AuditLogger (Issue #1419)', () => {
       }
 
       await expect(audit.log('system', 'key.create', 'Symlink write should fail')).rejects.toThrow(/symlink path/);
+    });
+  });
+
+
+  describe('Issue #2781: inter-process file lock for hash chain integrity', () => {
+    it('should maintain chain integrity when two AuditLogger instances share the same directory', async () => {
+      const sharedDir = join(tmpdir(), `aegis-audit-race-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+      const logger1 = new AuditLogger(sharedDir);
+      const logger2 = new AuditLogger(sharedDir);
+      await logger1.init();
+      await logger2.init();
+
+      try {
+        // Write interleaved records from both loggers
+        const r1 = await logger1.log('key-1', 'session.create', 'Session 1 started', 'sess-1');
+        const r2 = await logger2.log('key-2', 'session.create', 'Session 2 started', 'sess-2');
+        const r3 = await logger1.log('key-1', 'session.kill', 'Session 1 killed', 'sess-1');
+        const r4 = await logger2.log('key-2', 'session.kill', 'Session 2 killed', 'sess-2');
+
+        // All 4 records should form a valid chain
+        expect(r2.prevHash).toBe(r1.hash);
+        expect(r3.prevHash).toBe(r2.hash);
+        expect(r4.prevHash).toBe(r3.hash);
+
+        // Verify the full chain from disk
+        const verification = await logger1.verify();
+        expect(verification.valid).toBe(true);
+      } finally {
+        try { await rm(sharedDir, { recursive: true }); } catch { /* ignore */ }
+      }
+    });
+
+    it('should maintain chain integrity under concurrent writes from multiple loggers', async () => {
+      const sharedDir = join(tmpdir(), `aegis-audit-concurrent-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+      const loggers: AuditLogger[] = [];
+      for (let i = 0; i < 3; i++) {
+        const logger = new AuditLogger(sharedDir);
+        await logger.init();
+        loggers.push(logger);
+      }
+
+      try {
+        // Fire 10 writes from each logger concurrently
+        const writes: Promise<AuditRecord>[] = [];
+        for (let i = 0; i < 10; i++) {
+          for (const logger of loggers) {
+            writes.push(logger.log('key-test', 'session.create', `Concurrent write ${i}`, `sess-${i}`));
+          }
+        }
+
+        await Promise.all(writes);
+
+        // Verify the chain is intact — all 30 records should chain correctly
+        const verification = await loggers[0]!.verify();
+        expect(verification.valid).toBe(true);
+
+        // Verify we have exactly 30 records
+        const records = await loggers[0]!.queryAll();
+        expect(records).toHaveLength(30);
+      } finally {
+        try { await rm(sharedDir, { recursive: true }); } catch { /* ignore */ }
+      }
+    });
+
+    it('should clean up stale file locks', async () => {
+      const staleDir = join(tmpdir(), `aegis-audit-stale-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      const logger = new AuditLogger(staleDir);
+      await logger.init();
+
+      try {
+        // Create a stale lock directory
+        const lockPath = join(staleDir, '.audit.lock');
+        await mkdir(lockPath);
+
+        // Manually set mtime to 60 seconds ago to simulate a stale lock
+        const oldTime = new Date(Date.now() - 60_000);
+        const { utimes } = await import('node:fs/promises');
+        await utimes(lockPath, oldTime, oldTime);
+
+        // Writing should succeed by cleaning up the stale lock
+        const record = await logger.log('system', 'key.create', 'After stale lock cleanup');
+        expect(record.hash).toMatch(/^[a-f0-9]{64}$/);
+
+        // Lock should be cleaned up
+        const lockExists = existsSync(lockPath);
+        expect(lockExists).toBe(false);
+      } finally {
+        try { await rm(staleDir, { recursive: true }); } catch { /* ignore */ }
+      }
+    });
+
+    it('should recover chain correctly after process restart simulation', async () => {
+      const sharedDir = join(tmpdir(), `aegis-audit-restart-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+      // First process writes some records
+      const logger1 = new AuditLogger(sharedDir);
+      await logger1.init();
+      const r1 = await logger1.log('key-1', 'session.create', 'Before restart', 'sess-1');
+      const r2 = await logger1.log('key-1', 'session.kill', 'Before restart kill', 'sess-1');
+
+      // Simulate a new process with a fresh AuditLogger instance
+      const logger2 = new AuditLogger(sharedDir);
+      await logger2.init();
+
+      try {
+        const r3 = await logger2.log('key-2', 'session.create', 'After restart', 'sess-2');
+
+        // r3 should chain to r2 (the last record written by the first process)
+        expect(r3.prevHash).toBe(r2.hash);
+
+        const verification = await logger2.verify();
+        expect(verification.valid).toBe(true);
+      } finally {
+        try { await rm(sharedDir, { recursive: true }); } catch { /* ignore */ }
+      }
     });
   });
 });

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -12,7 +12,7 @@
  */
 
 import { createHash, createHmac, pbkdf2Sync, scryptSync } from 'node:crypto';
-import { appendFile, readFile, mkdir, readdir, lstat } from 'node:fs/promises';
+import { appendFile, readFile, mkdir, rmdir, readdir, lstat, stat } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -301,6 +301,12 @@ export class AuditLogger {
   private lastHash: string;
   private writeLock: Promise<void>;
 
+  /** #2781: Inter-process file lock settings. */
+  private static readonly FILE_LOCK_DIR = '.audit.lock';
+  private static readonly FILE_LOCK_STALE_MS = 30_000;
+  private static readonly FILE_LOCK_RETRY_MS = 50;
+  private static readonly FILE_LOCK_TIMEOUT_MS = 5_000;
+
   constructor(logDir?: string) {
     this.logDir = logDir ?? join(homedir(), '.aegis', 'audit');
     this.lastHash = '';
@@ -324,6 +330,51 @@ export class AuditLogger {
     await this.assertNotSymlink(this.logDir);
     await this.assertNotSymlink(dirname(filePath));
     await this.assertNotSymlink(filePath);
+  }
+
+  /**
+   * #2781: Acquire an inter-process file lock using mkdir (atomic on all platforms).
+   * If the lock directory exists and is older than FILE_LOCK_STALE_MS, remove it (stale cleanup).
+   * Retries every FILE_LOCK_RETRY_MS until FILE_LOCK_TIMEOUT_MS is reached.
+   */
+  private async acquireFileLock(): Promise<void> {
+    const lockPath = join(this.logDir, AuditLogger.FILE_LOCK_DIR);
+    const deadline = Date.now() + AuditLogger.FILE_LOCK_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      try {
+        await mkdir(lockPath, { recursive: false });
+        return; // Acquired
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'EEXIST') {
+          // Check for stale lock
+          try {
+            const stats = await stat(lockPath);
+            const age = Date.now() - stats.mtimeMs;
+            if (age > AuditLogger.FILE_LOCK_STALE_MS) {
+              await rmdir(lockPath).catch(() => {});
+              // Retry immediately
+              continue;
+            }
+          } catch {
+            // Lock disappeared between checks — retry
+            continue;
+          }
+          // Wait before retrying
+          await new Promise(r => setTimeout(r, AuditLogger.FILE_LOCK_RETRY_MS));
+        } else {
+          throw err;
+        }
+      }
+    }
+    throw new Error(`Audit file lock acquisition timed out after ${AuditLogger.FILE_LOCK_TIMEOUT_MS}ms`);
+  }
+
+  /** #2781: Release the inter-process file lock. */
+  private async releaseFileLock(): Promise<void> {
+    const lockPath = join(this.logDir, AuditLogger.FILE_LOCK_DIR);
+    await rmdir(lockPath).catch(() => {});
   }
 
   /** Initialize the audit logger — ensure directory exists, read last hash. */
@@ -413,35 +464,46 @@ export class AuditLogger {
     try {
       await previous.catch(() => {});
 
-      const ts = new Date().toISOString();
-      const partial: Omit<AuditRecord, 'hash'> = {
-        ts,
-        actor,
-        action,
-        sessionId,
-        detail,
-        prevHash: this.lastHash,
-        tenantId,
-      };
-      const hash = computeHash(partial);
-      const record: AuditRecord = { ...partial, hash };
+      // #2781: Acquire inter-process file lock to serialize across multiple
+      // AuditLogger instances that may share the same audit directory.
+      await this.acquireFileLock();
+      try {
+        // Re-read chain tip from disk — another process may have appended
+        // records since our last write, making the in-memory lastHash stale.
+        await this.recoverLastHash();
 
-      const line = JSON.stringify(record) + '\n';
-      const file = this.filePath(new Date(ts));
-      await this.assertAuditPathSafe(file);
+        const ts = new Date().toISOString();
+        const partial: Omit<AuditRecord, 'hash'> = {
+          ts,
+          actor,
+          action,
+          sessionId,
+          detail,
+          prevHash: this.lastHash,
+          tenantId,
+        };
+        const hash = computeHash(partial);
+        const record: AuditRecord = { ...partial, hash };
 
-      // Ensure directory exists (in case it was cleaned)
-      if (!existsSync(dirname(file))) {
-        await mkdir(dirname(file), { recursive: true });
-        await this.assertNotSymlink(dirname(file));
+        const line = JSON.stringify(record) + '\n';
+        const file = this.filePath(new Date(ts));
+        await this.assertAuditPathSafe(file);
+
+        // Ensure directory exists (in case it was cleaned)
+        if (!existsSync(dirname(file))) {
+          await mkdir(dirname(file), { recursive: true });
+          await this.assertNotSymlink(dirname(file));
+        }
+
+        // Append-only — never overwrite
+        await appendFile(file, line, { mode: 0o600 });
+        await secureFilePermissions(file);
+
+        this.lastHash = hash;
+        return record;
+      } finally {
+        await this.releaseFileLock();
       }
-
-      // Append-only — never overwrite
-      await appendFile(file, line, { mode: 0o600 });
-      await secureFilePermissions(file);
-
-      this.lastHash = hash;
-      return record;
     } finally {
       release();
     }


### PR DESCRIPTION
## Summary

Fixes #2781 — audit logger race condition where concurrent writes from multiple processes break hash chain integrity.

## Root Cause

Multiple `AuditLogger` instances (one per server process) sharing the same audit directory each maintain their own in-memory `lastHash`. When two processes read the same chain tip and both write records referencing it, the hash chain produces orphan branches that `verify()` correctly detects as breaks.

14 chain breaks found during E2E dogfooding across audit files from 2026-04-11 to 2026-05-06.

## Fix

- **Inter-process file lock**: `mkdir`-based atomic lock (`.audit.lock` directory) with:
  - 50ms retry interval, 5s timeout
  - Stale lock detection: if lock dir mtime > 30s old, remove and retry
- **Re-read chain tip under lock**: `recoverLastHash()` called inside the critical section to get the true latest hash from disk
- **Keeps existing intra-process lock**: promise-chain `writeLock` still serializes within a single process
- **No new dependencies**: uses only Node.js built-in `mkdir`/`rmdir`

## Tests Added (4 new)

1. Two AuditLogger instances sharing the same directory maintain chain integrity
2. Concurrent writes from 3 loggers (30 parallel writes) — full chain validates
3. Stale file lock cleanup (lock dir with mtime 60s ago)
4. Process restart simulation (new logger picks up chain from where previous left off)

## Quality Gate

```
npx tsc --noEmit: ✅ zero errors
npm run build: ✅ success
npm test: ✅ 3914 passed, 0 failed (251 files + 1 skipped)
```

Pre-existing: `isAncestorPid.test.ts` vitest forks pool teardown timeout (not introduced by this PR).

## Files Changed

- `src/audit.ts`: +88 lines (acquireFileLock, releaseFileLock, log() file lock integration)
- `src/__tests__/audit.test.ts`: +123 lines (4 new tests)