### PR TITLE
fix(acp): log child process stderr + global name alias (#3135, #3134)

### DIFF
--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -311,6 +311,10 @@ export function redactSession(session: Record<string, unknown>): Record<string, 
   if (activeSubagents instanceof Set) {
     (redacted as Record<string, unknown>).activeSubagents = [...activeSubagents];
   }
+  // Issue #3134: Add 'name' alias for backward compat (API consumers expect 'name')
+  if (redacted.displayName !== undefined && redacted.name === undefined) {
+    (redacted as Record<string, unknown>).name = redacted.displayName;
+  }
   return redacted;
 }
 

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -470,9 +470,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       ? 'Session created but prompt not delivered: ACP is disabled. Set AEGIS_ACP_ENABLED=true or add "acpEnabled": true to config to enable Claude Code sessions.'
       : undefined;
 
-    // Issue #3134: Include 'name' alias for backward compat (API consumers expect 'name')
-    const sessionResponse = redactSession(session as unknown as Record<string, unknown>);
-    return reply.status(201).send({ ...sessionResponse, name: sessionResponse.displayName ?? sessionResponse.name, promptDelivery, ...(acpWarning ? { warning: acpWarning } : {}) });
+    return reply.status(201).send({ ...redactSession(session as unknown as Record<string, unknown>), promptDelivery, ...(acpWarning ? { warning: acpWarning } : {}) });
   }
   registerWithLegacy(app, 'post', '/v1/sessions', {
     config: {

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -962,6 +962,15 @@ export function createDefaultAcpBackendClient(
     ...options.childProcessOptions,
     cwd: context.cwd,
   });
+  // Issue #3135: Forward ACP child process stderr for debugging.
+  // Without this, errors from claude-agent-acp (API key issues, crashes)
+  // are silently discarded, making diagnosis impossible.
+  child.on('stderr', (event) => {
+    const text = typeof event.chunk === 'string' ? event.chunk.trim() : '';
+    if (text) {
+      console.error(`[ACP stderr:${context.durableSessionId.slice(0, 8)}] ${text}`);
+    }
+  });
   return new AcpJsonRpcClient({
     ...options.jsonRpcClientOptions,
     child,


### PR DESCRIPTION
## Problem
Two issues:

1. **ACP child process stderr is silently discarded** — when `claude-agent-acp` encounters errors (invalid API key, connection failures, crashes), they're written to stderr but never captured. This makes diagnosing ACP handshake failures (#3135) extremely difficult.

2. **`name` alias only in create response** — PR #3144 added `name: displayName` alias only to the create session response. GET and list endpoints still return only `displayName`, not `name`.

## Fix
1. **ACP stderr forwarding**: Attach `stderr` listener to `AcpChildProcess` in `createDefaultAcpBackendClient`. All stderr output is logged with session ID prefix for debugging.

2. **Global name alias**: Move the alias from create-only to `redactSession()` so it appears in ALL session responses (GET, list, create).

## Files
- `src/services/acp/backend.ts`: forward child process stderr
- `src/routes/context.ts`: add name alias in redactSession
- `src/routes/sessions.ts`: remove duplicate alias (now global)