### PR TITLE
security: add sensitive file patterns to .dockerignore (#2879)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,23 @@ dashboard/node_modules/
 dist/
 dashboard/dist/
 .tmp*/
+
+# Sensitive files — defense-in-depth (#2879)
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+credentials*.json
+
+# Claude Code / MCP local state
+.claude/
+.mcp.json
+
+# Log and data files
+*.log
+*.jsonl
+
+# Local settings overrides
+settings.local.json


### PR DESCRIPTION
## Summary

Fixes #2879 — .dockerignore missing sensitive file patterns (defense-in-depth).

**Problem:** `.dockerignore` only excluded 5 patterns. Building from a dirty worktree (e.g. with `.env`, `*.pem`, `credentials.json`) would bake sensitive files into Docker image layers.

**Fix:** Append 12 patterns matching `.gitignore` coverage.

## Patterns added
```
.env, .env.*          — environment files
*.pem, *.key          — TLS private keys
*.p12, *.pfx          — PKCS bundles
credentials*.json     — credential files
.claude/              — Claude Code local state
.mcp.json             — MCP config
*.log                 — log files
*.jsonl               — data files
settings.local.json   — local settings overrides
```

## Verification
```
tsc --noEmit: ✅
npm run build: ✅
npm test: ✅ 3907 passed (253 files), 2 skipped
```

**Security review:** Requested from Themis (issue filed by Themis).