### PR TITLE
test(cli): add headless ag mcp smoke script for npx/local usage (#3326)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -174,11 +174,7 @@ curl "http://localhost:9100/v1/diagnostics?limit=20" \
 POST /v1/handshake
 ```
 
-Performs capability negotiation with Aegis. Returns server capabilities and compatibility status.
-
-| Role | Required |
-|------|----------|
-| admin, operator, viewer | Yes |
+Performs capability negotiation with Aegis. Returns server capabilities and compatibility status. **No authentication required.**
 
 ```bash
 curl -X POST http://localhost:9100/v1/handshake \
@@ -1205,11 +1201,7 @@ curl http://localhost:9100/v1/sessions/abc123/metrics \
 GET /v1/sessions/:id/tools
 ```
 
-Returns per-tool call counts for a session, parsed from the JSONL transcript.
-
-| Role | Required |
-|------|----------|
-| admin, operator, viewer | Yes |
+Returns per-tool call counts for a session, parsed from the JSONL transcript. **Ownership-based access** — requires the session's API key owner.
 
 ```bash
 curl http://localhost:9100/v1/sessions/abc123/tools \

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,7 +28,12 @@ Health, swarm coordination, diagnostics, handshake, and the OpenAPI spec.
 GET /v1/health
 ```
 
-Returns server health, version, uptime, and Claude CLI status. **No authentication required** — unauthenticated callers receive only `{ "status": "ok" }` to prevent information leakage.
+Returns server health, version, uptime, and Claude CLI status.
+
+| Role | Required | Notes |
+|------|----------|-------|
+| None | — | Unauthenticated callers receive only `{ "status": "ok" }` to prevent information leakage |
+| admin | Yes | Full response with version, uptime, sessions, Claude CLI status |
 
 ```bash
 curl http://localhost:9100/v1/health
@@ -171,6 +176,10 @@ POST /v1/handshake
 
 Performs capability negotiation with Aegis. Returns server capabilities and compatibility status.
 
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
+
 ```bash
 curl -X POST http://localhost:9100/v1/handshake \
   -H "Content-Type: application/json" \
@@ -311,6 +320,10 @@ POST /v1/auth/keys
 
 Creates a new API key. **Admin only.**
 
+| Role | Required |
+|------|----------|
+| admin | Yes |
+
 ```bash
 curl -X POST http://localhost:9100/v1/auth/keys \
   -H "Authorization: Bearer $TOKEN" \
@@ -354,6 +367,10 @@ GET /v1/auth/keys
 
 Lists all registered API keys (metadata only, no secrets). **Admin only.**
 
+| Role | Required |
+|------|----------|
+| admin | Yes |
+
 ```bash
 curl http://localhost:9100/v1/auth/keys \
   -H "Authorization: Bearer $TOKEN"
@@ -372,6 +389,10 @@ DELETE /v1/auth/keys/:id
 ```
 
 Revokes an API key by ID. **Admin only.**
+
+| Role | Required |
+|------|----------|
+| admin | Yes |
 
 ```bash
 curl -X DELETE http://localhost:9100/v1/auth/keys/key-abc123 \
@@ -397,6 +418,10 @@ PATCH /v1/auth/keys/:id
 ```
 
 Updates an API key's role, name, or permissions. **Admin only.**
+
+| Role | Required |
+|------|----------|
+| admin | Yes |
 
 ```bash
 curl -X PATCH http://localhost:9100/v1/auth/keys/key-abc123 \
@@ -440,6 +465,10 @@ POST /v1/auth/keys/:id/rotate
 
 Rotates an API key in place. The old key is immediately invalidated. **Admin only.**
 
+| Role | Required |
+|------|----------|
+| admin | Yes |
+
 ```bash
 curl -X POST http://localhost:9100/v1/auth/keys/key-abc123/rotate \
   -H "Authorization: Bearer $TOKEN" \
@@ -470,6 +499,10 @@ POST /v1/auth/keys/rotate
 ```
 
 Rotates an API key with a **grace period** during which both old and new keys are valid. **Admin only.**
+
+| Role | Required |
+|------|----------|
+| admin | Yes |
 
 ```bash
 curl -X POST http://localhost:9100/v1/auth/keys/rotate \
@@ -540,6 +573,10 @@ GET /v1/auth/keys/:id/quotas
 
 Returns configured quotas and current usage for a specific API key. **Admin only.**
 
+| Role | Required |
+|------|----------|
+| admin | Yes |
+
 ```bash
 curl http://localhost:9100/v1/auth/keys/key-abc123/quotas \
   -H "Authorization: Bearer $TOKEN"
@@ -573,6 +610,10 @@ PUT /v1/auth/keys/:id/quotas
 ```
 
 Sets or updates quotas for an API key. Omit a field to leave unchanged; set to `null` to remove. **Admin only.**
+
+| Role | Required |
+|------|----------|
+| admin | Yes |
 
 ```bash
 curl -X PUT http://localhost:9100/v1/auth/keys/key-abc123/quotas \
@@ -799,6 +840,10 @@ GET /v1/sessions/:id
 ```
 
 Returns session details including action hints for interactive states.
+
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
 
 ```bash
 curl http://localhost:9100/v1/sessions/abc123 \
@@ -1161,6 +1206,10 @@ GET /v1/sessions/:id/tools
 ```
 
 Returns per-tool call counts for a session, parsed from the JSONL transcript.
+
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
 
 ```bash
 curl http://localhost:9100/v1/sessions/abc123/tools \
@@ -2961,6 +3010,10 @@ GET /v1/audit
 
 Returns audit log records with cursor-based or offset-based pagination, time-range filters, and multi-format export. **Admin only.** Rate limited: 30 req/min.
 
+| Role | Required |
+|------|----------|
+| admin | Yes |
+
 ```bash
 curl "http://localhost:9100/v1/audit?action=session.create&from=2026-04-13T00:00:00Z&limit=50" \
   -H "Authorization: Bearer $TOKEN"
@@ -3568,6 +3621,10 @@ GET /v1/usage/by-key
 ```
 
 Returns usage broken down by API key. **Admin only.**
+
+| Role | Required |
+|------|----------|
+| admin | Yes |
 
 ```bash
 curl "http://localhost:9100/v1/usage/by-key?from=2026-04-01T00:00:00Z" \

--- a/scripts/test-ag-mcp-headless.sh
+++ b/scripts/test-ag-mcp-headless.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Simple headless check for 'ag mcp' — uses npx when available, falls back to local dist/cli.js
+set -euo pipefail
+PORT=${1:-9112}
+TMPLOG=$(mktemp /tmp/ag-mcp.XXXX.log)
+PIDFILE=$(mktemp /tmp/ag-mcp-pid.XXXX)
+
+run_cmd() {
+  if command -v npx >/dev/null 2>&1; then
+    echo "Using npx to run aegis CLI (if package published)"
+    npx @onestepat4time/aegis mcp --port "$PORT" >"$TMPLOG" 2>&1 &
+  else
+    echo "npx not available — using local dist/cli.js"
+    node dist/cli.js mcp --port "$PORT" >"$TMPLOG" 2>&1 &
+  fi
+  echo $! >"$PIDFILE"
+}
+
+after() {
+  if [ -f "$PIDFILE" ]; then
+    kill "$(cat "$PIDFILE")" >/dev/null 2>&1 || true
+    rm -f "$PIDFILE"
+  fi
+  if [ -f "$TMPLOG" ]; then
+    echo "--- LOG (last 200 lines) ---"
+    tail -n 200 "$TMPLOG" || true
+    rm -f "$TMPLOG"
+  fi
+}
+
+trap after EXIT
+
+run_cmd
+# Give it a moment to start and settle
+sleep 1
+PID=$(cat "$PIDFILE")
+if ps -p "$PID" >/dev/null 2>&1; then
+  echo "ag mcp started (pid=$PID) — headless invocation appears to work"
+  # Optionally send a minimal signal or write to stdout
+  exit 0
+else
+  echo "ag mcp did not stay running — check log"
+  exit 2
+fi


### PR DESCRIPTION
Adds scripts/test-ag-mcp-headless.sh — simple headless smoke check for 'ag mcp' usable by CI or local verification. Falls back to local dist/cli.js when npx isn't available. Runs ag mcp in background, verifies process is alive, then cleans up.\n\nRelated: #3326