### PR TITLE
docs: document systemPrompt param and CI/PR panel (#2917, #2911)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -685,7 +685,8 @@ curl -X POST http://localhost:9100/v1/sessions \
     "name": "feature-auth",
     "workDir": "/home/user/my-project",
     "model": "claude-sonnet-4-20250514",
-    "prompt": "Build a login page with email/password fields."
+    "prompt": "Build a login page with email/password fields.",
+    "systemPrompt": "You are a senior frontend developer. Use TypeScript and React."
   }'
 ```
 
@@ -707,6 +708,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 | `autoApprove` | boolean | no | Skip permission prompts (= `permissionMode: bypassPermissions`) |
 | `parentId` | string (UUID) | no | Set parent session — child appears in parent's `/children` |
 | `memoryKeys` | string[] | no | Pre-load memory entries into session (max 50) |
+| `systemPrompt` | string | no | Per-session custom system prompt passed via ACP `_meta.systemPrompt` (max 100k chars; ACP only) |
 
 > **Multi-tenancy:** Sessions inherit `tenantId` from the creating API key.
 


### PR DESCRIPTION
## What

Documents two recently merged features:

### 1. Per-session custom system prompts (#2917 → #2913)
- **api-reference.md**: Added `systemPrompt` to the Create Session parameter table and curl example
- Field: string, optional, max 100k chars, ACP only
- Passed via `_meta.systemPrompt` in ACP `session/new`

### 2. CI/PR Integration Panel (#2911 → #2907)
- **dashboard.md**: Added PR tab description to session detail page
- Transcript-based PR detection (gh pr create, git push parsing)
- Phase 1 (frontend-only); Phase 2 planned for GitHub API integration

## Files changed
- `docs/api-reference.md` — systemPrompt in Create Session
- `docs/dashboard.md` — PR tab in session detail