### PR TITLE
fix(build): rmSync before cpSync to prevent dashboard build doubling (#2825)

### DIFF
--- a/scripts/copy-dashboard.mjs
+++ b/scripts/copy-dashboard.mjs
@@ -6,14 +6,22 @@
  * Validates that the copy succeeds and index.html is present.
  *
  * Issue #1699 / ARC-6: Added post-copy validation and proper error handling.
+ * Issue #2825: Use rmSync before cpSync to prevent stale file accumulation.
  */
-import { cpSync, existsSync } from "node:fs";
+import { cpSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 const src = join("dashboard", "dist");
 const dst = join("dist", "dashboard");
 
 if (existsSync(src)) {
+  // Remove stale destination BEFORE copying to prevent file accumulation (#2825)
+  // Without this, cpSync with recursive:true merges into existing dirs,
+  // leaving old hashed chunks from previous builds.
+  if (existsSync(dst)) {
+    rmSync(dst, { recursive: true, force: true });
+  }
+
   cpSync(src, dst, { recursive: true });
 
   // Post-copy validation: ensure index.html was copied


### PR DESCRIPTION
## Summary

Fixes #2825 — dashboard build output doubles from ~8MB to ~18MB on repeated builds because `cpSync(src, dst, { recursive: true })` merges files into the existing `dist/dashboard/` instead of replacing it.

## Root Cause

`copy-dashboard.mjs` uses `cpSync` with `recursive: true` which preserves existing files in the destination. On repeated builds, stale hashed chunks from previous builds accumulate.

## Fix

Add `rmSync(dst, { recursive: true, force: true })` before `cpSync` to ensure a clean copy every time.

## Verification

```
Run 1: 43 JS files, 7.9MB ✅
Run 2: 43 JS files, 7.9MB ✅ (no doubling)
```

Before fix: 78 JS files, 18MB on second build.

## Quality Gate

- [x] Build passes
- [x] Manual verification — no file accumulation after repeated runs
- [x] Minimal change — 9 lines added, 1 import added