### PR TITLE
docs: document SSE auth two-step flow (#2816)

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -98,7 +98,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `GET` | `/v1/sessions/{id}/tools` | Bearer | Per-session tool usage counts |
 | `POST` | `/v1/sessions/{id}/screenshot` | Bearer | Capture screenshot (Playwright) |
 | `POST` | `/v1/sessions/{id}/verify` | Bearer | Run verification protocol |
-| `GET` | `/v1/sessions/{id}/events` | Bearer | Per-session SSE event stream |
+| `GET` | `/v1/sessions/{id}/events` | SSE Token | Per-session SSE event stream |
 
 ## Permissions
 
@@ -137,7 +137,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `GET` | `/v1/auth/keys` | Bearer | List API keys |
 | `DELETE` | `/v1/auth/keys/{id}` | Bearer | Revoke API key |
 | `POST` | `/v1/auth/keys/{id}/rotate` | Bearer | Rotate API key |
-| `POST` | `/v1/auth/sse-token` | Bearer | Generate SSE auth token |
+| `POST` | `/v1/auth/sse-token` | Bearer | Generate SSE auth token (required for SSE endpoints) |
 | `POST` | `/v1/keys` | Bearer | Create API key (alias) |
 | `GET` | `/v1/keys` | Bearer | List API keys (alias) |
 | `DELETE` | `/v1/keys/{id}` | Bearer | Revoke API key (alias) |
@@ -187,7 +187,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 
 | Method | Path | Auth | Summary |
 |--------|------|------|---------|
-| `GET` | `/v1/events` | Bearer | Global SSE event stream (all sessions) |
+| `GET` | `/v1/events` | SSE Token | Global SSE event stream (all sessions) |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -463,20 +463,30 @@ curl -X POST http://localhost:9100/v1/auth/keys/rotate \
 POST /v1/auth/sse-token
 ```
 
-Returns a short-lived token for SSE event stream authentication.
+Returns a short-lived token (`sse_`-prefixed) required to authenticate SSE event stream connections. **SSE endpoints reject regular Bearer tokens** — you must obtain an SSE token first.
 
 ```bash
 curl -X POST http://localhost:9100/v1/auth/sse-token \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-**Response (`201 Created`):** SSE token object.
+**Response (`201 Created`):**
+
+```json
+{ "token": "sse_3799ebe2daa4a0b6...", "expiresAt": 1778111504485 }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token` | string | `sse_`-prefixed token for SSE stream auth |
+| `expiresAt` | number | Expiration timestamp (ms since epoch). Tokens are valid for **60 seconds**. |
 
 **Errors:**
 
 | Status | Condition |
 |--------|-----------|
-| 429 | SSE token limit reached |
+| 401 | Invalid or expired API key |
+| 429 | SSE token limit reached (max 10 outstanding per key) |
 
 ---
 
@@ -1150,9 +1160,14 @@ Server-Sent Events stream for session-specific events (state changes, permission
 **Alias:** `GET /v1/sessions/:id/stream` — identical behavior.
 
 ```bash
-curl -N http://localhost:9100/v1/sessions/abc123/events \
-  -H "Authorization: Bearer $TOKEN"
+# Step 1: Get an SSE token
+curl -s -X POST http://localhost:9100/v1/auth/sse-token \
+  -H "Authorization: Bearer $API_KEY"
+# Step 2: Connect to the session stream
+curl -N "http://localhost:9100/v1/sessions/abc123/events?token=$SSE_TOKEN"
 ```
+
+**Authentication:** SSE token via query parameter (`?token=<sse-token>`) or Bearer header (`Authorization: Bearer sse_...`). Regular API keys are rejected. See [Create SSE Token](#create-sse-token) above.
 
 **Rate limited:** Per-IP and global connection limits apply.
 
@@ -3116,19 +3131,25 @@ curl http://localhost:9100/v1/hooks/hook-abc123/deliveries \
 
 ## 13. Events (SSE Stream)
 
+> **⚠️ Auth required:** SSE endpoints do not accept regular Bearer tokens. You must first obtain an SSE token via `POST /v1/auth/sse-token`, then pass it either as a query parameter (`?token=<sse-token>`) or as a Bearer header (`Authorization: Bearer sse_...`). Using a regular API key returns `401 Unauthorized — SSE token required for event streams`.
+
 ### Global SSE Event Stream
 
 ```
 GET /v1/events
 ```
 
-Server-Sent Events stream aggregating events from **all** active sessions. Supports token-based authentication via query parameter: `?token=<sse-token>`.
+Server-Sent Events stream aggregating events from **all** active sessions.
 
 ```bash
+# Step 1: Get an SSE token
+curl -s -X POST http://localhost:9100/v1/auth/sse-token \
+  -H "Authorization: Bearer $API_KEY"
+# Step 2: Connect to the stream
 curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN"
 ```
 
-**Authentication:** Bearer token header or SSE token query parameter.
+**Authentication:** SSE token via query parameter (`?token=<sse-token>`) or Bearer header (`Authorization: Bearer sse_...`). Regular API keys are rejected.
 
 **Event types:** `connected`, `heartbeat`, `session.created`, `session.idle`, `session.working`, `session.stalled`, `session.killed`, `permission.requested`, `permission.granted`, `permission.denied`, `message.user`, `status.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`.
 


### PR DESCRIPTION
## Summary

Closes #2816 — documents the non-obvious two-step SSE authentication flow that causes 401s for dashboard devs and API integrators.

## Changes

### `docs/api-reference.md`
- **Create SSE Token** — added response schema (`token`, `expiresAt`), TTL (60s), and 401 error row
- **Global SSE Event Stream** — fixed incorrect "Bearer token header or SSE token" auth claim; added two-step curl example; added ⚠️ callout explaining SSE token requirement
- **Per-Session Events** — fixed curl example that used a Bearer token directly (would 401); added auth clarification with anchor link to Create SSE Token

### `docs/api-quick-ref.md`
- Changed SSE endpoints from "Bearer" to "SSE Token" auth column
- Added "(required for SSE endpoints)" to `/v1/auth/sse-token` row

## Verified against source
- `src/services/auth/AuthManager.ts` — `SSE_TOKEN_TTL_MS = 60_000`, `SSE_TOKEN_MAX_PER_KEY = 10`
- `src/server.ts` — `isSSERoute` regex covers `/v1/events`, `/v1/sessions/:id/events`, `/v1/sessions/:id/stream`
- Error message: `"SSE token required for event streams"` (no guidance — doc-only fix)

## Note
The error message improvement (`"POST /v1/auth/sse-token to generate one"`) and `ttl` field in the response are code changes — tracked separately in #2816 suggestions. This PR covers the docs-only portion.