### PR TITLE
fix(acp): /read endpoint returns messages from ACP event store (#3143)

### DIFF
--- a/src/__tests__/read-acp-transcript-3143.test.ts
+++ b/src/__tests__/read-acp-transcript-3143.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Issue #3143: /read endpoint returns empty messages for ACP sessions.
+ *
+ * Tests that SessionTranscripts falls back to ACP event store when no JSONL
+ * file exists, correctly converting ACP events to ParsedEntry format.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { SessionTranscripts } from '../session-transcripts.js';
+import type { SessionInfo, UIState } from '../session.js';
+import type { Config } from '../config.js';
+import type { AcpEventStore, AcpEventRecord } from '../services/acp/event-store.js';
+import type { AcpEventJsonValue } from '../services/acp/event-store.js';
+
+function makeConfig(): Config {
+  return {
+    claudeProjectsDir: '/tmp/nonexistent',
+    stateDir: '/tmp/aegis-test-3143',
+    worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+  } as unknown as Config;
+}
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'test-session-3143',
+    windowId: '',
+    displayName: 'test-session',
+    workDir: '/tmp/test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle' as UIState,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 30_000,
+    permissionStallMs: 60_000,
+    permissionMode: 'default',
+    ownerKeyId: 'key-1',
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+function makeEvent(eventType: string, payload: AcpEventJsonValue, seq = 1): AcpEventRecord {
+  return {
+    sessionId: 'test-session-3143',
+    tenantId: 'tenant-1',
+    ownerKeyId: 'key-1',
+    eventSeq: seq,
+    eventId: `evt-${seq}`,
+    eventType,
+    occurredAt: new Date(),
+    ingestedAt: new Date(),
+    payload,
+  };
+}
+
+describe('Issue #3143: ACP event store fallback for /read', () => {
+  it('returns empty when no JSONL path and no ACP event store', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+    const session = makeSession();
+    const result = await transcripts.readMessages(session);
+    expect(result.messages).toEqual([]);
+  });
+
+  it('reads messages from ACP event store when no JSONL path exists', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockEvents: AcpEventRecord[] = [
+      makeEvent('message.delta', { text: 'Hello ', messageId: 'msg-1' }, 1),
+      makeEvent('message.delta', { text: 'world!', messageId: 'msg-1' }, 2),
+      makeEvent('tool.started', { toolCallId: 'tc-1', title: 'ReadFile' }, 3),
+      makeEvent('tool.completed', { toolCallId: 'tc-1', output: 'file contents' }, 4),
+    ];
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue(mockEvents),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession();
+    const result = await transcripts.readMessages(session);
+
+    expect(result.messages.length).toBe(3);
+    // Message delta accumulated into single entry
+    expect(result.messages[0]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        contentType: 'text',
+        text: 'Hello world!',
+      }),
+    );
+    // Tool use
+    expect(result.messages[1]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        contentType: 'tool_use',
+        text: 'ReadFile',
+        toolUseId: 'tc-1',
+      }),
+    );
+    // Tool result
+    expect(result.messages[2]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        contentType: 'tool_result',
+        text: 'file contents',
+        toolUseId: 'tc-1',
+      }),
+    );
+
+    // Should have called list with correct scope
+    expect(mockStore.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'test-session-3143',
+        limit: 10_000,
+      }),
+    );
+  });
+
+  it('handles thinking delta events', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockEvents: AcpEventRecord[] = [
+      makeEvent('thinking.delta', { text: 'Let me think...' }, 1),
+      makeEvent('message.delta', { text: 'Here is the answer', messageId: 'msg-1' }, 2),
+    ];
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue(mockEvents),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession();
+    const result = await transcripts.readMessages(session);
+
+    expect(result.messages.length).toBe(2);
+    expect(result.messages[0].contentType).toBe('thinking');
+    expect(result.messages[0].text).toBe('Let me think...');
+    expect(result.messages[1].contentType).toBe('text');
+    expect(result.messages[1].text).toBe('Here is the answer');
+  });
+
+  it('flushes pending message when messageId changes', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockEvents: AcpEventRecord[] = [
+      makeEvent('message.delta', { text: 'First message', messageId: 'msg-1' }, 1),
+      makeEvent('message.delta', { text: 'Second message', messageId: 'msg-2' }, 2),
+    ];
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue(mockEvents),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession();
+    const result = await transcripts.readMessages(session);
+
+    expect(result.messages.length).toBe(2);
+    expect(result.messages[0].text).toBe('First message');
+    expect(result.messages[1].text).toBe('Second message');
+  });
+
+  it('handles permission request events', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockEvents: AcpEventRecord[] = [
+      makeEvent('approval.requested', {
+        toolCall: { title: 'Write file foo.txt', toolCallId: 'tc-1' },
+        options: [{ id: 'allow', label: 'Allow' }],
+      }, 1),
+    ];
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue(mockEvents),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession();
+    const result = await transcripts.readMessages(session);
+
+    expect(result.messages.length).toBe(1);
+    expect(result.messages[0]).toEqual(
+      expect.objectContaining({
+        role: 'system',
+        contentType: 'permission_request',
+        text: 'Write file foo.txt',
+      }),
+    );
+  });
+
+  it('skips unsupported event types', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockEvents: AcpEventRecord[] = [
+      makeEvent('session.updated', { updateType: 'session_info_update' }, 1),
+      makeEvent('usage.updated', { inputTokens: 100 }, 2),
+      makeEvent('turn.completed', { stopReason: 'end_turn' }, 3),
+    ];
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue(mockEvents),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession();
+    const result = await transcripts.readMessages(session);
+
+    expect(result.messages).toEqual([]);
+  });
+
+  it('getCachedEntries falls back to ACP when no JSONL', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockEvents: AcpEventRecord[] = [
+      makeEvent('message.delta', { text: 'Test message', messageId: 'msg-1' }, 1),
+    ];
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue(mockEvents),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession();
+
+    // readTranscript uses getCachedEntries internally
+    const result = await transcripts.readTranscript(session);
+    expect(result.messages.length).toBe(1);
+    expect(result.messages[0].text).toBe('Test message');
+  });
+
+  it('handles tool error in tool.completed', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockEvents: AcpEventRecord[] = [
+      makeEvent('tool.completed', { toolCallId: 'tc-1', status: 'error', output: 'Permission denied' }, 1),
+    ];
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue(mockEvents),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession();
+    const result = await transcripts.readMessages(session);
+
+    expect(result.messages.length).toBe(1);
+    expect(result.messages[0].contentType).toBe('tool_error');
+  });
+
+  it('uses default scope when tenantId/ownerKeyId missing', async () => {
+    const transcripts = new SessionTranscripts(makeConfig());
+
+    const mockStore = {
+      append: vi.fn(),
+      list: vi.fn().mockResolvedValue([]),
+    } as unknown as AcpEventStore;
+
+    transcripts.setAcpEventStore(mockStore);
+    const session = makeSession({ tenantId: undefined, ownerKeyId: undefined });
+    await transcripts.readMessages(session);
+
+    expect(mockStore.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'default',
+        ownerKeyId: '',
+      }),
+    );
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -882,6 +882,9 @@ async function main(): Promise<void> {
     sessions.setEncryptionKey(config.authToken);
   }
 
