### PR TITLE
fix(ci): SDK Auto-Sync workflow uses PR-based flow instead of direct push

### DIFF
--- a/.github/workflows/sdk-sync.yml
+++ b/.github/workflows/sdk-sync.yml
@@ -2,7 +2,7 @@ name: SDK Auto-Sync
 
 # Issue #2939: Keep generated SDKs in sync when OpenAPI sources change.
 # Triggered on push to develop — detects openapi/route/schema changes,
-# regenerates SDKs, and commits them back. The [skip ci] marker prevents
+# regenerates SDKs, and opens a PR. The [skip ci] marker prevents
 # infinite loops.
 
 on:
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: sdk-sync-${{ github.ref }}
@@ -72,11 +73,26 @@ jobs:
             git diff --stat
           fi
 
-      - name: Commit and push regenerated SDKs
+      - name: Create PR with regenerated SDKs
         if: steps.check-diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH="sdk-sync/auto-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add openapi.yaml packages/client/src/generated/ packages/python-client/src/
           git commit -m "chore(sdk): auto-sync generated SDKs [skip ci]"
-          git push origin develop
+          git push origin "$BRANCH"
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore(sdk): auto-sync generated SDKs" \
+            --body "Automated SDK regeneration from OpenAPI spec changes.
+
+          This PR was created by the SDK Auto-Sync workflow.
+
+          ---
+          *github-actions[bot]*" \
+            --label "dependencies" || true


### PR DESCRIPTION
## Problem
The `sdk-sync.yml` workflow tries to push directly to `develop`, which branch protection rejects:
```
remote: error: GH006: Protected branch update failed for refs/heads/develop.
remote: - Changes must be made through a pull request.
```

## Fix
Instead of pushing directly, the workflow now:
1. Creates a timestamped branch (`sdk-sync/auto-YYYYMMDD-HHMMSS`)
2. Commits the generated SDK files to that branch
3. Opens a PR targeting `develop` using `gh pr create`
4. Falls back gracefully if a PR already exists (`|| true`)

### Changes
- Added `pull-requests: write` permission
- Replaced `git push origin develop` with branch + PR creation
- No more branch protection violations

### Testing
- Workflow logic is identical up to the push step
- PR creation uses `GH_TOKEN` (automatic in GitHub Actions)
- The `[skip ci]` marker in commit messages still prevents loops

---
*Hermes 🚚*