### PR TITLE
fix(cli): retry health check after spawn failure (#3067)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -208,11 +208,20 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
     writeLine(io.stdout, '  ⏳ Waiting for server...');
     const started = await waitForServer(baseUrl, authToken, 15_000);
     if (!started) {
-      writeLine(io.stderr, '  ❌ Server failed to start within 15 seconds.');
-      writeLine(io.stderr, '     Try starting manually: ag');
-      return 1;
+      // Issue #3067: Race condition — an existing Aegis server may be on the port
+      // but was in a crash loop when we first checked. Retry health check once
+      // more before giving up — the existing server may have recovered.
+      writeLine(io.stdout, '  ⏳ Retrying health check (existing server may have recovered)...');
+      if (await isServerHealthy(baseUrl, authToken)) {
+        writeLine(io.stdout, '  ✅ Connected to existing server');
+      } else {
+        writeLine(io.stderr, '  ❌ Server failed to start within 15 seconds.');
+        writeLine(io.stderr, '     Try starting manually: ag');
+        return 1;
+      }
+    } else {
+      writeLine(io.stdout, '  ✅ Server started');
     }
-    writeLine(io.stdout, '  ✅ Server started');
   }
 
   // Create session


### PR DESCRIPTION
## Problem
Issue #3067: `ag run` fails with EADDRINUSE when a server is already running but was in a crash loop when the health check ran.

The race condition:
1. `ag run` checks health → server crashing/not responding → false
2. `ag run` spawns new server
3. New server can't bind port 9100 (EADDRINUSE — existing server still bound)
4. Recovery skips the existing PID (it's in the PID file) → fails
5. `ag run` errors out despite a healthy server existing

## Fix
After the spawned server fails to start within 15s, retry the health check once. If the existing server has recovered (common after crash loop stabilizes), use it instead of erroring out.

## Files
- `src/commands/run.ts`: add retry health check after spawn timeout