### PR TITLE
fix(acp): route prompts through ACP runtime instead of stub (#3093)

### DIFF
--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -24,6 +24,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   const {
     sessions, auth, quotas, config, metrics, monitor, eventBus, channels,
     toolRegistry, getAuditLogger, validateWorkDir,
+    acpBackend,
   } = ctx;
 
   // Send message (with delivery verification — Issue #1)
@@ -51,7 +52,9 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       }
     }
     try {
-      const result = await sessions.sendMessage(sessionId, text);
+      const result = acpBackend && config.acpEnabled
+        ? await acpBackend.sendPrompt(sessionId, text, { tenantId: (req as any).tenantId ?? 'system', ownerKeyId: (req as any).authKeyId ?? 'master' })
+        : await sessions.sendMessage(sessionId, text);
       // Issue #1809: Re-fetch stall info AFTER delivery to avoid false-positive.
       // Previously we called getStallInfo BEFORE send, capturing a stale state
       // (session was temporarily quiet but became active after message delivery).
@@ -257,7 +260,9 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     const { command } = parsed.data;
     try {
       const cmd = command.startsWith('/') ? command : `/${command}`;
-      await sessions.sendMessage(session.id, cmd);
+      const cmdResult = acpBackend && config.acpEnabled
+        ? await acpBackend.sendPrompt(session.id, cmd, { tenantId: (req as any).tenantId ?? 'system', ownerKeyId: (req as any).authKeyId ?? 'master' })
+        : await sessions.sendMessage(session.id, cmd);
       return { ok: true };
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -387,7 +387,9 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
               finalPrompt = lines.join('\n');
             }
           }
-          promptDelivery = await sessions.sendInitialPrompt(existing.id, finalPrompt);
+          promptDelivery = acpBackend && ctx.config.acpEnabled
+          ? await acpBackend.sendPrompt(existing.id, finalPrompt, { tenantId: req.tenantId ?? 'system', ownerKeyId: req.authKeyId ?? 'master' })
+          : await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
         return reply.status(200).send({ ...redactSession(existing as unknown as Record<string, unknown>), reused: true, promptDelivery });
@@ -448,7 +450,9 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           finalPrompt = lines.join('\n');
         }
       }
-      promptDelivery = await sessions.sendInitialPrompt(session.id, finalPrompt);
+      promptDelivery = acpBackend && ctx.config.acpEnabled
+        ? await acpBackend.sendPrompt(session.id, finalPrompt, { tenantId: req.tenantId ?? 'system', ownerKeyId: req.authKeyId ?? 'master' })
+        : await sessions.sendInitialPrompt(session.id, finalPrompt);
       metrics.promptSent(promptDelivery.delivered);
     }
 

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -363,6 +363,53 @@ export class AcpBackend {
     return { client: runtime.client, agentCapabilities: runtime.agentCapabilities };
   }
 
+
+  /**
+   * Issue #3093: Direct prompt delivery to ACP runtime.
+   * Bypasses the action queue for immediate prompt delivery during session creation
+   * and send_message API calls. Returns {delivered, attempts} matching the session.ts stub contract.
+   */
+  async sendPrompt(
+    sessionId: string,
+    text: string,
+    scope: AcpSessionScope
+  ): Promise<{ delivered: boolean; attempts: number; error?: string }> {
+    const runtime = this.runtimes.get(sessionId);
+    if (!runtime) {
+      return { delivered: false, attempts: 0, error: 'no_acp_runtime' };
+    }
+
+    // Issue #2805: Reject concurrent prompts — CC blocks on background terminals
+    const existing = this.inFlightPrompts.get(sessionId);
+    if (existing) {
+      throw new AcpBackendLifecycleError(
+        `Session ${sessionId} already has a prompt in-flight. ` +
+        'Claude Code blocks on background terminals — wait for the current prompt to complete or cancel it.'
+      );
+    }
+
+    const abort = new AbortController();
+    this.inFlightPrompts.set(sessionId, abort);
+
+    try {
+      const session = await this.sessionService.getSession(sessionId, scope);
+      const acpSessionId = session.acpAgentSessionId;
+      if (!acpSessionId) {
+        return { delivered: false, attempts: 0, error: 'no_agent_session' };
+      }
+
+      await runtime.client.request<AcpJsonValue>('session/prompt', {
+        sessionId: acpSessionId,
+        prompt: [{ type: 'text', text }],
+      });
+      return { delivered: true, attempts: 1 };
+    } catch (err) {
+      return { delivered: false, attempts: 1, error: (err as Error).message };
+    } finally {
+      this.inFlightPrompts.delete(sessionId);
+    }
+  }
+
   async claimDriver(input: AcpBackendClaimDriverInput): Promise<AcpBackendDriverResult> {
     const scope = scopeFromInput(input);
     await this.sessionService.getSession(input.sessionId, scope);


### PR DESCRIPTION
## Problem

Issue #3093: `sendInitialPrompt()` and `sendMessage()` in `session.ts` are ACP stubs that always return `{delivered: false}`. When ACP is enabled, prompts are stored in the session record but **never forwarded** to the running Claude Code process via the ACP JSON-RPC transport.

## Root Cause

The full pipeline works up to CC spawning:
```
ag init ✅ → ag start ✅ → create session ✅ → ACP handshake ✅ → CC spawns ✅ → prompt delivery ❌
```

The `session/prompt` JSON-RPC call was only implemented inside `dispatchPromptAction()` (used by the action queue for multi-agent orchestration), but was never wired into the REST API prompt delivery path.

## Fix

1. **`AcpBackend.sendPrompt()`** — new method that directly sends `session/prompt` via JSON-RPC to the runtime client, bypassing the action queue for immediate single-prompt delivery. Includes:
   - Runtime lookup
   - Agent session ID resolution
   - Concurrent prompt rejection (#2805)
   - Graceful fallback when no runtime or no agent session

2. **Route wiring** — when `acpBackend` is available and `acpEnabled` is true, prompts are routed through `acpBackend.sendPrompt()` instead of the stub:
   - `POST /v1/sessions` (create path)
   - `POST /v1/sessions` (reuse path)  
   - `POST /v1/sessions/:id/send` (send_message)
   - `POST /v1/sessions/:id/command` (slash commands)

3. **Fallback** — when ACP is disabled or no runtime exists, falls back to the original stub (returns `{delivered: false}` with appropriate warning).

## Verification

```
tsc --noEmit ✅  zero errors
npm run build  ✅  success
npm test       ✅  3957 passed, 2 skipped (pre-existing)
```

## Files Changed

| File | Change |
|------|--------|
| `src/services/acp/backend.ts` | +47 lines: `sendPrompt()` method |
| `src/routes/sessions.ts` | +4 lines: ACP routing in create + reuse paths |
| `src/routes/session-actions.ts` | +9 lines: ACP routing in send + command paths |