### PR TITLE
docs: add /v1/version endpoint + fix stale /pane references (#2812, #2870)

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -35,7 +35,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `POST` | `/v1/sessions/{id}/escape` | Bearer | Send Escape key |
 | `POST` | `/v1/sessions/{id}/interrupt` | Bearer | Send Ctrl+C (interrupt) |
 | `DELETE` | `/v1/sessions/{id}` | Bearer | Kill session |
-| `GET` | `/v1/sessions/{id}/pane` | Bearer | Capture raw terminal pane |
+| `GET` | `/v1/sessions/{id}/pane` | Bearer | Capture raw terminal pane (tmux only — returns 501 in ACP mode) |
 | `GET` | `/v1/sessions/{id}/children` | Bearer | Get child sessions |
 | `POST` | `/v1/sessions/{id}/spawn` | Bearer | Spawn a child session |
 | `POST` | `/v1/sessions/{id}/fork` | Bearer | Fork the session |
@@ -166,6 +166,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | Method | Path | Auth | Summary |
 |--------|------|------|---------|
 | `GET` | `/v1/health` | No Auth | Server health check |
+| `GET` | `/v1/version` | No Auth | Server version discovery |
 | `POST` | `/v1/handshake` | No Auth | Protocol handshake |
 | `GET` | `/v1/swarm` | Bearer | Swarm awareness scan |
 | `GET` | `/v1/alerts/stats` | Bearer | Alert manager stats |
@@ -221,7 +222,7 @@ See [API Rate Limiting](api-rate-limiting.md) for full documentation.
 ## See Also
 
 - [API Reference](api-reference.md) — detailed endpoint docs with schemas
-- [API Examples](api-examples.md) — curl examples for all 58 endpoints
+- [API Examples](api-examples.md) — curl examples for all 59 endpoints
 - [Authentication](api-reference.md#authentication) — auth setup
 - [Rate Limiting](api-rate-limiting.md) — rate limits and headers
 - [Webhook Retry](webhook-retry.md) — webhook delivery with retry

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -66,6 +66,40 @@ curl http://localhost:9100/v1/health
 
 ---
 
+### Version Discovery
+
+```
+GET /v1/version
+```
+
+Returns the server package name and version. **No authentication required** — this is a public endpoint for service discovery and monitoring. The response also includes an `X-Aegis-Version` header.
+
+```bash
+curl http://localhost:9100/v1/version
+```
+
+**Response:**
+
+```json
+{
+  "name": "@onestepat4time/aegis",
+  "version": "0.6.6"
+}
+```
+
+**Headers:**
+
+| Header | Value |
+|--------|-------|
+| `X-Aegis-Version` | Server package version (e.g. `0.6.6`) |
+
+**Use cases:**
+- Load balancer health checks that need version info
+- CI/CD pipelines verifying deployed version
+- Monitoring dashboards tracking fleet versions
+
+---
+
 ### Swarm Status
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -339,4 +339,4 @@ See the [Worktree Guide](./worktree-guide.md) for detailed setup instructions.
 | Dashboard won't load | Verify Aegis is running on port 9100: `curl http://localhost:9100/v1/health` |
 | `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 ag` |
 | Screenshot returns 501 | Install Playwright: `npx playwright install chromium` |
-| No output from `/read` | Wait for transcript entries, or check raw terminal: `curl /v1/sessions/:id/pane` |
+| No output from `/read` | Wait for transcript entries, or check session events via SSE: `curl http://localhost:9100/v1/sessions/:id/events` |


### PR DESCRIPTION
## Changes

### New: `/v1/version` endpoint docs (follows #2870 / #2814)
- Added `GET /v1/version` section to `api-reference.md` — response schema, headers (`X-Aegis-Version`), use cases
- Added endpoint to `api-quick-ref.md` Health section (No Auth)
- Updated endpoint count 58 → 59

### Fix: stale `/pane` references (#2812)
- `getting-started.md`: replaced `/pane` fallback with SSE events guidance
- `api-quick-ref.md`: noted `/pane` returns 501 in ACP mode (tmux only)

Closes #2812

## Files Changed
- `docs/api-reference.md` — new version discovery section
- `docs/api-quick-ref.md` — version row + pane note
- `docs/getting-started.md` — troubleshooting fix