### PR TITLE
fix(dashboard): add type='button' to 96 buttons across 36 files (recovery)

### DIFF
--- a/dashboard/src/__tests__/a11y-pages.test.tsx
+++ b/dashboard/src/__tests__/a11y-pages.test.tsx
@@ -25,7 +25,7 @@ import Layout from '../components/Layout';
 vi.mock('../components/overview/HomeStatusPanel', () => ({
   default: ({ onCreateFirstSession }: { onCreateFirstSession: () => void }) => (
     <div data-testid="home-status-panel">
-      <button onClick={onCreateFirstSession}>Create first session</button>
+      <button type="button" onClick={onCreateFirstSession}>Create first session</button>
     </div>
   ),
 }));

--- a/dashboard/src/__tests__/i18n-context.test.tsx
+++ b/dashboard/src/__tests__/i18n-context.test.tsx
@@ -16,7 +16,7 @@ function TestComponent() {
       <div data-testid="title">{t('overview.title')}</div>
       <div data-testid="subtitle">{t('overview.subtitle')}</div>
       <div data-testid="missing">{t('nonexistent.key')}</div>
-      <button onClick={() => setLocale('de-DE')}>Change to German</button>
+      <button type="button" onClick={() => setLocale('de-DE')}>Change to German</button>
     </div>
   );
 }

--- a/dashboard/src/__tests__/i18n-integration.test.tsx
+++ b/dashboard/src/__tests__/i18n-integration.test.tsx
@@ -67,8 +67,8 @@ describe('i18n integration', () => {
         <div>
           <span data-testid="current-locale">{locale}</span>
           <span>{t('settings.display.title')}</span>
-          <button onClick={() => setLocale('it-IT')}>Switch to Italian</button>
-          <button onClick={() => setLocale('en-US')}>Switch to English</button>
+          <button type="button" onClick={() => setLocale('it-IT')}>Switch to Italian</button>
+          <button type="button" onClick={() => setLocale('en-US')}>Switch to English</button>
         </div>
       );
     }
