### PR TITLE
docs: add CCMeter overview, OTel tool spans, ACP dashboard integration

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -201,11 +201,52 @@ Aegis emits distributed traces via OTLP HTTP when tracing is enabled.
 | `session.create` | INTERNAL | `aegis.session.id`, `workDir` |
 | `session.send` | INTERNAL | `aegis.session.id` |
 | `session.kill` | INTERNAL | `aegis.session.id` |
+| `tool.invoke` | INTERNAL | `aegis.session.id`, `aegis.tool.name`, `aegis.tool.use_id`, `aegis.tool.result`, `aegis.tool.duration_ms` |
 | `acp.send_prompt` | INTERNAL | `aegis.session.id` |
 | `acp.respond_approval` | INTERNAL | `aegis.session.id` |
 | `monitor.poll` | INTERNAL | — |
 | `monitor.stall_check` | INTERNAL | `stall_type` |
 | HTTP spans | SERVER | Auto-instrumented |
+
+### Tool Invocation Spans
+
+Aegis creates `tool.*` spans for every tool invocation (Bash, Read, Write, Edit, etc.), giving visibility into tool execution within traces. These spans work in both **CC HTTP hooks mode** and **ACP JSONL monitor mode**:
+
+**CC HTTP hooks path** (`hooks.ts`):
+- `PreToolUse` hook → creates `tool.invoke` span
+- `PostToolUse` hook → sets success result, ends span
+- `PostToolUseFailure` hook → sets failure result, ends span
+
+**ACP monitor path** (`monitor.ts`):
+- `assistant:tool_use` event → creates `tool.invoke` span
+- `assistant:tool_result` event → sets result, ends span
+
+**Tool span attributes:**
+
+| Attribute | Description |
+|-----------|-------------|
+| `aegis.session.id` | Session that invoked the tool |
+| `aegis.tool.name` | Tool name (e.g. `Bash`, `Read`, `Write`, `Edit`) |
+| `aegis.tool.use_id` | Unique tool use ID from Claude Code |
+| `aegis.tool.input_tokens` | Input token count (optional) |
+| `aegis.tool.output_tokens` | Output token count (optional) |
+| `aegis.tool.result` | `"success"` or `"failure"` |
+| `aegis.tool.duration_ms` | Execution duration in milliseconds |
+
+**Querying in Jaeger/Tempo:**
+
+```text
+# Find slow tool invocations (duration > 5s)
+span.attributes["aegis.tool.result"] = "success" AND duration > 5s
+
+# Filter by tool name
+span.attributes["aegis.tool.name"] = "Bash"
+
+# Group by session
+span.attributes["aegis.session.id"] = "abc-123"
+```
+
+**Zero overhead when disabled:** When `AEGIS_OTEL_ENABLED` is not set, the tracer returns no-op spans with zero performance cost.
 
 ### Collector Configurations
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -66,15 +66,50 @@ Export filtered session records as CSV from the Sessions page:
 
 The CSV includes all visible columns: ID, name, status, created date, and last activity.
 
-### Metric Cards with Sparklines
+### CCMeter-Inspired Overview Layout
 
-The Overview page displays key metrics with mini sparkline charts:
+The Overview page (`/dashboard/`) uses a CCMeter-inspired terminal aesthetic with real-time analytics:
 
-- **Active sessions** count
-- **Token usage** trends
-- **Session duration** averages
+**Layout zones:**
 
