### PR TITLE
fix(openapi): resolve package.json path to show correct version (#2796)

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -176,7 +176,7 @@ function readPackageInfo(): PackageInfo {
   if (cachedPkg) return cachedPkg;
   try {
     const thisFile = fileURLToPath(import.meta.url);
-    const pkgPath = new URL('../../package.json', `file://${thisFile}`);
+    const pkgPath = new URL('../package.json', `file://${thisFile}`);
     const data = JSON.parse(fs.readFileSync(fileURLToPath(pkgPath), 'utf-8'));
     cachedPkg = { name: data.name ?? '@onestepat4time/aegis', version: data.version ?? '0.0.0' };
     return cachedPkg;


### PR DESCRIPTION
## Summary
Fixes #2796 — OpenAPI spec returned version `0.0.0` instead of actual package version.

## Root Cause
`readPackageInfo()` in `src/openapi.ts` used `../../package.json` relative to `dist/openapi.js`. This resolved to `/home/bubuntu/projects/package.json` (wrong) instead of `/home/bubuntu/projects/aegis/package.json` (correct). The `catch` block fell back to `0.0.0`.

## Fix
Changed path from `../../package.json` to `../package.json` — one level up from `dist/` to project root.

## Verification
```
GET /v1/openapi.json → version: 0.6.6-preview.1 ✅ (was 0.0.0)
tsc --noEmit: zero errors ✅
```

One-line fix. Low risk.