@@ -94,7 +94,7 @@ describe('i18n integration', () => {
   it('persists locale choice to localStorage', () => {
     function LocaleWriter() {
       const { setLocale } = useLocale();
-      return <button onClick={() => setLocale('it-IT')}>Set Italian</button>;
+      return <button type="button" onClick={() => setLocale('it-IT')}>Set Italian</button>;
     }
 
     render(

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -210,7 +210,7 @@ export default function ActivityStream({
 
             {/* Clear filters */}
             {(filterSession || filterType) && (
-              <button
+              <button type="button"
                 onClick={() => { setFilterSession(null); setFilterType(null); }}
                 className="min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
               >

--- a/dashboard/src/components/CreatePipelineModal.tsx
+++ b/dashboard/src/components/CreatePipelineModal.tsx
@@ -124,7 +124,7 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
         {/* Header */}
         <div className="flex items-center justify-between px-4 sm:px-5 py-4 border-b border-[var(--color-void-lighter)]">
           <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">New Pipeline</h2>
-          <button aria-label={t("aria.close")}
+          <button type="button" aria-label={t("aria.close")}
             onClick={handleClose}
             className="min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
           >

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -237,7 +237,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               )}
             </div>
           </div>
-          <button aria-label={t("aria.close")}
+          <button type="button" aria-label={t("aria.close")}
             onClick={handleClose}
             className="min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
           >

--- a/dashboard/src/components/KeyboardShortcutsHelp/index.tsx
+++ b/dashboard/src/components/KeyboardShortcutsHelp/index.tsx
@@ -42,7 +42,7 @@ export function KeyboardShortcutsHelp({
             <Keyboard className="h-5 w-5 text-[var(--color-accent-cyan)]" />
             <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">Keyboard Shortcuts</h2>
           </div>
-          <button
+          <button type="button"
             onClick={onClose}
             className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-void-lighter)]/50 hover:text-[var(--color-text-primary)] transition-colors"
             aria-label={t("aria.close")}

--- a/dashboard/src/components/SaveTemplateModal.tsx
+++ b/dashboard/src/components/SaveTemplateModal.tsx
@@ -103,7 +103,7 @@ export default function SaveTemplateModal({ open, onClose, sessionId }: SaveTemp
         {/* Header */}
         <div className="flex items-center justify-between px-4 sm:px-5 py-4 border-b border-[var(--color-void-lighter)]">
           <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Save as Template</h2>
-          <button aria-label={t("aria.close")}
+          <button type="button" aria-label={t("aria.close")}
             onClick={handleClose}
             className="min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
           >

--- a/dashboard/src/components/TemplateModal.tsx
+++ b/dashboard/src/components/TemplateModal.tsx
@@ -166,7 +166,7 @@ export default function TemplateModal({ open, onClose, template, onSaved }: Temp
           <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
             {isEditing ? 'Edit Template' : 'Create Template'}
           </h2>
-          <button aria-label={t("aria.close")}
+          <button type="button" aria-label={t("aria.close")}
             onClick={handleClose}
             className="min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
           >

--- a/dashboard/src/components/ToastContainer.tsx
+++ b/dashboard/src/components/ToastContainer.tsx
@@ -130,7 +130,7 @@ function ToastItem({
         )}
       </div>
       {undoAction && (
-        <button
+        <button type="button"
           onClick={handleUndo}
           className="shrink-0 flex items-center gap-1 rounded px-2 py-1 text-xs font-medium opacity-80 hover:opacity-100 transition-opacity bg-current/10"
           aria-label={t("aria.undo")}
@@ -139,7 +139,7 @@ function ToastItem({
           Undo
         </button>
       )}
-      <button
+      <button type="button"
         onClick={() => removeToast(id)}
         className="shrink-0 rounded p-0.5 opacity-60 hover:opacity-100 transition-opacity"
         aria-label={t("aria.dismiss")}
@@ -165,7 +165,7 @@ export default function ToastContainer() {
     >
       {toasts.length > 1 && (
         <div className="flex justify-end pointer-events-auto">
-          <button
+          <button type="button"
             onClick={() => toasts.forEach((t) => removeToast(t.id))}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
             aria-label={t("aria.dismissAll")}

--- a/dashboard/src/components/brand/OnboardingScreen.tsx
+++ b/dashboard/src/components/brand/OnboardingScreen.tsx
@@ -63,7 +63,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
       className="fixed inset-0 z-50 flex flex-col items-center justify-center"
       style={{ backgroundColor: 'var(--color-void)' }}
     >
-      <button
+      <button type="button"
         onClick={handleSkip}
         className="absolute top-6 right-6 px-4 py-2 text-sm font-medium rounded-md transition-colors"
         style={{

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -60,7 +60,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
 
         <div className="flex shrink-0 items-center gap-1.5">
           {needsApproval(session) && (
-            <button
+            <button type="button"
               onClick={(e) => onApprove(e, session.id)}
               disabled={currentAction === 'approve'}
               aria-label={`Approve session ${session.displayName || session.id}`}
@@ -70,7 +70,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
               <Play className="h-4 w-4" />
             </button>
           )}
-          <button
+          <button type="button"
             onClick={(e) => onInterrupt(e, session.id)}
             disabled={currentAction === 'interrupt' || currentAction === 'kill'}
             aria-label={`Interrupt session ${session.displayName || session.id}`}
@@ -79,7 +79,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
           >
             <Ban className="h-4 w-4" />
           </button>
-          <button
+          <button type="button"
             onClick={(e) => onKill(e, session.id)}
             disabled={currentAction === 'kill'}
             aria-label={`Kill session ${session.displayName || session.id}`}

--- a/dashboard/src/components/routines/CalendarGrid.tsx
+++ b/dashboard/src/components/routines/CalendarGrid.tsx
@@ -104,21 +104,21 @@ export default function CalendarGrid({
           {format(currentMonth, 'MMMM yyyy')}
         </h3>
         <div className="flex items-center gap-1">
-          <button
+          <button type="button"
             onClick={handleToday}
             className="px-2 py-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors rounded"
             aria-label={t("aria.goToToday")}
           >
             Today
           </button>
-          <button
+          <button type="button"
             onClick={handlePrevMonth}
             className="p-1 rounded hover:bg-[var(--color-void-dark)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
             aria-label={t("aria.prevMonth")}
           >
             <ChevronLeft className="w-4 h-4" />
           </button>
-          <button
+          <button type="button"
             onClick={handleNextMonth}
             className="p-1 rounded hover:bg-[var(--color-void-dark)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
             aria-label={t("aria.nextMonth")}
@@ -152,7 +152,7 @@ export default function CalendarGrid({
           const today = isToday(day);
 
           return (
-            <button
+            <button type="button"
               key={dateKey}
               onClick={() => onSelectDate(day)}
               disabled={!inCurrentMonth}

--- a/dashboard/src/components/routines/RoutineCard.tsx
+++ b/dashboard/src/components/routines/RoutineCard.tsx
@@ -97,7 +97,7 @@ export default function RoutineCard({
 
         {/* Quick actions */}
         <div className="flex items-center gap-1" role="group" aria-label={t("aria.routineActions")}>
-          <button
+          <button type="button"
             onClick={() => onTogglePause?.(routine.id)}
             className={`
               p-1.5 rounded transition-colors
@@ -111,7 +111,7 @@ export default function RoutineCard({
           >
             {isActive ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
           </button>
-          <button
+          <button type="button"
             onClick={() => onTriggerNow?.(routine.id)}
             className="p-1.5 rounded text-blue-400 hover:bg-blue-500/10 transition-colors"
             aria-label={t("aria.triggerRoutine")}
@@ -119,7 +119,7 @@ export default function RoutineCard({
           >
             <Zap className="w-4 h-4" />
           </button>
-          <button
+          <button type="button"
             onClick={() => onDelete?.(routine.id)}
             className="p-1.5 rounded text-red-400 hover:bg-red-500/10 transition-colors"
             aria-label={t("aria.deleteRoutine")}

--- a/dashboard/src/components/session/AcpApprovalModal.tsx
+++ b/dashboard/src/components/session/AcpApprovalModal.tsx
@@ -160,7 +160,7 @@ export function AcpApprovalModal({
         <div className="flex items-center gap-2 rounded-lg bg-red-500/10 px-3 py-2 text-sm text-red-400" role="alert">
           <span className="flex-1">{error}</span>
           {onClearError && (
-            <button onClick={onClearError} className="text-red-400 hover:text-red-300" aria-label={t("aria.dismissError")}>
+            <button type="button" onClick={onClearError} className="text-red-400 hover:text-red-300" aria-label={t("aria.dismissError")}>
               ✕
             </button>
           )}

--- a/dashboard/src/components/session/DriverControlBar.tsx
+++ b/dashboard/src/components/session/DriverControlBar.tsx
@@ -78,7 +78,7 @@ export function DriverControlBar({
         <div className="flex items-center gap-2 rounded bg-red-500/10 px-3 py-2 text-sm text-red-400" role="alert">
           <span className="flex-1">{error}</span>
           {onClearError && (
-            <button
+            <button type="button"
               onClick={onClearError}
               className="text-red-400 hover:text-red-300"
               aria-label={t("aria.dismissError")}
@@ -120,7 +120,7 @@ export function DriverControlBar({
       {/* Action buttons */}
       <div className="flex items-center gap-2">
         {!hasDriver && (
-          <button
+          <button type="button"
             onClick={() => onClaim?.()}
             disabled={!canAct}
             className="flex items-center gap-2 rounded-md bg-blue-500/20 px-3 py-2 text-sm font-medium text-blue-400 transition-colors hover:bg-blue-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -133,7 +133,7 @@ export function DriverControlBar({
 
         {isDriver && (
           <>
-            <button
+            <button type="button"
               onClick={() => onRelease?.()}
               disabled={!canAct}
               className="flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] disabled:opacity-50"
@@ -142,7 +142,7 @@ export function DriverControlBar({
               {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Eye className="h-4 w-4" />}
               Release (become observer)
             </button>
-            <button
+            <button type="button"
               onClick={() => setShowTransferForm(true)}
               disabled={!canAct}
               className="flex items-center gap-2 rounded-md bg-amber-500/20 px-3 py-2 text-sm font-medium text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-50"
@@ -155,7 +155,7 @@ export function DriverControlBar({
         )}
 
         {hasDriver && !isDriver && canOperate && (
-          <button
+          <button type="button"
             onClick={() => setShowTransferForm(true)}
             disabled={!canAct}
             className="flex items-center gap-2 rounded-md bg-amber-500/20 px-3 py-2 text-sm font-medium text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-50"
@@ -196,7 +196,7 @@ export function DriverControlBar({
             className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-warning)]/50 focus:outline-none"
           />
           <div className="flex items-center gap-2">
-            <button
+            <button type="button"
               onClick={handleTransfer}
               disabled={!transferTarget.trim() || isLoading}
               className="flex items-center gap-1 rounded-md bg-amber-500 px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-amber-400 disabled:opacity-50"
@@ -205,7 +205,7 @@ export function DriverControlBar({
               {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRightLeft className="h-4 w-4" />}
               Transfer
             </button>
-            <button
+            <button type="button"
               onClick={() => { setShowTransferForm(false); setTransferTarget(''); setTransferReason(''); }}
               className="rounded-md border border-[var(--color-border-strong)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
               aria-label={t("aria.cancelTransfer")}

--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -61,7 +61,7 @@ function ThinkingBlock({ entry }: { entry: ParsedEntry }) {
   return (
     <div className="flex justify-start mb-3">
       <div className="max-w-[80%] w-full">
-        <button
+        <button type="button"
           onClick={() => setOpen(o => !o)}
           className="flex items-center gap-2 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-muted)] transition-colors py-1 group"
         >
@@ -109,7 +109,7 @@ function ToolUseCard({ entry }: { entry: ParsedEntry }) {
           </div>
         )}
         {rawText.length > 100 && (
-          <button
+          <button type="button"
             onClick={() => setExpanded(e => !e)}
             className="w-full text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-text-muted)] py-1 border-t border-[var(--color-void-lighter)] transition-colors"
           >
@@ -155,7 +155,7 @@ function ToolResultCard({ entry }: { entry: ParsedEntry }) {
           </div>
         )}
         {rawText.length > 100 && (
-          <button
+          <button type="button"
             onClick={() => setExpanded(e => !e)}
             className="w-full text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-text-muted)] py-1 border-t border-[var(--color-void-lighter)] transition-colors"
           >

--- a/dashboard/src/components/session/PanePreview.tsx
+++ b/dashboard/src/components/session/PanePreview.tsx
@@ -27,7 +27,7 @@ export function PanePreview({ status, content, loading }: PanePreviewProps) {
   return (
     <div className="bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg overflow-hidden">
       {/* Toggle header */}
-      <button
+      <button type="button"
         onClick={() => setCollapsed(c => !c)}
         className="flex items-center justify-between w-full px-4 py-2 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors border-b border-[var(--color-void-lighter)]"
       >

--- a/dashboard/src/components/session/PauseControlBar.tsx
+++ b/dashboard/src/components/session/PauseControlBar.tsx
@@ -89,7 +89,7 @@ export function PauseControlBar({
         <div className="flex items-center gap-2 rounded bg-red-500/10 px-3 py-2 text-sm text-red-400" role="alert">
           <span className="flex-1">{error}</span>
           {onClearError && (
-            <button
+            <button type="button"
               onClick={onClearError}
               className="text-red-400 hover:text-red-300"
               aria-label={t("aria.dismissError")}
@@ -104,7 +104,7 @@ export function PauseControlBar({
       {isRunning && (
         <div className="flex items-center gap-2">
           {!showPauseForm ? (
-            <button
+            <button type="button"
               onClick={() => setShowPauseForm(true)}
               disabled={!canAct}
               className="flex items-center gap-2 rounded-md bg-amber-500/20 px-3 py-2 text-sm font-medium text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -130,7 +130,7 @@ export function PauseControlBar({
                   autoFocus
                 />
               </div>
-              <button
+              <button type="button"
                 onClick={handlePause}
                 disabled={!pauseReason.trim() || isLoading}
                 className="flex items-center gap-1 rounded-md bg-amber-500 px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-amber-400 disabled:opacity-50"
@@ -139,7 +139,7 @@ export function PauseControlBar({
                 {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Pause className="h-4 w-4" />}
                 Confirm
               </button>
-              <button
+              <button type="button"
                 onClick={() => { setShowPauseForm(false); setPauseReason(''); }}
                 className="rounded-md border border-[var(--color-void-lighter)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
                 aria-label={t("aria.cancelPause")}
@@ -157,7 +157,7 @@ export function PauseControlBar({
           <span className="rounded bg-amber-500/20 px-2 py-1 text-xs font-medium text-amber-400">
             Paused
           </span>
-          <button
+          <button type="button"
             onClick={() => onIntervene?.()}
             disabled={!canAct}
             className="flex items-center gap-2 rounded-md bg-blue-500/20 px-3 py-2 text-sm font-medium text-blue-400 transition-colors hover:bg-blue-500/30 disabled:opacity-50"
@@ -166,7 +166,7 @@ export function PauseControlBar({
             <Hand className="h-4 w-4" />
             Intervene
           </button>
-          <button
+          <button type="button"
             onClick={() => onResume?.()}
             disabled={!canAct}
             className="flex items-center gap-2 rounded-md bg-green-500/20 px-3 py-2 text-sm font-medium text-green-400 transition-colors hover:bg-green-500/30 disabled:opacity-50"
@@ -186,7 +186,7 @@ export function PauseControlBar({
               Intervening
             </span>
             {!showGuidanceForm && (
-              <button
+              <button type="button"
                 onClick={() => setShowGuidanceForm(true)}
                 disabled={!canAct}
                 className="flex items-center gap-2 rounded-md bg-blue-500/20 px-3 py-2 text-sm font-medium text-blue-400 transition-colors hover:bg-blue-500/30 disabled:opacity-50"
@@ -213,7 +213,7 @@ export function PauseControlBar({
                 autoFocus
               />
               <div className="flex items-center gap-2">
-                <button
+                <button type="button"
                   onClick={handleComplete}
                   disabled={isLoading}
                   className="flex items-center gap-1 rounded-md bg-blue-500 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-400 disabled:opacity-50"
@@ -222,7 +222,7 @@ export function PauseControlBar({
                   {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4" />}
                   Submit &amp; Resume
                 </button>
-                <button
+                <button type="button"
                   onClick={() => { setShowGuidanceForm(false); setGuidance(''); }}
                   className="rounded-md border border-[var(--color-void-lighter)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
                   aria-label={t("aria.cancelIntervention")}
@@ -234,7 +234,7 @@ export function PauseControlBar({
           )}
 
           {!showGuidanceForm && (
-            <button
+            <button type="button"
               onClick={() => onResume?.()}
               disabled={!canAct}
               className="flex items-center gap-2 self-start rounded-md bg-green-500/20 px-3 py-2 text-sm font-medium text-green-400 transition-colors hover:bg-green-500/30 disabled:opacity-50"

--- a/dashboard/src/components/session/SessionPreviewCard.tsx
+++ b/dashboard/src/components/session/SessionPreviewCard.tsx
@@ -109,7 +109,7 @@ export function SessionPreviewCard({ session, anchorRef, onClose }: SessionPrevi
           <StatusDot status={session.status} />
           <span className="text-sm font-medium text-[var(--color-text-primary)]">{session.displayName || session.id}</span>
         </div>
-        <button
+        <button type="button"
           onClick={onClose}
           className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
         >

--- a/dashboard/src/components/session/TerminalPassthrough.tsx
+++ b/dashboard/src/components/session/TerminalPassthrough.tsx
@@ -412,7 +412,7 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
         <div className="flex items-center gap-3">
           <span className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-wider">Filter:</span>
           {(['thinking', 'tool_use', 'tool_result'] as const).map(key => (
-            <button
+            <button type="button"
               key={key}
               onClick={() => toggleFilter(key)}
               aria-pressed={filters[key]}

--- a/dashboard/src/components/session/TranscriptBubble.tsx
+++ b/dashboard/src/components/session/TranscriptBubble.tsx
@@ -121,7 +121,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
         className="flex justify-start mb-3 group"
       >
         <div className="max-w-[90%] w-full">
-          <button
+          <button type="button"
             onClick={(e) => {
               e.stopPropagation();
               setCollapsed(!collapsed);
@@ -171,7 +171,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
             </div>
           )}
           <div className="flex-1">
-            <button
+            <button type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 setCollapsed(!collapsed);

--- a/dashboard/src/components/session/TranscriptView.tsx
+++ b/dashboard/src/components/session/TranscriptView.tsx
@@ -169,7 +169,7 @@ export function TranscriptView({ sessionId }: TranscriptViewProps) {
       <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-[var(--color-void-lighter)] bg-[var(--color-void)] shrink-0">
         <span className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-wider">Filter:</span>
         {(['thinking', 'tool_use', 'tool_result'] as const).map(key => (
-          <button
+          <button type="button"
             key={key}
             onClick={() => toggleFilter(key)}
             aria-pressed={filters[key]}
@@ -254,7 +254,7 @@ export function TranscriptView({ sessionId }: TranscriptViewProps) {
 
       {/* Scroll to bottom button */}
       {showScrollBtn && (
-        <button
+        <button type="button"
           onClick={scrollToBottom}
           className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-accent)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
           title="Scroll to bottom"

--- a/dashboard/src/components/session/TranscriptViewer.tsx
+++ b/dashboard/src/components/session/TranscriptViewer.tsx
@@ -186,7 +186,7 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
       <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-[var(--color-void-lighter)] bg-[var(--color-void)] shrink-0">
         <span className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-wider">Filter:</span>
         {(['thinking', 'tool_use', 'tool_result'] as const).map(key => (
-          <button
+          <button type="button"
             key={key}
             onClick={() => toggleFilter(key)}
             aria-pressed={filters[key]}
@@ -238,7 +238,7 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
 
       {/* Scroll to bottom button */}
       {showScrollBtn && (
-        <button
+        <button type="button"
           onClick={scrollToBottom}
           className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-accent)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
           title="Scroll to bottom"

--- a/dashboard/src/components/shared/BudgetAlertBanner.tsx
+++ b/dashboard/src/components/shared/BudgetAlertBanner.tsx
@@ -117,7 +117,7 @@ export function BudgetAlertBanner() {
       <AlertTriangle className="h-4 w-4 flex-shrink-0" />
       <span className="flex-1 font-medium">{alert.message}</span>
       {!isCritical && (
-        <button
+        <button type="button"
           onClick={() => {
             sessionStorage.setItem(DISMISS_KEY, String(Date.now()));
             setAlert(null);

--- a/dashboard/src/components/shared/CodeBlock.tsx
+++ b/dashboard/src/components/shared/CodeBlock.tsx
@@ -65,7 +65,7 @@ export function CodeBlock({ code, language }: CodeBlockProps) {
     <div className="my-2 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void-deepest)] overflow-hidden">
       <div className="flex items-center justify-between px-3 py-1 border-b border-[var(--color-void-lighter)]">
         <span className="text-[10px] text-[var(--color-text-muted)] font-mono">{language || 'code'}</span>
-        <button
+        <button type="button"
           onClick={handleCopy}
           className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
           aria-label={t("aria.copyCode")}

--- a/dashboard/src/components/shared/ErrorBoundary.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.tsx
@@ -54,7 +54,7 @@ export class ErrorBoundary extends Component<Props, State> {
               {this.state.error?.message || 'An unexpected error occurred'}
             </p>
           </div>
-          <button
+          <button type="button"
             onClick={this.handleRetry}
             className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-100 px-4 py-2 text-sm text-red-600 transition-colors hover:bg-red-200 dark:border-red-500/30 dark:bg-red-500/20 dark:text-red-300 dark:hover:bg-red-500/30"
           >

--- a/dashboard/src/components/shared/SessionHealthBanner.tsx
+++ b/dashboard/src/components/shared/SessionHealthBanner.tsx
@@ -102,7 +102,7 @@ export function SessionHealthBanner({ errorRates, loading }: SessionHealthBanner
           </p>
         )}
       </div>
-      <button
+      <button type="button"
         onClick={handleDismiss}
         className="shrink-0 p-1 rounded hover:bg-white/10 transition-colors"
         aria-label={t("aria.dismissHealthAlert")}

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -388,7 +388,7 @@ function DetailDrawer({
               <Eye className="h-4 w-4 text-[var(--color-accent-cyan)]" />
               <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Record Detail</h3>
             </div>
-            <button
+            <button type="button"
               onClick={onClose}
               className="rounded p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-muted)] dark:hover:text-[var(--color-text-primary)] transition-colors"
               aria-label={t("aria.closeDetailDrawer")}
@@ -411,7 +411,7 @@ function DetailDrawer({
             <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)]/50 p-3">
               <div className="flex items-center justify-between">
                 <p className="text-xs uppercase tracking-wide text-[var(--color-text-muted)]">Hash</p>
-                <button
+                <button type="button"
                   onClick={() => { void handleCopy('hash', record.hash); }}
                   className="flex min-h-[44px] items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
                 >
@@ -425,7 +425,7 @@ function DetailDrawer({
             <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)]/50 p-3">
               <div className="flex items-center justify-between">
                 <p className="text-xs uppercase tracking-wide text-[var(--color-text-muted)]">Previous Hash</p>
-                <button
+                <button type="button"
                   onClick={() => { void handleCopy('prevHash', record.prevHash); }}
                   className="flex min-h-[44px] items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
                 >
@@ -440,7 +440,7 @@ function DetailDrawer({
             <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)]/50 p-3">
               <div className="flex items-center justify-between">
                 <p className="text-xs uppercase tracking-wide text-[var(--color-text-muted)]">Full Record (JSON)</p>
-                <button
+                <button type="button"
                   onClick={() => { void handleCopy('json', JSON.stringify(record, null, 2)); }}
                   className="flex min-h-[44px] items-center gap-1 rounded px-2 py-0.5 text-xs text-[var(--color-accent-cyan)] hover:bg-[var(--color-accent-cyan)]/10 transition-colors"
                 >
@@ -676,7 +676,7 @@ export default function AuditPage() {
 
         <div className="flex flex-wrap items-center gap-2">
           {/* Live tail toggle */}
-          <button
+          <button type="button"
             onClick={() => setLiveTail((prev) => !prev)}
             disabled={page !== 1}
             className={`flex min-h-[44px] items-center gap-1.5 rounded border px-3 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
@@ -690,7 +690,7 @@ export default function AuditPage() {
             {liveTail ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
             {liveTail ? 'LIVE' : 'Follow'}
           </button>
-          <button
+          <button type="button"
             onClick={() => { void fetchData(); }}
             disabled={loading}
             className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-2 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-50"
@@ -698,7 +698,7 @@ export default function AuditPage() {
             <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
             Refresh
           </button>
-          <button
+          <button type="button"
             onClick={() => { void handleExport('csv'); }}
             disabled={loading || exportingFormat !== null}
             className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:opacity-50"
@@ -707,7 +707,7 @@ export default function AuditPage() {
             <Download className="h-3.5 w-3.5" />
             {exportingFormat === 'csv' ? 'Exporting CSV…' : 'Export CSV'}
           </button>
-          <button
+          <button type="button"
             onClick={() => { void handleExport('ndjson'); }}
             disabled={loading || exportingFormat !== null}
             className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-2 text-xs font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:opacity-50"
@@ -798,13 +798,13 @@ export default function AuditPage() {
         </div>
 
         <div className="mt-4 flex flex-wrap items-center gap-3">
-          <button
+          <button type="button"
             onClick={applyFilters}
             className="min-h-[44px] rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
           >
             Apply
           </button>
-          <button
+          <button type="button"
             onClick={clearFilters}
             className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-void-lighter)]"
           >
@@ -838,7 +838,7 @@ export default function AuditPage() {
           <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-500" />
           <p className="font-medium text-red-400">Failed to load audit logs</p>
           <p className="mt-1 text-xs text-[var(--color-text-muted)]">{error}</p>
-          <button
+          <button type="button"
             onClick={() => { void fetchData(); }}
             className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-4 py-2 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
           >
@@ -920,7 +920,7 @@ export default function AuditPage() {
               <span className="text-xs text-[var(--color-text-muted)]">
                 Page {page} of {totalPages}
               </span>
-              <button
+              <button type="button"
                 onClick={() => setPage((current) => Math.max(1, current - 1))}
                 disabled={page <= 1}
                 className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:opacity-40"
@@ -928,7 +928,7 @@ export default function AuditPage() {
               >
                 <ChevronLeft className="h-3.5 w-3.5" />
               </button>
-              <button
+              <button type="button"
                 onClick={() => setPage((current) => current + 1)}
                 disabled={!hasMore || page >= totalPages}
                 className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:opacity-40"

--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -91,7 +91,7 @@ export default function NewSessionPage() {
     <div className="max-w-2xl mx-auto">
       {/* Header */}
       <div className="flex items-center gap-4 mb-6">
-        <button
+        <button type="button"
           onClick={() => navigate(-1)}
           className="p-2 rounded hover:bg-[var(--color-void-lighter)] transition-colors text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
           title={t('newSession.goBack')}

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -172,7 +172,7 @@ export default function OverviewPage() {
             </p>
           </div>
         </div>
-        <button
+        <button type="button"
           onClick={() => setModalOpen(true)}
           className="inline-flex min-h-[44px] items-center justify-center gap-1.5 rounded-lg border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-4 py-2 text-xs font-semibold text-[var(--color-accent-cyan)] transition-all hover:bg-[var(--color-accent-cyan)]/20 hover:border-[var(--color-accent-cyan)]/50"
           aria-label={t("aria.createNewSession")}

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -144,7 +144,7 @@ export default function PipelinesPage() {
             Manage and monitor session pipelines
           </p>
         </div>
-        <button
+        <button type="button"
           onClick={() => setModalOpen(true)}
           className="flex min-h-[44px] items-center gap-1.5 px-3 py-2 text-xs font-medium rounded bg-[var(--color-accent-cyan)]/10 hover:bg-[var(--color-accent-cyan)]/20 text-[var(--color-accent-cyan)] border border-[var(--color-accent-cyan)]/30 transition-colors"
         >
@@ -182,7 +182,7 @@ export default function PipelinesPage() {
           <option value="name">Name</option>
           <option value="status">Status</option>
         </select>
-        <button
+        <button type="button"
           onClick={() => setSortAsc(!sortAsc)}
           className="min-h-[44px] min-w-[44px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:border-[var(--color-accent-cyan)]/50 transition-colors"
           aria-label={sortAsc ? 'Sort ascending' : 'Sort descending'}

--- a/dashboard/src/pages/RoutinesPage.tsx
+++ b/dashboard/src/pages/RoutinesPage.tsx
@@ -89,7 +89,7 @@ export default function RoutinesPage() {
               {t('routines.subtitle')}
             </p>
           </div>
-          <button
+          <button type="button"
             onClick={handleCreate}
             className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]"
             aria-label={t('routines.createNew')}
@@ -115,7 +115,7 @@ export default function RoutinesPage() {
             {t('routines.taskCount', { count: routines.length })}
           </p>
         </div>
-        <button
+        <button type="button"
           onClick={handleCreate}
           className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]"
           aria-label={t('routines.createNew')}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -600,7 +600,7 @@ export default function SessionDetailPage() {
 
           <div className="relative flex gap-2 py-1" role="tablist">
             {TABS.map((tab) => (
-              <button
+              <button type="button"
                 key={tab.id}
                 id={`tab-${tab.id}`}
                 onClick={() => setActiveTab(tab.id)}

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -433,7 +433,7 @@ export default function SessionHistoryPage() {
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">{t('sessionHistory.subtitle')}</p>
         </div>
         <div className="flex items-center gap-2">
-          <button
+          <button type="button"
             onClick={() => { void fetchData(); }}
             aria-label={t('sessionHistory.refresh')}
             disabled={loading}
@@ -443,7 +443,7 @@ export default function SessionHistoryPage() {
             {t('sessionHistory.refresh')}
           </button>
           {records.length > 0 && (
-            <button
+            <button type="button"
               onClick={() => void handleExport()}
               disabled={exporting}
               className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-2 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:opacity-50 disabled:cursor-not-allowed"
@@ -560,14 +560,14 @@ export default function SessionHistoryPage() {
             </select>
           </div>
 
-          <button
+          <button type="button"
             onClick={applyFilters}
             className="min-h-[44px] rounded border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20"
           >
             {t('sessionHistory.apply')}
           </button>
 
-          <button
+          <button type="button"
             onClick={clearFilters}
             className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-void-lighter)]"
           >
@@ -595,7 +595,7 @@ export default function SessionHistoryPage() {
           {selectedIds.size > 0 && (
             <div className="flex items-center gap-3 border-b border-[var(--color-accent-cyan)]/20 bg-[var(--color-accent-cyan)]/5 px-4 py-2.5">
               <span className="text-sm font-medium text-[var(--color-accent-cyan)]">{t('sessionHistory.selected', { count: selectedIds.size })}</span>
-              <button
+              <button type="button"
                 onClick={() => void handleExport()}
                 disabled={exporting}
                 className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:opacity-50 disabled:cursor-not-allowed"
@@ -604,7 +604,7 @@ export default function SessionHistoryPage() {
                 <Icon name="Download" size={12} />
                 {exporting ? t('sessionHistory.exporting') : t('sessionHistory.export')}
               </button>
-              <button
+              <button type="button"
                 onClick={() => setConfirmDeleteOpen(true)}
                 className="flex min-h-[44px] items-center gap-1.5 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-300 transition-colors hover:bg-rose-500/20"
                 aria-label={t('sessionHistory.kill')}
@@ -612,7 +612,7 @@ export default function SessionHistoryPage() {
                 <Trash2 className="h-3 w-3" />
                 {t('sessionHistory.kill')}
               </button>
-              <button
+              <button type="button"
                 onClick={handleShareLink}
                 className="flex min-h-[44px] items-center gap-1.5 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)]"
                 aria-label={t('sessionHistory.shareLink')}
@@ -620,7 +620,7 @@ export default function SessionHistoryPage() {
                 <Share2 className="h-3 w-3" />
                 {t('sessionHistory.shareLink')}
               </button>
-              <button
+              <button type="button"
                 onClick={() => setSelectedIds(new Set())}
                 className="ml-auto flex min-h-[44px] items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
                 aria-label={t('sessionHistory.clear')}
@@ -666,7 +666,7 @@ export default function SessionHistoryPage() {
                         title={t('sessionHistory.noRecords')}
                         description={t('sessionHistory.noRecordsDescription')}
                         action={
-                          <button
+                          <button type="button"
                             className="mt-4 px-4 py-2 text-sm rounded-lg bg-[var(--color-void-lighter)] hover:bg-[var(--color-void-lighter)] transition-colors"
                             onClick={() => {
                               setFilterSearch('');
@@ -709,7 +709,7 @@ export default function SessionHistoryPage() {
                           >
                             {shortId(record.id)}
                           </span>
-                          <button
+                          <button type="button"
                             data-no-nav
                             onClick={(e) => copySessionId(record.id, e)}
                             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-[var(--color-text-muted)] opacity-0 transition-opacity hover:text-[var(--color-text-primary)] group-hover/id:opacity-100"
@@ -767,7 +767,7 @@ export default function SessionHistoryPage() {
                 ))}
               </select>
 
-              <button
+              <button type="button"
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1 || loading}
                 aria-label={t('sessionHistory.prev')}
@@ -776,7 +776,7 @@ export default function SessionHistoryPage() {
                 <ChevronLeft className="h-3 w-3" /> {t('sessionHistory.prev')}
               </button>
 
-              <button
+              <button type="button"
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page >= totalPages || loading}
                 className="inline-flex min-h-[44px] items-center gap-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:opacity-40"
@@ -799,14 +799,14 @@ export default function SessionHistoryPage() {
               {t('sessionHistory.killDialogDescription')}
             </p>
             <div className="mt-5 flex gap-3">
-              <button
+              <button type="button"
                 onClick={handleBulkDelete}
                 disabled={deleting}
                 className="flex-1 rounded bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
               >
                 {deleting ? t('sessionHistory.killing') : t('sessionHistory.killCount', { count: selectedIds.size })}
               </button>
-              <button
+              <button type="button"
                 onClick={() => setConfirmDeleteOpen(false)}
                 disabled={deleting}
                 className="flex-1 rounded border border-[var(--color-void-lighter)] px-4 py-2 text-sm font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] hover:bg-[var(--color-void-lighter)] disabled:opacity-50"

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -178,7 +178,7 @@ export default function SettingsPage() {
               <p className="text-sm text-[var(--color-text-primary)]">{t('settings.display.theme')}</p>
               <p className="text-xs text-[var(--color-text-muted)]">{t('settings.display.themeDescription')}</p>
             </div>
-            <button
+            <button type="button"
               onClick={toggleTheme}
               className="min-h-[44px] rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
             >
@@ -195,7 +195,7 @@ export default function SettingsPage() {
               </div>
               <div className="flex gap-1.5">
                 {LIGHT_VARIANTS.map(({ value, label, description }) => (
-                  <button
+                  <button type="button"
                     key={value}
                     onClick={() => setTheme(value)}
                     title={description}
@@ -253,7 +253,7 @@ export default function SettingsPage() {
             </div>
             <div className="flex gap-1.5">
               {READING_FONTS.map(({ value, label, description }) => (
-                <button
+                <button type="button"
                   key={value}
                   onClick={() => setReadingFont(value)}
                   title={description}


### PR DESCRIPTION
## Recovery PR
Original PR #3292 was accidentally merged as an empty diff due to a botched rebase. This PR recreates the changes from scratch.

## Changes
- Add `type="button"` to all buttons missing explicit type attribute
- Prevents latent form-submit bugs
- 36 files, 96 changes

Supersedes #3292, #3296