### PR TITLE
docs: fix config example, name/label restrictions, ACP warning (#3091, #3068, #3088)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -695,8 +695,8 @@ curl -X POST http://localhost:9100/v1/sessions \
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `workDir` | string | **yes** | Absolute path to an existing directory (file paths are rejected) |
-| `name` | string | no | Session name (max 200 chars; defaults to auto-generated) |
-| `label` | string | no | Alias for `name` (backward compat; `name` takes precedence) |
+| `name` | string | no | Session name (max 200 chars, `a-zA-Z0-9_ ./@-=` only; defaults to auto-generated) |
+| `label` | string | no | Alias for `name` (same character restrictions; `name` takes precedence) |
 | `prompt` | string | no | Initial prompt to send after boot (max 100k chars; must be non-empty if provided) |
 | `prd` | string | no | Product Requirements Document text (max 100k chars) |
 | `resumeSessionId` | string (UUID) | no | Resume an existing session by UUID |
@@ -725,7 +725,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 }
 ```
 
-> **Note:** `promptDelivery.delivered` is `false` when ACP is disabled — no backend process is spawned to handle the prompt. Enable ACP via `AEGIS_ACP_ENABLED=true` or `"acpEnabled": true` in config.
+> **Note:** `promptDelivery.delivered` is `false` when ACP is disabled — no backend process is spawned to handle the prompt. The response includes a `warning` field explaining the issue. Enable ACP via `AEGIS_ACP_ENABLED=true` or `"acpEnabled": true` in config.
 
 **Response (`200 OK`):** Returned when reusing an existing idle session (`reused: true`).
 
@@ -733,7 +733,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 
 | Status | Code | Condition |
 |--------|------|-----------|
-| 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, env denylist rejection |
+| 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, disallowed characters in `name`/`label`, env denylist rejection |
 | 403 | `TENANT_WORKDIR_DENIED` | workDir outside tenant root |
 | 422 | `CC_VERSION_TOO_OLD` | Claude Code version below minimum |
 | 429 | `QUOTA_EXCEEDED` | Per-key session quota exceeded |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -305,7 +305,7 @@ Or use a config file (`.aegis/config.yaml` is the preferred bootstrap path, and 
 ```yaml
 baseUrl: http://127.0.0.1:9100
 dashboardEnabled: true
-clientAuthToken: your-token
+authToken: your-token
 memoryBridge:
   enabled: true
 ```


### PR DESCRIPTION
## Accuracy fixes for 3 merged PRs

### #3088 — `authToken` vs `clientAuthToken` in config example
- `getting-started.md` config example showed `clientAuthToken` (legacy field)
- Changed to `authToken` (the field `AuthManager` actually reads)

### #3091 — Session name/label character validation
- `name` and `label` fields validated against `SAFE_NAME_RE` (`a-zA-Z0-9_ ./@-=`)
- Updated field descriptions with character restriction
- Added `disallowed characters in name/label` to 400 error conditions

### #3068/#3083 — ACP disabled warning
- `POST /v1/sessions` response includes a `warning` field when prompt provided but ACP disabled
- Updated `promptDelivery` note to document the warning field

## Verification
- Read `src/routes/sessions.ts` for SAFE_NAME_RE, warning field
- Read `src/config.ts` for authToken vs clientAuthToken
- Read `src/validation.ts` for schema fields