### PR TITLE
docs: fix API accuracy drift from security + validation PRs (#2994, #3008, #3022)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -694,10 +694,10 @@ curl -X POST http://localhost:9100/v1/sessions \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `workDir` | string | **yes** | Absolute path to working directory (must exist) |
+| `workDir` | string | **yes** | Absolute path to an existing directory (file paths are rejected) |
 | `name` | string | no | Session name (max 200 chars; defaults to auto-generated) |
 | `label` | string | no | Alias for `name` (backward compat; `name` takes precedence) |
-| `prompt` | string | no | Initial prompt to send after boot (max 100k chars) |
+| `prompt` | string | no | Initial prompt to send after boot (max 100k chars; must be non-empty if provided) |
 | `prd` | string | no | Product Requirements Document text (max 100k chars) |
 | `resumeSessionId` | string (UUID) | no | Resume an existing session by UUID |
 | `model` | string | no | Model name for analytics grouping (max 200 chars) |
@@ -721,9 +721,11 @@ curl -X POST http://localhost:9100/v1/sessions \
   "workDir": "/home/user/my-project",
   "status": "working",
   "createdAt": 1712650800000,
-  "promptDelivery": { "delivered": true, "attempts": 1 }
+  "promptDelivery": { "delivered": false, "attempts": 0 }
 }
 ```
+
+> **Note:** `promptDelivery.delivered` is `false` when ACP is disabled — no backend process is spawned to handle the prompt. Enable ACP via `AEGIS_ACP_ENABLED=true` or `"acpEnabled": true` in config.
 
 **Response (`200 OK`):** Returned when reusing an existing idle session (`reused: true`).
 
@@ -731,7 +733,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 
 | Status | Code | Condition |
 |--------|------|-----------|
-| 400 | — | Invalid request body, missing `workDir`, env denylist rejection |
+| 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, env denylist rejection |
 | 403 | `TENANT_WORKDIR_DENIED` | workDir outside tenant root |
 | 422 | `CC_VERSION_TOO_OLD` | Claude Code version below minimum |
 | 429 | `QUOTA_EXCEEDED` | Per-key session quota exceeded |
@@ -2646,6 +2648,10 @@ GET /v1/channels/health
 
 Returns health status for all connected channels (Telegram, Slack, Email, webhooks).
 
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
+
 ```bash
 curl http://localhost:9100/v1/channels/health \
   -H "Authorization: Bearer $TOKEN"
@@ -3138,6 +3144,10 @@ GET /v1/webhooks/dead-letter
 ```
 
 Lists failed webhook deliveries across all channels for inspection and retry.
+
+| Role | Required |
+|------|----------|
+| admin | Yes |
 
 ```bash
 curl http://localhost:9100/v1/webhooks/dead-letter \


### PR DESCRIPTION
## Summary

Fixes 5 documentation accuracy gaps found during PHASE 3 heartbeat audit of 25 recently merged PRs.

### Changes

| PR Source | Doc Fix |
|-----------|---------|
| #2994 (auth on /metrics, dead-letter, channels/health) | Add `admin` role table to `GET /v1/webhooks/dead-letter` |
| #2994 | Add `admin, operator, viewer` role table to `GET /v1/channels/health` |
| #3022 (honest prompt delivery status) | Update `promptDelivery` example from `delivered: true` → `delivered: false` + add note about ACP requirement |
| #3008 (reject file workDir) | Clarify `workDir` must be a directory, not just any existing path |
| #3008 (reject empty prompt) | Document `prompt` must be non-empty if provided + update 400 error description |

### Verification

- Read code diffs from PRs #2994, #3008, #3022 to confirm behavioral changes
- Cross-referenced with `docs/api-reference.md` to identify drift
- No new features documented — accuracy fixes only