### PR TITLE
fix(docker): add multi-stage Dockerfile with proper dashboard deps (#2794)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+node_modules/
+dashboard/node_modules/
+dist/
+dashboard/dist/
+.tmp*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# ── Stage 1: Build ───────────────────────────────────────────
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /app
+
+# Install root dependencies (including devDependencies for build tooling)
+COPY package*.json ./
+RUN npm ci
+
+# Copy dashboard manifest and install its dependencies separately
+# This ensures dashboard/node_modules exists before the source arrives
+COPY dashboard/package*.json dashboard/
+RUN cd dashboard && npm ci
+
+# Copy all source
+COPY . .
+
+# Build: tsc + openapi + dashboard + copy-dashboard
+RUN npm run build
+
+# Verify dashboard was built and copied correctly
+RUN test -f dist/dashboard/index.html || \
+    (echo "ERROR: dist/dashboard/index.html not found after build" && exit 1)
+
+# ── Stage 2: Production ─────────────────────────────────────
+FROM node:22-bookworm-slim AS production
+
+WORKDIR /app
+
+# Install only production dependencies for runtime
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Create non-root user
+RUN groupadd --gid 1001 aegis && \
+    useradd --uid 1001 --gid aegis --shell /bin/bash --create-home aegis
+
+# Copy built artifacts from builder
+COPY --from=builder --chown=aegis:aegis /app/dist ./dist
+COPY --from=builder --chown=aegis:aegis /app/openapi.yaml ./
+
+USER aegis
+
+ENV NODE_ENV=production
+EXPOSE 9100
+
+ENTRYPOINT ["node", "dist/server.js"]


### PR DESCRIPTION
## Problem
Docker build from a clean checkout fails with `error TS2307: Cannot find module 'react-window'` because:
1. `npm ci --omit=dev` skips `typescript` (a root devDependency needed for build)
2. `dashboard/node_modules` is never installed before `npm run build` triggers `build-dashboard.mjs`

Closes #2794

## Fix
Added a proper multi-stage `Dockerfile`:
- **Builder stage**: `npm ci` (full, no `--omit=dev`) for root + separate `npm ci` in `dashboard/`
- **Production stage**: `npm ci --omit=dev` for runtime deps only
- Added `.dockerignore` to exclude `.git/`, `node_modules/`, `dist/` from Docker context

## Files
- `Dockerfile` — new, multi-stage build
- `.dockerignore` — new, keeps context small

## Testing
- `tsc --noEmit` passes
- Build logic mirrors what works in CI (root `npm ci` + dashboard `npm ci` + `npm run build`)
- Non-root user for security

## Review notes for Argus
Pure DevOps/Docker — no application code changes. The Dockerfile follows the pattern already documented in `docs/production-deployment.md` but fixes the broken install sequence.