### PR TITLE
chore(client): regenerate types.gen.ts for systemPrompt field

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -92,6 +92,10 @@ export type CreateSessionRequest = {
      * Stall detection threshold override
      */
     stallThresholdMs?: number;
+    /**
+     * Per-session custom system prompt. Passed to Claude Code via ACP _meta.systemPrompt. Supported only when ACP is enabled.
+     */
+    systemPrompt?: string;
 };
 
 export type SessionCreated = {


### PR DESCRIPTION
## What
Regenerated `packages/client/src/generated/types.gen.ts` from the latest `openapi.yaml`.

## Change
- Added `systemPrompt` field to `CreateSessionRequest` type (4 lines)
- Per-session custom system prompt, passed to Claude Code via ACP `_meta.systemPrompt`

## Why
The generated types were out of sync with the OpenAPI spec — `systemPrompt` was added to the API but the client types weren't regenerated.

Generated via: `npm --prefix packages/client run generate`