### PR TITLE
fix(cli): ag init writes authToken instead of clientAuthToken (#3085)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -291,7 +291,7 @@ function buildInitComparisonConfig(
   if (!hasGeneratedToken) {
     return config;
   }
-  return { ...config, clientAuthToken: '__generated__' };
+  return { ...config, authToken: '__generated__' };
 }
 
 function formatPromptDefault(defaultValue: string): string {


### PR DESCRIPTION
## Issue
#3085 — `ag init` writes `clientAuthToken` but `AuthManager` reads `authToken`. Fresh users cannot authenticate after running `ag init`.

## Fix
One-line change: `clientAuthToken: '__generated__'` → `authToken: '__generated__'`

## Verification
- `tsc --noEmit` ✅