### PR TITLE
feat(tracing): add OTel tool span helpers for observability (#2807 PR 1)

### DIFF
--- a/src/__tests__/tracing-tool-spans-2807.test.ts
+++ b/src/__tests__/tracing-tool-spans-2807.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Test for #2807: OTel tool span helpers.
+ *
+ * Verifies that startToolSpan and setToolResult create spans with correct
+ * attributes, and that they work correctly in both enabled and no-op modes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  startToolSpan,
+  setToolResult,
+  spanOk,
+  spanError,
+  initTracing,
+  type ToolSpanAttributes,
+} from '../tracing.js';
+import type { Span } from '@opentelemetry/api';
+
+describe('startToolSpan (#2807)', () => {
+  it('creates a span without throwing', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-1',
+      toolName: 'Bash',
+      toolUseId: 'tool-abc',
+    });
+    expect(span).toBeDefined();
+    span.end();
+  });
+
+  it('creates a span with minimal attributes', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-1',
+      toolName: 'Read',
+    });
+    expect(span).toBeDefined();
+    span.end();
+  });
+
+  it('creates a span with all attributes including tokens', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-1',
+      toolName: 'Edit',
+      toolUseId: 'tool-edit-1',
+      inputTokens: 150,
+      outputTokens: 200,
+    });
+    expect(span).toBeDefined();
+    span.end();
+  });
+
+  it('can call end() multiple times without error (idempotent)', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-1',
+      toolName: 'Bash',
+    });
+    span.end();
+    // Ending a span twice should not throw
+    expect(() => span.end()).not.toThrow();
+  });
+});
+
+describe('setToolResult (#2807)', () => {
+  it('sets success result on a tool span', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-1',
+      toolName: 'Bash',
+      toolUseId: 'tool-1',
+    });
+
+    setToolResult(span, {
+      success: true,
+      durationMs: 150,
+      outputTokens: 50,
+    });
+
+    // Should not throw when ending
+    expect(() => span.end()).not.toThrow();
+  });
+
+  it('sets failure result with error message', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-1',
+      toolName: 'Write',
+    });
+
+    setToolResult(span, {
+      success: false,
+      error: 'Permission denied',
+      durationMs: 10,
+    });
+
+    expect(() => span.end()).not.toThrow();
+  });
+
+  it('sets result with only success flag', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-1',
+      toolName: 'Read',
+    });
+
+    setToolResult(span, { success: true });
+    expect(() => span.end()).not.toThrow();
+  });
+});
+
+describe('tool span lifecycle (#2807)', () => {
+  it('full lifecycle: start → setToolResult → end', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-lifecycle',
+      toolName: 'Bash',
+      toolUseId: 'tool-lifecycle-1',
+      inputTokens: 100,
+    });
+
+    // Simulate tool execution
+    setToolResult(span, {
+      success: true,
+      durationMs: 250,
+      outputTokens: 75,
+    });
+
+    spanOk(span, 'Tool executed successfully');
+    span.end();
+
+    // No assertions on span internals (no-op tracer in test env)
+    // This verifies the API contract doesn't throw
+  });
+
+  it('full lifecycle with error: start → spanError → end', () => {
+    const span = startToolSpan('invoke', {
+      sessionId: 'sess-error',
+      toolName: 'Bash',
+    });
+
+    spanError(span, new Error('Command failed with exit code 1'));
+    span.end();
+  });
+
+  it('multiple tool spans from same session', () => {
+    const spans: Span[] = [];
+    for (let i = 0; i < 5; i++) {
+      const span = startToolSpan('invoke', {
+        sessionId: 'sess-multi',
+        toolName: `Tool${i}`,
+        toolUseId: `tool-${i}`,
+      });
+      setToolResult(span, { success: true, durationMs: i * 10 });
+      span.end();
+      spans.push(span);
+    }
+
+    expect(spans).toHaveLength(5);
+  });
+});
+
+describe('ToolSpanAttributes type contract', () => {
+  it('accepts minimal attributes (sessionId + toolName only)', () => {
+    const attrs: ToolSpanAttributes = {
+      sessionId: 'sess-1',
+      toolName: 'Bash',
+    };
+
+    const span = startToolSpan('invoke', attrs);
+    expect(span).toBeDefined();
+    span.end();
+  });
+
+  it('accepts full attributes with all optional fields', () => {
+    const attrs: ToolSpanAttributes = {
+      sessionId: 'sess-1',
+      toolName: 'Edit',
+      toolUseId: 'tool-1',
+      inputTokens: 500,
+      outputTokens: 1000,
+    };
+
+    const span = startToolSpan('invoke', attrs);
+    expect(span).toBeDefined();
+    span.end();
+  });
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -27,10 +27,15 @@ type UIState =
   | 'ask_question' | 'bash_approval' | 'settings' | 'error';
 import { evaluatePermissionProfile } from './services/permission/index.js';
 import { timingSafeStringEqual } from './crypto-utils.js';
+import { startToolSpan, setToolResult, spanOk as tracingSpanOk, spanError as tracingSpanError } from './tracing.js';
+import type { Span } from '@opentelemetry/api';
 
 /** CC hook events that require a decision response. */
 
 const DECISION_EVENTS = new Set(['PreToolUse', 'PermissionRequest']);
+
+// Active tool spans — maps "sessionId:toolUseId" → Span for lifecycle tracking (#2807)
+const activeToolSpans = new Map<string, Span>();
 
 /** Permission modes that should be auto-approved via hook response. */
 const AUTO_APPROVE_MODES = new Set(['bypassPermissions', 'dontAsk', 'acceptEdits', 'auto']);
@@ -374,10 +379,43 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
           }
           break;
         }
