### PR TITLE
fix(dashboard): ErrorBoundary uses theme-aware colors for light mode

### DIFF
--- a/dashboard/src/components/shared/ErrorBoundary.test.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * ErrorBoundary.test.tsx — Vitest tests for the error boundary component.
+ *
+ * @see #2829
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+// Suppress React error-boundary console noise in tests
+const originalError = console.error;
+beforeEach(() => {
+  console.error = vi.fn((...args: unknown[]) => {
+    const msg = typeof args[0] === 'string' ? args[0] : '';
+    if (msg.includes('The above error occurred in the React component')) return;
+    if (msg.includes('Uncaught')) return;
+    originalError.call(console, ...args);
+  });
+});
+
+/** Component that always throws when rendered. */
+function ThrowOnRender({ error }: { error?: Error }): React.ReactElement {
+  throw error ?? new Error('Test error');
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <p>All good</p>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('All good')).not.toBeNull();
+  });
+
+  it('shows fallback UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowOnRender />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Something went wrong')).not.toBeNull();
+    expect(screen.getByText('Test error')).not.toBeNull();
+    expect(screen.getByRole('alert')).not.toBeNull();
+  });
+
+  it('renders custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={<p>Custom fallback</p>}>
+        <ThrowOnRender />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Custom fallback')).not.toBeNull();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+
+  it('resets state when retry button is clicked', () => {
+    let shouldThrow = true;
+
+    function ConditionalThrow(): React.ReactElement {
+      if (shouldThrow) throw new Error('boom');
+      return <p>Recovered</p>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <ConditionalThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('boom')).not.toBeNull();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(screen.getByText('Recovered')).not.toBeNull();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+
+  it('displays the error message in the fallback', () => {
+    const customError = new Error('Specific error message');
+    render(
+      <ErrorBoundary>
+        <ThrowOnRender error={customError} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Specific error message')).not.toBeNull();
+  });
+
+  it('shows generic message when error has no message', () => {
+    function ThrowNull(): React.ReactElement {
+      throw new Error();
+    }
+    render(
+      <ErrorBoundary>
+        <ThrowNull />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('An unexpected error occurred')).not.toBeNull();
+  });
+});

--- a/dashboard/src/components/shared/ErrorBoundary.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.tsx
@@ -1,5 +1,8 @@
 /**
  * components/shared/ErrorBoundary.tsx — React error boundary with fallback UI.
+ *
+ * Uses theme-aware colors via dark: variants so the fallback is
+ * legible in both light and dark mode (fixes #2829).
  */
 
 import { Component, type ReactNode } from 'react';
@@ -35,21 +38,27 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback;
       }
       return (
-        <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
-          <div className="rounded-full bg-red-500/10 p-4">
-            <AlertTriangle className="h-8 w-8 text-red-400" />
+        <div
+          className="flex flex-col items-center justify-center gap-4 p-8 text-center"
+          role="alert"
+          aria-live="assertive"
+        >
+          <div className="rounded-full bg-red-100 p-4 dark:bg-red-500/10">
+            <AlertTriangle className="h-8 w-8 text-red-500 dark:text-red-400" aria-hidden="true" />
           </div>
           <div>
-            <p className="text-lg font-medium text-red-300">Something went wrong</p>
-            <p className="mt-1 text-sm text-zinc-500">
+            <p className="text-lg font-medium text-red-600 dark:text-red-300">
+              Something went wrong
+            </p>
+            <p className="mt-1 text-sm text-[var(--color-text-muted)]">
               {this.state.error?.message || 'An unexpected error occurred'}
             </p>
           </div>
           <button
             onClick={this.handleRetry}
-            className="flex items-center gap-2 rounded-lg bg-red-500/20 px-4 py-2 text-sm text-red-300 hover:bg-red-500/30 transition-colors border border-red-500/30"
+            className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-100 px-4 py-2 text-sm text-red-600 transition-colors hover:bg-red-200 dark:border-red-500/30 dark:bg-red-500/20 dark:text-red-300 dark:hover:bg-red-500/30"
           >
-            <RefreshCw className="h-4 w-4" />
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
             Try again
           </button>
         </div>


### PR DESCRIPTION
## Summary
Fixes #2829

The ErrorBoundary fallback UI used hardcoded dark-mode colors (`text-red-300`, `bg-red-500/10`, etc.) that were invisible in light mode.

## Changes
- Replaced all hardcoded dark-only Tailwind classes with `dark:` variants and CSS var references
- Added `role="alert"` and `aria-live="assertive"` for screen reader support
- Added `aria-hidden="true"` to decorative icons (AlertTriangle, RefreshCw)
- Added 6 new Vitest tests covering all ErrorBoundary behaviors

## Color mapping
| Before | After |
|--------|-------|
| `text-red-400` | `text-red-500 dark:text-red-400` |
| `text-red-300` | `text-red-600 dark:text-red-300` |
| `text-zinc-500` | `text-[var(--color-text-muted)]` |
| `bg-red-500/10` | `bg-red-100 dark:bg-red-500/10` |
| `bg-red-500/20` | `bg-red-100 dark:bg-red-500/20` |
| `border-red-500/30` | `border-red-300 dark:border-red-500/30` |

## Test plan
- [x] 6 new Vitest tests pass
- [x] `npm run build` succeeds
- [x] Verified fallback is legible in both light and dark mode