### PR TITLE
docs: add ag run hang troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ npx --package=@onestepat4time/aegis ag run "Build a login page with email/passwo
 
 That's it. `ag run` bootstraps config, starts the server, creates a session, and streams output to your terminal.
 
+> **If `ag run` hangs** without creating a session, use the step-by-step setup below instead — it separates server start from session creation and gives clearer error output.
+
 <details>
 <summary>With a global install (optional)</summary>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,8 @@ If the server is already running, `ag run` skips bootstrap and start — goes st
 | `--port <number>` | Server port override |
 | `--no-stream` | Don't stream output; print curl commands instead |
 
+> **Troubleshooting:** If `ag run` hangs without creating a session, fall back to the step-by-step setup below. It separates server start from session creation and gives clearer error output.
+
 ---
 
 *Everything below is for advanced setups — most users can stop here.*


### PR DESCRIPTION
## Summary

Adds a troubleshooting note for the `ag run` hang that hit our first external tester (broski, #3247).

## Changes
- **README Quick Start**: Added fallback note — if `ag run` hangs, use step-by-step setup instead
- **getting-started.md**: Added troubleshooting callout pointing to the step-by-step section

## Context
- The docs already show ONE primary path (`npx ag run`)
- The inconsistency broski reported was from two agents giving different instructions in chat, not from the docs themselves
- The `ag run` hang is a code bug (#3247), not a docs bug — but users need a fallback until it's fixed

Refs #3247