### PR TITLE
docs: add --force flag to cli.md, SSE auth note to API table

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ All endpoints under `/v1/`.
 | `GET` | `/v1/sessions` | List sessions |
 | `GET` | `/v1/sessions/:id` | Session details |
 | `GET` | `/v1/sessions/:id/read` | Parsed transcript |
-| `GET` | `/v1/sessions/:id/events` | SSE event stream |
+| `GET` | `/v1/sessions/:id/events` | SSE event stream *(requires `sse_`-prefixed token)* |
 | `POST` | `/v1/sessions/:id/send` | Send a message |
 | `POST` | `/v1/sessions/:id/approve` | Approve permission |
 | `POST` | `/v1/sessions/:id/reject` | Reject permission |

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -21,11 +21,12 @@ Create `.aegis/config.yaml` with an API token, preferred base URL, optional BYO-
 ```bash
 ag init
 ag init --yes            # Non-interactive defaults for CI
+ag init --yes --force     # Overwrite existing config in non-interactive mode
 ag init --list-templates
 ag init --from-template code-reviewer
 ```
 
-The interactive flow is idempotent: if `.aegis/config.yaml` already exists, `ag init` keeps it unless you confirm an overwrite.
+The interactive flow is idempotent: if `.aegis/config.yaml` already exists, `ag init` keeps it unless you confirm an overwrite. In `--yes` mode, existing config is preserved by default — use `--force` (or `-f`) to allow overwriting.
 
 `ag init` also exposes the built-in starter gallery for Claude Code helpers:
 


### PR DESCRIPTION
## Accuracy fixes post-#3040

Two gaps remaining after #3040 merged:

### 1. cli.md missing `--force` flag (refs #3028)
- Added `ag init --yes --force` example
- Documented `--force` / `-f` behavior in `--yes` mode

### 2. SSE endpoint missing auth note (refs #3030)
- Added `*(requires sse_-prefixed token)*` to API reference table in README

**Files changed:** `docs/integrations/cli.md`, `README.md`

Closes #3039, #3041 (replaced — both had conflicts from pre-#3040 develop)