### PR TITLE
docs: add PATCH /v1/auth/keys/:id and strictRBAC config

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -137,6 +137,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `POST` | `/v1/auth/keys` | Bearer | Create API key |
 | `GET` | `/v1/auth/keys` | Bearer | List API keys |
 | `DELETE` | `/v1/auth/keys/{id}` | Bearer | Revoke API key |
+| `PATCH` | `/v1/auth/keys/{id}` | Bearer | Update API key role/name/permissions |
 | `POST` | `/v1/auth/keys/{id}/rotate` | Bearer | Rotate API key |
 | `POST` | `/v1/auth/sse-token` | Bearer | Generate SSE auth token (required for SSE endpoints) |
 | `POST` | `/v1/keys` | Bearer | Create API key (alias) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -390,6 +390,48 @@ curl -X DELETE http://localhost:9100/v1/auth/keys/key-abc123 \
 
 ---
 
+### Update API Key
+
+```
+PATCH /v1/auth/keys/:id
+```
+
+Updates an API key's role, name, or permissions. **Admin only.**
+
+```bash
+curl -X PATCH http://localhost:9100/v1/auth/keys/key-abc123 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "operator"}'
+```
+
+**Request body:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | no | New key name (must be unique) |
+| `role` | string | no | New role: `admin`, `operator`, or `viewer` |
+| `permissions` | string[]\|null | no | Explicit permissions array, or `null` to reset to role defaults |
+
+**Behavior:**
+
+- Changing `role` resets permissions to that role's defaults (unless `permissions` is also provided).
+- Setting `permissions` to `null` resets to role defaults.
+- The last admin cannot demote themselves (returns 409).
+- Key names must be unique (returns 409 on conflict).
+
+**Response:** Updated key object.
+
+**Errors:**
+
+| Status | Condition |
+|--------|----------|
+| 404 | Key not found |
+| 409 | Cannot demote last admin, or key name already in use |
+| 403 | Auth is not enabled |
+
+---
+
 ### Rotate API Key
 
 ```

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -120,6 +120,28 @@ Query the session's `ownerKeyId` via `GET /v1/sessions/:id`:
 
 
 
+## Strict RBAC Mode
+
+By default, when auth is disabled (no `AEGIS_AUTH_TOKEN`, no API keys), role-based access control checks are bypassed — all endpoints are accessible without authentication. This is fine for single-user local development but risky in production.
+
+Enable strict RBAC to enforce role checks even when auth is disabled:
+
+```bash
+AEGIS_STRICT_RBAC=true AEGIS_AUTH_TOKEN=your-token ag
+```
+
+When enabled:
+- Unauthenticated requests to role-protected endpoints (`requireRole`, `requirePermission`) return **401 Unauthorized** instead of being allowed through
+- This prevents accidental exposure of admin/operator endpoints in production deployments
+- A startup warning is logged when auth is disabled and `strictRBAC` is `false`
+
+| `strictRBAC` | Auth enabled | Behavior |
+|---|---|---|
+| `false` | No | All endpoints open (dev default) |
+| `false` | Yes | Normal RBAC with bearer token |
+| `true` | No | Protected endpoints return 401 |
+| `true` | Yes | Normal RBAC with bearer token |
+
 ## Rate Limiting
 
 Aegis includes built-in rate limiting at multiple levels:
@@ -254,6 +276,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | Variable | Default | Description |
 |---|---|---|
 | `AEGIS_ALLOWED_WORKDIRS` | _(home, cwd)_ | JSON array of allowed session working directories. System temp dirs (`/tmp`, `/var/tmp`) are excluded by default for security — add them explicitly if needed |
+| `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC checks even when auth is disabled. When `true`, unauthenticated requests to role/permission-protected endpoints return 401 instead of being allowed through |
 
 #### Hooks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -297,6 +297,7 @@ Aegis is configured via environment variables:
 | `AEGIS_PG_POOL_MAX` | `5` | PostgreSQL connection pool max size |
 | `AEGIS_REDIS_URL` | `redis://localhost:6379` | Redis URL (used when `AEGIS_SESSION_STORE=redis`) |
 | `AEGIS_REDIS_KEY_PREFIX` | `aegis` | Redis key prefix |
+| `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC on protected endpoints even when auth is disabled |
 
 See the [Enterprise Deployment Guide](enterprise.md#configuration-reference) for the complete environment variable reference (rate limiting, OIDC, hooks, notifications, alerting, and more).
 


### PR DESCRIPTION
## Summary

Documents two merged features that were missing from docs:

### 1. PATCH /v1/auth/keys/:id (PR #3207 → #3212)
- New endpoint to update API key role, name, or permissions
- Admin-only, self-demotion guard, name uniqueness check
- Added to `api-reference.md` (full docs) and `api-quick-ref.md` (endpoint table)

### 2. strictRBAC config (PR #3211)
- `AEGIS_STRICT_RBAC` env var to enforce RBAC even when auth is disabled
- Added "Strict RBAC Mode" section to `enterprise.md` with behavior table
- Added to Security config table in `enterprise.md`
- Added to config table in `getting-started.md`

### Files changed
- `docs/api-reference.md` — PATCH /v1/auth/keys/:id endpoint docs
- `docs/api-quick-ref.md` — PATCH entry in auth keys table
- `docs/enterprise.md` — Strict RBAC Mode section + config entry
- `docs/getting-started.md` — AEGIS_STRICT_RBAC in config table