### PR TITLE
fix(api): include allowed directories in workDir validation error (#3060)

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -733,7 +733,10 @@ export async function validateWorkDir(
   const resolved = path.resolve(workDir);
   const preAllowed = candidateSafeDirs.some((dir) => isUnderOrEqual(resolved, dir));
   if (!preAllowed) {
-    return { error: 'workDir is not in the allowed directories list', code: 'INVALID_WORKDIR' };
+        const allowedList = candidateSafeDirs.length <= 5
+      ? candidateSafeDirs.join(', ')
+      : candidateSafeDirs.slice(0, 5).join(', ') + ` (+${candidateSafeDirs.length - 5} more)`;
+    return { error: `workDir ${resolved} is not in the allowed directories list. Allowed: ${allowedList}`, code: 'INVALID_WORKDIR' };
   }
 
   // Step 3: Follow symlinks.
@@ -747,7 +750,10 @@ export async function validateWorkDir(
   // Step 4: Canonical allowlist check after symlink resolution.
   const allowed = candidateSafeDirs.some((dir) => isUnderOrEqual(realPath, dir));
   if (!allowed) {
-    return { error: 'workDir is not in the allowed directories list', code: 'INVALID_WORKDIR' };
+        const allowedList = candidateSafeDirs.length <= 5
+      ? candidateSafeDirs.join(', ')
+      : candidateSafeDirs.slice(0, 5).join(', ') + ` (+${candidateSafeDirs.length - 5} more)`;
+    return { error: `workDir ${resolved} is not in the allowed directories list. Allowed: ${allowedList}`, code: 'INVALID_WORKDIR' };
   }
 
   // Step 5: Ensure workDir is a directory, not a file.


### PR DESCRIPTION
## Fix for #3060 — workDir error doesn't list allowed directories

### Before
```
workDir is not in the allowed directories list
```

### After
```
workDir /tmp is not in the allowed directories list. Allowed: /home/user/project1, /home/user/project2
```

Shows up to 5 dirs, with count for more: `Allowed: /dir1, /dir2, /dir3, /dir4, /dir5 (+3 more)`

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258/258, 3947 passed
``

Commit: aa58cbc8