### PR TITLE
fix(acp): increase default prompt timeout 60s to 120s for BYO-LLM proxies (#3243)

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -52,6 +52,7 @@ describe('config', () => {
       expect(config.tgGroupId).toBe('');
       expect(config.tgTopicTtlMs).toBe(24 * 60 * 60 * 1000);
       expect(config.hookSecretHeaderOnly).toBe(false);
+      expect(config.acpPromptTimeoutMs).toBe(120_000);
     });
   });
 

--- a/src/__tests__/health-auth-2458.test.ts
+++ b/src/__tests__/health-auth-2458.test.ts
@@ -112,7 +112,7 @@ async function buildApp(tmpDir: string): Promise<{ app: FastifyInstance; auth: A
     shutdownGraceMs: 15000,
     keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20000,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/__tests__/mcp-integration-smoke-1898.test.ts
+++ b/src/__tests__/mcp-integration-smoke-1898.test.ts
@@ -218,7 +218,7 @@ async function buildTestServer(): Promise<{
     shutdownGraceMs: 15_000,
       keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20_000,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/__tests__/oidc-auth-routes.test.ts
+++ b/src/__tests__/oidc-auth-routes.test.ts
@@ -103,7 +103,7 @@ function makeConfig(): Config {
     shutdownGraceMs: 1,
     keyRotationGraceSeconds: 1,
     shutdownHardMs: 1,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     stateStore: 'file',
     postgresUrl: '',
     dashboardEnabled: true,

--- a/src/__tests__/oidc-dashboard-manager.test.ts
+++ b/src/__tests__/oidc-dashboard-manager.test.ts
@@ -114,7 +114,7 @@ function makeConfig(): Config {
     shutdownGraceMs: 1,
     keyRotationGraceSeconds: 1,
     shutdownHardMs: 1,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     stateStore: 'file',
     postgresUrl: '',
     dashboardEnabled: true,

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -117,7 +117,7 @@ async function buildRouteContext(tmpDir: string): Promise<{
     shutdownGraceMs: 15_000,
       keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20_000,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/__tests__/session-label-2530.test.ts
+++ b/src/__tests__/session-label-2530.test.ts
@@ -84,7 +84,7 @@ async function buildRouteContext(tmpDir: string) {
       strictRBAC: false,
     sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
     shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file', postgresUrl: '', defaultTenantId: 'default', acpEnabled: false,
     tenantWorkdirs: {},

--- a/src/__tests__/session-name-validation-3091.test.ts
+++ b/src/__tests__/session-name-validation-3091.test.ts
@@ -85,7 +85,7 @@ async function buildRouteContext(tmpDir: string) {
       strictRBAC: false,
     sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
     shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file', postgresUrl: '', defaultTenantId: 'default', acpEnabled: false,
     tenantWorkdirs: {},

--- a/src/__tests__/version-endpoint-2814.test.ts
+++ b/src/__tests__/version-endpoint-2814.test.ts
@@ -111,7 +111,7 @@ async function buildApp(tmpDir: string): Promise<FastifyInstance> {
     shutdownGraceMs: 15000,
     keyRotationGraceSeconds: 3600,
     shutdownHardMs: 20000,
-      acpPromptTimeoutMs: 60_000,
+      acpPromptTimeoutMs: 120_000,
     rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
     stateStore: 'file',
     postgresUrl: '',

--- a/src/config.ts
+++ b/src/config.ts
@@ -233,7 +233,7 @@ const defaults: Config = {
   postgresUrl: '',
   rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
   acpEnabled: true,
-  acpPromptTimeoutMs: 60_000, // Issue #3223: 60s default for BYO-LLM proxy setups
+  acpPromptTimeoutMs: 120_000, // Issue #3243: 120s default for BYO-LLM proxy setups
 };
 
 /** Parse CLI args for --config flag */

--- a/src/services/acp/json-rpc-client.ts
+++ b/src/services/acp/json-rpc-client.ts
@@ -4,7 +4,7 @@ import type {
   AcpChildProcessShutdownOptions,
 } from './child-process.js';
 
-const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 const DEFAULT_ID_NAMESPACE = 'aegis-acp';
 const DEFAULT_ABANDONED_RESPONSE_GRACE_MS = 60_000;
 


### PR DESCRIPTION
## Summary
Fixes #3243 — ACP prompt delivery timeout still insufficient for BYO-LLM proxies after #3225.

### Problem
After increasing JSON-RPC timeout from 15s to 60s in #3225, session creation via API (`POST /v1/sessions`) still times out with z.ai/glm-5.1 proxy:

```
[ACP prompt timeout] session=aaebbbfd method=session/prompt timeout=60000ms
```

The `ag run` CLI path works because it uses streaming, but direct API session creation blocks for the full 60s and often fails.

### Fix
Increase default `acpPromptTimeoutMs` from 60s to 120s in:
- `src/services/acp/json-rpc-client.ts` (`DEFAULT_REQUEST_TIMEOUT_MS`)
- `src/config.ts` (default value)
- 8 test files with inline Config objects

### Verification
```bash
tsc --noEmit  ✓ (zero errors)
npm run build  ✓ (success)
npm test       ✓ (4084 passed, 1 pre-existing flake in server-core-coverage.test.ts)
```

### Next step (separate PR)
Long-term fix: make session creation async (202 + poll) so timeout doesn't block the HTTP response.

Session: Aegis session 3449acf3 (partial) + direct completion
Commit: c780641d