### PR TITLE
docs: fix allowed workDir defaults — /tmp is excluded (#3080)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -172,7 +172,7 @@ Next steps:
 
 Save the `id` — you'll need it for follow-up commands.
 
-> **Note:** `workDir` must be under an allowed directory. By default, Aegis allows `$HOME`, `/tmp`, and the current working directory. To restrict sessions to specific directories, set `allowedWorkDirs` in `.aegis/config.yaml` (or `aegis.config.json`). Changes are hot-reloaded without restart.
+> **Note:** `workDir` must be under an allowed directory. By default, Aegis allows `$HOME` and the server's current working directory. System temp dirs (`/tmp`, `/var/tmp`) are intentionally excluded for security. To allow additional directories, set `allowedWorkDirs` in `.aegis/config.yaml` (or `aegis.config.json`). Changes are hot-reloaded without restart.
 
 ## 5. Monitor Progress
 


### PR DESCRIPTION
## Fix

The getting-started guide incorrectly stated `/tmp` is an allowed workDir. Since #2945, system temp dirs are intentionally excluded from defaults for security.

**Before:** `By default, Aegis allows $HOME, /tmp, and the current working directory.`
**After:** `By default, Aegis allows $HOME and the server's current working directory. System temp dirs (/tmp, /var/tmp) are intentionally excluded for security.`

Verified against `src/validation.ts` `getDefaultSafeDirs()` which returns `[os.homedir(), process.cwd()]`.

1 file changed: `docs/getting-started.md` (+1/-1)

Closes #3080