### PR TITLE
docs: fix SSE auth in examples, add unknown session state (#3030, #3032)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ All endpoints under `/v1/`.
 | `GET` | `/v1/sessions` | List sessions |
 | `GET` | `/v1/sessions/:id` | Session details |
 | `GET` | `/v1/sessions/:id/read` | Parsed transcript |
-| `GET` | `/v1/sessions/:id/events` | SSE event stream |
+| `GET` | `/v1/sessions/:id/events` | SSE event stream *(requires `sse_`-prefixed token)* |
 | `POST` | `/v1/sessions/:id/send` | Send a message |
 | `POST` | `/v1/sessions/:id/approve` | Approve permission |
 | `POST` | `/v1/sessions/:id/reject` | Reject permission |
@@ -187,6 +187,7 @@ All endpoints under `/v1/`.
 
 | State | Meaning | Action |
 |-------|---------|--------|
+| `unknown` | Agent not yet responding | Wait a moment, then poll again |
 | `working` | Actively generating | Wait or poll `/read` |
 | `idle` | Waiting for input | Send via `/send` |
 | `permission_prompt` | Awaiting approval | `/approve` or `/reject` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -357,4 +357,4 @@ See the [Worktree Guide](./worktree-guide.md) for detailed setup instructions.
 | Dashboard won't load | Verify Aegis is running on port 9100: `curl http://localhost:9100/v1/health` |
 | `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 ag` |
 | Screenshot returns 501 | Install Playwright: `npx playwright install chromium` |
-| No output from `/read` | Wait for transcript entries, or check session events via SSE: `curl http://localhost:9100/v1/sessions/:id/events` |
+| No output from `/read` | Wait for transcript entries, or check session events via SSE: `curl -N "http://localhost:9100/v1/sessions/:id/events?token=$SSE_TOKEN"` |


### PR DESCRIPTION
## Summary

Fixes two documentation bugs discovered during DevRel UAT (#2973).

### Changes

**#3030 — SSE examples missing authentication**
- README API table: `/v1/sessions/:id/events` now notes `*(requires sse_-prefixed token)*`
- getting-started.md troubleshooting: SSE curl fixed from bare URL to include `?token=$SSE_TOKEN`

**#3032 — Undocumented session state: `unknown`**
- README Session States table: added `unknown` — "Agent not yet responding" — "Wait a moment, then poll again"

### Files changed
| File | Change |
|------|--------|
| `README.md` | +`unknown` state in Session States table; +SSE token note in API table |
| `docs/getting-started.md` | Fixed troubleshooting SSE curl to include auth |

Closes #3030, Closes #3032