### PR TITLE
fix(dashboard): remove hardcoded demo pipelines from PipelinesPage (#2811)

### DIFF
--- a/dashboard/src/__tests__/TerminalDebugTab.test.tsx
+++ b/dashboard/src/__tests__/TerminalDebugTab.test.tsx
@@ -105,9 +105,12 @@ describe('TerminalDebugTab', () => {
     expect(screen.getByLabelText('Terminal input')).toBeDefined();
   });
 
-  it('renders mock terminal output', () => {
+  it('starts with empty terminal output (no mock data)', () => {
     render(<TerminalDebugTab sessionId="s1" />);
-    expect(screen.getByText(/Waiting for ACP terminal extension/)).toBeDefined();
+    // Should NOT show any mock scaffold messages
+    expect(screen.queryByText(/Waiting for ACP/)).toBeNull();
+    expect(screen.queryByText(/diagnostic surface only/)).toBeNull();
+    expect(screen.queryByText(/aegis session connect/)).toBeNull();
   });
 
   it('sets data-session-id', () => {

--- a/dashboard/src/components/session/TerminalDebugTab.tsx
+++ b/dashboard/src/components/session/TerminalDebugTab.tsx
@@ -67,15 +67,7 @@ export function TerminalDebugTab({
   const mode: AcpTerminalMode = fullConfig.mode;
 
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [terminalOutput, setTerminalOutput] = useState<string[]>([
-    '$ aegis session connect --id ' + sessionId.slice(0, 8),
-    '',
-    '⚠ Terminal debug tab — diagnostic surface only.',
-    '  This is NOT the primary control model.',
-    '',
-    'Waiting for ACP terminal extension...',
-    '',
-  ]);
+  const [terminalOutput, setTerminalOutput] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState('');
   const [terminalSize, setTerminalSize] = useState<AcpTerminalSize>(fullConfig.initialSize);
   const terminalRef = useRef<HTMLDivElement>(null);
@@ -93,33 +85,19 @@ export function TerminalDebugTab({
     if (onInput) onInput(text);
     setInputValue('');
 
-    // Mock echo for scaffold
+    // Terminal not connected to backend yet
     if (text === 'clear') {
       setTerminalOutput([]);
-    } else if (text === 'help') {
-      setTerminalOutput((prev) => [
-        ...prev,
-        'Available commands:',
-        '  clear     — Clear terminal output',
-        '  help      — Show this help message',
-        '  resize    — Toggle terminal size',
-        '',
-      ]);
     } else if (text === 'resize') {
       const newSize = terminalSize.cols === 80
         ? { cols: 120, rows: 36 }
         : { cols: 80, rows: 24 };
       setTerminalSize(newSize);
       onResize?.(newSize);
-      setTerminalOutput((prev) => [
-        ...prev,
-        `Terminal resized to ${newSize.cols}x${newSize.rows}`,
-        '',
-      ]);
     } else {
       setTerminalOutput((prev) => [
         ...prev,
-        `Command not available in scaffold mode: ${text}`,
+        'Terminal not connected — waiting for ACP backend.',
         '',
       ]);
     }

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -1,10 +1,12 @@
 /**
  * pages/PipelinesPage.tsx — Pipeline list with metrics and create action.
+ *
+ * Demo data removed — shows only real API data. (#2811)
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
-import { Plus, GitBranch, Sparkles } from 'lucide-react';
+import { Plus, GitBranch } from 'lucide-react';
 import EmptyState from '../components/shared/EmptyState';
 import { getPipelines } from '../api/client';
 import type { PipelineInfo } from '../api/client';
@@ -21,70 +23,6 @@ import { IdleTip } from '../components/shared/IdleTip';
 const BASE_POLL_INTERVAL_MS = 10_000;
 const SSE_HEALTHY_POLL_INTERVAL_MS = 30_000;
 const MAX_POLL_INTERVAL_MS = 60_000;
-const DEMO_TAG_KEY = 'aegis:demo-pipelines';
-const DEMO_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-// Mock demo pipelines
-const DEMO_PIPELINES: PipelineInfo[] = [
-  {
-    id: 'demo-ci-cd',
-    name: 'CI/CD Pipeline',
-    status: 'completed',
-    stages: [
-      { name: 'Build', status: 'completed', sessionId: 'demo-s1' },
-      { name: 'Test', status: 'completed', sessionId: 'demo-s2' },
-      { name: 'Deploy', status: 'completed', sessionId: 'demo-s3' },
-    ],
-    createdAt: Date.now() - 3600000,
-  },
-  {
-    id: 'demo-data-etl',
-    name: 'Data ETL',
-    status: 'running',
-    stages: [
-      { name: 'Extract', status: 'completed', sessionId: 'demo-s4' },
-      { name: 'Transform', status: 'running', sessionId: 'demo-s5' },
-    ],
-    createdAt: Date.now() - 7200000,
-  },
-  {
-    id: 'demo-security',
-    name: 'Security Scan',
-    status: 'pending',
-    stages: [
-      { name: 'Scan', status: 'pending' },
-    ],
-    createdAt: Date.now() - 1800000,
-  },
-];
-
-function getDemoPipelines(): PipelineInfo[] {
-  try {
-    const stored = localStorage.getItem(DEMO_TAG_KEY);
-    if (!stored) return [];
-    
-    const { timestamp } = JSON.parse(stored);
-    const age = Date.now() - timestamp;
-    
-    if (age > DEMO_EXPIRY_MS) {
-      localStorage.removeItem(DEMO_TAG_KEY);
-      return [];
-    }
-    
-    return DEMO_PIPELINES;
-  } catch {
-    return [];
-  }
-}
-
-function setDemoPipelines(): void {
-  try {
-    localStorage.setItem(DEMO_TAG_KEY, JSON.stringify({ timestamp: Date.now() }));
-    if (import.meta.env.DEV) console.info('[aegis] Demo pipelines created (auto-expire in 24h)');
-  } catch {
-    // Ignore storage errors
-  }
-}
 
 export default function PipelinesPage() {
   const [pipelines, setPipelines] = useState<PipelineInfo[]>([]);
@@ -98,10 +36,6 @@ export default function PipelinesPage() {
   const [sortAsc, setSortAsc] = useState(false);
   const sseConnected = useStore((s) => s.sseConnected);
   const addToast = useToastStore((t) => t.addToast);
-
-  // Demo pipelines state
-  const demoPipelines = useMemo(() => getDemoPipelines(), [pipelines.length]);
-  const allPipelines = useMemo(() => [...pipelines, ...demoPipelines], [pipelines, demoPipelines]);
 
   // Idle tips for empty state
   const { showTip, currentTip } = useIdleTips({
@@ -170,13 +104,13 @@ export default function PipelinesPage() {
   }, [fetchPipelines, sseConnected]);
 
   const counts = {
-    total: allPipelines.length,
-    running: allPipelines.filter((p) => p.status === 'running').length,
-    completed: allPipelines.filter((p) => p.status === 'completed').length,
-    failed: allPipelines.filter((p) => p.status === 'failed').length,
+    total: pipelines.length,
+    running: pipelines.filter((p) => p.status === 'running').length,
+    completed: pipelines.filter((p) => p.status === 'completed').length,
+    failed: pipelines.filter((p) => p.status === 'failed').length,
   };
 
-  const filteredPipelines = allPipelines
+  const filteredPipelines = pipelines
     .filter((p) => {
       const matchesSearch = p.name.toLowerCase().includes(searchQuery.toLowerCase());
       const matchesStatus = statusFilter === 'all' || p.status === statusFilter;
@@ -190,13 +124,7 @@ export default function PipelinesPage() {
       return sortAsc ? cmp : -cmp;
     });
 
-  function handleSurpriseMe() {
-    setDemoPipelines();
-    setPipelines([...pipelines]); // Trigger re-render
-    addToast('success', 'Demo pipelines created', 'Three example pipelines added (auto-expire in 24h)');
-  }
-
-  const isEmpty = pipelines.length === 0 && demoPipelines.length === 0;
+  const isEmpty = pipelines.length === 0;
 
   if (loading) {
     return (
@@ -273,7 +201,7 @@ export default function PipelinesPage() {
       </div>
 
       {/* Pipeline List */}
-      {(allPipelines.length === 0 || filteredPipelines.length === 0) && (loadError || searchQuery || statusFilter !== 'all') ? (
+      {(pipelines.length === 0 || filteredPipelines.length === 0) && (loadError || searchQuery || statusFilter !== 'all') ? (
         <EmptyState
           variant="empty-error"
           icon={<GitBranch className="h-8 w-8" />}
@@ -289,11 +217,11 @@ export default function PipelinesPage() {
             action={
               <button
                 type="button"
-                onClick={handleSurpriseMe}
+                onClick={() => setModalOpen(true)}
                 className="inline-flex min-h-[44px] items-center gap-2 px-4 py-2 rounded-lg border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 text-sm font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
               >
-                <Sparkles className="h-4 w-4" />
-                Surprise me
+                <Plus className="h-4 w-4" />
+                Create Pipeline
               </button>
             }
           />


### PR DESCRIPTION
## Summary
Partially fixes #2811 (parts 1 + 1.5)

### Part 1: PipelinesPage demo data removal
The PipelinesPage was injecting 3 fake demo pipelines (CI/CD, Data ETL, Security Scan) via localStorage and merging them with real API data.

**Removed:**
- `DEMO_PIPELINES` constant — 3 hardcoded fake pipelines
- `getDemoPipelines()` / `setDemoPipelines()` functions — localStorage-based demo injection
- `aegis:demo-pipelines` localStorage tag
- `allPipelines` merge logic (`[...pipelines, ...demoPipelines]`)
- "Surprise me" button that injected demo data → replaced with "Create Pipeline"
- `Sparkles` icon import (no longer used)

### Part 1.5: TerminalDebugTab mock data removal
Audited all 11 unwired session components. 10 are clean scaffolds with no mock data. TerminalDebugTab had:
- Initial fake terminal output with scaffold messages → now starts empty
- Mock echo responses (help, resize, generic) → now shows clean "not connected" message

**Net result: -91 lines** (113 removed, 22 added)

### Remaining (#2811 part 2)
10 components are clean scaffolds awaiting ACP backend endpoints (ACP-025, -061, -064). No mock data to remove — they already handle empty states correctly.

## Test plan
- [x] 11 PipelinesPage tests pass
- [x] 21 TerminalDebugTab tests pass
- [x] Full suite: 99 files, 1057 tests green
- [x] Build succeeds