### PR TITLE
build(deps): bump actions/attest-build-provenance from 2 to 4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -962,7 +962,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             *.tgz


### PR DESCRIPTION
Manual rebase of Dependabot PR #2859 (workflow file changes require manual rebase).

**Change:** `actions/attest-build-provenance@v2` → `v4` in `.github/workflows/release.yml`

Closes #2859