### PR TITLE
fix(auth): reset auth-fail rate limit on successful auth (#3072)

### DIFF
--- a/src/__tests__/fix-3072-auth-rate-limit-reset.test.ts
+++ b/src/__tests__/fix-3072-auth-rate-limit-reset.test.ts
@@ -1,0 +1,76 @@
+/**
+ * fix-3072-auth-rate-limit-reset.test.ts — Issue #3072:
+ * Auth failure rate limit should reset on successful auth.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RateLimiter } from '../services/auth/RateLimiter.js';
+
+describe('Auth fail rate limit reset on success (#3072)', () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    limiter = new RateLimiter();
+  });
+
+  it('should not be rate-limited after 4 failures', () => {
+    for (let i = 0; i < 4; i++) {
+      limiter.recordAuthFailure('1.2.3.4');
+    }
+    expect(limiter.checkAuthFailRateLimit('1.2.3.4')).toBe(false);
+  });
+
+  it('should be rate-limited after 5 failures', () => {
+    for (let i = 0; i < 5; i++) {
+      limiter.recordAuthFailure('1.2.3.4');
+    }
+    expect(limiter.checkAuthFailRateLimit('1.2.3.4')).toBe(true);
+  });
+
+  it('should reset failure counter on successful auth', () => {
+    // Accumulate 4 failures (just under the limit)
+    for (let i = 0; i < 4; i++) {
+      limiter.recordAuthFailure('1.2.3.4');
+    }
+    expect(limiter.checkAuthFailRateLimit('1.2.3.4')).toBe(false);
+
+    // Successful auth resets the counter
+    limiter.resetAuthFailures('1.2.3.4');
+
+    // Now 4 more failures should NOT trigger the limit (counter was reset)
+    for (let i = 0; i < 4; i++) {
+      limiter.recordAuthFailure('1.2.3.4');
+    }
+    expect(limiter.checkAuthFailRateLimit('1.2.3.4')).toBe(false);
+  });
+
+  it('should allow full 5 attempts after reset', () => {
+    // 4 failures
+    for (let i = 0; i < 4; i++) {
+      limiter.recordAuthFailure('1.2.3.4');
+    }
+    // Reset
+    limiter.resetAuthFailures('1.2.3.4');
+    // Now should tolerate 5 more
+    for (let i = 0; i < 5; i++) {
+      limiter.recordAuthFailure('1.2.3.4');
+    }
+    expect(limiter.checkAuthFailRateLimit('1.2.3.4')).toBe(true);
+  });
+
+  it('reset is idempotent and safe on unknown IPs', () => {
+    expect(() => limiter.resetAuthFailures('unknown.ip')).not.toThrow();
+    expect(limiter.checkAuthFailRateLimit('unknown.ip')).toBe(false);
+  });
+
+  it('different IPs have independent counters', () => {
+    for (let i = 0; i < 5; i++) {
+      limiter.recordAuthFailure('1.1.1.1');
+    }
+    expect(limiter.checkAuthFailRateLimit('1.1.1.1')).toBe(true);
+    expect(limiter.checkAuthFailRateLimit('2.2.2.2')).toBe(false);
+
+    limiter.resetAuthFailures('1.1.1.1');
+    expect(limiter.checkAuthFailRateLimit('1.1.1.1')).toBe(false);
+  });
+});

--- a/src/__tests__/server-core-coverage.test.ts
+++ b/src/__tests__/server-core-coverage.test.ts
@@ -77,6 +77,7 @@ vi.mock('../services/auth/RateLimiter.js', () => ({
     }
 
     recordAuthFailure(): void {}
+    resetAuthFailures(): void {}
     pruneAuthFailLimits(): void {}
     pruneIpRateLimits(): void {}
     dispose(): void {}

--- a/src/__tests__/server-phase3.test.ts
+++ b/src/__tests__/server-phase3.test.ts
@@ -38,6 +38,7 @@ const rateLimiterSpies = {
   checkIpRateLimitUnauth: vi.fn<(ip: string) => boolean>(() => false),
   checkAuthFailRateLimit: vi.fn<(ip: string) => boolean>(() => false),
   recordAuthFailure: vi.fn<(ip: string) => void>(),
+  resetAuthFailures: vi.fn<(ip: string) => void>(),
   pruneAuthFailLimits: vi.fn<() => void>(),
   pruneIpRateLimits: vi.fn<() => void>(),
   dispose: vi.fn<() => void>(),
@@ -53,6 +54,7 @@ vi.mock('../services/auth/RateLimiter.js', () => ({
     checkIpRateLimitUnauth = rateLimiterSpies.checkIpRateLimitUnauth;
     checkAuthFailRateLimit = rateLimiterSpies.checkAuthFailRateLimit;
     recordAuthFailure = rateLimiterSpies.recordAuthFailure;
+    resetAuthFailures = rateLimiterSpies.resetAuthFailures;
     pruneAuthFailLimits = rateLimiterSpies.pruneAuthFailLimits;
     pruneIpRateLimits = rateLimiterSpies.pruneIpRateLimits;
     dispose = rateLimiterSpies.dispose;

--- a/src/server.ts
+++ b/src/server.ts
@@ -583,6 +583,9 @@ function setupAuth(authManager: AuthManager): void {
 
     // #1419: Audit authenticated API calls (fire-and-forget, non-blocking)
     // #1640: Guard with simple truthiness check — auditLogger can be undefined
+    // #3072: Reset auth-fail counter on successful auth so prior typos are forgiven
+    rateLimiter.resetAuthFailures(clientIp);
+
     if (auditLogger) {
       void auditLogger.log(result.keyId ?? 'anonymous', 'api.authenticated', `${req.method} ${req.url?.split('?')[0] ?? req.url}`, undefined, result.tenantId);
     }

--- a/src/services/auth/RateLimiter.ts
+++ b/src/services/auth/RateLimiter.ts
@@ -160,6 +160,12 @@ export class RateLimiter {
     }
   }
 
+  /** #3072: Reset auth-fail counter on successful auth from this IP.
+   * Prevents a user who typos once from being locked out after correcting. */
+  resetAuthFailures(ip: string): void {
+    this.authFailLimits.delete(ip);
+  }
+
   pruneAuthFailLimits(): void {
     const cutoff = Date.now() - AUTH_FAIL_WINDOW_MS;
     for (const [ip, bucket] of this.authFailLimits) {


### PR DESCRIPTION
## Fix for #3072

Auth failure rate limit was too aggressive — prior typos accumulated and could lock out users even after presenting a valid token.

### Root Cause
The auth-fail counter for each IP was never reset on successful auth. Five failures (from typos, testing, etc.) triggered a 60-second lockout with no recovery path.

### Fix
- Added `RateLimiter.resetAuthFailures(ip)` — clears the failure bucket for an IP
- Called after every successful bearer token validation in server.ts
- Typo → correct → counter resets immediately

### Behavior
| Scenario | Before | After |
|----------|--------|-------|
| 4 typos, then correct token | Counter=4, 1 more typo = lockout | Counter=0 after success |
| 5 bad attempts | Locked out 60s | Locked out 60s (unchanged) |
| Attacker brute-force | Blocked at 5/min | Blocked at 5/min (unchanged) |

### Verification
- ✅ `tsc --noEmit` — zero errors
- ✅ 6 test cases covering reset, idempotency, per-IP isolation

---
*Hephaestus 🔨*