### PR TITLE
docs: add ag run — zero-to-session command (#3050, #3043)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,21 @@
 ## Quick Start
 
 ```bash
-# Install, bootstrap, and start
+# Install
 npm install -g @onestepat4time/aegis
+
+# Zero-to-session in one command (bootstraps config, starts server, creates session)
+ag run "Build a login page with email/password fields." --cwd /path/to/project
+
+# Or step by step
 ag init
 ag
+ag create "Build a login page with email/password fields." --cwd /path/to/project
 
 # Scaffold a repo-local starter
 ag init --list-templates
 ag init --from-template code-reviewer
 ag doctor
-
-# Create a session
-ag create "Build a login page with email/password fields." --cwd /path/to/project
 ```
 
 > **CLI naming:** the primary command is `ag` (e.g. `ag`, `ag mcp`, `ag create "brief"`). The legacy name `aegis` is preserved as an alias, so any existing scripts using `aegis` keep working.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,6 +122,38 @@ The dashboard displays the shortcut hint in the sidebar footer.
 
 ## 4. Create Your First Session
 
+### One-command mode (`ag run`)
+
+Skip all the setup — `ag run` bootstraps config, starts the server, creates a session, and streams output to your terminal:
+
+```bash
+ag run "Analyze this project. List the main technologies, directory structure, and any issues you spot." --cwd /path/to/your/project
+```
+
+```text
+🚀 ag run: Analyze this project...
+⏳ Server not running — starting...
+⏳ Waiting for server...
+✅ Server started
+✅ Session: run-analyze-this-proj- (ff3aafbb)
+📊 Dashboard: http://127.0.0.1:9100
+
+📡 Streaming session output (Ctrl+C to stop)...
+
+👤 Analyze this project...
+🤖 I'll analyze the project structure...
+```
+
+| Flag | Description |
+|------|-------------|
+| `--cwd <path>` | Working directory (default: current directory) |
+| `--port <number>` | Server port override |
+| `--no-stream` | Don't stream output; print curl commands instead |
+
+If the server is already running, `ag run` skips bootstrap and start — goes straight to session creation. Existing config is never overwritten.
+
+### Step-by-step (`ag create`)
+
 ```bash
 ag create "Analyze this project. List the main technologies, directory structure, and any issues you spot." --cwd /path/to/your/project
 ```

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -42,6 +42,35 @@ ag init --from-template docs-writer
 ag doctor
 ```
 
+### `ag run "prompt"` — Zero-to-Session
+
+Bootstrap config, start the server, create a session, and stream output — all in one command.
+
+```bash
+ag run "Build a REST API for managing tasks" --cwd .
+ag run "Fix the auth bug"                     # Uses current directory
+ag run "Refactor the utils" --no-stream       # Print curl commands instead of streaming
+ag run "Debug the tests" --port 3000          # Custom server port
+```
+
+**What it does:**
+
+1. Checks server health — is it running?
+2. If not: bootstraps config (if none exists) → starts server in background → waits up to 15s
+3. Creates a session with the prompt and working directory
+4. Streams session output to your terminal with role icons (`👤` user, `🤖` assistant)
+5. Prints the dashboard URL for follow-up monitoring
+
+If the server is already running, skips straight to session creation. Existing config is never overwritten (respects `--force` behavior from `ag init`).
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--cwd <path>` | Working directory (default: current directory) |
+| `--port <number>` | Server port override |
+| `--no-stream` | Don't stream output; print curl commands instead |
+
 ### `ag` — Start Server
 
 Start the Aegis HTTP server (port 9100).
@@ -185,6 +214,7 @@ ag                     Start HTTP server
 ag init                Bootstrap .aegis/config.yaml
 ag init --list-templates
 ag init --from-template code-reviewer
+ag run "prompt"        Zero-to-session (bootstrap + start + create + stream)
 ag doctor              Validate starter scaffolds
 ag --port 3000         Custom port
 ag mcp                 Start MCP server


### PR DESCRIPTION
## What

Documents the new `ag run` command introduced in PR #3050 (issue #3043).

## Changes

| File | Change |
|------|--------|
| `README.md` | Quick Start now shows `ag run` as the fastest path, with step-by-step as alternative |
| `docs/getting-started.md` | Section 4 rewritten — `ag run` (one-command mode) + `ag create` (step-by-step) |
| `docs/integrations/cli.md` | Full `ag run` reference: flags, behavior, quick reference updated |

## Verification

- [x] All flags match `src/commands/run.ts` (`--cwd`, `--port`, `--no-stream`)
- [x] Behavior description matches implementation (bootstrap → start → create → stream)
- [x] Example output matches actual CLI output format from PR description
- [x] No broken links or stale references

Refs #3043