### PR TITLE
fix(core): atomic writes for all JSON state files (#3045)

### DIFF
--- a/src/metering.ts
+++ b/src/metering.ts
@@ -6,7 +6,7 @@
  * usage, then provides aggregation endpoints for billing integration.
  */
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { SessionEventBus } from './events.js';
@@ -192,7 +192,10 @@ export class MeteringService {
       records: this.records,
       nextId: this.nextId,
     };
-    await writeFile(this.dataFile, JSON.stringify(data), 'utf-8');
+    // Issue #3045: atomic write to prevent truncation on SIGTERM/OOM kill
+    const tmpFile = `${this.dataFile}.tmp.${process.pid}`;
+    await writeFile(tmpFile, JSON.stringify(data), 'utf-8');
+    await rename(tmpFile, this.dataFile);
   }
 
   /** Subscribe to session lifecycle events for automatic recording. Starts periodic prune timer. */

--- a/src/permission-guard.ts
+++ b/src/permission-guard.ts
@@ -108,7 +108,10 @@ async function neutralizeOneFile(filePath: string, bpPath: string, targetMode: s
     // Patch
     if (!settings.permissions) settings.permissions = {};
     settings.permissions.defaultMode = targetMode;
-    await writeFile(filePath, JSON.stringify(settings, null, 2) + '\n');
+    // Issue #3045: atomic write to prevent truncation
+    const tmpFile = `${filePath}.tmp.${process.pid}`;
+    await writeFile(tmpFile, JSON.stringify(settings, null, 2) + '\n');
+    await rename(tmpFile, filePath);
 
     console.log(`Permission guard: neutralized bypassPermissions in ${filePath} (backup: ${bpPath})`);
     return true;

--- a/src/services/acp/local-storage.ts
+++ b/src/services/acp/local-storage.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile, rename } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { ServiceHealth } from '../../container.js';
@@ -158,8 +158,12 @@ export class FileAcpLocalStorageProfile implements AcpLocalStorageProfile {
     if (!this.started) {
       throw new Error('FileAcpLocalStorageProfile: start() must be called before use');
     }
+    // Issue #3045: atomic write to prevent truncation on SIGTERM/OOM kill
     const content = `${JSON.stringify(serializeState(this.state), null, 2)}\n`;
-    this.writeChain = this.writeChain.then(() => writeFile(this.config.filePath, content, 'utf8'));
+    const tmpFile = `${this.config.filePath}.tmp.${process.pid}`;
+    this.writeChain = this.writeChain.then(
+      () => writeFile(tmpFile, content, 'utf8').then(() => rename(tmpFile, this.config.filePath)),
+    );
     await this.writeChain;
   }
 }

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -8,7 +8,7 @@
 
 import { createHash, randomBytes } from 'node:crypto';
 import { timingSafeStringEqual } from '../../crypto-utils.js';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 import { authStoreSchema } from '../../validation.js';
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
@@ -221,8 +221,11 @@ export class AuthManager {
     if (!existsSync(dir)) {
       await mkdir(dir, { recursive: true });
     }
+    // Issue #3045: atomic write to prevent truncation on SIGTERM/OOM kill
     const data = { ...this.store, graceKeys: this.graceKeys };
-    await writeFile(this.keysFile, JSON.stringify(data, null, 2), { mode: 0o600 });
+    const tmpFile = `${this.keysFile}.tmp.${process.pid}`;
+    await writeFile(tmpFile, JSON.stringify(data, null, 2), { mode: 0o600 });
+    await rename(tmpFile, this.keysFile);
     await secureFilePermissions(this.keysFile);
   }
 


### PR DESCRIPTION
## Fix for #3045 — Non-atomic state file writes cause crash loops

### Problem
When the server receives SIGTERM or OOM kill during a state file write, the file is left truncated (0 bytes or partial JSON). On restart, `JSON.parse` fails and the server crash-loops until systemd gives up — leaving the dogfood environment dead for hours with zero alerting.

### Root Cause
State files were written with direct `writeFile()`. If the process is killed mid-write, the file is corrupted.

### Fix
All state file writers now use **atomic writes**: write to `.tmp` file, then `rename()` (atomic on same filesystem). If the process dies during write, the `.tmp` file is left behind (harmless) and the original file stays intact.

### Files changed
| File | State file | Before | After |
|------|-----------|--------|-------|
| `src/services/acp/local-storage.ts` | `acp-local-storage.json` | Direct `writeFile` | tmp + rename |
| `src/services/auth/AuthManager.ts` | `keys.json` | Direct `writeFile` | tmp + rename |
| `src/metering.ts` | metering data | Direct `writeFile` | tmp + rename |
| `src/permission-guard.ts` | settings patch | Direct `writeFile` | tmp + rename |

### Already atomic (unchanged)
- `src/services/state/JsonFileStore.ts` — already uses tmp + rename ✅
- `src/services/metrics-cache.ts` — already uses tmp + rename ✅

### Related
- #3036 — SyntaxError catch for empty files (already merged)
- #3046 — silent death alerting (separate issue)

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258/258, 3947 passed
``

Commit: 0af4f28b