### PR TITLE
fix(cli): replace scary 0-attempts warning with neutral queued message (#3059)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,9 +170,12 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
       body: JSON.stringify({ text: brief }),
     });
 
+    // Issue #3059: Don't show scary warning when agent hasn't started yet
     const result = await res.json() as { delivered?: boolean; attempts?: number };
     if (result.delivered) {
       writeLine(io.stdout, `  ✅ Brief delivered (attempt ${result.attempts})`);
+    } else if ((result.attempts ?? 0) === 0) {
+      writeLine(io.stdout, `  ✅ Brief queued — agent will pick up shortly`);
     } else {
       writeLine(io.stdout, `  ⚠️  Brief sent but delivery not confirmed after ${result.attempts} attempts`);
     }


### PR DESCRIPTION
## Fix for #3059 — Scary '0 attempts' warning on brief delivery

### Before
```
⚠️  Brief sent but delivery not confirmed after 0 attempts
```

### After
```
✅ Brief queued — agent will pick up shortly
```

When `attempts === 0` (agent hasn't started yet), show a neutral success message instead of a scary warning. The warning still shows if attempts > 0 but delivery failed.

### Verification
```
npx tsc --noEmit  ✅
npm run build     ✅
npm test          ✅ 258/258, 3947 passed
``

Commit: 99ea384f