### PR TITLE
fix(security): prevent session ID enumeration via 404/403 differentiation (#3071)

### DIFF
--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -259,7 +259,8 @@ export function requireSessionOwnership(
   if (callerTenantId && callerTenantId !== SYSTEM_TENANT && session.tenantId !== callerTenantId) {
     const audit = getAuditLogger();
     if (audit) void audit.log(resolveRequestAuditActor(auth, req, 'api-key'), 'session.action.denied', `Cross-tenant ${actionLabel} denied on session ${sessionId} (tenant: ${session.tenantId})`, sessionId, callerTenantId);
-    reply.status(403).send({ error: 'SESSION_FORBIDDEN', message: 'Session belongs to another tenant' });
+    // Issue #3071: Return 404 instead of 403 to prevent session ID enumeration
+    reply.status(404).send({ error: 'Session not found' });
     return null;
   }
 


### PR DESCRIPTION
## Problem
Issue #3071: `GET /v1/sessions/:id` returns 404 for non-existent sessions but 403 for sessions belonging to another tenant. This allows authenticated users with viewer access to enumerate valid session IDs.

## Fix
Return 404 for both cases — unauthorized sessions are indistinguishable from non-existent ones.

## Before
- Missing session → 404 `{error: 'Session not found'}`
- Other tenant's session → 403 `{error: 'SESSION_FORBIDDEN', message: '...'}`

## After  
- Missing session → 404 `{error: 'Session not found'}`
- Other tenant's session → 404 `{error: 'Session not found'}`

## Files
- `src/routes/context.ts`: cross-tenant denial returns 404 instead of 403