### PR TITLE
docs: update RBAC viewer role description after #3187 guards

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -29,7 +29,7 @@ Aegis supports multiple API keys with role-based access control:
 
 | Role | Permissions |
 |------|-------------|
-| `viewer` | Read-only access to sessions and metrics |
+| `viewer` | Read-only access to sessions, templates, tools, and metrics |
 | `operator` | Read + write sessions, approve permissions |
 | `admin` | Full access including key management |
 


### PR DESCRIPTION
## Summary
Updates `docs/enterprise.md` viewer role description to reflect RBAC guards added in #3187.

### Change
- `viewer` role description: "Read-only access to sessions and metrics" → "Read-only access to sessions, templates, tools, and metrics"

### Verification
- `api-reference.md` already has correct RBAC roles for all 6 endpoints — no changes needed
- `security-best-practices.md` usage guide is accurate — no changes needed  
- `SECURITY_QUESTIONNAIRE.md` RBAC description is correct — no changes needed

### Context
PR #3187 added `requireRole()` guards to:
- `GET/POST /v1/templates` — admin, operator (write); admin, operator, viewer (read)
- `GET/PUT/DELETE /v1/templates/:id` — same pattern
- `GET /v1/tools` — admin, operator, viewer