### PR TITLE
fix(security): reject duplicate API key names within the same tenant (#3073)

### DIFF
--- a/src/__tests__/fix-3073-duplicate-key-name.test.ts
+++ b/src/__tests__/fix-3073-duplicate-key-name.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Issue #3073: API key creation should reject duplicate names within the same tenant.
+ *
+ * Security rationale: Duplicate key names create operational confusion during
+ * incident response and key rotation. Admins cannot uniquely identify keys by
+ * name, leading to potential key confusion during emergency revocation.
+ *
+ * Expected: Throws DUPLICATE_KEY_NAME when creating a key with a name that
+ * already exists for the same tenant. Different tenants may have keys with
+ * the same name.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AuthManager } from '../auth.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rm } from 'node:fs/promises';
+
+describe('Issue #3073: Duplicate API key name rejection', () => {
+  let auth: AuthManager;
+  let tmpFile: string;
+
+  beforeEach(async () => {
+    tmpFile = join(tmpdir(), `aegis-3073-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+    auth = new AuthManager(tmpFile, '');
+  });
+
+  afterEach(async () => {
+    try { await rm(tmpFile); } catch { /* ignore */ }
+  });
+
+  it('should reject duplicate key names within the same tenant', async () => {
+    // Create first key (admin → _system tenant)
+    const first = await auth.createKey('dup-test', 100, undefined, 'admin');
+    expect(first.name).toBe('dup-test');
+
+    // Attempt duplicate name with same tenant — should throw
+    let thrown: any;
+    try {
+      await auth.createKey('dup-test', 100, undefined, 'admin');
+    } catch (err: any) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown.message).toContain('already exists');
+    expect(thrown.code).toBe('DUPLICATE_KEY_NAME');
+    expect(thrown.statusCode).toBe(409);
+  });
+
+  it('should allow same key name for different tenants', async () => {
+    // Create key for tenant-a
+    const first = await auth.createKey('shared-name', 100, undefined, 'viewer', undefined, 'tenant-a');
+    expect(first.name).toBe('shared-name');
+
+    // Create key for tenant-b with same name — should succeed
+    const second = await auth.createKey('shared-name', 100, undefined, 'viewer', undefined, 'tenant-b');
+    expect(second.name).toBe('shared-name');
+    expect(first.id).not.toBe(second.id);
+  });
+
+  it('should allow key creation after revoking a key with the same name', async () => {
+    // Create first key
+    const { id } = await auth.createKey('recyclable', 100, undefined, 'admin');
+
+    // Revoke it
+    await auth.revokeKey(id);
+
+    // Create again with same name — should succeed
+    const recreated = await auth.createKey('recyclable', 100, undefined, 'admin');
+    expect(recreated.name).toBe('recyclable');
+    expect(recreated.id).not.toBe(id);
+  });
+
+  it('should allow duplicate names across admin (system tenant) and named tenants', async () => {
+    // Admin key → always SYSTEM_TENANT
+    const admin = await auth.createKey('my-key', 100, undefined, 'admin');
+    expect(admin.tenantId).toBe('_system');
+
+    // Viewer key for tenant-a → different tenant, same name OK
+    const viewer = await auth.createKey('my-key', 100, undefined, 'viewer', undefined, 'tenant-a');
+    expect(viewer.tenantId).toBe('tenant-a');
+  });
+
+  it('should reject duplicate admin keys with the same name', async () => {
+    await auth.createKey('admin-key', 100, undefined, 'admin');
+
+    // Both admin keys resolve to SYSTEM_TENANT → should conflict
+    await expect(
+      auth.createKey('admin-key', 100, undefined, 'admin'),
+    ).rejects.toThrow('already exists');
+  });
+});

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -87,8 +87,13 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
     if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
     if (!requireRole(auth, req, reply, 'admin')) return;
     const { name, rateLimit, ttlDays, role = 'viewer', permissions, tenantId } = data;
-    const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
-    return reply.status(201).send(result);
+    try {
+      const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
+      return reply.status(201).send(result);
+    } catch (err: any) {
+      if (err.code === 'DUPLICATE_KEY_NAME') return reply.status(409).send({ error: err.message });
+      throw err;
+    }
   }));
 
   registerWithLegacy(app, 'get', '/v1/auth/keys', async (req: FastifyRequest, reply: FastifyReply) => {
@@ -195,8 +200,13 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
     if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
     if (!requireRole(auth, req, reply, 'admin')) return;
     const { name, rateLimit, ttlDays, role = 'viewer', permissions, tenantId } = data;
-    const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
-    return reply.status(201).send(result);
+    try {
+      const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
+      return reply.status(201).send(result);
+    } catch (err: any) {
+      if (err.code === 'DUPLICATE_KEY_NAME') return reply.status(409).send({ error: err.message });
+      throw err;
+    }
   }));
 
   registerWithLegacy(app, 'delete', '/v1/keys/:id', async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -258,6 +258,15 @@ export class AuthManager {
       ? SYSTEM_TENANT
       : tenantId ?? this.defaultTenantId;
 
+    // Issue #3073: Reject duplicate key names within the same tenant.
+    const duplicate = this.store.keys.find(k => k.name === name && k.tenantId === resolvedTenantId);
+    if (duplicate) {
+      const err = new Error(`An API key with the name "${name}" already exists for this tenant`);
+      (err as any).code = 'DUPLICATE_KEY_NAME';
+      (err as any).statusCode = 409;
+      throw err;
+    }
+
     const apiKey: ApiKey = {
       id,
       name,


### PR DESCRIPTION
## Fix for #3073

Rebases #3099 (by Argus) onto `develop` to resolve merge conflicts. The original branch was created from `main` instead of `develop`.

### Changes
- `AuthManager.createKey()` checks for existing keys with same name in same tenant
- Route handlers return 409 Conflict for duplicate key names
- Names scoped per-tenant, reuse allowed after revocation
- 5 test cases covering all scenarios

### Verification
- ✅ `tsc --noEmit` — zero errors
- ✅ `vitest run src/__tests__/fix-3073-duplicate-key-name.test.ts` — 5 passed

Supersedes #3099 (conflicting branch).

---
*Hephaestus 🔨*