### PR TITLE
fix(dashboard): add promptDelivery.status to schema, types, and equality check (#3256)

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -633,7 +633,7 @@ export function getScreenshot(id: string): Promise<{ image: string; mimeType?: s
 // ── Batch ──────────────────────────────────────────────────────
 
 export interface BatchResult {
-  sessions: Array<{ id: string; name: string; promptDelivery?: { delivered: boolean; attempts: number } }>;
+  sessions: Array<{ id: string; name: string; promptDelivery?: { delivered: boolean; attempts: number; status?: 'pending' | 'delivered' | 'failed' | 'timeout' } }>;
   created: number;
   failed: number;
   errors: string[];

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -201,7 +201,7 @@ export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
   permissionRespondedAt: z.number().optional(),
   pendingPermission: PendingPermissionInfoSchema.optional(),
   pendingQuestion: PendingQuestionInfoSchema.optional(),
-  promptDelivery: z.object({ delivered: z.boolean(), attempts: z.number() }).optional(),
+  promptDelivery: z.object({ delivered: z.boolean(), attempts: z.number(), status: z.enum(['pending', 'delivered', 'failed', 'timeout']).optional() }).optional(),
   actionHints: z.record(z.string(), z.object({
     method: z.string(),
     url: z.string(),

--- a/dashboard/src/store/useStore.ts
+++ b/dashboard/src/store/useStore.ts
@@ -57,6 +57,7 @@ function areSessionsEqual(a: SessionInfo[], b: SessionInfo[]): boolean {
       || left.settingsPatched !== right.settingsPatched
       || left.promptDelivery?.delivered !== right.promptDelivery?.delivered
       || left.promptDelivery?.attempts !== right.promptDelivery?.attempts
+      || left.promptDelivery?.status !== right.promptDelivery?.status
     ) {
       return false;
     }

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -63,7 +63,7 @@ export interface SessionInfo {
   permissionRespondedAt?: number;
   pendingPermission?: PendingPermissionInfo;
   pendingQuestion?: PendingQuestionInfo;
-  promptDelivery?: { delivered: boolean; attempts: number };
+  promptDelivery?: { delivered: boolean; attempts: number; status?: 'pending' | 'delivered' | 'failed' | 'timeout' };  // Issue #3256
   actionHints?: Record<string, {
     method: string;
     url: string;


### PR DESCRIPTION
## Summary
Fixes #3256 — Dashboard was not updated for the new `promptDelivery.status` field added in #3253.

### Changes
1. **`src/api-contracts.ts`** (source of truth) — added `status?: 'pending' | 'delivered' | 'failed' | 'timeout'` to promptDelivery type
2. **`dashboard/src/api/schemas.ts`** — added `status` to Zod schema so parsed data includes it
3. **`dashboard/src/api/client.ts`** — added `status` to inline type for batch endpoint
4. **`dashboard/src/store/useStore.ts`** — added `status` to equality check so pending→delivered transitions trigger re-renders

### Verification
```bash
tsc --noEmit (dashboard) ✓
npm run build ✓
```

Commit: 4379140f