### PR TITLE
fix: shutdown ACP backend on session kill to reap CC child processes (#3184)

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -291,6 +291,15 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         continue;
       }
       try {
+        // #3184: Shutdown ACP backend (CC child process) before marking session killed.
+        // Without this, the CC process becomes an orphan consuming ~250MB RSS.
+        if (acpBackend && ctx.config.acpEnabled) {
+          await acpBackend.shutdownSession({
+            sessionId: id,
+            tenantId: req.tenantId ?? SYSTEM_TENANT,
+            ownerKeyId: req.authKeyId ?? 'master',
+          }).catch(() => {}); // Best-effort: session may not have ACP runtime
+        }
         await sessions.killSession(id);
         eventBus.emitEnded(id, 'killed');
         void channels.sessionEnded(makePayload(sessions, 'session.ended', id, 'killed'));


### PR DESCRIPTION
## Summary

**Root cause:** `killSession()` in `session.ts` only marks the session as `killed` in state — it never calls `acpBackend.shutdownSession()` to terminate the actual Claude Code child process. Each orphaned CC process consumes ~250MB RSS, eventually causing OOM kills that block all development.

### Fix

In the `DELETE /v1/sessions/:id` handler (`src/routes/sessions.ts`), call `acpBackend.shutdownSession()` before `sessions.killSession()`.

The `shutdownSession` call:
1. Finds the ACP runtime for the session
2. Calls `client.shutdown()` which does: close stdin → wait for graceful exit → SIGTERM → wait → SIGKILL
3. Cleans up the runtime from the runtimes map

**Best-effort** with `.catch(() => {})` — session may not have an ACP runtime (non-ACP mode, already crashed process).

### Evidence

```
# Before fix: 6 killed sessions, 6 orphaned CC processes consuming ~1.3GB
PID 1080757 — session f5df9dcf (198MB RSS)
PID 1353742 — session 44eeb640 (257MB RSS)
PID 1357885 — session 4ba6aa54 (252MB RSS)
```

## Verification

```
npx tsc --noEmit  ✓ zero errors
npm run build     ✓ success
```

## Files changed
- `src/routes/sessions.ts` — add `acpBackend.shutdownSession()` call before `sessions.killSession()`

Fixes #3184.