### PR TITLE
fix: prevent state.json.tmp ENOENT race under concurrent saves (#2793)

### DIFF
--- a/src/services/state/JsonFileStore.ts
+++ b/src/services/state/JsonFileStore.ts
@@ -110,11 +110,13 @@ export class JsonFileStore implements StateStore {
   }
 
   async save(state: SerializedSessionState): Promise<void> {
+    // #2793: Use unique temp file per save to prevent ENOENT race when
+    // concurrent saves (SessionManager.doSave + putSession) overlap.
     const dir = dirname(this.stateFile);
     if (!existsSync(dir)) {
       await mkdir(dir, { recursive: true });
     }
-    const tmpFile = `${this.stateFile}.tmp`;
+    const tmpFile = `${this.stateFile}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`;
     await writeFile(tmpFile, JSON.stringify(state, null, 2));
     await rename(tmpFile, this.stateFile);
   }
@@ -196,7 +198,7 @@ export class JsonFileStore implements StateStore {
       return;
     }
 
-    const tmpFile = `${this.pipelineFile}.tmp`;
+    const tmpFile = `${this.pipelineFile}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`;
     await writeFile(tmpFile, JSON.stringify(state, null, 2));
     await rename(tmpFile, this.pipelineFile);
   }
@@ -259,7 +261,7 @@ export class JsonFileStore implements StateStore {
   private cleanTmpFiles(): void {
     try {
       for (const entry of readdirSync(this.stateDir)) {
-        if (entry.endsWith('.tmp')) {
+        if (entry.endsWith('.tmp') || entry.includes('.tmp.')) {
           const fullPath = join(this.stateDir, entry);
           try { unlinkSync(fullPath); } catch { /* best effort */ }
           console.log(`Cleaned stale tmp file: ${entry}`);


### PR DESCRIPTION
## Summary

Fixes #2793

When multiple sessions are saved concurrently (e.g., `SessionDiscovery.syncSessionMap` fires for multiple sessions at once), `JsonFileStore.save()` throws ENOENT trying to rename `state.json.tmp → state.json`.

### Root Cause
Concurrent saves share a single `state.json.tmp` temp file:
1. Save A writes `state.json.tmp`
2. Save B overwrites `state.json.tmp`
3. Save A renames `state.json.tmp → state.json` (succeeds)
4. Save B tries to rename `state.json.tmp → state.json` → **ENOENT** (already consumed by A)

### Fix
Use unique temp filenames per save (`state.json.tmp.PID.timestamp.random`). Each save writes to its own temp file, eliminating the race entirely.

Also applied to pipeline state saves. Updated `cleanTmpFiles()` to match both old `.tmp` and new `.tmp.*` patterns.

## Changes
- `src/services/state/JsonFileStore.ts`: Unique temp filenames for `save()` and `savePipelines()`

## Verification

```
Commit: 48338829
Worktree: /home/bubuntu/projects/wt/issue-2793

tsc --noEmit: ✅ zero errors
npm run build: ✅ success
npm test: ✅ 3892 passed, 2 skipped, 0 failed (250 files)
```