### PR TITLE
docs: add Docker auto-detection (#2891) + rate limit headers on custom 429s (#2888)

### DIFF
--- a/docs/api-rate-limiting.md
+++ b/docs/api-rate-limiting.md
@@ -19,12 +19,15 @@ When a limit is exceeded, the server returns `429 Too Many Requests`.
 
 ## Response Headers
 
-Every API response includes rate limit headers:
+Every API response includes rate limit headers — including custom `429`
+responses from authentication middleware (auth failure limits, unauthenticated
+IP limits):
 
 ```
 X-RateLimit-Limit: 30
 X-RateLimit-Remaining: 27
 X-RateLimit-Reset: 1713782460
+Retry-After: 12
 ```
 
 | Header | Description |
@@ -32,6 +35,11 @@ X-RateLimit-Reset: 1713782460
 | `X-RateLimit-Limit` | Maximum requests allowed in the current window |
 | `X-RateLimit-Remaining` | Requests remaining in the current window |
 | `X-RateLimit-Reset` | Unix timestamp when the window resets |
+| `Retry-After` | Seconds until the rate limit window resets |
+
+All `429` responses include these headers — whether from the global
+`@fastify/rate-limit` plugin or from the custom auth-middleware rate limiter
+(e.g., too many failed auth attempts, unauthenticated IP overuse).
 
 ---
 
@@ -51,9 +59,14 @@ curl -X POST http://localhost:9100/v1/sessions \
 {"error": "Rate limit exceeded. Retry after 12 seconds."}
 ```
 
-A `Retry-After` header is also included:
+The response also includes `X-RateLimit-*` and `Retry-After` headers so
+clients can programmatically determine when to retry without parsing the
+error body:
 
 ```
+X-RateLimit-Limit: 30
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1746597600
 Retry-After: 12
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ This guide covers deploying Aegis in development, CI/CD, and production environm
 |----------|----------|---------|-------------|
 | `AEGIS_AUTH_TOKEN` | Yes | - | Bearer token for API authentication |
 | `AEGIS_PORT` | No | `9100` | HTTP server port |
-| `AEGIS_HOST` | No | `127.0.0.1` | Bind address |
+| `AEGIS_HOST` | No | `127.0.0.1` (Docker: `0.0.0.0`) | Bind address — [auto-detects Docker](#docker-auto-detection) |
 | `AEGIS_STATE_DIR` | No | `~/.aegis` | Session state, audit logs, and runtime metadata storage |
 | `AEGIS_DASHBOARD_URL` | No | `http://localhost:9100/dashboard` | Dashboard URL |
 | `CLAUDE_DATA_DIR` | No | `~/.claude` | Claude Code data directory |
@@ -98,6 +98,26 @@ sudo systemctl enable aegis
 sudo systemctl start aegis
 ```
 
+### Docker Auto-Detection
+
+When running inside a Docker container, Aegis automatically detects the
+environment and binds to `0.0.0.0` instead of `127.0.0.1`. This avoids the
+classic issue where Docker port forwarding (`-p 9100:9100`) cannot reach a
+process listening on container-localhost.
+
+Detection checks:
+
+1. `/.dockerenv` file exists (standard Docker indicator)
+2. `/proc/1/cgroup` contains `docker` or `containerd` strings
+
+Setting `AEGIS_HOST` explicitly **always overrides** auto-detection.
+
+| Environment | Default bind address |
+|-------------|---------------------|
+| Bare metal / VM | `127.0.0.1` |
+| Docker (no `AEGIS_HOST`) | `0.0.0.0` |
+| Any + `AEGIS_HOST=x.x.x.x` | `x.x.x.x` |
+
 ### Docker
 
 ```bash
@@ -111,6 +131,9 @@ docker run -d \
   -v claude-data:/root/.claude \
   ghcr.io/onestepat4time/aegis:latest
 ```
+
+> **Note:** You no longer need to set `-e AEGIS_HOST=0.0.0.0` — Aegis
+> auto-detects Docker and binds to all interfaces automatically.
 
 ### Docker Compose
 


### PR DESCRIPTION
## Summary

Documents two recently merged feature PRs:

### 1. Docker Auto-Detection (#2891)
- **deployment.md**: New "Docker Auto-Detection" section explaining how Aegis auto-detects Docker and binds to `0.0.0.0`
- Updated env var table: `AEGIS_HOST` default now shows `127.0.0.1 (Docker: 0.0.0.0)`
- Added note on Docker run command that `-e AEGIS_HOST=0.0.0.0` is no longer needed
- Detection checks documented (`.dockerenv` + `/proc/1/cgroup`)
- Override behavior: explicit `AEGIS_HOST` always wins

### 2. Rate Limit Headers on Custom 429s (#2888)
- **api-rate-limiting.md**: Documents that `X-RateLimit-*` + `Retry-After` headers now appear on ALL 429 responses
- Clarifies this covers both `@fastify/rate-limit` plugin responses AND custom auth-middleware 429s (too many auth failures, unauthenticated IP limits)
- Added `Retry-After` to the header table
- Updated 429 response example to show full header set

### Test plan
- [x] Read rendered output for accuracy
- [x] Checked links resolve within docs
- [x] Verified against source code (`src/detect-docker.ts`, PR #2888 description)
- [x] No code changes — docs only