### PR TITLE
fix(security): add periodic prune timer to StaticRateLimiter (#3227)

### DIFF
--- a/src/__tests__/dashboard-static-rate-limit.test.ts
+++ b/src/__tests__/dashboard-static-rate-limit.test.ts
@@ -8,7 +8,7 @@
  * to ensure the full plugin lifecycle works end-to-end.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Fastify from 'fastify';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -90,6 +90,71 @@ describe('StaticRateLimiter unit tests (#3220)', () => {
     }
     const info = limiter.getBucketInfo('1.2.3.4');
     expect(info.remaining).toBe(0);
+  });
+});
+
+// ── Prune timer tests (#3227) ──────────────────────────────────────────────
+
+describe('StaticRateLimiter prune timer (#3227)', () => {
+  let mockDashboardDir: string;
+
+  beforeEach(() => {
+    mockDashboardDir = path.join(os.tmpdir(), `aegis-test-dashboard-${Date.now()}`);
+    fs.mkdirSync(mockDashboardDir, { recursive: true });
+    fs.writeFileSync(path.join(mockDashboardDir, 'index.html'), '<html>test</html>');
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fs.rmSync(mockDashboardDir, { recursive: true, force: true });
+  });
+
+  it('registerDashboardStatic returns a prune interval handle when dashboard is available', async () => {
+    const app = Fastify();
+    try {
+      const handle = await registerDashboardStatic(app, { _dashboardRoot: mockDashboardDir });
+      expect(handle).not.toBeNull();
+      if (handle) clearInterval(handle);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('registerDashboardStatic returns null when dashboard is disabled', async () => {
+    const app = Fastify();
+    try {
+      const handle = await registerDashboardStatic(app, { enabled: false });
+      expect(handle).toBeNull();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('prune interval calls limiter.prune() every 60 seconds', async () => {
+    const limiter = new StaticRateLimiter();
+    const pruneSpy = vi.spyOn(limiter, 'prune');
+    const app = Fastify();
+    try {
+      const handle = await registerDashboardStatic(app, {
+        _dashboardRoot: mockDashboardDir,
+        rateLimiter: limiter,
+      });
+      expect(handle).not.toBeNull();
+
+      expect(pruneSpy).toHaveBeenCalledTimes(0);
+      vi.advanceTimersByTime(60_000);
+      expect(pruneSpy).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(60_000);
+      expect(pruneSpy).toHaveBeenCalledTimes(2);
+
+      if (handle) clearInterval(handle);
+
+      vi.advanceTimersByTime(60_000);
+      expect(pruneSpy).toHaveBeenCalledTimes(2); // stopped after clearInterval
+    } finally {
+      await app.close();
+    }
   });
 });
 

--- a/src/plugins/dashboard-static.ts
+++ b/src/plugins/dashboard-static.ts
@@ -163,6 +163,8 @@ export interface DashboardStaticOptions {
   enabled?: boolean;
   /** External rate limiter instance (optional). If not provided, an internal one is created. */
   rateLimiter?: StaticRateLimiter;
+  /** @internal Test-only: override the resolved dashboard root directory. */
+  _dashboardRoot?: string;
 }
 
 /**
@@ -170,15 +172,16 @@ export interface DashboardStaticOptions {
  * and manifest.json endpoint.
  *
  * Gracefully handles missing dashboard build (warns, serves nothing).
- * Returns true if dashboard is available, false otherwise.
+ * Returns the prune interval handle (caller must clearInterval on shutdown),
+ * or null if the dashboard is unavailable or disabled.
  */
 export async function registerDashboardStatic(
   app: FastifyInstance,
   options: DashboardStaticOptions = {}
-): Promise<boolean> {
+): Promise<ReturnType<typeof setInterval> | null> {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
-  const dashboardRoot = path.join(__dirname, '..', 'dashboard');
+  const dashboardRoot = options._dashboardRoot ?? path.join(__dirname, '..', 'dashboard');
   const dashboardEnabled = options.enabled !== false;
   let dashboardAvailable = false;
 
@@ -199,10 +202,15 @@ export async function registerDashboardStatic(
     }
   }
 
-  if (!dashboardAvailable) return false;
+  if (!dashboardAvailable) return null;
 
   // #3220: Rate limiting for dashboard static asset routes
   const limiter = options.rateLimiter ?? new StaticRateLimiter();
+
+  // #3227: Periodic prune to evict stale IP buckets (mirrors server.ts pattern)
+  const pruneInterval = setInterval(() => limiter.prune(), 60_000);
+  pruneInterval.unref();
+
   app.addHook('onRequest', async (req, reply) => {
     const url = req.url ?? '/';
     const isStaticRoute =
@@ -277,5 +285,5 @@ export async function registerDashboardStatic(
     return reply.status(404).send({ error: "Not found" });
   });
 
-  return true;
+  return pruneInterval;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1105,6 +1105,8 @@ async function main(): Promise<void> {
   const authSweepInterval = setInterval(() => auth.sweepStaleRateLimits(), 5 * 60_000);
   // #2452: Sweep expired quota usage entries every 5 minutes to prevent unbounded growth
   const quotaSweepInterval = setInterval(() => routeCtx.quotas.sweep(), 5 * 60_000);
+  // #3227: Prune interval from StaticRateLimiter — assigned after registerDashboardStatic()
+  let staticPruneInterval: ReturnType<typeof setInterval> | null = null;
   let pidFilePath = '';
 
   // Issue #361: Graceful shutdown handler
@@ -1177,6 +1179,7 @@ async function main(): Promise<void> {
       clearInterval(authFailPruneInterval);
       clearInterval(authSweepInterval);
       clearInterval(quotaSweepInterval);
+      if (staticPruneInterval) clearInterval(staticPruneInterval);
       rateLimiter.dispose();
 
       // 3. Close file watchers, pipelines, and reaper
@@ -1360,7 +1363,8 @@ async function main(): Promise<void> {
 
 
   // #3154: Dashboard static serving extracted to plugins/dashboard-static.ts
-  await registerDashboardStatic(app, { enabled: config.dashboardEnabled !== false });
+  // #3227: Capture prune interval handle for cleanup on shutdown
+  staticPruneInterval = await registerDashboardStatic(app, { enabled: config.dashboardEnabled !== false });
   await container.assertHealthy();
   await listenWithRetry(app, config.port, config.host, config.stateDir);
   pidFilePath = await writePidFile(config.stateDir);


### PR DESCRIPTION
## Summary

Security hardening per issue #3227 — follow-up to #3222 (dashboard rate limiting).

## Problem

`StaticRateLimiter.prune()` was implemented but never called on a periodic timer. Expired per-IP buckets accumulated indefinitely, only cleaned by O(n) eviction at the 2,000-entry threshold. The main `RateLimiter` in `server.ts` correctly uses `setInterval(pruneIpRateLimits, 60_000)` — `StaticRateLimiter` had no equivalent.

## Changes

### `src/plugins/dashboard-static.ts`
- Added `setInterval(() => limiter.prune(), 60_000)` in `registerDashboardStatic()`
- `.unref()` on the interval handle — does not block process exit
- Changed return type from `boolean` to `ReturnType<typeof setInterval> | null` — caller receives the handle for cleanup
- Added `_dashboardRoot` test-only option for deterministic test setup

### `src/server.ts`
- Captures prune interval handle from `registerDashboardStatic()` into `staticPruneInterval`
- `clearInterval(staticPruneInterval)` added to graceful shutdown path alongside all other interval cleanup

### `src/__tests__/dashboard-static-rate-limit.test.ts`
- 3 new tests using `vi.useFakeTimers()`:
  1. Returns interval handle when dashboard is available
  2. Returns null when dashboard is disabled
  3. Prune called every 60s, stops after `clearInterval`

## Acceptance Criteria (#3227)
- [x] `StaticRateLimiter.prune()` is called on a 60s interval
- [x] Interval is `.unref()`'d to not block process exit
- [x] Interval is cleared on server shutdown
- [x] Existing tests still pass

## Verification
```
npx vitest run src/__tests__/dashboard-static-rate-limit.test.ts
  ✓ 14 tests passed (11 existing + 3 new)

npx tsc --noEmit
  ✅ zero errors
```

Closes #3227