### PR TITLE
fix: allow non-UUID key IDs on auth key routes (#2788)

### DIFF
--- a/src/__tests__/fix-2788-auth-key-id.test.ts
+++ b/src/__tests__/fix-2788-auth-key-id.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for Issue #2788: Auth key routes reject non-UUID key IDs.
+ *
+ * The global onRequest hook validates all :id params as UUIDs, but
+ * auth key IDs are hex strings (e.g. "9c855a8b4680011c"), not UUIDs.
+ * The fix skips UUID validation for /v1/auth/keys/* and /v1/keys/* routes.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidUUID(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
+// Mirrors the logic in server.ts post-fix
+const AUTH_KEY_ID_PREFIXES = ['/v1/auth/keys/', '/v1/keys/'];
+
+function shouldValidateAsUUID(urlPath: string): boolean {
+  const stripped = urlPath.split('?')[0] ?? '';
+  const isAuthKeyRoute = AUTH_KEY_ID_PREFIXES.some(p => stripped.startsWith(p));
+  return !isAuthKeyRoute;
+}
+
+describe('#2788: auth key ID validation', () => {
+  it('should skip UUID check for /v1/auth/keys/:id routes', () => {
+    expect(shouldValidateAsUUID('/v1/auth/keys/9c855a8b4680011c')).toBe(false);
+    expect(shouldValidateAsUUID('/v1/auth/keys/9c855a8b4680011c/rotate')).toBe(false);
+    expect(shouldValidateAsUUID('/v1/auth/keys/9c855a8b4680011c/quotas')).toBe(false);
+  });
+
+  it('should skip UUID check for /v1/keys/:id routes', () => {
+    expect(shouldValidateAsUUID('/v1/keys/9c855a8b4680011c')).toBe(false);
+  });
+
+  it('should enforce UUID check for session routes', () => {
+    expect(shouldValidateAsUUID('/v1/sessions/not-a-uuid')).toBe(true);
+    expect(shouldValidateAsUUID('/v1/sessions/abc123/send')).toBe(true);
+  });
+
+  it('should enforce UUID check for other :id routes', () => {
+    expect(shouldValidateAsUUID('/v1/sessions/abc-123/events')).toBe(true);
+  });
+
+  it('should validate hex key ID as non-UUID', () => {
+    const keyId = '9c855a8b4680011c';
+    expect(isValidUUID(keyId)).toBe(false);
+  });
+
+  it('should accept valid UUID for session routes', () => {
+    const sessionId = '00000000-0000-0000-0000-000000000001';
+    expect(isValidUUID(sessionId)).toBe(true);
+  });
+
+  it('should not skip UUID check for /v1/sessions routes', () => {
+    // These should still be validated as UUIDs
+    expect(shouldValidateAsUUID('/v1/sessions/00000000-0000-0000-0000-000000000001')).toBe(true);
+    expect(shouldValidateAsUUID('/v1/sessions/00000000-0000-0000-0000-000000000001/send')).toBe(true);
+    expect(shouldValidateAsUUID('/v1/sessions/00000000-0000-0000-0000-000000000001/events')).toBe(true);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -578,9 +578,13 @@ function setupAuth(authManager: AuthManager): void {
 // ── v1 API Routes ───────────────────────────────────────────────────
 
 // #412: Reject non-UUID session IDs at the routing layer
+// #2788: Skip UUID check for auth key routes — key IDs are hex strings, not UUIDs.
+const AUTH_KEY_ID_PREFIXES = ['/v1/auth/keys/', '/v1/keys/'];
 app.addHook('onRequest', async (req, reply) => {
+  const urlPath = req.url?.split('?')[0] ?? '';
+  const isAuthKeyRoute = AUTH_KEY_ID_PREFIXES.some(p => urlPath.startsWith(p));
   const id = (req.params as Record<string, string | undefined>).id;
-  if (id !== undefined && !isValidUUID(id)) {
+  if (!isAuthKeyRoute && id !== undefined && !isValidUUID(id)) {
     return reply.status(400).send({ error: 'Invalid session ID — must be a UUID' });
   }
 });


### PR DESCRIPTION
## Summary

Fixes #2788

The global `onRequest` hook validates all `:id` params as UUIDs, but auth key IDs are hex strings (e.g. `9c855a8b4680011c`), not UUIDs. This caused key management endpoints to fail:

- `POST /v1/auth/keys/:id/rotate` → 400 "Invalid session ID — must be a UUID"
- `DELETE /v1/auth/keys/:id` → 400 "Invalid session ID — must be a UUID"
- `GET /v1/auth/keys/:id/quotas` → 400 "Invalid session ID — must be a UUID"
- `PUT /v1/auth/keys/:id/quotas` → 400 "Invalid session ID — must be a UUID"

## Fix

Skip UUID validation when the request path starts with `/v1/auth/keys/` or `/v1/keys/`. Session routes continue to enforce UUID validation.

## Changes

- `src/server.ts`: Added `AUTH_KEY_ID_PREFIXES` guard in the global `onRequest` hook
- `src/__tests__/fix-2788-auth-key-id.test.ts`: 7 tests covering the fix

## Verification

```
Aegis API: v0.6.6-preview.1
Commit: 3020a0b1
Worktree: /home/bubuntu/projects/wt/issue-2788

tsc --noEmit: ✅ zero errors
npm run build: ✅ success
npm test: ✅ 3899 passed, 2 skipped, 0 failed (251 files)
```