### PR TITLE
fix(ci): include scripts/ in Docker and npm package for postinstall-verify

### DIFF
--- a/.github/workflows/helm-smoke.yml
+++ b/.github/workflows/helm-smoke.yml
@@ -94,6 +94,7 @@ jobs:
           FROM node:20-bookworm-slim
           WORKDIR /app
           COPY package*.json ./
+          COPY scripts/ scripts/
           RUN npm ci --omit=dev \
             && apt-get update \
             && apt-get install -y --no-install-recommends ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /app
 
 # Install only production dependencies for runtime
 COPY package*.json ./
+COPY scripts/ scripts/
 RUN npm ci --omit=dev
 
 # Create non-root user

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist",
+    "scripts",
     "templates",
     "!dist/__tests__",
     "!dist/**/*.map"


### PR DESCRIPTION
## Problem
Helm Smoke and Release Dry Run are failing on `develop` with:
```
Error: Cannot find module '/app/scripts/postinstall-verify.cjs'
```

## Root Cause
The new `postinstall` script (`node scripts/postinstall-verify.cjs`) runs during `npm ci --omit=dev` in Docker builds, but the `scripts/` directory is never copied into the production Docker stage. Additionally, `scripts/` is not in the npm `files` array, so the release tarball also misses it.

## Fix
1. Add `COPY scripts/ scripts/` before `npm ci --omit=dev` in both:
   - Helm smoke inline Dockerfile (`.github/workflows/helm-smoke.yml`)
   - Repo `Dockerfile`
2. Add `"scripts"` to `package.json` `files` array for npm publish

## Testing
- CI will validate via Helm Smoke and Release Dry Run