### PR TITLE
fix(security): reject system temp dirs in workDir validation

### DIFF
--- a/src/__tests__/path-traversal-workdir-435.test.ts
+++ b/src/__tests__/path-traversal-workdir-435.test.ts
@@ -34,7 +34,7 @@ async function sameCanonicalPath(a: string, b: string): Promise<boolean> {
   return samePath(leftReal, rightReal);
 }
 
-const tmpBase = path.join(os.tmpdir(), 'aegis-test-435');
+const tmpBase = path.join(process.cwd(), 'aegis-test-435-tmp');
 
 describe('validateWorkDir — Issue #435', () => {
   beforeEach(async () => {
@@ -92,17 +92,21 @@ describe('validateWorkDir — Issue #435', () => {
   // Valid paths that should be accepted
   // -------------------------------------------------------------------------
   describe('accepts legitimate paths', () => {
-    it('accepts an existing tmp subdirectory', async () => {
-      const dir = path.join(tmpBase, 'project');
+    it('accepts a subdirectory of cwd', async () => {
+      const dir = path.join(process.cwd(), 'test-tmp-project-435');
       await fs.mkdir(dir, { recursive: true });
-      const result = await validateWorkDir(dir);
-      expect(typeof result).toBe('string');
-      expect(await sameCanonicalPath(result as string, dir)).toBe(true);
+      try {
+        const result = await validateWorkDir(dir);
+        expect(typeof result).toBe('string');
+        expect(await sameCanonicalPath(result as string, dir)).toBe(true);
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+      }
     });
 
-    it('accepts /tmp itself', async () => {
+    it('rejects /tmp — system temp dir (Issue #2945)', async () => {
       const result = await validateWorkDir('/tmp');
-      expect(typeof result).toBe('string');
+      expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
     });
 
     it('accepts the current working directory', async () => {
@@ -143,7 +147,7 @@ describe('validateWorkDir — Issue #435', () => {
   // -------------------------------------------------------------------------
   describe('rejects non-existent paths', () => {
     it('rejects a path that does not exist', async () => {
-      const result = await validateWorkDir('/tmp/this-path-definitely-does-not-exist-abc123');
+      const result = await validateWorkDir(path.join(os.homedir(), 'this-path-definitely-does-not-exist-abc123'));
       expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
       if (typeof result === 'object') {
         expect(result.error).toContain('does not exist');
@@ -177,9 +181,9 @@ describe('validateWorkDir — Issue #435', () => {
       expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
     });
 
-    it('accepts /tmp (in default safe dirs)', async () => {
+    it('rejects /tmp — system temp dir (Issue #2945)', async () => {
       const result = await validateWorkDir('/tmp');
-      expect(typeof result).toBe('string');
+      expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
     });
   });
 
@@ -276,10 +280,10 @@ describe('validateWorkDir — Issue #435', () => {
   // Type validation
   // -------------------------------------------------------------------------
   describe('type validation', () => {
-    it('rejects empty allowlist as default (uses safe dirs)', async () => {
-      // Empty array triggers default safe dirs behavior
+    it('rejects /tmp with default safe dirs (Issue #2945)', async () => {
+      // Empty array triggers default safe dirs behavior (homedir + cwd only)
       const result = await validateWorkDir('/tmp');
-      expect(typeof result).toBe('string');
+      expect(isError(result, 'INVALID_WORKDIR')).toBe(true);
     });
   });
 });

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -644,17 +644,13 @@ export function extractCCVersion(output: string): string | null {
  *  Includes os.tmpdir() to cover platform-specific temp paths
  *  (e.g. macOS /var/folders/... which differs from /tmp). */
 function getDefaultSafeDirs(): string[] {
-  const dirs = [
+  // Issue #2945: system temp dirs (/tmp, /var/tmp, os.tmpdir()) are intentionally
+  // excluded — they are world-writable and unsuitable as Claude Code work directories.
+  // If temp dir access is needed, configure allowedWorkDirs explicitly.
+  return [
     os.homedir(),
-    '/tmp',
-    '/var/tmp',
     process.cwd(),
   ];
-  const osTmp = os.tmpdir();
-  if (!dirs.includes(osTmp)) {
-    dirs.push(osTmp);
-  }
-  return dirs;
 }
 
 /** Returns true when any path segment resolves to "..".


### PR DESCRIPTION
## Summary

Removes `/tmp`, `/var/tmp`, and `os.tmpdir()` from `getDefaultSafeDirs()`. These world-writable system directories are unsuitable as Claude Code work directories — allowing sessions to run in `/tmp` poses a security risk.

Closes #2945

## Changes

- **`src/validation.ts`**: `getDefaultSafeDirs()` now returns only `os.homedir()` and `process.cwd()`. Removed `/tmp`, `/var/tmp`, and `os.tmpdir()` from the default safe directories list.
- **`src/__tests__/path-traversal-workdir-435.test.ts`**: Updated test fixtures:
  - Changed `tmpBase` from `os.tmpdir()` to `process.cwd()` (no longer under safe dirs)
  - Updated 3 tests that asserted `/tmp` should be accepted → now assert rejection
  - Updated non-existent path test to use `os.homedir()` instead of `/tmp`

## Verification

```
npx tsc --noEmit → 0 errors
npx vitest run src/__tests__/path-traversal-workdir-435.test.ts → 26 passed
npx vitest run src/__tests__/workdir-not-found-458.test.ts → 5 passed
npx vitest run src/__tests__/template-workdir-validation-1125.test.ts → 10 passed
```

## Security Impact

Before: `POST /v1/sessions {"workDir": "/tmp"}` → session created ✅
After: `POST /v1/sessions {"workDir": "/tmp"}` → 400 `workDir is not in the allowed directories list` ❌

Path traversal (`../etc/passwd`) was **already blocked** — this fix only addresses the explicit allowlisting of system temp dirs.

## Backward Compatibility

Users who relied on `/tmp` as a valid workDir must now configure `allowedWorkDirs` in their `config.json`:
```json
{ "allowedWorkDirs": ["/tmp", "/home/user/projects"] }
```