### PR TITLE
fix(dashboard): four UAT bug fixes from QA sprint

### DIFF
--- a/dashboard/src/__tests__/RoutinesPage.test.tsx
+++ b/dashboard/src/__tests__/RoutinesPage.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { I18nProvider } from '../i18n/context';
 import RoutinesPage from '../pages/RoutinesPage';
 
 // Mock useAuthStore so ProtectedRoute doesn't redirect
@@ -16,7 +17,7 @@ vi.mock('../store/useAuthStore', () => ({
 }));
 
 function renderWithRouter(ui: React.ReactElement) {
-  return render(<MemoryRouter>{ui}</MemoryRouter>);
+  return render(<I18nProvider><MemoryRouter>{ui}</MemoryRouter></I18nProvider>);
 }
 
 describe('RoutinesPage', () => {

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -283,6 +283,17 @@ export const en = {
     stopped: 'Stopped',
   },
   
+  routines: {
+    title: 'Routines',
+    subtitle: 'Scheduled tasks that run on a recurring basis',
+    upcoming: 'Upcoming',
+    forDate: 'Routines for selected date',
+    emptyTitle: 'No routines yet',
+    emptyDescription: 'Create a routine to schedule recurring tasks on a calendar.',
+    newRoutine: 'New Routine',
+    count: '{count} scheduled tasks',
+  },
+  
   errors: {
     notFound: 'Page not found',
     notFoundDescription: 'The page you are looking for does not exist',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -286,6 +286,17 @@ export const it = {
     stopped: 'Fermato',
   },
 
+  routines: {
+    title: 'Routine',
+    subtitle: 'Attività pianificate eseguite su base ricorrente',
+    upcoming: 'Prossime',
+    forDate: 'Routine per la data selezionata',
+    emptyTitle: 'Nessuna routine',
+    emptyDescription: 'Crea una routine per pianificare attività ricorrenti su un calendario.',
+    newRoutine: 'Nuova Routine',
+    count: '{count} attività pianificate',
+  },
+
   errors: {
     notFound: 'Pagina non trovata',
     notFoundDescription: 'La pagina che cerchi non esiste',

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useT } from '../i18n/context';
 import { DollarSign, TrendingUp, AlertTriangle, Calendar } from 'lucide-react';
 import { SkeletonStatCard, SkeletonCard } from '../components/shared/Skeleton';
@@ -60,6 +61,7 @@ function CustomTooltip({ active, payload, label }: {
 
 export default function CostPage() {
   const t = useT();
+  const navigate = useNavigate();
   const [costData, setCostData] = useState<AnalyticsCostsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [dataError, setDataError] = useState<string | null>(null);
@@ -340,7 +342,7 @@ export default function CostPage() {
               Configure daily and monthly spending caps in{' '}
               <button
                 type="button"
-                onClick={() => window.location.hash = '#budget'}
+                onClick={() => navigate('/settings#budget')}
                 className="inline-flex min-h-[44px] items-center underline hover:text-amber-200"
               >
                 Settings

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -107,7 +107,7 @@ export default function OverviewPage() {
   const avgCostPerDay = activeDays > 0 ? totalCost / activeDays : 0;
 
   // Build KPI items
-  function buildKPIItems(): KPIItem[] {
+  function buildKPIItems(analytics: AnalyticsSummary): KPIItem[] {
     return [
       {
         id: 'cost',
@@ -140,12 +140,12 @@ export default function OverviewPage() {
         id: 'errors',
         label: 'Error Rate',
         value: totalSessions > 0
-          ? `${((analytics!.errorRates.failedSessions / totalSessions) * 100).toFixed(1)}%`
+          ? `${((analytics.errorRates.failedSessions / totalSessions) * 100).toFixed(1)}%`
           : '0%',
-        color: totalSessions > 0 && (analytics!.errorRates.failedSessions / totalSessions) > 0.05
+        color: totalSessions > 0 && (analytics.errorRates.failedSessions / totalSessions) > 0.05
           ? 'cost'
           : 'efficiency',
-        trend: totalSessions > 0 && (analytics!.errorRates.failedSessions / totalSessions) > 0.05
+        trend: totalSessions > 0 && (analytics.errorRates.failedSessions / totalSessions) > 0.05
           ? 'up'
           : 'flat',
       },
@@ -191,7 +191,7 @@ export default function OverviewPage() {
 
       {/* Zone B: KPI Banner */}
       {!analyticsLoading && analytics && (
-        <KPIBanner items={buildKPIItems()} />
+        <KPIBanner items={buildKPIItems(analytics)} />
       )}
       {analyticsLoading && (
         <div className="flex items-center justify-center py-4" role="status" aria-busy="true">

--- a/dashboard/src/pages/RoutinesPage.tsx
+++ b/dashboard/src/pages/RoutinesPage.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useCallback } from 'react';
+import { useT } from '../i18n/context';
 import { Calendar, Plus } from 'lucide-react';
 import EmptyState from '../components/shared/EmptyState';
 import { CalendarGrid } from '../components/routines';
@@ -15,6 +16,7 @@ import RoutineCard from '../components/routines/RoutineCard';
 import type { RoutineSchedule } from '../components/routines/CalendarGrid';
 
 export default function RoutinesPage() {
+  const t = useT();
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
   // Phase 1: No backend yet — routines will come from API in Phase 2
@@ -52,13 +54,13 @@ export default function RoutinesPage() {
       {/* Sidebar: routines list */}
       <div className="space-y-4">
         <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
-          {selectedDate ? `Routines for selected date` : 'Upcoming'}
+          {selectedDate ? t('routines.forDate') : t('routines.upcoming')}
         </h2>
         {routines.length === 0 ? (
           <EmptyState
             icon={<Calendar className="w-8 h-8" />}
-            title="No routines yet"
-            description="Create a routine to schedule recurring tasks on a calendar."
+            title={t("routines.emptyTitle")}
+            description={t("routines.emptyDescription")}
           />
         ) : (
           routines.map((routine) => (
@@ -80,9 +82,9 @@ export default function RoutinesPage() {
       <div className="p-6 space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-bold text-[var(--color-text-primary)]">Routines</h1>
+            <h1 className="text-xl font-bold text-[var(--color-text-primary)]">{t('routines.title')}</h1>
             <p className="text-sm text-[var(--color-text-muted)] mt-1">
-              Scheduled tasks that run on a recurring basis
+              {t('routines.subtitle')}
             </p>
           </div>
           <button
@@ -104,9 +106,9 @@ export default function RoutinesPage() {
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-bold text-[var(--color-text-primary)]">Routines</h1>
+          <h1 className="text-xl font-bold text-[var(--color-text-primary)]">{t('routines.title')}</h1>
           <p className="text-sm text-[var(--color-text-muted)] mt-1">
-            {routines.length} scheduled task{routines.length !== 1 ? 's' : ''}
+            {t('routines.count', { count: routines.length })}
           </p>
         </div>
         <button

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -298,13 +298,70 @@ export default function SessionHistoryPage() {
     setSearchParams(new URLSearchParams(), { replace: true });
   };
 
-  const handleExport = () => {
-    const toExport = selectedIds.size > 0
-      ? sortedRecords.filter((r) => selectedIds.has(r.id))
-      : records;
-    const csv = generateSessionHistoryCSV(toExport);
-    const date = new Date().toISOString().slice(0, 10);
-    downloadCSV(csv, `aegis-sessions-${date}.csv`);
+  const handleExport = async () => {
+    try {
+      const toExport = selectedIds.size > 0
+        ? sortedRecords.filter((r) => selectedIds.has(r.id))
+        : await exportAllRecords();
+      const csv = generateSessionHistoryCSV(toExport);
+      const date = new Date().toISOString().slice(0, 10);
+      downloadCSV(csv, `aegis-sessions-${date}.csv`);
+    } catch {
+      addToast('error', 'Export failed', 'Could not export session history');
+    }
+  };
+
+  /** Fetch all records matching current filters (all pages) for CSV export. */
+  const exportAllRecords = async (): Promise<SessionHistoryRecord[]> => {
+    const allRecords: SessionHistoryRecord[] = [];
+    let currentPage = 1;
+    const batchSize = 100;
+    let hasMore = true;
+    while (hasMore) {
+      const data = await fetchSessionHistory({
+        ...buildExportParams(),
+        page: currentPage,
+        limit: batchSize,
+      });
+      allRecords.push(...data.records);
+      hasMore = allRecords.length < data.pagination.total;
+      currentPage++;
+    }
+    return allRecords;
+  };
+
+  /** Build filter params for export (mirrors fetchData filter logic). */
+  const buildExportParams = (): Omit<FetchSessionHistoryParams, 'page' | 'limit' | 'signal'> => {
+    const params: Omit<FetchSessionHistoryParams, 'page' | 'limit' | 'signal'> = {};
+    if (filterOwner) params.ownerKeyId = filterOwner;
+    if (filterStatus) params.status = filterStatus as FetchSessionHistoryParams['status'];
+    if (filterSearch) params.nameSearch = filterSearch;
+    const now = Date.now();
+    if (filterDateRange === '1h') {
+      params.createdAfter = Math.floor((now - 60 * 60 * 1000) / 1000);
+    } else if (filterDateRange === 'today') {
+      const startOfDay = new Date(); startOfDay.setHours(0, 0, 0, 0);
+      params.createdAfter = Math.floor(startOfDay.getTime() / 1000);
+    } else if (filterDateRange === 'yesterday') {
+      const startOfYesterday = new Date(); startOfYesterday.setHours(0, 0, 0, 0); startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+      const endOfYesterday = new Date(startOfYesterday); endOfYesterday.setHours(23, 59, 59, 999);
+      params.createdAfter = Math.floor(startOfYesterday.getTime() / 1000);
+      params.createdBefore = Math.floor(endOfYesterday.getTime() / 1000);
+    } else if (filterDateRange === '7d') {
+      params.createdAfter = Math.floor((now - 7 * 24 * 60 * 60 * 1000) / 1000);
+    } else if (filterDateRange === '30d') {
+      params.createdAfter = Math.floor((now - 30 * 24 * 60 * 60 * 1000) / 1000);
+    } else if (filterDateRange === 'month') {
+      const startOfMonth = new Date(); startOfMonth.setDate(1); startOfMonth.setHours(0, 0, 0, 0);
+      params.createdAfter = Math.floor(startOfMonth.getTime() / 1000);
+    } else if (filterDateRange === 'custom' && customDateFrom) {
+      params.createdAfter = Math.floor(new Date(customDateFrom).getTime() / 1000);
+      if (customDateTo) params.createdBefore = Math.floor(new Date(customDateTo).getTime() / 1000) + 86400;
+    }
+    if (filterSort === 'newest') { params.sortBy = 'createdAt'; params.sortOrder = 'desc'; }
+    else if (filterSort === 'oldest') { params.sortBy = 'createdAt'; params.sortOrder = 'asc'; }
+    else if (filterSort === 'status') { params.sortBy = 'status'; params.sortOrder = 'asc'; }
+    return params;
   };
 
   const handleShareLink = () => {


### PR DESCRIPTION
## Summary

Batch fix for 4 bugs found during Dashboard UAT sprint (#2971).

### Fixes
| Issue | Bug | Fix |
|-------|-----|-----|
| #3009 | OverviewPage uses `analytics!` non-null assertion | `buildKPIItems` now accepts `analytics` as explicit parameter |
| #3015 | CostPage budget link sets hash instead of navigating | Uses `useNavigate("/settings#budget")` for proper SPA routing |
| #3012 | CSV export only exports current page | New `exportAllRecords()` fetches all pages matching current filters |
| #3010 | RoutinesPage has no i18n — all strings hardcoded | Added `useT` hook, message keys in en/it catalogs |

### Quality Gate
- TypeScript: 0 dashboard errors
- Build: clean (1.70s)
- Tests: 1209/1209 pass (120 files)

Closes #3009, #3010, #3012, #3015

— Daedalus 🏛️