### PR TITLE
fix(auth): reject unsafe characters in API key names (#3364)

### DIFF
--- a/src/__tests__/fix-3364-key-name-validation.test.ts
+++ b/src/__tests__/fix-3364-key-name-validation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Issue #3364: Null bytes and special characters accepted in API key names.
+ * Input validation should reject unsafe key name characters.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { authKeySchema, updateKeySchema } from '../validation.js';
+
+describe('Issue #3364: API key name validation', () => {
+  const validNames = [
+    'my-key',
+    'production',
+    'claude-desktop',
+    'a',
+    'key.with.dots',
+    'KEY_123',
+    'under_score',
+    'MixedCase-123',
+    'x'.repeat(100),
+  ];
+
+  const invalidNames = [
+    'test\x00null',          // null byte
+    '',                       // empty
+    'x'.repeat(101),         // too long
+    'has spaces',             // spaces
+    'has/slash',              // slash
+    'has\\backslash',         // backslash
+    'name"quote',             // double quote
+    "name'apostrophe",        // single quote
+    'name<script>',           // angle brackets
+    'name\nnewline',          // newline
+    'name\ttab',              // tab
+    'name;semicolon',         // semicolon
+    'name&amp',               // ampersand
+    '(paren)',                // parens
+    '{curly}',                // curly braces
+    'has@at',                 // at sign
+    'has:colon',              // colon
+    'has|pipe',               // pipe
+    'has!bang',               // exclamation
+  ];
+
+  describe('authKeySchema (POST /v1/auth/keys)', () => {
+    for (const name of validNames) {
+      it(`accepts valid name: ${JSON.stringify(name.slice(0, 30))}`, () => {
+        const result = authKeySchema.safeParse({ name });
+        expect(result.success).toBe(true);
+      });
+    }
+
+    for (const name of invalidNames) {
+      it(`rejects invalid name: ${JSON.stringify(name.slice(0, 30).replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/\x00/g, '\\0'))}`, () => {
+        const result = authKeySchema.safeParse({ name });
+        expect(result.success).toBe(false);
+      });
+    }
+
+    it('accepts minimal valid body', () => {
+      const result = authKeySchema.safeParse({ name: 'test' });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('updateKeySchema (PATCH /v1/auth/keys/:id)', () => {
+    for (const name of validNames) {
+      it(`accepts valid name update: ${JSON.stringify(name.slice(0, 30))}`, () => {
+        const result = updateKeySchema.safeParse({ name });
+        expect(result.success).toBe(true);
+      });
+    }
+
+    for (const name of invalidNames) {
+      it(`rejects invalid name update: ${JSON.stringify(name.slice(0, 30).replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/\x00/g, '\\0'))}`, () => {
+        const result = updateKeySchema.safeParse({ name });
+        expect(result.success).toBe(false);
+      });
+    }
+
+    it('accepts update without name', () => {
+      const result = updateKeySchema.safeParse({ role: 'admin' });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -15,8 +15,11 @@ import { API_KEY_PERMISSION_VALUES } from './services/auth/permissions.js';
 export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** POST /v1/auth/keys */
+/** #3364: Safe pattern for API key names — rejects control chars, null bytes, etc. */
+export const KEY_NAME_REGEX = /^[a-zA-Z0-9._-]{1,100}$/;
+
 export const authKeySchema = z.object({
-  name: z.string().min(1),
+  name: z.string().regex(KEY_NAME_REGEX, "Key name must be 1-100 alphanumeric characters, dots, hyphens, or underscores"),
   rateLimit: z.number().int().positive().optional(),
   ttlDays: z.number().int().positive().optional(),
   role: z.enum(['admin', 'operator', 'viewer']).optional(),
@@ -27,7 +30,7 @@ export const authKeySchema = z.object({
 
 /** PATCH /v1/auth/keys/:id — update key role/name/permissions (#3207) */
 export const updateKeySchema = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().regex(KEY_NAME_REGEX, "Key name must be 1-100 alphanumeric characters, dots, hyphens, or underscores").optional(),
   role: z.enum(['admin', 'operator', 'viewer']).optional(),
   permissions: z.array(z.enum(API_KEY_PERMISSION_VALUES)).max(API_KEY_PERMISSION_VALUES.length).nullable().optional(),
 }).strict();


### PR DESCRIPTION
## Summary

Fixes #3364 — null bytes and special characters accepted in API key names.

## Fix

Added `KEY_NAME_REGEX = /^[a-zA-Z0-9._-]{1,100}$/` applied to:
- `authKeySchema` (POST /v1/auth/keys)
- `updateKeySchema` (PATCH /v1/auth/keys/:id)

Rejects null bytes, control characters, quotes, HTML, shell metacharacters. Allows alphanumeric, dots, hyphens, underscores.

## Verification

- tsc --noEmit: clean
- Tests: 58/58 passed (10 valid + 19 invalid names × 2 schemas + 1 edge case)

## Backward compatibility

Existing keys with safe names are unaffected. Keys with special characters (if any exist) can still be used but cannot be renamed to unsafe names. New keys with unsafe names are rejected at the schema validation layer.