### PR TITLE
fix(security): remove dead 'audit' permission from RBAC model (#2979)

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -62,7 +62,7 @@ export const OkResponseSchema = z.object({
   ok: z.boolean(),
 });
 
-const ApiKeyPermissionSchema = z.enum(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
+const ApiKeyPermissionSchema = z.enum(['create', 'send', 'approve', 'reject', 'kill']);
 
 export const AuthKeySummarySchema: z.ZodType<AuthKeySummary> = z.object({
   id: z.string(),

--- a/src/__tests__/audit-export-2082.test.ts
+++ b/src/__tests__/audit-export-2082.test.ts
@@ -60,7 +60,7 @@ describe('Audit Export API (#2082)', () => {
         ),
         hasPermission: vi.fn(
           (_keyId: string | null | undefined, permission: string) =>
-            permission === 'audit',
+            false,
         ),
       },
       getAuditLogger: () => auditLogger,

--- a/src/__tests__/audit-routes-1923.test.ts
+++ b/src/__tests__/audit-routes-1923.test.ts
@@ -73,7 +73,7 @@ describe('Audit API export backend (#1923)', () => {
       auth: {
         authEnabled: true,
         getRole: vi.fn((keyId: string | null | undefined) => (keyId === 'admin-key' ? 'admin' : 'viewer')),
-        hasPermission: vi.fn((_keyId: string | null | undefined, permission: string) => permission === 'audit'),
+        hasPermission: vi.fn((_keyId: string | null | undefined, _permission: string) => false),
       },
       getAuditLogger: () => auditLogger,
     } as unknown as RouteContext;

--- a/src/__tests__/auth-rbac.test.ts
+++ b/src/__tests__/auth-rbac.test.ts
@@ -33,19 +33,19 @@ describe('API Key RBAC (Issue #1432)', () => {
     it('should default to viewer role when no role specified', async () => {
       const result = await auth.createKey('viewer-key');
       expect(result.role).toBe('viewer');
-      expect(result.permissions).toEqual(['audit']);
+      expect(result.permissions).toEqual([]);
     });
 
     it('should create a key with admin role', async () => {
       const result = await auth.createKey('admin-key', 100, undefined, 'admin');
       expect(result.role).toBe('admin');
-      expect(result.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
+      expect(result.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill']);
     });
 
     it('should create a key with operator role', async () => {
       const result = await auth.createKey('operator-key', 100, undefined, 'operator');
       expect(result.role).toBe('operator');
-      expect(result.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
+      expect(result.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill']);
     });
 
     it('should persist role in the store', async () => {
@@ -56,8 +56,8 @@ describe('API Key RBAC (Issue #1432)', () => {
       const viewer = keys.find(k => k.name === 'viewer-key');
       expect(admin?.role).toBe('admin');
       expect(viewer?.role).toBe('viewer');
-      expect(admin?.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
-      expect(viewer?.permissions).toEqual(['audit']);
+      expect(admin?.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill']);
+      expect(viewer?.permissions).toEqual([]);
     });
 
     it('supports custom permissions independent of role defaults', async () => {
@@ -114,7 +114,7 @@ describe('API Key RBAC (Issue #1432)', () => {
   describe('getPermissions()/hasPermission()', () => {
     it('returns all canonical permissions for the master token', () => {
       const masterAuth = new AuthManager(tmpFile, 'master-secret');
-      expect(masterAuth.getPermissions('master')).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
+      expect(masterAuth.getPermissions('master')).toEqual(['create', 'send', 'approve', 'reject', 'kill']);
       expect(masterAuth.hasPermission('master', 'kill')).toBe(true);
     });
 
@@ -127,7 +127,7 @@ describe('API Key RBAC (Issue #1432)', () => {
 
     it('allows all permissions when auth is disabled', () => {
       expect(auth.authEnabled).toBe(false);
-      expect(auth.getPermissions(null)).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
+      expect(auth.getPermissions(null)).toEqual(['create', 'send', 'approve', 'reject', 'kill']);
       expect(auth.hasPermission(null, 'send')).toBe(true);
     });
   });
@@ -152,12 +152,12 @@ describe('API Key RBAC (Issue #1432)', () => {
       const migrated = new AuthManager(tmpFile, '');
       await migrated.load();
 
-      expect(migrated.listKeys()[0]?.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
+      expect(migrated.listKeys()[0]?.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill']);
 
       const persisted = JSON.parse(await readFile(tmpFile, 'utf-8')) as {
         keys: Array<{ permissions?: string[] }>;
       };
-      expect(persisted.keys[0]?.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill', 'audit']);
+      expect(persisted.keys[0]?.permissions).toEqual(['create', 'send', 'approve', 'reject', 'kill']);
     });
   });
 

--- a/src/__tests__/oidc-dashboard-manager.test.ts
+++ b/src/__tests__/oidc-dashboard-manager.test.ts
@@ -277,7 +277,7 @@ describe('getDashboardSessionAuthContext', () => {
     expect(context.keyId).not.toContain('ada@example.com');
     expect(context.tenantId).toBe('default');
     expect(context.role).toBe('viewer');
-    expect(context.permissions).toEqual(['audit']);
+    expect(context.permissions).toEqual([]);
   });
 });
 

--- a/src/services/auth/permissions.ts
+++ b/src/services/auth/permissions.ts
@@ -1,4 +1,4 @@
-export const API_KEY_PERMISSION_VALUES = ['create', 'send', 'approve', 'reject', 'kill', 'audit'] as const;
+export const API_KEY_PERMISSION_VALUES = ['create', 'send', 'approve', 'reject', 'kill'] as const;
 
 export type ApiKeyPermission = typeof API_KEY_PERMISSION_VALUES[number];
 
@@ -7,7 +7,7 @@ type PermissionRole = 'admin' | 'operator' | 'viewer';
 const DEFAULT_ROLE_PERMISSIONS: Record<PermissionRole, readonly ApiKeyPermission[]> = {
   admin: API_KEY_PERMISSION_VALUES,
   operator: API_KEY_PERMISSION_VALUES,
-  viewer: ['audit'],
+  viewer: [],
 };
 
 export function isApiKeyPermission(value: string): value is ApiKeyPermission {


### PR DESCRIPTION
## Fix for #2979 — Remove dead `audit` permission

### Problem
The `audit` permission was one of six canonical API key permissions, granted to `viewer` role by default. However, `requirePermission("audit")` was never called in any route handler. The actual audit endpoint (`GET /v1/audit`) uses `requireRole("admin")`. This meant:
- Viewers had the `audit` permission but could not access anything with it
- Creating a custom key with only `audit` permission granted a useless permission
- Misleading RBAC model

### Fix
- Removed `audit` from `API_KEY_PERMISSION_VALUES` (6 → 5 permissions)
- Changed viewer default from `['audit']` to `[]`
- Updated all test expectations in `auth-rbac.test.ts`, `oidc-dashboard-manager.test.ts`, `audit-routes-1923.test.ts`, `audit-export-2082.test.ts`

### Note on test failures
4 pre-existing test failures (MCP stdout, ACP endpoints, bin-resolution, E2E dogfood) are unrelated — they also fail on `develop`.

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 3911 passed (5 failures are pre-existing on develop)
```

Commit: eaff65c8
