### PR TITLE
fix(cost): fix 3 bugs in cost tracking API

### DIFF
--- a/src/routes/cost.ts
+++ b/src/routes/cost.ts
@@ -135,15 +135,26 @@ export function registerCostRoutes(app: FastifyInstance, ctx: RouteContext): voi
    *   from — ISO timestamp lower bound (inclusive)
    *   to   — ISO timestamp upper bound (inclusive)
    */
+
+/** Validate from/to query params for cost endpoints. */
+function validateDateRange(from?: string, to?: string): { error: string; statusCode: number } | null {
+  if (from && isNaN(Date.parse(from))) return { error: 'Invalid "from" date format. Use ISO 8601.', statusCode: 400 };
+  if (to && isNaN(Date.parse(to))) return { error: 'Invalid "to" date format. Use ISO 8601.', statusCode: 400 };
+  if (from && to && new Date(from) > new Date(to)) return { error: '"from" must be before "to".', statusCode: 400 };
+  return null;
+}
+
   registerWithLegacy(app, 'get', '/v1/cost/summary', async (req: FastifyRequest, reply: FastifyReply) => {
     if (!requireRole(ctx.auth, req, reply, 'admin', 'operator', 'viewer')) return;
 
     const query = req.query as { from?: string; to?: string };
+    const dateError = validateDateRange(query.from, query.to);
+    if (dateError) return reply.status(dateError.statusCode).send({ code: 'INVALID_DATE_RANGE', message: dateError.error });
     const summary = metering.getUsageSummary({ from: query.from, to: query.to });
 
     const response: CostSummaryResponse = {
-      from: summary.from ?? null,
-      to: summary.to ?? null,
+      from: query.from ?? summary.from ?? null,
+      to: query.to ?? summary.to ?? null,
       totalInputTokens: summary.totalInputTokens,
       totalOutputTokens: summary.totalOutputTokens,
       totalCacheCreationTokens: summary.totalCacheCreationTokens,
@@ -168,6 +179,8 @@ export function registerCostRoutes(app: FastifyInstance, ctx: RouteContext): voi
     if (!requireRole(ctx.auth, req, reply, 'admin', 'operator', 'viewer')) return;
 
     const query = req.query as { from?: string; to?: string };
+    const dateError = validateDateRange(query.from, query.to);
+    if (dateError) return reply.status(dateError.statusCode).send({ code: 'INVALID_DATE_RANGE', message: dateError.error });
     const summary = metering.getUsageSummary({ from: query.from, to: query.to });
     const metricsCache = ctx.metricsCache;
     const analytics = metricsCache.getMetrics();

--- a/src/server.ts
+++ b/src/server.ts
@@ -967,6 +967,9 @@ async function main(): Promise<void> {
   });
   await container.start(['sessionManager', 'sessionMonitor', 'authManager', 'channelManager', 'acpLocalProfile', 'acpBackend']);
 
+  // Issue #3264: Initialize MeteringService for persistent cost tracking.
+  const metering = new MeteringService(eventBus, (sid) => sessions.getSession(sid)?.ownerKeyId, path.join(config.stateDir, 'metering.jsonl'));
+
   // Issue #488: Accumulate token usage from JSONL events into per-session metrics.
   // Issue #2536: Also count messages and tool calls from JSONL events.
   jsonlWatcher.onEntries((event) => {
@@ -975,6 +978,10 @@ async function main(): Promise<void> {
       if (tokenUsageDelta.inputTokens > 0 || tokenUsageDelta.outputTokens > 0) {
         const model = sessions.getSession(event.sessionId)?.model;
         metrics.recordTokenUsage(event.sessionId, tokenUsageDelta, model);
+        // Issue #3264: Persist token usage to MeteringService for cost API queries.
+        if (metering) {
+          metering.recordTokenUsage(event.sessionId, tokenUsageDelta, model);
+        }
       }
       // Issue #2536: Count messages and tool calls from parsed entries.
       for (const msg of event.messages) {
@@ -1050,7 +1057,7 @@ async function main(): Promise<void> {
     validateWorkDir: validateWorkDirWithConfig,
     serverState,
     quotas: new QuotaManager(),
-    metering: new MeteringService(eventBus, (sid) => sessions.getSession(sid)?.ownerKeyId, path.join(config.stateDir, 'metering.jsonl')),
+    metering,
     metricsCache,
     dashboardOidc,
     dashboardTokenSessions,


### PR DESCRIPTION
## Summary

Fixes 3 bugs found by @Daedalus during dogfood testing of the cost API.

### Bug 1 (P2): `/v1/cost/summary` ignores `from/to` query params
The summary endpoint returned `summary.from`/`summary.to` (derived from metering records) instead of echoing back the query params. When no records exist, `from`/`to` are always `null` even when valid params are provided.

**Fix:** Use `query.from ?? summary.from ?? null` (same fallback pattern as `/v1/cost/by-model`).

### Bug 2 (P3): Invalid date ranges silently accepted
`?from=invalid&to=invalid` and `?from=future&to=past` both returned 200 with null dates instead of 400.

**Fix:** Added `validateDateRange()` helper that returns 400 for malformed ISO dates and reversed ranges. Applied to both `/summary` and `/by-model`.

### Bug 3 (P2): All cost data is zero despite sessions with token usage
**Root cause:** `MetricsCollector` (in-memory, fed by `jsonlWatcher`) and `MeteringService` (file-based, used by cost API) were completely disconnected. Token data from JSONL transcripts was recorded to MetricsCollector but never persisted to MeteringService.

**Fix:** Extract `MeteringService` to a variable before the `jsonlWatcher.onEntries` callback, and call `metering.recordTokenUsage()` alongside `metrics.recordTokenUsage()`. Now token data flows to both systems.

## Verification

```
tsc --noEmit    ✅ Zero errors
npm run build   ✅ Success
npm test        ✅ 4142 passed / 0 failed
```

## Files Changed
- `src/routes/cost.ts` — Bug 1 + Bug 2 fixes
- `src/server.ts` — Bug 3 fix (metering wiring)

Dogfood credits: @Daedalus for finding all three bugs.