### PR TITLE
docs: competitive differentiators — Aegis vs cc-connect vs Verdent AI

### DIFF
--- a/docs/competitive-differentiators.md
+++ b/docs/competitive-differentiators.md
@@ -1,0 +1,274 @@
+# Aegis Competitive Differentiators
+
+> **Audience:** Technical decision-makers evaluating Claude Code orchestration platforms.
+> **Last updated:** 2026-05-14 | **Sources:** Issue #2764 positioning, #3216 (Verdent AI), #3316 (hooks), competitive-threat-matrix.md, Orpheus gap analyses.
+
+## Executive Summary
+
+Aegis is the **only open-source, API-first Claude Code orchestration middleware** with enterprise-grade security, observability, and deployment. Competitors win on simplicity or agent count. Aegis wins on **production readiness**: the layer between "someone typed a message" and "code shipped to production."
+
+This document compares Aegis against two key competitors across three pillars: **Security**, **Deployment**, and **Extensibility**.
+
+---
+
+## Competitors Covered
+
+| | Aegis | cc-connect | Verdent AI |
+|---|---|---|---|
+| **License** | MIT (open source) | Proprietary | Proprietary |
+| **Architecture** | Node.js API server + MCP | Go binary + TOML | Mac desktop app |
+| **Agent support** | Claude Code (1 runner) | 10+ agent backends | Parallel agents (proprietary) |
+| **Target market** | Enterprise / DevOps | Developer tools | Consumer / prosumer |
+| **⭐ Stars** | ~200 | 8K | N/A (closed) |
+
+---
+
+## Pillar 1: Security
+
+### Aegis
+
+| Feature | Details |
+|---------|---------|
+| **RBAC** | 3 roles (admin, operator, viewer) enforced on 48+ endpoints. `requireRole()` guards on every sensitive route. `strictRBAC` config for enforcing RBAC even when auth is disabled. |
+| **OIDC/SSO** | Enterprise identity via OpenID Connect. Dashboard session management with PKCE flow. |
+| **API key management** | Full CRUD + rotation (immediate and grace-period), per-key quotas, per-key permissions, per-key rate limits. |
+| **Audit trail** | Hash-chained, immutable audit log. CSV/NDJSON export. Queryable via REST API. Every session action recorded. |
+| **Hook authentication** | `X-Hook-Secret` with timing-safe comparison. Header-only mode prevents URL secret leakage. Event allowlist rejects unknown hook names. |
+| **Session isolation** | 404 for both missing and forbidden sessions (prevents ID enumeration). Per-session hook secrets. |
+| **Supply chain** | Sigstore release signing. npm provenance. |
+| **Compliance** | SOC2-aligned audit trail. GDPR-ready data handling. |
+
+### cc-connect
+
+| Feature | Details |
+|---------|---------|
+| **RBAC** | None. Token-only auth. |
+| **OIDC/SSO** | None. |
+| **API key management** | Basic token auth. No rotation, no per-key quotas, no per-key permissions. |
+| **Audit trail** | None. |
+| **Hook authentication** | Basic token on HTTP callbacks. No timing-safe comparison. No event allowlist. |
+| **Session isolation** | No session ID enumeration protection. |
+| **Supply chain** | Binary distribution. No provenance. |
+| **Compliance** | None. |
+
+### Verdent AI
+
+| Feature | Details |
+|---------|---------|
+| **RBAC** | None. Single-user desktop app. |
+| **OIDC/SSO** | None. |
+| **API key management** | BYOK (user provides their own LLM API key). No access management. |
+| **Audit trail** | None. |
+| **Hook authentication** | N/A — no hook system. |
+| **Session isolation** | Local-only, no multi-user. |
+| **Supply chain** | Mac App Store distribution. |
+| **Compliance** | None. |
+
+### Security Scorecard
+
+| Capability | Aegis | cc-connect | Verdent AI |
+|-----------|-------|-----------|-----------|
+| RBAC with roles | ✅ 3 roles | ❌ | ❌ |
+| OIDC/SSO | ✅ | ❌ | ❌ |
+| Audit trail (hash-chained) | ✅ | ❌ | ❌ |
+| API key rotation | ✅ immediate + grace period | ❌ | ❌ |
+| Per-key quotas | ✅ | ❌ | ❌ |
+| Per-key permissions | ✅ | ❌ | ❌ |
+| Hook secret auth | ✅ timing-safe | ⚠️ basic | N/A |
+| Session ID enumeration protection | ✅ | ❌ | N/A |
+| Release signing | ✅ Sigstore | ❌ | ✅ App Store |
+| SOC2/GDPR readiness | ✅ | ❌ | ❌ |
+
+**Verdict:** Aegis is the only option for organizations that need compliance, audit, and access control. Neither competitor has any enterprise security story.
+
+---
+
+## Pillar 2: Deployment
+
+### Aegis
+
+| Feature | Details |
+|---------|---------|
+| **REST API** | 108 endpoints with full CRUD, pagination, cursor-based transcript streaming. Structured error responses. |
+| **MCP server** | 34 tools exposed via Model Context Protocol. Any MCP host can control Aegis sessions programmatically. |
+| **Dashboard** | Full React web UI — session management, real-time SSE updates, cost analytics, agent contributions. |
+| **SSE streaming** | Per-session and global event streams. Real-time status updates. |
+| **Container deployment** | Docker + Kubernetes + Helm chart. Production-ready orchestration. |
+| **Multi-platform** | Linux, macOS, Docker, K8s. No platform lock-in. |
+| **CI/CD integration** | REST API + MCP tools enable full pipeline automation. `ag run` for one-shot CI tasks. |
+| **SDK** | TypeScript + Python client libraries. |
+| **Monitoring** | Prometheus metrics, OpenTelemetry tracing, Grafana dashboards. |
+| **Multi-channel** | Telegram, Slack, Email, generic webhooks. |
+
+### cc-connect
+
+| Feature | Details |
+|---------|---------|
+| **REST API** | None. TOML config + CLI only. |
+| **MCP server** | None. |
+| **Dashboard** | Basic web admin UI. |
+| **SSE streaming** | None. |
+| **Container deployment** | Binary distribution. No container support. |
+| **Multi-platform** | Mac, Linux, Windows (Go binary). |
+| **CI/CD integration** | CLI-based. No API for pipeline automation. |
+| **SDK** | None. Go binary only. |
+| **Monitoring** | Basic logging. No structured metrics. |
+| **Multi-channel** | 11 chat platforms (Telegram, Slack, WeChat, QQ, DingTalk, LINE, Feishu, Weibo, Discord, +2). |
+
+### Verdent AI
+
+| Feature | Details |
+|---------|---------|
+| **REST API** | None. Desktop app only. |
+| **MCP server** | None. |
+| **Dashboard** | Desktop app UI. |
+| **SSE streaming** | None. |
+| **Container deployment** | None. Mac desktop app only. |
+| **Multi-platform** | macOS only (Apple Silicon). No Linux, no Windows. |
+| **CI/CD integration** | None. No headless mode. |
+| **SDK** | None. |
+| **Monitoring** | None. |
+| **Multi-channel** | Slack + Telegram (message-based task assignment). |
+
+### Deployment Scorecard
+
+| Capability | Aegis | cc-connect | Verdent AI |
+|-----------|-------|-----------|-----------|
+| REST API (programmatic) | ✅ 108 endpoints | ❌ | ❌ |
+| MCP server | ✅ 34 tools | ❌ | ❌ |
+| Web dashboard | ✅ full React | ⚠️ basic | ❌ (desktop) |
+| Docker/K8s deployment | ✅ Helm chart | ❌ | ❌ |
+| SSE event streaming | ✅ per-session + global | ❌ | ❌ |
+| CI/CD automation | ✅ `ag run` + API | ⚠️ CLI-only | ❌ |
+| Client SDKs | ✅ TS + Python | ❌ | ❌ |
+| Prometheus/OTel | ✅ | ❌ | ❌ |
+| Chat platform breadth | ⚠️ 4 platforms | ✅ 11 platforms | ⚠️ 2 platforms |
+| Cross-platform | ✅ Linux/Mac/Docker | ✅ Mac/Linux/Win | ❌ Mac only |
+
+**Verdict:** Aegis is the only infrastructure-grade option. cc-connect wins on chat breadth. Verdent AI is consumer-only — cannot be deployed as infrastructure.
+
+---
+
+## Pillar 3: Extensibility
+
+### Aegis
+
+| Feature | Details |
+|---------|---------|
+| **MCP tools** | 34 tools for programmatic session control. Other MCP hosts can consume Aegis. |
+| **Lifecycle hooks** | 29 CC lifecycle events captured, enriched, and broadcast. Permission policies, circuit breaker, OTel tracing on every event. |
+| **ACP (Agent Control Protocol)** | Extensible runner architecture. `TmuxRunner` today, `AnthropicApiRunner` tomorrow. Swap runners without API changes. |
+| **Session templates** | Reusable session configurations. Pipeline orchestration for sequential/batch tasks. |
+| **Memory Bridge** | Cross-session state persistence. Key-value store with REST API. |
+| **Permission profiles** | Per-session, per-tool, per-path rules. Configurable policies for `PreToolUse` decisions. |
+| **Custom webhooks** | Configurable per-endpoint delivery. Dead-letter queue for failed deliveries. |
+| **Plugin architecture** | Fastify plugin system. Community can add route plugins without forking. |
+
+### cc-connect
+
+| Feature | Details |
+|---------|---------|
+| **MCP tools** | None. |
+| **Lifecycle hooks** | Basic HTTP callbacks. No permission evaluation, no circuit breaker, no tracing. |
+| **ACP** | None. |
+| **Session templates** | TOML-based configuration. No pipeline orchestration. |
+| **Memory Bridge** | None. |
+| **Permission profiles** | Flat allow/deny lists in TOML. |
+| **Custom webhooks** | Basic. No delivery tracking. |
+| **Plugin architecture** | None. Go binary, not extensible. |
+
+### Verdent AI
+
+| Feature | Details |
+|---------|---------|
+| **MCP tools** | None. |
+| **Lifecycle hooks** | None. No hook system. |
+| **ACP** | None. |
+| **Session templates** | None. |
+| **Memory Bridge** | Project memory (proprietary) — remembers context across sessions. |
+| **Permission profiles** | None. |
+| **Custom webhooks** | None. |
+| **Plugin architecture** | None. Closed-source desktop app. |
+
+### Extensibility Scorecard
+
+| Capability | Aegis | cc-connect | Verdent AI |
+|-----------|-------|-----------|-----------|
+| MCP server (34 tools) | ✅ | ❌ | ❌ |
+| Lifecycle hooks (29 events) | ✅ with policy engine | ⚠️ basic callbacks | ❌ |
+| ACP runner abstraction | ✅ | ❌ | ❌ |
+| Session templates | ✅ | ⚠️ TOML config | ❌ |
+| Pipeline orchestration | ✅ | ❌ | ❌ |
+| Cross-session memory | ✅ Memory Bridge | ❌ | ✅ project memory |
+| Permission profiles | ✅ per-tool/per-path | ⚠️ flat lists | ❌ |
+| Plugin system | ✅ Fastify plugins | ❌ | ❌ |
+| Dead-letter queue | ✅ | ❌ | ❌ |
+| Parallel agents | ❌ | ✅ multi-backend | ✅ core feature |
+
+**Verdict:** Aegis is the most extensible platform for programmatic control. Verdent AI wins on parallel agent execution and project memory — both identified gaps. cc-connect is rigid — TOML config, no API, no plugins.
+
+---
+
+## Why Aegis Wins for Enterprise
+
+### The 6 Pillars No Competitor Has
+
+No single competitor has **all six** of these enterprise capabilities:
+
+1. **Kubernetes deployment** — production-grade orchestration
+2. **OIDC/SSO** — enterprise identity management
+3. **Hash-chained audit trail** — compliance-ready logging
+4. **OpenTelemetry tracing** — production observability
+5. **Sigstore release signing** — supply chain security
+6. **Client SDKs** — programmatic integration (TypeScript + Python)
+
+### The Integration Argument
+
+```
+Enterprise stack:
+
+  Slack/Telegram ──┐
+  CI/CD pipeline ──┤
+  Custom dashboard ┼──▶ Aegis API ──▶ Claude Code sessions
+  Monitoring (OTel)┤
+  Compliance audit ┘
+
+Consumer tools (Verdent, cc-connect):
+
+  Desktop app ──▶ Claude Code session
+```
+
+Aegis is the **middleware** that connects enterprise systems to AI coding agents. Consumer tools connect one user to one agent. This is a fundamentally different value proposition.
+
+### The Open Source Advantage
+
+- **Self-hosted** — data never leaves your infrastructure
+- **Auditable** — every line of security code is reviewable
+- **Extensible** — Fastify plugins, MCP tools, REST API
+- **No vendor lock-in** — MIT license, standard protocols (HTTP, MCP, SSE, OTel)
+
+---
+
+## What Aegis Doesn't Have (Honest Gaps)
+
+| Gap | Who has it | Priority |
+|-----|-----------|----------|
+| **Parallel agents** | Verdent AI, cc-connect, Ruflo | P0 |
+| **Project memory** | Verdent AI, Ruflo | P1 |
+| **Chat platform breadth** (11 platforms) | cc-connect | P1 |
+| **Desktop app** | Verdent AI | P2 |
+| **Task decomposition** | Verdent AI | P2 |
+| **Academic credibility** (ICSE paper) | Verdent AI | P3 |
+
+These are real gaps. But they're **feature gaps**, not architectural gaps. Adding parallel agents to Aegis is a runner backend. Adding project memory is a storage layer. Adding chat platforms is a channel adapter.
+
+What competitors **cannot easily add** is enterprise security, audit, observability, and API-first architecture — those require fundamental redesign.
+
+---
+
+## See Also
+
+- [Competitive Threat Matrix](./competitive-threat-matrix.md) — full competitive landscape with star counts and market pulse
+- [Lifecycle Hooks Guide](./hooks-guide.md) — detailed hook architecture comparison
+- [Architecture Overview](./architecture.md) — Aegis internal architecture
+- [API Reference](./api-reference.md) — full REST API documentation


