### PR TITLE
fix(dashboard): PWA manifest uses proper SVG icons instead of emoji data URIs (#2826)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6,6 +6,7 @@
     <title>Aegis - Session Orchestrator</title>
     <meta name="description" content="Glamour UI for Aegis" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/dashboard/apple-touch-icon.svg" />
 
     <!-- PWA -->
     <link rel="manifest" href="/dashboard/manifest.json" />

--- a/dashboard/public/apple-touch-icon.svg
+++ b/dashboard/public/apple-touch-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" fill="none">
+  <rect width="180" height="180" rx="36" fill="#0f172a"/>
+  <defs>
+    <linearGradient id="sg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#22c55e"/>
+    </linearGradient>
+  </defs>
+  <path d="M90 36l-34 13.5v27c0 23.6 15.8 45.7 38.4 54 22.6-8.3 38.4-30.4 38.4-54V49.5L90 36z" fill="url(#sg)"/>
+</svg>

--- a/dashboard/public/icon-192.svg
+++ b/dashboard/public/icon-192.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" fill="none">
+  <rect width="192" height="192" rx="36" fill="#0f172a"/>
+  <defs>
+    <linearGradient id="sg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#22c55e"/>
+    </linearGradient>
+  </defs>
+  <path d="M96 38l-36 14.4v28.8c0 25.2 16.8 48.72 40.8 57.6 24-8.88 40.8-32.4 40.8-57.6V52.4L96 38z" fill="url(#sg)"/>
+</svg>

--- a/dashboard/public/icon-512.svg
+++ b/dashboard/public/icon-512.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <rect width="512" height="512" rx="96" fill="#0f172a"/>
+  <defs>
+    <linearGradient id="sg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#22c55e"/>
+    </linearGradient>
+  </defs>
+  <path d="M256 102l-96 38.4v76.8c0 67.2 44.8 129.92 108.8 153.6 64-23.68 108.8-86.4 108.8-153.6V140.4L256 102z" fill="url(#sg)"/>
+</svg>

--- a/dashboard/public/manifest.json
+++ b/dashboard/public/manifest.json
@@ -8,13 +8,13 @@
   "background_color": "#0F172A",
   "icons": [
     {
-      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'><rect width='192' height='192' fill='%230F172A'/><text x='96' y='145' font-size='140' text-anchor='middle'>🛡️</text></svg>",
+      "src": "/dashboard/icon-192.svg",
       "sizes": "192x192",
       "type": "image/svg+xml",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
-      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><rect width='512' height='512' fill='%230F172A'/><text x='256' y='380' font-size='380' text-anchor='middle'>🛡️</text></svg>",
+      "src": "/dashboard/icon-512.svg",
       "sizes": "512x512",
       "type": "image/svg+xml",
       "purpose": "any maskable"


### PR DESCRIPTION
## Summary
Fixes #2826

The PWA manifest was using inline emoji SVG data URIs for icons — inconsistent rendering across platforms, no iOS support, and large data embedded in every response.

## Changes
- **manifest.json**: Replaced `data:image/svg+xml,...🛡️...` data URIs with file-based SVG icon references
- **icon-192.svg**: Proper Aegis shield logo at 192x192
- **icon-512.svg**: Proper Aegis shield logo at 512x512 (maskable with safe zone)
- **apple-touch-icon.svg**: 180x180 icon for iOS/Safari (added)
- **index.html**: Added `<link rel="apple-touch-icon">` for iOS home screen

## Icon design
- Dark navy background (`#0f172a`) with rounded corners
- Cyan-to-green gradient shield — matches existing favicon.svg
- Maskable icon has proper padding (shield centered, not edge-to-edge)

## Before vs After
| | Before | After |
|---|--------|-------|
| 192x192 | `data:image/svg+xml,...🛡️...` (inline) | `/dashboard/icon-192.svg` (file) |
| 512x512 | `data:image/svg+xml,...🛡️...` (inline) | `/dashboard/icon-512.svg` (file) |
| Apple | Missing | `apple-touch-icon.svg` ✅ |
| Data URI size | ~600 bytes inline | 0 (file reference) |

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] Icons copied to dist/
- [x] apple-touch-icon link present in dist/index.html
- [x] manifest.json references file paths, not data URIs