### PR TITLE
fix(dashboard): promptDelivery schema missing status field (#3256)

### DIFF
--- a/dashboard/src/__tests__/schemas.test.ts
+++ b/dashboard/src/__tests__/schemas.test.ts
@@ -119,6 +119,35 @@ describe('SessionInfoSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+  it('accepts promptDelivery with status field', () => {
+    const result = SessionInfoSchema.safeParse({
+      ...validPayload,
+      promptDelivery: { delivered: false, attempts: 0, status: 'pending' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.promptDelivery?.status).toBe('pending');
+    }
+  });
+
+  it('accepts promptDelivery without status (backward compatible)', () => {
+    const result = SessionInfoSchema.safeParse({
+      ...validPayload,
+      promptDelivery: { delivered: true, attempts: 1 },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.promptDelivery?.status).toBeUndefined();
+    }
+  });
+
+  it('rejects promptDelivery with invalid status', () => {
+    const result = SessionInfoSchema.safeParse({
+      ...validPayload,
+      promptDelivery: { delivered: false, attempts: 0, status: 'unknown' },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('SessionSSEEventDataSchema', () => {

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -633,7 +633,7 @@ export function getScreenshot(id: string): Promise<{ image: string; mimeType?: s
 // ── Batch ──────────────────────────────────────────────────────
 
 export interface BatchResult {
-  sessions: Array<{ id: string; name: string; promptDelivery?: { delivered: boolean; attempts: number } }>;
+  sessions: Array<{ id: string; name: string; promptDelivery?: { delivered: boolean; attempts: number; status?: 'pending' | 'delivered' | 'failed' | 'timeout' } }>;
   created: number;
   failed: number;
   errors: string[];

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -201,7 +201,7 @@ export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
   permissionRespondedAt: z.number().optional(),
   pendingPermission: PendingPermissionInfoSchema.optional(),
   pendingQuestion: PendingQuestionInfoSchema.optional(),
-  promptDelivery: z.object({ delivered: z.boolean(), attempts: z.number() }).optional(),
+  promptDelivery: z.object({ delivered: z.boolean(), attempts: z.number(), status: z.enum(['pending', 'delivered', 'failed', 'timeout']).optional() }).optional(),
   actionHints: z.record(z.string(), z.object({
     method: z.string(),
     url: z.string(),

--- a/dashboard/src/store/useStore.ts
+++ b/dashboard/src/store/useStore.ts
@@ -57,6 +57,7 @@ function areSessionsEqual(a: SessionInfo[], b: SessionInfo[]): boolean {
       || left.settingsPatched !== right.settingsPatched
       || left.promptDelivery?.delivered !== right.promptDelivery?.delivered
       || left.promptDelivery?.attempts !== right.promptDelivery?.attempts
+      || left.promptDelivery?.status !== right.promptDelivery?.status
     ) {
       return false;
     }

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -63,7 +63,7 @@ export interface SessionInfo {
   permissionRespondedAt?: number;
   pendingPermission?: PendingPermissionInfo;
   pendingQuestion?: PendingQuestionInfo;
-  promptDelivery?: { delivered: boolean; attempts: number };
+  promptDelivery?: { delivered: boolean; attempts: number; status?: 'pending' | 'delivered' | 'failed' | 'timeout' };  // Issue #3256
   actionHints?: Record<string, {
     method: string;
     url: string;


### PR DESCRIPTION
## Summary
Fixes #3256 — Dashboard was not updated for async prompt delivery from #3253.

## Problem
PR #3253 added `promptDelivery.status` (`pending | delivered | failed | timeout`) to the backend, but the dashboard's Zod schema, inline types, and store equality check were not updated.

This caused:
1. **Schema stripping** — Zod schema silently dropped the `status` field during parsing
2. **Stale renders** — Store equality check didn't compare `status`, so `pending → delivered` transitions wouldn't trigger re-renders

## Changes
- `dashboard/src/api/schemas.ts` — Added `status` enum to Zod schema
- `dashboard/src/api/client.ts` — Added `status` to BatchResult inline type
- `dashboard/src/store/useStore.ts` — Added `status` to equality check
- `src/api-contracts.ts` — Added `status` to canonical SessionInfo type
- `dashboard/src/__tests__/schemas.test.ts` — 3 new tests: status accepted, backward compatible, invalid status rejected

## Verification
- `npx tsc --noEmit` — 0 errors
- `npm test` — 1265 passed, 0 failed (128 files)
- Backward compatible: `status` is optional in all locations

— Daedalus 🏛️