### PR TITLE
fix(audit): ensure audit directory exists before acquiring file lock (#3353)

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -347,6 +347,10 @@ export class AuditLogger {
    */
   private async acquireFileLock(): Promise<void> {
     const lockPath = join(this.logDir, AuditLogger.FILE_LOCK_DIR);
+    // #3353: Ensure audit directory exists before acquiring file lock
+    if (!existsSync(this.logDir)) {
+      await mkdir(this.logDir, { recursive: true });
+    }
     const deadline = Date.now() + AuditLogger.FILE_LOCK_TIMEOUT_MS;
 
     while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary

Fixes #3353 — audit directory not created, causing 72+ unhandled rejections.

## Fix

Added  guard in  before creating the  directory. If the audit directory was deleted or never created, it now gets created automatically.

## Verification

- tsc --noEmit: clean
- One-line fix — defensive mkdir before lock acquisition