### PR TITLE
docs: fix SSE troubleshooting, ag init warning, unknown status (#3030, #3028, #3032)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ All endpoints under `/v1/`.
 | `permission_prompt` | Awaiting approval | `/approve` or `/reject` |
 | `asking` | Claude asked a question | Read `/read`, respond `/send` |
 | `stalled` | No output for >5 min | Nudge `/send` or `DELETE` |
+| `unknown` | Initial state, not yet connected | Wait a moment and re-poll |
+| `error` | Session crashed | Check diagnostics, recreate |
 
 </details>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,8 +18,12 @@ Install once, bootstrap `.aegis/config.yaml`, then start Aegis with the primary 
 ```bash
 npm install -g @onestepat4time/aegis
 ag init
-ag
 ```
+
+> **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml` and generates a new auth token. Restart the server to apply changes. Use `ag init --force` to skip the confirmation prompt.
+
+```bash
+ag
 
 > The primary CLI command is `ag`. The legacy name `aegis` is kept as an alias for backward compatibility — both resolve to the same binary.
 
@@ -357,4 +361,4 @@ See the [Worktree Guide](./worktree-guide.md) for detailed setup instructions.
 | Dashboard won't load | Verify Aegis is running on port 9100: `curl http://localhost:9100/v1/health` |
 | `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 ag` |
 | Screenshot returns 501 | Install Playwright: `npx playwright install chromium` |
-| No output from `/read` | Wait for transcript entries, or check session events via SSE: `curl http://localhost:9100/v1/sessions/:id/events` |
+| No output from `/read` | Wait for transcript entries, or check session events via SSE (see Section 5 for SSE token setup) |


### PR DESCRIPTION
## Fixes — clean branch from latest develop, docs only

**2 files changed:** README.md + docs/getting-started.md. Zero dashboard code.

### #3030 (P1) — SSE troubleshooting missing auth
- Replaced bare `curl /sessions/:id/events` with reference to Section 5 SSE token flow

### #3028 (P2) — ag init overwrites config without warning
- Added warning after `ag init` step (references `--force` flag from PR #3035)

### #3032 (P2) — unknown session state undocumented
- Added `unknown` (initial state before ACP connects) and `error` (crashed) to README session states table

Closes #3028
Closes #3030
Closes #3032

Supersedes #3034 and #3038 (those had branch contamination).