### PR TITLE
docs: restructure quickstart for 2-command install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,29 +30,52 @@
 
 ## Quick Start
 
+Two commands from zero to a running Claude Code session:
+
 ```bash
-# Install
-npm install -g @onestepat4time/aegis
-
-# Zero-to-session in one command (bootstraps config, starts server, creates session)
-ag run "Build a login page with email/password fields." --cwd /path/to/project
-
-# Or step by step
-ag init
-ag
-ag create "Build a login page with email/password fields." --cwd /path/to/project
-
-# Scaffold a repo-local starter
-ag init --list-templates
-ag init --from-template code-reviewer
-ag doctor
+# 1. Run Aegis (no install needed — npx handles everything)
+npx --package=@onestepat4time/aegis ag run "Build a login page with email/password fields." --cwd /path/to/project
 ```
 
-> **CLI naming:** the primary command is `ag` (e.g. `ag`, `ag mcp`, `ag create "brief"`). The legacy name `aegis` is preserved as an alias, so any existing scripts using `aegis` keep working.
+That's it. `ag run` bootstraps config, starts the server, creates a session, and streams output to your terminal.
 
-Built-in starter templates include `code-reviewer`, `ci-runner`, `pr-reviewer`, and `docs-writer`.
+<details>
+<summary>With a global install (optional)</summary>
+
+```bash
+npm install -g @onestepat4time/aegis
+ag run "Build a login page with email/password fields." --cwd /path/to/project
+```
+
+</details>
+
+<details>
+<summary>Step-by-step setup</summary>
+
+```bash
+ag init                    # Bootstrap config (use --force to overwrite)
+ag                         # Start server
+ag create "Your prompt" --cwd /path/to/project  # Create session
+ag doctor                  # Verify setup
+```
+
+</details>
+
+<details>
+<summary>Starter templates</summary>
+
+```bash
+ag init --list-templates
+ag init --from-template code-reviewer
+```
+
+Built-in templates: `code-reviewer`, `ci-runner`, `pr-reviewer`, `docs-writer`.
+
+</details>
 
 > **Prerequisites:** [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (authenticated). Aegis bundles `claude-agent-acp` — no separate install needed.
+
+> **CLI naming:** the primary command is `ag` (e.g. `ag`, `ag mcp`, `ag create "brief"`). The legacy name `aegis` is preserved as an alias, so any existing scripts using `aegis` keep working.
 
 ### Windows Setup
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Aegis
 
-Get from zero to orchestrating Claude Code sessions in under 5 minutes.
+Get from zero to orchestrating Claude Code sessions in **two commands**.
 
 ## Prerequisites
 
@@ -11,9 +11,36 @@ Get from zero to orchestrating Claude Code sessions in under 5 minutes.
 
 Aegis bundles `claude-agent-acp` — no tmux installation required.
 
-## 1. Bootstrap and Start Aegis
+## Quick Start (2 commands)
 
-Install once, bootstrap `.aegis/config.yaml`, then start Aegis with the primary `ag` CLI:
+```bash
+# Run Aegis — no install needed
+npx --package=@onestepat4time/aegis ag run "Analyze this project and list the main technologies." --cwd /path/to/your/project
+```
+
+`ag run` does everything for you:
+1. Bootstraps `.aegis/config.yaml` with sensible defaults
+2. Starts the server on **http://localhost:9100**
+3. Creates a Claude Code session
+4. Streams output to your terminal
+
+If the server is already running, `ag run` skips bootstrap and start — goes straight to session creation. Existing config is never overwritten.
+
+| Flag | Description |
+|------|-------------|
+| `--cwd <path>` | Working directory (default: current directory) |
+| `--port <number>` | Server port override |
+| `--no-stream` | Don't stream output; print curl commands instead |
+
+---
+
+*Everything below is for advanced setups — most users can stop here.*
+
+---
+
+## Step-by-Step Setup
+
+### 1. Install and Bootstrap
 
 ```bash
 npm install -g @onestepat4time/aegis
@@ -24,6 +51,7 @@ ag init
 
 ```bash
 ag
+```
 
 > The primary CLI command is `ag`. The legacy name `aegis` is kept as an alias for backward compatibility — both resolve to the same binary.
 
@@ -32,15 +60,6 @@ Aegis starts on **http://localhost:9100** by default. Verify it's running:
 ```bash
 curl http://localhost:9100/v1/health
 ```
-
-<details>
-<summary>Run without a global install (optional)</summary>
-
-```bash
-npx --package=@onestepat4time/aegis ag
-```
-
-</details>
 
 <details>
 <summary>Docker (alternative)</summary>
@@ -92,15 +111,13 @@ For **dashboard SSO**, also set `AEGIS_OIDC_CLIENT_SECRET`. The dashboard will r
 > ```bash
 > export TOKEN=your-secret-token
 > ```
-> All examples from section 5 onward use `$TOKEN` for brevity. No-auth setups can omit the `-H "Authorization: Bearer $TOKEN"` headers.
+> All examples from section 4 onward use `$TOKEN` for brevity. No-auth setups can omit the `-H "Authorization: Bearer $TOKEN"` headers.
 
 </details>
 
 ## 2. Open the Dashboard
 
 Visit **http://localhost:9100/dashboard/** in your browser. The dashboard shows all sessions, their status, and activity in real time.
-
-> **Note:** `ag init` can create an admin API token and save it in `.aegis/config.yaml`. Use that token to sign in, or keep using `AEGIS_AUTH_TOKEN` if you prefer an environment-based setup. If OIDC SSO is configured, the dashboard uses IdP-based login instead.
 
 ## 3. Dashboard Keyboard Shortcuts
 
@@ -120,39 +137,7 @@ Navigate the dashboard faster using keyboard shortcuts:
 
 The dashboard displays the shortcut hint in the sidebar footer.
 
-## 4. Create Your First Session
-
-### One-command mode (`ag run`)
-
-Skip all the setup — `ag run` bootstraps config, starts the server, creates a session, and streams output to your terminal:
-
-```bash
-ag run "Analyze this project. List the main technologies, directory structure, and any issues you spot." --cwd /path/to/your/project
-```
-
-```text
-🚀 ag run: Analyze this project...
-⏳ Server not running — starting...
-⏳ Waiting for server...
-✅ Server started
-✅ Session: run-analyze-this-proj- (ff3aafbb)
-📊 Dashboard: http://127.0.0.1:9100
-
-📡 Streaming session output (Ctrl+C to stop)...
-
-👤 Analyze this project...
-🤖 I'll analyze the project structure...
-```
-
-| Flag | Description |
-|------|-------------|
-| `--cwd <path>` | Working directory (default: current directory) |
-| `--port <number>` | Server port override |
-| `--no-stream` | Don't stream output; print curl commands instead |
-
-If the server is already running, `ag run` skips bootstrap and start — goes straight to session creation. Existing config is never overwritten.
-
-### Step-by-step (`ag create`)
+## 4. Create a Session
 
 ```bash
 ag create "Analyze this project. List the main technologies, directory structure, and any issues you spot." --cwd /path/to/your/project


### PR DESCRIPTION
## Summary

Addresses the install friction identified in #3181. Restructures README and getting-started to lead with the 2-command flow (`npx` + `ag run`) instead of requiring a global install.

## Changes

### README.md
- Quick Start now leads with `npx --package=@onestepat4time/aegis ag run` — no install needed
- Collapsed global install, step-by-step, and templates into expandable `<details>` sections
- Moved prerequisites and CLI naming notes below the fold

### getting-started.md
- New **Quick Start (2 commands)** section at the top with `npx` + `ag run` flow
- Added "Everything below is for advanced setups" divider
- Moved `npm install -g` + `ag init` + `ag` into "Step-by-Step Setup" section
- Removed duplicate `ag run` section from "Create Your First Session" (now just shows `ag create`)
- Removed `npx` from buried collapsible (promoted to top-level)
- Fixed section numbering and $TOKEN reference

## Target experience

```bash
npx --package=@onestepat4time/aegis ag run "Build a REST API" --cwd .
```

One command from zero to running session. No install, no config, no setup.

Refs #3181