### PR TITLE
feat(analytics): per-day token breakdown endpoint (#3282)

### DIFF
--- a/src/__tests__/analytics-tokens-daily-3282.test.ts
+++ b/src/__tests__/analytics-tokens-daily-3282.test.ts
@@ -1,0 +1,229 @@
+/**
+ * analytics-tokens-daily-3282.test.ts — Tests for per-day token breakdown.
+ *
+ * Issue #3282: GET /v1/analytics/tokens now includes dailyBreakdown
+ * with from/to query parameter support.
+ */
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { SYSTEM_TENANT } from '../config.js';
+import { registerAnalyticsRoutes } from '../routes/analytics.js';
+import type { RouteContext } from '../routes/context.js';
+
+const NOW = new Date('2026-05-13T12:00:00Z').getTime();
+const DAY = 86_400_000;
+
+const records = [
+  {
+    id: 1, sessionId: 's1', keyId: 'k1',
+    timestamp: '2026-05-10T10:00:00Z',
+    eventType: 'message', inputTokens: 100, outputTokens: 50,
+    cacheCreationTokens: 10, cacheReadTokens: 20,
+    costUsd: 0.01, model: 'sonnet',
+  },
+  {
+    id: 2, sessionId: 's2', keyId: 'k1',
+    timestamp: '2026-05-10T14:00:00Z',
+    eventType: 'message', inputTokens: 200, outputTokens: 100,
+    cacheCreationTokens: 30, cacheReadTokens: 40,
+    costUsd: 0.02, model: 'sonnet',
+  },
+  {
+    id: 3, sessionId: 's3', keyId: 'k1',
+    timestamp: '2026-05-12T10:00:00Z',
+    eventType: 'message', inputTokens: 300, outputTokens: 150,
+    cacheCreationTokens: 50, cacheReadTokens: 60,
+    costUsd: 0.03, model: 'sonnet',
+  },
+];
+
+function mockMetering() {
+  return {
+    getDailyTokenBreakdown: vi.fn((options?: { from?: string; to?: string }) => {
+      let filtered = records;
+      if (options?.from) filtered = filtered.filter(r => r.timestamp >= options.from!);
+      if (options?.to) filtered = filtered.filter(r => r.timestamp <= options.to!);
+
+      const dayMap = new Map<string, { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }>();
+      for (const r of filtered) {
+        const date = r.timestamp.slice(0, 10);
+        let bucket = dayMap.get(date);
+        if (!bucket) {
+          bucket = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+          dayMap.set(date, bucket);
+        }
+        bucket.inputTokens += r.inputTokens;
+        bucket.outputTokens += r.outputTokens;
+        bucket.cacheReadTokens += r.cacheReadTokens;
+        bucket.cacheWriteTokens += r.cacheCreationTokens;
+      }
+
+      return [...dayMap.entries()]
+        .map(([date, d]) => ({
+          date,
+          inputTokens: d.inputTokens,
+          outputTokens: d.outputTokens,
+          cacheReadTokens: d.cacheReadTokens,
+          cacheWriteTokens: d.cacheWriteTokens,
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+    }),
+    getUsageSummary: vi.fn(() => ({
+      totalInputTokens: 600, totalOutputTokens: 300,
+      totalCacheCreationTokens: 90, totalCacheReadTokens: 120,
+      totalCostUsd: 0.06, recordCount: 3, sessions: 3,
+    })),
+    getRateTiers: vi.fn(() => []),
+    getSessionUsage: vi.fn(() => []),
+    getCostByKey: vi.fn(() => []),
+    getUsageByKey: vi.fn(() => []),
+  };
+}
+
+function mockMetricsCache() {
+  return {
+    getMetrics: vi.fn(() => ({
+      tokenUsageByModel: [
+        {
+          model: 'sonnet', inputTokens: 600, outputTokens: 300,
+          cacheCreationTokens: 90, cacheReadTokens: 120,
+          estimatedCostUsd: 0.06,
+        },
+      ],
+      costTrends: [],
+      errorRates: { totalSessions: 3 },
+      topApiKeys: [],
+      generatedAt: new Date(NOW).toISOString(),
+    })),
+  };
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false });
+
+  app.addHook('onRequest', async (req: any) => {
+    req.authKeyId = 'admin-key';
+    req.tenantId = SYSTEM_TENANT;
+  });
+
+  const ctx = {
+    sessions: { listSessions: vi.fn(() => []), getSession: vi.fn() },
+    auth: { authEnabled: true },
+    metering: mockMetering() as any,
+    metricsCache: mockMetricsCache() as any,
+    quotas: {} as any,
+    config: { enforceSessionOwnership: true },
+  } as unknown as RouteContext;
+
+  registerAnalyticsRoutes(app, ctx);
+  return app;
+}
+
+describe('GET /v1/analytics/tokens — dailyBreakdown (Issue #3282)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function inject(uri: string) {
+    return app.inject({
+      method: 'GET',
+      url: uri,
+      headers: { authorization: 'Bearer admin-key' },
+    });
+  }
+
+  it('returns dailyBreakdown with aggregated token counts per day', async () => {
+    const res = await inject('/v1/analytics/tokens');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.dailyBreakdown).toHaveLength(2);
+
+    // May 10: 100+200=300 input, 50+100=150 output, 20+40=60 cacheRead, 10+30=40 cacheWrite
+    const may10 = body.dailyBreakdown.find((d: any) => d.date === '2026-05-10');
+    expect(may10).toBeDefined();
+    expect(may10.inputTokens).toBe(300);
+    expect(may10.outputTokens).toBe(150);
+    expect(may10.cacheReadTokens).toBe(60);
+    expect(may10.cacheWriteTokens).toBe(40);
+
+    // May 12: 300 input, 150 output, 60 cacheRead, 50 cacheWrite
+    const may12 = body.dailyBreakdown.find((d: any) => d.date === '2026-05-12');
+    expect(may12).toBeDefined();
+    expect(may12.inputTokens).toBe(300);
+    expect(may12.outputTokens).toBe(150);
+  });
+
+  it('filters dailyBreakdown by from/to query params', async () => {
+    const res = await inject('/v1/analytics/tokens?from=2026-05-12T00:00:00Z&to=2026-05-12T23:59:59Z');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.dailyBreakdown).toHaveLength(1);
+    expect(body.dailyBreakdown[0].date).toBe('2026-05-12');
+    expect(body.dailyBreakdown[0].inputTokens).toBe(300);
+  });
+
+  it('returns empty dailyBreakdown for out-of-range dates', async () => {
+    const res = await inject('/v1/analytics/tokens?from=2020-01-01T00:00:00Z&to=2020-01-02T00:00:00Z');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.dailyBreakdown).toEqual([]);
+  });
+
+  it('returns empty dailyBreakdown when no records exist', async () => {
+    // Build app with empty records
+    const app2 = Fastify({ logger: false });
+    app2.addHook('onRequest', async (req: any) => {
+      req.authKeyId = 'admin-key';
+      req.tenantId = SYSTEM_TENANT;
+    });
+
+    const emptyMetering = mockMetering();
+    emptyMetering.getDailyTokenBreakdown = vi.fn(() => []);
+
+    const ctx = {
+      sessions: { listSessions: vi.fn(() => []), getSession: vi.fn() },
+      auth: { authEnabled: true },
+      metering: emptyMetering as any,
+      metricsCache: mockMetricsCache() as any,
+      quotas: {} as any,
+      config: { enforceSessionOwnership: true },
+    } as unknown as RouteContext;
+
+    registerAnalyticsRoutes(app2, ctx);
+
+    const res = await app2.inject({
+      method: 'GET',
+      url: '/v1/analytics/tokens',
+      headers: { authorization: 'Bearer admin-key' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().dailyBreakdown).toEqual([]);
+
+    await app2.close();
+  });
+
+  it('preserves backward-compatible fields (totalTokens, modelDistribution, dailyCost)', async () => {
+    const res = await inject('/v1/analytics/tokens');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    // Legacy fields still present
+    expect(body.totalTokens).toBeDefined();
+    expect(body.modelDistribution).toBeDefined();
+    expect(body.dailyCost).toBeDefined();
+    expect(body.generatedAt).toBeDefined();
+
+    // New field
+    expect(body.dailyBreakdown).toBeDefined();
+  });
+});

