### PR TITLE
fix(ci): skip postinstall-verify in published package installs

### DIFF
--- a/scripts/postinstall-verify.cjs
+++ b/scripts/postinstall-verify.cjs
@@ -8,16 +8,23 @@ const fs = require('fs');
 const path = require('path');
 
 const root = path.resolve(__dirname, '..');
+
+// When installed as a dependency (npm install @onestepat4time/aegis), there is
+// no package-lock.json in the installed location. The checks below are only
+// meaningful in the source/development checkout. Skip entirely for published
+// package installs to avoid false failures in CI dry-run and downstream consumers.
 const lockPath = path.join(root, 'package-lock.json');
+if (!fs.existsSync(lockPath)) {
+  // Not a source checkout — skip integrity checks.
+  console.log('ℹ️  postinstall-verify: skipping (installed package, not source checkout)');
+  process.exit(0);
+}
+
 const integrityPath = path.join(root, 'node_modules', '.package-lock.json');
 
 let errors = 0;
 
 // 1. Check lockfile exists in node_modules (npm install creates this)
-if (!fs.existsSync(lockPath)) {
-  console.error('❌ postinstall-verify: package-lock.json missing');
-  errors++;
-}
 if (!fs.existsSync(integrityPath)) {
   console.error('❌ postinstall-verify: node_modules/.package-lock.json missing — install may be incomplete');
   errors++;


### PR DESCRIPTION
## Problem

The release dry-run workflow (`release-dry-run.yml`) fails at the install smoke test step. When it runs `npm install` on the packed tarball in a clean temp directory, `postinstall-verify.cjs` fires and fails because:

1. No `package-lock.json` exists (this is a tarball install, not a source checkout)
2. No `node_modules/.package-lock.json` exists
3. Critical deps not found (they are flattened differently in consumer installs)

This is a **false positive** — the script was designed to catch corruption in the *source* checkout, not in published package installs.

## Fix

Add early-exit detection: if `package-lock.json` is missing at the root, the script is running in a published package context (not source development), so skip all integrity checks with exit 0.

## Testing

- ✅ `node -c scripts/postinstall-verify.cjs` — syntax valid
- ✅ Runs in `/tmp` (no lockfile) → `ℹ️ skipping` → exit 0
- ✅ Runs in source checkout → `✅ node_modules integrity OK` → exit 0

## CI run that failed
Run `25539021985` — `Release dry run` job failed at `npm install` smoke test.