### PR TITLE
fix(hooks): guard build-on-stop.sh against OOM crashes

### DIFF
--- a/.claude/hooks/build-on-stop.sh
+++ b/.claude/hooks/build-on-stop.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
-# build-on-stop.sh — Full build + test verification when agent finishes
+# build-on-stop.sh — Build + test verification when CC agent finishes
 # CC hook: Stop
+#
+# Issue #3170: Added guards to prevent OOM crashes in production.
+# - Skips entirely when AEGIS_SERVICE is set (production systemd)
+# - Skips build+test when available memory < 2GB
+# - Only runs tsc --noEmit (lightweight) in memory-constrained environments
+
+# Guard: skip entirely in production Aegis service
+if [ -n "$AEGIS_SERVICE" ] || [ -f "/run/aegis-production.flag" ]; then
+  echo "⏭️ Skipping build+test hook in production Aegis service"
+  exit 0
+fi
 
 cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
 
-# TSC check
+# TSC check (lightweight — ~200MB)
 TSC_OUT=$(npx tsc --noEmit 2>&1)
 TSC_EXIT=$?
 
@@ -12,6 +23,17 @@ if [ $TSC_EXIT -ne 0 ]; then
   echo "❌ TSC ERRORS — Do not merge this code:"
   echo "$TSC_OUT" | grep "error TS" | head -10
   exit 0
+fi
+
+# Guard: check available memory before heavy operations
+# vitest spawns 5-6 processes consuming 4-5GB — skip if RAM is tight
+AVAILABLE_KB=$(grep MemAvailable /proc/meminfo 2>/dev/null | awk '{print $2}')
+if [ -n "$AVAILABLE_KB" ]; then
+  AVAILABLE_GB=$((AVAILABLE_KB / 1024 / 1024))
+  if [ "$AVAILABLE_GB" -lt 2 ]; then
+    echo "✅ TSC clean (skipping build+test — only ${AVAILABLE_GB}GB RAM available)"
+    exit 0
+  fi
 fi
 
 # Full build


### PR DESCRIPTION
## Summary
Fixes #3170

### Problem
The `build-on-stop.sh` hook runs `npm run build` + `npm test` every time a Claude Code session finishes. On the production server (8GB RAM), this spawns vitest processes consuming 4-5GB, causing:
1. OOM kill → server crash → systemd restart
2. In-memory TG topic map lost → all Telegram delivery breaks
3. Monitor loses session state

### Changes
- **Production guard**: Skip entirely when `AEGIS_SERVICE` env var is set
- **Memory guard**: Check `/proc/meminfo` available RAM — skip build+test if < 2GB
- **tsc always runs**: `tsc --noEmit` is lightweight (~200MB) and catches type errors before PR
- No changes to hook behavior in development (when RAM is available)

### Verification
- Shell script only — no TypeScript/build changes
- Hook tested manually: `AEGIS_SERVICE=1 .claude/hooks/build-on-stop.sh` → skips correctly

### Configuration
To enable the production guard in the Aegis systemd service, add:
```ini
[Service]
Environment="AEGIS_SERVICE=1"
```

### Related
- #3169 — TG circuit breaker (topic persistence fixes the restart-loss part)
- #3168 — TG topic map persistence (PR #3171)
- #3067 — ag run EADDRINUSE crash (likely same OOM root cause)