### PR TITLE
fix(dashboard): add missing aria-labels to TemplatesPage, AuthKeysPage, SessionHistoryPage

### DIFF
--- a/dashboard/src/__tests__/AuthKeysPage.test.tsx
+++ b/dashboard/src/__tests__/AuthKeysPage.test.tsx
@@ -103,7 +103,7 @@ describe('AuthKeysPage', () => {
     });
 
     fireEvent.change(screen.getByLabelText('Key Name'), { target: { value: 'ops-primary' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Create Auth Key' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create new auth key' }));
 
     await waitFor(() => {
       expect(mockCreateAuthKey).toHaveBeenCalledWith('ops-primary');
@@ -113,7 +113,7 @@ describe('AuthKeysPage', () => {
       expect(screen.getAllByText('create').length).toBeGreaterThan(0);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Reveal secret' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle secret visibility' }));
 
     expect(screen.getByText('aegis_super_secret_key_1234567890')).toBeDefined();
     expect(mockGetAuthKeys).toHaveBeenCalledTimes(2);
@@ -145,7 +145,7 @@ describe('AuthKeysPage', () => {
       expect(screen.getByText('ops-primary')).toBeDefined();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    fireEvent.click(screen.getByRole('button', { name: /Revoke auth key/ }));
 
     // Confirm in the dialog — scope query to the dialog to avoid ambiguity
     await waitFor(() => {

--- a/dashboard/src/pages/AuthKeysPage.tsx
+++ b/dashboard/src/pages/AuthKeysPage.tsx
@@ -236,6 +236,7 @@ export default function AuthKeysPage() {
         <button
           type="button"
           onClick={() => void fetchKeys(true)}
+          aria-label="Refresh auth keys"
           disabled={refreshing}
           className="flex min-h-[44px] items-center justify-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)] disabled:cursor-not-allowed disabled:opacity-60"
         >
@@ -272,6 +273,7 @@ export default function AuthKeysPage() {
             <button
               type="submit"
               disabled={creating || !name.trim()}
+              aria-label="Create new auth key"
               className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-sm font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <KeyRound className="h-4 w-4" />
@@ -295,6 +297,7 @@ export default function AuthKeysPage() {
                     setSecretVisible(false);
                   }}
                   className="text-xs font-medium text-emerald-200/80 transition-colors hover:text-emerald-200"
+                  aria-label="Dismiss created key"
                 >
                   Dismiss
                 </button>
@@ -324,6 +327,7 @@ export default function AuthKeysPage() {
                   type="button"
                   onClick={() => setSecretVisible((current) => !current)}
                   className="flex min-h-[40px] items-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
+                  aria-label="Toggle secret visibility"
                 >
                   {secretVisible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                   {secretVisible ? 'Hide secret' : 'Reveal secret'}
@@ -332,6 +336,7 @@ export default function AuthKeysPage() {
                   type="button"
                   onClick={() => void handleCopySecret()}
                   className="flex min-h-[40px] items-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
+                  aria-label="Copy secret to clipboard"
                 >
                   <Copy className="h-3.5 w-3.5" />
                   Copy secret
@@ -392,6 +397,7 @@ export default function AuthKeysPage() {
                       type="button"
                       onClick={() => void handleRevoke(key.id, key.name)}
                       disabled={revokingId === key.id}
+                      aria-label={`Revoke auth key ${key.name}`}
                        className="flex min-h-[40px] items-center justify-center gap-2 rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-700 dark:text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       <Trash2 className="h-3.5 w-3.5" />

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -399,6 +399,7 @@ export default function SessionHistoryPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => { void fetchData(); }}
+            aria-label="Refresh session history"
             disabled={loading}
             className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-50"
           >
@@ -560,6 +561,7 @@ export default function SessionHistoryPage() {
               <button
                 onClick={() => handleExport()}
                 className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)]"
+                aria-label="Export selected sessions as CSV"
               >
                 <Icon name="Download" size={12} />
                 Export
@@ -567,6 +569,7 @@ export default function SessionHistoryPage() {
               <button
                 onClick={() => setConfirmDeleteOpen(true)}
                 className="flex min-h-[44px] items-center gap-1.5 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-300 transition-colors hover:bg-rose-500/20"
+                aria-label="Kill selected sessions"
               >
                 <Trash2 className="h-3 w-3" />
                 Kill
@@ -574,6 +577,7 @@ export default function SessionHistoryPage() {
               <button
                 onClick={handleShareLink}
                 className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)]"
+                aria-label="Copy shareable link"
               >
                 <Share2 className="h-3 w-3" />
                 Share link
@@ -581,6 +585,7 @@ export default function SessionHistoryPage() {
               <button
                 onClick={() => setSelectedIds(new Set())}
                 className="ml-auto flex min-h-[44px] items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+                aria-label="Clear selection"
               >
                 <X className="h-3 w-3" />
                 Clear
@@ -727,6 +732,7 @@ export default function SessionHistoryPage() {
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1 || loading}
+                aria-label="Previous page"
                 className="inline-flex min-h-[44px] items-center gap-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:opacity-40"
               >
                 <ChevronLeft className="h-3 w-3" /> Prev
@@ -736,6 +742,7 @@ export default function SessionHistoryPage() {
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page >= totalPages || loading}
                 className="inline-flex min-h-[44px] items-center gap-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:opacity-40"
+                aria-label="Next page"
               >
                 Next <ChevronRight className="h-3 w-3" />
               </button>

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -171,6 +171,7 @@ export default function TemplatesPage() {
           <button
             type="button"
             onClick={() => void fetchTemplates(true)}
+            aria-label="Refresh templates"
             disabled={refreshing}
             className="flex min-h-[44px] items-center justify-center gap-2 rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)] disabled:cursor-not-allowed disabled:opacity-60"
           >
@@ -180,6 +181,7 @@ export default function TemplatesPage() {
           <button
             type="button"
             onClick={handleCreate}
+            aria-label="Create new template"
             className="flex min-h-[44px] items-center justify-center gap-2 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -200,6 +202,7 @@ export default function TemplatesPage() {
           <button
             type="button"
             onClick={() => void fetchTemplates()}
+            aria-label="Retry loading templates"
             className="mt-4 rounded border border-amber-500/30 px-3 py-2 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-500/10"
           >
             Retry
@@ -215,6 +218,7 @@ export default function TemplatesPage() {
           <button
             type="button"
             onClick={handleCreate}
+            aria-label="Create your first template"
             className="mt-4 flex min-h-[40px] items-center gap-2 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-4 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -262,6 +266,7 @@ export default function TemplatesPage() {
                   <button
                     type="button"
                     onClick={() => void handleUseTemplate(template)}
+                    aria-label={`Use template ${template.name}`}
                     disabled={usingId === template.id}
                     className="flex min-h-[40px] items-center justify-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:cursor-not-allowed disabled:opacity-60"
                   >
@@ -275,6 +280,7 @@ export default function TemplatesPage() {
                   <button
                     type="button"
                     onClick={() => handleEdit(template)}
+                    aria-label={`Edit template ${template.name}`}
                     className="flex min-h-[40px] items-center justify-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
                   >
                     <Pencil className="h-3.5 w-3.5" />
@@ -283,6 +289,7 @@ export default function TemplatesPage() {
                   <button
                     type="button"
                     onClick={() => void handleDuplicate(template)}
+                    aria-label={`Duplicate template ${template.name}`}
                     className="flex min-h-[40px] items-center justify-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:border-[var(--color-accent-cyan)]/30 hover:text-[var(--color-accent-cyan)]"
                     title="Duplicate template"
                   >
@@ -292,6 +299,7 @@ export default function TemplatesPage() {
                   <button
                     type="button"
                     onClick={() => setDeleteTarget({ id: template.id, name: template.name })}
+                    aria-label={`Delete template ${template.name}`}
                     disabled={deletingId === template.id}
                     className="flex min-h-[40px] items-center justify-center gap-1.5 rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-700 dark:text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
                   >


### PR DESCRIPTION
## Summary

Adds descriptive `aria-label` attributes to all interactive buttons that were missing them across three dashboard pages.

## Changes

### TemplatesPage (Closes #2961)
- 8 buttons now have aria-labels: Refresh, Create Template, Retry, Create first template, Use/Edit/Duplicate/Delete per template row

### AuthKeysPage (Closes #2964)
- 6 buttons now have aria-labels: Refresh, Create Auth Key, Dismiss created key, Toggle secret visibility, Copy secret to clipboard, Revoke per key

### SessionHistoryPage (Closes #2964)
- 7 buttons now have aria-labels: Refresh, Bulk export, Kill selected, Share link, Clear selection, Previous page, Next page
- (Already had: Export CSV header, Select all/individual checkboxes, Copy session ID)

## Quality Gate
- `tsc --noEmit` — 0 errors ✅
- `npm run build` — clean, 1.85s ✅
- No bundle size change (21 lines of JSX attributes only)

## Test Plan
- [x] Typecheck passes
- [x] Build passes
- [ ] Screen reader verification (manual audit recommended)