### PR TITLE
fix(ci): pin auto-label action to CJS-compatible deps (#2978)

### DIFF
--- a/.github/actions/auto-label/package.json
+++ b/.github/actions/auto-label/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "dependencies": {
-    "@actions/core": "^3.0.1",
-    "@actions/github": "^9.1.1"
+    "@actions/core": "^1.11.1",
+    "@actions/github": "^6.0.1"
   },
   "devDependencies": {
     "vitest": "^3.0.0"


### PR DESCRIPTION
## Fix for #2978 — auto-label action ESM/CJS crash

### Problem
The `.github/actions/auto-label` action crashed on every issue open with `ERR_PACKAGE_PATH_NOT_EXPORTED` because:
- `@actions/core@3` and `@actions/github@9` are ESM-only
- The action uses `require()` (CJS) with `using: node20` in action.yml
- No `"type": "module"` in package.json

### Fix
Pins to last CJS-compatible versions:
- `@actions/core`: `^3.0.1` → `^1.11.1`
- `@actions/github`: `^9.1.1` → `^6.0.1`

No code changes — the API surface used (`getInput`, `getOctokit`, `context.repo`, etc.) is compatible.

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258 files, 3947 passed
```

Commit: ad9d7261
