### PR TITLE
feat(sessions): async prompt delivery for ACP sessions (#3243)

### DIFF
--- a/src/__tests__/async-session-create-3243.test.ts
+++ b/src/__tests__/async-session-create-3243.test.ts
@@ -1,0 +1,365 @@
+/**
+ * async-session-create-3243.test.ts — Tests for Issue #3243.
+ *
+ * POST /v1/sessions with ACP enabled + prompt must return 201 immediately
+ * with promptDelivery: { delivered: false, attempts: 0, status: 'pending' }.
+ * Prompt delivery runs asynchronously and updates session.promptDelivery
+ * once complete.
+ */
+
+import Fastify from 'fastify';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { afterAll, beforeAll, describe, expect, it, vi, type Mock } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+import { SessionManager } from '../session.js';
+import { AuthManager, DashboardSessionStore, QuotaManager, type ApiKeyPermission } from '../services/auth/index.js';
+import { MetricsCollector } from '../metrics.js';
+import { SessionMonitor } from '../monitor.js';
+import { SessionEventBus } from '../events.js';
+import { ChannelManager } from '../channels/index.js';
+import { JsonlWatcher } from '../jsonl-watcher.js';
+import { PipelineManager } from '../pipeline.js';
+import { ToolRegistry } from '../tool-registry.js';
+import { AlertManager } from '../alerting.js';
+import { SSEConnectionLimiter } from '../sse-limiter.js';
+import type { SessionInfo } from '../session.js';
+
+import {
+  registerHealthRoutes,
+  registerSessionRoutes,
+  registerSessionActionRoutes,
+  registerSessionDataRoutes,
+  registerAuthRoutes,
+  registerAuditRoutes,
+  registerEventRoutes,
+  registerTemplateRoutes,
+  registerPipelineRoutes,
+  type RouteContext,
+} from '../routes/index.js';
+
+import { type Config } from '../config.js';
+
+const MASTER_TOKEN = 'aegis-master-3243';
+
+/** Wait for async microtasks/timers to settle. */
+async function flushAsync(ms = 50): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+function buildMockAcpBackend(sendPromptImpl?: () => Promise<{ delivered: boolean; attempts: number }>) {
+  const sessionId = crypto.randomUUID();
+  const mockAcpSession = {
+    id: sessionId,
+    tenantId: '_system',
+    ownerKeyId: 'master',
+    conversationId: 'conv-1',
+    transcriptId: 'trans-1',
+    status: 'idle' as const,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+  return {
+    _mockSessionId: sessionId,
+    createSession: vi.fn().mockResolvedValue({
+      session: mockAcpSession,
+      initializeResult: {},
+      backendRunId: 'run-1',
+    }),
+    sendPrompt: vi.fn(sendPromptImpl ?? (() => Promise.resolve({ delivered: true, attempts: 1 }))),
+    shutdownSession: vi.fn().mockResolvedValue({}),
+  };
+}
+
+async function buildRouteContext(tmpDir: string, acpBackend?: ReturnType<typeof buildMockAcpBackend>) {
+  const config = {
+    port: 0, host: '127.0.0.1', authToken: MASTER_TOKEN,
+    stateDir: tmpDir,
+    claudeProjectsDir: join(tmpDir, 'projects'),
+    maxSessionAgeMs: 2 * 60 * 60 * 1000, reaperIntervalMs: 60 * 60 * 1000,
+    continuationPointerTtlMs: 24 * 60 * 60 * 1000,
+    tgBotToken: '', tgGroupId: '', tgAllowedUsers: [], tgTopicTtlMs: 0,
+    tgTopicAutoDelete: true, tgVerbose: false, tgTopicTTLHours: 0,
+    stallThresholdMs: 5 * 60 * 1000, defaultPermissionMode: 'default',
+    allowedWorkDirs: [], defaultSessionEnv: {}, metricsToken: '',
+    hookSecretHeaderOnly: false, pipelineStageTimeoutMs: 30_000,
+    webhooks: [], sseMaxConnections: 100, sseMaxPerIp: 10,
+    memoryBridge: { enabled: false }, worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+    verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
+    alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
+    envDenylist: [], envAdminAllowlist: [], enforceSessionOwnership: true,
+    strictRBAC: false,
+    sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
+    shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
+    acpPromptTimeoutMs: 120_000,
+    rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
+    stateStore: 'file', postgresUrl: '', defaultTenantId: 'default',
+    acpEnabled: acpBackend !== undefined,
+    tenantWorkdirs: {},
+  } satisfies Config;
+
+  const sessions = new SessionManager(config);
+  await sessions.load();
+
+  const auth = new AuthManager(join(tmpDir, 'keys.json'), MASTER_TOKEN);
+  auth.setHost('127.0.0.1');
+
+  const metrics = new MetricsCollector(join(tmpDir, 'metrics.json'));
+  await metrics.load();
+
+  const eventBus = new SessionEventBus();
+  const channels = new ChannelManager();
+  const monitor = new SessionMonitor(sessions, channels);
+  const jsonlWatcher = new JsonlWatcher();
+  const toolRegistry = new ToolRegistry();
+  const alertManager = new AlertManager({ webhooks: [] });
+  const sseLimiter = new SSEConnectionLimiter();
+  const pipelines = new PipelineManager(sessions, eventBus, undefined, config.pipelineStageTimeoutMs);
+  const requestKeyMap = new Map<string, string>();
+  const dashboardTokenSessions = new DashboardSessionStore();
+
+  const ctx: RouteContext = {
+    sessions,
+    auth, quotas: new QuotaManager(), config, metrics, monitor, eventBus, channels,
+    jsonlWatcher, pipelines, toolRegistry,
+    getAuditLogger: () => undefined, alertManager, sseLimiter,
+    memoryBridge: null, requestKeyMap, serverState: { draining: false },
+    validateWorkDir: async (wd: string) => wd,
+    acpBackend: acpBackend as unknown as RouteContext['acpBackend'],
+    metering: {
+      getUsageSummary: () => ({ totalInputTokens: 0, totalOutputTokens: 0, totalCacheCreationTokens: 0, totalCacheReadTokens: 0, totalCostUsd: 0, recordCount: 0, sessions: 0 }),
+      getUsageByKey: () => [], getSessionUsage: () => [], getRateTiers: () => [],
+      recordTokenUsage: () => {}, recordToolCall: () => {}, setRateTiers: () => {},
+      onUsage: () => () => {}, cleanupSession: () => {}, pruneOlderThan: () => 0,
+      start: () => {}, stop: () => {}, load: async () => {}, save: async () => {},
+      recordCount: 0,
+    } as unknown as import('../metering.js').MeteringService,
+    metricsCache: { getMetrics: vi.fn(() => ({ sessionVolume: [], tokenUsageByModel: [], costTrends: [], topApiKeys: [], durationTrends: [], errorRates: { totalSessions: 0, failedSessions: 0, failureRate: 0, permissionPrompts: 0, approvals: 0, autoApprovals: 0 }, generatedAt: new Date().toISOString() })), start: vi.fn(async () => {}), stop: vi.fn(async () => {}), invalidate: vi.fn(), flush: vi.fn(async () => {}) } as unknown as RouteContext['metricsCache'],
+    dashboardTokenSessions,
+  };
+
+  return { ctx, sessions, auth };
+}
+
+async function buildApp(ctx: RouteContext) {
+  const app = Fastify({ logger: false });
+
+  app.decorateRequest('authKeyId', null as unknown as string);
+  app.decorateRequest('tenantId', undefined as unknown as string);
+  app.decorateRequest('matchedPermission', null as unknown as ApiKeyPermission);
+  app.decorateRequest('authRole', null);
+  app.decorateRequest('authPermissions', null);
+  app.decorateRequest('authActor', null);
+
+  app.addHook('onRequest', async (req: FastifyRequest, reply: FastifyReply) => {
+    const urlPath = req.url?.split('?')[0] ?? '';
+    if (urlPath === '/health' || urlPath === '/v1/health') return;
+    if (urlPath === '/v1/auth/verify') return;
+
+    const header = req.headers.authorization;
+    const token = header?.startsWith('Bearer ') ? header.slice(7) : undefined;
+    if (!token) return reply.status(401).send({ error: 'Unauthorized' });
+    const result = ctx.auth.validate(token);
+    if (!result.valid) return reply.status(401).send({ error: 'Unauthorized' });
+    req.authKeyId = result.keyId;
+    req.tenantId = result.keyId === 'master' ? '_system' : undefined;
+  });
+
+  registerHealthRoutes(app, ctx);
+  registerAuthRoutes(app, ctx);
+  registerAuditRoutes(app, ctx);
+  registerSessionRoutes(app, ctx);
+  registerSessionActionRoutes(app, ctx);
+  registerSessionDataRoutes(app, ctx);
+  registerEventRoutes(app, ctx);
+  registerTemplateRoutes(app, ctx);
+  registerPipelineRoutes(app, ctx);
+
+  const address = await app.listen({ port: 0, host: '127.0.0.1' });
+  const port = parseInt(address.split(':').pop()!, 10);
+  return { app, port };
+}
+
+const authHeaders = (token = MASTER_TOKEN) => ({
+  Authorization: `Bearer ${token}`,
+  'Content-Type': 'application/json',
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Issue #3243 — async session create (ACP + prompt)', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-async-create-3243-'));
+  });
+
+  describe('POST /v1/sessions — fire-and-forget sendPrompt', () => {
+    it('returns 201 immediately with promptDelivery.status: pending', async () => {
+      // sendPrompt resolves instantly — check that response has status: 'pending' regardless
+      const acpBackend = buildMockAcpBackend(() => Promise.resolve({ delivered: true, attempts: 1 }));
+      const { ctx, sessions } = await buildRouteContext(tmpDir, acpBackend);
+      const { app, port } = await buildApp(ctx);
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/v1/sessions`, {
+          method: 'POST',
+          headers: authHeaders(),
+          body: JSON.stringify({ workDir: tmpDir, prompt: 'Build a REST API' }),
+        });
+
+        expect(res.status).toBe(201);
+        const body = await res.json() as Record<string, unknown>;
+        expect(body.id).toBeDefined();
+
+        const pd = body.promptDelivery as { delivered: boolean; attempts: number; status: string } | undefined;
+        expect(pd).toBeDefined();
+        expect(pd?.status).toBe('pending');
+        expect(pd?.delivered).toBe(false);
+        expect(pd?.attempts).toBe(0);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('updates session.promptDelivery.status to delivered after sendPrompt resolves', async () => {
+      let resolvePrompt!: (val: { delivered: boolean; attempts: number }) => void;
+      const deferredPrompt = new Promise<{ delivered: boolean; attempts: number }>((r) => {
+        resolvePrompt = r;
+      });
+
+      const acpBackend = buildMockAcpBackend(() => deferredPrompt);
+      const subTmpDir = mkdtempSync(join(tmpdir(), 'aegis-async-3243b-'));
+      const { ctx, sessions } = await buildRouteContext(subTmpDir, acpBackend);
+      const { app, port } = await buildApp(ctx);
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/v1/sessions`, {
+          method: 'POST',
+          headers: authHeaders(),
+          body: JSON.stringify({ workDir: subTmpDir, prompt: 'Do the thing' }),
+        });
+        expect(res.status).toBe(201);
+        const body = await res.json() as Record<string, unknown>;
+        const sessionId = body.id as string;
+
+        // At this point promptDelivery.status must be 'pending'
+        expect((body.promptDelivery as Record<string, unknown>)?.status).toBe('pending');
+
+        // Resolve sendPrompt — simulating successful prompt delivery
+        resolvePrompt({ delivered: true, attempts: 1 });
+
+        // Wait for the fire-and-forget callback to update session state
+        await flushAsync(100);
+
+        // GET the session and verify promptDelivery was updated
+        const getRes = await fetch(`http://127.0.0.1:${port}/v1/sessions/${sessionId}`, {
+          headers: authHeaders(),
+        });
+        expect(getRes.status).toBe(200);
+        const session = await getRes.json() as Record<string, unknown>;
+        const pd = session.promptDelivery as { delivered: boolean; attempts: number; status: string };
+        expect(pd.status).toBe('delivered');
+        expect(pd.delivered).toBe(true);
+        expect(pd.attempts).toBe(1);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('updates session.promptDelivery.status to failed after sendPrompt rejects', async () => {
+      let rejectPrompt!: (err: Error) => void;
+      const deferredPrompt = new Promise<{ delivered: boolean; attempts: number }>((_, r) => {
+        rejectPrompt = r;
+      });
+
+      const acpBackend = buildMockAcpBackend(() => deferredPrompt);
+      const subTmpDir = mkdtempSync(join(tmpdir(), 'aegis-async-3243c-'));
+      const { ctx, sessions } = await buildRouteContext(subTmpDir, acpBackend);
+      const { app, port } = await buildApp(ctx);
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/v1/sessions`, {
+          method: 'POST',
+          headers: authHeaders(),
+          body: JSON.stringify({ workDir: subTmpDir, prompt: 'Fail me' }),
+        });
+        expect(res.status).toBe(201);
+        const body = await res.json() as Record<string, unknown>;
+        const sessionId = body.id as string;
+
+        expect((body.promptDelivery as Record<string, unknown>)?.status).toBe('pending');
+
+        // Reject sendPrompt — simulating delivery failure
+        rejectPrompt(new Error('timeout'));
+
+        await flushAsync(100);
+
+        const getRes = await fetch(`http://127.0.0.1:${port}/v1/sessions/${sessionId}`, {
+          headers: authHeaders(),
+        });
+        const session = await getRes.json() as Record<string, unknown>;
+        const pd = session.promptDelivery as { delivered: boolean; attempts: number; status: string };
+        expect(pd.status).toBe('failed');
+        expect(pd.delivered).toBe(false);
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('SessionInfo.promptDelivery — status field', () => {
+    it('accepts status: pending on promptDelivery', () => {
+      const session: SessionInfo = {
+        id: 'test', windowId: '', displayName: 'test', workDir: '/tmp',
+        byteOffset: 0, monitorOffset: 0, status: 'pending',
+        createdAt: Date.now(), lastActivity: Date.now(),
+        stallThresholdMs: 300_000, permissionStallMs: 300_000,
+        permissionMode: 'default',
+        promptDelivery: { delivered: false, attempts: 0, status: 'pending' },
+      };
+      expect(session.promptDelivery?.status).toBe('pending');
+    });
+
+    it('accepts status: delivered on promptDelivery', () => {
+      const session: SessionInfo = {
+        id: 'test', windowId: '', displayName: 'test', workDir: '/tmp',
+        byteOffset: 0, monitorOffset: 0, status: 'idle',
+        createdAt: Date.now(), lastActivity: Date.now(),
+        stallThresholdMs: 300_000, permissionStallMs: 300_000,
+        permissionMode: 'default',
+        promptDelivery: { delivered: true, attempts: 1, status: 'delivered' },
+      };
+      expect(session.promptDelivery?.status).toBe('delivered');
+    });
+
+    it('accepts status: failed on promptDelivery', () => {
+      const session: SessionInfo = {
+        id: 'test', windowId: '', displayName: 'test', workDir: '/tmp',
+        byteOffset: 0, monitorOffset: 0, status: 'error',
+        createdAt: Date.now(), lastActivity: Date.now(),
+        stallThresholdMs: 300_000, permissionStallMs: 300_000,
+        permissionMode: 'default',
+        promptDelivery: { delivered: false, attempts: 1, status: 'failed' },
+      };
+      expect(session.promptDelivery?.status).toBe('failed');
+    });
+
+    it('accepts status: timeout on promptDelivery', () => {
+      const session: SessionInfo = {
+        id: 'test', windowId: '', displayName: 'test', workDir: '/tmp',
+        byteOffset: 0, monitorOffset: 0, status: 'idle',
+        createdAt: Date.now(), lastActivity: Date.now(),
+        stallThresholdMs: 300_000, permissionStallMs: 300_000,
+        permissionMode: 'default',
+        promptDelivery: { delivered: false, attempts: 1, status: 'timeout' },
+      };
+      expect(session.promptDelivery?.status).toBe('timeout');
+    });
+  });
+});

--- a/src/__tests__/run-prompt-poll-3243.test.ts
+++ b/src/__tests__/run-prompt-poll-3243.test.ts
@@ -1,0 +1,218 @@
+/**
+ * run-prompt-poll-3243.test.ts — Tests for Issue #3243.
+ *
+ * After ag run creates a session with a prompt, if promptDelivery.status is
+ * 'pending', handleRun must poll GET /v1/sessions/:id every 2s until the
+ * status is no longer 'pending' (max 180s).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleRun } from '../commands/run.js';
+
+// Module-scoped mocks (hoisted by vitest)
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn().mockResolvedValue({
+    port: 9100,
+    host: '127.0.0.1',
+    authToken: '',
+    baseUrl: 'http://127.0.0.1:9100',
+    acpEnabled: true,
+  }),
+  readConfigFile: vi.fn().mockResolvedValue({
+    authToken: '',
+    baseUrl: 'http://127.0.0.1:9100',
+  }),
+  writeConfigFile: vi.fn(),
+  serializeConfigFile: vi.fn().mockReturnValue(''),
+}));
+
+vi.mock('../base-url.js', () => ({
+  deriveBaseUrl: vi.fn().mockReturnValue('http://127.0.0.1:9100'),
+  getConfiguredBaseUrl: vi.fn().mockReturnValue('http://127.0.0.1:9100'),
+  normalizeBaseUrl: vi.fn((u: string) => u),
+}));
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeIO() {
+  const outLines: string[] = [];
+  const errLines: string[] = [];
+  return {
+    io: {
+      stdin: { pipe: vi.fn() } as unknown as NodeJS.ReadableStream,
+      stdout: {
+        write: vi.fn((text: string) => { outLines.push(text); return true; }),
+      } as unknown as NodeJS.WritableStream,
+      stderr: {
+        write: vi.fn((text: string) => { errLines.push(text); return true; }),
+      } as unknown as NodeJS.WritableStream,
+    },
+    outLines,
+    errLines,
+  };
+}
+
+/** Build a fetch mock that handles the run flow in sequence. */
+function buildFetchMock(opts: {
+  sessionResponse: { id: string; displayName: string; promptDelivery?: { status: string } };
+  pollResponses?: Array<{ promptDelivery?: { status: string } }>;
+}) {
+  const { sessionResponse, pollResponses = [] } = opts;
+  let pollCallCount = 0;
+
+  return vi.fn(async (url: string | URL | Request, fetchOpts?: RequestInit) => {
+    const urlStr = String(url);
+
+    // Health check
+    if (urlStr.includes('/v1/health')) {
+      return {
+        ok: true,
+        json: async () => ({ healthy: true, version: '0.0.0' }),
+      } as Response;
+    }
+
+    // Session creation
+    if (urlStr.endsWith('/v1/sessions') && fetchOpts?.method === 'POST') {
+      return {
+        ok: true,
+        json: async () => sessionResponse,
+      } as Response;
+    }
+
+    // Poll GET /v1/sessions/:id (no trailing path segment after UUID)
+    const pollMatch = /\/v1\/sessions\/[0-9a-f-]+$/.test(urlStr);
+    if (pollMatch && (!fetchOpts?.method || fetchOpts.method === 'GET')) {
+      const response = pollResponses[pollCallCount] ?? { promptDelivery: { status: 'delivered' } };
+      pollCallCount++;
+      return {
+        ok: true,
+        json: async () => response,
+      } as Response;
+    }
+
+    // Default: success
+    return { ok: true, json: async () => ({}) } as Response;
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Issue #3243 — ag run polls for prompt delivery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('does not poll when promptDelivery is absent from the session response', async () => {
+    const mockFetch = buildFetchMock({
+      sessionResponse: { id: '00000000-0000-0000-0000-000000000001', displayName: 'run-test' },
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { io } = makeIO();
+    const runPromise = handleRun(['do the thing', '--no-stream'], io);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    // No poll call should happen (no UUID GET after session creation)
+    const pollCalls = mockFetch.mock.calls.filter(([url]) => {
+      const urlStr = String(url);
+      return /\/v1\/sessions\/[0-9a-f-]+$/.test(urlStr);
+    });
+    expect(pollCalls).toHaveLength(0);
+  });
+
+  it('polls GET /v1/sessions/:id when promptDelivery.status is pending', async () => {
+    const mockFetch = buildFetchMock({
+      sessionResponse: {
+        id: '00000000-0000-0000-0000-000000000002',
+        displayName: 'run-pending',
+        promptDelivery: { status: 'pending' },
+      },
+      pollResponses: [{ promptDelivery: { status: 'delivered' } }],
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { io } = makeIO();
+    const runPromise = handleRun(['do the thing', '--no-stream'], io);
+    // Advance the 2s poll interval
+    await vi.advanceTimersByTimeAsync(2500);
+    await runPromise;
+
+    const pollCalls = mockFetch.mock.calls.filter(([url]) => {
+      return /\/v1\/sessions\/[0-9a-f-]+$/.test(String(url));
+    });
+    expect(pollCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stops polling when promptDelivery.status is no longer pending', async () => {
+    let pollCount = 0;
+    const mockFetch = vi.fn(async (url: string | URL | Request, fetchOpts?: RequestInit) => {
+      const urlStr = String(url);
+      if (urlStr.includes('/v1/health')) {
+        return { ok: true, json: async () => ({}) } as Response;
+      }
+      if (urlStr.endsWith('/v1/sessions') && fetchOpts?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({ id: '00000000-0000-0000-0000-000000000003', displayName: 'run-stops', promptDelivery: { status: 'pending' } }),
+        } as Response;
+      }
+      if (/\/v1\/sessions\/[0-9a-f-]+$/.test(urlStr)) {
+        pollCount++;
+        if (pollCount === 1) return { ok: true, json: async () => ({ promptDelivery: { status: 'pending' } }) } as Response;
+        return { ok: true, json: async () => ({ promptDelivery: { status: 'delivered' } }) } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { io } = makeIO();
+    const runPromise = handleRun(['do the thing', '--no-stream'], io);
+    // Advance past 2 poll intervals (2s each)
+    await vi.advanceTimersByTimeAsync(5000);
+    await runPromise;
+
+    // Should have polled twice: first returned pending, second returned delivered → stopped
+    expect(pollCount).toBe(2);
+  });
+
+  it('times out after 180s if promptDelivery.status stays pending', async () => {
+    const mockFetch = buildFetchMock({
+      sessionResponse: {
+        id: '00000000-0000-0000-0000-000000000004',
+        displayName: 'run-timeout',
+        promptDelivery: { status: 'pending' },
+      },
+      // All poll responses stay 'pending'
+      pollResponses: Array(200).fill({ promptDelivery: { status: 'pending' } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { io } = makeIO();
+    const runPromise = handleRun(['do the thing', '--no-stream'], io);
+    // Advance past 180s timeout
+    await vi.advanceTimersByTimeAsync(185_000);
+    const code = await runPromise;
+
+    // Should exit cleanly (not error) after timeout
+    expect(code).toBe(0);
+
+    // Should NOT have polled indefinitely
+    const pollCalls = mockFetch.mock.calls.filter(([url]) => {
+      return /\/v1\/sessions\/[0-9a-f-]+$/.test(String(url));
+    });
+    // 180s / 2s interval = 90 polls max
+    expect(pollCalls.length).toBeLessThanOrEqual(91);
+  });
+});

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -232,7 +232,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
   try {
     const res = await fetch(`${baseUrl}/v1/sessions`, {
       method: 'POST',
-      signal: AbortSignal.timeout(120_000),  // Issue #3247: prevent indefinite hang
+      signal: AbortSignal.timeout(30_000),  // Issue #3243: session creation is now fast (prompt delivery is async)
       headers,
       body: JSON.stringify({
         workDir: cwd,
@@ -247,9 +247,41 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
       return 1;
     }
 
-    const session = await res.json() as { id: string; displayName: string };
+    const session = await res.json() as { id: string; displayName: string; promptDelivery?: { status?: string } };
     sessionId = session.id;
     writeLine(io.stdout, `  ✅ Session: ${session.displayName} (${sessionId.slice(0, 8)})`);
+
+    // Issue #3243: Poll for async prompt delivery if pending
+    if (session.promptDelivery?.status === 'pending') {
+      writeLine(io.stdout, '  ⏳ Delivering prompt...');
+      const pollStart = Date.now();
+      const pollTimeout = 180_000; // 3 min max wait for prompt delivery
+      while (Date.now() - pollStart < pollTimeout) {
+        await new Promise(r => setTimeout(r, 2000));
+        try {
+          const pollRes = await fetch(`${baseUrl}/v1/sessions/${sessionId}`, {
+            headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+            signal: AbortSignal.timeout(5000),
+          });
+          if (pollRes.ok) {
+            const pollData = await pollRes.json() as { promptDelivery?: { status?: string; delivered?: boolean } };
+            const pdStatus = pollData.promptDelivery?.status;
+            if (pdStatus === 'delivered') {
+              writeLine(io.stdout, '  ✅ Prompt delivered');
+              break;
+            } else if (pdStatus === 'failed' || pdStatus === 'timeout') {
+              writeLine(io.stderr, `  ⚠️  Prompt delivery ${pdStatus}. Session exists but agent may not have received the prompt.`);
+              break;
+            }
+          }
+        } catch {
+          // Polling error — session may still be initializing
+        }
+      }
+      if (Date.now() - pollStart >= pollTimeout) {
+        writeLine(io.stderr, '  ⚠️  Prompt delivery timed out after 3 minutes. Session exists but agent may be slow to respond.');
+      }
+    }
   } catch (e) {
     const cause = (e as { cause?: { code?: string } }).cause;
     const errMessage = getErrorMessage(e);

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -456,7 +456,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       meta: prompt ? { prompt: prompt.slice(0, 200), permissionMode: permissionMode ?? (autoApprove ? 'bypassPermissions' : undefined) } : undefined,
     });
 
-    let promptDelivery: { delivered: boolean; attempts: number } | undefined;
+    let promptDelivery: { delivered: boolean; attempts: number; status?: 'pending' | 'delivered' | 'failed' | 'timeout' } | undefined;
     if (prompt) {
       let finalPrompt = prompt;
       if (memoryKeys && memoryKeys.length > 0 && memoryBridge) {
@@ -468,10 +468,27 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           finalPrompt = lines.join('\n');
         }
       }
-      promptDelivery = acpBackend && ctx.config.acpEnabled
-        ? await acpBackend.sendPrompt(session.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
-        : await sessions.sendInitialPrompt(session.id, finalPrompt);
-      metrics.promptSent(promptDelivery.delivered);
+
+      if (acpBackend && ctx.config.acpEnabled) {
+        // Issue #3243: Async prompt delivery for ACP sessions.
+        // Return immediately with status 'pending'; deliver prompt in background.
+        // The client polls GET /v1/sessions/:id to check promptDelivery.status.
+        promptDelivery = { delivered: false, attempts: 0, status: 'pending' };
+        session.promptDelivery = promptDelivery;
+        const deliverAsync = async () => {
+          try {
+            const result = await acpBackend.sendPrompt(session.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' });
+            session.promptDelivery = { delivered: result.delivered, attempts: result.attempts, status: result.delivered ? 'delivered' : 'failed' };
+            metrics.promptSent(result.delivered);
+          } catch (e) {
+            session.promptDelivery = { delivered: false, attempts: 1, status: 'failed' };
+          }
+        };
+        void deliverAsync();
+      } else {
+        promptDelivery = await sessions.sendInitialPrompt(session.id, finalPrompt);
+        metrics.promptSent(promptDelivery.delivered);
+      }
     }
 
     // Issue #3068: Warn when ACP is disabled — sessions are created but no agent runs

--- a/src/session.ts
+++ b/src/session.ts
@@ -129,7 +129,7 @@ export interface SessionInfo {
   autoApprove?: boolean;        // API contract compat: auto-approve flag
   pendingPermission?: PendingPermissionInfo;  // API contract compat: active permission prompt
   pendingQuestion?: PendingQuestionInfo;       // API contract compat: active question
-  promptDelivery?: { delivered: boolean; attempts: number };  // API contract compat: prompt status
+  promptDelivery?: { delivered: boolean; attempts: number; status?: "pending" | "delivered" | "failed" | "timeout" };  // Issue #3243: async prompt delivery status
   actionHints?: Record<string, { method: string; url: string; description: string }>;  // API contract compat: actionable hints
   // Issue #2518: Hook failure circuit breaker
   hookFailureTimestamps?: number[];   // Sliding window of StopFailure timestamps (ms)


### PR DESCRIPTION
## Summary
Fixes #3243 — `POST /v1/sessions` no longer blocks on prompt delivery.

### Problem
Session creation with a prompt blocks on `acpBackend.sendPrompt()` which can take 120s+ with slow BYO-LLM proxies (z.ai/glm-5.1). The client hangs waiting for the HTTP response, and if the server-side timeout fires first, the prompt is never delivered.

### Solution
**Server:** For ACP sessions with a prompt, return 201 immediately with `promptDelivery: { delivered: false, attempts: 0, status: 'pending' }`. Deliver the prompt in the background via fire-and-forget. Update `session.promptDelivery.status` to `delivered`/`failed` when the background task completes.

**Client (`ag run`):** After creating a session, if `promptDelivery.status === 'pending'`, poll `GET /v1/sessions/:id` every 2s until status changes (max 180s).

**Backward compatible:** Non-ACP sessions (tmux mode) still use synchronous prompt delivery. Session reuse path unchanged.

### Files Changed
- `src/session.ts` — Extended `promptDelivery` type with `status?: 'pending' | 'delivered' | 'failed' | 'timeout'`
- `src/routes/sessions.ts` — Async prompt delivery for ACP sessions (fire-and-forget)
- `src/commands/run.ts` — Client polling for prompt delivery status
- `src/__tests__/run-prompt-poll-3243.test.ts` — Fixed test session IDs (non-UUID caused mock mismatch)
- `src/__tests__/async-session-create-3243.test.ts` — 7 server-side async tests (pre-existing TDD scaffold)

### Verification
```bash
tsc --noEmit  ✓ (0 errors)
npm run build  ✓
npm test       ✓ (4095 passed, 1 pre-existing flake in server-core-coverage)
```

All 11 new/updated tests pass:
- 4 client polling tests (`run-prompt-poll-3243.test.ts`)
- 7 server async tests (`async-session-create-3243.test.ts`)

Commit: bfde2a0a