### PR TITLE
fix(systemd): increase restart burst limit and add health-start check (#3069)

### DIFF
--- a/deploy/systemd/aegis.service
+++ b/deploy/systemd/aegis.service
@@ -35,10 +35,12 @@ WorkingDirectory=/opt/aegis
 
 # Server
 ExecStart=/usr/bin/node dist/server.js
+# Wait for health endpoint to respond (max 15s) before marking service as active
+ExecStartPost=/bin/bash -c 'for i in $(seq 1 15); do curl -sf http://localhost:${AEGIS_PORT:-9100}/health && exit 0; sleep 1; done; echo "WARN: health endpoint not responding after 15s"' 
 Restart=on-failure
 RestartSec=5
 StartLimitIntervalSec=300
-StartLimitBurst=5
+StartLimitBurst=10
 
 # Note: WatchdogSec (Type=notify + sd_notify) can be added once the server
 # implements sd_notify pings. The health-check timer covers this gap.


### PR DESCRIPTION
## Summary

Fixes #3069

The systemd unit had too aggressive restart limits (5 bursts in 300s). When the server hits transient startup failures, systemd gives up permanently, requiring manual `systemctl reset-failed`.

### Changes
- **`StartLimitBurst`**: 5 → 10 (within same 300s window) — more tolerant of transient startup issues
- **`ExecStartPost`**: Added health endpoint check that polls `localhost:9100/health` up to 15 seconds before marking the service as active. Warns in logs if the endpoint is slow but doesn't cause a hard failure.

### Note
This is a config-only change (systemd unit template). No TypeScript changes — no build/test needed.

### Operator Action Required
After merge, the deployed unit file needs to be updated on the host:
```bash
sudo cp deploy/systemd/aegis.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl reset-failed aegis
sudo systemctl start aegis
```
