### PR TITLE
fix(dashboard): responsive breakpoints and error boundaries for 4 pages

### DIFF
--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -65,7 +65,7 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[var(--color-void)]">
-      <div className="w-full max-w-sm rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-8">
+      <div className="w-full max-w-sm rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-4 sm:p-8">
         {/* Logo / Title */}
         <div className="mb-8 flex flex-col items-center gap-2">
           <Shield className="h-10 w-10 text-blue-500" />

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -129,7 +129,7 @@ export default function PipelineDetailPage() {
       </nav>
 
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">{pipeline.name}</h1>
           <PipelineStatusBadge status={pipeline.status} />

--- a/dashboard/src/pages/RoutinesPage.tsx
+++ b/dashboard/src/pages/RoutinesPage.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useCallback } from 'react';
 import { Calendar, Plus } from 'lucide-react';
+import { ErrorBoundary } from '../components/shared/ErrorBoundary';
 import { useT } from '../i18n/context';
 import EmptyState from '../components/shared/EmptyState';
 import { CalendarGrid } from '../components/routines';
@@ -79,8 +80,9 @@ export default function RoutinesPage() {
 
   if (!loading && routines.length === 0) {
     return (
+      <ErrorBoundary>
       <div className="p-6 space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-xl font-bold text-[var(--color-text-primary)]">{t('routines.title')}</h1>
             <p className="text-sm text-[var(--color-text-muted)] mt-1">
@@ -98,13 +100,15 @@ export default function RoutinesPage() {
         </div>
         {calendarContent}
       </div>
+      </ErrorBoundary>
     );
   }
 
   // Populated state
   return (
+    <ErrorBoundary>
     <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-xl font-bold text-[var(--color-text-primary)]">{t('routines.title')}</h1>
           <p className="text-sm text-[var(--color-text-muted)] mt-1">
@@ -122,5 +126,6 @@ export default function RoutinesPage() {
       </div>
       {calendarContent}
     </div>
+    </ErrorBoundary>
   );
 }

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -171,7 +171,7 @@ export default function SettingsPage() {
         </div>
         <div className="space-y-4">
           {/* Dark / Light toggle */}
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm text-[var(--color-text-primary)]">Theme</p>
               <p className="text-xs text-[var(--color-text-muted)]">Switch between dark and light mode</p>
@@ -186,7 +186,7 @@ export default function SettingsPage() {
 
           {/* Light sub-theme picker — shown only in light mode */}
           {isLight && (
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-sm text-[var(--color-text-primary)]">Light variant</p>
                 <p className="text-xs text-[var(--color-text-muted)]">Choose a light-mode sub-theme</p>
@@ -211,7 +211,7 @@ export default function SettingsPage() {
           )}
 
           {/* Auto theme toggle */}
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm text-[var(--color-text-primary)]">Auto theme</p>
               <p className="text-xs text-[var(--color-text-muted)]">Follow system <code className="font-mono text-[11px]">prefers-color-scheme</code></p>
@@ -225,7 +225,7 @@ export default function SettingsPage() {
           </div>
 
           {/* Default page size */}
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm text-[var(--color-text-primary)]">Default page size</p>
               <p className="text-xs text-[var(--color-text-muted)]">Rows per page in session history</p>
@@ -244,7 +244,7 @@ export default function SettingsPage() {
           </div>
 
           {/* Reading font toggle */}
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm text-[var(--color-text-primary)]">Reading font</p>
               <p className="text-xs text-[var(--color-text-muted)]">Choose a body font for readability</p>
@@ -268,7 +268,7 @@ export default function SettingsPage() {
           </div>
 
           {/* Locale picker */}
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm text-[var(--color-text-primary)]">Language & Region</p>
               <p className="text-xs text-[var(--color-text-muted)]">Set display language and regional formats</p>
@@ -296,7 +296,7 @@ export default function SettingsPage() {
           <h3 className="text-lg font-medium text-[var(--color-text-primary)]">Auto-Refresh</h3>
         </div>
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm text-[var(--color-text-primary)]">Enable auto-refresh</p>
               <p className="text-xs text-[var(--color-text-muted)]">Automatically update dashboard data</p>
@@ -308,7 +308,7 @@ export default function SettingsPage() {
             />
           </div>
           {settings.autoRefresh && (
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-sm text-[var(--color-text-primary)]">Refresh interval</p>
                 <p className="text-xs text-[var(--color-text-muted)]">How often to poll for updates</p>
@@ -337,7 +337,7 @@ export default function SettingsPage() {
           <h3 className="text-lg font-medium text-[var(--color-text-primary)]">Budget & Cost Alerts</h3>
         </div>
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm text-[var(--color-text-primary)]">Enable budget alerts</p>
               <p className="text-xs text-[var(--color-text-muted)]">Warning at 80% of cap</p>
@@ -351,7 +351,7 @@ export default function SettingsPage() {
 
           {settings.budgetAlertEnabled && (
             <>
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-sm text-[var(--color-text-primary)]">Daily spending cap</p>
                   <p className="text-xs text-[var(--color-text-muted)]">Maximum USD per day</p>
@@ -370,7 +370,7 @@ export default function SettingsPage() {
                 </div>
               </div>
 
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-sm text-[var(--color-text-primary)]">Monthly spending cap</p>
                   <p className="text-xs text-[var(--color-text-muted)]">Maximum USD per month</p>
@@ -389,7 +389,7 @@ export default function SettingsPage() {
                 </div>
               </div>
 
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-sm text-[var(--color-text-primary)]">Hard stop at 100%</p>
                   <p className="text-xs text-[var(--color-text-muted)]">Block new sessions when cap reached</p>


### PR DESCRIPTION
## What
Fixes responsive layout issues found during Dashboard UAT audit (#3128).

### Changes
- **LoginPage**: `p-8` → `p-4 sm:p-8` — better padding on small screens
- **SettingsPage**: 12 setting rows now stack vertically on mobile (`flex-col gap-2 sm:flex-row sm:items-center sm:justify-between`)
- **PipelineDetailPage**: Header stacks on mobile
- **RoutinesPage**: Header stacks on mobile + wrapped in `ErrorBoundary`

### Why
Pages with `flex items-center justify-between` rows were overlapping on mobile — labels and controls would compress into the same row with no wrapping.

### Testing
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — zero errors
- [x] No new dependencies
- [x] Dark theme compatible

Closes #3128

---
Daedalus 🏛️