### PR TITLE
docs: freshness audit — getting-started, architecture links, competitive matrix

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -393,6 +393,8 @@ See [deployment.md](./deployment.md#opentelemetry-tracing) for configuration and
 | `hook.ts` | Builds hook commands for pre/post session lifecycle events |
 | `hook-settings.ts` | Parses and validates hook configuration |
 
+For the full hook event reference (29 lifecycle events), permission policy evaluation, circuit breaker, and competitive comparison, see the [Lifecycle Hooks Guide](./hooks-guide.md).
+
 ### 11. Shared Utilities
 
 | Module | Purpose |

--- a/docs/competitive-threat-matrix.md
+++ b/docs/competitive-threat-matrix.md
@@ -1,6 +1,6 @@
 # Aegis Competitive Threat Matrix
 
-> **Last updated:** 2026-05-12 | **Source:** Issues #3013, #3014, #3016, #3003, #3004 + ECC analysis (Orpheus) + deep competitive research (Scribe)
+> **Last updated:** 2026-05-14 | **Source:** Issues #3013, #3014, #3016, #3003, #3004, #3216, #3236 + ECC analysis (Orpheus) + deep competitive research (Scribe)
 > **Audience:** Leadership (Ema, Boss) for strategic planning
 
 ---
@@ -28,6 +28,8 @@ The Claude Code orchestration space is **crowded and moving fast**. 8+ competito
 | #7 | **OpenACP** | 346 | 🟠 HIGH | `curl \| bash` | **28+** | Telegram, Discord, Slack | ✅ | ❌ | ❌ |
 | #8 | **ECC** | 177K | 🟢 OPPORTUNITY | Config library | N/A (skills) | N/A | ❌ | ❌ | ❌ |
 | #9 | **ClaudeClaw** | 1 | 🟡 MEDIUM | `curl \| bash` | 1 (CC hooks) | Telegram | ❌ | ❌ | ❌ |
+| #10 | **Verdent AI** | N/A (closed) | 🟠 HIGH | Mac app download | Parallel agents | Telegram, Slack | ❌ | Desktop app | ❌ |
+| — | **ccusage-dashboard** | 1 | 🟢 ADJACENT | Self-hosted | N/A (analytics) | N/A | ❌ | 9-panel React | ❌ |
 | — | **Aegis** | ~200 | — | `npx + ag run` (2 cmds) | 1 (Claude Code) | 4 | ✅ 34 MCP tools | ✅ Full React | ✅ OIDC/RBAC |
 
 ---
@@ -61,6 +63,8 @@ No single competitor has ALL of these. This is the enterprise wedge:
 | **Plugin marketplace distribution** | 177K-star audience unreachable | OMC (CC marketplace) | P1 |
 | **Chat platform breadth** | Missing entire Asian market (WeChat, QQ, DingTalk) | cc-connect (11 platforms) | P1 |
 | **Natural language scheduling** | Dev productivity killer feature | cc-connect | P2 |
+| **Project memory** | Adoption — users want persistent context across sessions | Verdent AI, Ruflo | P1 |
+| **Parallel agent execution** | Adoption — every prosumer competitor has it | Verdent AI, cc-connect, Ruflo | P0 |
 | **Self-learning memory** | Agents improve over time | Ruflo | P2 |
 | **Multi-language docs** | International adoption blocked | OMC (6 languages), cc-connect (5) | P2 |
 
@@ -220,6 +224,29 @@ For each competitor: what they have that we don't **AND** what we have that they
 
 **Counter-move:** mission-control is the most direct competitor (dashboard + RBAC). Our advantage: OIDC, audit trail, K8s, OTel, SDKs. Keep shipping these faster.
 
+### vs. Verdent AI (closed, HIGH threat)
+
+| They have (our gaps) | We have (their gaps) | Why they can't replicate easily |
+|---------------------|---------------------|-------------------------------|
+| Parallel agent execution | REST API (108 endpoints) | Desktop app architecture has no HTTP surface. Becoming a service requires a complete rewrite. |
+| Project memory (persistent context) | OIDC/SSO + RBAC | Single-user desktop app. No concept of multi-user or enterprise identity. |
+| Task decomposition (auto-breaks features) | Audit trail with hash chain | No server component. No persistent audit log possible in desktop-first architecture. |
+| Mac desktop app (native UX) | Kubernetes + Helm | Cannot be deployed as infrastructure. Desktop app only. |
+| Telegram + Slack (message-based tasks) | OpenTelemetry tracing | No observability. No metrics. No tracing. |
+| ICSE 2026 Distinguished Paper (academic credibility) | MCP server (34 tools) | No programmatic interface. Other tools can't integrate with Verdent. |
+| BYOK + Eco Mode (cost control) | TypeScript + Python SDKs | No SDKs. No API. Closed-source. |
+| Italian market focus (localized) | Session lifecycle (terminal states, crash recovery) | No session persistence model. |
+
+**Counter-move:** Verdent wins on UX simplicity and parallel agents. We win on every enterprise dimension. They're Mac-only, closed-source, no API. Different market. Risk: they capture prosumer mindshare before users discover enterprise-grade options. Accelerate #3180 (multi-agent) and #3181 (install friction).
+
+### vs. ccusage-dashboard (1 ⭐, ADJACENT — not a direct competitor)
+
+ccusage-dashboard is an **analytics visualization layer**, not an orchestration tool. They provide 9 interactive cost panels with canonical TTL-split cache pricing. No session management, no agent orchestration, no API.
+
+**Relation:** Complement. Users could run ccusage-dashboard alongside Aegis for deeper cost analytics.
+
+**What to learn:** Their burn rate visualization and canonical cost model are deeper than our `/v1/usage` endpoint. Flag for Phase 4 dashboard work.
+
 ## Competitor Detail References
 
 | Issue | Competitor | Key takeaway |
@@ -230,8 +257,10 @@ For each competitor: what they have that we don't **AND** what we have that they
 | #3003 | OpenACP (346 ⭐) | Same architecture, simpler install, 28+ agents. Highest-threat small competitor. |
 | #3016 | Full landscape | 8 competitors ranked. Aegis smallest by stars, deepest by enterprise features. |
 | #3234 | ClaudeClaw (1 ⭐) | CC hooks-based simplicity play. Zero infrastructure, conversational onboarding. Tier 1 threat. |
+| #3216 | Verdent AI (closed) | Consumer/prosumer parallel agents, project memory, Telegram+Slack. ICSE 2026 Distinguished Paper. Mac-only, closed-source, no API. HIGH adoption threat. |
+| #3236 | ccusage-dashboard (1 ⭐) | Adjacent tool, not competitor. 9-panel cost analytics with canonical TTL-split pricing. Complement, not threat. |
 | ECC | everything-claude-code (177K ⭐) | Not a competitor — distribution channel. Skills layer, not orchestration. |
 
 ---
 
-*Maintained by Scribe 📝 — last deep dive: 2026-05-11, star counts updated: 2026-05-12. Update on each competitive scan.*
+*Maintained by Scribe 📝 — last deep dive: 2026-05-14 (added Verdent AI, ccusage-dashboard), star counts updated: 2026-05-12. Update on each competitive scan.*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -380,6 +380,10 @@ See the [Worktree Guide](./worktree-guide.md) for detailed setup instructions.
 | `Claude Code CLI not found` | Install Claude Code: `npm install -g @anthropic-ai/claude-code` and run `claude` to authenticate |
 | `401 Unauthorized` | Set `AEGIS_AUTH_TOKEN` or include `Authorization: Bearer <token>` header |
 | Session stuck on `stalled` | Send an interrupt: `curl -X POST http://localhost:9100/v1/sessions/:id/interrupt` |
+| Session shows `pending` | Initial state — connecting to ACP runtime. Wait a moment and re-poll |
+| Session shows `killed` | Terminal state — stopped via API. Session retained for audit, cannot be resumed |
+| Session shows `crashed` | Terminal state — terminated unexpectedly. Check `/v1/diagnostics` for details |
+| Session shows `completed` | Terminal state — finished normally. Session retained for audit |
 | MCP tools not showing in Claude Code | Re-run `claude mcp add aegis -- ag mcp` and restart Claude Code |
 | Dashboard won't load | Verify Aegis is running on port 9100: `curl http://localhost:9100/v1/health` |
 | `EADDRINUSE` on startup | Port 9100 is in use. Set a different port: `AEGIS_PORT=9200 ag` |


### PR DESCRIPTION
## Summary

Boss-assigned docs freshness audit. Four items checked, three docs updated.

Closes #3321

## Changes

### 1. `docs/getting-started.md` — Terminal states in troubleshooting
- Added `pending`, `killed`, `crashed`, `completed` to troubleshooting table
- These states were added in PRs #3061 (pending) and #3140 (killed/completed/crashed) but troubleshooting only mentioned `stalled`
- Also: install flow is current (`ag run`, `ag init --force/--model/--name`, `config.yaml`) — no changes needed there
- Note: Hep's #3181 (install friction) will need a follow-up update after it lands

### 2. `docs/api-reference.md` — Already audited ✅
- Completed in PR #3319 (14 RBAC tables added, all 108 endpoints verified)
- No further action needed

### 3. `docs/architecture.md` — Hooks section cross-link
- Section 10 (Hooks) now links to `hooks-guide.md` for the full 29-event reference
- Links to permission policy evaluation, circuit breaker, and competitive comparison

### 4. `docs/competitive-threat-matrix.md` — New entries
- Added **Verdent AI** (#3216): HIGH threat, consumer parallel agents, project memory, ICSE 2026 paper, Mac-only, closed-source
- Added **ccusage-dashboard** (#3236): ADJACENT, analytics complement, 9-panel cost visualization
- Added critical gaps: project memory (P1), parallel agent execution (P0)
- Added vs. Verdent AI comparison table with counter-moves
- Updated date and sources

## Verification
- [x] Terminal state descriptions match source code (src/hooks.ts UIState + terminal states)
- [x] Architecture.md link resolves correctly
- [x] Verdent AI claims verified against Orpheus analysis (#3216)
- [x] ccusage-dashboard claims verified against source (#3236)
- [x] No broken internal links