### PR TITLE
fix(server): skip auth for root / redirect

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -396,7 +396,7 @@ function setupAuth(authManager: AuthManager): void {
     if (urlPath === '/v1/auth/device/authorize' || urlPath === '/v1/auth/device/token') return;
     // Issue #1942: Dashboard OIDC endpoints authenticate with HttpOnly cookies.
     if (urlPath === '/auth/login' || urlPath === '/auth/callback' || urlPath === '/auth/session' || urlPath === '/auth/logout') return;
-    if (urlPath === '/dashboard' || urlPath.startsWith('/dashboard/')) return;
+    if (urlPath === '/' || urlPath === '/dashboard' || urlPath.startsWith('/dashboard/')) return;
     // Issue #3092: manifest.json must be public for PWA install.
     if (urlPath === '/manifest.json') return;
     // Hook routes — exact match: /v1/hooks/{eventName} (alpha only, no path traversal)


### PR DESCRIPTION
## Bug found during E2E testing

The root `/` redirect (added in #3076 / #3110) required auth, returning 401 for unauthenticated users instead of 302 redirect to `/dashboard/`.

### Fix
Added `/` to the auth skip list alongside `/dashboard/`.

### Before
```
GET / (no auth) → 401 Unauthorized
```

### After
```
GET / (no auth) → 302 → /dashboard/
```

### Verification (E2E test)
```
✅ Root: 302
✅ Dashboard: 200
✅ Manifest: 200
✅ Health: ok
✅ Auth reject: 401
```