### PR TITLE
feat(dashboard): file diff viewer for session detail (#2906)

### DIFF
--- a/dashboard/src/__tests__/DiffViewer.test.tsx
+++ b/dashboard/src/__tests__/DiffViewer.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * __tests__/DiffViewer.test.tsx — File diff viewer tests (#2906).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  DiffViewer,
+  parseFileChanges,
+  computeDiff,
+} from '../components/session/DiffViewer';
+import type { ParsedEntry } from '../types';
+
+function makeToolEntry(toolName: string, text: string): ParsedEntry {
+  return {
+    role: 'assistant',
+    contentType: 'tool_use',
+    toolName,
+    text,
+    toolUseId: `tool-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+describe('parseFileChanges', () => {
+  it('returns empty array for no tool entries', () => {
+    const entries: ParsedEntry[] = [
+      { role: 'user', contentType: 'text', text: 'hello', timestamp: '' },
+    ];
+    expect(parseFileChanges(entries)).toHaveLength(0);
+  });
+
+  it('parses edit tool_use entries', () => {
+    const entries = [
+      makeToolEntry('edit', JSON.stringify({
+        file_path: '/src/app.ts',
+        old_string: 'const x = 1;',
+        new_string: 'const x = 2;',
+      })),
+    ];
+    const changes = parseFileChanges(entries);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].filePath).toBe('/src/app.ts');
+    expect(changes[0].type).toBe('edit');
+    expect(changes[0].oldContent).toBe('const x = 1;');
+    expect(changes[0].newContent).toBe('const x = 2;');
+  });
+
+  it('parses write tool_use entries', () => {
+    const entries = [
+      makeToolEntry('write', JSON.stringify({
+        file_path: '/src/new-file.ts',
+        content: 'export const hello = "world";',
+      })),
+    ];
+    const changes = parseFileChanges(entries);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].filePath).toBe('/src/new-file.ts');
+    expect(changes[0].type).toBe('write');
+    expect(changes[0].oldContent).toBeNull();
+    expect(changes[0].newContent).toBe('export const hello = "world";');
+  });
+
+  it('ignores non-edit/write tools', () => {
+    const entries = [
+      makeToolEntry('bash', 'git status'),
+      makeToolEntry('read', '/src/app.ts'),
+    ];
+    expect(parseFileChanges(entries)).toHaveLength(0);
+  });
+
+  it('ignores malformed JSON', () => {
+    const entries = [
+      makeToolEntry('edit', 'not valid json'),
+    ];
+    expect(parseFileChanges(entries)).toHaveLength(0);
+  });
+
+  it('parses multiple changes', () => {
+    const entries = [
+      makeToolEntry('edit', JSON.stringify({ file_path: '/a.ts', old_string: 'a', new_string: 'b' })),
+      makeToolEntry('write', JSON.stringify({ file_path: '/b.ts', content: 'new' })),
+      makeToolEntry('edit', JSON.stringify({ file_path: '/c.ts', old_string: 'c', new_string: 'd' })),
+    ];
+    const changes = parseFileChanges(entries);
+    expect(changes).toHaveLength(3);
+  });
+});
+
+describe('computeDiff', () => {
+  it('marks all lines as add for new file', () => {
+    const lines = computeDiff(null, 'line1\nline2\nline3');
+    expect(lines).toHaveLength(3);
+    expect(lines.every(l => l.type === 'add')).toBe(true);
+  });
+
+  it('shows context for unchanged lines', () => {
+    const lines = computeDiff('same', 'same');
+    expect(lines).toHaveLength(1);
+    expect(lines[0].type).toBe('context');
+  });
+
+  it('shows remove+add for changed lines', () => {
+    const lines = computeDiff('old', 'new');
+    expect(lines).toHaveLength(2);
+    expect(lines[0].type).toBe('remove');
+    expect(lines[0].content).toBe('old');
+    expect(lines[1].type).toBe('add');
+    expect(lines[1].content).toBe('new');
+  });
+
+  it('handles added lines', () => {
+    const lines = computeDiff('a', 'a\nb');
+    expect(lines).toHaveLength(2);
+    expect(lines[0].type).toBe('context');
+    expect(lines[1].type).toBe('add');
+    expect(lines[1].content).toBe('b');
+  });
+
+  it('handles removed lines', () => {
+    const lines = computeDiff('a\nb', 'a');
+    expect(lines).toHaveLength(2);
+    expect(lines[0].type).toBe('context');
+    expect(lines[1].type).toBe('remove');
+    expect(lines[1].content).toBe('b');
+  });
+});
+
+describe('DiffViewer', () => {
+  it('renders loading state', () => {
+    render(<DiffViewer entries={[]} isLoading={true} />);
+    expect(screen.getByText(/Scanning transcript/)).not.toBeNull();
+  });
+
+  it('renders empty state when no changes', () => {
+    render(<DiffViewer entries={[]} isLoading={false} />);
+    expect(screen.getByText(/No file changes detected/)).not.toBeNull();
+  });
+
+  it('renders file list when changes exist', () => {
+    const entries = [
+      makeToolEntry('edit', JSON.stringify({ file_path: '/src/app.ts', old_string: 'a', new_string: 'b' })),
+      makeToolEntry('write', JSON.stringify({ file_path: '/src/new.ts', content: 'hello' })),
+    ];
+    const { container } = render(<DiffViewer entries={entries} isLoading={false} />);
+    expect(screen.getByText('app.ts')).not.toBeNull();
+    expect(screen.getByText('new.ts')).not.toBeNull();
+    expect(screen.getByText('2 files changed')).not.toBeNull();
+  });
+
+  it('shows diff content for selected file', () => {
+    const entries = [
+      makeToolEntry('edit', JSON.stringify({ file_path: '/src/app.ts', old_string: 'old line', new_string: 'new line' })),
+    ];
+    render(<DiffViewer entries={entries} isLoading={false} />);
+    expect(screen.getByText('/src/app.ts')).not.toBeNull();
+    expect(screen.getByText('modified')).not.toBeNull();
+  });
+
+  it('shows "created" badge for write operations', () => {
+    const entries = [
+      makeToolEntry('write', JSON.stringify({ file_path: '/src/new.ts', content: 'content' })),
+    ];
+    render(<DiffViewer entries={entries} isLoading={false} />);
+    expect(screen.getByText('created')).not.toBeNull();
+  });
+});

--- a/dashboard/src/__tests__/DiffViewer.test.tsx
+++ b/dashboard/src/__tests__/DiffViewer.test.tsx
@@ -142,7 +142,7 @@ describe('DiffViewer', () => {
       makeToolEntry('edit', JSON.stringify({ file_path: '/src/app.ts', old_string: 'a', new_string: 'b' })),
       makeToolEntry('write', JSON.stringify({ file_path: '/src/new.ts', content: 'hello' })),
     ];
-    const { container } = render(<DiffViewer entries={entries} isLoading={false} />);
+    render(<DiffViewer entries={entries} isLoading={false} />);
     expect(screen.getByText('app.ts')).not.toBeNull();
     expect(screen.getByText('new.ts')).not.toBeNull();
     expect(screen.getByText('2 files changed')).not.toBeNull();

--- a/dashboard/src/components/session/DiffViewer.tsx
+++ b/dashboard/src/components/session/DiffViewer.tsx
@@ -1,0 +1,245 @@
+/**
+ * components/session/DiffViewer.tsx — File diff viewer for session detail (#2906).
+ *
+ * Parses Edit/Write tool_use events from transcript and renders
+ * an inline diff view with file list sidebar.
+ *
+ * Data source: ParsedEntry[] from getSessionMessages()
+ * - Edit: toolName="edit", text contains JSON with file_path, old_string, new_string
+ * - Write: toolName="write", text contains JSON with file_path, content
+ */
+
+import { useMemo, useState } from 'react';
+import { FileEdit, FilePlus2, File, ChevronRight, Loader2 } from 'lucide-react';
+import type { ParsedEntry } from '../../types';
+
+/** A parsed file change from transcript. */
+export interface FileChange {
+  /** Unique ID for this change. */
+  id: string;
+  /** File path. */
+  filePath: string;
+  /** Type of change. */
+  type: 'edit' | 'write';
+  /** Old content (for edits). */
+  oldContent: string | null;
+  /** New content. */
+  newContent: string;
+  /** Timestamp of the change. */
+  timestamp: string;
+}
+
+/** Parse file changes from transcript entries. */
+export function parseFileChanges(entries: ParsedEntry[]): FileChange[] {
+  const changes: FileChange[] = [];
+
+  for (const entry of entries) {
+    if (entry.contentType !== 'tool_use') continue;
+
+    const toolName = entry.toolName?.toLowerCase();
+    if (toolName !== 'edit' && toolName !== 'write') continue;
+
+    try {
+      // CC tool input is in the text field — try JSON parse
+      const input = JSON.parse(entry.text);
+      const filePath = input.file_path ?? input.path ?? '';
+
+      if (!filePath) continue;
+
+      if (toolName === 'edit') {
+        const oldStr = input.old_string ?? input.oldText ?? '';
+        const newStr = input.new_string ?? input.newText ?? '';
+        changes.push({
+          id: `${entry.toolUseId ?? entry.timestamp}-${filePath}`,
+          filePath,
+          type: 'edit',
+          oldContent: oldStr,
+          newContent: newStr,
+          timestamp: entry.timestamp ?? '',
+        });
+      } else if (toolName === 'write') {
+        changes.push({
+          id: `${entry.toolUseId ?? entry.timestamp}-${filePath}`,
+          filePath,
+          type: 'write',
+          oldContent: null,
+          newContent: input.content ?? '',
+          timestamp: entry.timestamp ?? '',
+        });
+      }
+    } catch {
+      // Not valid JSON — skip. Some tool_use entries have non-JSON text.
+      continue;
+    }
+  }
+
+  return changes;
+}
+
+/** Compute unified diff lines from old and new content. */
+export function computeDiff(oldContent: string | null, newContent: string): DiffLine[] {
+  const lines: DiffLine[] = [];
+
+  if (oldContent === null) {
+    // New file — all lines are additions
+    for (const line of newContent.split('\n')) {
+      lines.push({ type: 'add', content: line });
+    }
+    return lines;
+  }
+
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  // Simple line-by-line diff (LCS would be better but this works for now)
+  const maxLen = Math.max(oldLines.length, newLines.length);
+  for (let i = 0; i < maxLen; i++) {
+    const oldLine = i < oldLines.length ? oldLines[i] : undefined;
+    const newLine = i < newLines.length ? newLines[i] : undefined;
+
+    if (oldLine === undefined && newLine !== undefined) {
+      lines.push({ type: 'add', content: newLine });
+    } else if (oldLine !== undefined && newLine === undefined) {
+      lines.push({ type: 'remove', content: oldLine });
+    } else if (oldLine !== newLine) {
+      lines.push({ type: 'remove', content: oldLine! });
+      lines.push({ type: 'add', content: newLine! });
+    } else {
+      lines.push({ type: 'context', content: oldLine! });
+    }
+  }
+
+  return lines;
+}
+
+export interface DiffLine {
+  type: 'add' | 'remove' | 'context';
+  content: string;
+}
+
+export interface DiffViewerProps {
+  /** Transcript entries to parse for file changes. */
+  entries: ParsedEntry[];
+  /** Whether transcript is still loading. */
+  isLoading?: boolean;
+}
+
+export function DiffViewer({ entries, isLoading }: DiffViewerProps) {
+  const changes = useMemo(() => parseFileChanges(entries), [entries]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8" role="status" aria-busy="true">
+        <Loader2 className="h-4 w-4 animate-spin text-[var(--color-accent-cyan)]" />
+        <span className="ml-2 text-sm text-[var(--color-text-muted)]">Scanning transcript for file changes…</span>
+      </div>
+    );
+  }
+
+  if (changes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <File className="h-8 w-8 text-[var(--color-text-muted)] opacity-40" aria-hidden="true" />
+        <p className="mt-3 text-sm text-[var(--color-text-muted)]">No file changes detected in this session.</p>
+        <p className="mt-1 text-xs text-[var(--color-text-muted)] opacity-60">
+          Edit and Write operations will appear here as inline diffs.
+        </p>
+      </div>
+    );
+  }
+
+  const selectedChange = changes[selectedIndex];
+
+  return (
+    <div className="flex h-full min-h-[300px] divide-x divide-[var(--color-border-strong)]" role="region" aria-label="File diff viewer">
+      {/* File list sidebar */}
+      <nav className="w-56 shrink-0 overflow-y-auto bg-[var(--color-surface)]" aria-label="Changed files">
+        <div className="p-2">
+          <h3 className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+            {changes.length} file{changes.length !== 1 ? 's' : ''} changed
+          </h3>
+          <ul className="mt-1 space-y-0.5" role="listbox" aria-label="File list">
+            {changes.map((change, i) => (
+              <li key={change.id}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={i === selectedIndex}
+                  onClick={() => setSelectedIndex(i)}
+                  className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs transition-colors ${
+                    i === selectedIndex
+                      ? 'bg-[var(--color-accent-cyan)]/10 text-[var(--color-accent-cyan)]'
+                      : 'text-[var(--color-text-muted)] hover:bg-[var(--color-void-lighter)]'
+                  }`}
+                >
+                  {change.type === 'edit' ? (
+                    <FileEdit className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  ) : (
+                    <FilePlus2 className="h-3.5 w-3.5 shrink-0 text-[var(--color-success)]" aria-hidden="true" />
+                  )}
+                  <span className="truncate font-mono">{change.filePath.split('/').pop()}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </nav>
+
+      {/* Diff content */}
+      <div className="flex-1 overflow-auto bg-[var(--color-surface-strong)]">
+        {/* File header */}
+        <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-[var(--color-border-strong)] bg-[var(--color-surface)] px-4 py-2">
+          <ChevronRight className="h-3.5 w-3.5 text-[var(--color-text-muted)]" aria-hidden="true" />
+          <span className="font-mono text-xs text-[var(--color-text-primary)]">{selectedChange.filePath}</span>
+          <span className={`ml-2 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+            selectedChange.type === 'edit'
+              ? 'bg-amber-500/10 text-amber-400'
+              : 'bg-emerald-500/10 text-emerald-400'
+          }`}>
+            {selectedChange.type === 'edit' ? 'modified' : 'created'}
+          </span>
+        </div>
+
+        {/* Diff lines */}
+        <div className="p-0">
+          <DiffContent change={selectedChange} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DiffContent({ change }: { change: FileChange }) {
+  const diffLines = useMemo(() => computeDiff(change.oldContent, change.newContent), [change]);
+
+  return (
+    <pre className="text-xs leading-5 font-mono" role="presentation">
+      {diffLines.map((line, i) => (
+        <div
+          key={i}
+          className={`flex ${
+            line.type === 'add'
+              ? 'bg-emerald-500/10'
+              : line.type === 'remove'
+                ? 'bg-red-500/10'
+                : ''
+          }`}
+        >
+          <span className="w-8 shrink-0 select-none text-right pr-2 text-[var(--color-text-muted)] opacity-40">
+            {line.type === 'add' ? '+' : line.type === 'remove' ? '−' : ' '}
+          </span>
+          <span className={
+            line.type === 'add'
+              ? 'text-emerald-400'
+              : line.type === 'remove'
+                ? 'text-red-400'
+                : 'text-[var(--color-text-muted)]'
+          }>
+            {line.content}
+          </span>
+        </div>
+      ))}
+    </pre>
+  );
+}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -36,6 +36,7 @@ import { AcpApprovalModal } from '../components/session/AcpApprovalModal';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PendingQuestionCard } from '../components/session/PendingQuestionCard';
 import { PRStatusPanel } from '../components/session/PRStatusPanel';
+import { DiffViewer } from '../components/session/DiffViewer';
 import { PermissionPromptSheet } from '../components/session/PermissionPromptSheet';
 import SaveTemplateModal from '../components/SaveTemplateModal';
 import { sanitizeErrorMessage } from '../utils/sanitizeErrorMessage';
@@ -47,7 +48,7 @@ interface ScreenshotState {
   capturedAt: number;
 }
 
-type TabId = 'stream' | 'metrics' | 'audit' | 'timeline' | 'pr';
+type TabId = 'stream' | 'metrics' | 'audit' | 'timeline' | 'pr' | 'diff';
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'stream', label: 'Stream' },
@@ -55,6 +56,7 @@ const TABS: { id: TabId; label: string }[] = [
   { id: 'audit', label: 'Audit' },
   { id: 'timeline', label: 'Timeline' },
   { id: 'pr', label: 'PR' },
+  { id: 'diff', label: 'Diff' },
 ];
 
 const COMMON_SLASH_COMMANDS = ['/clear', '/compact', '/cost', '/config'] as const;
