### PR TITLE
docs: add reserved MCP server name note for CC 2.1.128+

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -15,6 +15,12 @@ claude mcp add aegis -- ag mcp
 
 This connects Claude Code to the Aegis MCP server running on `localhost:9100`.
 
+### Reserved MCP Server Names
+
+Claude Code v2.1.128+ reserves the name **`workspace`** as a built-in MCP server. If you configure a custom MCP server with this name, it will be silently skipped with a warning.
+
+Aegis registers itself as **`aegis`** (not `workspace`), so this does not affect the default setup above. However, if you manage custom MCP servers alongside Aegis, avoid using `workspace` as a server name.
+
 ## Tools
 
 ### Session Management


### PR DESCRIPTION
## Summary

Addresses #2806 — adds a note in `docs/mcp-tools.md` documenting that Claude Code v2.1.128+ reserves `workspace` as an MCP server name.

## Changes

- Added "Reserved MCP Server Names" subsection after Setup
- Confirms Aegis uses `aegis` (not `workspace`) so default setup is unaffected
- Warns users who manage custom MCP servers alongside Aegis to avoid the name

## Checklist

- [x] Docs only — no code changes
- [x] Verified against issue audit (Aegis source does not use `workspace`)

Closes #2806