### PR TITLE
fix(dashboard): add Activity to sidebar, close stale audit issues (#2884)

### DIFF
--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -475,6 +475,7 @@ describe('Layout sidebar', () => {
     // Verify OPERATIONS group items
     expect(screen.getByText('Audit')).toBeDefined();
     expect(screen.getByText('Cost')).toBeDefined();
+    expect(screen.getByText('Activity')).toBeDefined();
 
     // Verify ADMIN group items
     expect(screen.getByText('Auth Keys')).toBeDefined();
@@ -489,10 +490,10 @@ describe('Layout sidebar', () => {
     expect(screen.queryByText('New Session')).toBeNull();
     expect(screen.queryByText('Audit Trail')).toBeNull();
 
-    // Count nav links (9 main in nav: 4 workspace + 4 operations + 1 admin)
+    // Count nav links (10 main in nav: 4 workspace + 5 operations + 1 admin)
     const nav = document.querySelector('nav[aria-label="Main navigation"]');
     const links = nav?.querySelectorAll('a');
-    expect(links?.length).toBe(9);
+    expect(links?.length).toBe(10);
   });
 
   it('Settings nav link is rendered in sidebar footer', () => {

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -30,6 +30,7 @@ import {
   TrendingUp,
   Cog,
   Terminal,
+  Radio,
 } from 'lucide-react';
 import { useStore } from '../store/useStore';
 import { useAuthStore } from '../store/useAuthStore.js';
@@ -68,6 +69,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: '/metrics', label: 'Metrics', icon: TrendingUp },
       { to: '/cost', label: 'Cost', icon: DollarSign },
       { to: '/analytics', label: 'Analytics', icon: BarChart3 },
+      { to: '/activity', label: 'Activity', icon: Radio },
     ],
   },
   {


### PR DESCRIPTION
## Summary
Fixes #2884 (Activity page not in sidebar)

Also closes 3 stale issues that were already fixed by prior PRs:
- Closes #2883 (CostPage dark mode) — already fixed by #2857 (52 CSS var refs, 0 hardcoded colors)
- Closes #2885 (Settings not in sidebar) — already present in Layout.tsx bottom section
- Closes #2804 (PipelinesPage demo data) — already fixed by #2878

## Changes
- Added Activity page (`/activity`) to OPERATIONS section of sidebar with `Radio` icon
- Updated Layout test to expect 10 nav links (was 9)

## Test plan
- [x] 27/27 Layout tests pass
- [x] Build succeeds
- [x] Activity page accessible from sidebar