### PR TITLE
fix(validation): reject file workDir and empty prompt (#2989, #2990)

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -37,7 +37,7 @@ function buildCreateSessionSchema(ctx: RouteContext) {
     name: z.string().max(200).optional(),
     /** Alias for `name`; accepted for backward compatibility with dashboard/CLI callers. */
     label: z.string().max(200).optional(),
-    prompt: z.string().max(100_000).optional(),
+    prompt: z.string().min(1).max(100_000).optional(),
     prd: z.string().max(100_000).optional(),
     resumeSessionId: z.string().uuid().optional(),
     claudeCommand: z.string().max(500).regex(SAFE_COMMAND_RE).optional(),

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -750,6 +750,12 @@ export async function validateWorkDir(
     return { error: 'workDir is not in the allowed directories list', code: 'INVALID_WORKDIR' };
   }
 
+  // Step 5: Ensure workDir is a directory, not a file.
+  const resolvedStat = await fs.stat(realPath);
+  if (!resolvedStat.isDirectory()) {
+    return { error: `workDir must be a directory, not a file: ${resolved}`, code: 'INVALID_WORKDIR' };
+  }
+
   return realPath;
 }
 


### PR DESCRIPTION
## Fix for #2989 + #2990 — Session creation input validation

### Problems
1. **#2989:** `POST /v1/sessions` accepted a file path as `workDir` — session would be created but CC would fail silently when trying to use a file as working directory
2. **#2990:** `POST /v1/sessions` accepted empty string `""` as `prompt` — session created with no meaningful work

### Fixes
1. Added directory check in `validateWorkDir()` (Step 5): `fs.stat(realPath).isDirectory()` — rejects file paths with clear error
2. Added `.min(1)` to prompt Zod schema — rejects empty strings while keeping the field optional for prd-only sessions

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258 files, 3947 passed
```

Commit: 0b0d3bf7
