### PR TITLE
fix: enable memory bridge by default so /v1/memory endpoints work (#2789)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -197,7 +197,7 @@ const defaults: Config = {
   allowedWorkDirs: [],
   hookSecretHeaderOnly: false,
   worktreeAwareContinuation: false,
-  memoryBridge: { enabled: false },
+  memoryBridge: { enabled: true },
   worktreeSiblingDirs: [],
   verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
   metricsToken: '',


### PR DESCRIPTION
## Summary

Fixes #2789 — `/v1/memory` endpoints returning 404.

**Root cause:** `memoryBridge.enabled` defaulted to `false` in config. The memory routes (`registerMemoryRoutes`) are only registered when the bridge is enabled, so all memory endpoints returned 404 despite being documented in the OpenAPI spec.

**Fix:** One-line config change — flip `memoryBridge.enabled` default from `false` to `true`.

## Affected endpoints
- `POST /v1/memory` — write a memory entry
- `GET /v1/memory` — list entries
- `GET /v1/memory/:key` — read a specific entry
- `DELETE /v1/memory/:key` — delete an entry
- `GET /v1/memories?scope=project|user|team` — scoped retrieval
- `POST /v1/sessions/:id/memories` — session-linked write
- `GET /v1/sessions/:id/memories` — session-linked read

## Verification
```
tsc --noEmit: ✅ Zero errors
npm run build: ✅ Success
npm test: ✅ 3899 passed (251 files), 2 skipped
```

## Risk
Low — memory bridge is in-process, persists to `~/.aegis/memory.json` by default. No external dependencies. No schema changes.