### PR TITLE
feat(dashboard): routines page with calendar-style view

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -15,6 +15,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "canvas-confetti": "^1.9.4",
+        "date-fns": "^4.1.0",
         "dompurify": "^3.3.3",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.14.0",
@@ -1778,6 +1779,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/decimal.js": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,6 +22,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "canvas-confetti": "^1.9.4",
+    "date-fns": "^4.1.0",
     "dompurify": "^3.3.3",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.14.0",

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -28,6 +28,7 @@ const PipelinesPage = lazy(() => import('./pages/PipelinesPage'));
 const PipelineDetailPage = lazy(() => import('./pages/PipelineDetailPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const TemplatesPage = lazy(() => import('./pages/TemplatesPage'));
+const RoutinesPage = lazy(() => import('./pages/RoutinesPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 
 function LoadingFallback() {
@@ -189,6 +190,14 @@ export default function App() {
               element={
                 <Suspense fallback={<LoadingFallback />}>
                   <PipelineDetailPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/routines"
+              element={
+                <Suspense fallback={<LoadingFallback />}>
+                  <RoutinesPage />
                 </Suspense>
               }
             />

--- a/dashboard/src/__tests__/CalendarGrid.test.tsx
+++ b/dashboard/src/__tests__/CalendarGrid.test.tsx
@@ -1,88 +1,117 @@
 /**
- * CalendarGrid.test.tsx — Tests for the monthly calendar grid component.
+ * __tests__/CalendarGrid.test.tsx — Tests for CalendarGrid component.
+ *
+ * Verifies: month display, day rendering, routine highlighting, navigation.
+ * @ticket #2908
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import CalendarGrid from '../components/routines/CalendarGrid';
+import { CalendarGrid } from '../components/routines';
 import type { RoutineSchedule } from '../components/routines/CalendarGrid';
 
 const mockRoutines: RoutineSchedule[] = [
   {
-    id: 'r1',
-    title: 'Daily build',
-    cronSchedule: '0 9 * * *',
-    nextRunAt: '2026-05-10T09:00:00Z',
+    id: 'routine-1',
+    title: 'Daily standup',
+    cronSchedule: '0 9 * * MON-FRI',
+    nextRunAt: new Date().toISOString(),
     status: 'active',
   },
   {
-    id: 'r2',
-    title: 'Weekly report',
-    cronSchedule: '0 10 * * 1',
-    nextRunAt: '2026-05-12T10:00:00Z',
+    id: 'routine-2',
+    title: 'Weekly deploy',
+    cronSchedule: '0 14 * * FRI',
+    nextRunAt: new Date().toISOString(),
     status: 'paused',
   },
 ];
 
 describe('CalendarGrid', () => {
+  const defaultProps = {
+    routines: [] as RoutineSchedule[],
+    selectedDate: null as Date | null,
+    onSelectDate: vi.fn(),
+  };
+
+  it('renders the current month and year', () => {
+    render(<CalendarGrid {...defaultProps} />);
+    const now = new Date();
+    const expected = now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    expect(screen.getByText(expected)).toBeTruthy();
+  });
+
   it('renders weekday headers', () => {
-    render(
-      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
-    );
-    expect(screen.getByText('Mon')).not.toBeNull();
-    expect(screen.getByText('Sun')).not.toBeNull();
+    render(<CalendarGrid {...defaultProps} />);
+    ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].forEach((day) => {
+      expect(screen.getByText(day)).toBeTruthy();
+    });
   });
 
-  it('renders calendar grid with aria-label', () => {
-    render(
-      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
-    );
-    const grid = screen.getByRole('grid', { name: 'Calendar' });
-    expect(grid).not.toBeNull();
+  it('renders navigation buttons', () => {
+    render(<CalendarGrid {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /previous month/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /next month/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /go to today/i })).toBeTruthy();
   });
 
-  it('navigates to previous month without crashing', () => {
-    render(
-      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
+  it('calls onSelectDate when a day is clicked', () => {
+    const onSelectDate = vi.fn();
+    render(<CalendarGrid {...defaultProps} onSelectDate={onSelectDate} />);
+    // Click on any day button in current month
+    const dayButtons = screen.getAllByRole('button').filter(
+      (btn) => btn.textContent && /^\d+$/.test(btn.textContent.trim()) && !btn.disabled
     );
-    const prevBtn = screen.getByLabelText('Previous month');
-    fireEvent.click(prevBtn);
-    expect(screen.getByLabelText('Next month')).not.toBeNull();
+    if (dayButtons.length > 0) {
+      fireEvent.click(dayButtons[0]);
+      expect(onSelectDate).toHaveBeenCalledTimes(1);
+    }
   });
 
-  it('navigates to next month without crashing', () => {
-    render(
-      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
-    );
-    const nextBtn = screen.getByLabelText('Next month');
+  it('highlights days with routines', () => {
+    render(<CalendarGrid {...defaultProps} routines={mockRoutines} />);
+    // Both routines have nextRunAt = today, so today should show routine labels
+    expect(screen.getByText('Daily standup')).toBeTruthy();
+    expect(screen.getByText('Weekly deploy')).toBeTruthy();
+  });
+
+  it('shows routine count overflow indicator', () => {
+    const manyRoutines: RoutineSchedule[] = Array.from({ length: 4 }, (_, i) => ({
+      id: `r-${i}`,
+      title: `Routine ${i}`,
+      cronSchedule: '0 9 * * *',
+      nextRunAt: new Date().toISOString(),
+      status: 'active' as const,
+    }));
+    render(<CalendarGrid {...defaultProps} routines={manyRoutines} />);
+    expect(screen.getByText('+2 more')).toBeTruthy();
+  });
+
+  it('advances to next month when next button is clicked', () => {
+    render(<CalendarGrid {...defaultProps} />);
+    const nextBtn = screen.getByRole('button', { name: /next month/i });
     fireEvent.click(nextBtn);
-    expect(screen.getByLabelText('Previous month')).not.toBeNull();
+    // The month header should have changed
+    const now = new Date();
+    const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const expected = nextMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    expect(screen.getByText(expected)).toBeTruthy();
   });
 
-  it('goes to today when Today button is clicked', () => {
-    render(
-      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
-    );
-    fireEvent.click(screen.getByLabelText('Next month'));
-    fireEvent.click(screen.getByLabelText('Go to today'));
-    expect(screen.getByRole('grid', { name: 'Calendar' })).not.toBeNull();
+  it('returns to current month when Today is clicked', () => {
+    render(<CalendarGrid {...defaultProps} />);
+    // Go forward first
+    fireEvent.click(screen.getByRole('button', { name: /next month/i }));
+    // Then click Today
+    fireEvent.click(screen.getByRole('button', { name: /go to today/i }));
+    const now = new Date();
+    const expected = now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    expect(screen.getByText(expected)).toBeTruthy();
   });
 
-  it('renders with routines data without crashing', () => {
-    render(
-      <CalendarGrid
-        routines={mockRoutines}
-        selectedDate={null}
-        onSelectDate={() => {}}
-      />
-    );
-    expect(screen.getByRole('grid', { name: 'Calendar' })).not.toBeNull();
-  });
-
-  it('renders Today shortcut button', () => {
-    render(
-      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
-    );
-    expect(screen.getByLabelText('Go to today')).not.toBeNull();
+  it('marks today with aria-current="date"', () => {
+    const { container } = render(<CalendarGrid {...defaultProps} />);
+    const todayEl = container.querySelector('[aria-current="date"]');
+    expect(todayEl).toBeTruthy();
   });
 });

--- a/dashboard/src/__tests__/CalendarGrid.test.tsx
+++ b/dashboard/src/__tests__/CalendarGrid.test.tsx
@@ -60,8 +60,11 @@ describe('CalendarGrid', () => {
     render(<CalendarGrid {...defaultProps} onSelectDate={onSelectDate} />);
     // Click on any day button in current month
     const dayButtons = screen.getAllByRole('button').filter(
-      (btn) => btn.textContent && /^\d+$/.test(btn.textContent.trim()) && !btn.disabled
-    );
+      (btn) => {
+        const el = btn as HTMLButtonElement;
+        return el.textContent != null && /^\d+$/.test(el.textContent.trim()) && !el.disabled;
+      }
+    ) as HTMLButtonElement[];
     if (dayButtons.length > 0) {
       fireEvent.click(dayButtons[0]);
       expect(onSelectDate).toHaveBeenCalledTimes(1);

--- a/dashboard/src/__tests__/CalendarGrid.test.tsx
+++ b/dashboard/src/__tests__/CalendarGrid.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * CalendarGrid.test.tsx — Tests for the monthly calendar grid component.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CalendarGrid from '../components/routines/CalendarGrid';
+import type { RoutineSchedule } from '../components/routines/CalendarGrid';
+
+const mockRoutines: RoutineSchedule[] = [
+  {
+    id: 'r1',
+    title: 'Daily build',
+    cronSchedule: '0 9 * * *',
+    nextRunAt: '2026-05-10T09:00:00Z',
+    status: 'active',
+  },
+  {
+    id: 'r2',
+    title: 'Weekly report',
+    cronSchedule: '0 10 * * 1',
+    nextRunAt: '2026-05-12T10:00:00Z',
+    status: 'paused',
+  },
+];
+
+describe('CalendarGrid', () => {
+  it('renders weekday headers', () => {
+    render(
+      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
+    );
+    expect(screen.getByText('Mon')).not.toBeNull();
+    expect(screen.getByText('Sun')).not.toBeNull();
+  });
+
+  it('renders calendar grid with aria-label', () => {
+    render(
+      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
+    );
+    const grid = screen.getByRole('grid', { name: 'Calendar' });
+    expect(grid).not.toBeNull();
+  });
+
+  it('navigates to previous month without crashing', () => {
+    render(
+      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
+    );
+    const prevBtn = screen.getByLabelText('Previous month');
+    fireEvent.click(prevBtn);
+    expect(screen.getByLabelText('Next month')).not.toBeNull();
+  });
+
+  it('navigates to next month without crashing', () => {
+    render(
+      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
+    );
+    const nextBtn = screen.getByLabelText('Next month');
+    fireEvent.click(nextBtn);
+    expect(screen.getByLabelText('Previous month')).not.toBeNull();
+  });
+
+  it('goes to today when Today button is clicked', () => {
+    render(
+      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
+    );
+    fireEvent.click(screen.getByLabelText('Next month'));
+    fireEvent.click(screen.getByLabelText('Go to today'));
+    expect(screen.getByRole('grid', { name: 'Calendar' })).not.toBeNull();
+  });
+
+  it('renders with routines data without crashing', () => {
+    render(
+      <CalendarGrid
+        routines={mockRoutines}
+        selectedDate={null}
+        onSelectDate={() => {}}
+      />
+    );
+    expect(screen.getByRole('grid', { name: 'Calendar' })).not.toBeNull();
+  });
+
+  it('renders Today shortcut button', () => {
+    render(
+      <CalendarGrid routines={[]} selectedDate={null} onSelectDate={() => {}} />
+    );
+    expect(screen.getByLabelText('Go to today')).not.toBeNull();
+  });
+});

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -490,10 +490,10 @@ describe('Layout sidebar', () => {
     expect(screen.queryByText('New Session')).toBeNull();
     expect(screen.queryByText('Audit Trail')).toBeNull();
 
-    // Count nav links (10 main in nav: 4 workspace + 5 operations + 1 admin)
+    // Count nav links (11 main in nav: 4 workspace + 6 operations + 1 admin)
     const nav = document.querySelector('nav[aria-label="Main navigation"]');
     const links = nav?.querySelectorAll('a');
-    expect(links?.length).toBe(10);
+    expect(links?.length).toBe(11);
   });
 
   it('Settings nav link is rendered in sidebar footer', () => {

--- a/dashboard/src/__tests__/RoutineCard.test.tsx
+++ b/dashboard/src/__tests__/RoutineCard.test.tsx
@@ -1,5 +1,8 @@
 /**
- * RoutineCard.test.tsx — Tests for the routine display card component.
+ * __tests__/RoutineCard.test.tsx — Tests for RoutineCard component.
+ *
+ * Verifies: title display, status badge, action buttons, next run time.
+ * @ticket #2908
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -8,74 +11,87 @@ import RoutineCard from '../components/routines/RoutineCard';
 import type { RoutineSchedule } from '../components/routines/CalendarGrid';
 
 const activeRoutine: RoutineSchedule = {
-  id: 'r1',
-  title: 'Daily build',
-  cronSchedule: '0 9 * * *',
-  nextRunAt: new Date(Date.now() + 3600000).toISOString(),
+  id: 'routine-1',
+  title: 'Daily standup',
+  cronSchedule: '0 9 * * MON-FRI',
+  nextRunAt: new Date(Date.now() + 3600000).toISOString(), // 1h from now
   status: 'active',
 };
 
 const pausedRoutine: RoutineSchedule = {
-  id: 'r2',
-  title: 'Weekly report',
-  cronSchedule: '0 10 * * 1',
-  nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+  id: 'routine-2',
+  title: 'Weekly deploy',
+  cronSchedule: '0 14 * * FRI',
+  nextRunAt: new Date(Date.now() + 86400000).toISOString(), // 1d from now
   status: 'paused',
 };
 
 describe('RoutineCard', () => {
-  it('renders routine title', () => {
+  it('renders the routine title', () => {
     render(<RoutineCard routine={activeRoutine} />);
-    expect(screen.getByText('Daily build')).not.toBeNull();
+    expect(screen.getByText('Daily standup')).toBeTruthy();
   });
 
-  it('renders cron schedule', () => {
+  it('shows active status badge for active routine', () => {
     render(<RoutineCard routine={activeRoutine} />);
-    expect(screen.getByText('0 9 * * *')).not.toBeNull();
+    expect(screen.getByText('Active')).toBeTruthy();
   });
 
-  it('shows Active status for active routine', () => {
-    render(<RoutineCard routine={activeRoutine} />);
-    expect(screen.getByText('Active')).not.toBeNull();
-  });
-
-  it('shows Paused status for paused routine', () => {
+  it('shows paused status badge for paused routine', () => {
     render(<RoutineCard routine={pausedRoutine} />);
-    expect(screen.getByText('Paused')).not.toBeNull();
+    expect(screen.getByText('Paused')).toBeTruthy();
   });
 
-  it('calls onTogglePause when pause button clicked', () => {
-    const handleToggle = vi.fn();
-    render(<RoutineCard routine={activeRoutine} onTogglePause={handleToggle} />);
-    fireEvent.click(screen.getByLabelText('Pause routine'));
-    expect(handleToggle).toHaveBeenCalledWith('r1');
-  });
-
-  it('calls onTogglePause (resume) for paused routine', () => {
-    const handleToggle = vi.fn();
-    render(<RoutineCard routine={pausedRoutine} onTogglePause={handleToggle} />);
-    fireEvent.click(screen.getByLabelText('Resume routine'));
-    expect(handleToggle).toHaveBeenCalledWith('r2');
-  });
-
-  it('calls onTriggerNow when trigger button clicked', () => {
-    const handleTrigger = vi.fn();
-    render(<RoutineCard routine={activeRoutine} onTriggerNow={handleTrigger} />);
-    fireEvent.click(screen.getByLabelText('Trigger routine now'));
-    expect(handleTrigger).toHaveBeenCalledWith('r1');
-  });
-
-  it('calls onDelete when delete button clicked', () => {
-    const handleDelete = vi.fn();
-    render(<RoutineCard routine={activeRoutine} onDelete={handleDelete} />);
-    fireEvent.click(screen.getByLabelText('Delete routine'));
-    expect(handleDelete).toHaveBeenCalledWith('r1');
-  });
-
-  it('has routine article role with aria-label', () => {
+  it('displays the cron schedule', () => {
     render(<RoutineCard routine={activeRoutine} />);
-    const article = screen.getByRole('article');
-    expect(article).not.toBeNull();
-    expect(article.getAttribute('aria-label')).toContain('Daily build');
+    expect(screen.getByText('0 9 * * MON-FRI')).toBeTruthy();
+  });
+
+  it('renders pause button for active routine', () => {
+    render(<RoutineCard routine={activeRoutine} />);
+    expect(screen.getByRole('button', { name: /pause routine/i })).toBeTruthy();
+  });
+
+  it('renders resume button for paused routine', () => {
+    render(<RoutineCard routine={pausedRoutine} />);
+    expect(screen.getByRole('button', { name: /resume routine/i })).toBeTruthy();
+  });
+
+  it('renders trigger now button', () => {
+    render(<RoutineCard routine={activeRoutine} />);
+    expect(screen.getByRole('button', { name: /trigger routine now/i })).toBeTruthy();
+  });
+
+  it('renders delete button', () => {
+    render(<RoutineCard routine={activeRoutine} />);
+    expect(screen.getByRole('button', { name: /delete routine/i })).toBeTruthy();
+  });
+
+  it('calls onTogglePause when pause button is clicked', () => {
+    const onTogglePause = vi.fn();
+    render(<RoutineCard routine={activeRoutine} onTogglePause={onTogglePause} />);
+    fireEvent.click(screen.getByRole('button', { name: /pause routine/i }));
+    expect(onTogglePause).toHaveBeenCalledWith('routine-1');
+  });
+
+  it('calls onTriggerNow when trigger button is clicked', () => {
+    const onTriggerNow = vi.fn();
+    render(<RoutineCard routine={activeRoutine} onTriggerNow={onTriggerNow} />);
+    fireEvent.click(screen.getByRole('button', { name: /trigger routine now/i }));
+    expect(onTriggerNow).toHaveBeenCalledWith('routine-1');
+  });
+
+  it('calls onDelete when delete button is clicked', () => {
+    const onDelete = vi.fn();
+    render(<RoutineCard routine={activeRoutine} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole('button', { name: /delete routine/i }));
+    expect(onDelete).toHaveBeenCalledWith('routine-1');
+  });
+
+  it('does not show next run time for paused routine', () => {
+    render(<RoutineCard routine={pausedRoutine} />);
+    // Paused routines don't show the clock/next run
+    const clockIcon = screen.queryByTitle('Next run');
+    expect(clockIcon).toBeNull();
   });
 });

--- a/dashboard/src/__tests__/RoutineCard.test.tsx
+++ b/dashboard/src/__tests__/RoutineCard.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * RoutineCard.test.tsx — Tests for the routine display card component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RoutineCard from '../components/routines/RoutineCard';
+import type { RoutineSchedule } from '../components/routines/CalendarGrid';
+
+const activeRoutine: RoutineSchedule = {
+  id: 'r1',
+  title: 'Daily build',
+  cronSchedule: '0 9 * * *',
+  nextRunAt: new Date(Date.now() + 3600000).toISOString(),
+  status: 'active',
+};
+
+const pausedRoutine: RoutineSchedule = {
+  id: 'r2',
+  title: 'Weekly report',
+  cronSchedule: '0 10 * * 1',
+  nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+  status: 'paused',
+};
+
+describe('RoutineCard', () => {
+  it('renders routine title', () => {
+    render(<RoutineCard routine={activeRoutine} />);
+    expect(screen.getByText('Daily build')).not.toBeNull();
+  });
+
+  it('renders cron schedule', () => {
+    render(<RoutineCard routine={activeRoutine} />);
+    expect(screen.getByText('0 9 * * *')).not.toBeNull();
+  });
+
+  it('shows Active status for active routine', () => {
+    render(<RoutineCard routine={activeRoutine} />);
+    expect(screen.getByText('Active')).not.toBeNull();
+  });
+
+  it('shows Paused status for paused routine', () => {
+    render(<RoutineCard routine={pausedRoutine} />);
+    expect(screen.getByText('Paused')).not.toBeNull();
+  });
+
+  it('calls onTogglePause when pause button clicked', () => {
+    const handleToggle = vi.fn();
+    render(<RoutineCard routine={activeRoutine} onTogglePause={handleToggle} />);
+    fireEvent.click(screen.getByLabelText('Pause routine'));
+    expect(handleToggle).toHaveBeenCalledWith('r1');
+  });
+
+  it('calls onTogglePause (resume) for paused routine', () => {
+    const handleToggle = vi.fn();
+    render(<RoutineCard routine={pausedRoutine} onTogglePause={handleToggle} />);
+    fireEvent.click(screen.getByLabelText('Resume routine'));
+    expect(handleToggle).toHaveBeenCalledWith('r2');
+  });
+
+  it('calls onTriggerNow when trigger button clicked', () => {
+    const handleTrigger = vi.fn();
+    render(<RoutineCard routine={activeRoutine} onTriggerNow={handleTrigger} />);
+    fireEvent.click(screen.getByLabelText('Trigger routine now'));
+    expect(handleTrigger).toHaveBeenCalledWith('r1');
+  });
+
+  it('calls onDelete when delete button clicked', () => {
+    const handleDelete = vi.fn();
+    render(<RoutineCard routine={activeRoutine} onDelete={handleDelete} />);
+    fireEvent.click(screen.getByLabelText('Delete routine'));
+    expect(handleDelete).toHaveBeenCalledWith('r1');
+  });
+
+  it('has routine article role with aria-label', () => {
+    render(<RoutineCard routine={activeRoutine} />);
+    const article = screen.getByRole('article');
+    expect(article).not.toBeNull();
+    expect(article.getAttribute('aria-label')).toContain('Daily build');
+  });
+});

--- a/dashboard/src/__tests__/RoutinesPage.test.tsx
+++ b/dashboard/src/__tests__/RoutinesPage.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * RoutinesPage.test.tsx — Tests for the Routines page scaffold.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RoutinesPage from '../pages/RoutinesPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RoutinesPage />
+    </MemoryRouter>
+  );
+}
+
+describe('RoutinesPage', () => {
+  it('renders page heading', () => {
+    renderPage();
+    expect(screen.getByText('Routines')).not.toBeNull();
+  });
+
+  it('renders empty state when no routines', () => {
+    renderPage();
+    expect(screen.getByText('No routines yet')).not.toBeNull();
+  });
+
+  it('renders New Routine button', () => {
+    renderPage();
+    expect(screen.getByLabelText('Create new routine')).not.toBeNull();
+  });
+
+  it('renders calendar grid', () => {
+    renderPage();
+    expect(screen.getByRole('grid', { name: 'Calendar' })).not.toBeNull();
+  });
+
+  it('renders weekday headers in calendar', () => {
+    renderPage();
+    expect(screen.getByText('Mon')).not.toBeNull();
+    expect(screen.getByText('Sun')).not.toBeNull();
+  });
+
+  it('renders sidebar with Upcoming label', () => {
+    renderPage();
+    expect(screen.getByText('Upcoming')).not.toBeNull();
+  });
+});

--- a/dashboard/src/__tests__/RoutinesPage.test.tsx
+++ b/dashboard/src/__tests__/RoutinesPage.test.tsx
@@ -1,49 +1,65 @@
 /**
- * RoutinesPage.test.tsx — Tests for the Routines page scaffold.
+ * __tests__/RoutinesPage.test.tsx — Tests for the RoutinesPage scaffold.
+ *
+ * Verifies: empty state rendering, navigation elements, calendar presence.
+ * @ticket #2908
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import RoutinesPage from '../pages/RoutinesPage';
 
-function renderPage() {
-  return render(
-    <MemoryRouter>
-      <RoutinesPage />
-    </MemoryRouter>
-  );
+// Mock useAuthStore so ProtectedRoute doesn't redirect
+vi.mock('../store/useAuthStore', () => ({
+  useAuthStore: vi.fn(() => ({ isAuthenticated: true })),
+}));
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
 }
 
 describe('RoutinesPage', () => {
-  it('renders page heading', () => {
-    renderPage();
-    expect(screen.getByText('Routines')).not.toBeNull();
+  it('renders the page title', () => {
+    renderWithRouter(<RoutinesPage />);
+    expect(screen.getByText('Routines')).toBeTruthy();
   });
 
-  it('renders empty state when no routines', () => {
-    renderPage();
-    expect(screen.getByText('No routines yet')).not.toBeNull();
+  it('renders the subtitle description', () => {
+    renderWithRouter(<RoutinesPage />);
+    expect(screen.getByText('Scheduled tasks that run on a recurring basis')).toBeTruthy();
   });
 
-  it('renders New Routine button', () => {
-    renderPage();
-    expect(screen.getByLabelText('Create new routine')).not.toBeNull();
+  it('shows the New Routine button', () => {
+    renderWithRouter(<RoutinesPage />);
+    expect(screen.getByRole('button', { name: /create new routine/i })).toBeTruthy();
   });
 
-  it('renders calendar grid', () => {
-    renderPage();
-    expect(screen.getByRole('grid', { name: 'Calendar' })).not.toBeNull();
+  it('shows empty state when no routines exist', () => {
+    renderWithRouter(<RoutinesPage />);
+    expect(screen.getByText('No routines yet')).toBeTruthy();
   });
 
-  it('renders weekday headers in calendar', () => {
-    renderPage();
-    expect(screen.getByText('Mon')).not.toBeNull();
-    expect(screen.getByText('Sun')).not.toBeNull();
+  it('renders the calendar grid', () => {
+    renderWithRouter(<RoutinesPage />);
+    // Calendar grid has role="grid" with aria-label="Calendar"
+    expect(screen.getByRole('grid', { name: 'Calendar' })).toBeTruthy();
   });
 
-  it('renders sidebar with Upcoming label', () => {
-    renderPage();
-    expect(screen.getByText('Upcoming')).not.toBeNull();
+  it('renders weekday headers', () => {
+    renderWithRouter(<RoutinesPage />);
+    expect(screen.getByText('Mon')).toBeTruthy();
+    expect(screen.getByText('Sun')).toBeTruthy();
+  });
+
+  it('renders Today button in calendar header', () => {
+    renderWithRouter(<RoutinesPage />);
+    expect(screen.getByRole('button', { name: /go to today/i })).toBeTruthy();
+  });
+
+  it('renders month navigation buttons', () => {
+    renderWithRouter(<RoutinesPage />);
+    expect(screen.getByRole('button', { name: /previous month/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /next month/i })).toBeTruthy();
   });
 });

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -14,6 +14,7 @@ import { NewSessionDrawer } from './NewSessionDrawer';
 import { Sun, Moon, Plus, Search } from 'lucide-react';
 import {
   Activity,
+  Calendar,
   AlertTriangle,
   BarChart3,
   ChevronLeft,
@@ -60,6 +61,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: '/sessions', label: 'Sessions', icon: Terminal },
       { to: '/templates', label: 'Templates', icon: FileText },
       { to: '/pipelines', label: 'Pipelines', icon: Activity },
+      { to: '/routines', label: 'Routines', icon: Calendar },
     ],
   },
   {

--- a/dashboard/src/components/routines/CalendarGrid.tsx
+++ b/dashboard/src/components/routines/CalendarGrid.tsx
@@ -1,0 +1,183 @@
+/**
+ * components/routines/CalendarGrid.tsx — Monthly calendar grid for the Routines page.
+ *
+ * Displays a month view with clickable days. Days with scheduled routines
+ * are highlighted. Navigation between months via prev/next buttons.
+ */
+
+import { useMemo, useCallback, useState } from 'react';
+import {
+  format,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  eachDayOfInterval,
+  isSameMonth,
+  isSameDay,
+  isToday,
+  addMonths,
+  subMonths,
+} from 'date-fns';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+export interface RoutineSchedule {
+  id: string;
+  title: string;
+  cronSchedule: string;
+  nextRunAt: string;
+  status: 'active' | 'paused';
+}
+
+interface CalendarGridProps {
+  routines: RoutineSchedule[];
+  selectedDate: Date | null;
+  onSelectDate: (date: Date) => void;
+  className?: string;
+}
+
+const WEEKDAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+export default function CalendarGrid({
+  routines,
+  selectedDate,
+  onSelectDate,
+  className = '',
+}: CalendarGridProps) {
+  const [currentMonth, setCurrentMonth] = useState(() => new Date());
+
+  const days = useMemo(() => {
+    const monthStart = startOfMonth(currentMonth);
+    const monthEnd = endOfMonth(currentMonth);
+    const calStart = startOfWeek(monthStart, { weekStartsOn: 1 });
+    const calEnd = endOfWeek(monthEnd, { weekStartsOn: 1 });
+    return eachDayOfInterval({ start: calStart, end: calEnd });
+  }, [currentMonth]);
+
+  // Build a map of dates that have routines scheduled
+  const routineDates = useMemo(() => {
+    const map = new Map<string, RoutineSchedule[]>();
+    for (const r of routines) {
+      const key = format(new Date(r.nextRunAt), 'yyyy-MM-dd');
+      const existing = map.get(key) ?? [];
+      existing.push(r);
+      map.set(key, existing);
+    }
+    return map;
+  }, [routines]);
+
+  const handlePrevMonth = useCallback(() => {
+    setCurrentMonth((prev) => subMonths(prev, 1));
+  }, []);
+
+  const handleNextMonth = useCallback(() => {
+    setCurrentMonth((prev) => addMonths(prev, 1));
+  }, []);
+
+  const handleToday = useCallback(() => {
+    setCurrentMonth(new Date());
+  }, []);
+
+  return (
+    <div className={`rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)]">
+        <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+          {format(currentMonth, 'MMMM yyyy')}
+        </h3>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={handleToday}
+            className="px-2 py-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors rounded"
+            aria-label="Go to today"
+          >
+            Today
+          </button>
+          <button
+            onClick={handlePrevMonth}
+            className="p-1 rounded hover:bg-[var(--color-void-dark)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+            aria-label="Previous month"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+          <button
+            onClick={handleNextMonth}
+            className="p-1 rounded hover:bg-[var(--color-void-dark)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+            aria-label="Next month"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 border-b border-[var(--color-border)]" role="row">
+        {WEEKDAY_LABELS.map((day) => (
+          <div
+            key={day}
+            className="px-2 py-2 text-center text-xs font-medium text-[var(--color-text-muted)]"
+            role="columnheader"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Day cells */}
+      <div className="grid grid-cols-7" role="grid" aria-label="Calendar">
+        {days.map((day) => {
+          const dateKey = format(day, 'yyyy-MM-dd');
+          const dayRoutines = routineDates.get(dateKey);
+          const hasRoutines = dayRoutines && dayRoutines.length > 0;
+          const inCurrentMonth = isSameMonth(day, currentMonth);
+          const isSelected = selectedDate && isSameDay(day, selectedDate);
+          const today = isToday(day);
+
+          return (
+            <button
+              key={dateKey}
+              onClick={() => onSelectDate(day)}
+              disabled={!inCurrentMonth}
+              className={`
+                relative p-2 min-h-[4rem] text-left transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset
+                ${!inCurrentMonth ? 'opacity-30 cursor-default' : 'hover:bg-[var(--color-void-dark)] cursor-pointer'}
+                ${isSelected ? 'bg-blue-500/10 ring-1 ring-blue-500/30' : ''}
+              `}
+              aria-label={`${format(day, 'EEEE, MMMM d, yyyy')}${hasRoutines ? `, ${dayRoutines.length} routine${dayRoutines.length > 1 ? 's' : ''}` : ''}`}
+              aria-current={today ? 'date' : undefined}
+            >
+              <span
+                className={`
+                  text-sm font-medium
+                  ${today ? 'text-blue-400' : inCurrentMonth ? 'text-[var(--color-text-primary)]' : 'text-[var(--color-text-muted)]'}
+                `}
+              >
+                {format(day, 'd')}
+              </span>
+              {hasRoutines && (
+                <div className="mt-1 flex flex-col gap-0.5">
+                  {dayRoutines.slice(0, 2).map((r) => (
+                    <span
+                      key={r.id}
+                      className={`
+                        text-[10px] leading-tight truncate px-1 py-0.5 rounded
+                        ${r.status === 'active' ? 'bg-green-500/20 text-green-400' : 'bg-amber-500/20 text-amber-400'}
+                      `}
+                    >
+                      {r.title}
+                    </span>
+                  ))}
+                  {dayRoutines.length > 2 && (
+                    <span className="text-[10px] text-[var(--color-text-muted)] px-1">
+                      +{dayRoutines.length - 2} more
+                    </span>
+                  )}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/routines/RoutineCard.tsx
+++ b/dashboard/src/components/routines/RoutineCard.tsx
@@ -1,0 +1,116 @@
+/**
+ * components/routines/RoutineCard.tsx — Single routine display card.
+ *
+ * Shows routine title, schedule, next run time, status badge,
+ * and quick action buttons (pause/resume, trigger-now, delete).
+ */
+
+import { Play, Pause, Zap, Trash2, Clock, Repeat } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import type { RoutineSchedule } from './CalendarGrid';
+
+interface RoutineCardProps {
+  routine: RoutineSchedule;
+  onTogglePause?: (id: string) => void;
+  onTriggerNow?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  className?: string;
+}
+
+export default function RoutineCard({
+  routine,
+  onTogglePause,
+  onTriggerNow,
+  onDelete,
+  className = '',
+}: RoutineCardProps) {
+  const isActive = routine.status === 'active';
+  const nextRunLabel = (() => {
+    try {
+      return formatDistanceToNow(new Date(routine.nextRunAt), { addSuffix: true });
+    } catch {
+      return 'N/A';
+    }
+  })();
+
+  return (
+    <div
+      className={`
+        rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]
+        p-4 transition-colors hover:border-[var(--color-border-hover)]
+        ${className}
+      `}
+      role="article"
+      aria-label={`Routine: ${routine.title}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h4 className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
+              {routine.title}
+            </h4>
+            <span
+              className={`
+                inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium
+                ${isActive
+                  ? 'bg-green-500/20 text-green-400'
+                  : 'bg-amber-500/20 text-amber-400'
+                }
+              `}
+              aria-label={isActive ? 'Active' : 'Paused'}
+            >
+              <span className={`w-1.5 h-1.5 rounded-full ${isActive ? 'bg-green-400' : 'bg-amber-400'}`} />
+              {isActive ? 'Active' : 'Paused'}
+            </span>
+          </div>
+          <div className="mt-2 flex items-center gap-4 text-xs text-[var(--color-text-muted)]">
+            <span className="flex items-center gap-1" title="Cron schedule">
+              <Repeat className="w-3 h-3" />
+              <code className="font-mono text-[11px]">{routine.cronSchedule}</code>
+            </span>
+            {isActive && (
+              <span className="flex items-center gap-1" title="Next run">
+                <Clock className="w-3 h-3" />
+                {nextRunLabel}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Quick actions */}
+        <div className="flex items-center gap-1" role="group" aria-label="Routine actions">
+          <button
+            onClick={() => onTogglePause?.(routine.id)}
+            className={`
+              p-1.5 rounded transition-colors
+              ${isActive
+                ? 'text-amber-400 hover:bg-amber-500/10'
+                : 'text-green-400 hover:bg-green-500/10'
+              }
+            `}
+            aria-label={isActive ? 'Pause routine' : 'Resume routine'}
+            title={isActive ? 'Pause' : 'Resume'}
+          >
+            {isActive ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+          </button>
+          <button
+            onClick={() => onTriggerNow?.(routine.id)}
+            className="p-1.5 rounded text-blue-400 hover:bg-blue-500/10 transition-colors"
+            aria-label="Trigger routine now"
+            title="Run now"
+          >
+            <Zap className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => onDelete?.(routine.id)}
+            className="p-1.5 rounded text-red-400 hover:bg-red-500/10 transition-colors"
+            aria-label="Delete routine"
+            title="Delete"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/routines/index.ts
+++ b/dashboard/src/components/routines/index.ts
@@ -1,0 +1,3 @@
+export { default as CalendarGrid } from './CalendarGrid';
+export type { RoutineSchedule } from './CalendarGrid';
+export { default as RoutineCard } from './RoutineCard';

--- a/dashboard/src/pages/RoutinesPage.tsx
+++ b/dashboard/src/pages/RoutinesPage.tsx
@@ -1,0 +1,135 @@
+/**
+ * pages/RoutinesPage.tsx — Scheduled tasks / routines with calendar-style view.
+ *
+ * Phase 1 scaffold: Calendar UI with empty states.
+ * Backend API endpoints for routines will be added in Phase 2.
+ *
+ * Related: #2908
+ */
+
+import { useState, useCallback } from 'react';
+import { Calendar, Plus } from 'lucide-react';
+import EmptyState from '../components/shared/EmptyState';
+import { CalendarGrid } from '../components/routines';
+import RoutineCard from '../components/routines/RoutineCard';
+import type { RoutineSchedule } from '../components/routines/CalendarGrid';
+
+export default function RoutinesPage() {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  // Phase 1: No backend yet — routines will come from API in Phase 2
+  const routines: RoutineSchedule[] = [];
+  const loading = false;
+
+  const handleTogglePause = useCallback((_id: string) => {
+    // Phase 2: Call API to pause/resume
+  }, []);
+
+  const handleTriggerNow = useCallback((_id: string) => {
+    // Phase 2: Call API to trigger immediate run
+  }, []);
+
+  const handleDelete = useCallback((_id: string) => {
+    // Phase 2: Call API to delete routine
+  }, []);
+
+  const handleCreate = useCallback(() => {
+    // Phase 2: Open create routine modal
+  }, []);
+
+  // Empty state — no routines yet
+  if (!loading && routines.length === 0) {
+    return (
+      <div className="p-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-[var(--color-text-primary)]">Routines</h1>
+            <p className="text-sm text-[var(--color-text-muted)] mt-1">
+              Scheduled tasks that run on a recurring basis
+            </p>
+          </div>
+          <button
+            onClick={handleCreate}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]"
+            aria-label="Create new routine"
+          >
+            <Plus className="w-4 h-4" />
+            New Routine
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Calendar takes 2 columns */}
+          <div className="lg:col-span-2">
+            <CalendarGrid
+              routines={routines}
+              selectedDate={selectedDate}
+              onSelectDate={setSelectedDate}
+            />
+          </div>
+
+          {/* Sidebar: routines list */}
+          <div className="space-y-4">
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+              {selectedDate ? `Routines for selected date` : 'Upcoming'}
+            </h2>
+            <EmptyState
+              icon={<Calendar className="w-8 h-8" />}
+              title="No routines yet"
+              description="Create a routine to schedule recurring tasks on a calendar."
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Populated state — routines exist
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-[var(--color-text-primary)]">Routines</h1>
+          <p className="text-sm text-[var(--color-text-muted)] mt-1">
+            {routines.length} scheduled task{routines.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+        <button
+          onClick={handleCreate}
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]"
+          aria-label="Create new routine"
+        >
+          <Plus className="w-4 h-4" />
+          New Routine
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Calendar */}
+        <div className="lg:col-span-2">
+          <CalendarGrid
+            routines={routines}
+            selectedDate={selectedDate}
+            onSelectDate={setSelectedDate}
+          />
+        </div>
+
+        {/* Sidebar: routine cards */}
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+            {selectedDate ? 'Routines for selected date' : 'All routines'}
+          </h2>
+          {routines.map((routine) => (
+            <RoutineCard
+              key={routine.id}
+              routine={routine}
+              onTogglePause={handleTogglePause}
+              onTriggerNow={handleTriggerNow}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 1 scaffold for the Routines page — scheduled tasks with calendar-style view.

Closes #2908

## Changes

### New Components
- **RoutinesPage** (`pages/RoutinesPage.tsx`) — Calendar grid layout with sidebar routine cards, empty state, create button
- **CalendarGrid** (`components/routines/CalendarGrid.tsx`) — Monthly calendar view with navigation, routine highlights, date selection
- **RoutineCard** (`components/routines/RoutineCard.tsx`) — Single routine display with status badge, cron schedule, quick actions

### New Dependency
- **`date-fns ^4.1.0`** — Lightweight, tree-shakeable date utility for calendar calculations

### Route & Navigation
- `/routines` route added to `App.tsx`
- "Routines" entry added to sidebar nav (WORKSPACE group, Calendar icon)

### Tests
- 29 Vitest tests across 3 test files
- tsc ✅ | build ✅ | 1194/1194 dashboard tests pass ✅

## Backend (Phase 2 — future PR)
- CRUD API for routines
- Cron execution engine
- Session integration for routine runs

## Screenshots
_This is a scaffold with empty states — calendar grid renders correctly with month navigation._