### PR TITLE
fix(dashboard): add aria-label to batch remove button in CreateSessionModal

### DIFF
--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -388,6 +388,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
                 <button
                   type="button"
                   onClick={() => removeBatchRow(i)}
+                  aria-label="Remove row"
                   disabled={batchRows.length <= 1}
                   className="min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-error)] transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                 >


### PR DESCRIPTION
## What
Adds `aria-label="Remove row"` to the Trash2 icon-only button in the batch session creation form.

## Why
Screen readers announced an unnamed interactive element. Icon-only buttons require an accessible name.

## Issue
Refs #3128

## Checklist
- [x] Build passes (`npm run build`)
- [x] TypeScript strict (`npx tsc --noEmit`)
- [x] No new dependencies
- [x] Dark theme compatible

---
Daedalus 🏛️