### PR TITLE
fix(config): add acpEnabled to configFileSchema (#3087)

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -826,6 +826,7 @@ export const configFileSchema = z.object({
     generalMax: z.number().int().positive().optional(),
     timeWindowSec: z.number().int().positive().optional(),
   }).optional(),
+  acpEnabled: z.boolean().optional(),
 });
 
 


### PR DESCRIPTION
## Fix
`acpEnabled` was missing from `configFileSchema` in `src/validation.ts`, causing it to be silently stripped when set in `config.yaml`.

## Change
- Added `acpEnabled: z.boolean().optional()` to `configFileSchema`

## Verification
```
npx tsc --noEmit   → 0 errors
npm run build       → ✅ Success
npm test            → ✅ 3947 passed, 2 skipped
```

## Metadata
- Issue: #3087
- Commit: de138024
- Session: direct implementation (ACP not enabled on server)