### PR TITLE
feat(dashboard): CCMeter layout assembly — KPI banner, model distribution, shortcuts bar (#2832 PR 2)

### DIFF
--- a/dashboard/src/__tests__/KeyboardShortcutsBar.test.tsx
+++ b/dashboard/src/__tests__/KeyboardShortcutsBar.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * __tests__/KeyboardShortcutsBar.test.tsx — Tests for CCMeter keyboard shortcuts bar.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { KeyboardShortcutsBar } from '../components/shared/KeyboardShortcutsBar';
+
+describe('KeyboardShortcutsBar', () => {
+  it('renders default shortcuts', () => {
+    render(<KeyboardShortcutsBar />);
+    expect(screen.getByText('New session')).not.toBeNull();
+    expect(screen.getByText('Command palette')).not.toBeNull();
+    expect(screen.getByText('Toggle theme')).not.toBeNull();
+    expect(screen.getByText('Show shortcuts')).not.toBeNull();
+  });
+
+  it('renders custom shortcuts', () => {
+    render(
+      <KeyboardShortcutsBar
+        shortcuts={[
+          { keys: ['Ctrl', 'S'], label: 'Save' },
+          { keys: ['Esc'], label: 'Close' },
+        ]}
+      />
+    );
+    expect(screen.getByText('Save')).not.toBeNull();
+    expect(screen.getByText('Close')).not.toBeNull();
+  });
+
+  it('has contentinfo role', () => {
+    render(<KeyboardShortcutsBar />);
+    expect(screen.getByRole('contentinfo', { name: 'Keyboard shortcuts' })).not.toBeNull();
+  });
+
+  it('renders kbd elements for keys', () => {
+    const { container } = render(<KeyboardShortcutsBar />);
+    const kbds = container.querySelectorAll('kbd');
+    expect(kbds.length).toBeGreaterThan(0);
+  });
+});

--- a/dashboard/src/components/shared/KeyboardShortcutsBar.tsx
+++ b/dashboard/src/components/shared/KeyboardShortcutsBar.tsx
@@ -1,0 +1,56 @@
+/**
+ * components/shared/KeyboardShortcutsBar.tsx — CCMeter-inspired keyboard shortcuts bar.
+ *
+ * Fixed bar at the bottom of the screen showing available keyboard shortcuts.
+ * Only visible on desktop (hidden on mobile).
+ * Uses CSS vars for all colors (light + dark mode).
+ */
+
+export interface ShortcutDef {
+  keys: string[];
+  label: string;
+}
+
+const DEFAULT_SHORTCUTS: ShortcutDef[] = [
+  { keys: ['N'], label: 'New session' },
+  { keys: ['⌘', 'K'], label: 'Command palette' },
+  { keys: ['T'], label: 'Toggle theme' },
+  { keys: ['?'], label: 'Show shortcuts' },
+];
+
+interface KeyboardShortcutsBarProps {
+  shortcuts?: ShortcutDef[];
+  className?: string;
+}
+
+export function KeyboardShortcutsBar({
+  shortcuts = DEFAULT_SHORTCUTS,
+  className = '',
+}: KeyboardShortcutsBarProps) {
+  return (
+    <div
+      className={`hidden md:flex items-center justify-center gap-6 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-6 py-2 text-[10px] text-[var(--color-text-muted)] ${className}`}
+      role="contentinfo"
+      aria-label="Keyboard shortcuts"
+    >
+      {shortcuts.map((shortcut, i) => (
+        <span key={shortcut.label} className="flex items-center gap-1.5">
+          {shortcut.keys.map((key, ki) => (
+            <span key={ki}>
+              <kbd className="rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--color-text-primary)]">
+                {key}
+              </kbd>
+              {ki < shortcut.keys.length - 1 && (
+                <span className="mx-0.5 text-[var(--color-text-muted)]" aria-hidden="true">+</span>
+              )}
+            </span>
+          ))}
+          <span className="ml-0.5">{shortcut.label}</span>
+          {i < shortcuts.length - 1 && (
+            <span className="ml-3 mr-0 h-3 w-px bg-[var(--color-void-lighter)]" aria-hidden="true" />
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -22,6 +22,9 @@ import {
   CartesianGrid,
 } from 'recharts';
 import { BarChart3, Loader2 } from 'lucide-react';
+import { KPIBanner } from '../components/analytics/KPIBanner';
+import type { KPIItem } from '../components/analytics/KPIBanner';
+import { ModelDistributionBar } from '../components/analytics/ModelDistributionBar';
 import { getAnalyticsSummary, getRateLimitAnalytics } from '../api/client';
 import { formatCurrency } from '../utils/formatNumber';
 import { formatDateShort } from '../utils/formatDate';
@@ -139,6 +142,54 @@ export default function AnalyticsPage() {
       )
     : 0;
 
+  // Build KPI items from analytics data
+  function buildKPIItems(
+    analytics: AnalyticsSummary,
+    cost: number,
+    tokens: number,
+    avgDur: number,
+  ): KPIItem[] {
+    const totalSessions = analytics.errorRates.totalSessions;
+    const errorRate = totalSessions > 0
+      ? ((analytics.errorRates.failedSessions / totalSessions) * 100).toFixed(1)
+      : '0';
+    return [
+      {
+        id: 'cost',
+        label: 'Total Cost',
+        value: formatCurrency(cost),
+        color: 'cost',
+        subtitle: analytics.costTrends.length > 1 ? 'Last 14 days' : undefined,
+      },
+      {
+        id: 'tokens',
+        label: 'Total Tokens',
+        value: formatTokenCount(tokens),
+        color: 'input',
+        subtitle: tokens > 0 ? `${formatTokenCount(tokens)} processed` : undefined,
+      },
+      {
+        id: 'sessions',
+        label: 'Sessions',
+        value: String(totalSessions),
+        color: 'neutral',
+      },
+      {
+        id: 'duration',
+        label: 'Avg Duration',
+        value: formatDuration(avgDur),
+        color: 'time',
+      },
+      {
+        id: 'errors',
+        label: 'Error Rate',
+        value: `${errorRate}%`,
+        color: parseFloat(errorRate) > 5 ? 'cost' : 'efficiency',
+        trend: parseFloat(errorRate) > 5 ? 'up' : 'flat',
+      },
+    ];
+  }
+
   return (
     <div className="flex flex-col gap-6">
       {/* Page header */}
@@ -173,6 +224,23 @@ export default function AnalyticsPage() {
         }
         return null;
       })()}
+
+      {/* CCMeter-style KPI Banner */}
+      <KPIBanner items={buildKPIItems(data, totalCost, totalTokens, avgDuration)} />
+
+      {/* Model Distribution Bar */}
+      {data.tokenUsageByModel.length > 0 && (
+        <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
+          <h3 className="mb-3 text-sm font-medium text-[var(--color-text-primary)]">Model Distribution</h3>
+          <ModelDistributionBar
+            segments={data.tokenUsageByModel.map((m) => ({
+              model: m.model,
+              fraction: m.estimatedCostUsd / (totalCost || 1),
+            }))}
+            barHeight={10}
+          />
+        </div>
+      )}
 
       {/* Summary cards */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">


### PR DESCRIPTION
## Summary
Part of #2832 — CCMeter-inspired redesign (PR 2 of 2)

Wires the CCMeter components from PR #2890 into the AnalyticsPage layout.

### Changes

**AnalyticsPage** (`pages/AnalyticsPage.tsx`)
- Added `KPIBanner` with 5 color-coded metrics above summary cards:
  - Cost (orange), Tokens (blue), Sessions (neutral), Duration (cyan), Error Rate (green/red)
- Added `ModelDistributionBar` showing model cost distribution (Opus/Sonnet/Haiku)
- Layout hierarchy now: Header → KPI Banner → Model Distribution → Summary Cards → Charts

**KeyboardShortcutsBar** (`components/shared/KeyboardShortcutsBar.tsx`)
- New component: desktop-only bottom bar showing keyboard shortcuts
- Default shortcuts: N (new session), ⌘K (command palette), T (toggle theme), ? (show shortcuts)
- Supports custom shortcut definitions

### Design Principles
- **CSS vars only** — no hardcoded colors
- **Light + dark mode** from day one
- **Accessible** — contentinfo role, kbd elements, proper labels
- **Desktop-first** — shortcuts bar hidden on mobile

### Files
| File | Lines | Purpose |
|------|-------|---------|
| `AnalyticsPage.tsx` | +68 | Layout restructure + KPI helper |
| `KeyboardShortcutsBar.tsx` | 56 | Shortcuts bar component |
| `KeyboardShortcutsBar.test.tsx` | 41 | 4 tests |

**Total: +165 lines**

### Test plan
- [x] TypeScript strict: zero errors
- [x] 4/4 new tests pass
- [x] Build succeeds
- [x] All colors use CSS vars