### PR TITLE
fix(api): honest prompt delivery status when ACP disabled (#2995)

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -843,8 +843,11 @@ export class SessionManager {
    *  Returns true if the last assistant message has text content only (no tool_use). */
 
   /** Send initial prompt (ACP stub — prompts sent via JSON-RPC). */
+  // Issue #2995: Return honest delivery status when ACP is disabled.
+  // In ACP mode, prompts are delivered through the ACP backend during session
+  // creation — this stub is only reached when acpEnabled is false.
   async sendInitialPrompt(_id: string, _prompt: string): Promise<{ delivered: boolean; attempts: number }> {
-    return { delivered: true, attempts: 1 };
+    return { delivered: false, attempts: 0 };
   }
 
   /** Find an idle session by workDir (ACP mode: state-based lookup with acquisition).


### PR DESCRIPTION
## Fix for #2995 — Sessions report delivered:true but nothing runs

### Root Cause
`SessionManager.sendInitialPrompt()` is a stub that always returns `{delivered: true, attempts: 1}`. In ACP mode, prompts are delivered through the ACP backend during session creation — this stub is only called when `acpEnabled: false`, meaning no backend processes the prompt at all. The `delivered: true` response was misleading users into thinking their session was running.

### Fix
Changed the stub to return `{delivered: false, attempts: 0}` — the honest status when no ACP backend is active.

### Important Note
The **real fix** for users experiencing this is to enable ACP:
```json
// ~/.aegis/config.json
{ "acpEnabled": true }
```
Or: `AEGIS_ACP_ENABLED=true` env var.

Without ACP enabled, sessions are created but no Claude process is spawned to process them. This is by design — ACP is the only session backend.

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 257 passed, 1 pre-existing E2E failure
```

Commit: 47faa490
