### PR TITLE
fix(ci): replace broken TRUSTED grep with case statement in discord-notify

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -33,22 +33,23 @@ jobs:
           ACTOR: ${{ github.actor }}
           EVENT: ${{ github.event_name }}
         run: |
-          TRUSTED="OneStepAt4time\naegis-gh-agent[bot]\ndependabot[bot]"
-
+          # Stars always notify regardless of actor
           if [ "$EVENT" = "watch" ]; then
             echo "should_notify=true" >> "$GITHUB_OUTPUT"
             echo "event_type=star" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Use grep -Fxq for literal exact-line matching (avoids [bot] being
-          # interpreted as a regex character class)
-          if printf '%s\n' "$TRUSTED" | grep -Fxq "$ACTOR"; then
-            echo "should_notify=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_notify=true" >> "$GITHUB_OUTPUT"
-            echo "event_type=activity" >> "$GITHUB_OUTPUT"
-          fi
+          # Suppress notifications from trusted team/bot actors
+          case "$ACTOR" in
+            OneStepAt4time|'aegis-gh-agent[bot]'|'dependabot[bot]')
+              echo "should_notify=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "should_notify=true" >> "$GITHUB_OUTPUT"
+              echo "event_type=activity" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
       - name: Notify — Star ⭐
         if: steps.check.outputs.should_notify == 'true' && steps.check.outputs.event_type == 'star'


### PR DESCRIPTION
## What
Replace the broken `TRUSTED` actor filter in `discord-notify.yml` with a case statement that actually works.

## Root Cause
The TRUSTED list used `"\n"` in a double-quoted bash string — bash does NOT interpret `\n` as newline there. The entire list was one concatenated string: `OneStepAt4time\naegis-gh-agent[bot]\ndependabot[bot]`. `grep -Fxq` tried to match actors against this single line and always failed.

Result: every issue, comment, and PR from team members and bots fired as "External" — 7+ false alerts tonight alone.

## Fix
Replace grep-based matching with a `case` statement:
- Handles `[bot]` bracket characters safely (no regex escaping issues)
- No newline parsing at all — eliminates the entire class of bug
- Stars still notify for all actors (preserved existing behavior)

## Testing
```bash
# All 8 cases verified locally:
Trusted actors (OneStepAt4time, aegis-gh-agent[bot], dependabot[bot]) → should_notify=false ✅
External actors (randomuser, some-contributor, friendly-forker) → should_notify=true ✅
Stars from any actor → should_notify=true ✅
```

## Impact
- Eliminates all false "External Issue 🐛" and "External Comment 💬" notifications from team/bot activity
- Preserves legitimate external contributor notifications
- Preserves star notifications from all actors

Closes #3329