### PR TITLE
feat(dashboard): session health alert banner (#3000)

### DIFF
--- a/dashboard/src/__tests__/SessionHealthBanner.test.tsx
+++ b/dashboard/src/__tests__/SessionHealthBanner.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionHealthBanner, SessionHealthDot } from '../components/shared/SessionHealthBanner';
+import type { AnalyticsErrorRates } from '../../../src/api-contracts';
+
+const mockHealthyRates: AnalyticsErrorRates = {
+  totalSessions: 100,
+  failedSessions: 2,
+  failureRate: 0.02,
+  infraFailures: 0,
+  adjustedFailureRate: 0.02,
+  permissionPrompts: 10,
+  approvals: 10,
+  autoApprovals: 8,
+};
+
+const mockWarningRates: AnalyticsErrorRates = {
+  totalSessions: 100,
+  failedSessions: 12,
+  failureRate: 0.12,
+  infraFailures: 3,
+  adjustedFailureRate: 0.12,
+  permissionPrompts: 20,
+  approvals: 18,
+  autoApprovals: 15,
+};
+
+const mockCriticalRates: AnalyticsErrorRates = {
+  totalSessions: 127,
+  failedSessions: 120,
+  failureRate: 0.945,
+  infraFailures: 118,
+  adjustedFailureRate: 0.945,
+  permissionPrompts: 5,
+  approvals: 5,
+  autoApprovals: 0,
+};
+
+describe('SessionHealthBanner', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('renders nothing when healthy (<5% failure)', () => {
+    const { container } = render(<SessionHealthBanner errorRates={mockHealthyRates} loading={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when loading', () => {
+    const { container } = render(<SessionHealthBanner errorRates={mockCriticalRates} loading={true} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing with too few sessions (<5)', () => {
+    const fewSessions = { ...mockWarningRates, totalSessions: 3, failedSessions: 2 };
+    const { container } = render(<SessionHealthBanner errorRates={fewSessions} loading={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders warning banner at 12% failure rate', () => {
+    render(<SessionHealthBanner errorRates={mockWarningRates} loading={false} />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeTruthy();
+    expect(alert.textContent).toContain('Warning');
+    expect(alert.textContent).toContain('12.0%');
+    expect(alert.textContent).toContain('12 of 100 sessions failed');
+    expect(alert.textContent).toContain('3 infrastructure failures');
+  });
+
+  it('renders critical banner at 94.5% failure rate', () => {
+    render(<SessionHealthBanner errorRates={mockCriticalRates} loading={false} />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeTruthy();
+    expect(alert.textContent).toContain('Critical');
+    expect(alert.textContent).toContain('94.5%');
+    expect(alert.textContent).toContain('Check ACP child process');
+  });
+
+  it('dismisses the banner and re-shows when rate increases 5%+', () => {
+    const { rerender } = render(<SessionHealthBanner errorRates={mockWarningRates} loading={false} />);
+    expect(screen.getByRole('alert')).toBeTruthy();
+
+    // Dismiss
+    fireEvent.click(screen.getByLabelText('Dismiss health alert'));
+    expect(screen.queryByRole('alert')).toBeNull();
+
+    // Same rate — still dismissed
+    rerender(<SessionHealthBanner errorRates={mockWarningRates} loading={false} />);
+    expect(screen.queryByRole('alert')).toBeNull();
+
+    // Rate increased by 5%+ — re-shows
+    const higherRate = { ...mockWarningRates, failedSessions: 20, adjustedFailureRate: 0.20, failureRate: 0.20 };
+    rerender(<SessionHealthBanner errorRates={higherRate} loading={false} />);
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+
+  it('renders nothing when errorRates is undefined', () => {
+    const { container } = render(<SessionHealthBanner errorRates={undefined} loading={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('SessionHealthDot', () => {
+  it('renders nothing when healthy', () => {
+    const { container } = render(<SessionHealthDot errorRates={mockHealthyRates} loading={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders pulsing dot with failure rate text at 12%', () => {
+    render(<SessionHealthDot errorRates={mockWarningRates} loading={false} />);
+    expect(screen.getByText('12.0% failure rate')).toBeTruthy();
+    const dot = document.querySelector('.animate-pulse');
+    expect(dot).toBeTruthy();
+    expect(dot?.className).toContain('bg-yellow-500');
+  });
+
+  it('renders pulsing dot with critical color at 94.5%', () => {
+    render(<SessionHealthDot errorRates={mockCriticalRates} loading={false} />);
+    expect(screen.getByText('94.5% failure rate')).toBeTruthy();
+    const dot = document.querySelector('.animate-pulse');
+    expect(dot?.className).toContain('bg-red-500');
+  });
+});

--- a/dashboard/src/components/shared/SessionHealthBanner.tsx
+++ b/dashboard/src/components/shared/SessionHealthBanner.tsx
@@ -1,0 +1,139 @@
+/**
+ * components/shared/SessionHealthBanner.tsx — Session failure rate alert banner.
+ *
+ * Displays a color-coded health indicator on the dashboard overview based on
+ * the session failure rate from analytics. Related: #3000. // token-ok
+ *
+ * Thresholds:
+ * - Green (<5%): Healthy — no banner shown
+ * - Yellow (5–25%): Warning — elevated failure rate
+ * - Red (>25%): Critical — session infrastructure may be broken
+ *
+ * The banner is dismissible per session but reappears if the failure rate
+ * increases by 5+ percentage points.
+ */
+
+import { useState, useEffect } from 'react';
+import { AlertTriangle, X, AlertCircle } from 'lucide-react';
+import type { AnalyticsErrorRates } from '../../../../src/api-contracts';
+
+interface SessionHealthBannerProps {
+  errorRates: AnalyticsErrorRates | undefined;
+  loading: boolean;
+}
+
+type HealthLevel = 'healthy' | 'warning' | 'critical';
+
+function getHealthLevel(errorRates: AnalyticsErrorRates | undefined): HealthLevel {
+  if (!errorRates || errorRates.totalSessions < 5) return 'healthy';
+  const rate = errorRates.adjustedFailureRate ?? (errorRates.failedSessions / errorRates.totalSessions);
+  if (rate > 0.25) return 'critical';
+  if (rate > 0.05) return 'warning';
+  return 'healthy';
+}
+
+const STORAGE_KEY = 'aegis-session-health-dismissed-rate';
+
+export function SessionHealthBanner({ errorRates, loading }: SessionHealthBannerProps) {
+  const [dismissedRate, setDismissedRate] = useState<number | null>(null);
+
+  // Load dismissed rate from sessionStorage
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem(STORAGE_KEY);
+      if (stored) setDismissedRate(parseFloat(stored));
+    } catch { /* ignore */ }
+  }, []);
+
+  if (loading || !errorRates || errorRates.totalSessions < 5) return null;
+
+  const level = getHealthLevel(errorRates);
+  if (level === 'healthy') return null;
+
+  const failureRate = errorRates.adjustedFailureRate
+    ?? (errorRates.failedSessions / errorRates.totalSessions);
+  const ratePercent = (failureRate * 100).toFixed(1);
+  const totalFailed = errorRates.failedSessions;
+  const totalSessions = errorRates.totalSessions;
+  const infraFailed = errorRates.infraFailures;
+
+  // Re-show if rate increased by 5% since dismissal
+  if (dismissedRate !== null && (failureRate - dismissedRate) < 0.05) return null;
+
+  const handleDismiss = () => {
+    setDismissedRate(failureRate);
+    try { sessionStorage.setItem(STORAGE_KEY, String(failureRate)); } catch { /* ignore */ }
+  };
+
+  const isCritical = level === 'critical';
+
+  const bgColor = isCritical
+    ? 'bg-red-500/10 border-red-500/30'
+    : 'bg-yellow-500/10 border-yellow-500/30';
+  const textColor = isCritical
+    ? 'text-red-400'
+    : 'text-yellow-400';
+  const Icon = isCritical ? AlertCircle : AlertTriangle;
+
+  const title = isCritical
+    ? `Critical: Session failure rate at ${ratePercent}%`
+    : `Warning: Elevated session failure rate (${ratePercent}%)`;
+
+  return (
+    <div
+      role="alert"
+      className={`relative flex items-start gap-3 rounded-lg border px-4 py-3 ${bgColor}`}
+    >
+      <Icon className={`h-5 w-5 shrink-0 mt-0.5 ${textColor}`} />
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm font-medium ${textColor}`}>
+          {title}
+        </p>
+        <p className="text-xs text-[var(--color-text-muted)] mt-1">
+          {totalFailed} of {totalSessions} sessions failed
+          {infraFailed > 0 && ` (${infraFailed} infrastructure failures)`}
+        </p>
+        {isCritical && (
+          <p className="text-xs text-[var(--color-text-muted)] mt-1">
+            Check ACP child process spawning and server logs.
+          </p>
+        )}
+      </div>
+      <button
+        onClick={handleDismiss}
+        className="shrink-0 p-1 rounded hover:bg-white/10 transition-colors"
+        aria-label="Dismiss health alert"
+      >
+        <X className="h-4 w-4 text-[var(--color-text-muted)]" />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Compact health indicator for the KPI banner area.
+ * Shows a small colored dot + label.
+ */
+export function SessionHealthDot({ errorRates, loading }: SessionHealthBannerProps) {
+  if (loading || !errorRates || errorRates.totalSessions < 5) return null;
+
+  const level = getHealthLevel(errorRates);
+  const failureRate = errorRates.adjustedFailureRate
+    ?? (errorRates.failedSessions / errorRates.totalSessions);
+  const ratePercent = (failureRate * 100).toFixed(1);
+
+  const dotColor = level === 'critical'
+    ? 'bg-red-500'
+    : level === 'warning'
+      ? 'bg-yellow-500'
+      : 'bg-green-500';
+
+  if (level === 'healthy') return null;
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
+      <span className={`inline-block h-2 w-2 rounded-full ${dotColor} animate-pulse`} />
+      <span>{ratePercent}% failure rate</span>
+    </div>
+  );
+}

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -22,6 +22,7 @@ import { ModelDistributionBar } from '../components/analytics/ModelDistributionB
 import { EfficiencyGauge } from '../components/analytics/EfficiencyGauge';
 import { useSessionRealtimeUpdates } from '../hooks/useSessionRealtimeUpdates';
 import { useT } from '../i18n/context';
+import { SessionHealthBanner } from '../components/shared/SessionHealthBanner';
 import { useStore } from '../store/useStore';
 import { getAnalyticsSummary } from '../api/client';
 import { formatCurrency, formatNumber } from '../utils/formatNumber';
@@ -180,6 +181,9 @@ export default function OverviewPage() {
           New Session
         </button>
       </div>
+
+      {/* Session Health Alert */}
+      <SessionHealthBanner errorRates={analytics?.errorRates} loading={analyticsLoading} />
 
       {/* Zone A: Heatmap Cards (4-column) — needs daily token breakdown from backend */}
       <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">


### PR DESCRIPTION
## Summary

Partially addresses #3000 — adds a session health alert banner to the dashboard OverviewPage.

### What it does
Shows a color-coded alert banner when session failure rate exceeds thresholds:
- **Yellow (5–25%):** "Warning: Elevated session failure rate"
- **Red (>25%):** "Critical: Session failure rate at X%" with actionable guidance

### Features
- Uses `analytics.errorRates.adjustedFailureRate` (excludes infrastructure noise)
- Minimum 5 sessions before showing (avoids false alerts on small samples)
- **Dismissible** — stores dismissed rate in sessionStorage
- **Re-shows** if failure rate increases by 5+ percentage points since dismissal
- Shows infrastructure failure count when present
- Includes `SessionHealthDot` compact variant for KPI banner area
- 10 Vitest tests covering all thresholds, dismiss behavior, and edge cases

### Files changed
| File | Change |
|------|--------|
| `components/shared/SessionHealthBanner.tsx` | New — banner + dot components |
| `pages/OverviewPage.tsx` | Import + render banner below header |
| `__tests__/SessionHealthBanner.test.tsx` | New — 10 tests |

### Verification
- ✅ TypeScript: 0 errors
- ✅ tokens-gate: pass
- ✅ clickable-gate: pass
- ✅ Tests: 10/10 new + 5/5 OverviewPage tests
- ✅ Build: clean (+0.66 kB)

### What's NOT in this PR
Backend work for #3000 (metric endpoint, configurable threshold, alert channels) is Hep's territory. This PR covers the dashboard UI component only.

— Daedalus 🏛️