### PR TITLE
fix(security): add requireRole check to GET /v1/sessions (#2975)

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -196,6 +196,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
   });
 
   app.get<{ Querystring: { page?: string; limit?: string; status?: string; project?: string } }>('/v1/sessions', async (req, reply) => {
+    if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
     const parsed = sessionsListQuerySchema.safeParse(req.query);
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid query params', details: parsed.error.issues });


### PR DESCRIPTION
## Fix for #2975 — Missing requireRole on GET /v1/sessions

### Problem
`GET /v1/sessions` (paginated list) did not call `requireRole()` before serving session data. The legacy `GET /sessions` route explicitly calls `requireRole(auth, req, reply, "admin", "operator", "viewer")`, but the v1 route only relied on the global auth middleware. This meant any authenticated API key (including viewer with only `audit` permission) could list sessions.

### Fix
Added `requireRole(auth, req, reply, 'admin', 'operator', 'viewer')` at the top of the `GET /v1/sessions` handler, consistent with the legacy route.

### Verification
```
npx tsc --noEmit  ✅ zero errors
npm run build     ✅ success
npm test          ✅ 258 files, 3947 passed, 2 skipped
```

Commit: 99d804c2
