### PR TITLE
fix(security): escape double quotes in esc() to prevent XSS

### DIFF
--- a/src/__tests__/telegram-formatting.test.ts
+++ b/src/__tests__/telegram-formatting.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect } from 'vitest';
 // Test the formatting logic directly (these mirror the internal functions)
 
 function esc(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 function truncate(text: string, maxLen: number): string {
@@ -163,6 +163,14 @@ describe('Telegram formatting (Issue #43)', () => {
 
     it('should handle empty string', () => {
       expect(esc('')).toBe('');
+    });
+
+    it('should escape double quotes to prevent attribute injection', () => {
+      expect(esc('hello "world"')).toBe('hello &quot;world&quot;');
+    });
+
+    it('should escape all HTML-special characters together', () => {
+      expect(esc('<a href="x">&')).toBe('&lt;a href=&quot;x&quot;&gt;&amp;');
     });
   });
 

--- a/src/__tests__/telegram-style.test.ts
+++ b/src/__tests__/telegram-style.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect } from 'vitest';
 
 // Re-implement formatting functions for testing (mirrors telegram.ts)
 function esc(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 function truncate(text: string, maxLen: number): string {

--- a/src/channels/telegram-style.ts
+++ b/src/channels/telegram-style.ts
@@ -19,7 +19,8 @@ export function esc(text: string): string {
   return text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }
 
 export function bold(text: string): string {


### PR DESCRIPTION
## Summary

Fixes #3209

The `esc()` function in `src/channels/telegram-style.ts` escaped `&`, `<`, `>` but **not double quotes**. When `esc()` output is interpolated into HTML attribute values (e.g. `<a href="...">`), unescaped quotes allow attribute injection via crafted URLs.

CodeQL alert: https://github.com/OneStepAt4time/aegis/security/code-scanning/142

## Changes

- Add `.replace(/"/g, "&quot;")` to `esc()` in `src/channels/telegram-style.ts`
- Mirror fix in test helper `esc()` functions (`telegram-style.test.ts`, `telegram-formatting.test.ts`)
- Add 2 new tests: double-quote escaping and combined HTML-special characters

## Verification

```
npx tsc --noEmit  → ✅ 0 errors
npm run build     → ✅ success
npm test          → ✅ 4023 passed, 1 skipped (1 flaky pre-existing timeout in server-core-coverage — unrelated)
```

Targeted test run:
```
src/__tests__/telegram-formatting.test.ts → ✅ 25 tests passed
src/__tests__/telegram-style.test.ts      → ✅ 19 tests passed
```

Commit: 93813674
Worktree: ../wt/issue-3209

## Security

Defense-in-depth fix. `sanitizeHref()` already restricts protocols — this prevents attribute breakout even if a crafted URL containing `"` passes through.