### PR TITLE
fix(cli): add timeout to ag run session creation fetch (#3247)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -232,6 +232,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
   try {
     const res = await fetch(`${baseUrl}/v1/sessions`, {
       method: 'POST',
+      signal: AbortSignal.timeout(120_000),  // Issue #3247: prevent indefinite hang
       headers,
       body: JSON.stringify({
         workDir: cwd,
@@ -251,10 +252,14 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
     writeLine(io.stdout, `  ✅ Session: ${session.displayName} (${sessionId.slice(0, 8)})`);
   } catch (e) {
     const cause = (e as { cause?: { code?: string } }).cause;
-    if (cause?.code === 'ECONNREFUSED') {
+    const errMessage = getErrorMessage(e);
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      writeLine(io.stderr, `  ❌ Session creation timed out after 120s. The server may be slow to respond with your LLM provider.`);
+      writeLine(io.stderr, `     Try setting AEGIS_ACP_PROMPT_TIMEOUT_MS=180000 and restarting.`);
+    } else if (cause?.code === 'ECONNREFUSED') {
       writeLine(io.stderr, `  ❌ Cannot connect to server at ${baseUrl}.`);
     } else {
-      writeLine(io.stderr, `  ❌ ${getErrorMessage(e)}`);
+      writeLine(io.stderr, `  ❌ ${errMessage}`);
     }
     return 1;
   }


### PR DESCRIPTION
## Summary
Fixes #3247 — `ag run` hangs silently when session creation is slow.

### Problem
`ag run` has no timeout on the `POST /v1/sessions` fetch call. When the server is slow (ACP prompt delivery with BYO-LLM proxies), the client hangs indefinitely with no feedback — exactly what broski hit as our first external tester.

### Root Cause
Two compounding issues:
1. **No client timeout**: The fetch call in `handleRun()` has no `AbortSignal.timeout()` — it hangs forever if the server is slow
2. **Server-side**: v0.6.6 has 15s ACP timeout (fixed on develop at 120s), but even with 120s the client should have its own timeout

### Fix
- Added `AbortSignal.timeout(120_000)` to the session creation fetch call
- Added specific error message for timeout: tells user to try increasing `AEGIS_ACP_PROMPT_TIMEOUT_MS`
- If timeout fires, user gets a clear error instead of silent hang

### Important note
Broski installed v0.6.6 which does NOT include the `ag run` command (added after v0.6.6 in #3043). This fix needs to ship in v0.6.7 release along with the 120s server-side timeout (#3243).

### Verification
```bash
tsc --noEmit  ✓
npm run build  ✓
npm test       ✓ (5 pre-existing failures unrelated to this change)
```

Commit: 7dadd328