### PR TITLE
fix(cli): add --force flag and config-exists warning to ag init (#3028)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -197,6 +197,7 @@ function printHelp(io: CliIO): void {
     ag                     Start the server (port 9100)
     ag init                Bootstrap .aegis/config.yaml
     ag init --yes          Non-interactive bootstrap for CI
+    ag init --force          Overwrite existing config (use with caution)
     ag init --list-templates
     ag init --from-template code-reviewer
     ag doctor              Validate starter templates here or run local diagnostics

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -542,6 +542,7 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   // --- Config bootstrap path ---
 
   const yes = args.includes('--yes') || args.includes('-y');
+  const force = args.includes("--force") || args.includes("-f");
   const configPath = resolveInitConfigPath(args);
   const displayConfigPath = formatConfigPath(configPath);
   const commandPrefix = commandPrefixForConfig(configPath);
@@ -557,6 +558,17 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   const stateDir = currentConfig.stateDir;
   await mkdir(stateDir, { recursive: true });
   writeLine(io.stdout, `  ✅ State directory: ${stateDir}`);
+
+  // Issue #3028: Warn when config already exists
+  if (existingConfigText !== null && !force) {
+    writeLine(io.stdout, `  ⚠️  ${displayConfigPath} already exists.`);
+    if (existingToken) {
+      writeLine(io.stdout, `  ⚠️  Existing auth token will be preserved.`);
+    }
+    if (yes) {
+      writeLine(io.stdout, `  ℹ️  Use --force to overwrite in non-interactive mode.`);
+    }
+  }
 
   if (existingConfigText !== null && existingConfig === null && yes) {
     writeLine(
@@ -620,8 +632,8 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   const needsWrite = existingConfigText === null || existingConfig === null || desiredComparison !== existingComparison;
 
   if (existingConfigText !== null && needsWrite) {
-    if (yes) {
-      writeLine(io.stdout, `  ℹ️  Left ${displayConfigPath} unchanged because --yes never overwrites existing files.`);
+    if (yes && !force) {
+      writeLine(io.stdout, `  ℹ️  Left ${displayConfigPath} unchanged because --yes never overwrites (use --force to override) existing files.`);
       printInitSummary(io, {
         authToken: existingToken,
         baseUrl: existingConfig?.baseUrl ? normalizeBaseUrl(existingConfig.baseUrl) : baseUrl,


### PR DESCRIPTION
## Fix for #3028 — ag init silently overwrites existing config

### Problem
Running `ag init` when a config already exists could silently overwrite it, breaking a running server that expects the old auth token.

### Changes
1. **Early warning** when config file already exists — shows path and auth token status
2. **`--force` flag** (`-f`) — allows overwriting in `--yes` mode
3. **Updated guard** — `--yes` mode now says "use --force to override" instead of just refusing
4. Interactive mode already had overwrite confirmation (unchanged)

### Before (`--yes` mode with existing config)
```
ℹ️  Left config unchanged because --yes never overwrites existing files.
```

### After (`--yes` mode with existing config)
```
⚠️  .aegis/config.yaml already exists.
⚠️  Existing auth token will be preserved.
ℹ️  Use --force to overwrite in non-interactive mode.
```

### After (`--yes --force` with existing config)
Config is overwritten, new token created if requested.

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258/258, 3947 passed
``

Commit: e7a0c667