### PR TITLE
feat: add /v1/version endpoint for server version discovery (#2814)

### DIFF
--- a/src/__tests__/version-endpoint-2814.test.ts
+++ b/src/__tests__/version-endpoint-2814.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Test for #2814: /v1/version endpoint returns server version.
+ *
+ * Verifies:
+ *   - Returns 200 with { name, version } JSON
+ *   - Returns X-Aegis-Version response header
+ *   - Does not require authentication
+ *   - Version matches package.json
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import Fastify from 'fastify';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { ApiKeyPermission } from '../services/auth/index.js';
+
+// Mock child_process so getClaudeCliStatus() doesn't exec a real 'claude' binary
+vi.mock('node:child_process', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...original,
+    execFile: (
+      _file: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout: 'Claude Code 1.0.0\n', stderr: '' });
+    },
+  };
+});
+
+import { AuthManager, QuotaManager, DashboardSessionStore } from '../services/auth/index.js';
+import { MetricsCollector } from '../metrics.js';
+import { SessionManager } from '../session.js';
+import { SessionMonitor } from '../monitor.js';
+import { SessionEventBus } from '../events.js';
+import { ChannelManager } from '../channels/index.js';
+import { JsonlWatcher } from '../jsonl-watcher.js';
+import { PipelineManager } from '../pipeline.js';
+import { ToolRegistry } from '../tool-registry.js';
+import { AlertManager } from '../alerting.js';
+import { SSEConnectionLimiter } from '../sse-limiter.js';
+import { registerHealthRoutes, type RouteContext } from '../routes/index.js';
+import type { Config } from '../config.js';
+
+function createMockTmux() {
+  return {
+    ensureSession: vi.fn().mockResolvedValue(undefined),
+    listWindows: vi.fn().mockResolvedValue([]),
+    createWindow: vi.fn().mockResolvedValue({ windowId: '@1', displayName: 'mock', freshSessionId: 'mock-session' }),
+    capturePane: vi.fn().mockResolvedValue(''),
+    capturePaneDirect: vi.fn().mockResolvedValue(''),
+    listPanePid: vi.fn().mockResolvedValue(12345),
+    isPidAlive: vi.fn().mockResolvedValue(true),
+    getWindowHealth: vi.fn().mockResolvedValue({ windowExists: true, paneCommand: null, claudeRunning: false, paneDead: false }),
+    windowExists: vi.fn().mockResolvedValue(true),
+    sendKeys: vi.fn().mockResolvedValue({ success: true }),
+    sendKeysVerified: vi.fn().mockResolvedValue({ delivered: true, attempts: 1 }),
+    sendSpecialKey: vi.fn().mockResolvedValue({ success: true }),
+    killWindow: vi.fn().mockResolvedValue({ success: true }),
+    killSession: vi.fn().mockResolvedValue({ success: true }),
+    isServerHealthy: vi.fn().mockResolvedValue({ healthy: true, error: null }),
+    isTmuxServerError: vi.fn().mockReturnValue(false),
+  };
+}
+
+const MASTER_TOKEN = 'aegis-test-version-2814';
+
+async function buildApp(tmpDir: string): Promise<FastifyInstance> {
+  const config = {
+    port: 0,
+    host: '127.0.0.1',
+    authToken: MASTER_TOKEN,
+    stateDir: tmpDir,
+    claudeProjectsDir: join(tmpDir, 'projects'),
+    maxSessionAgeMs: 7200000,
+    reaperIntervalMs: 3600000,
+    continuationPointerTtlMs: 86400000,
+    tgBotToken: '',
+    tgGroupId: '',
+    tgAllowedUsers: [],
+    tgTopicTtlMs: 0,
+    tgTopicAutoDelete: true,
+    tgTopicTTLHours: 0,
+    stallThresholdMs: 300000,
+    defaultPermissionMode: 'default',
+    allowedWorkDirs: [],
+    defaultSessionEnv: {},
+    metricsToken: '',
+    hookSecretHeaderOnly: false,
+    pipelineStageTimeoutMs: 30000,
+    webhooks: [],
+    sseMaxConnections: 100,
+    sseMaxPerIp: 10,
+    memoryBridge: { enabled: false },
+    worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+    verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
+    alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600000 },
+    envDenylist: [],
+    envAdminAllowlist: [],
+    enforceSessionOwnership: true,
+    sseIdleMs: 60000,
+    sseClientTimeoutMs: 300000,
+    hookTimeoutMs: 10000,
+    shutdownGraceMs: 15000,
+    keyRotationGraceSeconds: 3600,
+    shutdownHardMs: 20000,
+    rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
+    stateStore: 'file',
+    postgresUrl: '',
+    defaultTenantId: 'default',
+    acpEnabled: false,
+    tenantWorkdirs: {},
+  } satisfies Config;
+
+  const sessions = new SessionManager(config);
+  await sessions.load();
+
+  const auth = new AuthManager(join(tmpDir, 'keys.json'), MASTER_TOKEN);
+  auth.setHost('127.0.0.1');
+
+  const metrics = new MetricsCollector(join(tmpDir, 'metrics.json'));
+  await metrics.load();
+
+  const eventBus = new SessionEventBus();
+  const channels = new ChannelManager();
+  const monitor = new SessionMonitor(sessions, channels);
+  const jsonlWatcher = new JsonlWatcher();
+  const toolRegistry = new ToolRegistry();
+  const alertManager = new AlertManager({ webhooks: [] });
+  const sseLimiter = new SSEConnectionLimiter();
+  const pipelines = new PipelineManager(sessions, eventBus, undefined, config.pipelineStageTimeoutMs);
+  const dashboardTokenSessions = new DashboardSessionStore();
+
+  const ctx: RouteContext = {
+    sessions,
+    auth,
+    quotas: new QuotaManager(),
+    config,
+    metrics,
+    monitor,
+    eventBus,
+    channels,
+    jsonlWatcher,
+    pipelines,
+    toolRegistry,
+    getAuditLogger: () => undefined,
+    alertManager,
+    sseLimiter,
+    memoryBridge: null,
+    requestKeyMap: new Map(),
+    serverState: { draining: false },
+    validateWorkDir: async (wd: string) => wd,
+    metering: {
+      getUsageSummary: () => ({ totalInputTokens: 0, totalOutputTokens: 0, totalCacheCreationTokens: 0, totalCacheReadTokens: 0, totalCostUsd: 0, recordCount: 0, sessions: 0 }),
+      getUsageByKey: () => [],
+      getSessionUsage: () => [],
+      getRateTiers: () => [],
+      recordTokenUsage: () => {},
+      recordToolCall: () => {},
+      setRateTiers: () => {},
+      onUsage: () => () => {},
+      cleanupSession: () => {},
+      pruneOlderThan: () => 0,
+      start: () => {},
+      stop: () => {},
+      load: async () => {},
+      save: async () => {},
+      recordCount: 0,
+    } as unknown as import('../metering.js').MeteringService,
+    metricsCache: {
+      getMetrics: vi.fn(() => ({ sessionVolume: [], tokenUsageByModel: [], costTrends: [], topApiKeys: [], durationTrends: [], errorRates: { totalSessions: 0, failedSessions: 0, failureRate: 0, permissionPrompts: 0, approvals: 0, autoApprovals: 0 }, generatedAt: new Date().toISOString() })),
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      invalidate: vi.fn(),
+      flush: vi.fn(async () => {}),
+    } as unknown as RouteContext['metricsCache'],
+    dashboardTokenSessions,
+  };
+
+  const app = Fastify({ logger: false });
+  app.decorateRequest('authKeyId', null as unknown as string);
+  app.decorateRequest('tenantId', undefined as unknown as string);
+  app.decorateRequest('matchedPermission', null as unknown as ApiKeyPermission);
+  app.decorateRequest('authRole', null);
+  app.decorateRequest('authPermissions', null);
+  app.decorateRequest('authActor', null);
+
+  // Auth middleware — version endpoint is public (no auth required)
+  app.addHook('onRequest', async (req: FastifyRequest, reply: FastifyReply) => {
+    const urlPath = req.url?.split('?')[0] ?? '';
+    if (urlPath === '/health' || urlPath === '/v1/health') return;
+    if (urlPath === '/v1/version') return; // Issue #2814: public version discovery
+    const header = req.headers.authorization;
+    const token = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
+    if (!token) return reply.status(401).send({ error: 'Unauthorized' });
+    const result = auth.validate(token);
+    if (!result.valid) return reply.status(401).send({ error: 'Unauthorized — invalid API key' });
+    req.authKeyId = result.keyId;
+    req.tenantId = result.keyId === 'master' ? '_system' : undefined;
+  });
+
+  registerHealthRoutes(app, ctx);
+  await app.ready();
+
+  return app;
+}
+
+describe('Issue #2814: GET /v1/version endpoint', () => {
+  let app: FastifyInstance;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-ver-2814-'));
+    app = await buildApp(tmpDir);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 200 with name and version', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/version' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+    expect(body.name).toBe('@onestepat4time/aegis');
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('returns X-Aegis-Version response header', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/version' });
+
+    expect(res.headers['x-aegis-version']).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('does not require authentication', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/version',
+      headers: {}, // No Authorization header
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('version matches package.json', async () => {
+    const pkg = await import('../../package.json', { with: { type: 'json' } });
+    const res = await app.inject({ method: 'GET', url: '/v1/version' });
+
+    expect((res.json() as Record<string, unknown>).version).toBe(pkg.default.version);
+  });
+});

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -194,4 +194,13 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
       v1_base: '/v1/',
     });
   });
