### PR TITLE
fix(cli): use AuthManager for ag run auth bootstrap (#3261)

### DIFF
--- a/src/__tests__/fix-3261-ag-run-auth.test.ts
+++ b/src/__tests__/fix-3261-ag-run-auth.test.ts
@@ -1,0 +1,140 @@
+/**
+ * fix-3261-ag-run-auth.test.ts
+ *
+ * Issue #3261: `ag run` fails with Unauthorized when server has keys.json
+ * but no config.yaml. The root cause was ensureConfig() generating a random
+ * token not registered in keys.json. Fix: use AuthManager.createKey() to
+ * properly register the key, and show a helpful 401 error message.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const AUTH_MANAGER_PATH = '../services/auth/index.js';
+const CONFIG_PATH = '../config.js';
+
+describe('Issue #3261: ag run auth bootstrap', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `aegis-test-3261-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('ensureConfig creates a key in keys.json via AuthManager (not a random token)', async () => {
+    const { AuthManager } = await import(AUTH_MANAGER_PATH);
+
+    const keysFile = join(tmpDir, 'keys.json');
+    const authManager = new AuthManager(keysFile);
+    await authManager.load();
+
+    const createdKey = await authManager.createKey('ag-run-admin', 100, undefined, 'admin');
+
+    expect(createdKey.key).toBeTruthy();
+    // AuthManager generates keys with 'aegis_' prefix
+    expect(createdKey.key).toMatch(/^aegis_/);
+    expect(createdKey.role).toBe('admin');
+
+    // Verify the key was persisted to keys.json
+    const authManager2 = new AuthManager(keysFile);
+    await authManager2.load();
+
+    const result = authManager2.validate(createdKey.key);
+    expect(result.valid).toBe(true);
+  });
+
+  it('ensureConfig-generated token is recognized by a fresh AuthManager load', async () => {
+    const { AuthManager } = await import(AUTH_MANAGER_PATH);
+
+    const keysFile = join(tmpDir, 'keys.json');
+
+    const m1 = new AuthManager(keysFile);
+    await m1.load();
+    const key = await m1.createKey('test-admin', 100, undefined, 'admin');
+
+    // Simulate server loading keys.json fresh
+    const m2 = new AuthManager(keysFile);
+    await m2.load();
+
+    const result = m2.validate(key.key);
+    expect(result.valid).toBe(true);
+    expect(result.keyId).toBe(key.id);
+  });
+
+  it('random token not in keys.json is rejected when keys exist', async () => {
+    const { AuthManager } = await import(AUTH_MANAGER_PATH);
+
+    const keysFile = join(tmpDir, 'keys.json');
+    const authManager = new AuthManager(keysFile);
+    await authManager.load();
+
+    // Create a real key first (so the store is non-empty and validate doesn't allow-all)
+    await authManager.createKey('real-key', 100, undefined, 'admin');
+
+    // This is what the OLD ensureConfig generated — a token not in keys.json
+    const randomToken = `aegis-quickstart-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+    const result = authManager.validate(randomToken);
+    expect(result.valid).toBe(false);
+  });
+
+  it('ensureConfig reads existing config and returns its token', async () => {
+    const { serializeConfigFile } = await import(CONFIG_PATH);
+    const configPath = join(tmpDir, 'config.yaml');
+    const existingToken = 'aegis-existing-token-12345';
+    const configText = serializeConfigFile({
+      authToken: existingToken,
+      baseUrl: 'http://127.0.0.1:9100',
+      dashboardEnabled: true,
+    }, configPath);
+    writeFileSync(configPath, configText, 'utf-8');
+
+    const { readConfigFile } = await import(CONFIG_PATH);
+    const read = await readConfigFile(configPath);
+    expect(read).not.toBeNull();
+    expect(read!.authToken).toBe(existingToken);
+  });
+
+  it('401 response triggers helpful error message', async () => {
+    const { handleRun } = await import('../commands/run.js');
+
+    const outputLines: string[] = [];
+    const io = {
+      stdin: process.stdin,
+      stdout: { write: (text: string) => outputLines.push(text) } as any,
+      stderr: { write: (text: string) => outputLines.push(text) } as any,
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string, opts: any) => {
+      if (String(url).includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (String(url).includes('/v1/sessions') && opts?.method === 'POST') {
+        return new Response(
+          JSON.stringify({ code: 'UNAUTHORIZED', message: 'Unauthorized — Bearer token required' }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+
+    try {
+      const result = await handleRun(['test prompt'], io);
+      expect(result).toBe(1);
+
+      const output = outputLines.join('');
+      expect(output).toContain('Unauthorized');
+      expect(output).toContain('ag init');
+      expect(output).toContain('AEGIS_AUTH_TOKEN');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -16,6 +16,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { deriveBaseUrl, getConfiguredBaseUrl, normalizeBaseUrl } from '../base-url.js';
+import { AuthManager } from '../services/auth/index.js';
 import { loadConfig, readConfigFile, writeConfigFile, serializeConfigFile, type Config } from '../config.js';
 import { getErrorMessage, parseIntSafe } from '../validation.js';
 
@@ -55,20 +56,30 @@ async function waitForServer(baseUrl: string, authToken: string | undefined, tim
   return false;
 }
 
-/** Bootstrap config with sensible defaults if none exists. */
-async function ensureConfig(configPath: string): Promise<string | undefined> {
+/**
+ * Bootstrap config with sensible defaults if none exists.
+ * Issue #3261: Use AuthManager to create a proper key in keys.json,
+ * not a random token that the server won't recognize.
+ */
+async function ensureConfig(configPath: string, stateDir: string): Promise<string | undefined> {
   const existing = await readConfigFile(configPath);
   if (existing) {
     return existing.authToken || existing.clientAuthToken || undefined;
   }
 
-  // Create minimal config with generated auth token
-  const token = `aegis-quickstart-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  // Issue #3261: Use AuthManager to register the key in keys.json.
+  // This mirrors what `ag init` does — the freshly-started server will
+  // load keys.json and recognize the generated token.
+  const authManager = new AuthManager(join(stateDir, 'keys.json'));
+  await authManager.load();
+  const createdKey = await authManager.createKey('ag-run-admin', 100, undefined, 'admin');
+  const token = createdKey.key;
+
   const config: Partial<Config> = {
     authToken: token,
     baseUrl: 'http://127.0.0.1:9100',
     dashboardEnabled: true,
-    acpEnabled: true,  // Issue #3068: Enable ACP by default so sessions actually run
+    acpEnabled: true,
   };
 
   const content = serializeConfigFile(config, configPath);
@@ -192,10 +203,10 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
   if (!serverRunning) {
     writeLine(io.stdout, '  ⏳ Server not running — starting...');
 
-    // Ensure config exists
+    // Ensure config exists (creates proper key in keys.json via AuthManager)
     if (!existingConfig) {
       writeLine(io.stdout, '  ⏳ No config found — bootstrapping with defaults...');
-      const generatedToken = await ensureConfig(configPath);
+      const generatedToken = await ensureConfig(configPath, config.stateDir);
       if (generatedToken) authToken = generatedToken;
       writeLine(io.stdout, `  ✅ Config created: ${configPath}`);
     }
@@ -242,6 +253,25 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
     });
 
     if (!res.ok) {
+      // Issue #3261: When a server is already running with auth but the CLI has
+      // no matching token, provide a clear actionable error instead of a generic one.
+      if (res.status === 401) {
+        const errBody = await res.json().catch(() => ({ error: res.statusText }));
+        writeLine(io.stderr, '');
+        writeLine(io.stderr, '  ❌ Unauthorized — the server requires authentication.');
+        writeLine(io.stderr, '');
+        writeLine(io.stderr, '  This happens when a server is already running with API keys configured');
+        writeLine(io.stderr, '  but no matching auth token is available locally.');
+        writeLine(io.stderr, '');
+        writeLine(io.stderr, '  To fix this:');
+        writeLine(io.stderr, '    1. Run `ag init` to create a new API key and config');
+        writeLine(io.stderr, '    2. Or set AEGIS_AUTH_TOKEN=<your-key> in your environment');
+        writeLine(io.stderr, '');
+        writeLine(io.stderr, '  If you set up the server, your original token was shown by `ag init`.');
+        writeLine(io.stderr, '  Check your shell history or re-run `ag init --force` to generate a new one.');
+        return 1;
+      }
+
       const err = await res.json().catch(() => ({ error: res.statusText }));
       writeLine(io.stderr, `  ❌ Failed to create session: ${(err as { error?: string }).error || res.statusText}`);
       return 1;


### PR DESCRIPTION
## Summary

Fixes #3261

### Problem
`ag run "prompt"` fails with `Unauthorized — Bearer token required` when a server is already running with `keys.json` but no local `config.yaml`.

### Root Cause
`ensureConfig()` in `run.ts` generated a random token (`aegis-quickstart-...`) and wrote it to `config.yaml`. This token was **never registered in `keys.json`**. The server validates auth tokens against `keys.json` SHA-256 hashes, so the random token was always rejected.

### Fix
1. **`ensureConfig()` now uses `AuthManager.createKey()`** to properly register the key in `keys.json` — mirroring what `ag init` already does. The freshly-started server loads `keys.json` and recognizes the generated token.

2. **Clear 401 error message** when connecting to an existing server without a matching auth token, directing users to:
   - Run `ag init` to create a new API key and config
   - Or set `AEGIS_AUTH_TOKEN=<your-key>` in their environment

### Changes
- `src/commands/run.ts`: Fix `ensureConfig` to use `AuthManager`, add 401 error handling
- `src/__tests__/fix-3261-ag-run-auth.test.ts`: 5 new tests

## Verification
```
Aegis server: UP, v0.6.7-preview.1
Commit: b840f4ad
Branch: fix/3261-ag-run-auth

tsc --noEmit: ✅ Zero errors
npm run build: ✅ Success
npm test: ✅ 4099 passed, 2 skipped (pre-existing server-core-coverage flaky timeouts unrelated to this change)
New tests: ✅ 5/5 passed
```