@@ -776,6 +778,26 @@ export default function SessionDetailPage() {
                   className="p-4"
                 >
                   <PRStatusPanel
+                    entries={prEntries}
+                    isLoading={prLoading}
+                  />
+                </motion.div>
+              )}
+
+              {activeTab === 'diff' && (
+                <motion.div
+                  key="panel-diff"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  transition={{ duration: 0.2 }}
+                  id="panel-diff"
+                  role="tabpanel"
+                  aria-labelledby="tab-diff"
+                  tabIndex={0}
+                  className="p-4"
+                >
+                  <DiffViewer
                     entries={prEntries}
                     isLoading={prLoading}
                   />


### PR DESCRIPTION
## Summary

Adds inline file diff viewer to session detail — the highest-impact gap from the competitive audit.

### What it does
- Parses `edit` tool_use entries → extracts file_path, old_string, new_string
- Parses `write` tool_use entries → extracts file_path, content (new file)
- **File list sidebar** — all changed files with edit/create icons
- **Inline diff view** — green (add) / red (remove) / gray (context) line highlighting
- Empty state when no file changes detected
- Loading state while transcript fetches

### New tab
`Diff` tab added to SessionDetailPage (6 tabs now: Stream | Metrics | Audit | Timeline | PR | **Diff**)

### Why this matters
CC Desktop and Claude Squad both prioritize **seeing what the agent changed** — diffs are first-class UI. Our dashboard showed *that* a session ran but not *what it did to files*. This closes that gap.

### Data source
- Reuses existing transcript fetch (same as PR tab)
- All parsing is client-side from ParsedEntry[] data
- No backend changes needed

### Testing
- 16 Vitest tests ✅ (6 parser + 5 diff engine + 5 component)
- tsc clean ✅
- Build passes ✅

Closes #2906.