### PR TITLE
fix(api): warn when ACP disabled + enable by default in ag run (#3068)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -68,6 +68,7 @@ async function ensureConfig(configPath: string): Promise<string | undefined> {
     authToken: token,
     baseUrl: 'http://127.0.0.1:9100',
     dashboardEnabled: true,
+    acpEnabled: true,  // Issue #3068: Enable ACP by default so sessions actually run
   };
 
   const content = serializeConfigFile(config, configPath);

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -451,7 +451,12 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       metrics.promptSent(promptDelivery.delivered);
     }
 
-    return reply.status(201).send({ ...redactSession(session as unknown as Record<string, unknown>), promptDelivery });
+    // Issue #3068: Warn when ACP is disabled — sessions are created but no agent runs
+    const acpWarning = prompt && !ctx.config.acpEnabled && promptDelivery && !promptDelivery.delivered
+      ? 'Session created but prompt not delivered: ACP is disabled. Set AEGIS_ACP_ENABLED=true or add "acpEnabled": true to config to enable Claude Code sessions.'
+      : undefined;
+
+    return reply.status(201).send({ ...redactSession(session as unknown as Record<string, unknown>), promptDelivery, ...(acpWarning ? { warning: acpWarning } : {}) });
   }
   registerWithLegacy(app, 'post', '/v1/sessions', {
     config: {


### PR DESCRIPTION
## Issue
#3068 — Sessions created via API stay `pending` forever. CC never starts.

## Root Cause
`acpEnabled` defaults to `false`. New users create sessions, the prompt never gets delivered, and there's **zero feedback** about why.

## Fix
1. **API warning**: `POST /v1/sessions` returns a `warning` field when ACP is disabled and prompt wasn't delivered — tells the user exactly what to do
2. **ag run default**: `ensureConfig()` now sets `acpEnabled: true` so the one-liner experience works out of the box

## Files Changed
- `src/routes/sessions.ts` — add warning in response
- `src/commands/run.ts` — default `acpEnabled: true`

## Verification
- `tsc --noEmit` ✅
- `npm run build` ✅
- Session tests (376) ✅