### PR TITLE
docs: fix wrong env var names and stale references (#2835)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -310,7 +310,7 @@ scripts, or support bundles.
 curl http://localhost:9100/v1/health
 
 # Try with explicit URL
-AEGIS_URL=http://localhost:9100 ag sessions list
+AEGIS_BASE_URL=http://localhost:9100 ag sessions list
 ```
 
 ---
@@ -332,15 +332,12 @@ echo $AEGIS_AUTH_TOKEN
 
 ### High memory usage with many sessions
 
-**Cause:** Sessions accumulate without cleanup. No idle timeout configured.
+**Cause:** Sessions accumulate without cleanup. Session age limit not configured.
 
 **Fix:**
 ```bash
-# Set idle timeout (default: 10 minutes)
-AEGIS_IDLE_TIMEOUT_MS=300000 ag
-
-# Set max sessions
-AEGIS_MAX_SESSIONS=10 ag
+# Set max session age (default: 2 hours)
+AEGIS_MAX_SESSION_AGE_MS=7200000 ag
 ```
 
 ---


### PR DESCRIPTION
Fixes #2835

## Changes
- **AEGIS_URL → AEGIS_BASE_URL** — matches `src/config.ts:415`
- **AEGIS_IDLE_TIMEOUT_MS → AEGIS_MAX_SESSION_AGE_MS** — the actual env var for session lifetime
- **Removed AEGIS_MAX_SESSIONS** — no such config exists
- **Fixed default value** — 2 hours, not 10 minutes (`maxSessionAgeMs` defaults to `2 * 60 * 60 * 1000`)

Verified against `src/config.ts` env var definitions.