--- a/src/__tests__/metering.test.ts
+++ b/src/__tests__/metering.test.ts
@@ -561,4 +561,79 @@ describe('MeteringService', () => {
       expect(svc.recordCount).toBe(10);
     });
   });
+  // ── getDailyTokenBreakdown (Issue #3282) ─────────────────────────
+  describe('getDailyTokenBreakdown', () => {
+    it('returns empty array when no records exist', () => {
+      expect(metering.getDailyTokenBreakdown()).toEqual([]);
+    });
+
+    it('aggregates tokens by date', async () => {
+      metering.recordTokenUsage('s1', { inputTokens: 100, outputTokens: 50, cacheCreationTokens: 10, cacheReadTokens: 20 }, 'sonnet');
+      await flushAsync();
+
+      metering.recordTokenUsage('s2', { inputTokens: 200, outputTokens: 100, cacheCreationTokens: 30, cacheReadTokens: 40 }, 'sonnet');
+      await flushAsync();
+
+      const result = metering.getDailyTokenBreakdown();
+      expect(result).toHaveLength(1);
+
+      const today = new Date().toISOString().slice(0, 10);
+      expect(result[0].date).toBe(today);
+      expect(result[0].inputTokens).toBe(300);
+      expect(result[0].outputTokens).toBe(150);
+      expect(result[0].cacheReadTokens).toBe(60);
+      expect(result[0].cacheWriteTokens).toBe(40);
+    });
+
+    it('filters by from/to date range', async () => {
+      metering.recordTokenUsage('s1', { inputTokens: 100, outputTokens: 50, cacheCreationTokens: 10, cacheReadTokens: 20 }, 'sonnet');
+      await flushAsync();
+      const records = (metering as any).records as UsageRecord[];
+      if (records.length > 0) records[records.length - 1].timestamp = '2026-05-10T10:00:00Z';
+
+      metering.recordTokenUsage('s2', { inputTokens: 200, outputTokens: 100, cacheCreationTokens: 30, cacheReadTokens: 40 }, 'sonnet');
+      await flushAsync();
+      const records2 = (metering as any).records as UsageRecord[];
+      if (records2.length > 1) records2[records2.length - 1].timestamp = '2026-05-12T10:00:00Z';
+
+      const result = metering.getDailyTokenBreakdown({ from: '2026-05-12T00:00:00Z', to: '2026-05-12T23:59:59Z' });
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe('2026-05-12');
+      expect(result[0].inputTokens).toBe(200);
+    });
+
+    it('returns empty for out-of-range dates', async () => {
+      metering.recordTokenUsage('s1', { inputTokens: 100, outputTokens: 50, cacheCreationTokens: 10, cacheReadTokens: 20 }, 'sonnet');
+      await flushAsync();
+
+      const result = metering.getDailyTokenBreakdown({ from: '2020-01-01T00:00:00Z', to: '2020-01-02T00:00:00Z' });
+      expect(result).toEqual([]);
+    });
+
+    it('separates records across different dates', async () => {
+      metering.recordTokenUsage('s1', { inputTokens: 100, outputTokens: 50, cacheCreationTokens: 10, cacheReadTokens: 20 }, 'sonnet');
+      await flushAsync();
+
+      metering.recordTokenUsage('s2', { inputTokens: 200, outputTokens: 100, cacheCreationTokens: 30, cacheReadTokens: 40 }, 'sonnet');
+      await flushAsync();
+
+      metering.recordTokenUsage('s3', { inputTokens: 300, outputTokens: 150, cacheCreationTokens: 50, cacheReadTokens: 60 }, 'sonnet');
+      await flushAsync();
+
+      // Backdate records to different days
+      const recs = (metering as any).records as UsageRecord[];
+      recs[0].timestamp = '2026-05-10T10:00:00Z';
+      recs[1].timestamp = '2026-05-11T10:00:00Z';
+      recs[2].timestamp = '2026-05-12T10:00:00Z';
+
+      const result = metering.getDailyTokenBreakdown();
+      expect(result).toHaveLength(3);
+      expect(result[0].date).toBe('2026-05-10');
+      expect(result[0].inputTokens).toBe(100);
+      expect(result[1].date).toBe('2026-05-11');
+      expect(result[1].inputTokens).toBe(200);
+      expect(result[2].date).toBe('2026-05-12');
+      expect(result[2].inputTokens).toBe(300);
+    });
+  });
 });

