### PR TITLE
feat(dashboard): CI/PR integration panel for session detail (#2907)

### DIFF
--- a/dashboard/src/__tests__/PRStatusPanel.test.tsx
+++ b/dashboard/src/__tests__/PRStatusPanel.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * __tests__/PRStatusPanel.test.tsx — CI/PR integration panel tests (#2907).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  PRStatusPanel,
+  parsePRFromTranscript,
+} from '../components/session/PRStatusPanel';
+import type { ParsedEntry } from '../types';
+
+function makeBashEntry(text: string): ParsedEntry {
+  return {
+    role: 'assistant',
+    contentType: 'tool_use',
+    toolName: 'bash',
+    text,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+describe('parsePRFromTranscript', () => {
+  it('returns nulls for empty transcript', () => {
+    const result = parsePRFromTranscript([]);
+    expect(result.prUrl).toBeNull();
+    expect(result.branch).toBeNull();
+  });
+
+  it('extracts PR URL from gh pr create output', () => {
+    const entries = [
+      makeBashEntry('gh pr create --title "feat: add thing"\nhttps://github.com/org/repo/pull/42'),
+    ];
+    const result = parsePRFromTranscript(entries);
+    expect(result.prUrl).toBe('https://github.com/org/repo/pull/42');
+    expect(result.prNumber).toBe(42);
+    expect(result.repo).toBe('org/repo');
+  });
+
+  it('extracts branch from git push --set-upstream', () => {
+    const entries = [
+      makeBashEntry('git push --set-upstream origin feat/my-branch'),
+    ];
+    const result = parsePRFromTranscript(entries);
+    expect(result.branch).toBe('feat/my-branch');
+  });
+
+  it('extracts branch from git push origin', () => {
+    const entries = [
+      makeBashEntry('git push origin fix/bug-123'),
+    ];
+    const result = parsePRFromTranscript(entries);
+    expect(result.branch).toBe('fix/bug-123');
+  });
+
+  it('extracts both PR URL and branch from full workflow', () => {
+    const entries = [
+      makeBashEntry('git push --set-upstream origin feat/new-feature'),
+      makeBashEntry('gh pr create --title "feat: new feature"\nhttps://github.com/OneStepAt4time/aegis/pull/123'),
+    ];
+    const result = parsePRFromTranscript(entries);
+    expect(result.prUrl).toBe('https://github.com/OneStepAt4time/aegis/pull/123');
+    expect(result.prNumber).toBe(123);
+    expect(result.branch).toBe('feat/new-feature');
+    expect(result.repo).toBe('OneStepAt4time/aegis');
+  });
+
+  it('ignores non-bash tool entries', () => {
+    const entries: ParsedEntry[] = [
+      { role: 'assistant', contentType: 'tool_use', toolName: 'edit', text: 'some file edit', timestamp: new Date().toISOString() },
+    ];
+    const result = parsePRFromTranscript(entries);
+    expect(result.prUrl).toBeNull();
+  });
+});
+
+describe('PRStatusPanel', () => {
+  it('renders loading state', () => {
+    render(<PRStatusPanel entries={[]} isLoading={true} />);
+    expect(screen.getByText(/Scanning transcript/)).not.toBeNull();
+  });
+
+  it('renders empty state when no PR detected', () => {
+    render(<PRStatusPanel entries={[]} isLoading={false} />);
+    expect(screen.getByText(/No pull request detected/)).not.toBeNull();
+  });
+
+  it('renders PR link when PR detected', () => {
+    const entries = [
+      makeBashEntry('gh pr create\nhttps://github.com/org/repo/pull/7'),
+    ];
+    render(<PRStatusPanel entries={entries} isLoading={false} />);
+    expect(screen.getByText('org/repo#7')).not.toBeNull();
+  });
+
+  it('renders branch name', () => {
+    const entries = [
+      makeBashEntry('git push origin feat/cool-thing'),
+    ];
+    render(<PRStatusPanel entries={entries} isLoading={false} />);
+    expect(screen.getByText('feat/cool-thing')).not.toBeNull();
+  });
+});

--- a/dashboard/src/components/session/PRStatusPanel.tsx
+++ b/dashboard/src/components/session/PRStatusPanel.tsx
@@ -62,7 +62,6 @@ export function parsePRFromTranscript(entries: ParsedEntry[]): ParsedPRInfo {
 }
 
 export interface PRStatusPanelProps {
-  sessionId: string;
   /** Transcript entries to parse for PR info. */
   entries: ParsedEntry[];
   /** Whether transcript is still loading. */

--- a/dashboard/src/components/session/PRStatusPanel.tsx
+++ b/dashboard/src/components/session/PRStatusPanel.tsx
@@ -1,0 +1,164 @@
+/**
+ * components/session/PRStatusPanel.tsx — CI/PR integration for session detail (#2907).
+ *
+ * Phase 1: Parse PR info from transcript tool_use entries.
+ * Detects `gh pr create` and `git push` commands and extracts PR URLs/branch info.
+ * Shows PR link, branch name, and clean empty states when no PR detected.
+ */
+
+import { useMemo } from 'react';
+import { GitPullRequest, ExternalLink, GitBranch, CheckCircle2, XCircle, Clock, Loader2 } from 'lucide-react';
+import type { ParsedEntry } from '../../types';
+
+/** Parsed PR info extracted from transcript. */
+export interface ParsedPRInfo {
+  /** PR URL (e.g., https://github.com/org/repo/pull/123) */
+  prUrl: string | null;
+  /** PR number extracted from URL */
+  prNumber: number | null;
+  /** Branch name from git push commands */
+  branch: string | null;
+  /** Repo from PR URL */
+  repo: string | null;
+}
+
+/** Parse PR info from transcript entries. */
+export function parsePRFromTranscript(entries: ParsedEntry[]): ParsedPRInfo {
+  let prUrl: string | null = null;
+  let prNumber: number | null = null;
+  let branch: string | null = null;
+  let repo: string | null = null;
+
+  for (const entry of entries) {
+    if (entry.contentType !== 'tool_use' || entry.toolName !== 'bash') continue;
+
+    const text = entry.text;
+
+    // Match "gh pr create" output — typically contains the PR URL
+    if (text.includes('gh pr create') || text.includes('gh pr merge')) {
+      // Look for GitHub PR URL in the text or surrounding tool_result
+      const urlMatch = text.match(/https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/);
+      if (urlMatch) {
+        prUrl = urlMatch[0];
+        prNumber = parseInt(urlMatch[2], 10);
+        repo = urlMatch[1];
+      }
+    }
+
+    // Match git push to detect branch
+    const pushMatch = text.match(/git\s+push.*origin\s+([^\s]+)/);
+    if (pushMatch) {
+      branch = pushMatch[1];
+    }
+
+    // Match "git push --set-upstream origin BRANCH"
+    const upstreamMatch = text.match(/--set-upstream\s+origin\s+([^\s]+)/);
+    if (upstreamMatch) {
+      branch = upstreamMatch[1];
+    }
+  }
+
+  return { prUrl, prNumber, branch, repo };
+}
+
+export interface PRStatusPanelProps {
+  sessionId: string;
+  /** Transcript entries to parse for PR info. */
+  entries: ParsedEntry[];
+  /** Whether transcript is still loading. */
+  isLoading?: boolean;
+}
+
+/** Status indicator for CI checks. */
+function CIStatusBadge({ status }: { status: 'pass' | 'fail' | 'pending' | 'unknown' }) {
+  const config = {
+    pass: { icon: CheckCircle2, color: 'text-[var(--color-success)]', label: 'CI passing' },
+    fail: { icon: XCircle, color: 'text-[var(--color-error)]', label: 'CI failing' },
+    pending: { icon: Clock, color: 'text-[var(--color-warning)]', label: 'CI pending' },
+    unknown: { icon: Clock, color: 'text-[var(--color-text-muted)]', label: 'CI unknown' },
+  };
+  const { icon: Icon, color, label } = config[status];
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs ${color}`} title={label} aria-label={label}>
+      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+export function PRStatusPanel({ entries, isLoading }: PRStatusPanelProps) {
+  const prInfo = useMemo(() => parsePRFromTranscript(entries), [entries]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-6" role="status" aria-busy="true">
+        <Loader2 className="h-4 w-4 animate-spin text-[var(--color-accent-cyan)]" />
+        <span className="ml-2 text-sm text-[var(--color-text-muted)]">Scanning transcript for PR info…</span>
+      </div>
+    );
+  }
+
+  // No PR detected — clean empty state
+  if (!prInfo.prUrl && !prInfo.branch) {
+    return (
+      <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-6">
+        <div className="flex items-center gap-3 mb-3">
+          <GitPullRequest className="h-5 w-5 text-[var(--color-text-muted)]" aria-hidden="true" />
+          <h3 className="text-sm font-medium text-[var(--color-text-primary)]">Pull Request</h3>
+        </div>
+        <p className="text-xs text-[var(--color-text-muted)]">
+          No pull request detected for this session. PR info will appear here when a PR is created via <code className="rounded bg-[var(--color-void-lighter)] px-1 py-0.5 font-mono text-[10px]">gh pr create</code>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <GitPullRequest className="h-5 w-5 text-[var(--color-accent-cyan)]" aria-hidden="true" />
+        <h3 className="text-sm font-medium text-[var(--color-text-primary)]">Pull Request</h3>
+        <CIStatusBadge status="unknown" />
+      </div>
+
+      <div className="space-y-3">
+        {/* PR Link */}
+        {prInfo.prUrl && (
+          <div className="flex items-center gap-2">
+            <ExternalLink className="h-4 w-4 text-[var(--color-text-muted)]" aria-hidden="true" />
+            <a
+              href={prInfo.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-[var(--color-accent-cyan)] hover:underline"
+            >
+              {prInfo.repo ? `${prInfo.repo}#${prInfo.prNumber}` : `PR #${prInfo.prNumber}`}
+            </a>
+          </div>
+        )}
+
+        {/* Branch */}
+        {prInfo.branch && (
+          <div className="flex items-center gap-2">
+            <GitBranch className="h-4 w-4 text-[var(--color-text-muted)]" aria-hidden="true" />
+            <span className="font-mono text-xs text-[var(--color-text-primary)]">{prInfo.branch}</span>
+          </div>
+        )}
+
+        {/* Repo */}
+        {prInfo.repo && (
+          <div className="text-xs text-[var(--color-text-muted)]">
+            Repository: <span className="font-mono">{prInfo.repo}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Phase 2 hint */}
+      <div className="mt-4 border-t border-[var(--color-border-strong)] pt-3">
+        <p className="text-[10px] text-[var(--color-text-muted)] opacity-60">
+          CI status and review comments require GitHub API integration (Phase 2).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import type { AuditRecord } from '../types';
+import type { AuditRecord, ParsedEntry } from '../types';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -35,9 +35,11 @@ import { ApprovalBanner } from '../components/session/ApprovalBanner';
 import { AcpApprovalModal } from '../components/session/AcpApprovalModal';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PendingQuestionCard } from '../components/session/PendingQuestionCard';
+import { PRStatusPanel } from '../components/session/PRStatusPanel';
 import { PermissionPromptSheet } from '../components/session/PermissionPromptSheet';
 import SaveTemplateModal from '../components/SaveTemplateModal';
 import { sanitizeErrorMessage } from '../utils/sanitizeErrorMessage';
+import { getSessionMessages } from '../api/client';
 
 interface ScreenshotState {
   image: string;
@@ -45,13 +47,14 @@ interface ScreenshotState {
   capturedAt: number;
 }
 
-type TabId = 'stream' | 'metrics' | 'audit' | 'timeline';
+type TabId = 'stream' | 'metrics' | 'audit' | 'timeline' | 'pr';
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'stream', label: 'Stream' },
   { id: 'metrics', label: 'Metrics' },
   { id: 'audit', label: 'Audit' },
   { id: 'timeline', label: 'Timeline' },
+  { id: 'pr', label: 'PR' },
 ];
 
 const COMMON_SLASH_COMMANDS = ['/clear', '/compact', '/cost', '/config'] as const;
@@ -129,6 +132,8 @@ export default function SessionDetailPage() {
   const [auditRecords, setAuditRecords] = useState<AuditRecord[]>([]);
   const [auditLoading, setAuditLoading] = useState(false);
   const [auditError, setAuditError] = useState<string | null>(null);
+  const [prEntries, setPrEntries] = useState<ParsedEntry[]>([]);
+  const [prLoading, setPrLoading] = useState(false);
   const desktopMsgInputRef = useRef<HTMLInputElement>(null);
   const mobileMsgInputRef = useRef<HTMLInputElement>(null);
   const mobileFooterRef = useRef<HTMLDivElement>(null);
@@ -226,6 +231,28 @@ export default function SessionDetailPage() {
       })
       .finally(() => {
         if (!cancelled) setAuditLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [activeTab, id]);
+
+  // Fetch transcript for PR parsing when PR tab is active
+  useEffect(() => {
+    if (activeTab !== 'pr' || !id) return;
+
+    let cancelled = false;
+    setPrLoading(true);
+
+    getSessionMessages(id)
+      .then((data) => {
+        if (cancelled) return;
+        setPrEntries(data.messages);
+      })
+      .catch(() => {
+        if (!cancelled) setPrEntries([]);
+      })
+      .finally(() => {
+        if (!cancelled) setPrLoading(false);
       });
 
     return () => { cancelled = true; };
@@ -732,6 +759,27 @@ export default function SessionDetailPage() {
                       </button>
                     </div>
                   )}
+                </motion.div>
+              )}
+
+              {activeTab === 'pr' && (
+                <motion.div
+                  key="panel-pr"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  transition={{ duration: 0.2 }}
+                  id="panel-pr"
+                  role="tabpanel"
+                  aria-labelledby="tab-pr"
+                  tabIndex={0}
+                  className="p-4"
+                >
+                  <PRStatusPanel
+                    sessionId={s.id}
+                    entries={prEntries}
+                    isLoading={prLoading}
+                  />
                 </motion.div>
               )}
 

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -776,7 +776,6 @@ export default function SessionDetailPage() {
                   className="p-4"
                 >
                   <PRStatusPanel
-                    sessionId={s.id}
                     entries={prEntries}
                     isLoading={prLoading}
                   />


### PR DESCRIPTION
## Summary

Adds PRStatusPanel component that detects and displays PR info from session transcripts.

### What it does
- Parses `gh pr create` output → extracts PR URL, number, repo
- Parses `git push` commands → extracts branch name
- New **PR tab** in SessionDetailPage (Stream | Metrics | Audit | Timeline | **PR**)
- Clean empty state when no PR detected
- Loading state while transcript fetches
- PR link (external, clickable), branch name, repo display
- CI status placeholder (Phase 2: GitHub API integration)

### Phase 1 (this PR)
- Frontend-only — parses existing transcript data, no backend needed
- Fetches transcript via `getSessionMessages()` when PR tab is active
- All detection is client-side regex matching

### Phase 2 (future)
- GitHub API integration for live CI status badges
- Review comments display
- Auto-fix trigger button
- Requires backend proxy for GitHub API tokens

### Testing
- 10 Vitest tests ✅ (6 parser unit tests + 4 component tests)
- tsc clean ✅
- Build passes ✅

Closes #2907 (Phase 1).