### PR TITLE
docs: mention Routines page in dashboard features (#2929)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Aegis ships with a built-in dashboard at `http://localhost:9100/dashboard/` — 
 - Session search, filter by date range, CSV export
 - Metric cards with sparkline mini-charts
 - Consistent empty states across all pages
+- Routines page with calendar-style view for scheduled tasks (Phase 1 — UI scaffold)
 - Toast notifications for user feedback
 
 ```bash


### PR DESCRIPTION
## Summary

PR #2929 added a Routines page scaffold (calendar-style view,  route) to the dashboard. This adds a single-line mention to the dashboard features list in README.

Closes no issues — documentation follow-up for #2929.

## Changes
- README.md: added Routines page to dashboard features bullet list

## Notes
- Phase 1 scaffold only (no backend API yet) — full docs will follow when Phase 2 ships CRUD + cron engine.