### PR TITLE
docs: clarify session reuse is workDir-based, not name-based (#2988)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ All endpoints under `/v1/`.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/v1/health` | Server health & uptime |
-| `POST` | `/v1/sessions` | Create (or reuse) a session |
+| `POST` | `/v1/sessions` | Create a session (reuse if `workDir` matches an idle session) |
 | `GET` | `/v1/sessions` | List sessions |
 | `GET` | `/v1/sessions/:id` | Session details |
 | `GET` | `/v1/sessions/:id/read` | Parsed transcript |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,6 +229,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:9100/v1/sessions
 ```
 
 Supports pagination: `?page=1&limit=20&status=active`. Invalid values (e.g. `page=-1`, `limit=999`) return `400`.
+\n> **Note:** The `name` field is a display label only — it does not affect session reuse. Sessions are reused automatically when `workDir` matches an existing idle session (see Session Reuse in the README).
 
 ## 10. Set Up MCP Integration
 


### PR DESCRIPTION
## Fix

Session reuse is by `workDir` (idle sessions sharing the same directory get reused), not by `name`. The `name` field is a display label only.

### Changes
- README API table: `Create (or reuse) a session` → `Create a session (reuse if workDir matches an idle session)`
- getting-started.md: added note that `name` is display-only and reuse is workDir-based

Hep investigated and confirmed — no code change needed, just docs clarification.

Closes #2988