### PR TITLE
fix(acp): send mcpServers as empty array not empty object

### DIFF
--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -621,7 +621,7 @@ export class AcpBackend {
       const response = await runtime.client.request<AcpBackendSessionResult>('session/load', {
         sessionId: acpAgentSessionId,
         cwd,
-        ...(mcpServers ? { mcpServers } : {}),
+        mcpServers: mcpServers ?? [],
         _meta: this.buildAegisMetadata(session.id, backendRunId),
       });
       const attachment = attachmentFromResult(response.result, backendRunId);
@@ -770,7 +770,7 @@ export class AcpBackend {
   ): AcpJsonObject {
     return {
       cwd,
-      ...(mcpServers ? { mcpServers } : {}),
+      mcpServers: mcpServers ?? [],
       _meta: {
         ...this.buildAegisMetadata(durableSessionId, backendRunId),
         ...(systemPrompt ? { systemPrompt } : {}),


### PR DESCRIPTION
## Root Cause
Daedalus found during E2E testing: `claude-agent-acp` expects `mcpServers` as an **array** (line 35 of acp-agent.js: `const servers = [...(params.mcpServers ?? [])]`), but Aegis sent `{}` (empty object) when no MCP servers were configured.

This caused `-32602 Invalid params` from the ACP agent → `"ACP JSON-RPC request failed"` → HTTP 500.

## Fix
`buildSessionStartParams()` now sends `mcpServers: []` instead of `mcpServers: {}` when no servers configured.

## Verification
- `tsc --noEmit` ✅
- Daedalus confirmed manually: session starts, Claude spawns, works with `mcpServers: []`

## Files
- `src/services/acp/backend.ts` — 2 occurrences (lines 624, 773)