### PR TITLE
fix(test): use flexible version assertion in acp-backend test

### DIFF
--- a/src/__tests__/acp-backend.test.ts
+++ b/src/__tests__/acp-backend.test.ts
@@ -111,7 +111,7 @@ describe('AcpBackend session lifecycle', () => {
         params: {
           protocolVersion: 1,
           clientCapabilities: {},
-          clientInfo: { name: 'aegis', version: '0.6.6-preview.1' },
+          clientInfo: { name: 'aegis', version: expect.any(String) },
         },
       },
       {


### PR DESCRIPTION
The acp-backend test hardcoded `0.6.6-preview.1` as the expected version in the ACP initialize request snapshot. This breaks every time Release Please bumps the version.

## Fix
Replace hardcoded version with `expect.any(String)` so the test validates structure, not specific version string.

## Why
This exact test failure blocked the v0.6.6 release workflow (first attempt failed on this assertion alone).

Tested: Release workflow attempt 3 with this fix — all 3900 tests passing.