### PR TITLE
fix(monitor): route assistant messages to channels for ACP .claude workdirs (#3286)

### DIFF
--- a/src/__tests__/path-utils-909.test.ts
+++ b/src/__tests__/path-utils-909.test.ts
@@ -21,4 +21,9 @@ describe('Issue #909: computeProjectHash cross-platform normalization', () => {
   it('returns fallback for empty input', () => {
     expect(computeProjectHash('')).toBe('-');
   });
+
+  it('replaces dots in segments to match Claude Code slug (Issue #3286)', () => {
+    expect(computeProjectHash('/home/me/.claude/repo')).toBe('-home-me--claude-repo');
+    expect(computeProjectHash('/Users/x/Documents/aegis/.claude/worktrees/foo')).toBe('-Users-x-Documents-aegis--claude-worktrees-foo');
+  });
 });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -627,8 +627,11 @@ export class SessionMonitor {
     const result = await this.sessions.readMessagesForMonitor(session.id);
     const prevStatus = this.lastStatus.get(session.id);
 
-    // Forward messages only when watcher is NOT active (fallback polling path)
-    if (!this.jsonlWatcher && result.messages.length > 0) {
+    // Forward messages only when watcher is NOT active for THIS session (#3286).
+    // Checking the watcher instance alone misses the discovery poll where the
+    // fallback just set jsonlPath but the watcher hasn't started yet — entries
+    // read here would otherwise be dropped before the watcher subscribes.
+    if (!this.jsonlWatcher?.isWatching(session.id) && result.messages.length > 0) {
       this.rateLimitedSessions.delete(session.id);
       for (const msg of result.messages) {
         await this.forwardMessage(session, msg);

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -15,7 +15,7 @@ export function computeProjectHash(workDir: string): string {
   const segments = withLowerDrive
     .split('/')
     .filter(Boolean)
-    .map((segment) => segment.replace(/:/g, '').replace(/\s+/g, '-'));
+    .map((segment) => segment.replace(/:/g, '').replace(/\s+/g, '-').replace(/\./g, '-'));
 
   if (segments.length === 0) return '-';
   return `-${segments.join('-')}`;


### PR DESCRIPTION
## Summary

Closes #3286. Two coupled root causes prevented `message.assistant` (and the user-facing equivalent) from reaching any notification channel (Telegram, Slack, webhook, email) — or `/v1/sessions/:id/transcript` — for sessions whose workdir contains a dotted segment (e.g. `.claude/worktrees/...`).

**Commit 1 — `path-utils.ts`:** `computeProjectHash` preserved `.` inside segments. Claude Code replaces every `.` with `-`, so `…/aegis/.claude/worktrees/x` mapped to `-…-aegis-.claude-…` while CC's on-disk slug is `-…-aegis--claude-…`. `discoverFromFilesystemFallback` in `session-transcripts.ts` (and the equivalent in `session-discovery.ts`) looked in the wrong directory and never resolved `session.jsonlPath`.

**Commit 2 — `monitor.ts`:** Even with the slug fixed, `checkSession` guarded forwarding with `!this.jsonlWatcher` (instance presence) instead of per-session watching state. On the exact poll where the fallback discovered the JSONL and read every existing entry, those entries were dropped — and the watcher then attached at end-of-file and saw no further changes for the content that pre-dated its attachment. Result: 4 historical user prompts forwarded only by coincidence (timing-dependent), 0 assistant entries forwarded. Switching the guard to `!this.jsonlWatcher?.isWatching(session.id)` lets `checkSession` flush the discovery-poll backlog before the watcher takes over.

## End-to-end verification (with Telegram channel)

Instrumented `tgApi` and `monitor` paths, ran a fresh session in `.claude/worktrees/verify-tg-trace2`, waited 60 s, killed the session. Trace:

```
[poll]    jsonlPath=false isWatching=false            ← initial state
Transcripts (#1768 fallback): session mapped         ← slug fix worked
[fwd]     role=user × 4                              ← watcher-check fix worked
[poll]    jsonlPath=true  isWatching=true            ← watcher owns it now
[watcher] msgs=1
[fwd]     role=assistant type=text TRACE2_ASSISTANT_OK ← reaches channels.message
[tg]      → sendMessage thread=topic_id text="✨ TRACE2_ASSISTANT_OK"
```

Aegis's session-ended summary in the topic shows `5 msgs · No errors` (4 user + 1 assistant) instead of the previous `0 msgs` / `4 msgs`.

Same session, no fix applied → no `[fwd] role=assistant`, summary `0 msgs`.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `src/__tests__/path-utils-909.test.ts` — 6/6 pass (5 existing + 1 new for the `.claude` case).
- [x] `src/__tests__/monitor-fixes.test.ts`, `monitor-idle-broadcast.test.ts`, `monitor-initial-offset.test.ts`, `jsonl-watcher.test.ts` — 41/41 pass.
- [x] Runtime spot-check: `computeProjectHash('/Users/…/aegis/.claude/worktrees/foo')` now matches the on-disk `~/.claude/projects/…--claude-worktrees-foo`.
- [x] End-to-end Telegram delivery: instrumented Aegis + real Telegram API. Assistant text lands in the topic after both fixes; was missing before either fix alone.

## Files changed

- `src/path-utils.ts` — 1-line addition to segment sanitization.
- `src/__tests__/path-utils-909.test.ts` — 1 assertion for the `.claude` case.
- `src/monitor.ts` — 4 lines (guard + 2-line comment explaining the hand-off).

3 files, +11/-3 lines.

## Gate notes (pre-existing, not introduced here)

`npm run gate` continues to fail on `dashboard:tokens:gate`, `dashboard:clickable:gate`, and 3 unrelated test cases on pristine `origin/develop@c4cab08c`. None touch monitor / channel / path-utils.

## Aegis version
**Developed with:** v0.6.7-preview.1