### PR TITLE
chore: fix stale docblock in validateWorkDir

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -704,7 +704,7 @@ function isUnderOrEqual(childPath: string, parentPath: string): boolean {
  *  2. Resolve to absolute path and resolve symlinks via fs.realpath().
  *  3. Verify the resolved path is under an allowed directory:
  *     - If allowedWorkDirs is configured, use that list.
- *     - Otherwise, use default safe dirs (home, /tmp, cwd).
+ *     - Otherwise, use default safe dirs (home, cwd).
  *  Returns the resolved real path on success, or an error object on failure. */
 export async function validateWorkDir(
   workDir: string,


### PR DESCRIPTION
Trivial follow-up to #2948 — docblock on line 712 still referenced `/tmp` in the default safe dirs list. Updated to `home, cwd` to match the code.