### PR DESCRIPTION
## Summary

Per Boss's #2764 position ("document-first, don't chase"), this doc captures existing Aegis advantages before writing new code. Three-pillar comparison across security, deployment, and extensibility.

## Content

**Three pillars:**
1. **Security** — RBAC, OIDC/SSO, audit trail, hook auth, supply chain, compliance
2. **Deployment** — REST API, MCP server, dashboard, containers, CI/CD, monitoring
3. **Extensibility** — MCP tools (34), lifecycle hooks (29 events), ACP runners, templates, Memory Bridge

**Scorecards:** Each pillar has a feature comparison table across Aegis, cc-connect, and Verdent AI.

**Key arguments:**
- "6 Enterprise Pillars" — no competitor has all 6 (K8s + OIDC + audit + OTel + Sigstore + SDKs)
- Integration topology — Aegis as middleware vs consumer tools as point solutions
- Open source advantage — self-hosted, auditable, extensible, no vendor lock-in

**Honest gaps:** Parallel agents, project memory, chat breadth, desktop app — acknowledged with architectural argument for why they're fillable.

## Sources
- Issue #2764 (Boss positioning)
- Issue #3216 (Verdent AI competitive intel, Orpheus analysis)
- Issue #3236 (ccusage-dashboard adjacent analysis)
- `competitive-threat-matrix.md` (full landscape)
- `hooks-guide.md` (hook architecture comparison)
- Live site review (verdent.ai, cc-connect docs)

## Scope
Documentation only. No code changes.

## Review
Argus for merge. Accuracy on competitive claims matters.