### PR TITLE
docs: add auth prerequisite for ag create and ag run (#3349)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,6 +26,12 @@ npx --package=@onestepat4time/aegis ag run "Analyze this project and list the ma
 
 If the server is already running, `ag run` skips bootstrap and start — goes straight to session creation. Existing config is never overwritten.
 
+> **Auth note:** If you previously configured an API token during `ag init`, set `AEGIS_AUTH_TOKEN` before running CLI commands:
+> ```bash
+> export AEGIS_AUTH_TOKEN=your-secret-token
+> ```
+> Without this, `ag run` and `ag create` return `401 Unauthorized`.
+
 | Flag | Description |
 |------|-------------|
 | `--cwd <path>` | Working directory (default: current directory) |
@@ -49,7 +55,7 @@ npm install -g @onestepat4time/aegis
 ag init
 ```
 
-> **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml` and generates a new auth token. Restart the server to apply changes. Use `ag init --force` to skip the confirmation prompt.
+> **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml`. Restart the server to apply changes. Use `ag init --force` to skip confirmation prompts.
 >
 > `ag init` now supports conversational onboarding with `--model` and `--name` flags for non-interactive setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session.
 
@@ -142,6 +148,12 @@ Navigate the dashboard faster using keyboard shortcuts:
 The dashboard displays the shortcut hint in the sidebar footer.
 
 ## 4. Create a Session
+
+> **Auth required?** If you answered "yes" to the API token prompt during `ag init` (or set `AEGIS_AUTH_TOKEN`), you must export the token before using `ag create` or `ag run`:
+> ```bash
+> export AEGIS_AUTH_TOKEN=your-secret-token
+> ```
+> Without this, CLI commands return `401 Unauthorized`. No-auth setups can skip this.
 
 ```bash
 ag create "Analyze this project. List the main technologies, directory structure, and any issues you spot." --cwd /path/to/your/project


### PR DESCRIPTION
## What
Fixes #3349 — `ag create` fails with 401 when `AEGIS_AUTH_TOKEN` is not set, but the getting-started guide doesn't mention this prerequisite.

## Changes
- **Quick Start section:** Added auth note after the `ag run` description — warns users who configured auth during `ag init` that they need to export the token
- **Section 4 (Create a Session):** Added auth callout before the `ag create` command — same warning, with clear steps
- **ag init warning:** Fixed wording (removed misleading "generates a new auth token" since `ag init` prompts for it)

## Testing
Walked through getting-started.md as a real user during dogfooding. Confirmed the 401 error reproduces without the token, and the fix explains the prerequisite clearly.

## Root cause
Auth setup was hidden inside a `<details>` collapsible in section 1. Users following the top-level Quick Start or jumping to section 4 never saw it.