### PR TITLE
feat(dashboard): agent contributions panel — per-agent git attribution

### DIFF
--- a/dashboard/src/components/analytics/AgentContributionsPanel.tsx
+++ b/dashboard/src/components/analytics/AgentContributionsPanel.tsx
@@ -1,0 +1,244 @@
+/**
+ * AgentContributionsPanel.tsx — Per-agent git contribution stats.
+ *
+ * Shows commit count, lines changed, PRs opened, and contribution bars
+ * for each agent. Part of issue #3269: agent git identity tracking.
+ *
+ * Mock data until backend provides per-agent git identity (#3269 backend).
+ */
+
+import { BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid, Cell } from 'recharts';
+import { ChartFrame } from '../shared/ChartFrame';
+import { formatCompact } from '../../utils/formatNumber';
+import { GitBranch, GitCommit, GitPullRequest, Users } from 'lucide-react';
+
+export interface AgentContribution {
+  agent: string;
+  commits: number;
+  additions: number;
+  deletions: number;
+  prs: number;
+  role: string;
+}
+
+export interface AgentContributionsPanelProps {
+  data?: AgentContribution[];
+  loading?: boolean;
+  className?: string;
+}
+
+const AGENT_COLORS: Record<string, string> = {
+  'Daedalus': 'var(--color-accent-cyan)',
+  'Hephaestus': 'var(--color-accent-purple)',
+  'Argus': 'var(--color-success)',
+  'Athena': 'var(--color-warning)',
+  'Scribe': 'var(--color-info)',
+  'Hermes': 'var(--color-warning)',
+  'Orpheus': 'var(--color-accent-cyan)',
+  'Themis': 'var(--color-danger)',
+  other: 'var(--color-text-muted)',
+};
+
+const MOCK_DATA: AgentContribution[] = [
+  { agent: 'Hephaestus', commits: 87, additions: 12840, deletions: 3210, prs: 12, role: 'Backend' },
+  { agent: 'Daedalus', commits: 64, additions: 9650, deletions: 1820, prs: 9, role: 'Frontend' },
+  { agent: 'Argus', commits: 31, additions: 2100, deletions: 890, prs: 5, role: 'Review' },
+  { agent: 'Scribe', commits: 22, additions: 4320, deletions: 420, prs: 4, role: 'Docs' },
+  { agent: 'Hermes', commits: 15, additions: 1800, deletions: 600, prs: 3, role: 'DevOps' },
+  { agent: 'Athena', commits: 8, additions: 920, deletions: 180, prs: 2, role: 'PM' },
+];
+
+function CustomTooltip({ active, payload }: {
+  active?: boolean;
+  payload?: Array<{ payload: AgentContribution }>;
+}) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0].payload;
+  return (
+    <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3 shadow-xl">
+      <p className="mb-1 text-sm font-medium text-[var(--color-text-primary)]">
+        {point.agent}
+        <span className="ml-2 text-xs text-[var(--color-text-muted)]">{point.role}</span>
+      </p>
+      <div className="mt-2 space-y-1 text-xs">
+        <div className="flex justify-between gap-6">
+          <span className="text-[var(--color-text-muted)]">Commits</span>
+          <span className="font-mono font-medium text-[var(--color-text-primary)]">{point.commits}</span>
+        </div>
+        <div className="flex justify-between gap-6">
+          <span className="text-[var(--color-success)]">+{formatCompact(point.additions)}</span>
+          <span className="text-[var(--color-danger)]">-{formatCompact(point.deletions)}</span>
+        </div>
+        <div className="flex justify-between gap-6">
+          <span className="text-[var(--color-text-muted)]">PRs</span>
+          <span className="font-mono font-medium text-[var(--color-text-primary)]">{point.prs}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AgentContributionsPanel({ data, loading = false, className = '' }: AgentContributionsPanelProps) {
+  const contributions = data ?? MOCK_DATA;
+
+  const totalCommits = contributions.reduce((s, a) => s + a.commits, 0);
+  const totalAdditions = contributions.reduce((s, a) => s + a.additions, 0);
+  const totalDeletions = contributions.reduce((s, a) => s + a.deletions, 0);
+  const totalPRs = contributions.reduce((s, a) => s + a.prs, 0);
+
+  if (loading) {
+    return (
+      <section
+        className={`rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5 ${className}`}
+        aria-label="Agent contributions loading"
+      >
+        <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
+          Agent Contributions
+        </h3>
+        <div className="flex h-64 items-center justify-center">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--color-accent-cyan)] border-t-transparent" />
+        </div>
+      </section>
+    );
+  }
+
+  if (contributions.length === 0) {
+    return (
+      <section
+        className={`rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5 ${className}`}
+        aria-label="Agent contributions"
+      >
+        <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
+          Agent Contributions
+        </h3>
+        <p className="py-12 text-center text-sm text-[var(--color-text-muted)]">
+          No agent contribution data available yet.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className={`rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5 ${className}`}
+      aria-label="Agent contributions panel"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-medium text-[var(--color-text-primary)]">
+          <Users className="mr-2 inline h-5 w-5 text-[var(--color-accent-cyan)]" />
+          Agent Contributions
+        </h3>
+        <span className="text-xs text-[var(--color-text-muted)]">
+          Per-agent git attribution
+        </span>
+      </div>
+
+      {/* Summary KPIs */}
+      <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3">
+          <div className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
+            <GitCommit className="h-3 w-3" />
+            Commits
+          </div>
+          <div className="mt-1 text-lg font-bold font-mono text-[var(--color-text-primary)]">
+            {formatCompact(totalCommits)}
+          </div>
+        </div>
+        <div className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3">
+          <div className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
+            <GitBranch className="h-3 w-3" />
+            Lines Changed
+          </div>
+          <div className="mt-1 text-lg font-bold font-mono text-[var(--color-text-primary)]">
+            <span className="text-[var(--color-success)]">+{formatCompact(totalAdditions)}</span>
+            <span className="mx-1 text-[var(--color-text-muted)]">/</span>
+            <span className="text-[var(--color-danger)]">-{formatCompact(totalDeletions)}</span>
+          </div>
+        </div>
+        <div className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3">
+          <div className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
+            <GitPullRequest className="h-3 w-3" />
+            PRs
+          </div>
+          <div className="mt-1 text-lg font-bold font-mono text-[var(--color-text-primary)]">
+            {totalPRs}
+          </div>
+        </div>
+        <div className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-3">
+          <div className="text-xs text-[var(--color-text-muted)]">
+            <Users className="inline h-3 w-3 mr-1" />
+            Active Agents
+          </div>
+          <div className="mt-1 text-lg font-bold font-mono text-[var(--color-text-primary)]">
+            {contributions.length}
+          </div>
+        </div>
+      </div>
+
+      {/* Commit chart — horizontal bar */}
+      <ChartFrame className="h-56 min-w-0" label="Agent commits chart loading">
+        {({ width, height }) => (
+          <BarChart width={width} height={height} data={contributions} layout="vertical" margin={{ left: 10 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-void-lighter)" horizontal={false} />
+            <XAxis
+              type="number"
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+              stroke="var(--color-void-lighter)"
+            />
+            <YAxis
+              type="category"
+              dataKey="agent"
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+              stroke="var(--color-void-lighter)"
+              width={90}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Bar dataKey="commits" radius={[0, 4, 4, 0]} animationDuration={500}>
+              {contributions.map((entry) => (
+                <Cell
+                  key={entry.agent}
+                  fill={AGENT_COLORS[entry.agent] ?? AGENT_COLORS.other}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        )}
+      </ChartFrame>
+
+      {/* Agent list */}
+      <div className="mt-4 space-y-2">
+        {contributions.map((agent) => {
+          const commitPct = totalCommits > 0 ? (agent.commits / totalCommits) * 100 : 0;
+          return (
+            <div key={agent.agent} className="flex items-center gap-3">
+              <div
+                className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
+                style={{ backgroundColor: AGENT_COLORS[agent.agent] ?? AGENT_COLORS.other }}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-[var(--color-text-primary)]">
+                    {agent.agent}
+                    <span className="ml-1.5 text-xs text-[var(--color-text-muted)]">({agent.role})</span>
+                  </span>
+                  <span className="text-xs font-mono text-[var(--color-text-muted)]">
+                    {agent.commits} commits · {agent.prs} PRs
+                  </span>
+                </div>
+                <div className="mt-1 h-1.5 w-full rounded-full bg-[var(--color-void-light)]">
+                  <div
+                    className="h-1.5 rounded-full transition-all duration-500"
+                    style={{
+                      width: `${commitPct}%`,
+                      backgroundColor: AGENT_COLORS[agent.agent] ?? AGENT_COLORS.other,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/components/analytics/__tests__/AgentContributionsPanel.test.tsx
+++ b/dashboard/src/components/analytics/__tests__/AgentContributionsPanel.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * AgentContributionsPanel.test.tsx — Tests for agent contributions panel.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentContributionsPanel } from '../AgentContributionsPanel';
+
+describe('AgentContributionsPanel', () => {
+  it('renders with mock data by default', () => {
+    const { container } = render(<AgentContributionsPanel />);
+    expect(container.querySelector('section')).toBeTruthy();
+    expect(screen.getByText('Agent Contributions')).toBeTruthy();
+  });
+
+  it('renders empty state when data is empty array', () => {
+    render(<AgentContributionsPanel data={[]} />);
+    expect(screen.getByText(/No agent contribution data available yet/)).toBeTruthy();
+  });
+
+  it('renders loading state', () => {
+    render(<AgentContributionsPanel loading />);
+    expect(screen.getByText('Agent Contributions')).toBeTruthy();
+  });
+
+  it('renders with custom data', () => {
+    const data = [
+      { agent: 'Daedalus', commits: 10, additions: 500, deletions: 100, prs: 2, role: 'Frontend' },
+      { agent: 'Hephaestus', commits: 20, additions: 1000, deletions: 300, prs: 3, role: 'Backend' },
+    ];
+    render(<AgentContributionsPanel data={data} />);
+    expect(screen.getByText('Agent Contributions')).toBeTruthy();
+    // Check summary KPIs
+    expect(screen.getByText('30')).toBeTruthy();
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('has correct aria-label', () => {
+    render(<AgentContributionsPanel />);
+    expect(screen.getByLabelText('Agent contributions panel')).toBeTruthy();
+  });
+
+  it('shows agent names in the list', () => {
+    const data = [
+      { agent: 'TestAgent', commits: 5, additions: 200, deletions: 50, prs: 1, role: 'Test' },
+    ];
+    render(<AgentContributionsPanel data={data} />);
+    expect(screen.getByText(/TestAgent/)).toBeTruthy();
+  });
+});

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -31,6 +31,7 @@ import { formatDateShort } from '../utils/formatDate';
 import type { AnalyticsSummary, RateLimitAnalyticsResponse } from '../types';
 import { RateLimitChart } from '../components/analytics/RateLimitChart';
 import { RateLimitForecastCard } from '../components/analytics/RateLimitForecastCard';
+import { AgentContributionsPanel } from '../components/analytics/AgentContributionsPanel';
 
 const MODEL_COLORS: Record<string, string> = {
   'claude-sonnet-4.6': 'var(--color-accent-cyan)',
@@ -480,6 +481,9 @@ export default function AnalyticsPage() {
           <RateLimitForecastCard forecast={rateLimitData.forecast} />
         </div>
       )}
+
+      {/* Agent Contributions (#3269) */}
+      <AgentContributionsPanel />
     </div>
   );
 }


### PR DESCRIPTION
## What

Implements the **dashboard component** for **#3269** — agent commits lack distinct git identity.

### New Component (`dashboard/src/components/analytics/AgentContributionsPanel.tsx`)

- **Horizontal bar chart**: commits per agent, color-coded by role
- **Summary KPIs**: total commits, lines changed (+/-), PRs opened, active agents
- **Agent list**: name, role, commit count with progress bars showing share
- **Custom tooltip**: agent details on hover (commits, additions/deletions, PRs)

### Integration
Added to **AnalyticsPage** (below rate limit section).

### Mock Data
Ships with realistic mock data for the Aegis team (6 agents). Backend wiring follows once #3269 backend lands (per-session `GIT_AUTHOR_*` env vars + co-authored-by trailers).

### Design
- Uses existing `ChartFrame` + `recharts` + CSS vars
- Dark-theme consistent
- Loading / empty states
- `aria-label` for accessibility
- Responsive (1280px+)

### Test Evidence
- **6 new Vitest tests** — all passing
- **Build**: clean

Refs: #3269