### PR TITLE
fix(acp): kill entire process group on session shutdown (#3250)

### DIFF
--- a/src/services/acp/child-process.ts
+++ b/src/services/acp/child-process.ts
@@ -42,6 +42,7 @@ export interface AcpChildProcessSpawnOptions {
   env: NodeJS.ProcessEnv;
   stdio: 'pipe';
   windowsHide: true;
+  detached?: boolean;
 }
 
 export interface AcpReadableProcessStream {
@@ -241,6 +242,7 @@ export class AcpChildProcess {
       ),
       stdio: 'pipe',
       windowsHide: true,
+      detached: true,  // Issue #3250: new process group for clean tree-kill
     };
 
     let child: AcpChildProcessHandle;
@@ -330,12 +332,13 @@ export class AcpChildProcess {
     const gracefulExit = await this.waitForExitWithin(graceMs);
     if (gracefulExit) return gracefulExit;
 
-    this.child.kill('SIGTERM');
+    // Issue #3250: Kill entire process group (catches hook child processes)
+    try { process.kill(-this.child.pid!, 'SIGTERM'); } catch { this.child.kill('SIGTERM'); }
     const terminatedExit = await this.waitForExitWithin(graceMs);
     if (terminatedExit) return terminatedExit;
 
     this.shutdownEscalated = true;
-    this.child.kill('SIGKILL');
+    try { process.kill(-this.child.pid!, 'SIGKILL'); } catch { this.child.kill('SIGKILL'); }
     return this.waitForExit();
   }
 


### PR DESCRIPTION
## Summary
Fixes #3250 — CC build-on-stop hook processes orphaned after session delete.

### Problem
When a session is deleted, the CC child process is killed with `child.kill('SIGTERM')` which only kills the direct child, not its descendants. CC's `.claude/hooks/build-on-stop.sh` hooks (grandchild processes) survive as orphans.

### Evidence
After stress testing create/delete cycles:
```
4 × /bin/sh -c "$CLAUDE_PROJECT_DIR"/.claude/hooks/build-on-stop.sh
```

### Fix
1. **Spawn with `detached: true`** — creates a new process group for the CC child
2. **Kill process group** — `process.kill(-pid, 'SIGTERM')` kills the entire tree (CC + hooks + any other descendants)
3. **Fallback** — if group kill fails (e.g. already exited), falls back to individual kill

### Verification
```bash
tsc --noEmit  ✓
npm run build  ✓
npm test       ✓ (5 pre-existing failures, none related to child-process.ts)
```

Commit: 0fa3e899