### PR TITLE
fix(sdk): regenerate Python client models with systemPrompt field

### DIFF
--- a/packages/python-client/src/aegis_python_client/models.py
+++ b/packages/python-client/src/aegis_python_client/models.py
@@ -105,6 +105,10 @@ class CreateSessionRequest(BaseModel):
     stallThresholdMs: int | None = Field(
         None, description='Stall detection threshold override'
     )
+    systemPrompt: constr(max_length=100000) | None = Field(
+        None,
+        description='Per-session custom system prompt. Passed to Claude Code via ACP _meta.systemPrompt. Supported only when ACP is enabled.',
+    )
 
 
 class PromptDelivery(BaseModel):


### PR DESCRIPTION
## Problem
The **Release Dry Run** CI workflow on `develop` is failing because the OpenAPI spec added a `systemPrompt` field to `CreateSessionRequest`, but the generated Python SDK models were not updated.

**Failed run:** [25512154264](https://github.com/OneStepAt4time/aegis/actions/runs/25512154264)

## Fix
Regenerated `packages/python-client/src/aegis_python_client/models.py` via `npm run sdk:py:generate` to sync with `openapi.yaml`.

### Diff
- Adds `systemPrompt: constr(max_length=100000) | None` field to `CreateSessionRequest`

## Testing
- `sdk:py:check` diff confirms only the expected 4-line addition
- No other models affected