### PR TITLE
fix(security): add strictRBAC config for RBAC enforcement (#3208)

### DIFF
--- a/src/__tests__/health-auth-2458.test.ts
+++ b/src/__tests__/health-auth-2458.test.ts
@@ -105,6 +105,7 @@ async function buildApp(tmpDir: string): Promise<{ app: FastifyInstance; auth: A
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 60000,
     sseClientTimeoutMs: 300000,
     hookTimeoutMs: 10000,

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -211,6 +211,7 @@ async function buildTestServer(): Promise<{
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 60_000,
     sseClientTimeoutMs: 300_000,
     hookTimeoutMs: 10_000,

--- a/src/__tests__/oidc-auth-routes.test.ts
+++ b/src/__tests__/oidc-auth-routes.test.ts
@@ -96,6 +96,7 @@ function makeConfig(): Config {
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 1,
     sseClientTimeoutMs: 1,
     hookTimeoutMs: 1,

--- a/src/__tests__/oidc-dashboard-manager.test.ts
+++ b/src/__tests__/oidc-dashboard-manager.test.ts
@@ -107,6 +107,7 @@ function makeConfig(): Config {
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 1,
     sseClientTimeoutMs: 1,
     hookTimeoutMs: 1,

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -110,6 +110,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 60_000,
     sseClientTimeoutMs: 300_000,
     hookTimeoutMs: 10_000,

--- a/src/__tests__/session-label-2530.test.ts
+++ b/src/__tests__/session-label-2530.test.ts
@@ -81,6 +81,7 @@ async function buildRouteContext(tmpDir: string) {
     verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
     alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
     envDenylist: [], envAdminAllowlist: [], enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
     shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },

--- a/src/__tests__/session-name-validation-3091.test.ts
+++ b/src/__tests__/session-name-validation-3091.test.ts
@@ -82,6 +82,7 @@ async function buildRouteContext(tmpDir: string) {
     verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
     alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
     envDenylist: [], envAdminAllowlist: [], enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
     shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },

--- a/src/__tests__/strictRBAC-3208.test.ts
+++ b/src/__tests__/strictRBAC-3208.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Issue #3208: strictRBAC enforcement when auth is disabled.
+ *
+ * When auth is disabled (no master token, no API keys), requireRole()
+ * and requirePermission() normally bypass all RBAC checks (dev mode).
+ * With strictRBAC=true, unauthenticated requests to role/permission-protected
+ * endpoints are rejected with 401.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { requireRole, requirePermission, setRouteConfig } from '../routes/context.js';
+import type { AuthManager } from '../services/auth/index.js';
+import type { Config } from '../config.js';
+
+function mockReq(authKeyId?: string | null, authRole?: string | null): FastifyRequest {
+  return {
+    authKeyId: authKeyId ?? null,
+    authRole: authRole ?? null,
+    authPermissions: null,
+  } as unknown as FastifyRequest;
+}
+
+function mockReply(): FastifyReply {
+  const reply = { statusCode: 200, body: null } as unknown as FastifyReply;
+  reply.status = vi.fn().mockReturnValue(reply);
+  reply.send = vi.fn().mockReturnValue(reply);
+  return reply;
+}
+
+function mockAuth(enabled: boolean): AuthManager {
+  return {
+    authEnabled: enabled,
+    getRole: vi.fn().mockReturnValue('admin'),
+    getKey: vi.fn(),
+  } as unknown as AuthManager;
+}
+
+describe('strictRBAC enforcement (Issue #3208)', () => {
+  beforeEach(() => {
+    // Reset config to default (strictRBAC=false)
+    setRouteConfig({ strictRBAC: false } as Config);
+  });
+
+  describe('requireRole', () => {
+    it('allows unauthenticated requests when auth disabled and strictRBAC=false (dev mode)', () => {
+      const auth = mockAuth(false);
+      const req = mockReq();
+      const reply = mockReply();
+      const result = requireRole(auth, req, reply, 'admin');
+      expect(result).toBe(true);
+      expect(reply.status).not.toHaveBeenCalled();
+    });
+
+    it('rejects unauthenticated requests when auth disabled and strictRBAC=true', () => {
+      setRouteConfig({ strictRBAC: true } as Config);
+      const auth = mockAuth(false);
+      const req = mockReq();
+      const reply = mockReply();
+      const result = requireRole(auth, req, reply, 'admin');
+      expect(result).toBe(false);
+      expect(reply.status).toHaveBeenCalledWith(401);
+    });
+
+    it('allows authenticated requests with correct role when strictRBAC=true', () => {
+      setRouteConfig({ strictRBAC: true } as Config);
+      const auth = mockAuth(false);
+      const req = mockReq('key-1', 'admin');
+      const reply = mockReply();
+      const result = requireRole(auth, req, reply, 'admin');
+      expect(result).toBe(true);
+      expect(reply.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requirePermission', () => {
+    it('allows unauthenticated requests when auth disabled and strictRBAC=false (dev mode)', () => {
+      const auth = mockAuth(false);
+      const req = mockReq();
+      const reply = mockReply();
+      const result = requirePermission(auth, req, reply, 'sessions:create');
+      expect(result).toBe(true);
+    });
+
+    it('rejects unauthenticated requests when auth disabled and strictRBAC=true', () => {
+      setRouteConfig({ strictRBAC: true } as Config);
+      const auth = mockAuth(false);
+      const req = mockReq();
+      const reply = mockReply();
+      const result = requirePermission(auth, req, reply, 'sessions:create');
+      expect(result).toBe(false);
+      expect(reply.status).toHaveBeenCalledWith(401);
+    });
+  });
+});

--- a/src/__tests__/strictRBAC-3208.test.ts
+++ b/src/__tests__/strictRBAC-3208.test.ts
@@ -77,7 +77,7 @@ describe('strictRBAC enforcement (Issue #3208)', () => {
       const auth = mockAuth(false);
       const req = mockReq();
       const reply = mockReply();
-      const result = requirePermission(auth, req, reply, 'sessions:create');
+      const result = requirePermission(auth, req, reply, 'create');
       expect(result).toBe(true);
     });
 
@@ -86,7 +86,7 @@ describe('strictRBAC enforcement (Issue #3208)', () => {
       const auth = mockAuth(false);
       const req = mockReq();
       const reply = mockReply();
-      const result = requirePermission(auth, req, reply, 'sessions:create');
+      const result = requirePermission(auth, req, reply, 'create');
       expect(result).toBe(false);
       expect(reply.status).toHaveBeenCalledWith(401);
     });

--- a/src/__tests__/version-endpoint-2814.test.ts
+++ b/src/__tests__/version-endpoint-2814.test.ts
@@ -104,6 +104,7 @@ async function buildApp(tmpDir: string): Promise<FastifyInstance> {
     envDenylist: [],
     envAdminAllowlist: [],
     enforceSessionOwnership: true,
+      strictRBAC: false,
     sseIdleMs: 60000,
     sseClientTimeoutMs: 300000,
     hookTimeoutMs: 10000,

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,11 @@ export interface Config {
   /** Issue #1910: Enforce session ownership on action routes (default: true).
    *  When false, any authenticated key can operate on any session. */
   enforceSessionOwnership: boolean;
+  /** Issue #3208: Enforce RBAC role checks even when auth is disabled (default: false).
+   *  When false (dev mode), unauthenticated requests to requireRole-guarded routes are allowed.
+   *  When true, all RBAC checks are enforced regardless of auth status — returns 401 for
+   *  unauthenticated requests to role-protected endpoints. Recommended for production. */
+  strictRBAC: boolean;
   /** Issue #1911: Milliseconds of SSE silence before emitting a heartbeat ping. Default: 60000 (1 min). */
   sseIdleMs: number;
   /** Issue #1911: Milliseconds before closing an SSE connection that hasn't consumed data. Default: 300000 (5 min). */
@@ -212,6 +217,7 @@ const defaults: Config = {
   envDenylist: [],
   envAdminAllowlist: [],
   enforceSessionOwnership: true,
+  strictRBAC: false,
   sseIdleMs: 60_000,
   sseClientTimeoutMs: 300_000,
   hookTimeoutMs: 10_000,
@@ -452,6 +458,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_DASHBOARD_ENABLED', manus: '', key: 'dashboardEnabled' },
     { aegis: 'AEGIS_DEFAULT_TENANT_ID', manus: '', key: 'defaultTenantId' },
     { aegis: 'AEGIS_ENFORCE_SESSION_OWNERSHIP', manus: '', key: 'enforceSessionOwnership' },
+    { aegis: 'AEGIS_STRICT_RBAC', manus: '', key: 'strictRBAC' },
     { aegis: 'AEGIS_ACP_ENABLED', manus: '', key: 'acpEnabled' },
   ];
 

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -18,6 +18,12 @@ import type { AuthManager, ApiKeyPermission, ApiKeyRole } from '../services/auth
 import type { QuotaManager } from '../services/auth/QuotaManager.js';
 import type { Config } from '../config.js';
 import { SYSTEM_TENANT } from '../config.js';
+
+/** Issue #3208: Module-level config ref for strictRBAC enforcement. */
+let _config: Config | null = null;
+
+/** Set the config reference during route initialization. */
+export function setRouteConfig(config: Config): void { _config = config; }
 import type { MetricsCollector } from '../metrics.js';
 import type { SessionMonitor } from '../monitor.js';
 import type { SessionEventBus } from '../events.js';
@@ -126,7 +132,15 @@ export function requireRole(
   reply: FastifyReply,
   ...allowedRoles: ApiKeyRole[]
 ): boolean {
-  if (!auth.authEnabled && !hasRequestAuthContext(req)) return true;
+  // Issue #3208: strictRBAC enforcement — when enabled, reject unauthenticated
+  // requests to role-protected endpoints even when auth is disabled.
+  if (!auth.authEnabled && !hasRequestAuthContext(req)) {
+    if (_config?.strictRBAC) {
+      reply.status(401).send({ error: 'Unauthorized — strictRBAC requires authentication' });
+      return false;
+    }
+    return true;
+  }
   if (auth.authEnabled && (req.authKeyId === null || req.authKeyId === undefined)) {
     reply.status(401).send({ error: 'Unauthorized — Bearer token required' });
     return false;
@@ -146,7 +160,12 @@ export function requirePermission(
   reply: FastifyReply,
   permission: ApiKeyPermission,
 ): boolean {
+  // Issue #3208: strictRBAC enforcement for permission-guarded routes
   if (!auth.authEnabled && !hasRequestAuthContext(req)) {
+    if (_config?.strictRBAC) {
+      reply.status(401).send({ error: 'Unauthorized — strictRBAC requires authentication' });
+      return false;
+    }
     req.matchedPermission = permission;
     return true;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,7 +97,7 @@ import {
   registerOpenApiRoute,
   type RouteContext,
 } from './routes/index.js';
-import { makePayload as makePayloadFromCtx } from './routes/context.js';
+import { makePayload as makePayloadFromCtx, setRouteConfig } from './routes/context.js';
 import { registerDeviceAuthRoutes } from './routes/device-auth.js';
 import {
   createDashboardOidcManagerFromEnv,
@@ -1055,6 +1055,19 @@ async function main(): Promise<void> {
     eventStore: acpLocalProfile?.eventStore ?? undefined,
     terminalBridge: acpTerminalBridge ?? undefined,
   };
+  // Issue #3208: Set config ref for strictRBAC enforcement in route guards
+  setRouteConfig(config);
+
+  // Issue #3208: Warn when auth is disabled and RBAC-guarded routes are active
+  if (!auth.authEnabled && !config.strictRBAC) {
+    logger.warn({
+      component: 'server',
+      operation: 'rbac_warning',
+      errorCode: 'RBAC_DISABLED_NO_AUTH',
+      attributes: { message: 'Auth is disabled and strictRBAC is false — all RBAC guards are bypassed. Set AEGIS_STRICT_RBAC=true for production.' },
+    });
+  }
+
   registerHealthRoutes(app, routeCtx);
   registerAuthRoutes(app, routeCtx);
   registerOidcAuthRoutes(app, routeCtx);


### PR DESCRIPTION
## Problem

When auth is disabled (default dev mode — no master token, no API keys), `requireRole()` and `requirePermission()` bypass ALL RBAC checks, allowing anonymous access to role-protected endpoints. This is intentional for single-user setups but creates risk in production deployments where RBAC expectations differ.

## Solution

Add `strictRBAC` config option (default: `false`):
- **`false` (dev mode)**: Current behavior preserved — unauthenticated requests bypass RBAC
- **`true` (production)**: Unauthenticated requests to role/permission-protected endpoints return 401, even when auth is disabled

### Changes

1. **`src/config.ts`**: Add `strictRBAC: boolean` field + `AEGIS_STRICT_RBAC` env var
2. **`src/routes/context.ts`**: `requireRole()` and `requirePermission()` check `strictRBAC` before bypassing
3. **`src/server.ts`**: Log startup warning when auth is disabled and `strictRBAC=false`
4. **Tests**: 5 new tests + 7 existing test files updated with config field

### Usage

```bash
# Production: enforce RBAC even without auth configured
AEGIS_STRICT_RBAC=true node dist/server.js
```

### Verification

- `tsc --noEmit` — zero errors
- 128 existing tests pass
- 5 new strictRBAC tests pass
- Startup warning logged when auth disabled

Closes #3208