### PR TITLE
fix(api): add pending and rate_limit to batch-delete status enum (#3075)

### DIFF
--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -86,9 +86,9 @@ const createSessionSchema = z.object({
 const batchDeleteSchema = z.object({
   ids: z.array(z.string().uuid()).max(100).optional(),
   status: z.enum([
-    'idle', 'working', 'compacting', 'context_warning', 'waiting_for_input',
+    'pending', 'idle', 'working', 'compacting', 'context_warning', 'waiting_for_input',
     'permission_prompt', 'plan_mode', 'ask_question', 'bash_approval',
-    'settings', 'error', 'unknown',
+    'settings', 'error', 'rate_limit', 'unknown',
   ]).optional(),
 });
 

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -59,7 +59,7 @@ function buildCreateSessionSchema(ctx: RouteContext) {
 const batchDeleteSchema = z.object({
   ids: z.array(z.string().uuid()).max(100).optional(),
   status: z.enum([
-    'idle', 'working', 'compacting', 'context_warning', 'waiting_for_input',
+    'pending', 'idle', 'working', 'compacting', 'context_warning', 'waiting_for_input',
     'permission_prompt', 'plan_mode', 'ask_question', 'bash_approval',
     'settings', 'error', 'rate_limit', 'unknown',
   ]).optional(),


### PR DESCRIPTION
## Summary
Fixes #3075

The `DELETE /v1/sessions/batch` endpoint rejected `status=pending` because it was not included in the Zod status enum. Sessions stuck at `pending` (common when ACP is not connected) could not be bulk-deleted.

### Changes
- Added `pending` to `batchDeleteSchema` status enum in `src/routes/sessions.ts`
- Added `pending` to `batchDeleteSchema` status enum in `src/routes/openapi.ts`
- Also added `rate_limit` to openapi.ts (was missing, already present in sessions.ts)

## Verification
- ✅ `tsc --noEmit` — zero errors
- ✅ `npm run build` — success
- ✅ `npm test` — 3957 passed, 2 skipped

Signed-off-by: Hephaestus 🔨