### PR TITLE
fix(config): default acpEnabled to true (#3078)

### DIFF
--- a/src/__tests__/fix-3078-acp-enabled-default.test.ts
+++ b/src/__tests__/fix-3078-acp-enabled-default.test.ts
@@ -1,0 +1,25 @@
+/**
+ * fix-3078-acp-enabled-default.test.ts — Issue #3078:
+ * acpEnabled should default to true so sessions use ACP when available.
+ *
+ * Previously defaulted to false — sessions created without CC transport
+ * even when ACP binary was available. Now defaults to true.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('acpEnabled default (#3078)', () => {
+  it('is true in the default config object', async () => {
+    // Read the source to verify the default — the 'defaults' object is not exported
+    const fs = await import('fs');
+    const path = await import('path');
+    const configSrc = fs.readFileSync(
+      path.resolve(import.meta.dirname, '../config.ts'),
+      'utf-8'
+    );
+    // Check that the default line is present (not "acpEnabled: false")
+    const acpLine = configSrc.split('\n').find(l => /^\s*acpEnabled: (true|false),?\s*$/.test(l));
+    expect(acpLine).toBeDefined();
+    expect(acpLine!.trim()).toBe('acpEnabled: true,');
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -221,7 +221,7 @@ const defaults: Config = {
   stateStore: 'file',
   postgresUrl: '',
   rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
-  acpEnabled: false,
+  acpEnabled: true,
 };
 
 /** Parse CLI args for --config flag */


### PR DESCRIPTION
## Fix for #3078

Root cause of sessions stuck at pending: `acpEnabled` defaulted to `false`, so sessions were created without spawning a Claude Code process even when the ACP binary was available.

### Change
- `src/config.ts`: Changed `acpEnabled` default from `false` to `true`
- Added test verifying the default value

### Why this is safe
- The binary resolver already handles missing binaries gracefully (throws at spawn time)
- `acpBackend` is always instantiated; the `if (acpBackend && ctx.config.acpEnabled)` guard still works
- Users who explicitly want to disable ACP can set `AEGIS_ACP_ENABLED=false`

### Verification
- ✅ `tsc --noEmit` — zero errors
- ✅ Test passes — 1 test

### Impact
Every user who installs Aegis without explicitly setting `AEGIS_ACP_ENABLED` now gets working sessions by default.

---
*Hephaestus 🔨*