### PR TITLE
docs: add session export user guide + competitive threat matrix

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,6 +1,6 @@
 # Advanced Features
 
-Aegis provides orchestration primitives beyond basic session management. This guide covers the Memory Bridge, Model Router, Session Templates, Verification Protocol, and Diagnostics.
+Aegis provides orchestration primitives beyond basic session management. This guide covers the Memory Bridge, Session Export, Session Templates, Verification Protocol, Pipeline Orchestration, and Diagnostics.
 
 For OpenAI-compatible model routing via Claude Code (`ANTHROPIC_BASE_URL` + custom models), see [BYO LLM](./byo-llm.md).
 
@@ -152,6 +152,120 @@ curl -X POST http://localhost:9100/v1/sessions \
     "memoryKeys": ["auth/audit-results"]
   }'
 ```
+
+---
+
+## Session Export
+
+Download the full session transcript as JSONL (NDJSON) or Markdown. Useful for archiving, sharing results, or feeding session context into other tools.
+
+### Quick Example
+
+```bash
+# Export as JSONL (default)
+curl "http://localhost:9100/v1/sessions/abc123/export" \
+  -H "Authorization: Bearer $TOKEN" \
+  -o session.jsonl
+
+# Export as readable Markdown
+curl "http://localhost:9100/v1/sessions/abc123/export?format=markdown" \
+  -H "Authorization: Bearer $TOKEN" \
+  -o session.md
+```
+
+### Formats
+
+| Format | Query param | Content type | Best for |
+|--------|------------|-------------|----------|
+| JSONL | `?format=jsonl` (default) | `application/x-ndjson` | Programmatic processing, piping to jq, feeding into other tools |
+| Markdown | `?format=markdown` | `text/markdown` | Human review, sharing, pasting into docs |
+
+### JSONL Output
+
+Each line is a JSON object:
+
+```json
+{"role":"user","contentType":"text","text":"Fix the auth bug","timestamp":"2026-05-10T15:00:00Z"}
+{"role":"assistant","contentType":"thinking","text":"Let me analyze the auth flow...","timestamp":"2026-05-10T15:00:01Z"}
+{"role":"assistant","contentType":"tool_use","text":"cat src/auth.ts","toolName":"Bash","timestamp":"2026-05-10T15:00:02Z"}
+{"role":"assistant","contentType":"text","text":"Found the issue — missing token expiry check.","timestamp":"2026-05-10T15:00:05Z"}
+```
+
+Fields per entry:
+
+| Field | Always present | Description |
+|-------|---------------|-------------|
+| `role` | ✅ | `user` or `assistant` |
+| `contentType` | ✅ | `text`, `thinking`, `tool_use`, `tool_result`, `tool_error` |
+| `text` | ✅ | Message content (truncated to 2000 chars in markdown) |
+| `toolName` | tool calls only | Name of the invoked tool (e.g. `Bash`, `Read`) |
+| `toolUseId` | tool calls only | Unique ID for the tool invocation |
+| `timestamp` | ✅ | ISO 8601 timestamp |
+
+### Markdown Output
+
+Renders a human-readable document:
+
+```markdown
+# Session Export: fix-auth-bug
+
+> Exported: 2026-05-10T15:30:00Z
+> Session ID: abc123
+> Status: idle
+
+---
+
+👤 **User:** Fix the auth bug
+
+🤖 **Assistant:** Let me analyze the auth flow...
+
+### 🔧 Tool: Bash
+<details>
+<summary>cat src/auth.ts</summary>
+
+...file contents...
+</details>
+
+🤖 **Assistant:** Found the issue — missing token expiry check.
+```
+
+### Use Cases
+
+**Archive completed sessions:**
+```bash
+# Export all completed sessions
+for sid in $(curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9100/v1/sessions?status=idle&limit=100" | \
+  jq -r '.sessions[].id'); do
+  curl -s -H "Authorization: Bearer $TOKEN" \
+    "http://localhost:9100/v1/sessions/$sid/export?format=jsonl" \
+    -o "archives/$sid.jsonl"
+done
+```
+
+**Share session results as a readable doc:**
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9100/v1/sessions/$SID/export?format=markdown" \
+  -o result.md
+```
+
+**Pipe JSONL into jq for analysis:**
+```bash
+# Count tool calls per tool name
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9100/v1/sessions/$SID/export" | \
+  jq -r '.toolName' | sort | uniq -c | sort -rn
+```
+
+### Errors
+
+| Status | Condition |
+|--------|----------|
+| `401` | Missing or invalid auth token |
+| `403` | Not the session owner |
+| `404` | Session not found or no transcript data available |
+| `400` | Invalid format (must be `jsonl` or `markdown`) |
 
 ---
 

--- a/docs/competitive-threat-matrix.md
+++ b/docs/competitive-threat-matrix.md
@@ -1,0 +1,103 @@
+# Aegis Competitive Threat Matrix
+
+> **Last updated:** 2026-05-10 | **Source:** Issues #3013, #3014, #3016, #3003, #3004 + ECC analysis (Orpheus)
+> **Audience:** Leadership (Ema, Boss) for strategic planning
+
+---
+
+## Executive Summary
+
+The Claude Code orchestration space is **crowded and moving fast**. 8+ competitors with 200×–470× Aegis's star count. The market is bifurcating into **simple developer tools** (win on ease-of-use) and **enterprise platforms** (win on depth and governance). Aegis is an enterprise platform — the moat is real but the **simplicity gap is existential**.
+
+**Bottom line:** We cannot out-feature ruflo (47K ⭐, 98 agents, 314 MCP tools). We cannot out-simplify oh-my-claudecode (33K ⭐, zero-config install). We *can* own the **enterprise orchestration middleware** niche — API-first, compliant, auditable — if we close the install friction gap and ship multi-agent support.
+
+---
+
+## Threat Matrix
+
+| Rank | Competitor | ⭐ | Threat | Installs in | Agent count | Chat platforms | API | Dashboard | Enterprise auth |
+|------|-----------|-----|--------|-------------|-------------|---------------|-----|-----------|----------------|
+| #1 | **Ruflo** | 47K | 🔴 CRITICAL | `npx ruflo init` | 98 | UI only | ✅ (undocumented) | ✅ (beta) | ❌ |
+| #2 | **oh-my-claudecode** | 33K | 🔴 CRITICAL | `/plugin install` (1 cmd) | Multi-agent | Plugin (inside CC) | ❌ | ❌ | ❌ |
+| #3 | **cc-connect** | 8K | 🟠 HIGH | Binary download | 10+ | **11** (inc. WeChat, QQ) | ❌ | ✅ (basic) | Token only |
+| #4 | **Composio** | 6.9K | 🟠 HIGH | `npm install` | Multi-agent | CI/CD focus | ✅ | ❌ | ❌ |
+| #5 | **open-multi-agent** | 6.1K | 🟡 MEDIUM | `npm install` | Multi-agent | MCP only | ✅ | Tracing UI | ❌ |
+| #6 | **mission-control** | 4.7K | 🟠 HIGH | `npm install` | Multi-gateway | Skills Hub | ✅ | ✅ | ✅ RBAC |
+| #7 | **OpenACP** | 346 | 🟠 HIGH | `curl \| bash` | **28+** | Telegram, Discord, Slack | ✅ | ❌ | ❌ |
+| #8 | **ECC** | 177K | 🟢 OPPORTUNITY | Config library | N/A (skills) | N/A | ❌ | ❌ | ❌ |
+| — | **Aegis** | ~200 | — | `npm + init + config` | 1 (Claude Code) | 4 | ✅ 34 MCP tools | ✅ Full React | ✅ OIDC/RBAC |
+
+---
+
+## Aegis-Only Features (Our Moat)
+
+No single competitor has ALL of these. This is the enterprise wedge:
+
+- ✅ Full REST API (65+ endpoints) with CRUD + pagination
+- ✅ MCP server (34 tools)
+- ✅ SSE real-time event streaming
+- ✅ OIDC/SSO enterprise auth + RBAC roles
+- ✅ Audit trail with hash chain integrity
+- ✅ OpenTelemetry tracing
+- ✅ Billing/metering with cost tracking
+- ✅ TypeScript + Python client SDKs
+- ✅ Kubernetes / Helm deployment
+- ✅ Sigstore release signing
+- ✅ Session templates + pipeline orchestration
+- ✅ Memory Bridge (cross-session state)
+- ✅ Session export (JSONL download)
+
+---
+
+## Critical Gaps (What Competitors Have That We Don't)
+
+| Gap | Impact | Who has it | Priority |
+|-----|--------|-----------|----------|
+| **Multi-agent support** | Existential — every competitor supports 2+ agents | All except ECC | P0 |
+| **Simple install** (≤2 commands) | Users never reach Aegis if OMC is easier | OMC, OpenACP, Ruflo | P0 |
+| **Plugin marketplace distribution** | 177K-star audience unreachable | OMC (CC marketplace) | P1 |
+| **Chat platform breadth** | Missing entire Asian market (WeChat, QQ, DingTalk) | cc-connect (11 platforms) | P1 |
+| **Natural language scheduling** | Dev productivity killer feature | cc-connect | P2 |
+| **Self-learning memory** | Agents improve over time | Ruflo | P2 |
+| **Multi-language docs** | International adoption blocked | OMC (6 languages), cc-connect (5) | P2 |
+
+---
+
+## Strategic Recommendations
+
+### Immediate (v0.7.0)
+1. **Close the install gap** — `ag run "task"` is a start. Make it the default. Zero-config should be 1 command, not 4.
+2. **Multi-agent support** — at minimum, add Codex and Gemini as runner backends (ACP already supports them)
+3. **ACP registry listing** — register Aegis for discoverability
+
+### Short-term (v0.8.0)
+4. **Claude Code plugin marketplace** — get Aegis listed as a plugin, not just an npm package
+5. **ECC integration guide** — "Run ECC Skills as a Service with Aegis" captures their 177K-star audience
+6. **Discord channel** — cc-connect has it, we don't
+
+### Medium-term (v1.0)
+7. **Asian market** — WeChat, QQ, DingTalk adapters
+8. **Natural language scheduling** — "every Monday at 9am, run tests"
+9. **Multi-language docs** — at minimum EN + ZH + JA
+
+### Defensive Positioning
+> **"ECC makes your agents smart. Aegis makes them accessible."** — Orpheus
+
+This is the tagline. Ruflo and OMC are developer tools. Aegis is **enterprise middleware** — the layer between "someone typed a message" and "code shipped to production." The moat is compliance, governance, observability. Don't compete on agent count. Compete on trust.
+
+---
+
+## Competitor Detail References
+
+| Issue | Competitor | Key takeaway |
+|-------|-----------|-------------|
+| #3013 | Ruflo (47K ⭐) | Full-stack, 98 agents, self-learning. Enterprise moat still defensible. |
+| #3014 | oh-my-claudecode (33K ⭐) | Zero-config is our biggest UX gap. `/autopilot` mode to replicate. |
+| #3004 | cc-connect (8K ⭐) | 11 chat platforms, multi-agent. Converging on our enterprise features. |
+| #3003 | OpenACP (346 ⭐) | Same architecture, simpler install, 28+ agents. Highest-threat small competitor. |
+| #3016 | Full landscape | 8 competitors ranked. Aegis smallest by stars, deepest by enterprise features. |
+| ECC | everything-claude-code (177K ⭐) | Not a competitor — distribution channel. Skills layer, not orchestration. |
+
+---
+
+*Maintained by Scribe 📝 — update on each competitive scan.*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -353,7 +353,7 @@ See [`packages/python-client/`](../packages/python-client/) for source and the f
 - **[MCP Tools Reference](./mcp-tools.md)** — Full documentation for all 34 MCP tools
 - **[API Reference](./api-reference.md)** — Complete REST API documentation
 - **[Verifying Releases](./verify-release.md)** — SHA verification, npm integrity, Sigstore attestations, version policy
-- **[Advanced Features](./advanced.md)** — Pipelines, Memory Bridge, templates
+- **[Advanced Features](./advanced.md)** — Session Export, Pipelines, Memory Bridge, templates
 - **[Enterprise Deployment](./enterprise.md)** — Auth, rate limiting, production setup
 - **[ACP Migration Guide](./acp-migration-guide.md)** — Upgrading from `aegis-bridge`
 - **[TypeDoc API](https://onestepat4time.github.io/aegis/)** — Auto-generated TypeScript reference


### PR DESCRIPTION
## Changes

- **Session Export user guide** in `advanced.md` — JSONL/Markdown formats, field reference, use cases (archive, share, jq analysis), error codes
- **Competitive Threat Matrix** (`competitive-threat-matrix.md`) — compiles all 5 intel issues (#3013, #3014, #3016, #3003, #3004) into a single leadership-facing doc with threat rankings, feature gap analysis, and phased strategic recommendations
- Updated `getting-started.md` Next Steps to mention Session Export

## Test Plan
- [x] Read through rendered Markdown for formatting
- [x] Verified API examples match source code (`session-data.ts` export route)
- [x] Cross-referenced field names against implementation
- [x] Competitive data sourced from existing research issues

Refs #3153, #3013, #3014, #3016, #3003, #3004