### PR TITLE
fix(acp): default acpEnabled to true — sessions no longer stuck at pending (#3078)

### DIFF
--- a/src/__tests__/fix-3078-acp-enabled-default.test.ts
+++ b/src/__tests__/fix-3078-acp-enabled-default.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Issue #3078: acpEnabled should default to true so sessions
+ * get ACP transport when the binary is available.
+ */
+import { describe, it, expect } from 'vitest';
+import { loadConfig } from '../config.js';
+
+describe('Issue #3078 — acpEnabled defaults to true', () => {
+  it('acpEnabled is true in default config', async () => {
+    // loadConfig without AEGIS_ACP_ENABLED env var should return acpEnabled: true
+    const original = process.env.AEGIS_ACP_ENABLED;
+    delete process.env.AEGIS_ACP_ENABLED;
+    try {
+      const config = await loadConfig();
+      expect(config.acpEnabled).toBe(true);
+    } finally {
+      if (original !== undefined) process.env.AEGIS_ACP_ENABLED = original;
+    }
+  });
+
+  it('acpEnabled can be explicitly disabled via AEGIS_ACP_ENABLED=false', async () => {
+    const original = process.env.AEGIS_ACP_ENABLED;
+    process.env.AEGIS_ACP_ENABLED = 'false';
+    try {
+      const config = await loadConfig();
+      expect(config.acpEnabled).toBe(false);
+    } finally {
+      if (original !== undefined) process.env.AEGIS_ACP_ENABLED = original;
+      else delete process.env.AEGIS_ACP_ENABLED;
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -221,7 +221,7 @@ const defaults: Config = {
   stateStore: 'file',
   postgresUrl: '',
   rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
-  acpEnabled: false,
+  acpEnabled: true,
 };
 
 /** Parse CLI args for --config flag */


### PR DESCRIPTION
## Fix for #3078: acpEnabled defaults to false — sessions stuck at pending

### Problem
`acpEnabled` in config defaults to `false`. When no `AEGIS_ACP_ENABLED` env var is set, sessions are created in-memory only — no Claude Code process is spawned. They stay at `pending` forever, even when the ACP binary is available and `ag doctor` reports it as ✅.

### Root Cause
```
src/config.ts:224 — acpEnabled: false
src/routes/sessions.ts:402 — if (acpBackend && ctx.config.acpEnabled)
```
The `acpBackend` is always instantiated but the config flag blocks it from being used.

### Fix
**One-line change:** default `acpEnabled` to `true`.

Safe because:
- `acpBackend` gates on binary availability internally — if no binary found, no ACP session regardless of flag
- Users can still explicitly disable via `AEGIS_ACP_ENABLED=false` or `"acpEnabled": false` in config
- Existing tests that explicitly set `acpEnabled: false` are unaffected

### Changes (2 files, 33 insertions, 1 deletion)
| File | Change |
|------|--------|
| `src/config.ts` | `acpEnabled: false` → `acpEnabled: true` |
| `src/__tests__/fix-3078-acp-enabled-default.test.ts` | 2 new tests |

### Verification
```
✓ tsc --noEmit — zero errors
✓ vitest run — 2/2 tests passed
```