### PR TITLE
fix(session): new sessions start as 'pending' instead of 'unknown' (#3058)

### DIFF
--- a/dashboard/src/__tests__/AccessibilityIssue309.test.tsx
+++ b/dashboard/src/__tests__/AccessibilityIssue309.test.tsx
@@ -121,6 +121,7 @@ describe('Issue 309 accessibility fixes', () => {
       bash_approval: 0,
       settings: 0,
       error: 0,
+      pending: 0,
       unknown: 0,
     });
   });

--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -47,7 +47,8 @@ const counts: SessionStatusCounts = {
   settings: 0,
   error: 0,
   rate_limit: 0,
-  unknown: 0,
+  pending: 0,
+      unknown: 0,
 };
 
 const sessions: SessionInfo[] = [

--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -48,7 +48,7 @@ const counts: SessionStatusCounts = {
   error: 0,
   rate_limit: 0,
   pending: 0,
-      unknown: 0,
+    unknown: 0,
 };
 
 const sessions: SessionInfo[] = [

--- a/dashboard/src/__tests__/client.test.ts
+++ b/dashboard/src/__tests__/client.test.ts
@@ -215,6 +215,7 @@ describe('getSessionStatusCounts', () => {
       settings: 0,
       error: 0,
       rate_limit: 0,
+      pending: 0,
       unknown: 0,
     });
 

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -337,7 +337,8 @@ export async function getSessionStatusCounts(): Promise<SessionStatusCounts> {
     settings: 0,
     error: 0,
     rate_limit: 0,
-    unknown: 0,
+    pending: 0,
+      unknown: 0,
   };
 
   SESSION_STATUS_VALUES.forEach((status) => {

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -338,7 +338,7 @@ export async function getSessionStatusCounts(): Promise<SessionStatusCounts> {
     error: 0,
     rate_limit: 0,
     pending: 0,
-      unknown: 0,
+    unknown: 0,
   };
 
   SESSION_STATUS_VALUES.forEach((status) => {

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -39,6 +39,7 @@ const UIState = z.enum([
   'bash_approval',
   'settings',
   'error',
+  'pending',
   'unknown',
 ]);
 

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -53,7 +53,7 @@ const EMPTY_COUNTS: SessionStatusCounts = {
   error: 0,
   rate_limit: 0,
   pending: 0,
-      unknown: 0,
+    unknown: 0,
 };
 const STATUS_FILTERS: SessionStatusFilter[] = [
   'all',

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -52,7 +52,8 @@ const EMPTY_COUNTS: SessionStatusCounts = {
   settings: 0,
   error: 0,
   rate_limit: 0,
-  unknown: 0,
+  pending: 0,
+      unknown: 0,
 };
 const STATUS_FILTERS: SessionStatusFilter[] = [
   'all',

--- a/dashboard/src/components/overview/StatusDot.tsx
+++ b/dashboard/src/components/overview/StatusDot.tsx
@@ -18,7 +18,7 @@ const STATUS_COLORS: Record<UIState, string> = {
   compacting: 'var(--color-warning)',
   context_warning: 'var(--color-warning)',
   waiting_for_input: 'var(--color-warning)',
-  pending: '#888',
+  pending: '#f0ad4e',  // amber — visually distinct from unknown gray
   unknown: '#666',
 };
 

--- a/dashboard/src/components/overview/StatusDot.tsx
+++ b/dashboard/src/components/overview/StatusDot.tsx
@@ -18,6 +18,7 @@ const STATUS_COLORS: Record<UIState, string> = {
   compacting: 'var(--color-warning)',
   context_warning: 'var(--color-warning)',
   waiting_for_input: 'var(--color-warning)',
+  pending: '#888',
   unknown: '#666',
 };
 
@@ -51,6 +52,7 @@ const STATUS_LABELS: Record<UIState, string> = {
   compacting: 'Compacting',
   context_warning: 'Context warning',
   waiting_for_input: 'Waiting for input',
+  pending: 'Pending',
   unknown: 'Unknown',
 };
 

--- a/dashboard/src/components/session/SessionStateBadge.tsx
+++ b/dashboard/src/components/session/SessionStateBadge.tsx
@@ -23,6 +23,7 @@ export type SessionBadgeStatus =
   | 'error'
   | 'compacting'
   | 'offline'
+  | 'pending'
   | 'unknown';
 
 export interface SessionStateBadgeProps {
@@ -40,6 +41,7 @@ const STATUS_TO_DOT: Record<SessionBadgeStatus, StatusDotVariant> = {
   error: 'error',
   compacting: 'compacting',
   offline: 'unknown',
+  pending: 'idle',
   unknown: 'unknown',
 };
 
@@ -51,6 +53,7 @@ const STATUS_LABEL: Record<SessionBadgeStatus, string> = {
   error: 'Error',
   compacting: 'Compacting',
   offline: 'Offline',
+  pending: 'Pending',
   unknown: 'Unknown',
 };
 

--- a/dashboard/src/components/session/SessionSummaryCard.tsx
+++ b/dashboard/src/components/session/SessionSummaryCard.tsx
@@ -15,6 +15,7 @@ const STATUS_LABELS: Record<UIState, string> = {
   compacting: 'Compacting',
   context_warning: 'Context warning',
   waiting_for_input: 'Waiting for input',
+  pending: 'Pending',
   unknown: 'Unknown',
 };
 

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -20,7 +20,7 @@ const MAX_POLL_INTERVAL_MS = 60_000;
 const VALID_UI_STATES: ReadonlySet<string> = new Set([
   'idle', 'working', 'compacting', 'context_warning',
   'waiting_for_input', 'permission_prompt', 'plan_mode',
-  'ask_question', 'bash_approval', 'settings', 'error', 'unknown',
+  'ask_question', 'bash_approval', 'settings', 'error', 'pending', 'unknown',
 ] as const);
 
 /**

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -20,6 +20,7 @@ export type UIState =
   | 'settings'
   | 'error'
   | 'rate_limit'
+  | 'pending'
   | 'unknown';
 
 export type SessionStatusFilter = 'all' | UIState;

--- a/src/session.ts
+++ b/src/session.ts
@@ -34,7 +34,7 @@ import { startSessionSpan, spanError, spanOk } from './tracing.js';
 export type UIState =
   | 'idle' | 'working' | 'compacting' | 'context_warning'
   | 'waiting_for_input' | 'permission_prompt' | 'plan_mode'
-  | 'ask_question' | 'bash_approval' | 'settings' | 'error' | 'unknown';
+  | 'ask_question' | 'bash_approval' | 'settings' | 'error' | 'pending' | 'unknown';
 
 /** Stub: detect UI state from terminal pane text (ACP mode). */
 function detectUIState(_paneText: string): UIState {
@@ -692,7 +692,7 @@ export class SessionManager {
       claudeSessionId: freshSessionId || undefined,
       byteOffset: 0,
       monitorOffset: 0,
-      status: 'unknown',
+      status: 'pending',
       createdAt: Date.now(),
       lastActivity: Date.now(),
       stallThresholdMs: opts.stallThresholdMs || SessionManager.DEFAULT_STALL_THRESHOLD_MS,


### PR DESCRIPTION
## Fix for #3058 — Sessions should start as pending, not unknown

### Problem
New sessions created via `ag create` or `ag run` start with status `unknown`. The dashboard shows a gray dot and "Unknown" label, confusing users about whether the session started successfully.

### Fix
Added `'pending'` to the `UIState` union. New sessions now initialize with `status: 'pending'` instead of `status: 'unknown'`.

### Changes (12 files)
**Backend:**
- `src/session.ts` — add `'pending'` to UIState, change initial status
- `src/api-contracts.ts` — add `'pending'` to exported UIState type

**Dashboard:**
- `StatusDot.tsx` — pending color (#888) + label
- `SessionStateBadge.tsx` — pending → idle dot, "Pending" label
- `SessionSummaryCard.tsx` — pending label
- `PipelineDetailPage.tsx` — add to VALID_UI_STATES
- `SessionTable.tsx` — add to status counts
- `api/client.ts` — add to count initializer
- `api/schemas.ts` — add to UI state enum
- Test files updated accordingly

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258/258, 3947 passed
``

Commit: 64d721d6