### PR TITLE
fix(security): reject duplicate API key names within the same tenant (#3073)

### DIFF
--- a/src/__tests__/fix-3073-duplicate-key-name.test.ts
+++ b/src/__tests__/fix-3073-duplicate-key-name.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #3073: Duplicate API key names should be rejected with 409 Conflict.
+ * Keys with the same name cannot coexist within the same tenant.
+ * Different tenants may reuse the same key name.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AuthManager } from '../services/auth/AuthManager.js';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('Issue #3073 — Duplicate key name rejection', () => {
+  let auth: AuthManager;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `aegis-test-3073-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+    auth = new AuthManager(join(tmpDir, 'keys.json'), 'master-token', 'default');
+    await auth.load();
+  });
+
+  it('rejects creating a key with a duplicate name in the same tenant', async () => {
+    await auth.createKey('my-key', 100, undefined, 'admin');
+
+    await expect(auth.createKey('my-key', 100, undefined, 'admin'))
+      .rejects.toThrow('already exists');
+  });
+
+  it('allows creating a key with the same name in a different tenant', async () => {
+    await auth.createKey('my-key', 100, undefined, 'viewer', undefined, 'tenant-A');
+    const result = await auth.createKey('my-key', 100, undefined, 'viewer', undefined, 'tenant-B');
+
+    expect(result.name).toBe('my-key');
+    expect(result.tenantId).toBe('tenant-B');
+  });
+
+  it('throws error with code DUPLICATE_KEY_NAME and statusCode 409', async () => {
+    await auth.createKey('dup-key', 100, undefined, 'admin');
+
+    try {
+      await auth.createKey('dup-key', 100, undefined, 'admin');
+      expect.unreachable('Should have thrown');
+    } catch (err: any) {
+      expect(err.code).toBe('DUPLICATE_KEY_NAME');
+      expect(err.statusCode).toBe(409);
+      expect(err.message).toContain('dup-key');
+    }
+  });
+
+  it('allows reusing a name after the key is revoked', async () => {
+    const { id } = await auth.createKey('recyclable', 100, undefined, 'admin');
+    await auth.revokeKey(id);
+
+    const result = await auth.createKey('recyclable', 100, undefined, 'admin');
+    expect(result.name).toBe('recyclable');
+  });
+
+  it('allows creating keys with different names in the same tenant', async () => {
+    await auth.createKey('key-alpha', 100, undefined, 'admin');
+    const result = await auth.createKey('key-beta', 100, undefined, 'admin');
+
+    expect(result.name).toBe('key-beta');
+  });
+});

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -87,8 +87,13 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
     if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
     if (!requireRole(auth, req, reply, 'admin')) return;
     const { name, rateLimit, ttlDays, role = 'viewer', permissions, tenantId } = data;
-    const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
-    return reply.status(201).send(result);
+    try {
+      const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
+      return reply.status(201).send(result);
+    } catch (err: any) {
+      if (err.code === 'DUPLICATE_KEY_NAME') return reply.status(409).send({ error: err.message });
+      throw err;
+    }
   }));
 
   registerWithLegacy(app, 'get', '/v1/auth/keys', async (req: FastifyRequest, reply: FastifyReply) => {
@@ -195,8 +200,13 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
     if (!auth.authEnabled) return reply.status(403).send({ error: 'Auth is not enabled' });
     if (!requireRole(auth, req, reply, 'admin')) return;
     const { name, rateLimit, ttlDays, role = 'viewer', permissions, tenantId } = data;
-    const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
-    return reply.status(201).send(result);
+    try {
+      const result = await auth.createKey(name, rateLimit, ttlDays, role, permissions, tenantId);
+      return reply.status(201).send(result);
+    } catch (err: any) {
+      if (err.code === 'DUPLICATE_KEY_NAME') return reply.status(409).send({ error: err.message });
+      throw err;
+    }
   }));
 
   registerWithLegacy(app, 'delete', '/v1/keys/:id', async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -258,6 +258,15 @@ export class AuthManager {
       ? SYSTEM_TENANT
       : tenantId ?? this.defaultTenantId;
 
+    // Issue #3073: Reject duplicate key names within the same tenant.
+    const duplicate = this.store.keys.find(k => k.name === name && k.tenantId === resolvedTenantId);
+    if (duplicate) {
+      const err = new Error(`An API key with the name "${name}" already exists for this tenant`);
+      (err as any).code = 'DUPLICATE_KEY_NAME';
+      (err as any).statusCode = 409;
+      throw err;
+    }
+
     const apiKey: ApiKey = {
       id,
       name,


### PR DESCRIPTION
## Fix for #3073: Duplicate API Key Names

Clean re-spin of #3099 (896 files → 3 files).

### Problem
`POST /v1/auth/keys` accepted duplicate key names without error, allowing two keys with the same name and different roles to coexist. This creates operational confusion during incident response and key rotation.

### Solution
- **AuthManager.createKey()** — checks for existing keys with the same name in the same tenant before creation
- Throws `DUPLICATE_KEY_NAME` error (code + statusCode 409)
- **Route handlers** — both `POST /v1/auth/keys` and `POST /v1/keys` catch the error and return `409 Conflict`

### Scoping
- Names scoped **per-tenant**: different tenants can reuse key names
- Post-revocation reuse allowed: name becomes available after key deletion

### Changes (3 files, 88 insertions, 4 deletions)
| File | Change |
|------|--------|
| `src/services/auth/AuthManager.ts` | +9 lines: duplicate name check in `createKey()` |
| `src/routes/auth.ts` | +14 lines: 409 error handling in both key creation routes |
| `src/__tests__/fix-3073-duplicate-key-name.test.ts` | New: 5 tests |

### Verification
```
✓ tsc --noEmit — zero errors
✓ vitest run fix-3073 — 5/5 tests passed (28ms)
```

**Tested-by:** Themis (Security Auditor)