### PR TITLE
feat(dashboard): wire cost panels to real /v1/cost/* API endpoints (recovery)

### DIFF
--- a/dashboard/src/__tests__/a11y-pages.test.tsx
+++ b/dashboard/src/__tests__/a11y-pages.test.tsx
@@ -165,6 +165,18 @@ vi.mock('../api/client', () => ({
     ],
     generatedAt: new Date().toISOString(),
   }),
+  getCostSummary: vi.fn().mockResolvedValue({
+    from: null, to: null,
+    totalInputTokens: 3000, totalOutputTokens: 1500,
+    totalCacheCreationTokens: 600, totalCacheReadTokens: 2400,
+    cacheHitRate: 0.8, estimatedCostUsd: 12.34,
+    burnRateUsdPerHour: 1.5, sessions: 5,
+  }),
+  getCostByModel: vi.fn().mockResolvedValue({
+    from: null, to: null,
+    models: [{ model: 'claude-sonnet-4-20250514', inputTokens: 3000, outputTokens: 1500, cacheCreationTokens: 600, cacheReadTokens: 2400, estimatedCostUsd: 12.34, cacheHitRate: 0.8 }],
+    totalModels: 1, totalCostUsd: 12.34,
+  }),
   checkForUpdates: vi.fn().mockResolvedValue({
     currentVersion: '1.0.0',
     latestVersion: '1.0.0',

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -35,6 +35,8 @@ import type {
   AnalyticsSummary,
   RateLimitAnalyticsResponse,
   AnalyticsCostsResponse,
+  CostSummaryResponse,
+  CostByModelResponse,
 } from '../types';
 import type {
   AuditChainMetadata,
@@ -295,6 +297,24 @@ export function getRateLimitAnalytics(): Promise<RateLimitAnalyticsResponse> {
 // Issue #2802: Cost analytics
 export function getAnalyticsCosts(): Promise<AnalyticsCostsResponse> {
   return request('/v1/analytics/costs');
+}
+
+/** GET /v1/cost/summary — Aggregate cost with burn rate. */
+export function getCostSummary(params?: { from?: string; to?: string }): Promise<CostSummaryResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.from) searchParams.set("from", params.from);
+  if (params?.to) searchParams.set("to", params.to);
+  const qs = searchParams.toString();
+  return request(`/v1/cost/summary${qs ? `?${qs}` : ""}`);
+}
+
+/** GET /v1/cost/by-model — Cost grouped by model. */
+export function getCostByModel(params?: { from?: string; to?: string }): Promise<CostByModelResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.from) searchParams.set("from", params.from);
+  if (params?.to) searchParams.set("to", params.to);
+  const qs = searchParams.toString();
+  return request(`/v1/cost/by-model${qs ? `?${qs}` : ""}`);
 }
 
 // ── Sessions ────────────────────────────────────────────────────

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -26,8 +26,8 @@ import { useStore } from '../store/useStore';
 import { formatCurrency } from '../utils/formatNumber';
 import { formatDateShort } from '../utils/formatDate';
 import { ChartFrame } from '../components/shared/ChartFrame';
-import { getAnalyticsCosts } from '../api/client';
-import type { AnalyticsCostsResponse } from '../types';
+import { getAnalyticsCosts, getCostSummary, getCostByModel } from '../api/client';
+import type { AnalyticsCostsResponse, CostSummaryResponse, CostByModelResponse } from '../types';
 import { BudgetProgressBar } from '../components/shared/BudgetProgressBar';
 import { SpendSummary } from '../components/cost/SpendSummary';
 import { ForecastChart } from '../components/cost/ForecastChart';
@@ -166,12 +166,20 @@ export default function CostPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [dataError, setDataError] = useState<string | null>(null);
   const [timeRange, setTimeRange] = useState<TimeRange>('30d');
+  const [costSummary, setCostSummary] = useState<CostSummaryResponse | null>(null);
+  const [costByModel, setCostByModel] = useState<CostByModelResponse | null>(null);
   const sseConnected = useStore((s) => s.sseConnected);
 
   const fetchData = useCallback(async () => {
     try {
-      const data = await getAnalyticsCosts();
-      setCostData(data);
+      const [data, summary, byModel] = await Promise.allSettled([
+        getAnalyticsCosts(),
+        getCostSummary().catch(() => null),
+        getCostByModel().catch(() => null),
+      ]);
+      if (data.status === 'fulfilled') setCostData(data.value);
+      if (summary.status === 'fulfilled' && summary.value) setCostSummary(summary.value);
+      if (byModel.status === 'fulfilled' && byModel.value) setCostByModel(byModel.value);
       setDataError(null);
     } catch (err) {
       setDataError(err instanceof Error ? err.message : 'Failed to load cost data');
@@ -369,19 +377,24 @@ export default function CostPage() {
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-medium text-[var(--color-text-primary)]">
             Cost Analytics
+            {costSummary?.burnRateUsdPerHour && costSummary.burnRateUsdPerHour > 0 && (
+              <span className="ml-3 text-sm font-normal text-[var(--color-accent-cyan)]">
+                {formatCurrency(costSummary.burnRateUsdPerHour)}/hr burn rate
+              </span>
+            )}
           </h2>
           <TimeRangePicker value={timeRange} onChange={setTimeRange} />
         </div>
 
         {/* Burn rate — full width */}
         <div className="mb-4">
-          <BurnRateChart />
+          <BurnRateChart data={dailyData.map(d => ({ date: d.date, cost: d.estimatedCostUsd }))} />
         </div>
 
         {/* Token breakdown + Cost by model — side by side */}
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <TokenBreakdownChart />
-          <CostByModelChart />
+          <CostByModelChart data={costByModel?.models.map(m => ({ model: m.model, cost: m.estimatedCostUsd }))} />
         </div>
       </section>
 

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -213,3 +213,39 @@ export interface WsResizeMessage {
 
 export type WsOutboundMessage = WsInputMessage | WsResizeMessage;
 
+
+// ── Cost Tracking API (Issue #3264, #3273) ─────────────────────
+
+/** Response from GET /v1/cost/summary */
+export interface CostSummaryResponse {
+  from: string | null;
+  to: string | null;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheCreationTokens: number;
+  totalCacheReadTokens: number;
+  cacheHitRate: number;
+  estimatedCostUsd: number;
+  burnRateUsdPerHour: number | null;
+  sessions: number;
+}
+
+/** Per-model cost entry from GET /v1/cost/by-model */
+export interface ModelCostEntry {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  estimatedCostUsd: number;
+  cacheHitRate: number;
+}
+
+/** Response from GET /v1/cost/by-model */
+export interface CostByModelResponse {
+  from: string | null;
+  to: string | null;
+  models: ModelCostEntry[];
+  totalModels: number;
+  totalCostUsd: number;
+}


### PR DESCRIPTION
## Recovery PR
Original PR #3281 was accidentally merged as an empty diff due to a botched rebase. This PR recreates the changes from scratch.

## Changes
- Wire cost analytics panels to real API data
- Add `getCostSummary` and `getCostByModel` to API client
- Add `CostSummaryResponse` and `CostByModelResponse` types
- Update a11y test mocks

Supersedes #3281, #3295