### PR TITLE
fix(ci): use live PR title in feat-minor-bump-gate (#3240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,20 +78,21 @@ jobs:
               return;
             }
 
-            const title = pr.title || '';
+            // Fetch live PR data from the API instead of using the frozen payload.
+            // This ensures re-runs pick up title changes and labels added after the initial push.
+            const { data: livePr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            const title = livePr.title || '';
             const isFeat = /^feat(\(.+\))?!?:\s/i.test(title);
             if (!isFeat) {
               core.info(`PR title is not feat:* (${title}); gate passed.`);
               return;
             }
 
-            // Fetch live labels from the API instead of using the frozen payload.
-            // This ensures re-runs pick up labels added after the initial push.
-            const { data: livePr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-            });
             const labels = (livePr.labels || []).map(label => label.name);
 
             if (labels.includes('approved-minor-bump')) {


### PR DESCRIPTION
## Summary

Fixes #3240 — `feat-minor-bump-gate` reads frozen webhook title instead of live PR title.

### Problem
The `feat-minor-bump-gate` CI job uses `pr.title` from the frozen webhook payload for the `isFeat` regex check, while already fetching `livePr` from the API for labels. Title renames via GitHub UI or after amend+force-push don't take effect.

### Fix
Moved the `livePr` API fetch **before** the title check and changed `pr.title` → `livePr.title`. Single API call now provides both live title and live labels.

### Impact
- PRs #3222 and #3238 both hit this bug (title renames ignored)
- After this fix, title renames take effect on re-run without needing amend+force-push

## Verification

```bash
# Aegis session: 4033fa18-4513-4ce6-81e7-7c50558fe5a1
# Commit: 74cc00f7
# Branch: fix/3240-gate-frozen-title → develop
# Change: 1 file, 9 insertions(+), 8 deletions(-)
```

CI workflow changes don't have unit tests — verified by reading the diff. The logic is identical to before except `pr.title` → `livePr.title` and the API call is moved up.