--- a/src/metering.ts
+++ b/src/metering.ts
@@ -374,6 +374,27 @@ export class MeteringService {
   /**
    * Get per-session usage records.
    */
+  /** Get per-day token breakdown (Issue #3282). */
+  getDailyTokenBreakdown(options?: { from?: string; to?: string }): Array<{ date: string; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }> {
+    const filtered = this.filterRecords({ from: options?.from, to: options?.to });
+    const dayMap = new Map<string, { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }>();
+    for (const r of filtered) {
+      const date = r.timestamp.slice(0, 10);
+      let bucket = dayMap.get(date);
+      if (!bucket) {
+        bucket = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+        dayMap.set(date, bucket);
+      }
+      bucket.inputTokens += r.inputTokens;
+      bucket.outputTokens += r.outputTokens;
+      bucket.cacheReadTokens += r.cacheReadTokens;
+      bucket.cacheWriteTokens += r.cacheCreationTokens;
+    }
+    return [...dayMap.entries()]
+      .map(([date, d]) => ({ date, inputTokens: d.inputTokens, outputTokens: d.outputTokens, cacheReadTokens: d.cacheReadTokens, cacheWriteTokens: d.cacheWriteTokens }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }
+
   getSessionUsage(sessionId: string, options?: { from?: string; to?: string }): UsageRecord[] {
     return this.filterRecords({ sessionId, from: options?.from, to: options?.to });
   }

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -22,7 +22,7 @@ import type { ApiKey } from '../services/auth/types.js';
 const GLOBAL_RATE_LIMIT = { max: 600, timeWindowMs: 60_000 };
 
 export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext): void {
-  const { metricsCache, auth, quotas, sessions } = ctx;
+  const { metricsCache, auth, quotas, sessions, metering } = ctx;
 
   // ── Summary endpoint (delegates to MetricsCache) ────────────
   registerWithLegacy(app, 'get', '/v1/analytics/summary', {
@@ -73,12 +73,13 @@ export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext)
     },
   });
 
-  // ── Token usage endpoint (Issue #2247) ──────────────────────
+  // ── Token usage endpoint (Issue #2247, #3282) ──────────────
   registerWithLegacy(app, 'get', '/v1/analytics/tokens', {
     config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
     handler: async (req: FastifyRequest, reply: FastifyReply) => {
       if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
 
+      const query = req.query as { from?: string; to?: string };
       const metrics = metricsCache.getMetrics();
 
       const totalTokens = metrics.tokenUsageByModel.reduce(
@@ -89,6 +90,12 @@ export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext)
         (sum, m) => sum + m.estimatedCostUsd,
         0,
       );
+
+      // Per-day token breakdown from metering records (Issue #3282)
+      const dailyBreakdown = metering.getDailyTokenBreakdown({
+        from: query.from,
+        to: query.to,
+      });
 
       return {
         totalTokens,
@@ -106,6 +113,7 @@ export function registerAnalyticsRoutes(app: FastifyInstance, ctx: RouteContext)
           estimatedCostUsd: d.cost,
           sessions: d.sessions,
         })),
+        dailyBreakdown,
         generatedAt: metrics.generatedAt,
       };
     },

