### PR TITLE
build(ci): bump actions/attest-build-provenance from v2 to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -962,7 +962,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             *.tgz


### PR DESCRIPTION
Same change as Dependabot PR #2859, which can't be merged because the bot lacks `workflows` permission.

Bumps `actions/attest-build-provenance` from v2 to v4 in release.yml.

Closes #2859