-        case 'PreToolUse':
-        case 'PostToolUse':
+        case 'PreToolUse': {
+          const toolUseId = hookBody.tool_use_id || '';
+          const toolName = hookBody.tool_name || 'unknown';
+          if (toolUseId) {
+            const span = startToolSpan('invoke', { sessionId, toolName, toolUseId });
+            activeToolSpans.set(`${sessionId}:${toolUseId}`, span);
+          }
           deps.eventBus.emitStatus(sessionId, 'working', 'Claude is working (hook: tool use)');
           break;
+        }
+        case 'PostToolUse': {
+          const toolUseId = hookBody.tool_use_id || '';
+          const spanKey = `${sessionId}:${toolUseId}`;
+          const span = activeToolSpans.get(spanKey);
+          if (span && toolUseId) {
+            setToolResult(span, { success: true, durationMs: undefined });
+            tracingSpanOk(span);
+            span.end();
+            activeToolSpans.delete(spanKey);
+          }
+          deps.eventBus.emitStatus(sessionId, 'working', 'Claude is working (hook: tool use)');
+          break;
+        }
+        case 'PostToolUseFailure': {
+          const toolUseId = hookBody.tool_use_id || '';
+          const spanKey = `${sessionId}:${toolUseId}`;
+          const span = activeToolSpans.get(spanKey);
+          if (span && toolUseId) {
+            setToolResult(span, {
+              success: false,
+              error: String((hookBody as Record<string, unknown>).error || 'Tool execution failed'),
+            });
+            span.end();
+            activeToolSpans.delete(spanKey);
+          }
+          break;
+        }
         case 'PreCompact':
           deps.eventBus.emitStatus(sessionId, 'compacting', 'Claude is compacting context (hook: PreCompact)');
           break;

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -23,6 +23,8 @@ import { logger } from './logger.js';
 import { maybeInjectFault } from './fault-injection.js';
 import { type AlertManager } from './alerting.js';
 import { type MetricsCollector } from './metrics.js';
