### PR TITLE
fix(dashboard): wire CostPage to real /v1/analytics/costs API

### DIFF
--- a/dashboard/src/__tests__/a11y-pages.test.tsx
+++ b/dashboard/src/__tests__/a11y-pages.test.tsx
@@ -153,6 +153,18 @@ vi.mock('../api/client', () => ({
     forecast: { estimatedSessionsRemaining: null, bottleneck: null },
     generatedAt: new Date().toISOString(),
   }),
+  getAnalyticsCosts: vi.fn().mockResolvedValue({
+    totalCostUsd: 12.34,
+    totalSessions: 5,
+    byModel: [
+      { model: 'claude-sonnet-4.6', estimatedCostUsd: 8.50, inputTokens: 1000, outputTokens: 500, cacheCreationTokens: 0, cacheReadTokens: 0 },
+    ],
+    byKey: [],
+    dailyTrends: [
+      { date: '2026-05-06', estimatedCostUsd: 2.50, sessions: 1 },
+    ],
+    generatedAt: new Date().toISOString(),
+  }),
   checkForUpdates: vi.fn().mockResolvedValue({
     currentVersion: '1.0.0',
     latestVersion: '1.0.0',

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -34,6 +34,7 @@ import type {
   CreatedAuthKey,
   AnalyticsSummary,
   RateLimitAnalyticsResponse,
+  AnalyticsCostsResponse,
 } from '../types';
 import type {
   AuditChainMetadata,
@@ -289,6 +290,11 @@ export function getAnalyticsSummary(): Promise<AnalyticsSummary> {
 // Issue #2283: Rate-limit analytics
 export function getRateLimitAnalytics(): Promise<RateLimitAnalyticsResponse> {
   return request('/v1/analytics/rate-limits');
+}
+
+// Issue #2802: Cost analytics
+export function getAnalyticsCosts(): Promise<AnalyticsCostsResponse> {
+  return request('/v1/analytics/costs');
 }
 
 // ── Sessions ────────────────────────────────────────────────────

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -1,9 +1,9 @@
 /**
  * pages/CostPage.tsx — Global cost & billing dashboard with charts and budgets.
- * Recharts chosen for React-friendly API and TypeScript support.
+ * Wired to GET /v1/analytics/costs (Issue #2802).
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useT } from '../i18n/context';
 import { DollarSign, TrendingUp, AlertTriangle, Calendar } from 'lucide-react';
 import { SkeletonStatCard, SkeletonCard } from '../components/shared/Skeleton';
@@ -24,19 +24,8 @@ import { useStore } from '../store/useStore';
 import { formatCurrency } from '../utils/formatNumber';
 import { formatDateShort } from '../utils/formatDate';
 import { ChartFrame } from '../components/shared/ChartFrame';
-
-// Mock data structure (will be replaced with real API data)
-interface DailyCost {
-  date: string;
-  cost: number;
-  byKey?: Record<string, number>;
-}
-
-interface ModelCost {
-  model: string;
-  cost: number;
-  percentage: number;
-}
+import { getAnalyticsCosts } from '../api/client';
+import type { AnalyticsCostsResponse } from '../types';
 
 const MODEL_COLORS: Record<string, string> = {
   'claude-sonnet-4.6': 'var(--color-accent-cyan)',
@@ -69,81 +58,48 @@ function CustomTooltip({ active, payload, label }: {
   );
 }
 
-// Generate mock 14-day data
-function generateMockDailyData(): DailyCost[] {
-  const data: DailyCost[] = [];
-  const today = new Date();
-  
-  for (let i = 13; i >= 0; i--) {
-    const date = new Date(today);
-    date.setDate(date.getDate() - i);
-    const dateStr = date.toISOString().split('T')[0];
-    
-    // Random cost between $0.50 and $5.00
-    const cost = Math.random() * 4.5 + 0.5;
-    
-    data.push({
-      date: dateStr,
-      cost: parseFloat(cost.toFixed(3)),
-    });
-  }
-  
-  return data;
-}
-
-function generateMockModelData(totalCost: number): ModelCost[] {
-  const models = [
-    { model: 'claude-sonnet-4.6', percentage: 45 },
-    { model: 'claude-opus-4.7', percentage: 25 },
-    { model: 'claude-haiku-4.5', percentage: 15 },
-    { model: 'gpt-5.4', percentage: 10 },
-    { model: 'gpt-4.1', percentage: 5 },
-  ];
-  
-  return models.map(m => ({
-    ...m,
-    cost: (totalCost * m.percentage) / 100,
-  }));
-}
-
 export default function CostPage() {
   const t = useT();
-  const [dailyData, setDailyData] = useState<DailyCost[]>([]);
-  const [modelData, setModelData] = useState<ModelCost[]>([]);
+  const [costData, setCostData] = useState<AnalyticsCostsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [dataError, setDataError] = useState<string | null>(null);
   const sseConnected = useStore((s) => s.sseConnected);
 
-  // Load initial data
-  useEffect(() => {
+  const fetchData = useCallback(async () => {
     try {
-      const daily = generateMockDailyData();
-      setDailyData(daily);
-
-      const totalCost = daily.reduce((sum, d) => sum + d.cost, 0);
-      setModelData(generateMockModelData(totalCost));
+      const data = await getAnalyticsCosts();
+      setCostData(data);
       setDataError(null);
     } catch (err) {
-      setDataError(err instanceof Error ? err.message : 'Failed to generate cost data');
+      setDataError(err instanceof Error ? err.message : 'Failed to load cost data');
     } finally {
       setIsLoading(false);
     }
   }, []);
-  
-  // Calculate metrics
-  const totalCost = dailyData.reduce((sum, d) => sum + d.cost, 0);
-  const avgDailyCost = totalCost / 14;
-  const last7Days = dailyData.slice(-7);
-  const last7Total = last7Days.reduce((sum, d) => sum + d.cost, 0);
-  const last7Avg = last7Total / 7;
-  
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  // Derived data from real API response
+  const dailyData = costData?.dailyTrends ?? [];
+  const modelData = costData?.byModel ?? [];
+  const totalCost = costData?.totalCostUsd ?? 0;
+  const daysWithData = dailyData.length || 1;
+  const avgDailyCost = totalCost / daysWithData;
+
+  // Last 7 days calculation
+  const last7 = dailyData.slice(-7);
+  const last7Total = last7.reduce((sum, d) => sum + d.estimatedCostUsd, 0);
+  const last7Avg = last7.length > 0 ? last7Total / last7.length : 0;
+
   // Burn rate calculation
   const today = new Date();
   const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
   const daysPassed = today.getDate();
   const daysRemaining = daysInMonth - daysPassed;
-  const projectedMonthCost = (totalCost / Math.min(daysPassed, 14)) * daysInMonth;
-  
+  const projectedMonthCost = daysWithData > 0 ? (totalCost / daysWithData) * daysInMonth : 0;
+
   // Loading state
   if (isLoading) {
     return (
@@ -177,13 +133,13 @@ export default function CostPage() {
             <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Cost & Billing</h1>
           </div>
         </div>
-        <ErrorState variant="server-5xx" message={dataError} onRetry={() => window.location.reload()} />
+        <ErrorState variant="server-5xx" message={dataError} onRetry={() => { setIsLoading(true); void fetchData(); }} />
       </div>
     );
   }
 
   // Empty state — no cost data recorded
-  const hasData = dailyData.length > 0 && dailyData.some((d) => d.cost > 0);
+  const hasData = dailyData.length > 0 && dailyData.some((d) => d.estimatedCostUsd > 0);
   if (!hasData) {
     return (
       <div className="flex flex-col gap-6">
@@ -220,23 +176,25 @@ export default function CostPage() {
           </p>
         </div>
       </div>
-      
+
       {/* Summary cards */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
-          <div className="mb-1 text-xs text-[var(--color-text-muted)]">14-Day Total</div>
+          <div className="mb-1 text-xs text-[var(--color-text-muted)]">
+            {daysWithData > 7 ? `${daysWithData}-Day` : 'Total'} Cost
+          </div>
           <div className="text-2xl font-bold font-mono text-[var(--color-text-primary)]">
             {formatCurrency(totalCost)}
           </div>
         </div>
-        
+
         <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
-          <div className="mb-1 text-xs text-[var(--color-text-muted)]">Avg Daily (14d)</div>
+          <div className="mb-1 text-xs text-[var(--color-text-muted)]">Avg Daily</div>
           <div className="text-2xl font-bold font-mono text-[var(--color-text-primary)]">
             {formatCurrency(avgDailyCost)}
           </div>
         </div>
-        
+
         <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
           <div className="mb-1 flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
             <TrendingUp className="h-3 w-3" />
@@ -245,11 +203,13 @@ export default function CostPage() {
           <div className="text-2xl font-bold font-mono text-[var(--color-text-primary)]">
             {formatCurrency(last7Avg)}
           </div>
-          <div className="mt-1 text-[10px] text-[var(--color-text-muted)]">
-            {last7Avg > avgDailyCost ? '+' : ''}{((last7Avg / avgDailyCost - 1) * 100).toFixed(1)}% vs 14d avg
-          </div>
+          {avgDailyCost > 0 && (
+            <div className="mt-1 text-[10px] text-[var(--color-text-muted)]">
+              {last7Avg > avgDailyCost ? '+' : ''}{((last7Avg / avgDailyCost - 1) * 100).toFixed(1)}% vs avg
+            </div>
+          )}
         </div>
-        
+
         <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
           <div className="mb-1 flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
             <Calendar className="h-3 w-3" />
@@ -263,104 +223,111 @@ export default function CostPage() {
           </div>
         </div>
       </div>
-      
+
       {/* Daily spend chart */}
-      <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
-        <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
-          Daily Spend (Last 14 Days)
-        </h3>
-        <ChartFrame className="h-64 min-w-0" label={t("cost.loadingDailySpend")}>
-          {({ width, height }) => (
-            <BarChart width={width} height={height} data={dailyData}>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
-              <XAxis
-                dataKey="date"
-                tickFormatter={formatDateShort}
-                tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
-                stroke="var(--color-void-lighter)"
-              />
-              <YAxis
-                tickFormatter={(value) => `$${value.toFixed(2)}`}
-                tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
-                stroke="var(--color-void-lighter)"
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Bar
-                dataKey="cost"
-                name={t("cost.dailyCost")}
-                fill="var(--color-accent-cyan)"
-                radius={[4, 4, 0, 0]}
-              />
-            </BarChart>
-          )}
-        </ChartFrame>
-      </section>
-      
-      {/* Model breakdown */}
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        {/* Pie chart */}
+      {dailyData.length > 0 && (
         <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
-            Cost by Model
+            Daily Spend ({dailyData.length} days)
           </h3>
-          <ChartFrame className="h-64 min-w-0" label={t("cost.loadingCostByModel")}>
+          <ChartFrame className="h-64 min-w-0" label={t("cost.loadingDailySpend")}>
             {({ width, height }) => (
-              <PieChart width={width} height={height}>
-                <Pie
-                  data={modelData}
-                  dataKey="cost"
-                  nameKey="model"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={80}
-                  label
-                  labelLine={{ stroke: 'var(--color-text-muted)' }}
-                >
-                  {modelData.map((entry) => (
-                    <Cell
-                      key={entry.model}
-                      fill={MODEL_COLORS[entry.model] || MODEL_COLORS.other}
-                    />
-                  ))}
-                </Pie>
+              <BarChart width={width} height={height} data={dailyData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={formatDateShort}
+                  tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+                  stroke="var(--color-void-lighter)"
+                />
+                <YAxis
+                  tickFormatter={(value) => `$${value.toFixed(2)}`}
+                  tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+                  stroke="var(--color-void-lighter)"
+                />
                 <Tooltip content={<CustomTooltip />} />
-              </PieChart>
+                <Bar
+                  dataKey="estimatedCostUsd"
+                  name={t("cost.dailyCost")}
+                  fill="var(--color-accent-cyan)"
+                  radius={[4, 4, 0, 0]}
+                />
+              </BarChart>
             )}
           </ChartFrame>
         </section>
-        
-        {/* Model list */}
-        <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
-          <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
-            Model Details
-          </h3>
-          <div className="space-y-3">
-            {modelData.map((model) => (
-              <div key={model.model} className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <div
-                    className="h-3 w-3 rounded-full"
-                    style={{ backgroundColor: MODEL_COLORS[model.model] || MODEL_COLORS.other }}
-                  />
-                  <span className="text-sm font-mono text-[var(--color-text-primary)]">
-                    {model.model}
-                  </span>
-                </div>
-                <div className="text-right">
-                  <div className="text-sm font-mono font-medium text-[var(--color-text-primary)]">
-                    {formatCurrency(model.cost)}
+      )}
+
+      {/* Model breakdown */}
+      {modelData.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {/* Pie chart */}
+          <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
+            <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
+              Cost by Model
+            </h3>
+            <ChartFrame className="h-64 min-w-0" label={t("cost.loadingCostByModel")}>
+              {({ width, height }) => (
+                <PieChart width={width} height={height}>
+                  <Pie
+                    data={modelData}
+                    dataKey="estimatedCostUsd"
+                    nameKey="model"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    label
+                    labelLine={{ stroke: 'var(--color-text-muted)' }}
+                  >
+                    {modelData.map((entry) => (
+                      <Cell
+                        key={entry.model}
+                        fill={MODEL_COLORS[entry.model] || MODEL_COLORS.other}
+                      />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<CustomTooltip />} />
+                </PieChart>
+              )}
+            </ChartFrame>
+          </section>
+
+          {/* Model list */}
+          <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
+            <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
+              Model Details
+            </h3>
+            <div className="space-y-3">
+              {modelData.map((model) => {
+                const pct = totalCost > 0 ? (model.estimatedCostUsd / totalCost) * 100 : 0;
+                return (
+                  <div key={model.model} className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="h-3 w-3 rounded-full"
+                        style={{ backgroundColor: MODEL_COLORS[model.model] || MODEL_COLORS.other }}
+                      />
+                      <span className="text-sm font-mono text-[var(--color-text-primary)]">
+                        {model.model}
+                      </span>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-sm font-mono font-medium text-[var(--color-text-primary)]">
+                        {formatCurrency(model.estimatedCostUsd)}
+                      </div>
+                      <div className="text-xs text-[var(--color-text-muted)]">
+                        {pct.toFixed(1)}%
+                      </div>
+                    </div>
                   </div>
-                  <div className="text-xs text-[var(--color-text-muted)]">
-                    {model.percentage}%
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      </div>
-      
-      {/* Budget warning placeholder */}
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      )}
+
+      {/* Budget warning */}
       <section className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4" aria-label="Budget alerts">
         <div className="flex items-start gap-3">
           <AlertTriangle className="h-5 w-5 text-amber-500 flex-shrink-0 mt-0.5" />

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -98,7 +98,10 @@ export default function CostPage() {
   const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
   const daysPassed = today.getDate();
   const daysRemaining = daysInMonth - daysPassed;
-  const projectedMonthCost = daysWithData > 0 ? (totalCost / daysWithData) * daysInMonth : 0;
+  // Guard: avoid inflated projections from too few data points (Argus review)
+  const projectedMonthCost = daysWithData >= 3
+    ? (totalCost / daysWithData) * daysInMonth
+    : last7Avg > 0 ? last7Avg * daysInMonth : 0;
 
   // Loading state
   if (isLoading) {

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -51,6 +51,9 @@ export type {
   RateLimitForecast,
   GlobalRateLimits,
   RateLimitAnalyticsResponse,
+  AnalyticsCostsResponse,
+  AnalyticsCostByModel,
+  AnalyticsCostDailyTrend,
 } from '../../../src/api-contracts';
 
 // ── Audit Trail ─────────────────────────────────────────────────

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -489,3 +489,41 @@ export interface AggregateMetricsResponse {
   byKey: AggregateMetricsByKey[];
   anomalies: AggregateMetricsAnomaly[];
 }
+
+// ── Cost Analytics (Issue #2246, #2802) ──────────────────────────
+
+/** Per-model cost breakdown from /v1/analytics/costs. */
+export interface AnalyticsCostByModel {
+  model: string;
+  estimatedCostUsd: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+}
+
+/** Per-key cost breakdown from /v1/analytics/costs. */
+export interface AnalyticsCostByKey {
+  keyId: string;
+  keyName: string;
+  estimatedCostUsd: number;
+  sessions: number;
+  messages: number;
+}
+
+/** Daily cost trend from /v1/analytics/costs. */
+export interface AnalyticsCostDailyTrend {
+  date: string;
+  estimatedCostUsd: number;
+  sessions: number;
+}
+
+/** Response from GET /v1/analytics/costs (Issue #2246). */
+export interface AnalyticsCostsResponse {
+  totalCostUsd: number;
+  totalSessions: number;
+  byModel: AnalyticsCostByModel[];
+  byKey: AnalyticsCostByKey[];
+  dailyTrends: AnalyticsCostDailyTrend[];
+  generatedAt: string;
+}


### PR DESCRIPTION
## Summary
Replace all mock data in CostPage with real API calls to `GET /v1/analytics/costs`.

## Changes
- **api-contracts.ts**: Add `AnalyticsCostsResponse`, `AnalyticsCostByModel`, `AnalyticsCostByKey`, `AnalyticsCostDailyTrend` types
- **client.ts**: Add `getAnalyticsCosts()` API function
- **CostPage.tsx**: Rewrite to fetch real cost data instead of generating random mock data
  - Daily spend chart uses `dailyTrends[].estimatedCostUsd`
  - Model breakdown uses `byModel[]` with calculated percentages
  - Summary cards derive from real API response
  - Proper loading/error/empty states
- **a11y-pages.test.tsx**: Update mock with non-zero cost data

## Removed
- `generateMockDailyData()` — random 14-day cost generator
- `generateMockModelData()` — fake model breakdown with hardcoded percentages

## Testing
- TypeScript: clean (`tsc --noEmit`)
- Tests: 98 files / 1051 pass / 2 skipped
- Verified against live server: `/v1/analytics/costs` returns real data structure

Fixes #2802, #2791