### PR TITLE
fix(worktree): force baseRef=head to prevent silent data loss (#3155)

### DIFF
--- a/src/__tests__/hook-settings.test.ts
+++ b/src/__tests__/hook-settings.test.ts
@@ -284,6 +284,46 @@ describe('writeHookSettingsFile — Issue #339 merge', () => {
       if (existsSync(filePath)) unlinkSync(filePath);
     }
   });
+  it('should inject worktree.baseRef="head" (Issue #3155)', async () => {
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'worktree-baseref', 'test-secret-123');
+
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+
+      expect(parsed.worktree).toBeDefined();
+      const worktree = parsed.worktree as Record<string, unknown>;
+      expect(worktree.baseRef).toBe('head');
+    } finally {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  });
+
+  it('should preserve existing worktree settings and override baseRef (Issue #3155)', async () => {
+    const projectSettings = {
+      worktree: { baseRef: 'fresh' as const, customKey: 'preserved' },
+    };
+    writeFileSync(settingsPath, JSON.stringify(projectSettings, null, 2));
+
+    const filePath = await writeHookSettingsFile('http://localhost:9100', 'worktree-merge', 'test-secret-123', workDir);
+
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+
+      expect(parsed.worktree).toBeDefined();
+      const worktree = parsed.worktree as Record<string, unknown>;
+      // baseRef forced to "head"
+      expect(worktree.baseRef).toBe('head');
+      // other worktree settings preserved
+      expect(worktree.customKey).toBe('preserved');
+    } finally {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  });
+
 
   it('should preserve env vars when settings.local.json starts with UTF-8 BOM', async () => {
     const projectSettings = {

--- a/src/hook-settings.ts
+++ b/src/hook-settings.ts
@@ -206,6 +206,15 @@ export async function writeHookSettingsFile(baseUrl: string, sessionId: string, 
   ((combined as Record<string, unknown>).env = (combined.env || {}) as Record<string, string>);
   ((combined.env || {}) as Record<string, string>)["MCP_CONNECTION_NONBLOCKING"] = "true";
 
+  // Issue #3155: Force worktree.baseRef to "head" so CC worktrees branch from
+  // local HEAD (not origin/<default>). Prevents silent data loss when Aegis
+  // creates worktrees with unpushed commits. CC 2.1.133 changed the default
+  // to "fresh" (origin/<default>).
+  (combined as Record<string, unknown>).worktree = {
+    ...((combined.worktree || {}) as Record<string, unknown>),
+    baseRef: "head",
+  };
+
   // Issue #648: Use unpredictable directory name and restrictive permissions
   // to prevent symlink attacks and information disclosure in /tmp.
   const suffix = randomBytes(4).toString('hex');


### PR DESCRIPTION
## Problem
Issue #3155: Claude Code 2.1.133 changed the default `worktree.baseRef` from `head` (local HEAD) to `fresh` (`origin/<default>`). When CC creates worktrees, unpushed commits are silently dropped.

Aegis creates worktrees externally (via git worktree), but CC can also create internal worktrees via `EnterWorktree` during sessions. In that case, the new default would lose unpushed commits.

## Fix
Inject `worktree.baseRef: "head"` into the per-session settings file that Aegis already writes for hooks and env vars (`writeHookSettingsFile()`).

- Preserves any existing `worktree` settings from the project's `settings.local.json`
- Only overrides `baseRef`, keeps other worktree keys intact
- No API changes

## Testing
- 2 new tests: verifies injection and merge behavior
- All 34 hook-settings tests pass (including 2 new)
- tsc clean

## Files
- `src/hook-settings.ts`: add worktree.baseRef injection
- `src/__tests__/hook-settings.test.ts`: 2 new test cases