### PR TITLE
fix(telegram): clear stale getUpdates on startup (409 Conflict)

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -838,6 +838,20 @@ export class TelegramChannel implements Channel {
     this.onInbound = onInbound;
     this.polling = true;
     this.startTopicCleanupSweep();
+    // Pre-flight: clear stale pending updates to avoid 409 Conflict
+    try {
+      const stale = (await this.tgApi('getUpdates', {
+        offset: -1,
+        timeout: 0,
+        allowed_updates: ['message', 'callback_query'],
+      })) as Array<{ update_id: number }>;
+      if (Array.isArray(stale) && stale.length > 0) {
+        this.pollOffset = stale[stale.length - 1].update_id + 1;
+        console.log(`Telegram pre-flight: cleared ${stale.length} stale update(s), offset now ${this.pollOffset}`);
+      }
+    } catch {
+      // Pre-flight failure is non-fatal — the poll loop will retry
+    }
     this.pollLoopPromise = this.pollLoop(); // store promise for graceful shutdown
     console.log(`Telegram channel: polling started, group ${this.config.groupChatId}`);
   }


### PR DESCRIPTION
## Problem

On server restart, the Telegram bot's long-poll connection may still be active on Telegram's side. When the new instance calls `getUpdates`, Telegram returns `409 Conflict: terminated by other getUpdates request`. This cascades into repeated poll failures.

Additionally, Node.js tries IPv6 first for `api.telegram.org`, and IPv6 is broken on this server. The IPv6 timeout fires the AbortSignal before IPv4 fallback completes, causing `TypeError: fetch failed`.

## Fix

**Pre-flight `getUpdates` with `offset=-1, timeout=0`** on startup:
- Clears any pending updates from the previous instance
- Initializes `pollOffset` from the last cleared update
- Non-fatal: if pre-flight fails, the poll loop retries normally

**IPv4 fix** (ops-level, not in this PR):
- Add `NODE_OPTIONS=--dns-result-order=ipv4first` to systemd service

## Testing

Server restarted with this code — no poll errors after startup. Previously, errors appeared within 10 minutes.

Gate: tsc ✓, build ✓

Fixes the 409 Conflict root cause