### PR TITLE
fix(cors): skip auth on OPTIONS preflight requests (#2809)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -367,6 +367,8 @@ app.addHook('onResponse', (req, _reply, done) => {
 
 function setupAuth(authManager: AuthManager): void {
   app.addHook('onRequest', async (req, reply) => {
+    // #2809: CORS preflight — browsers send OPTIONS without auth headers.
+    if (req.method === 'OPTIONS') return;
     // Skip auth for health endpoint and dashboard (Issue #349: exact path matching)
     // #126: Dashboard is served as public static files; API endpoints are protected
     const urlPath = req.url?.split('?')[0] ?? '';


### PR DESCRIPTION
## Summary
Fixes #2809 — CORS preflight OPTIONS requests returned 401 because the auth hook ran before CORS handling.

## Root Cause
The `onRequest` auth hook fires on ALL requests including OPTIONS. Browsers send OPTIONS preflight WITHOUT Authorization headers — that's the fetch spec. The auth hook rejected them with 401.

## Fix
One-line: early return from auth hook when `req.method === 'OPTIONS'`.

## Verification
```
# Without CORS_ORIGIN: OPTIONS → 404 (auth bypassed, no CORS handler) ✅
# With CORS_ORIGIN=http://localhost:3000:
OPTIONS /v1/sessions → 204 No Content ✅
  access-control-allow-origin: http://localhost:3000
  access-control-allow-headers: Authorization, Content-Type

# Normal POST still requires auth:
POST /v1/sessions (no auth) → 401 ✅
```

tsc --noEmit: zero errors ✅