### PR TITLE
fix(acp): increase JSON-RPC timeout to 60s and make configurable (#3223)

### DIFF
--- a/src/__tests__/health-auth-2458.test.ts
+++ b/src/__tests__/health-auth-2458.test.ts
@@ -112,6 +112,7 @@ async function buildApp(tmpDir: string): Promise<{ app: FastifyInstance; auth: A
     shutdownGraceMs: 15000,
     keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20000,
+      acpPromptTimeoutMs: 60_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -218,6 +218,7 @@ async function buildTestServer(): Promise<{
     shutdownGraceMs: 15_000,
       keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20_000,
+      acpPromptTimeoutMs: 60_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/__tests__/oidc-auth-routes.test.ts
+++ b/src/__tests__/oidc-auth-routes.test.ts
@@ -103,6 +103,7 @@ function makeConfig(): Config {
     shutdownGraceMs: 1,
     keyRotationGraceSeconds: 1,
     shutdownHardMs: 1,
+      acpPromptTimeoutMs: 60_000,
     stateStore: 'file',
     postgresUrl: '',
     dashboardEnabled: true,

--- a/src/__tests__/oidc-dashboard-manager.test.ts
+++ b/src/__tests__/oidc-dashboard-manager.test.ts
@@ -114,6 +114,7 @@ function makeConfig(): Config {
     shutdownGraceMs: 1,
     keyRotationGraceSeconds: 1,
     shutdownHardMs: 1,
+      acpPromptTimeoutMs: 60_000,
     stateStore: 'file',
     postgresUrl: '',
     dashboardEnabled: true,

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -117,6 +117,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     shutdownGraceMs: 15_000,
       keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20_000,
+      acpPromptTimeoutMs: 60_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/__tests__/session-label-2530.test.ts
+++ b/src/__tests__/session-label-2530.test.ts
@@ -84,6 +84,7 @@ async function buildRouteContext(tmpDir: string) {
       strictRBAC: false,
     sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
     shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
+      acpPromptTimeoutMs: 60_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file', postgresUrl: '', defaultTenantId: 'default', acpEnabled: false,
     tenantWorkdirs: {},

--- a/src/__tests__/session-name-validation-3091.test.ts
+++ b/src/__tests__/session-name-validation-3091.test.ts
@@ -85,6 +85,7 @@ async function buildRouteContext(tmpDir: string) {
       strictRBAC: false,
     sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
     shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
+      acpPromptTimeoutMs: 60_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file', postgresUrl: '', defaultTenantId: 'default', acpEnabled: false,
     tenantWorkdirs: {},

--- a/src/__tests__/version-endpoint-2814.test.ts
+++ b/src/__tests__/version-endpoint-2814.test.ts
@@ -111,6 +111,7 @@ async function buildApp(tmpDir: string): Promise<FastifyInstance> {
     shutdownGraceMs: 15000,
     keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20000,
+      acpPromptTimeoutMs: 60_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/config.ts
+++ b/src/config.ts
@@ -167,6 +167,8 @@ export interface Config {
   /** Enable ACP backend for session creation and control actions (default: false).
    *  Transitional flag for Phase 3.5 ACP backend migration. */
   acpEnabled: boolean;
+  /** ACP JSON-RPC request timeout in ms (default: 60000). Issue #3223. */
+  acpPromptTimeoutMs: number;
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -231,6 +233,7 @@ const defaults: Config = {
   postgresUrl: '',
   rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
   acpEnabled: true,
+  acpPromptTimeoutMs: 60_000, // Issue #3223: 60s default for BYO-LLM proxy setups
 };
 
 /** Parse CLI args for --config flag */
@@ -367,7 +370,8 @@ type NumericConfigEnvKey =
   | 'sseClientTimeoutMs'
   | 'hookTimeoutMs'
   | 'shutdownGraceMs'
-  | 'shutdownHardMs';
+  | 'shutdownHardMs'
+  | 'acpPromptTimeoutMs';
 
 const MAX_ENV_INT = Number.MAX_SAFE_INTEGER;
 
@@ -386,6 +390,7 @@ const numericEnvBounds: Record<NumericConfigEnvKey, { min: number; max: number }
   hookTimeoutMs: { min: 100, max: MAX_ENV_INT },
   shutdownGraceMs: { min: 1000, max: MAX_ENV_INT },
   shutdownHardMs: { min: 1000, max: MAX_ENV_INT },
+  acpPromptTimeoutMs: { min: 1000, max: MAX_ENV_INT },
 };
 
 function parseNumericEnvOverride(
@@ -460,6 +465,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_ENFORCE_SESSION_OWNERSHIP', manus: '', key: 'enforceSessionOwnership' },
     { aegis: 'AEGIS_STRICT_RBAC', manus: '', key: 'strictRBAC' },
     { aegis: 'AEGIS_ACP_ENABLED', manus: '', key: 'acpEnabled' },
+    { aegis: 'AEGIS_ACP_PROMPT_TIMEOUT_MS', manus: '', key: 'acpPromptTimeoutMs' },
   ];
 
   for (const { aegis, manus, key } of envMappings) {
@@ -483,6 +489,7 @@ function applyEnvOverrides(config: Config): Config {
       case 'hookTimeoutMs':
       case 'shutdownGraceMs':
       case 'shutdownHardMs':
+      case 'acpPromptTimeoutMs':
         config[key] = parseNumericEnvOverride(envName, value, config[key], numericEnvBounds[key]);
         break;
       case 'hookSecretHeaderOnly':

--- a/src/server.ts
+++ b/src/server.ts
@@ -812,7 +812,10 @@ async function main(): Promise<void> {
   acpSessionService = new AcpSessionService(acpLocalProfile.sessionStore, {
     pauseInterventionStore: acpPauseStore ?? new InMemoryPauseInterventionStore(),
   });
-  acpBackend = new AcpBackend({ sessionService: acpSessionService });
+  acpBackend = new AcpBackend({
+    sessionService: acpSessionService,
+    jsonRpcClientOptions: { requestTimeoutMs: config.acpPromptTimeoutMs },
+  });
   acpTerminalBridge = new AcpTerminalBridge({
     sessionResolver: {
       getSession: (sessionId, scope) => acpSessionService!.getSession(sessionId, scope),

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -404,6 +404,11 @@ export class AcpBackend {
       });
       return { delivered: true, attempts: 1 };
     } catch (err) {
+      // Issue #3223: Log timeout details for BYO-LLM proxy diagnosis
+      if (err instanceof Error && err.message.includes('timed out')) {
+        const timeoutMs = this.options.jsonRpcClientOptions?.requestTimeoutMs ?? 60_000;
+        console.warn(`[ACP prompt timeout] session=${sessionId} method=session/prompt timeout=${timeoutMs}ms`);
+      }
       return { delivered: false, attempts: 1, error: (err as Error).message };
     } finally {
       this.inFlightPrompts.delete(sessionId);

--- a/src/services/acp/json-rpc-client.ts
+++ b/src/services/acp/json-rpc-client.ts
@@ -4,7 +4,7 @@ import type {
   AcpChildProcessShutdownOptions,
 } from './child-process.js';
 
-const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 const DEFAULT_ID_NAMESPACE = 'aegis-acp';
 const DEFAULT_ABANDONED_RESPONSE_GRACE_MS = 60_000;
 


### PR DESCRIPTION
## Summary

Fixes the ACP JSON-RPC prompt delivery timeout that was too tight (15s) for BYO-LLM proxy setups. The prompt was being delivered to CC but Aegis reported `delivered: false` because the JSON-RPC response didn't arrive within the 15s window.

## Changes

- **`DEFAULT_REQUEST_TIMEOUT_MS`**: 15s → 60s
- **New config field**: `acpPromptTimeoutMs` (default: 60s, env: `AEGIS_ACP_PROMPT_TIMEOUT_MS`)
- **Wired through**: `config.ts` → `server.ts` → `AcpBackend` → `AcpJsonRpcClient`
- **Timeout logging**: warns with session ID and timeout value when prompt delivery times out
- **8 test files**: added `acpPromptTimeoutMs: 60_000` to inline Config objects

## Verification
```
tsc --noEmit  ✅  (zero errors)
npm run build ✅
npm test      ✅  4081/4082 pass (1 pre-existing flaky timeout in server-core-coverage)
```

## Config Usage
```yaml
# .aegis/config.yaml
acpPromptTimeoutMs: 120000  # 2 minutes for slow proxies
```
```bash
# Or via env
AEGIS_ACP_PROMPT_TIMEOUT_MS=120000 npx @onestepat4time/aegis
```

Closes #3223