### PR TITLE
fix(acp): align unauth tenantId fallback with SYSTEM_TENANT (#3237)

### DIFF
--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -4,6 +4,7 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { SYSTEM_TENANT } from '../config.js';
 import { sendMessageSchema, commandSchema, permissionRuleSchema, permissionProfileSchema, type PermissionProfile } from '../validation.js';
 import type { PermissionPolicy } from '../validation.js';
 import { registerPermissionRoutes } from '../permission-routes.js';
@@ -54,7 +55,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     }
     try {
       const result = acpBackend && config.acpEnabled
-        ? await acpBackend.sendPrompt(sessionId, text, { tenantId: (req as any).tenantId ?? 'system', ownerKeyId: (req as any).authKeyId ?? 'master' })
+        ? await acpBackend.sendPrompt(sessionId, text, { tenantId: (req as any).tenantId ?? SYSTEM_TENANT, ownerKeyId: (req as any).authKeyId ?? 'master' })
         : await sessions.sendMessage(sessionId, text);
       // Issue #1809: Re-fetch stall info AFTER delivery to avoid false-positive.
       // Previously we called getStallInfo BEFORE send, capturing a stale state
@@ -272,7 +273,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     try {
       const cmd = command.startsWith('/') ? command : `/${command}`;
       const cmdResult = acpBackend && config.acpEnabled
-        ? await acpBackend.sendPrompt(session.id, cmd, { tenantId: (req as any).tenantId ?? 'system', ownerKeyId: (req as any).authKeyId ?? 'master' })
+        ? await acpBackend.sendPrompt(session.id, cmd, { tenantId: (req as any).tenantId ?? SYSTEM_TENANT, ownerKeyId: (req as any).authKeyId ?? 'master' })
         : await sessions.sendMessage(session.id, cmd);
       return { ok: true };
     } catch (e: unknown) {

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -398,7 +398,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
             }
           }
           promptDelivery = acpBackend && ctx.config.acpEnabled
-          ? await acpBackend.sendPrompt(existing.id, finalPrompt, { tenantId: req.tenantId ?? 'system', ownerKeyId: req.authKeyId ?? 'master' })
+          ? await acpBackend.sendPrompt(existing.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
           : await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
@@ -469,7 +469,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         }
       }
       promptDelivery = acpBackend && ctx.config.acpEnabled
-        ? await acpBackend.sendPrompt(session.id, finalPrompt, { tenantId: req.tenantId ?? 'system', ownerKeyId: req.authKeyId ?? 'master' })
+        ? await acpBackend.sendPrompt(session.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
         : await sessions.sendInitialPrompt(session.id, finalPrompt);
       metrics.promptSent(promptDelivery.delivered);
     }


### PR DESCRIPTION
## Summary

- Aligns four `acpBackend.sendPrompt(...)` call sites to use the `SYSTEM_TENANT` constant (`'_system'`) as the unauth fallback, matching the `acpBackend.createSession(...)` create scope. Previously they fell back to the literal `'system'`, so the lookup missed and prompt delivery failed for every ACP-routed request without an authenticated tenant.
- Affected routes: `POST /v1/sessions` (initial prompt + idle-reuse branch), `POST /v1/sessions/:id/send`, `POST /v1/sessions/:id/command`.
- Adds the missing `SYSTEM_TENANT` import to `src/routes/session-actions.ts`.

Closes #3237

## Reproduction (before fix)

```
AEGIS_DISABLE_AUTH=true node dist/cli.js
POST /v1/sessions { "workDir": "...", "prompt": "..." }
→ promptDelivery.delivered = false, error: "ACP session not found in the requested tenant and owner scope: <id>"
```

ACP child + Claude CLI spawn correctly; only the JSON-RPC `session/prompt` lookup fails because the scope doesn't match the create-time scope.

## After fix (locally validated)

Two-round trip on `develop` + this patch, with Claude Code 2.1.139:

```
POST /v1/sessions { prompt: "Reply with exactly: ROUND_1_OK" }
  → promptDelivery.delivered = true
  → JSONL assistant text: ROUND_1_OK
POST /v1/sessions/<id>/send { text: "Now reply with exactly: ROUND_2_OK" }
  → { ok: true, delivered: true, attempts: 1 }
  → JSONL assistant text: ROUND_2_OK
```

## Test plan

- [ ] CI green on the affected runners (Linux + macOS).
- [ ] Manual: with `AEGIS_DISABLE_AUTH=true`, `POST /v1/sessions` with a prompt returns `promptDelivery.delivered: true` and the JSONL transcript contains the assistant reply.
- [ ] Manual: `POST /v1/sessions/:id/send` and `POST /v1/sessions/:id/command` deliver in the same unauth path.
- [ ] Regression: authenticated tenant flows continue to use `req.tenantId` and are unchanged.

## Gate notes (pre-existing, not introduced here)

`npm run gate` fails on `dashboard:tokens:gate` and `dashboard:clickable:gate` against pristine `origin/develop@613fc30`, and on three unrelated test files (`config-yaml.test.ts`, `server-core-coverage.test.ts`, `e2e/e2e-dogfood.test.ts`). All three are unrelated to ACP / `sendPrompt` / `routes/sessions.*`. Confirmed by running on pristine `origin/develop` without this patch.

This PR's changed paths (`src/routes/sessions.ts`, `src/routes/session-actions.ts`) pass `tsc --noEmit` and `npm run build` cleanly.

## Aegis version
**Developed with:** v0.6.7-preview.1