### PR TITLE
fix(security): add RBAC requireRole guards to templates and tools endpoints (#3185, #3186)

### DIFF
--- a/src/routes/session-data.ts
+++ b/src/routes/session-data.ts
@@ -14,7 +14,7 @@ import { SSEWriter } from '../sse-writer.js';
 import type { SessionSSEEvent } from '../events.js';
 import {
   type RouteContext,
-  registerWithLegacy, withOwnership, withValidation,
+  registerWithLegacy, requireRole, withOwnership, withValidation,
 } from './context.js';
 
 export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContext): void {
@@ -39,8 +39,9 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
     return { sessionId: session.id, tools, totalCalls: tools.reduce((sum, t) => sum + t.count, 0) };
   }));
 
-  // Global tool definitions
-  registerWithLegacy(app, 'get', '/v1/tools', async (_req: FastifyRequest, _reply: FastifyReply) => {
+  // Global tool definitions (#3186: RBAC check — viewer can list tools but needs auth)
+  registerWithLegacy(app, 'get', '/v1/tools', async (req: FastifyRequest, reply: FastifyReply) => {
+    if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
     const definitions = toolRegistry.getToolDefinitions();
     const categories = [...new Set(definitions.map(t => t.category))];
     return { tools: definitions, categories, totalTools: definitions.length };

--- a/src/routes/templates.ts
+++ b/src/routes/templates.ts
@@ -6,7 +6,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import * as templateStore from '../template-store.js';
 import type { RouteContext } from './context.js';
-import { registerWithLegacy, withValidation } from './context.js';
+import { registerWithLegacy, withValidation, requireRole } from './context.js';
 
 // #1393: claudeCommand must not contain shell metacharacters
 const SAFE_COMMAND_RE = /^[a-zA-Z0-9_./@:= -]+$/;
@@ -43,7 +43,7 @@ export function registerTemplateRoutes(
   app: FastifyInstance,
   ctx: RouteContext,
 ): void {
-  const { sessions, validateWorkDir } = ctx;
+  const { sessions, validateWorkDir, auth } = ctx;
 
   const templateRateLimit = {
     max: 60,
@@ -54,6 +54,7 @@ export function registerTemplateRoutes(
   registerWithLegacy(app, 'post', '/v1/templates', {
     config: { rateLimit: templateRateLimit },
     handler: withValidation(createTemplateSchema, async (req: FastifyRequest, reply: FastifyReply, data) => {
+      if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
       const { name, description, sessionId, ...templateData } = data;
 
       const finalData = { ...templateData };
@@ -99,7 +100,8 @@ export function registerTemplateRoutes(
   // GET /v1/templates — List all templates
   registerWithLegacy(app, 'get', '/v1/templates', {
     config: { rateLimit: templateRateLimit },
-    handler: async (_req: FastifyRequest, _reply: FastifyReply) => {
+    handler: async (req: FastifyRequest, reply: FastifyReply) => {
+      if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
       try { return await templateStore.listTemplates(); } catch { return []; }
     },
   });
@@ -108,6 +110,7 @@ export function registerTemplateRoutes(
   registerWithLegacy(app, 'get', '/v1/templates/:id', {
     config: { rateLimit: templateRateLimit },
     handler: async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
       try {
         const template = await templateStore.getTemplate(req.params.id);
         if (!template) return reply.status(404).send({ error: 'Template not found' });
@@ -122,6 +125,7 @@ export function registerTemplateRoutes(
   registerWithLegacy(app, 'put', '/v1/templates/:id', {
     config: { rateLimit: templateRateLimit },
     handler: withValidation(createTemplateSchema.partial(), async (req: FastifyRequest, reply: FastifyReply, data) => {
+      if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
       try {
         const templateId = (req.params as { id: string }).id;
         const template = await templateStore.updateTemplate(templateId, data as Parameters<typeof templateStore.updateTemplate>[1]);
@@ -137,6 +141,7 @@ export function registerTemplateRoutes(
   registerWithLegacy(app, 'delete', '/v1/templates/:id', {
     config: { rateLimit: templateRateLimit },
     handler: async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      if (!requireRole(auth, req, reply, 'admin', 'operator')) return;
       try {
         const deleted = await templateStore.deleteTemplate(req.params.id);
         if (!deleted) return reply.status(404).send({ error: 'Template not found' });


### PR DESCRIPTION
## Summary

Security fix — add `requireRole()` RBAC guards to 6 endpoints that were missing them. Same pattern as #2340 (viewer-role RBAC bypass).

### Changes

**`src/routes/templates.ts`** — #3185
- `POST /v1/templates` → `requireRole(auth, req, reply, "admin", "operator")`
- `GET /v1/templates` → `requireRole(auth, req, reply, "admin", "operator", "viewer")`
- `GET /v1/templates/:id` → `requireRole(auth, req, reply, "admin", "operator", "viewer")`
- `PUT /v1/templates/:id` → `requireRole(auth, req, reply, "admin", "operator")`
- `DELETE /v1/templates/:id` → `requireRole(auth, req, reply, "admin", "operator")`

**`src/routes/session-data.ts`** — #3186
- `GET /v1/tools` → `requireRole(auth, req, reply, "admin", "operator", "viewer")`

### Impact

Without this fix, a viewer-role API key could:
- Create/modify/delete templates (including `permissionMode: "bypassPermissions"` injection)
- Enumerate the full tool surface for reconnaissance

With this fix, viewer-role keys get 403 Forbidden on write operations and 200 on read operations.

## Verification

```
npx tsc --noEmit  ✓ zero errors
npm run build     ✓ success
npx vitest run    ✓ 198 RBAC tests passed
```

## Files changed
- `src/routes/templates.ts` — import requireRole, add 5 guards
- `src/routes/session-data.ts` — import requireRole, add 1 guard

Awaiting Themis security sign-off.