### PR TITLE
fix(ux): add delivery failure reason to input response (#2787)

### DIFF
--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -573,6 +573,44 @@ describe('MCP Integration Smoke Tests (#1898)', () => {
       });
       expect(res.statusCode).toBe(401);
     });
+
+    // #2787: reason field when delivery fails
+    it('includes reason field when message delivery fails', async () => {
+      const createRes = await server.app.inject({
+        method: 'POST',
+        url: '/v1/sessions',
+        headers: AUTH_HEADER,
+        payload: { workDir: '/tmp' },
+      });
+      const { id } = JSON.parse(createRes.body);
+
+      // Override sendMessage to simulate delivery failure (no active transport)
+      server.sessions.sendMessage = vi.fn(async (_id: string, _text: string) => ({
+        delivered: false as boolean,
+        attempts: 0,
+        error: 'no_active_transport',
+      }));
+
+      const sendRes = await server.app.inject({
+        method: 'POST',
+        url: `/v1/sessions/${id}/send`,
+        headers: AUTH_HEADER,
+        payload: { text: 'Hello' },
+      });
+      expect(sendRes.statusCode).toBe(200);
+      const body = JSON.parse(sendRes.body);
+      expect(body.ok).toBe(true);
+      expect(body.delivered).toBe(false);
+      expect(body.attempts).toBe(0);
+      expect(body.reason).toBe('no_active_transport');
+
+      // Restore default mock
+      server.sessions.sendMessage = vi.fn(async (sid: string, _text: string) => {
+        const s = server.sessions.getSession(sid);
+        if (!s) throw new Error('Session not found');
+        return { delivered: true, attempts: 1 };
+      });
+    });
   });
 
   // ── GET /v1/sessions/:id/summary ─────────────────────────────────

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -388,7 +388,7 @@ export function registerOpenApiSpec(): void {
     parameters: [{ name: 'id', in: 'path', required: true, description: 'Session UUID', schema: z.string().uuid() }],
     requestBody: { content: { 'application/json': { schema: sendMessageSchema } } },
     responses: {
-      '200': okJsonResponse(z.object({ ok: z.boolean(), delivered: z.boolean(), attempts: z.number() })),
+      '200': okJsonResponse(z.object({ ok: z.boolean(), delivered: z.boolean(), attempts: z.number(), reason: z.string().optional() })),
       '400': validationErrorResponse(),
       '404': notFoundResponse,
     },

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -73,6 +73,9 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
         detail: text,
       });
       const response: Record<string, unknown> = { ok: true, delivered: result.delivered, attempts: result.attempts };
+      if (!result.delivered) {
+        response.reason = result.error ?? 'no_active_transport';
+      }
       if (currentStallInfo.stalled) response.stall = currentStallInfo;
       return response;
     } catch (e: unknown) {

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -34,6 +34,8 @@ export interface SendMessageResponse {
   ok: boolean;
   delivered: boolean;
   attempts: number;
+  /** Reason for delivery failure when delivered=false. */
+  reason?: string;
   stall?: { stalled: true; types: string[] } | { stalled: false };
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -899,7 +899,7 @@ export class SessionManager {
 
   /** Send message (ACP stub — use JSON-RPC). */
   async sendMessage(_id: string, _text: string): Promise<{ delivered: boolean; attempts: number; error?: string }> {
-    return { delivered: false, attempts: 0, error: 'ACP mode: use JSON-RPC messaging' };
+    return { delivered: false, attempts: 0, error: 'no_active_transport' };
   }
 
   /** Approve permission (ACP stub — handled by hooks). */


### PR DESCRIPTION
## Summary

Fixes #2787

When sending input to a session with no active ACP transport, the API returned:
```json
{"ok":true,"delivered":false,"attempts":0}
```

With no explanation for why delivery failed. Now returns:
```json
{"ok":true,"delivered":false,"attempts":0,"reason":"no_active_transport"}
```

## Changes

- `src/services/interfaces.ts`: Add optional `reason?: string` to `SendMessageResponse`
- `src/routes/session-actions.ts`: Surface `reason` from `sendMessage` result when `delivered=false`
- `src/session.ts`: Change ACP stub error message to `no_active_transport`
- `src/routes/openapi.ts`: Add `reason` to response schema
- Test: Verify `reason` field appears on delivery failure

## Verification

```
Aegis API: v0.6.6-preview.1
Commit: 1b8e2a66
Branch: fix/2787-input-delivery-reason (from origin/develop)

tsc --noEmit: ✅ zero errors
npm run build: ✅ success
npm test: ✅ 3914 passed, 0 regressions
  - 1 pre-existing flaky failure (fix-2534-lastusedat-persist ENOENT — unrelated)
  - isAncestorPid teardown timeout — pre-existing, known non-blocking issue
```

## Emergency Direct Implementation Exception

Aegis CC session `4ce61dac` was created but CC process failed to launch (no ACP transport, no tmux). Applied SOUL.md emergency exception for this focused 5-file change.