### PR TITLE
fix(cli): reject unknown commands instead of silently creating sessions (#3079)

### DIFF
--- a/src/__tests__/cli-unknown-command-3079.test.ts
+++ b/src/__tests__/cli-unknown-command-3079.test.ts
@@ -1,0 +1,67 @@
+/**
+ * cli-unknown-command-3079.test.ts — Tests for Issue #3079:
+ * Unknown CLI commands should error instead of silently creating sessions.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runCli } from '../cli.js';
+
+function mockIO() {
+  return {
+    stdin: { pipe: vi.fn() } as unknown as NodeJS.ReadableStream,
+    stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+    stderr: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+  };
+}
+
+describe('CLI unknown command rejection (#3079)', () => {
+  it('should reject unknown single-word commands', async () => {
+    const io = mockIO();
+    const code = await runCli(['status'], io);
+    expect(code).toBe(1);
+    const stderr = (io.stderr as { write: vi.Mock }).write.mock.calls.map((c: string[]) => c.join('')).join('');
+    expect(stderr).toContain('Unknown command: "status"');
+  });
+
+  it('should reject "ag health"', async () => {
+    const io = mockIO();
+    const code = await runCli(['health'], io);
+    expect(code).toBe(1);
+  });
+
+  it('should reject "ag list"', async () => {
+    const io = mockIO();
+    const code = await runCli(['list'], io);
+    expect(code).toBe(1);
+  });
+
+  it('should reject "ag version"', async () => {
+    const io = mockIO();
+    const code = await runCli(['version'], io);
+    expect(code).toBe(1);
+  });
+
+  it('should reject "ag sessions"', async () => {
+    const io = mockIO();
+    const code = await runCli(['sessions'], io);
+    expect(code).toBe(1);
+  });
+
+  it('should reject "ag auth"', async () => {
+    const io = mockIO();
+    const code = await runCli(['auth'], io);
+    expect(code).toBe(1);
+  });
+
+  it('should accept --help flag without error', async () => {
+    const io = mockIO();
+    const code = await runCli(['--help'], io);
+    expect(code).toBe(0);
+  });
+
+  it('should accept --version flag without error', async () => {
+    const io = mockIO();
+    const code = await runCli(['--version'], io);
+    expect(code).toBe(0);
+  });
+});

--- a/src/__tests__/cli-unknown-command-3079.test.ts
+++ b/src/__tests__/cli-unknown-command-3079.test.ts
@@ -3,7 +3,7 @@
  * Unknown CLI commands should error instead of silently creating sessions.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import { runCli } from '../cli.js';
 
 function mockIO() {
@@ -19,7 +19,8 @@ describe('CLI unknown command rejection (#3079)', () => {
     const io = mockIO();
     const code = await runCli(['status'], io);
     expect(code).toBe(1);
-    const stderr = (io.stderr as { write: vi.Mock }).write.mock.calls.map((c: string[]) => c.join('')).join('');
+    const stderrWrite = io.stderr.write as unknown as Mock;
+    const stderr = stderrWrite.mock.calls.map((c: string[]) => c.join('')).join('');
     expect(stderr).toContain('Unknown command: "status"');
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -312,9 +312,22 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
 
   if (argv[0] === 'whoami') {
     return handleWhoami(argv.slice(1), io);
-
   }
 
+  if (argv[0] === 'run') {
+    return handleRun(argv.slice(1), io);
+  }
+
+  // Issue #3079: Reject single-word args that look like unknown commands.
+  // Known subcommands are handled above; single-word non-flag args are likely
+  // typos (e.g. "ag status", "ag health") rather than intentional prompts.
+  // Multi-word args or quoted strings are treated as prompts (backward compat).
+  if (argv.length === 1 && !argv[0].startsWith('-') && !argv[0].includes(' ')) {
+    writeLine(io.stderr, `Unknown command: "${argv[0]}". Run ag --help for usage.`);
+    return 1;
+  }
+
+  // Multi-word bare args or explicit create: treat as prompt
   if (argv.length === 1 && !argv[0].startsWith('-')) {
     return handleCreate(argv, io);
   }


### PR DESCRIPTION
## Summary

Fixes #3079

Unknown CLI subcommands (e.g. `ag status`, `ag health`, `ag list`) were silently creating sessions with the command name as the prompt, instead of showing an error.

### Changes
1. **Unknown command guard**: Single-word non-flag args now print `Unknown command: "status". Run ag --help for usage.` and exit with code 1, instead of falling through to `handleCreate`
2. **Missing `run` dispatch**: Added `argv[0] === 'run'` route to `runCli()` — `handleRun` was imported but never dispatched, so `ag run "prompt"` would fall through to server start
3. **Backward compat**: Multi-word bare args (e.g. `ag "build me a foo"`) still work as prompts

### Reproduction (before fix)
```bash
ag status    # Created session "cc-status" — wrong
ag health    # Created session "cc-health" — wrong
```

### After fix
```bash
ag status    # Unknown command: "status". Run ag --help for usage.
ag health    # Unknown command: "health". Run ag --help for usage.
```

## Verification
- **tsc --noEmit**: ✅ zero errors
- **npm run build**: ✅ success
- **npm test**: ✅ 3965 passed (8 new tests), 2 skipped
- Commit: 9dad14b4
