### PR TITLE
docs: update ACP prompt timeout default 60s→120s

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -266,7 +266,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_AUTH_TOKEN` | _(empty)_ | Master bearer token (empty = no auth) |
 | `AEGIS_STATE_DIR` | `~/.aegis` | State directory (sessions, PID file) |
 | `AEGIS_ACP_BIN` | _(auto)_ | Path to the ACP binary (auto-detected if empty) |
-| `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `60000` | Timeout in ms for ACP JSON-RPC requests (default 60s). Increase for slow BYO-LLM proxy setups (min: 1000) |
+| `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (default 120s). Increase for slow BYO-LLM proxy setups (min: 1000) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Maximum concurrent sessions |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -283,7 +283,7 @@ Aegis is configured via environment variables:
 | `AEGIS_REDIS_URL` | `redis://localhost:6379` | Redis URL (used when `AEGIS_SESSION_STORE=redis`) |
 | `AEGIS_REDIS_KEY_PREFIX` | `aegis` | Redis key prefix |
 | `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC on protected endpoints even when auth is disabled |
-| `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `60000` | Timeout in ms for ACP JSON-RPC requests (increase for slow BYO-LLM proxy setups) |
+| `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (increase for slow BYO-LLM proxy setups) |
 
 See the [Enterprise Deployment Guide](enterprise.md#configuration-reference) for the complete environment variable reference (rate limiting, OIDC, hooks, notifications, alerting, and more).
 


### PR DESCRIPTION
## Summary

Accuracy fix: PR #3244 changed `acpPromptTimeoutMs` default from `60000` (60s) to `120000` (120s), but docs from PR #3226 still showed the old default.

### Changes
- `docs/enterprise.md`: default `60000`→`120000`, description `60s`→`120s`
- `docs/getting-started.md`: default `60000`→`120000`

### Verification
```bash
grep -n 'acpPromptTimeoutMs' src/config.ts
# → acpPromptTimeoutMs: 120_000  ✅ matches updated docs
```