+  // Issue #3143: Wire ACP event store into session transcript reader
+  sessions.setAcpEventStore(acpLocalProfile.eventStore);
+
   // Memory bridge (Issue #783)
   if (config.memoryBridge?.enabled) {
     const persistPath = config.memoryBridge.persistPath ?? path.join(config.stateDir, 'memory.json');

--- a/src/session-transcripts.ts
+++ b/src/session-transcripts.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { findSessionFile, readNewEntries, type ParsedEntry } from './transcript.js';
 import { findSessionFileWithFanout } from './worktree-lookup.js';
 import { computeProjectHash } from './path-utils.js';
+import type { AcpEventStore } from './services/acp/event-store.js';
 import type { Config } from './config.js';
 import type { SessionInfo } from './session.js';
 import type { UIState } from './session.js';
@@ -46,9 +47,15 @@ export class SessionTranscripts {
   private static readonly MAX_CACHE_ENTRIES_PER_SESSION = 10_000;
   private parsedEntriesCache = new Map<string, { entries: ParsedEntry[]; offset: number }>();
 
+  private acpEventStore: AcpEventStore | null = null;
   constructor(
     private config: Config,
   ) {}
+
+  /** Issue #3143: Inject ACP event store for reading ACP session transcripts. */
+  setAcpEventStore(store: AcpEventStore): void {
+    this.acpEventStore = store;
+  }
 
   /**
    * Read new messages from a session with UI state detection.
@@ -99,6 +106,14 @@ export class SessionTranscripts {
         session.byteOffset = result.newOffset;
       } catch {
         // File may not exist yet
+      }
+    } else if (this.acpEventStore) {
+      // Issue #3143: Fall back to ACP event store for ACP sessions.
+      // ACP sessions don't produce JSONL files — transcript data is in the event store.
+      try {
+        messages = await this.readFromAcpEvents(session);
+      } catch {
+        // ACP event read failed — return empty
       }
     }
 
@@ -304,6 +319,127 @@ export class SessionTranscripts {
     };
   }
 
+  /** Issue #3143: Read messages from ACP event store for ACP sessions.
+   *  Converts ACP events to ParsedEntry format compatible with JSONL-based reads. */
+  private async readFromAcpEvents(session: SessionInfo): Promise<ParsedEntry[]> {
+    if (!this.acpEventStore) return [];
+
+    const scope = {
+      tenantId: session.tenantId ?? 'default',
+      ownerKeyId: session.ownerKeyId ?? '',
+    };
+
+    const events = await this.acpEventStore.list({
+      sessionId: session.id,
+      ...scope,
+      limit: 10_000,
+    });
+
+    if (events.length === 0) return [];
+
+    const entries: ParsedEntry[] = [];
+    // Accumulate consecutive same-type delta events into single entries (like JSONL)
+    let pendingMessageText = '';
+    let pendingThinkingText = '';
+    let lastMessageId: string | undefined;
+    let lastDeltaType: 'message' | 'thinking' | null = null;
+
+    const flushPending = (): void => {
+      if (pendingThinkingText) {
+        entries.push({
+          role: 'assistant',
+          contentType: 'thinking',
+          text: pendingThinkingText.trim(),
+        });
+        pendingThinkingText = '';
+      }
+      if (pendingMessageText) {
+        entries.push({
+          role: 'assistant',
+          contentType: 'text',
+          text: pendingMessageText.trim(),
+        });
+        pendingMessageText = '';
+      }
+    };
+
+    for (const event of events) {
+      const payload = event.payload as Record<string, unknown> | null;
+      if (!payload) continue;
+
+      switch (event.eventType) {
+        case 'message.delta': {
+          const messageId = typeof payload.messageId === 'string' ? payload.messageId : undefined;
+          // Flush when switching from thinking to message, or messageId changes
+          if (lastDeltaType === 'thinking' || (messageId && messageId !== lastMessageId && lastMessageId !== undefined)) {
+            flushPending();
+          }
+          lastMessageId = messageId;
+          lastDeltaType = 'message';
+          const text = typeof payload.text === 'string' ? payload.text : '';
+          if (text) pendingMessageText += text;
+          break;
+        }
+        case 'thinking.delta': {
+          // Flush when switching from message to thinking
+          if (lastDeltaType === 'message') {
+            flushPending();
+          }
+          lastDeltaType = 'thinking';
+          const text = typeof payload.text === 'string' ? payload.text : '';
+          if (text) pendingThinkingText += text;
+          break;
+        }
+        case 'tool.started': {
+          flushPending();
+          const toolCallId = typeof payload.toolCallId === 'string' ? payload.toolCallId : undefined;
+          const title = typeof payload.title === 'string' ? payload.title : 'unknown';
+          entries.push({
+            role: 'assistant',
+            contentType: 'tool_use',
+            text: title,
+            toolName: title,
+            toolUseId: toolCallId,
+          });
+          break;
+        }
+        case 'tool.completed': {
+          const toolCallId = typeof payload.toolCallId === 'string' ? payload.toolCallId : undefined;
+          const isError = payload.isError === true || payload.status === 'error';
+          const outputText = typeof payload.output === 'string'
+            ? payload.output
+            : payload.output != null ? JSON.stringify(payload.output) : '';
+          entries.push({
+            role: 'assistant',
+            contentType: isError ? 'tool_error' : 'tool_result',
+            text: outputText.slice(0, 500),
+            toolUseId: toolCallId,
+          });
+          break;
+        }
+        case 'approval.requested': {
+          flushPending();
+          const toolCall = typeof payload.toolCall === 'object' && payload.toolCall !== null
+            ? payload.toolCall as Record<string, unknown>
+            : null;
+          const toolTitle = toolCall && typeof toolCall.title === 'string' ? toolCall.title : 'Permission request';
+          entries.push({
+            role: 'system',
+            contentType: 'permission_request',
+            text: toolTitle,
+          });
+          break;
+        }
+        default:
+          // Skip session.updated, usage.updated, turn.completed, etc.
+          break;
+      }
+    }
+
+    flushPending();
+    return entries;
+  }
+
   /** Remove cached entries for a session (e.g. on session kill). */
   clearCache(sessionId: string): void {
     this.parsedEntriesCache.delete(sessionId);
@@ -312,7 +448,17 @@ export class SessionTranscripts {
   /** #357: Get all parsed entries for a session, using a cache to avoid full reparse.
    *  Reads only the delta from the last cached offset. */
   private async getCachedEntries(session: SessionInfo): Promise<ParsedEntry[]> {
-    if (!session.jsonlPath || !existsSync(session.jsonlPath)) return [];
+    if (!session.jsonlPath || !existsSync(session.jsonlPath)) {
+      // Issue #3143: Fall back to ACP event store for ACP sessions.
+      if (this.acpEventStore) {
+        try {
+          return await this.readFromAcpEvents(session);
+        } catch {
+          return [];
+        }
+      }
+      return [];
+    }
     const cached = this.parsedEntriesCache.get(session.id);
     try {
       const fromOffset = cached ? cached.offset : 0;

--- a/src/session.ts
+++ b/src/session.ts
@@ -458,7 +458,11 @@ export class SessionManager {
     }, 2);
   }
 
-  /** #1644: Set the AES-256-GCM key derived from the master auth token. */
+  /** Issue #3143: Wire ACP event store into transcript reader. */
+  setAcpEventStore(store: import("./services/acp/event-store.js").AcpEventStore): void {
+    this.transcripts.setAcpEventStore(store);
+  }
+
   setEncryptionKey(masterToken: string): void {
     if (!masterToken) return;
     // scryptSync is synchronous — called once at startup, acceptable cost.


### PR DESCRIPTION
## Summary

Fixes #3143, fixes #3139

When no JSONL transcript file exists (ACP mode), the `/read`, `/transcript`, and `/transcript/cursor` endpoints returned empty messages. ACP sessions store transcript data in the ACP event store, not JSONL files.

### Changes
- **`src/session-transcripts.ts`**: Added `AcpEventStore` injection + `readFromAcpEvents()` method that converts ACP events to `ParsedEntry` format
  - `message.delta` → `assistant/text` (accumulates consecutive deltas)
  - `thinking.delta` → `assistant/thinking`
  - `tool.started` → `assistant/tool_use`
  - `tool.completed` → `assistant/tool_result` or `tool_error`
  - `approval.requested` → `system/permission_request`
- Fallback applied in `readMessages()`, `getCachedEntries()` (powers `/transcript` and `/transcript/cursor`)
- **`src/session.ts`**: Added `setAcpEventStore()` passthrough
- **`src/server.ts`**: Wires ACP event store after initialization
- **9 new tests** covering all event types, accumulation, type transitions, and error cases

### Verification
```
tsc --noEmit: ✅ 0 errors
npm run build: ✅ OK
npm test: ✅ 3971/3974 passed (1 pre-existing flaky, 2 skipped)
```

### Backward Compatibility
- JSONL-based sessions: unchanged (JSONL path takes precedence)
- ACP sessions without event store data: returns empty (same as before, no regression)
- ACP sessions with events: now returns messages (new functionality)
