### PR TITLE
fix(acp): pass HOME and Anthropic env vars to child process (#3135)

### DIFF
--- a/src/acp-spawn-env.ts
+++ b/src/acp-spawn-env.ts
@@ -40,10 +40,20 @@ function copyPlatformExecutionEnv(
     return;
   }
 
-  for (const key of ['PATH', 'TMPDIR', 'TEMP', 'TMP']) {
+  // Core execution env
+  for (const key of ['PATH', 'TMPDIR', 'TEMP', 'TMP', 'HOME', 'USER', 'SHELL', 'LANG', 'LC_ALL', 'LC_CTYPE']) {
     const value = source[key];
     if (value !== undefined) {
       target[key] = value;
+    }
+  }
+
+  // Issue #3135: Pass through Anthropic/Claude env vars so the ACP child
+  // process can authenticate. Without these, claude-agent-acp cannot find
+  // API keys or credentials and silently fails.
+  for (const key of Object.keys(source)) {
+    if (key.startsWith('ANTHROPIC_') || key.startsWith('CLAUDE_')) {
+      target[key] = source[key];
     }
   }
 }


### PR DESCRIPTION
## Problem
Issue #3135: ACP child process (`claude-agent-acp`) receives only 3 env vars: `PATH`, `TMPDIR`, `NO_COLOR`. Missing `HOME` means it can't find `~/.claude/credentials`. Missing `ANTHROPIC_*`/`CLAUDE_*` means it can't authenticate with the Anthropic API.

The child process starts, the JSON-RPC handshake completes, but `session/new` times out because CC can't connect to Anthropic. Sessions appear `idle` but `claudeRunning: false` and `claudeSessionId: null`.

## Root Cause
`buildAcpSpawnEnv()` in `src/acp-spawn-env.ts` constructs a minimal environment with only PATH and temp dirs. Everything else from `process.env` is filtered out.

## Fix
Pass through essential env vars to the ACP child process:
- `HOME`, `USER`, `SHELL`, `LANG`, `LC_ALL`, `LC_CTYPE` (system essentials)
- All `ANTHROPIC_*` prefixed vars (API keys, endpoints)
- All `CLAUDE_*` prefixed vars (config dir, executable path)

## Before
```
Child process env: { PATH, TMPDIR, NO_COLOR }  // 3 vars
```

## After
```
Child process env: { PATH, HOME, USER, SHELL, LANG, ANTHROPIC_API_KEY, CLAUDE_CONFIG_DIR, ... }
```

## Files
- `src/acp-spawn-env.ts`: expand `copyPlatformExecutionEnv` to include HOME and auth-related env vars