### PR TITLE
docs: add ACP prompt timeout config (AEGIS_ACP_PROMPT_TIMEOUT_MS)

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -265,6 +265,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_AUTH_TOKEN` | _(empty)_ | Master bearer token (empty = no auth) |
 | `AEGIS_STATE_DIR` | `~/.aegis` | State directory (sessions, PID file) |
 | `AEGIS_ACP_BIN` | _(auto)_ | Path to the ACP binary (auto-detected if empty) |
+| `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `60000` | Timeout in ms for ACP JSON-RPC requests (default 60s). Increase for slow BYO-LLM proxy setups (min: 1000) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Maximum concurrent sessions |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -298,6 +298,7 @@ Aegis is configured via environment variables:
 | `AEGIS_REDIS_URL` | `redis://localhost:6379` | Redis URL (used when `AEGIS_SESSION_STORE=redis`) |
 | `AEGIS_REDIS_KEY_PREFIX` | `aegis` | Redis key prefix |
 | `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC on protected endpoints even when auth is disabled |
+| `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `60000` | Timeout in ms for ACP JSON-RPC requests (increase for slow BYO-LLM proxy setups) |
 
 See the [Enterprise Deployment Guide](enterprise.md#configuration-reference) for the complete environment variable reference (rate limiting, OIDC, hooks, notifications, alerting, and more).
 


### PR DESCRIPTION
Documents the new `acpPromptTimeoutMs` config option introduced in #3225.

## Changes
- **enterprise.md**: Adds `AEGIS_ACP_PROMPT_TIMEOUT_MS` to the General config table (default: 60000, description, min note)
- **getting-started.md**: Adds entry to the env var table

## Source
- PR #3225 / Issue #3223 — ACP JSON-RPC timeout made configurable
- Config key: `acpPromptTimeoutMs` (default: 60000ms)
- Env var: `AEGIS_ACP_PROMPT_TIMEOUT_MS`
- Min value: 1000ms

No new API surface — internal config only.