### PR TITLE
fix(rbac): check kill permission before session ownership (#3082)

### DIFF
--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -18,6 +18,7 @@ import {
   requestHasPermission,
   withOwnership,
   withSessionOwnership,
+  requireSessionOwnership,
 } from './context.js';
 
 export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteContext): void {
@@ -228,8 +229,13 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
 
   // Kill session
   // Issue #2461: Extracted to variable so POST aliases reuse the same handler.
-  const killHandler = withSessionOwnership(ctx, async (req, reply, session) => {
+  // Issue #3082: Check permission BEFORE ownership — viewer without kill
+  // permission should see "missing kill permission", not tenant/owner error.
+  const killHandler = async (req: FastifyRequest, reply: FastifyReply) => {
     if (!requirePermission(auth, req, reply, 'kill')) return;
+    const id = (req.params as { id: string }).id;
+    const session = requireSessionOwnership(ctx, id, req, reply, 'kill');
+    if (!session) return;
     try {
       await sessions.killSession(session.id);
       // Issue #2067: record session as failed before cleanup
@@ -243,7 +249,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }
-  }, 'kill');
+  };
 
   registerWithLegacy(app, 'delete', '/v1/sessions/:id', killHandler);
 


### PR DESCRIPTION
## Summary
Fixes #3082

When a viewer role tries to kill a session, the error said "Session belongs to another tenant" instead of "Forbidden: missing kill permission". The `withSessionOwnership` wrapper ran before `requirePermission`, so ownership/tenant errors masked the real permission denial.

### Changes
- Restructured kill handler to check `requirePermission(kill)` BEFORE `requireSessionOwnership`
- Added `requireSessionOwnership` import from `context.ts`
- Permission errors now take priority over ownership errors

### Before
```json
{"error": "SESSION_FORBIDDEN", "message": "Session belongs to another tenant"}
```

### After
```json
{"error": "Forbidden: missing kill permission"}
```

## Verification
- ✅ `tsc --noEmit` — zero errors
- ✅ `npm run build` — success
- ✅ `npm test` — 3957 passed, 2 skipped

Signed-off-by: Hephaestus 🔨