### PR TITLE
chore: export security helpers, fix indentation, cache redactError

### DIFF
--- a/src/__tests__/telegram-md2html-security.test.ts
+++ b/src/__tests__/telegram-md2html-security.test.ts
@@ -3,51 +3,17 @@
  *
  * Tests URI scheme allowlist (sanitizeHref), topic name sanitization
  * (sanitizeTopicName), and callback_data length guard (safeCallbackData).
+ *
+ * Helpers are imported from the production module to ensure tests validate
+ * the actual implementation (not inline copies that could drift).
  */
 
 import { describe, it, expect } from 'vitest';
-
-// ── Inline copies of the helpers (they're private in telegram.ts) ──
-
-const ALLOWED_HREF_SCHEMES = ['http:', 'https:', '#:', 'mailto:'];
-
-function esc(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-function sanitizeHref(href: string): string {
-  const trimmed = href.trim();
-  if (trimmed.startsWith('#') || trimmed.startsWith('/')) return esc(trimmed);
-  const scheme = trimmed.split(':')[0]?.toLowerCase() + ':';
-  if (ALLOWED_HREF_SCHEMES.includes(scheme)) return esc(trimmed);
-  return '#';
-}
-
-function sanitizeTopicName(name: string): string {
-  return name
-    .replace(/[\u0000-\u001F\u007F-\u009F\u200E-\u200F\u202A-\u202E]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .slice(0, 64);
-}
-
-const MAX_CALLBACK_DATA_LENGTH = 64;
-
-function safeCallbackData(data: string): string {
-  if (Buffer.byteLength(data, 'utf-8') <= MAX_CALLBACK_DATA_LENGTH) return data;
-  const prefix = data.substring(0, data.lastIndexOf(':') + 1);
-  const value = data.substring(prefix.length);
-  let lo = 0, hi = value.length;
-  while (lo < hi) {
-    const mid = Math.ceil((lo + hi) / 2);
-    if (Buffer.byteLength(prefix + value.slice(0, mid), 'utf-8') <= MAX_CALLBACK_DATA_LENGTH) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  return prefix + value.slice(0, lo);
-}
+import {
+  sanitizeHref,
+  sanitizeTopicName,
+  safeCallbackData,
+} from '../channels/telegram.js';
 
 // ── Tests ──
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -255,7 +255,7 @@ function formatSubAgentTree(text: string): string | null {
 /** Allowlisted URI schemes for md2html() link hrefs. Prevents tg://, javascript:, data:, etc. */
 const ALLOWED_HREF_SCHEMES = ['http:', 'https:', '#:', 'mailto:'];
 
-function sanitizeHref(href: string): string {
+export function sanitizeHref(href: string): string {
   const trimmed = href.trim();
   // Allow relative/anchor links (no colon before slash/hash)
   if (trimmed.startsWith('#') || trimmed.startsWith('/')) return esc(trimmed);
@@ -266,7 +266,7 @@ function sanitizeHref(href: string): string {
 }
 
 /** Strip control chars, RTL overrides, and truncate topic names for Telegram forum topics. */
-function sanitizeTopicName(name: string): string {
+export function sanitizeTopicName(name: string): string {
   return name
     // Strip control characters (C0, C1, RTL overrides LRE/RLE/LRO/RLO/PDF)
     .replace(/[\u0000-\u001F\u007F-\u009F\u200E-\u200F\u202A-\u202E]/g, '')
@@ -279,7 +279,7 @@ function sanitizeTopicName(name: string): string {
 /** Max callback_data length per Telegram Bot API (64 bytes). */
 const MAX_CALLBACK_DATA_LENGTH = 64;
 
-function safeCallbackData(data: string): string {
+export function safeCallbackData(data: string): string {
   if (Buffer.byteLength(data, 'utf-8') <= MAX_CALLBACK_DATA_LENGTH) return data;
   // Truncate value portion to fit within 64 bytes
   const prefix = data.substring(0, data.lastIndexOf(':') + 1);
@@ -367,7 +367,7 @@ function md2html(md: string): string {
     processed = processed.replace(/(?<!\w)_([^_]+?)_(?!\w)/g, '<i>$1</i>');
 
     // Links: [text](url)
-        processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, href) => '<a href="' + sanitizeHref(href) + '">' + text + '</a>');
+    processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, href) => '<a href="' + sanitizeHref(href) + '">' + text + '</a>');
 
     // List bullets
     processed = processed.replace(/^(\s*)[-*]\s+/, '$1• ');
@@ -861,7 +861,7 @@ export class TelegramChannel implements Channel {
   }
 
   async onSessionCreated(payload: SessionEventPayload): Promise<void> {
-        const topicName = sanitizeTopicName(`🤖 ${payload.session.name}`);
+    const topicName = sanitizeTopicName(`🤖 ${payload.session.name}`);
     const result = (await this.tgApi('createForumTopic', {
       chat_id: this.config.groupChatId,
       name: topicName,
@@ -1638,9 +1638,10 @@ export class TelegramChannel implements Channel {
   /** Track delivery failure for health reporting. */
   private trackFailure(error: unknown): void {
     this.lastErrorAt = Date.now();
-    this.lastErrorMessage = this.redactError(error) instanceof Error
-      ? (this.redactError(error) as Error).message
-      : String(this.redactError(error));
+    const redacted = this.redactError(error);
+    this.lastErrorMessage = redacted instanceof Error
+      ? (redacted as Error).message
+      : String(redacted);
     this.deliveryFailCount++;
   }
 


### PR DESCRIPTION
## Summary

Three low-risk cleanups from Argus quality audit of PRs #3174 and #3171.

### Changes

1. **Export security helpers** — `sanitizeHref`, `sanitizeTopicName`, `safeCallbackData` are now exported from `src/channels/telegram.ts`
2. **Test import refactor** — `telegram-md2html-security.test.ts` now imports helpers from the production module instead of inlining copies. Prevents test/prod code drift where tests pass but production code is broken.
3. **Indentation fix** — 8-space → 4-space on `sanitizeHref` call in `md2html()` and `sanitizeTopicName` call in `onSessionCreated()` (regression from #3174)
4. **Cache `redactError()` in `trackFailure()`** — was called 3x per failure, now cached in local variable

## Verification

```
npx tsc --noEmit  ✓ zero errors
npx vitest run src/__tests__/telegram-md2html-security.test.ts  ✓ 30 tests passed
```

## Files changed
- `src/channels/telegram.ts` — export 3 functions, fix indentation, cache redactError
- `src/__tests__/telegram-md2html-security.test.ts` — import from production module, remove 34 lines of inline copies

Ref: Argus audit findings #1-#4