### PR TITLE
feat: Runner abstraction layer — pluggable agent backend interface (#3263)

### DIFF
--- a/src/__tests__/fix-3263-runner-abstraction.test.ts
+++ b/src/__tests__/fix-3263-runner-abstraction.test.ts
@@ -1,0 +1,197 @@
+/**
+ * fix-3263-runner-abstraction.test.ts — Tests for the Runner abstraction layer.
+ *
+ * Issue #3263: AgentRunner interface, RunnerRegistry, and stub runners.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type {
+  AgentRunner,
+  ProcessHandle,
+  RunnerStartConfig,
+  RunnerStartResult,
+  RunnerSendResult,
+  OutputChunk,
+  RunnerKillResult,
+} from '../runners/types.js';
+import { InMemoryRunnerRegistry } from '../runners/registry.js';
+import { CodexRunner } from '../runners/stubs/codex-runner.js';
+import { GeminiCliRunner } from '../runners/stubs/gemini-runner.js';
+
+// ── Test helpers ─────────────────────────────────────────────────
+
+/** A minimal mock runner for testing the registry. */
+class MockRunner implements AgentRunner {
+  readonly name: string;
+  private readonly handles = new Map<string, ProcessHandle>();
+  private alive = new Set<ProcessHandle>();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  async start(sessionId: string, _config: RunnerStartConfig): Promise<RunnerStartResult> {
+    const handle = `${this.name}-${sessionId}`;
+    this.handles.set(sessionId, handle);
+    this.alive.add(handle);
+    return { handle, capabilities: { mock: true }, agentInfo: { name: this.name } };
+  }
+
+  async sendInput(handle: ProcessHandle, _input: string): Promise<RunnerSendResult> {
+    if (!this.alive.has(handle)) return { delivered: false, attempts: 1, error: 'not alive' };
+    return { delivered: true, attempts: 1 };
+  }
+
+  async *readOutput(_handle: ProcessHandle): AsyncIterable<OutputChunk> {
+    yield { text: 'mock output', source: 'stdout', timestamp: new Date().toISOString() };
+  }
+
+  async kill(handle: ProcessHandle): Promise<RunnerKillResult> {
+    this.alive.delete(handle);
+    return { exitCode: 0, clean: true };
+  }
+
+  isAlive(handle: ProcessHandle): boolean {
+    return this.alive.has(handle);
+  }
+
+  getHandle(sessionId: string): ProcessHandle | undefined {
+    return this.handles.get(sessionId);
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('Issue #3263 — Runner abstraction layer', () => {
+  describe('AgentRunner interface', () => {
+    it('MockRunner satisfies the interface contract', async () => {
+      const runner = new MockRunner('test-runner');
+      expect(runner.name).toBe('test-runner');
+
+      const result = await runner.start('session-1', { cwd: '/tmp' });
+      expect(result.handle).toBe('test-runner-session-1');
+      expect(result.capabilities).toEqual({ mock: true });
+
+      expect(runner.isAlive(result.handle)).toBe(true);
+      expect(runner.getHandle('session-1')).toBe(result.handle);
+
+      const sendResult = await runner.sendInput(result.handle, 'hello');
+      expect(sendResult.delivered).toBe(true);
+
+      const killResult = await runner.kill(result.handle);
+      expect(killResult.clean).toBe(true);
+      expect(runner.isAlive(result.handle)).toBe(false);
+    });
+
+    it('runner swap does not break session lifecycle', async () => {
+      const runnerA = new MockRunner('runner-a');
+      const runnerB = new MockRunner('runner-b');
+
+      const resultA = await runnerA.start('swap-session', { cwd: '/tmp' });
+      expect(runnerA.isAlive(resultA.handle)).toBe(true);
+
+      await runnerA.kill(resultA.handle);
+      expect(runnerA.isAlive(resultA.handle)).toBe(false);
+
+      const resultB = await runnerB.start('swap-session', { cwd: '/tmp' });
+      expect(runnerB.isAlive(resultB.handle)).toBe(true);
+      expect(resultB.handle).not.toBe(resultA.handle);
+    });
+  });
+
+  describe('RunnerRegistry', () => {
+    it('registers and retrieves runners', () => {
+      const registry = new InMemoryRunnerRegistry();
+      const runner = new MockRunner('claude-code');
+      registry.register(runner);
+
+      expect(registry.get('claude-code')).toBe(runner);
+      expect(registry.listNames()).toEqual(['claude-code']);
+    });
+
+    it('first registered runner becomes default', () => {
+      const registry = new InMemoryRunnerRegistry();
+      const first = new MockRunner('first');
+      const second = new MockRunner('second');
+
+      registry.register(first);
+      registry.register(second);
+
+      expect(registry.getDefault()).toBe(first);
+      expect(registry.listNames()).toEqual(['first', 'second']);
+    });
+
+    it('throws when no runners registered and getDefault is called', () => {
+      const registry = new InMemoryRunnerRegistry();
+      expect(() => registry.getDefault()).toThrow('No runners registered');
+    });
+
+    it('returns undefined for unknown runner name', () => {
+      const registry = new InMemoryRunnerRegistry();
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+
+    it('supports multiple runners', () => {
+      const registry = new InMemoryRunnerRegistry();
+      registry.register(new MockRunner('claude-code'));
+      registry.register(new MockRunner('codex'));
+      registry.register(new MockRunner('gemini-cli'));
+
+      expect(registry.listNames()).toHaveLength(3);
+      expect(registry.listNames()).toContain('claude-code');
+      expect(registry.listNames()).toContain('codex');
+      expect(registry.listNames()).toContain('gemini-cli');
+    });
+  });
+
+  describe('CodexRunner stub', () => {
+    it('implements AgentRunner interface', () => {
+      const runner = new CodexRunner();
+      expect(runner.name).toBe('codex');
+      expect(runner.isAlive('any')).toBe(false);
+      expect(runner.getHandle('any')).toBeUndefined();
+    });
+
+    it('throws on start', async () => {
+      const runner = new CodexRunner();
+      await expect(runner.start('s1', { cwd: '/tmp' })).rejects.toThrow('not implemented');
+    });
+
+    it('throws on sendInput', async () => {
+      const runner = new CodexRunner();
+      await expect(runner.sendInput('h1', 'test')).rejects.toThrow('not implemented');
+    });
+
+    it('throws on kill', async () => {
+      const runner = new CodexRunner();
+      await expect(runner.kill('h1')).rejects.toThrow('not implemented');
+    });
+  });
+
+  describe('GeminiCliRunner stub', () => {
+    it('implements AgentRunner interface', () => {
+      const runner = new GeminiCliRunner();
+      expect(runner.name).toBe('gemini-cli');
+      expect(runner.isAlive('any')).toBe(false);
+      expect(runner.getHandle('any')).toBeUndefined();
+    });
+
+    it('throws on start', async () => {
+      const runner = new GeminiCliRunner();
+      await expect(runner.start('s1', { cwd: '/tmp' })).rejects.toThrow('not implemented');
+    });
+  });
+
+  describe('Integration: registry with stubs', () => {
+    it('all stub runners compile and register', () => {
+      const registry = new InMemoryRunnerRegistry();
+      registry.register(new CodexRunner());
+      registry.register(new GeminiCliRunner());
+
+      expect(registry.listNames()).toEqual(['codex', 'gemini-cli']);
+      expect(registry.get('codex')).toBeInstanceOf(CodexRunner);
+      expect(registry.get('gemini-cli')).toBeInstanceOf(GeminiCliRunner);
+    });
+  });
+});

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -1,0 +1,19 @@
+/**
+ * runners/index.ts — Barrel export for the runner abstraction.
+ *
+ * Issue #3263: Pluggable agent backend interface.
+ */
+
+export type {
+  AgentRunner,
+  RunnerRegistry,
+  ProcessHandle,
+  OutputChunk,
+  RunnerStartConfig,
+  RunnerStartResult,
+  RunnerSendResult,
+  RunnerKillOptions,
+  RunnerKillResult,
+} from './types.js';
+
+export { InMemoryRunnerRegistry } from './registry.js';

--- a/src/runners/registry.ts
+++ b/src/runners/registry.ts
@@ -1,0 +1,35 @@
+/**
+ * runners/registry.ts — In-memory RunnerRegistry implementation.
+ *
+ * Issue #3263: Manages registered agent runners and resolves them by name.
+ */
+
+import type { AgentRunner, RunnerRegistry } from './types.js';
+
+export class InMemoryRunnerRegistry implements RunnerRegistry {
+  private readonly runners = new Map<string, AgentRunner>();
+  private defaultRunner: AgentRunner | undefined;
+
+  register(runner: AgentRunner): void {
+    this.runners.set(runner.name, runner);
+    // First registered runner becomes the default
+    if (!this.defaultRunner) {
+      this.defaultRunner = runner;
+    }
+  }
+
+  get(name: string): AgentRunner | undefined {
+    return this.runners.get(name);
+  }
+
+  listNames(): string[] {
+    return [...this.runners.keys()];
+  }
+
+  getDefault(): AgentRunner {
+    if (!this.defaultRunner) {
+      throw new Error('No runners registered. Register at least one AgentRunner.');
+    }
+    return this.defaultRunner;
+  }
+}

--- a/src/runners/stubs/codex-runner.ts
+++ b/src/runners/stubs/codex-runner.ts
@@ -15,6 +15,7 @@ import type {
   RunnerKillOptions,
   RunnerKillResult,
 } from '../types.js';
+import { NotImplementedError } from './shared.js';
 
 /**
  * CodexRunner — stub implementation for OpenAI Codex CLI.
@@ -34,6 +35,8 @@ export class CodexRunner implements AgentRunner {
     throw new NotImplementedError('CodexRunner.sendInput');
   }
 
+  // Note: the throw occurs before any yield, so the caller gets a rejected
+  // promise rather than an error during iteration.
   async *readOutput(_handle: ProcessHandle): AsyncIterable<OutputChunk> {
     throw new NotImplementedError('CodexRunner.readOutput');
   }
@@ -48,12 +51,5 @@ export class CodexRunner implements AgentRunner {
 
   getHandle(_sessionId: string): ProcessHandle | undefined {
     return undefined;
-  }
-}
-
-class NotImplementedError extends Error {
-  constructor(method: string) {
-    super(`${method} is not implemented. CodexRunner is a stub for future Codex CLI integration.`);
-    this.name = 'NotImplementedError';
   }
 }

--- a/src/runners/stubs/codex-runner.ts
+++ b/src/runners/stubs/codex-runner.ts
@@ -1,0 +1,59 @@
+/**
+ * runners/stubs/codex-runner.ts — Stub Codex runner (interface only).
+ *
+ * Issue #3263: Placeholder for OpenAI Codex CLI integration.
+ * Will be implemented when Codex CLI gains ACP/stdio support.
+ */
+
+import type {
+  AgentRunner,
+  ProcessHandle,
+  RunnerStartConfig,
+  RunnerStartResult,
+  RunnerSendResult,
+  OutputChunk,
+  RunnerKillOptions,
+  RunnerKillResult,
+} from '../types.js';
+
+/**
+ * CodexRunner — stub implementation for OpenAI Codex CLI.
+ *
+ * All methods throw to indicate this runner is not yet implemented.
+ * Registered in the runner registry to prove interface compatibility
+ * and allow configuration references.
+ */
+export class CodexRunner implements AgentRunner {
+  readonly name = 'codex';
+
+  async start(_sessionId: string, _config: RunnerStartConfig): Promise<RunnerStartResult> {
+    throw new NotImplementedError('CodexRunner.start');
+  }
+
+  async sendInput(_handle: ProcessHandle, _input: string): Promise<RunnerSendResult> {
+    throw new NotImplementedError('CodexRunner.sendInput');
+  }
+
+  async *readOutput(_handle: ProcessHandle): AsyncIterable<OutputChunk> {
+    throw new NotImplementedError('CodexRunner.readOutput');
+  }
+
+  async kill(_handle: ProcessHandle, _options?: RunnerKillOptions): Promise<RunnerKillResult> {
+    throw new NotImplementedError('CodexRunner.kill');
+  }
+
+  isAlive(_handle: ProcessHandle): boolean {
+    return false;
+  }
+
+  getHandle(_sessionId: string): ProcessHandle | undefined {
+    return undefined;
+  }
+}
+
+class NotImplementedError extends Error {
+  constructor(method: string) {
+    super(`${method} is not implemented. CodexRunner is a stub for future Codex CLI integration.`);
+    this.name = 'NotImplementedError';
+  }
+}

--- a/src/runners/stubs/gemini-runner.ts
+++ b/src/runners/stubs/gemini-runner.ts
@@ -1,0 +1,59 @@
+/**
+ * runners/stubs/gemini-runner.ts — Stub Gemini CLI runner (interface only).
+ *
+ * Issue #3263: Placeholder for Google Gemini CLI integration.
+ * Will be implemented when Gemini CLI gains ACP/stdio support.
+ */
+
+import type {
+  AgentRunner,
+  ProcessHandle,
+  RunnerStartConfig,
+  RunnerStartResult,
+  RunnerSendResult,
+  OutputChunk,
+  RunnerKillOptions,
+  RunnerKillResult,
+} from '../types.js';
+
+/**
+ * GeminiCliRunner — stub implementation for Google Gemini CLI.
+ *
+ * All methods throw to indicate this runner is not yet implemented.
+ * Registered in the runner registry to prove interface compatibility
+ * and allow configuration references.
+ */
+export class GeminiCliRunner implements AgentRunner {
+  readonly name = 'gemini-cli';
+
+  async start(_sessionId: string, _config: RunnerStartConfig): Promise<RunnerStartResult> {
+    throw new NotImplementedError('GeminiCliRunner.start');
+  }
+
+  async sendInput(_handle: ProcessHandle, _input: string): Promise<RunnerSendResult> {
+    throw new NotImplementedError('GeminiCliRunner.sendInput');
+  }
+
+  async *readOutput(_handle: ProcessHandle): AsyncIterable<OutputChunk> {
+    throw new NotImplementedError('GeminiCliRunner.readOutput');
+  }
+
+  async kill(_handle: ProcessHandle, _options?: RunnerKillOptions): Promise<RunnerKillResult> {
+    throw new NotImplementedError('GeminiCliRunner.kill');
+  }
+
+  isAlive(_handle: ProcessHandle): boolean {
+    return false;
+  }
+
+  getHandle(_sessionId: string): ProcessHandle | undefined {
+    return undefined;
+  }
+}
+
+class NotImplementedError extends Error {
+  constructor(method: string) {
+    super(`${method} is not implemented. GeminiCliRunner is a stub for future Gemini CLI integration.`);
+    this.name = 'NotImplementedError';
+  }
+}

--- a/src/runners/stubs/gemini-runner.ts
+++ b/src/runners/stubs/gemini-runner.ts
@@ -15,6 +15,7 @@ import type {
   RunnerKillOptions,
   RunnerKillResult,
 } from '../types.js';
+import { NotImplementedError } from './shared.js';
 
 /**
  * GeminiCliRunner — stub implementation for Google Gemini CLI.
@@ -34,6 +35,8 @@ export class GeminiCliRunner implements AgentRunner {
     throw new NotImplementedError('GeminiCliRunner.sendInput');
   }
 
+  // Note: the throw occurs before any yield, so the caller gets a rejected
+  // promise rather than an error during iteration.
   async *readOutput(_handle: ProcessHandle): AsyncIterable<OutputChunk> {
     throw new NotImplementedError('GeminiCliRunner.readOutput');
   }
@@ -48,12 +51,5 @@ export class GeminiCliRunner implements AgentRunner {
 
   getHandle(_sessionId: string): ProcessHandle | undefined {
     return undefined;
-  }
-}
-
-class NotImplementedError extends Error {
-  constructor(method: string) {
-    super(`${method} is not implemented. GeminiCliRunner is a stub for future Gemini CLI integration.`);
-    this.name = 'NotImplementedError';
   }
 }

--- a/src/runners/stubs/shared.ts
+++ b/src/runners/stubs/shared.ts
@@ -1,0 +1,18 @@
+/**
+ * runners/stubs/shared.ts — Shared utilities for stub runners.
+ *
+ * Issue #3263: Common error types for placeholder runner implementations.
+ */
+
+/**
+ * Error thrown by stub runner methods that are not yet implemented.
+ *
+ * Stubs compile and register successfully but throw on any lifecycle operation,
+ * allowing the interface contract to be validated without a real agent binary.
+ */
+export class NotImplementedError extends Error {
+  constructor(method: string) {
+    super(`${method} is not implemented. This runner is a stub for future agent integration.`);
+    this.name = 'NotImplementedError';
+  }
+}

--- a/src/runners/types.ts
+++ b/src/runners/types.ts
@@ -1,0 +1,168 @@
+/**
+ * runners/types.ts — Agent Runner interface and common types.
+ *
+ * Issue #3263: Pluggable agent backend abstraction.
+ * Defines the contract for agent lifecycle operations (start, send, read, kill)
+ * that any runner (Claude Code, Codex, Gemini CLI, etc.) must implement.
+ */
+
+/** Unique identifier for a running agent process. */
+export type ProcessHandle = string;
+
+/** A chunk of output from a running agent. */
+export interface OutputChunk {
+  /** Text content. */
+  text: string;
+  /** Source stream. */
+  source: 'stdout' | 'stderr';
+  /** ISO timestamp when this chunk was emitted. */
+  timestamp: string;
+}
+
+/** Configuration for starting a new agent process. */
+export interface RunnerStartConfig {
+  /** Working directory for the agent process. */
+  cwd: string;
+  /** Optional system prompt to inject. */
+  systemPrompt?: string;
+  /** Optional MCP servers to expose to the agent. */
+  mcpServers?: Record<string, unknown>;
+  /** Optional environment variables. */
+  env?: Record<string, string>;
+  /** Optional display name for the session. */
+  displayName?: string;
+}
+
+/** Result of a successful start operation. */
+export interface RunnerStartResult {
+  /** The process handle for subsequent operations. */
+  handle: ProcessHandle;
+  /** Capabilities advertised by the agent (agent-specific shape). */
+  capabilities?: Record<string, unknown>;
+  /** Agent-reported metadata (name, version, etc.). */
+  agentInfo?: Record<string, unknown>;
+}
+
+/** Result of a send/prompt operation. */
+export interface RunnerSendResult {
+  /** Whether the input was delivered successfully. */
+  delivered: boolean;
+  /** Number of delivery attempts made. */
+  attempts: number;
+  /** Error message if delivery failed. */
+  error?: string;
+}
+
+/** Options for killing an agent process. */
+export interface RunnerKillOptions {
+  /** If true, force-kill (SIGKILL) instead of graceful shutdown. */
+  force?: boolean;
+  /** Timeout in ms to wait for graceful shutdown before force-killing. */
+  timeoutMs?: number;
+}
+
+/** Result of a kill operation. */
+export interface RunnerKillResult {
+  /** Exit code or signal. */
+  exitCode: number | null;
+  /** Whether the shutdown was clean (expected). */
+  clean: boolean;
+}
+
+/**
+ * AgentRunner — the pluggable agent backend interface.
+ *
+ * Each runner encapsulates one agent type (Claude Code, Codex, Gemini CLI, etc.)
+ * and manages its lifecycle through a standardized contract.
+ *
+ * Implementations MUST be stateless with respect to handles — all state
+ * should be keyed by ProcessHandle, allowing a single runner instance
+ * to manage multiple concurrent sessions.
+ */
+export interface AgentRunner {
+  /** Human-readable runner name (e.g., 'claude-code', 'codex', 'gemini-cli'). */
+  readonly name: string;
+
+  /**
+   * Start a new agent process.
+   *
+   * @param sessionId - The Aegis session ID this process belongs to.
+   * @param config - Start configuration (cwd, prompt, env, etc.).
+   * @returns A handle and optional capabilities/metadata.
+   */
+  start(sessionId: string, config: RunnerStartConfig): Promise<RunnerStartResult>;
+
+  /**
+   * Send input (prompt) to a running agent.
+   *
+   * @param handle - The process handle from start().
+   * @param input - The text input to send.
+   * @returns Delivery result.
+   */
+  sendInput(handle: ProcessHandle, input: string): Promise<RunnerSendResult>;
+
+  /**
+   * Read output from a running agent.
+   *
+   * Returns an async iterable that yields output chunks as they arrive.
+   * Callers should consume this in a loop and break when done.
+   *
+   * @param handle - The process handle from start().
+   */
+  readOutput(handle: ProcessHandle): AsyncIterable<OutputChunk>;
+
+  /**
+   * Kill a running agent process.
+   *
+   * Attempts graceful shutdown first, then force-kills after timeout.
+   *
+   * @param handle - The process handle from start().
+   * @param options - Kill options.
+   * @returns Kill result with exit info.
+   */
+  kill(handle: ProcessHandle, options?: RunnerKillOptions): Promise<RunnerKillResult>;
+
+  /**
+   * Check if an agent process is still alive.
+   *
+   * @param handle - The process handle from start().
+   */
+  isAlive(handle: ProcessHandle): boolean;
+
+  /**
+   * Get the process handle for an Aegis session, if one exists.
+   *
+   * @param sessionId - The Aegis session ID.
+   * @returns The process handle or undefined.
+   */
+  getHandle(sessionId: string): ProcessHandle | undefined;
+}
+
+/**
+ * RunnerRegistry — resolves runner names to AgentRunner instances.
+ *
+ * Allows the session manager to look up the correct runner for a given
+ * session based on configuration or session-level overrides.
+ */
+export interface RunnerRegistry {
+  /**
+   * Register a runner instance.
+   *
+   * @param runner - The runner to register.
+   */
+  register(runner: AgentRunner): void;
+
+  /**
+   * Get a runner by name.
+   *
+   * @param name - Runner name (e.g., 'claude-code').
+   * @returns The runner or undefined.
+   */
+  get(name: string): AgentRunner | undefined;
+
+  /** List all registered runner names. */
+  listNames(): string[];
+
+  /** Get the default runner. */
+  getDefault(): AgentRunner;
+}


### PR DESCRIPTION
## Summary

Closes #3263

Defines the `AgentRunner` interface — a pluggable agent backend abstraction that decouples session management from the Claude Code-specific `AcpBackend`. This is the architectural foundation for multi-agent support (#3180).

### New Modules

| Module | Description |
|--------|-------------|
| `src/runners/types.ts` | `AgentRunner` interface + all config/result types |
| `src/runners/registry.ts` | `InMemoryRunnerRegistry` for runner lookup |
| `src/runners/stubs/codex-runner.ts` | Codex CLI stub (throws NotImplementedError) |
| `src/runners/stubs/gemini-runner.ts` | Gemini CLI stub (throws NotImplementedError) |

### AgentRunner Interface

```typescript
interface AgentRunner {
  readonly name: string;
  start(sessionId, config): Promise<RunnerStartResult>;
  sendInput(handle, input): Promise<RunnerSendResult>;
  readOutput(handle): AsyncIterable<OutputChunk>;
  kill(handle, options?): Promise<RunnerKillResult>;
  isAlive(handle): boolean;
  getHandle(sessionId): ProcessHandle | undefined;
}
```

### Design Decisions
- **Pure additive** — no existing code modified, zero risk of regression
- **Interface-first** — stubs compile but throw, proving the contract is implementable
- **Registry pattern** — first registered runner becomes default, allowing future config-driven selection
- **ProcessHandle is opaque string** — runners define their own handle format

## Verification

```
tsc --noEmit    ✅ Zero errors
npm run build   ✅ Success
npm test        ✅ 4114 passed / 1 pre-existing flaky (e2e-dogfood)
```

### New test: `fix-3263-runner-abstraction.test.ts`
- 14 test cases covering interface contract, registry, stubs, and runner swap

## Unblocks
- #3180 — multi-agent support
- #3049 — ACP agent mode (uses Runner interface for agent registration)
- #3018 — ACP registry listing (blocked on #3049)

Refs: #3003, #3004