### PR TITLE
docs: update architecture guide with OTel tool spans + CCMeter overview

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,7 @@ App.tsx (Router)
 │       ├── Header (theme toggle, user info)
 │       ├── Sidebar (nav: Overview, Sessions, Pipelines, Audit, Users)
 │       └── Outlet (page content)
-│           ├── OverviewPage
+│           ├── OverviewPage     # CCMeter-inspired layout: KPI banner, cost/day chart, model distribution, efficiency gauge
 │           ├── SessionHistoryPage
 │           ├── SessionDetailPage
 │           ├── PipelinesPage
@@ -230,7 +230,7 @@ await client.sessions.send(sessionId, { content: 'refactor the auth module' })
 
 | Page | Route | Features |
 |---|---|---|
-| Overview | `/dashboard/overview` | Metric cards with sparklines, live session count, health status |
+| Overview | `/dashboard/overview` | CCMeter-inspired layout: KPI banner (cost, tokens, sessions, error rate), cost/day bar chart, model distribution, efficiency gauge, keyboard shortcuts |
 | Sessions | `/dashboard/sessions` | Search, date range filter, sortable table, CSV export |
 | Session Detail | `/dashboard/sessions/:id` | Transcript viewer, action buttons, pane/screenshot, breadcrumb |
 | Pipelines | `/dashboard/pipelines` | Pipeline list, status, create modal |
@@ -346,7 +346,7 @@ Backend selection via environment:
 | `sse-writer.ts` | Streams SSE events to HTTP clients |
 | `sse-limiter.ts` | Rate-limits SSE connections per client |
 | `ws-terminal.ts` | Relays terminal output over WebSocket using real-time PTY streaming |
-| `tracing.ts` | OpenTelemetry tracing — spans for HTTP routes, session create/kill, ACP operations, channel delivery |
+| `tracing.ts` | OpenTelemetry tracing — spans for HTTP routes, session lifecycle, tool invocations, ACP operations, channel delivery |
 
 #### OpenTelemetry Tracing
 
@@ -354,8 +354,11 @@ Aegis emits distributed traces via OTLP HTTP when enabled (`AEGIS_OTEL_ENABLED=t
 
 - **HTTP routes** — auto-instrumented via `@opentelemetry/instrumentation-fastify`
 - **Session lifecycle** — `session.create`, `session.kill` spans with `acp.spawn`/`acp.terminate` sub-spans
+- **Tool invocations** — `tool.invoke` spans for every Claude Code tool call, with `toolName`, `toolUseId`, `inputTokens`, `outputTokens` attributes. Covers both CC HTTP hooks (`PreToolUse`/`PostToolUse`) and JSONL transcript polling (`assistant:tool_use`/`assistant:tool_result`).
 - **Channel delivery** — `channel.deliver` spans in `ChannelManager.fanOut()`
 - **Log correlation** — structured logs include `trace_id` and `span_id` when tracing is active
+
+Key helpers: `startToolSpan(operation, attrs)` creates a `tool.*` span; `setToolResult(span, result)` records success/failure and duration before ending.
 
 See [deployment.md](./deployment.md#opentelemetry-tracing) for configuration and quick-start guides.
 
@@ -401,7 +404,7 @@ See [deployment.md](./deployment.md#opentelemetry-tracing) for configuration and
 | `retry.ts` | Generic retry with exponential backoff |
 | `suppress.ts` | Log suppression for noisy operations |
 | `logger.ts` | Structured logging with trace ID correlation |
-| `tracing.ts` | OpenTelemetry distributed tracing — spans for HTTP, session lifecycle, ACP, channel delivery |
+| `tracing.ts` | OpenTelemetry distributed tracing — spans for HTTP, session lifecycle, tool invocations, ACP, channel delivery |
 | `diagnostics.ts` | Health check and diagnostic data collection |
 | `fault-injection.ts` | Testing helper for simulating failures |
 | `shutdown-utils.ts` | Graceful shutdown coordination |


### PR DESCRIPTION
## Summary

Updates `docs/architecture.md` to reflect the new observability stack from recent merged PRs.

### Changes

**OpenTelemetry Tracing section:**
- Added `tool.invoke` spans — covers CC HTTP hooks (`PreToolUse`/`PostToolUse`) and JSONL transcript polling (`assistant:tool_use`/`assistant:tool_result`)
- Documented span attributes: `toolName`, `toolUseId`, `inputTokens`, `outputTokens`
- Added key helpers: `startToolSpan()`, `setToolResult()`

**Dashboard Architecture:**
- Updated OverviewPage in SPA layout tree and Key Dashboard Pages table
- CCMeter-inspired layout: KPI banner, cost/day chart, model distribution, efficiency gauge

**Module descriptions:**
- Updated `tracing.ts` entries (appears twice in the guide) to include "tool invocations"

### Source PRs
- #2902 — OTel tool span helpers + wiring
- #2903 — CCMeter overview page redesign

### Files changed
- `docs/architecture.md` (+7/-4)