### PR TITLE
docs: add 'pending' session status to README table (#3061)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ All endpoints under `/v1/`.
 | `permission_prompt` | Awaiting approval | `/approve` or `/reject` |
 | `asking` | Claude asked a question | Read `/read`, respond `/send` |
 | `stalled` | No output for >5 min | Nudge `/send` or `DELETE` |
-| `unknown` | Initial state, not yet connected | Wait a moment and re-poll |
+| `pending` | Initial state, connecting to ACP runtime | Wait a moment and re-poll |
+| `unknown` | Failed to determine state | Check diagnostics |
 | `error` | Session crashed | Check diagnostics, recreate |
 
 </details>


### PR DESCRIPTION
## What

After #3061 merged, new sessions start as `pending` (connecting to ACP runtime) instead of `unknown`. The README session states table needed updating.

### Changes
- Added `pending` status: "Initial state, connecting to ACP runtime"
- Updated `unknown` description: "Failed to determine state" (no longer the initial state)

Complements PR #3065 (api-reference.md update by Daedalus). This updates the README table.

**1 file changed:** README.md (+2/-1)