### PR TITLE
docs: add Telegram verbose mode (tgVerbose / AEGIS_TG_VERBOSE)

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -278,6 +278,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_EMAIL_SECURE` | `false` | Use TLS/SSL (auto-true for port 465) |
 | `AEGIS_TG_BOT_TOKEN` | _(none)_ | Telegram bot token |
 | `AEGIS_TG_GROUP_ID` | _(none)_ | Telegram group chat ID |
+| `AEGIS_TG_VERBOSE` | `false` | Forward full CC output (thinking, tool calls) to Telegram |
 
 ### Configuration File
 

--- a/docs/enterprise/01-architecture.md
+++ b/docs/enterprise/01-architecture.md
@@ -134,6 +134,7 @@ let lastCleanupWorkDir = '';
 | `AEGIS_TG_GROUP` | `''` | |
 | `AEGIS_TG_ALLOWED_USERS` | `[]` | |
 | `AEGIS_TG_TOPIC_TTL_MS` | `86400000` | |
+| `AEGIS_TG_VERBOSE` | `false` | Forward thinking + tool calls to Telegram |
 | `AEGIS_WEBHOOKS` | `[]` | |
 | `AEGIS_SSE_MAX_CONNECTIONS` | `100` | |
 | `AEGIS_SSE_MAX_PER_IP` | `10` | |

--- a/docs/integrations/notifications.md
+++ b/docs/integrations/notifications.md
@@ -29,6 +29,29 @@ AEGIS_TG_GROUP_ID=-1001234567890
 AEGIS_TG_ALLOWED_USERS=user1,user2  # optional
 ```
 
+### Verbose Mode
+
+Enable verbose mode to forward full Claude Code output (thinking, tool calls, code) to Telegram:
+
+```bash
+AEGIS_TG_VERBOSE=true
+```
+
+Or in `aegis.config.json`:
+
+```json
+{
+  "tgVerbose": true
+}
+```
+
+| Event | Without verbose | With verbose |
+|-------|----------------|-------------|
+| `message.thinking` | Silent | 💭 *thinking text* (truncated 800 chars) |
+| `message.tool_use` | Progress tracking only | 🔧 `tool.label` + code block (truncated 600 chars) |
+| `message.assistant` | Forwarded | Forwarded (unchanged) |
+| `message.user` | Forwarded | Forwarded (unchanged) |
+
 ### Events
 
 - `session.created` — new session started


### PR DESCRIPTION
## Summary

Documents the new `tgVerbose` config option introduced by PR #3196 — forward full Claude Code output (thinking, tool calls, code) to Telegram via configurable verbose mode.

## Changes

- **`docs/integrations/notifications.md`** — Added "Verbose Mode" section with setup instructions, config file example, and behavior comparison table
- **`docs/enterprise.md`** — Added `AEGIS_TG_VERBOSE` to the env var config table
- **`docs/enterprise/01-architecture.md`** — Added `AEGIS_TG_VERBOSE` to the complete env var inventory

## Behavior

| Event | Without verbose | With verbose |
|-------|----------------|-------------|
| `message.thinking` | Silent | 💭 *thinking text* (truncated 800 chars) |
| `message.tool_use` | Progress tracking only | 🔧 `tool.label` + code block (truncated 600 chars) |
| `message.assistant` | Forwarded | Forwarded (unchanged) |

Refs #3196