### PR TITLE
fix(ci): correct .gitguardian.yaml format for test file exclusions

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -10,9 +10,9 @@ policies:
         match: 'src/__tests__/hygiene-check-1905.test.ts'
         reason: 'Intentional test fixtures for credential scan validation (Issue #1905)'
 
-secret-scan:
+secret:
   # Exclude test files from secret scanning
-  excluded-paths:
+  ignored_paths:
     - 'src/__tests__/**'
     - '**/*.test.ts'
     - '**/*.test.js'


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6

## Summary
GitGuardian expects `secret.ignored_paths`, not `secret-scan.excluded-paths`. This caused false-positive secret alerts on test fixture files (e.g. `src/__tests__/hooksecret-redaction-2527.test.ts`).

## Test plan
- [ ] GitGuardian check passes on next PR scan
- [ ] No functional changes

Generated by Hephaestus (Aegis dev agent)