### PR TITLE
fix(cli): include auth header in curl output from ag create (#2996)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,10 +180,12 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
   }
 
   writeLine(io.stdout);
+  // Issue #2996: Include auth header in curl output when auth is configured.
+  const curlAuth = authToken ? ` -H "Authorization: Bearer ${authToken}"` : '';
   writeLine(io.stdout, '  Next steps:');
-  writeLine(io.stdout, `    Status:   curl ${baseUrl}/v1/sessions/${sessionId}/health`);
-  writeLine(io.stdout, `    Read:     curl ${baseUrl}/v1/sessions/${sessionId}/read`);
-  writeLine(io.stdout, `    Kill:     curl -X DELETE ${baseUrl}/v1/sessions/${sessionId}`);
+  writeLine(io.stdout, `    Status:   curl${curlAuth} ${baseUrl}/v1/sessions/${sessionId}/health`);
+  writeLine(io.stdout, `    Read:     curl${curlAuth} ${baseUrl}/v1/sessions/${sessionId}/read`);
+  writeLine(io.stdout, `    Kill:     curl -X DELETE${curlAuth} ${baseUrl}/v1/sessions/${sessionId}`);
   return 0;
 }
 


### PR DESCRIPTION
## Fix for #2996 — CLI curl output missing auth headers

### Problem
`ag create` outputs "Next steps" curl commands without the Authorization header. When auth is configured (recommended setup), copy-pasting these commands returns 401.

### Fix
Builds a `curlAuth` fragment from the already-resolved `authToken`:
- With auth: `curl -H "Authorization: Bearer <token>" http://...`
- Without auth: `curl http://...` (unchanged)

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258 files, 3947 passed
```

Commit: bd19da23
