### PR TITLE
fix(ci): copy scripts/ before npm ci in helm-smoke build stage

### DIFF
--- a/.github/workflows/helm-smoke.yml
+++ b/.github/workflows/helm-smoke.yml
@@ -87,6 +87,7 @@ jobs:
           FROM node:20-bookworm-slim AS build
           WORKDIR /app
           COPY package*.json ./
+          COPY scripts/ scripts/
           RUN npm ci
           COPY . .
           RUN npm run build


### PR DESCRIPTION
## Problem
Helm Smoke keeps failing with:
```
Error: Cannot find module '/app/scripts/postinstall-verify.cjs'
```

## Root Cause
The inline Dockerfile's **build stage** runs `npm ci` which triggers `postinstall → node scripts/postinstall-verify.cjs`. But `scripts/` is only copied AFTER `npm ci` (via `COPY . .`).

The production stage already has `COPY scripts/ scripts/` (from #2901), but the build stage was missed and my direct push fix was overwritten by a subsequent merge.

## Fix
Add `COPY scripts/ scripts/` to the build stage before `RUN npm ci`, same as the production stage.

## Lesson
Direct pushes to develop get overwritten. Always use PRs.