### PR TITLE
feat(helm): add OTel tracing configuration to values.yaml

### DIFF
--- a/charts/aegis/README.md
+++ b/charts/aegis/README.md
@@ -49,6 +49,9 @@ helm upgrade aegis ./charts/aegis \
 | `aegis.stateDir` | string | `/var/lib/aegis` | State dir mounted from PVC (`AEGIS_STATE_DIR`) |
 | `aegis.extraEnv` | list | `[]` | Additional env vars (`{name, value}` or `{name, valueFrom}`) |
 | `aegis.extraEnvFrom` | list | `[]` | Additional `envFrom` entries |
+| `otel.enabled` | bool | `false` | Enable OpenTelemetry tracing |
+| `otel.endpoint` | string | `""` | OTLP endpoint for exporting traces |
+| `otel.extraEnv` | list | `[]` | Additional OTel environment variables |
 | `auth.token` | string | `""` | Inline API token stored in a generated Secret |
 | `auth.existingSecret` | string | `""` | Existing Secret name (overrides `auth.token`) |
 | `auth.existingSecretKey` | string | `AEGIS_AUTH_TOKEN` | Key inside the Secret |

--- a/charts/aegis/templates/statefulset.yaml
+++ b/charts/aegis/templates/statefulset.yaml
@@ -92,6 +92,17 @@ spec:
             {{- with .Values.aegis.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.otel.enabled }}
+            - name: AEGIS_OTEL_ENABLED
+              value: "true"
+            {{- if .Values.otel.endpoint }}
+            - name: AEGIS_OTEL_OTLP_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.otel.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.aegis.extraEnvFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/aegis/values.yaml
+++ b/charts/aegis/values.yaml
@@ -36,6 +36,15 @@ aegis:
   # -- Additional envFrom entries appended to the container.
   extraEnvFrom: []
 
+otel:
+  # -- Enable OpenTelemetry tracing (AEGIS_OTEL_ENABLED).
+  enabled: false
+  # -- OTLP endpoint for exporting traces (AEGIS_OTEL_OTLP_ENDPOINT).
+  #    Example: "http://jaeger:4318/v1/traces"
+  endpoint: ""
+  # -- Additional OTel environment variables (list of {name, value} or {name, valueFrom}).
+  extraEnv: []
+
 auth:
   # -- Inline API token stored in a generated Secret and exposed as AEGIS_AUTH_TOKEN.
   token: ""


### PR DESCRIPTION
## What
Adds an `otel` section to the Helm chart so users can enable OpenTelemetry tracing without manually editing the deployment.

## Changes
- **values.yaml**: New `otel` section with `enabled`, `endpoint`, and `extraEnv`
- **statefulset.yaml**: Injects `AEGIS_OTEL_ENABLED` and `AEGIS_OTEL_OTLP_ENDPOINT` env vars when `otel.enabled=true`
- **README.md**: Documents the new parameters

## Usage
```yaml
otel:
  enabled: true
  endpoint: "http://jaeger:4318/v1/traces"
```

Or via CLI:
```bash
helm install aegis charts/aegis/ --set otel.enabled=true --set otel.endpoint=http://jaeger:4318
```

## Testing
- `helm template` verified: env vars render when enabled, absent when disabled
- `helm lint` passes

Closes #2909