### PR TITLE
docs: add RBAC role tables to templates and tools endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1285,6 +1285,10 @@ GET /v1/tools
 
 Lists all available MCP tools with their schemas.
 
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
+
 ```bash
 curl http://localhost:9100/v1/tools \
   -H "Authorization: Bearer $TOKEN"
@@ -2898,6 +2902,10 @@ GET /v1/templates
 
 Lists all registered session templates.
 
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
+
 ```bash
 curl http://localhost:9100/v1/templates \
   -H "Authorization: Bearer $TOKEN"
@@ -2914,6 +2922,10 @@ POST /v1/templates
 ```
 
 Creates a reusable session template with optional `{{variable}}` substitution. Rate limited: 60 req/min.
+
+| Role | Required |
+|------|----------|
+| admin, operator | Yes |
 
 ```bash
 curl -X POST http://localhost:9100/v1/templates \
@@ -2956,6 +2968,10 @@ GET /v1/templates/:id
 
 Returns a single template by ID.
 
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
+
 ```bash
 curl http://localhost:9100/v1/templates/tpl-abc123 \
   -H "Authorization: Bearer $TOKEN"
@@ -2978,6 +2994,10 @@ PUT /v1/templates/:id
 ```
 
 Partially updates a template. Only include fields to change.
+
+| Role | Required |
+|------|----------|
+| admin, operator | Yes |
 
 ```bash
 curl -X PUT http://localhost:9100/v1/templates/tpl-abc123 \
@@ -3005,6 +3025,10 @@ DELETE /v1/templates/:id
 ```
 
 Deletes a template by ID.
+
+| Role | Required |
+|------|----------|
+| admin, operator | Yes |
 
 ```bash
 curl -X DELETE http://localhost:9100/v1/templates/tpl-abc123 \


### PR DESCRIPTION
## Summary

Adds missing RBAC role tables to 6 endpoints that received `requireRole()` guards in PR #3187 (refs #3185, #3186).

### Changes in `api-reference.md`

**Templates (5 endpoints):**
- `GET /v1/templates` → admin, operator, viewer
- `POST /v1/templates` → admin, operator
- `GET /v1/templates/:id` → admin, operator, viewer
- `PUT /v1/templates/:id` → admin, operator
- `DELETE /v1/templates/:id` → admin, operator

**Tools (1 endpoint):**
- `GET /v1/tools` → admin, operator, viewer

Write operations (create/update/delete) restricted to admin+operator. Read operations (list/get) include viewer. Matches the `requireRole()` calls added in the code.

### Verification
- Role values match `src/routes/templates.ts` and `src/routes/session-data.ts` exactly
- Follows same table format as other RBAC-guarded endpoints in api-reference.md