### PR TITLE
build(deps): bump ip-address to 10.2.0 and express-rate-limit to 8.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@onestepat4time/aegis",
       "version": "0.6.6-preview.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "^0.32.0",
@@ -6426,12 +6427,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
   "overrides": {
     "zod": "^4.3.6",
     "@anthropic-ai/sdk": "^0.91.1",
-    "ip-address": "^10.1.1"
+    "ip-address": "^10.2.0",
+    "express-rate-limit": "^8.5.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What
Manual dependency bump replacing Dependabot PR #2839 which failed to rebase after 10+ hours.

## Changes
- `ip-address`: 10.1.0 → 10.2.0 (override updated to `^10.2.0`)
- `express-rate-limit`: 8.3.1 → 8.5.1 (override added)

## Why
These are transitive deps of `@modelcontextprotocol/sdk`. The overrides ensure the resolved versions match the latest releases.

Closes #2839 (Dependabot)