-Sparklines show the last 7 data points for quick trend visibility.
+| Zone | Content | Data Source |
+|------|---------|-------------|
+| **A** — Heatmap | Daily activity heatmap (placeholder — pending backend API) | — |
+| **B** — KPI Banner | Total cost, tokens, sessions, avg/day, error rate | `getAnalyticsSummary()` |
+| **C** — Summary | Session count, avg duration, date range, total cost | `getAnalyticsSummary()` |
+| **D** — Charts | Cost/day bar chart (Recharts) + Efficiency gauge (tokens/session) | `costTrends`, derived |
+| **E** — Model Distribution | Segmented cost bar by model | `tokenUsageByModel` |
+| **F** — Shortcuts | Keyboard hints (`N` new, `R` refresh, `Esc` back) | — |
+
+Below the analytics zones, the page shows the **System Health** panel and a **Recent Sessions** table (last 5 sessions) with live SSE updates.
+
+**Keyboard shortcuts on Overview:**
+
+| Key | Action |
+|-----|--------|
+| `N` | Open New Session modal |
+| `R` | Refresh analytics data |
+| `Esc` | Close modal / navigate back |
+
+### ACP Chat & Approval Integration
+
+The dashboard integrates with ACP (Agent Control Protocol) sessions for real-time chat and approval workflows:
+
+**ACP Chat** (`AcpChatPanel`):
+- Send prompts directly to ACP sessions from the dashboard
+- Real-time message streaming via SSE (`message.delta`, `message.complete`, `turn.completed`)
+- Usage tracking (input/output tokens per session)
+- Stop generation mid-stream
+- Optimistic UI — user messages appear instantly while delivery confirms
+
+**ACP Approval** (`AcpApprovalPanel`):
+- View pending tool approval requests in real time
+- Approve or reject with optional reason
+- Countdown timer showing time until approval expires
+- Auto-expiry handling when deadline passes
+- SSE-driven updates (`approval_request`, `approval_resolved` events)
+
+Both panels show clean empty states when no ACP backend is connected.
 
 ### Consistent Empty States
 
@@ -134,7 +169,7 @@ The dashboard sidebar is organized into three groups:
 
 | Group | Page | Path | Description |
 |-------|------|------|-------------|
-| **WORKSPACE** | Overview | `/` | System health, active sessions, metric sparklines |
+| **WORKSPACE** | Overview | `/` | CCMeter-inspired analytics, KPIs, model distribution, active sessions |
 | | Sessions | `/sessions` | All sessions with search, filter, CSV export |
 | | Templates | `/templates` | Reusable session templates |
 | | Pipelines | `/pipelines` | Pipeline management and monitoring |
@@ -150,7 +185,7 @@ The sidebar supports collapse/expand toggle and a mobile-responsive drawer for n
 ## Pages
 
 ### Overview (`/dashboard/` or `/dashboard/overview`)
-System health, active sessions count, and metric sparklines.
+CCMeter-inspired analytics dashboard with KPI banner, cost/day charts, model distribution bar, efficiency gauge, system health panel, and recent sessions table. Real-time SSE updates.
 
 ### Sessions (`/dashboard/sessions`)
 List of all sessions with search, filter, date range, and CSV export.


### PR DESCRIPTION
## Summary

Documents three recently merged feature PRs:

### 1. CCMeter-Inspired Overview (#2903, #2898)
- **dashboard.md**: Replaced stale "Metric Cards with Sparklines" section with full CCMeter-inspired layout description (zones A-F)
- KPI Banner, cost/day chart, model distribution bar, efficiency gauge, keyboard shortcuts
- Updated sidebar and Overview page descriptions

### 2. OTel Tool Spans (#2902)
- **OBSERVABILITY.md**: Added `tool.invoke` to span taxonomy table
- Documented all tool span attributes (`aegis.tool.name`, `aegis.tool.use_id`, `aegis.tool.result`, `aegis.tool.duration_ms`, etc.)
- Described both CC HTTP hooks and ACP JSONL monitor event paths
- Added Jaeger/Tempo query examples and zero-overhead note

### 3. ACP Dashboard Integration (#2899, #2897)
- **dashboard.md**: New "ACP Chat & Approval Integration" section
- ACP Chat: SSE streaming, usage tracking, stop generation, optimistic UI
- ACP Approval: pending requests, approve/reject, countdown timer, auto-expiry

## Verified against source
- `dashboard/src/pages/OverviewPage.tsx` — layout zones, data sources, keyboard shortcuts
- `dashboard/src/hooks/useAcpChat.ts` — SSE events, message flow, usage tracking
- `dashboard/src/hooks/useAcpApproval.ts` — countdown, approve/reject, SSE events
- `src/tracing.ts` — `startToolSpan()`, `setToolResult()`, `ToolSpanAttributes` interface
- `src/hooks.ts` — PreToolUse/PostToolUse/PostToolUseFailure span lifecycle
- `src/monitor.ts` — tool_use/tool_result event handling

## Test plan
- [x] Read rendered output for accuracy
- [x] No code changes — docs only
- [x] Branch verified clean (no unrelated files staged)