### PR TITLE
fix(api): preserve session status in ACP mode instead of overwriting with idle (#3081)

### DIFF
--- a/src/session-transcripts.ts
+++ b/src/session-transcripts.ts
@@ -15,9 +15,13 @@ import type { Config } from './config.js';
 import type { SessionInfo } from './session.js';
 import type { UIState } from './session.js';
 
-/** Stub: detect UI state from terminal pane text (ACP mode). */
-function detectUIState(_paneText: string): UIState {
-  return 'idle';
+/** Stub: detect UI state from terminal pane text (ACP mode).
+ * Issue #3081: In ACP mode there is no tmux pane to read, so we cannot
+ * detect the actual UI state. Return the session's current status instead
+ * of hardcoding 'idle', which was overwriting 'pending' on fresh sessions.
+ */
+function detectUIState(currentStatus: UIState): UIState {
+  return currentStatus;
 }
 
 
@@ -58,10 +62,10 @@ export class SessionTranscripts {
     interactiveContent: string | null;
   }> {
     // Detect UI state from terminal (stub: ACP mode)
-    const paneText = '';
-    const status = detectUIState(paneText);
-    const statusText = parseStatusLine(paneText);
-    const interactive = extractInteractiveContent(paneText);
+    // Issue #3081: Pass current status so stub preserves it
+    const status = detectUIState(session.status);
+    const statusText = parseStatusLine('');
+    const interactive = extractInteractiveContent('');
 
     session.status = status;
     session.lastActivity = Date.now();
@@ -117,10 +121,10 @@ export class SessionTranscripts {
     interactiveContent: string | null;
   }> {
     // Detect UI state from terminal (stub: ACP mode)
-    const paneText = '';
-    const status = detectUIState(paneText);
-    const statusText = parseStatusLine(paneText);
-    const interactive = extractInteractiveContent(paneText);
+    // Issue #3081: Pass current status so stub preserves it
+    const status = detectUIState(session.status);
+    const statusText = parseStatusLine('');
+    const interactive = extractInteractiveContent('');
 
     session.status = status;
 


### PR DESCRIPTION
## Summary
Fixes #3081

`GET /v1/sessions/:id` returned `status: "pending"` but `GET /v1/sessions/:id/read` returned `status: "idle"` for the same newly-created session.

### Root Cause
`detectUIState()` in `session-transcripts.ts` was an ACP stub that always returned `"idle"`. When `/read` was called, it overwrote the session's actual status (`"pending"`) with the hardcoded `"idle"`.

### Fix
Changed `detectUIState()` to accept the session's current status and return it unchanged in ACP mode, instead of always returning `"idle"`. Updated both `readMessages()` and `readMessagesForMonitor()` call sites.

### Before
```
GET /v1/sessions/:id      → status: "pending"
GET /v1/sessions/:id/read → status: "idle"   ← wrong, overwrites
```

### After
```
GET /v1/sessions/:id      → status: "pending"
GET /v1/sessions/:id/read → status: "pending" ← consistent
```

## Verification
- ✅ `tsc --noEmit` — zero errors
- ✅ `npm test` — 3957 passed, 2 skipped

Signed-off-by: Hephaestus 🔨