### PR TITLE
fix(security): add auth checks to /metrics, dead-letter, channels/health (#2976, #2977)

### DIFF
--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -123,6 +123,7 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
   // Issue #1412: Prometheus metrics scrape endpoint
   // Note: /metrics is a standard Prometheus path, not a v1 API path, so no legacy alias
   app.get('/metrics', async (req: FastifyRequest, reply: FastifyReply) => {
+    if (!requireRole(auth, req, reply, 'admin')) return;
     try {
       const promMetrics = await promRegistry.metrics();
       return reply
@@ -166,7 +167,8 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
   });
 
   // Issue #89 L14: Webhook dead letter queue
-  registerWithLegacy(app, 'get', '/v1/webhooks/dead-letter', async (_req: FastifyRequest, _reply: FastifyReply) => {
+  registerWithLegacy(app, 'get', '/v1/webhooks/dead-letter', async (req: FastifyRequest, reply: FastifyReply) => {
+    if (!requireRole(auth, req, reply, 'admin')) return;
     for (const ch of channels.getChannels()) {
       if (ch.name === 'webhook' && typeof ch.getDeadLetterQueue === 'function') {
         return ch.getDeadLetterQueue();
@@ -176,7 +178,8 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
   });
 
   // Issue #89 L15: Per-channel health reporting
-  registerWithLegacy(app, 'get', '/v1/channels/health', async (_req: FastifyRequest, _reply: FastifyReply) => {
+  registerWithLegacy(app, 'get', '/v1/channels/health', async (req: FastifyRequest, reply: FastifyReply) => {
+    if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
     return channels.getChannels().map(ch => {
       const health = ch.getHealth?.();
       if (health) return health;


### PR DESCRIPTION
## Fix for #2976 + #2977 — Unauthenticated endpoints

### Problem
Three endpoints had no authentication or authorization checks:
1. `GET /metrics` (Prometheus) — exposed operational metrics to any caller
2. `GET /v1/webhooks/dead-letter` — exposed webhook dead letter queue contents
3. `GET /v1/channels/health` — exposed channel health and configuration info

All were accessible without auth on localhost deployments.

### Fix
Added `requireRole` checks:
- `/metrics` → `requireRole(auth, req, reply, 'admin')`
- `/v1/webhooks/dead-letter` → `requireRole(auth, req, reply, 'admin')`
- `/v1/channels/health` → `requireRole(auth, req, reply, 'admin', 'operator', 'viewer')`

Also fixed underscore-prefixed params (`_req`, `_reply` → `req`, `reply`) since auth is now used.

### Verification
```
npx tsc --noEmit  ✅ zero errors
npm run build     ✅ success
npm test          ✅ 258 files, 3947 passed, 2 skipped
```

Commit: 0f9bd111