--- a/src/services/billing/metering.ts
+++ b/src/services/billing/metering.ts
@@ -232,6 +232,45 @@ export class BillingMeteringService {
     return result;
   }
 
+
+  /**
+   * Get per-day token breakdown aggregated from metering records.
+   * Returns an array of daily token counts sorted by date ascending.
+   */
+  getDailyTokenBreakdown(options?: { from?: string; to?: string }): Array<{
+    date: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+  }> {
+    const filtered = this.filterRecords({ from: options?.from, to: options?.to });
+    const dayMap = new Map<string, { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }>();
+
+    for (const r of filtered) {
+      const date = r.timestamp.slice(0, 10); // YYYY-MM-DD
+      let bucket = dayMap.get(date);
+      if (!bucket) {
+        bucket = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+        dayMap.set(date, bucket);
+      }
+      bucket.inputTokens += r.inputTokens;
+      bucket.outputTokens += r.outputTokens;
+      bucket.cacheReadTokens += r.cacheReadTokens;
+      bucket.cacheWriteTokens += r.cacheCreationTokens;
+    }
+
+    return [...dayMap.entries()]
+      .map(([date, d]) => ({
+        date,
+        inputTokens: d.inputTokens,
+        outputTokens: d.outputTokens,
+        cacheReadTokens: d.cacheReadTokens,
+        cacheWriteTokens: d.cacheWriteTokens,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }
+
   /**
    * Get per-session usage records.
    */


### PR DESCRIPTION
## Summary

Implements #3282 — per-day token aggregation API for the dashboard TokenBreakdownChart.

### Changes
- **MeteringService.getDailyTokenBreakdown()** — new method that aggregates inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens by YYYY-MM-DD date, with optional from/to time-range filtering
- **GET /v1/analytics/tokens** — now accepts ?from=X&to=Y query params and includes a dailyBreakdown array in the response
- Backward-compatible: existing fields (totalTokens, modelDistribution, dailyCost, generatedAt) are unchanged
- 10 new tests: 5 unit tests on MeteringService + 5 integration tests on the route

### Verification
```
tsc --noEmit: Zero errors
npm run build: Success
npm test: 4139 passed (2 pre-existing flaky failures)
```