### PR TITLE
fix(dashboard): avoid token-gate false positive on issue reference in comments

### DIFF
--- a/dashboard/src/components/shared/ErrorBoundary.test.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.test.tsx
@@ -1,7 +1,7 @@
 /**
  * ErrorBoundary.test.tsx — Vitest tests for the error boundary component.
  *
- * @see #2829
+ * @see issue 2829
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/dashboard/src/components/shared/ErrorBoundary.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.tsx
@@ -2,7 +2,7 @@
  * components/shared/ErrorBoundary.tsx — React error boundary with fallback UI.
  *
  * Uses theme-aware colors via dark: variants so the fallback is
- * legible in both light and dark mode (fixes #2829).
+ * legible in both light and dark mode (fixes issue 2829).
  */
 
 import { Component, type ReactNode } from 'react';


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.6

## Summary
`#2829` in JSDoc comments matched as hex color by `dashboard:tokens:gate`. Changed to `issue 2829` to prevent false positive.

## Test plan
- [x] `npm run dashboard:tokens:gate` passes
- [x] `npm run gate` passes (253 files, 3902 tests)

Generated by Hephaestus (Aegis dev agent)