+
+  // Issue #2814: Version discovery endpoint — unauthenticated, no sensitive data
+  registerWithLegacy(app, 'get', '/v1/version', async (_req: FastifyRequest, reply: FastifyReply) => {
+    const pkg = await import('../../package.json', { with: { type: 'json' } });
+    return reply.header('X-Aegis-Version', pkg.default.version).send({
+      name: '@onestepat4time/aegis',
+      version: pkg.default.version,
+    });
+  });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -377,6 +377,8 @@ function setupAuth(authManager: AuthManager): void {
     // #126: Dashboard is served as public static files; API endpoints are protected
     const urlPath = req.url?.split('?')[0] ?? '';
     if (urlPath === '/health' || urlPath === '/v1/health') return;
+    // Issue #2814: Version discovery is public (no sensitive data).
+    if (urlPath === '/v1/version') return;
     // Auth verification is a public bootstrap endpoint for dashboard login.
     if (urlPath === '/v1/auth/verify') return;
     // Issue #1943: Device auth endpoints are public (they proxy to the IdP).


### PR DESCRIPTION
## Summary

Fixes #2814 — adds `GET /v1/version` endpoint for version discovery.

**Problem:** No way for clients or dashboard to discover the server version. The `/v1/health` endpoint returns version info only when authenticated.

**Solution:** Dedicated public `/v1/version` endpoint that returns `{ name, version }` without authentication.

## Changes
- `src/routes/health.ts`: Add `/v1/version` route — returns `{ name: "@onestepat4time/aegis", version: "x.y.z" }` + `X-Aegis-Version` header
- `src/server.ts`: Skip auth for `/v1/version` (public, no sensitive data)
- `src/__tests__/version-endpoint-2814.test.ts`: 4 regression tests (200 response, header, no auth required, matches package.json)

## Verification
```
tsc --noEmit: ✅ Zero errors
npm run build: ✅ Success
npm test: ✅ 3903 passed (252 files), 2 skipped
```

## Response example
```bash
curl -s http://127.0.0.1:9100/v1/version
# {"name":"@onestepat4time/aegis","version":"0.6.6-preview.1"}
```

## Security
- No sensitive data exposed (just package name + version)
- No auth required (version is public information)
- Related: #2796 tracks OpenAPI spec version showing `0.0.0`