### PR TITLE
fix(api): add 'name' alias to session create response (#3134)

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -470,7 +470,9 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       ? 'Session created but prompt not delivered: ACP is disabled. Set AEGIS_ACP_ENABLED=true or add "acpEnabled": true to config to enable Claude Code sessions.'
       : undefined;
 
-    return reply.status(201).send({ ...redactSession(session as unknown as Record<string, unknown>), promptDelivery, ...(acpWarning ? { warning: acpWarning } : {}) });
+    // Issue #3134: Include 'name' alias for backward compat (API consumers expect 'name')
+    const sessionResponse = redactSession(session as unknown as Record<string, unknown>);
+    return reply.status(201).send({ ...sessionResponse, name: sessionResponse.displayName ?? sessionResponse.name, promptDelivery, ...(acpWarning ? { warning: acpWarning } : {}) });
   }
   registerWithLegacy(app, 'post', '/v1/sessions', {
     config: {


### PR DESCRIPTION
## Problem
Issue #3134: Session create returns `displayName` but consumers (dashboard, CLI) expect `name`. The field is confusing — you send `name` but get back `displayName`.

## Fix
Add a `name` alias to the create session response: `name: sessionResponse.displayName`. Both fields now present in response.

## Before
```json
{"displayName": "my-session", "id": "...", ...}
```

## After
```json
{"displayName": "my-session", "name": "my-session", "id": "...", ...}
```

## Files
- `src/routes/sessions.ts`: add name alias in create response