### PR TITLE
fix(acp): handle empty/malformed local storage file gracefully (#3036)

### DIFF
--- a/src/services/acp/local-storage.ts
+++ b/src/services/acp/local-storage.ts
@@ -610,6 +610,7 @@ async function loadState(filePath: string): Promise<LocalState> {
     return deserializeState(JSON.parse(await readFile(filePath, 'utf8')));
   } catch (error) {
     if (isNodeError(error) && error.code === 'ENOENT') return createEmptyState();
+    if (error instanceof SyntaxError) return createEmptyState();
     throw error;
   }
 }


### PR DESCRIPTION
## Fix for #3036 — Empty acp-local-storage.json crashes server on startup

### Problem
If `~/.aegis/acp-local-storage.json` becomes 0 bytes (empty write, disk full, crash during write), `JSON.parse` throws `SyntaxError` and the server crashes.

The existing code only handled `ENOENT` (file not found), not `SyntaxError` (malformed/empty file).

### Fix
Added `SyntaxError` catch in `loadState()` — falls back to `createEmptyState()` same as a missing file.

```typescript
catch (error) {
  if (isNodeError(error) && error.code === 'ENOENT') return createEmptyState();
  if (error instanceof SyntaxError) return createEmptyState();  // NEW
  throw error;
}
```

One line change. Gate: ✅ 258/258, 3947 tests.

Commit: 34a165bc