### PR TITLE
fix(telegram): reduce getUpdates long-poll timeout to avoid abort race

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1471,7 +1471,7 @@ export class TelegramChannel implements Channel {
       try {
         const updates = (await this.tgApi('getUpdates', {
           offset: this.pollOffset,
-          timeout: 10,
+          timeout: 5,
           allowed_updates: ['message', 'callback_query'],
         })) as Array<{ update_id: number; message?: unknown; callback_query?: unknown }>;
 


### PR DESCRIPTION
## Problem
The Telegram poll loop calls `getUpdates` with `timeout: 10` (10s long-poll), but `tgApi()` applies `AbortSignal.timeout(10_000ms)`. Both are equal — abort fires as Telegram returns, causing every poll to timeout.

## Fix
Reduce `getUpdates` long-poll from 10s to 5s, leaving 5s buffer before abort.

## Files
- `src/channels/telegram.ts`: timeout 10 → 5