### PR TITLE
docs: document name/label character restrictions and ACP warning (#3091, #3068)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -695,8 +695,8 @@ curl -X POST http://localhost:9100/v1/sessions \
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `workDir` | string | **yes** | Absolute path to an existing directory (file paths are rejected) |
-| `name` | string | no | Session name (max 200 chars; defaults to auto-generated) |
-| `label` | string | no | Alias for `name` (backward compat; `name` takes precedence) |
+| `name` | string | no | Session name (max 200 chars, only `a-zA-Z0-9_ ./@-=`; defaults to auto-generated) |
+| `label` | string | no | Alias for `name` (same character restrictions; backward compat; `name` takes precedence) |
 | `prompt` | string | no | Initial prompt to send after boot (max 100k chars; must be non-empty if provided) |
 | `prd` | string | no | Product Requirements Document text (max 100k chars) |
 | `resumeSessionId` | string (UUID) | no | Resume an existing session by UUID |
@@ -725,7 +725,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 }
 ```
 
-> **Note:** `promptDelivery.delivered` is `false` when ACP is disabled — no backend process is spawned to handle the prompt. Enable ACP via `AEGIS_ACP_ENABLED=true` or `"acpEnabled": true` in config.
+> **Note:** `promptDelivery.delivered` is `false` when ACP is disabled — no backend process is spawned to handle the prompt. When a prompt is provided but ACP is disabled, the response also includes a `warning` field explaining how to enable it. Enable ACP via `AEGIS_ACP_ENABLED=true` or `"acpEnabled": true` in config.
 
 **Response (`200 OK`):** Returned when reusing an existing idle session (`reused: true`).
 
@@ -733,7 +733,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 
 | Status | Code | Condition |
 |--------|------|-----------|
-| 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, env denylist rejection |
+| 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, disallowed characters in `name`/`label`, env denylist rejection |
 | 403 | `TENANT_WORKDIR_DENIED` | workDir outside tenant root |
 | 422 | `CC_VERSION_TOO_OLD` | Claude Code version below minimum |
 | 429 | `QUOTA_EXCEEDED` | Per-key session quota exceeded |


### PR DESCRIPTION
## Changes

Accuracy fixes for api-reference.md following merged PRs #3091 and #3068.

### #3091 — Session name/label character validation
- `name` and `label` fields now validated against `SAFE_NAME_RE` (`a-zA-Z0-9_ ./@-=`)
- Updated field descriptions to include character restriction
- Added `disallowed characters in name/label` to 400 error conditions

### #3068 — ACP disabled warning
- `POST /v1/sessions` response now includes a `warning` field when a prompt is provided but ACP is disabled
- Updated the `promptDelivery` note to document the warning field

## Verification
- Read `src/routes/sessions.ts` diff for both PRs to confirm exact behavior
- Regex pattern matches code: `/^[a-zA-Z0-9_ ./@\-=]{1,200}$/`