### PR TITLE
fix(dashboard): redirect root / to /dashboard/ (#3076)

### DIFF
--- a/src/__tests__/fix-3076-root-redirect.test.ts
+++ b/src/__tests__/fix-3076-root-redirect.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #3076: Root / should redirect to /dashboard/ when dashboard is available.
+ */
+import { describe, it, expect } from 'vitest';
+import Fastify from 'fastify';
+
+describe('Issue #3076 — Root redirect to /dashboard/', () => {
+  it('registers a GET / route that returns 302 to /dashboard/', async () => {
+    const app = Fastify();
+    let dashboardAvailable = true;
+
+    // Replicate the logic from server.ts
+    if (dashboardAvailable) {
+      app.get('/', async (_req, reply) => {
+        return reply.redirect('/dashboard/');
+      });
+    }
+
+    const res = await app.inject({ method: 'GET', url: '/' });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/dashboard/');
+    await app.close();
+  });
+
+  it('does not register redirect when dashboard is unavailable', async () => {
+    const app = Fastify();
+    let dashboardAvailable = false;
+
+    if (dashboardAvailable) {
+      app.get('/', async (_req, reply) => {
+        return reply.redirect('/dashboard/');
+      });
+    }
+
+    const res = await app.inject({ method: 'GET', url: '/' });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1437,6 +1437,13 @@ async function main(): Promise<void> {
     });
   }
 
+  // Issue #3076: Redirect root / to /dashboard/ when dashboard is available
+  if (dashboardAvailable) {
+    app.get('/', async (_req, reply) => {
+      return reply.redirect('/dashboard/');
+    });
+  }
+
   // SPA fallback for dashboard routes (Issue #105)
   app.setNotFoundHandler(async (req, reply) => {
     if (dashboardAvailable && (req.url === "/dashboard" || req.url?.startsWith("/dashboard/") || req.url?.startsWith("/dashboard?"))) {


### PR DESCRIPTION
## Fix for #3076: Dashboard root / returns 404

### Problem
Navigating to the server root `/` returns 404. Users expect to see the dashboard.

### Fix
When dashboard is available, `GET /` now returns **302 redirect** to `/dashboard/`.

No redirect when dashboard is disabled or unavailable (graceful degradation).

### Changes (2 files, 46 insertions)
| File | Change |
|------|--------|
| `src/server.ts` | +7 lines: root redirect route |
| `src/__tests__/fix-3076-root-redirect.test.ts` | +39 lines: 2 tests |

### Verification
```
✓ tsc --noEmit — zero errors
✓ vitest run — 2/2 tests passed
```