### PR TITLE
fix: add missing X-RateLimit-* headers to custom 429 responses (#2810)

### DIFF
--- a/src/__tests__/rate-limit-headers-2810.test.ts
+++ b/src/__tests__/rate-limit-headers-2810.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Test for #2810: Rate limit headers on 429 responses.
+ *
+ * Verifies that all 429 responses from the custom rate limiter include
+ * X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, and Retry-After.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RateLimiter } from '../services/auth/RateLimiter.js';
+
+describe('RateLimiter bucket info (#2810)', () => {
+  it('getIpBucketInfo returns limit, remaining, and reset', () => {
+    const limiter = new RateLimiter();
+    const info = limiter.getIpBucketInfo('127.0.0.1', false);
+
+    expect(info.limit).toBe(120);
+    expect(info.remaining).toBe(120);
+    expect(typeof info.reset).toBe('number');
+    expect(info.reset).toBeGreaterThan(0);
+  });
+
+  it('getIpBucketInfo reflects checkIpRateLimit consumption', () => {
+    const limiter = new RateLimiter();
+    limiter.checkIpRateLimit('127.0.0.1', false);
+    limiter.checkIpRateLimit('127.0.0.1', false);
+
+    const info = limiter.getIpBucketInfo('127.0.0.1', false);
+    expect(info.limit).toBe(120);
+    expect(info.remaining).toBe(118);
+  });
+
+  it('getIpBucketInfo with keyId uses per-key bucket', () => {
+    const limiter = new RateLimiter();
+    limiter.checkIpRateLimit('127.0.0.1', false, 'key-1');
+    limiter.checkIpRateLimit('127.0.0.1', false, 'key-1');
+    limiter.checkIpRateLimit('127.0.0.1', false, 'key-2');
+
+    const info1 = limiter.getIpBucketInfo('127.0.0.1', false, 'key-1');
+    expect(info1.remaining).toBe(118);
+
+    const info2 = limiter.getIpBucketInfo('127.0.0.1', false, 'key-2');
+    expect(info2.remaining).toBe(119);
+  });
+
+  it('getIpBucketInfo for master key returns 300 limit', () => {
+    const limiter = new RateLimiter();
+    const info = limiter.getIpBucketInfo('127.0.0.1', true);
+
+    expect(info.limit).toBe(300);
+  });
+
+  it('getUnauthIpBucketInfo returns unauth limit', () => {
+    const limiter = new RateLimiter();
+    limiter.checkIpRateLimitUnauth('127.0.0.1');
+
+    const info = limiter.getUnauthIpBucketInfo('127.0.0.1');
+    expect(info.limit).toBe(30);
+    expect(info.remaining).toBe(29);
+  });
+
+  it('getAuthFailBucketInfo returns auth fail limit', () => {
+    const limiter = new RateLimiter();
+    limiter.recordAuthFailure('127.0.0.1');
+    limiter.recordAuthFailure('127.0.0.1');
+
+    const info = limiter.getAuthFailBucketInfo('127.0.0.1');
+    expect(info.limit).toBe(5);
+    expect(info.remaining).toBe(3);
+  });
+
+  it('remaining is clamped to 0 when over limit', () => {
+    const limiter = new RateLimiter();
+    // Exhaust the bucket
+    for (let i = 0; i < 125; i++) {
+      limiter.checkIpRateLimit('127.0.0.1', false);
+    }
+
+    const info = limiter.getIpBucketInfo('127.0.0.1', false);
+    expect(info.remaining).toBe(0);
+  });
+
+  it('reset is a future epoch timestamp', () => {
+    const limiter = new RateLimiter();
+    const now = Math.ceil(Date.now() / 1000);
+    const info = limiter.getIpBucketInfo('127.0.0.1', false);
+
+    expect(info.reset).toBeGreaterThanOrEqual(now);
+    expect(info.reset).toBeLessThanOrEqual(now + 120); // within 2 minutes
+  });
+
+  it('dispose clears interval without error', () => {
+    const limiter = new RateLimiter();
+    expect(() => limiter.dispose()).not.toThrow();
+  });
+});