+import { startToolSpan, setToolResult, spanOk } from './tracing.js';
+import type { Span } from '@opentelemetry/api';
 
 /** Stub: parse "Cogitated for Xm Ys" from status text. Returns duration in ms or null. */
 function parseCogitatedDuration(_statusText: string): number | null {
@@ -59,6 +61,8 @@ export const DEFAULT_MONITOR_CONFIG: MonitorConfig = {
 export class SessionMonitor {
   private running = false;
   private lastStatus = new Map<string, UIState>();
+  /** Active tool spans for OTel lifecycle tracking (#2807) */
+  private _activeToolSpans = new Map<string, Span>();
   private lastBytesSeen = new Map<string, { bytes: number; at: number }>();
   // Issue #663: Nested Map for O(1) per-session stall lookup (was Set with O(n) prefix scan)
   private stallNotified = new Map<string, Set<string>>();  // sessionId → Set<stallType>
@@ -704,6 +708,27 @@ export class SessionMonitor {
     // Issue #32: Emit SSE message event (L11: include tool metadata)
     this.eventBus?.emitMessage(session.id, msg.role, msg.text, msg.contentType,
       msg.toolName || msg.toolUseId ? { tool_name: msg.toolName, tool_id: msg.toolUseId } : undefined);
+
+    // Issue #2807: Create OTel spans for tool events from CC output stream
+    if (event === 'message.tool_use' && msg.toolName) {
+      const span = startToolSpan('invoke', {
+        sessionId: session.id,
+        toolName: msg.toolName,
+        toolUseId: msg.toolUseId,
+      });
+      // Store span for closing on tool_result — use a simple class field
+      this._activeToolSpans.set(`${session.id}:${msg.toolUseId}`, span);
+    }
+    if (event === 'message.tool_result' && msg.toolUseId) {
+      const spanKey = `${session.id}:${msg.toolUseId}`;
+      const span = this._activeToolSpans.get(spanKey);
+      if (span) {
+        setToolResult(span, { success: true });
+        spanOk(span);
+        span.end();
+        this._activeToolSpans.delete(spanKey);
+      }
+    }
 
     await maybeInjectFault('monitor.forwardMessage.channels.message');
     await this.channels.message(this.makePayload(event, session, msg.text));

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -271,3 +271,93 @@ export function isTracingEnabled(): boolean {
 
 // Re-export for type usage
 export { trace, context, SpanStatusCode, SpanKind };
+
+// ── Tool span helpers (Issue #2807) ────────────────────────────────────
+
+/**
+ * Attributes for a tool invocation span.
+ *
+ * Captures both the invocation (PreToolUse) and the result (PostToolUse),
+ * including duration, success/failure, and optional token counts.
+ */
+export interface ToolSpanAttributes {
+  /** Session that invoked the tool */
+  sessionId: string;
+  /** Tool name (e.g. "Bash", "Read", "Write", "Edit") */
+  toolName: string;
+  /** Unique tool use ID from Claude Code */
+  toolUseId?: string;
+  /** Input token count for the tool call (if available) */
+  inputTokens?: number;
+  /** Output token count for the tool result (if available) */
+  outputTokens?: number;
+}
+
+/**
+ * Create a span for a tool invocation.
+ *
+ * The span tracks the full lifecycle: invocation → result.
+ * Call `span.end()` when the tool result is received (PostToolUse / tool_result).
+ *
+ * Usage:
+ * ```ts
+ * const span = startToolSpan('invoke', { sessionId, toolName: 'Bash', toolUseId });
+ * try {
+ *   // ... execute tool ...
+ *   spanOk(span);
+ * } catch (e) {
+ *   spanError(span, e);
+ * } finally {
+ *   span.end();
+ * }
+ * ```
+ */
+export function startToolSpan(
+  operation: string,
+  attrs: ToolSpanAttributes,
+): Span {
+  const { sessionId, toolName, toolUseId, inputTokens, outputTokens } = attrs;
+  return _tracer.startSpan(`tool.${operation}`, {
+    kind: SpanKind.INTERNAL,
+    attributes: {
+      'aegis.session.id': sessionId,
+      'aegis.tool.name': toolName,
+      ...(toolUseId && { 'aegis.tool.use_id': toolUseId }),
+      ...(inputTokens !== undefined && { 'aegis.tool.input_tokens': inputTokens }),
+      ...(outputTokens !== undefined && { 'aegis.tool.output_tokens': outputTokens }),
+    },
+  });
+}
+
+/**
+ * Set the result attributes on a tool span before ending it.
+ *
+ * Call this after the tool execution completes — it records success/failure
+ * and duration information on the span.
+ */
+export function setToolResult(
+  span: Span,
+  result: {
+    /** Whether the tool execution succeeded */
+    success: boolean;
+    /** Error message if the tool failed */
+    error?: string;
+    /** Duration of the tool execution in milliseconds */
+    durationMs?: number;
+    /** Output token count from the result (if available) */
+    outputTokens?: number;
+  },
+): void {
+  span.setAttribute('aegis.tool.result', result.success ? 'success' : 'failure');
+  if (result.durationMs !== undefined) {
+    span.setAttribute('aegis.tool.duration_ms', result.durationMs);
+  }
+  if (result.outputTokens !== undefined) {
+    span.setAttribute('aegis.tool.output_tokens', result.outputTokens);
+  }
+  if (result.error) {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: result.error });
+  } else {
+    span.setStatus({ code: SpanStatusCode.OK });
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2807 — OTel spans incomplete in ACP streaming mode.

**Problem:** Claude Code only emits `llm_request` spans in ACP mode. Tool invocations, tool results, and tool execution are invisible in OTel traces.

**Solution (2 commits):**

### Commit 1: Span helpers (`tracing.ts`)
- `startToolSpan(operation, { sessionId, toolName, toolUseId?, inputTokens?, outputTokens? })` → creates `tool.*` span
- `setToolResult(span, { success, error?, durationMs?, outputTokens? })` → records result + duration before ending
- `ToolSpanAttributes` interface for type safety
- 12 unit tests

### Commit 2: Wiring into event paths
- **hooks.ts** (CC HTTP hooks):
  - `PreToolUse` → creates `tool.invoke` span, stored in `activeToolSpans` map
  - `PostToolUse` → sets success result, ends span
  - `PostToolUseFailure` → sets failure result, ends span
- **monitor.ts** (JSONL transcript polling):
  - `assistant:tool_use` → creates `tool.invoke` span
  - `assistant:tool_result` → sets result, ends span

Both paths use `sessionId:toolUseId` as the span lifecycle key. Zero overhead when tracing is disabled.

## Span attributes (queryable in Jaeger/Tempo)
| Attribute | Description |
|---|---|
| `aegis.session.id` | Session that invoked the tool |
| `aegis.tool.name` | Tool name (Bash, Read, Write, Edit) |
| `aegis.tool.use_id` | Unique tool use ID from CC |
| `aegis.tool.input_tokens` | Input token count (optional) |
| `aegis.tool.output_tokens` | Output token count (optional) |
| `aegis.tool.result` | "success" or "failure" |
| `aegis.tool.duration_ms` | Execution duration in ms |

## Verification
```
tsc --noEmit: ✅ Zero errors
npm run build: ✅ Success
npm test: ✅ 3934 passed (256 files), 2 skipped
```

## Files changed
- `src/tracing.ts`: +90 lines (ToolSpanAttributes, startToolSpan, setToolResult)
- `src/hooks.ts`: +42 lines (PreToolUse/PostToolUse/PostToolUseFailure span wiring)
- `src/monitor.ts`: +25 lines (tool_use/tool_result span wiring)
- `src/__tests__/tracing-tool-spans-2807.test.ts`: +181 lines (12 tests)