### PR TITLE
fix(dashboard): SessionHistoryPage heading hierarchy — h2 to h1

### DIFF
--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -393,7 +393,7 @@ export default function SessionHistoryPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-[var(--color-text-primary)]">Session History</h2>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Session History</h1>
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">Merged audit and live session lifecycle records</p>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Closes #2933

Fixes heading hierarchy on SessionHistoryPage: changes `h2` "Session History" to `h1`. Also replaces hardcoded `text-gray-900` with CSS variable `text-[var(--color-text-primary)]`.

## Full Heading Audit

| Page | h1 Count | Status |
|------|----------|--------|
| ActivityPage | 1 | ✅ |
| AnalyticsPage | 1 | ✅ |
| AuditPage | 1 | ✅ |
| AuthKeysPage | 1 | ✅ |
| CostPage | 4 (one per render path) | ✅ |
| LoginPage | 1 | ✅ |
| MetricsPage | 1 | ✅ |
| OverviewPage | 1 | ✅ |
| PipelinesPage | 1 | ✅ |
| RoutinesPage | 2 (one per render path) | ✅ |
| SessionDetailPage | 1 (via SessionHeader) | ✅ |
| SessionHistoryPage | 1 | ✅ (this PR) |
| SessionsPage | 1 | ✅ |
| SettingsPage | 1 | ✅ |
| TemplatesPage | 1 | ✅ |

## Quality Gates
- [x] `tsc --noEmit` — zero errors
- [x] `npm run build` — success
- [x] 1 file changed, 1 insertion, 1 deletion