### PR TITLE
docs: update workDir security hardening (#2948)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The ACP (Agent Control Protocol) cutover is complete. This release removes the t
 
 ### Fixed
 
+- **workDir security hardening** — `/tmp`, `/var/tmp`, and `os.tmpdir()` removed from default safe directories; use `allowedWorkDirs` to re-enable if needed ([#2948](https://github.com/OneStepAt4time/aegis/pull/2948), closes [#2945](https://github.com/OneStepAt4time/aegis/issues/2945))
 - **ACP crash recovery** — implement `session/load` for restoring sessions after ACP process crashes (ACP-065) ([#2744](https://github.com/OneStepAt4time/aegis/pull/2744))
 - **Hardcoded demo data removal** — removed demo sessions from SessionTable ([#2900](https://github.com/OneStepAt4time/aegis/pull/2900))
 - **CI scripts/ in Docker** — include `scripts/` directory in Docker image and npm package for postinstall verification ([#2901](https://github.com/OneStepAt4time/aegis/pull/2901))

--- a/docs/api-v2-migration-template.md
+++ b/docs/api-v2-migration-template.md
@@ -61,10 +61,10 @@ curl http://localhost:9100/v2/sessions
 Example:
 ```bash
 # v1 — tenantId was optional
-curl -X POST http://localhost:9100/v1/sessions -d '{"workDir": "/tmp"}'
+curl -X POST http://localhost:9100/v1/sessions -d '{"workDir": "/home/user/project"}'
 
 # v2 — tenantId is required
-curl -X POST http://localhost:9100/v2/sessions -d '{"workDir": "/tmp", "tenantId": "acme"}'
+curl -X POST http://localhost:9100/v2/sessions -d '{"workDir": "/home/user/project", "tenantId": "acme"}'
 ```
 -->
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -253,7 +253,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 
 | Variable | Default | Description |
 |---|---|---|
-| `AEGIS_ALLOWED_WORKDIRS` | _(home, /tmp, cwd)_ | JSON array of allowed session working directories |
+| `AEGIS_ALLOWED_WORKDIRS` | _(home, cwd)_ | JSON array of allowed session working directories. System temp dirs (`/tmp`, `/var/tmp`) are excluded by default for security — add them explicitly if needed |
 
 #### Hooks
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -235,9 +235,11 @@ Config file: `~/.aegis/config.json`
   "host": "127.0.0.1",
   "port": 9100,
   "authToken": "your-secret-token",
-  "allowedWorkDirs": ["~/projects", "/tmp"]
+  "allowedWorkDirs": ["~/projects", "~/workspace"]
 }
 ```
+
+> **Security note:** System temp dirs (`/tmp`, `/var/tmp`) are **not** in the default safe directories list. If you need to use a temp directory as a workDir, add it explicitly to `allowedWorkDirs`.
 
 Environment variables override config values. Prefix with `AEGIS_`:
 - `AEGIS_HOST`, `AEGIS_PORT`, `AEGIS_AUTH_TOKEN`, `AEGIS_STATE_DIR`


### PR DESCRIPTION
## Summary

Documents the security hardening from #2948 (closes #2945) that removed `/tmp`, `/var/tmp`, and `os.tmpdir()` from default safe directories.

## Changes

- **`docs/enterprise.md`** — updated `AEGIS_ALLOWED_WORKDIRS` default from `_(home, /tmp, cwd)_` to `_(home, cwd)_` with security note
- **`docs/onboarding.md`** — replaced `/tmp` in config example with `~/workspace`; added security note about temp dir exclusion
- **`docs/api-v2-migration-template.md`** — fixed example curl commands to use real project paths instead of `/tmp`
- **`CHANGELOG.md`** — added workDir security hardening entry under Fixed section

## Verification

- All examples use valid project paths (no `/tmp`)
- Default values match `src/validation.ts` `getDefaultSafeDirs()` implementation
- Migration path documented: users who need `/tmp` must add it to `allowedWorkDirs` explicitly