--- a/src/__tests__/server-phase3.test.ts
+++ b/src/__tests__/server-phase3.test.ts
@@ -41,6 +41,10 @@ const rateLimiterSpies = {
   pruneAuthFailLimits: vi.fn<() => void>(),
   pruneIpRateLimits: vi.fn<() => void>(),
   dispose: vi.fn<() => void>(),
+  // Issue #2810: bucket info methods for rate limit headers
+  getIpBucketInfo: vi.fn<() => { limit: number; remaining: number; reset: number }>(() => ({ limit: 120, remaining: 119, reset: Math.ceil(Date.now() / 1000) + 60 })),
+  getUnauthIpBucketInfo: vi.fn<() => { limit: number; remaining: number; reset: number }>(() => ({ limit: 30, remaining: 29, reset: Math.ceil(Date.now() / 1000) + 60 })),
+  getAuthFailBucketInfo: vi.fn<() => { limit: number; remaining: number; reset: number }>(() => ({ limit: 5, remaining: 4, reset: Math.ceil(Date.now() / 1000) + 60 })),
 };
 
 vi.mock('../services/auth/RateLimiter.js', () => ({
@@ -52,6 +56,9 @@ vi.mock('../services/auth/RateLimiter.js', () => ({
     pruneAuthFailLimits = rateLimiterSpies.pruneAuthFailLimits;
     pruneIpRateLimits = rateLimiterSpies.pruneIpRateLimits;
     dispose = rateLimiterSpies.dispose;
+    getIpBucketInfo = rateLimiterSpies.getIpBucketInfo;
+    getUnauthIpBucketInfo = rateLimiterSpies.getUnauthIpBucketInfo;
+    getAuthFailBucketInfo = rateLimiterSpies.getAuthFailBucketInfo;
   },
 }));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -326,6 +326,17 @@ app.addHook('onSend', (req, reply, payload, done) => {
 // Auth middleware setup (Issue #39: multi-key auth with rate limiting)
 const rateLimiter = new RateLimiter();
 
+/** Issue #2810: Add X-RateLimit-* and Retry-After headers to a 429 response. */
+function addRateLimitHeaders(
+  reply: FastifyReply,
+  info: import("./services/auth/RateLimiter.js").RateLimitBucketInfo,
+): void {
+  reply.header("X-RateLimit-Limit", info.limit);
+  reply.header("X-RateLimit-Remaining", info.remaining);
+  reply.header("X-RateLimit-Reset", info.reset);
+  reply.header("Retry-After", Math.max(1, info.reset - Math.ceil(Date.now() / 1000)));
+}
+
 function checkIpRateLimit(ip: string, isMaster: boolean, keyId?: string): boolean {
   return rateLimiter.checkIpRateLimit(ip, isMaster, keyId);
 }
@@ -475,6 +486,7 @@ function setupAuth(authManager: AuthManager): void {
         }
         // #2456: Pass keyId so dashboard auth uses its own bucket
         if (checkIpRateLimit(clientIp, false, dashboardAuthContext.keyId)) {
+          addRateLimitHeaders(reply, rateLimiter.getIpBucketInfo(clientIp, false, dashboardAuthContext.keyId));
           return reply.status(429).send({ error: 'Rate limit exceeded — IP throttled' });
         }
         return;
@@ -488,6 +500,7 @@ function setupAuth(authManager: AuthManager): void {
     const isNoAuthLocalhost = !authManager.authEnabled && authManager.isLocalhostBinding;
     if (isNoAuthLocalhost) {
       if (checkIpRateLimit(clientIp, false)) {
+        addRateLimitHeaders(reply, rateLimiter.getIpBucketInfo(clientIp, false));
         return reply.status(429).send({ error: 'Rate limit exceeded — IP throttled' });
       }
       return;
@@ -497,6 +510,7 @@ function setupAuth(authManager: AuthManager): void {
       // #2456: Rate-limit no-token requests via the IP-only (unauth) bucket so they
       // cannot exhaust the per-key authenticated IP bucket for valid callers.
       if (checkIpRateLimit(clientIp, false)) {
+        addRateLimitHeaders(reply, rateLimiter.getIpBucketInfo(clientIp, false));
         return reply.status(429).send({ error: 'Rate limit exceeded — too many unauthenticated requests' });
       }
       return reply.status(401).send({ error: 'Unauthorized — Bearer token required' });
@@ -514,6 +528,7 @@ function setupAuth(authManager: AuthManager): void {
       // so a valid token from the same IP is never blocked by prior failures.
       // #632: Block IPs that exceeded auth failure rate limit (5 attempts/min)
       if (checkAuthFailRateLimit(clientIp)) {
+        addRateLimitHeaders(reply, rateLimiter.getAuthFailBucketInfo(clientIp));
         return reply.status(429).send({ error: 'Too many auth failures — try again later' });
       }
       recordAuthFailureOnce(req, clientIp);
@@ -523,6 +538,7 @@ function setupAuth(authManager: AuthManager): void {
     if (tokenMode === 'reject') {
       // #2456: Same pattern — check auth-fail rate limit inside the failure branch.
       if (checkAuthFailRateLimit(clientIp)) {
+        addRateLimitHeaders(reply, rateLimiter.getAuthFailBucketInfo(clientIp));
         return reply.status(429).send({ error: 'Too many auth failures — try again later' });
       }
       recordAuthFailureOnce(req, clientIp);
@@ -536,6 +552,7 @@ function setupAuth(authManager: AuthManager): void {
       // from the same IP are never blocked by unauth-triggered rate limits.
       // #632: Block IPs that exceeded auth failure rate limit (5 attempts/min)
       if (checkAuthFailRateLimit(clientIp)) {
+        addRateLimitHeaders(reply, rateLimiter.getAuthFailBucketInfo(clientIp));
         return reply.status(429).send({ error: 'Too many auth failures — try again later' });
       }
       recordAuthFailureOnce(req, clientIp);
@@ -547,6 +564,7 @@ function setupAuth(authManager: AuthManager): void {
     }
 
     if (result.rateLimited) {
+      addRateLimitHeaders(reply, rateLimiter.getIpBucketInfo(clientIp, result.keyId === 'master', result.keyId ?? undefined));
       return reply.status(429).send({ error: 'Rate limit exceeded — 100 req/min per key' });
     }
 
@@ -572,6 +590,7 @@ function setupAuth(authManager: AuthManager): void {
     // #2456: Pass keyId so authenticated requests get a dedicated bucket per API key
     const isMaster = result.keyId === 'master';
     if (checkIpRateLimit(clientIp, isMaster, result.keyId ?? undefined)) {
+      addRateLimitHeaders(reply, rateLimiter.getIpBucketInfo(clientIp, isMaster, result.keyId ?? undefined));
       return reply.status(429).send({ error: 'Rate limit exceeded — IP throttled' });
     }
   });

--- a/src/services/auth/RateLimiter.ts
+++ b/src/services/auth/RateLimiter.ts
@@ -7,6 +7,16 @@ interface AuthFailBucket {
   timestamps: number[];
 }
 
+/** Issue #2810: Rate limit bucket info for response headers. */
+export interface RateLimitBucketInfo {
+  /** Maximum requests per window. */
+  limit: number;
+  /** Remaining requests in current window. */
+  remaining: number;
+  /** Epoch seconds when the window resets. */
+  reset: number;
+}
+
 const IP_WINDOW_MS = 60_000;
 const IP_LIMIT_NORMAL = 120;
 const IP_LIMIT_MASTER = 300;
@@ -37,6 +47,9 @@ const STALE_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
  *
  * Issue #2494: Authenticated and unauthenticated buckets use separate
  * Maps so they cannot evict each other under contention.
+ *
+ * Issue #2810: getIpBucketInfo() / getAuthFailBucketInfo() expose
+ * bucket state for X-RateLimit-* response headers on 429s.
  */
 
 /** NUL-byte separator for compound bucket keys — cannot appear in IPs or keyIds. */
@@ -171,6 +184,70 @@ export class RateLimiter {
 
   dispose(): void {
     clearInterval(this.staleCleanupTimer);
+  }
+
+  // ── Issue #2810: Bucket info for X-RateLimit-* response headers ──
+
+  /**
+   * Get rate limit bucket info for an IP (or IP+key).
+   * Returns the current bucket state for adding X-RateLimit-* headers.
+   */
+  getIpBucketInfo(ip: string, isMaster: boolean, keyId?: string): RateLimitBucketInfo {
+    const bucketKey = keyId ? `${ip}${BUCKET_SEP}${keyId}` : ip;
+    const bucket = this.ipRateLimits.get(bucketKey);
+    const limit = isMaster ? IP_LIMIT_MASTER : IP_LIMIT_NORMAL;
+
+    if (!bucket) {
+      return {
+        limit,
+        remaining: limit,
+        reset: Math.ceil((Date.now() + IP_WINDOW_MS) / 1000),
+      };
+    }
+
+    const remaining = Math.max(0, limit - bucket.count);
+    const resetEpoch = Math.ceil((bucket.windowStart + IP_WINDOW_MS) / 1000);
+
+    return { limit, remaining, reset: resetEpoch };
+  }
+
+  /**
+   * Get rate limit bucket info for unauthenticated IP.
+   */
+  getUnauthIpBucketInfo(ip: string): RateLimitBucketInfo {
+    const bucketKey = `unauth${BUCKET_SEP}${ip}`;
+    const bucket = this.unauthRateLimits.get(bucketKey);
+
+    if (!bucket) {
+      return {
+        limit: IP_LIMIT_UNAUTH,
+        remaining: IP_LIMIT_UNAUTH,
+        reset: Math.ceil((Date.now() + IP_WINDOW_MS) / 1000),
+      };
+    }
+
+    const remaining = Math.max(0, IP_LIMIT_UNAUTH - bucket.count);
+    const resetEpoch = Math.ceil((bucket.windowStart + IP_WINDOW_MS) / 1000);
+
+    return { limit: IP_LIMIT_UNAUTH, remaining, reset: resetEpoch };
+  }
+
+  /**
+   * Get auth failure rate limit info for an IP.
+   */
+  getAuthFailBucketInfo(ip: string): RateLimitBucketInfo {
+    const cutoff = Date.now() - AUTH_FAIL_WINDOW_MS;
+    const bucket = this.authFailLimits.get(ip);
+    const count = bucket
+      ? bucket.timestamps.filter((t) => t >= cutoff).length
+      : 0;
+    const remaining = Math.max(0, AUTH_FAIL_MAX - count);
+
+    return {
+      limit: AUTH_FAIL_MAX,
+      remaining,
+      reset: Math.ceil((Date.now() + AUTH_FAIL_WINDOW_MS) / 1000),
+    };
   }
 
   /**

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -2,6 +2,7 @@ export { AuthManager, classifyBearerTokenForRoute } from './AuthManager.js';
 export { QuotaManager } from './QuotaManager.js';
 export type { QuotaCheckResult, QuotaUsage } from './QuotaManager.js';
 export { RateLimiter } from './RateLimiter.js';
+export type { RateLimitBucketInfo } from './RateLimiter.js';
 export {
   DASHBOARD_SESSION_COOKIE,
   OIDC_STATE_COOKIE,


### PR DESCRIPTION
## Summary

Fixes #2810 — Rate limit headers on custom 429 responses.

**Problem:** The custom `RateLimiter` class sends 429 responses without any `X-RateLimit-*` or `Retry-After` headers. While `@fastify/rate-limit` (global plugin) adds headers to its own 429s, the auth-middleware-level rate limiter sends plain 429s with no programmatic feedback. Clients can only discover limits after being rejected.

**Solution:**
- Added `getIpBucketInfo()`, `getUnauthIpBucketInfo()`, `getAuthFailBucketInfo()` to `RateLimiter` — each returns `{ limit, remaining, reset }` for the current bucket state
- Added `addRateLimitHeaders()` helper in `server.ts` that sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After`
- All 8 custom 429 responses now include these headers

## Changes
- `src/services/auth/RateLimiter.ts`: 3 new public methods + `RateLimitBucketInfo` type
- `src/services/auth/index.ts`: Export `RateLimitBucketInfo` type
- `src/server.ts`: `addRateLimitHeaders()` helper + applied to all 8 429 responses
- `src/__tests__/server-phase3.test.ts`: Updated mock with new methods
- `src/__tests__/rate-limit-headers-2810.test.ts`: 9 unit tests for bucket info

## Verification
```
tsc --noEmit: ✅ Zero errors
npm run build: ✅ Success
npm test: ✅ 3916 passed (254 files), 2 skipped
```

## Response example
```bash
# Before (custom 429)
HTTP/1.1 429
{ "error": "Too many auth failures — try again later" }

# After (custom 429)
HTTP/1.1 429
X-RateLimit-Limit: 5
X-RateLimit-Remaining: 0
X-RateLimit-Reset: 1746597600
Retry-After: 45
{ "error": "Too many auth failures — try again later" }
```