### PR TITLE
fix(cli): ag init --force replaces existing admin key instead of crashing (#3351)

### DIFF
--- a/src/__tests__/cli-init.test.ts
+++ b/src/__tests__/cli-init.test.ts
@@ -294,4 +294,36 @@ describe('ag init --model flag', () => {
     };
     expect(config.defaultSessionEnv?.ANTHROPIC_DEFAULT_MODEL).toBe('gpt-5');
   });
+
+  it('replaces existing admin key on --force (issue #3351)', async () => {
+    // First init creates a key
+    let stdin = new PassThrough();
+    let stdout = new CaptureStream();
+    let stderr = new CaptureStream();
+    let runPromise = runCli(['init', '--yes'], { stdin, stdout, stderr });
+    setImmediate(() => stdin.end());
+    let code = await runPromise;
+    expect(code).toBe(0);
+
+    // Read first token
+    const configPath = join(projectDir, '.aegis', 'config.yaml');
+    const config1 = parseYaml(readFileSync(configPath, 'utf-8')) as { clientAuthToken: string };
+    const token1 = config1.clientAuthToken;
+    expect(token1).toBeTruthy();
+
+    // Second init with --force should replace the key, not crash
+    stdin = new PassThrough();
+    stdout = new CaptureStream();
+    stderr = new CaptureStream();
+    runPromise = runCli(['init', '--yes', '--force'], { stdin, stdout, stderr });
+    setImmediate(() => stdin.end());
+    code = await runPromise;
+    expect(code).toBe(0);
+
+    // Verify new token is different
+    const config2 = parseYaml(readFileSync(configPath, 'utf-8')) as { clientAuthToken: string };
+    const token2 = config2.clientAuthToken;
+    expect(token2).toBeTruthy();
+    expect(token2).not.toBe(token1);
+  });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -583,7 +583,7 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
     return 1;
   }
 
-  let createAdminToken = !existingToken;
+  let createAdminToken = !existingToken || force;
   let baseUrl = existingConfig?.baseUrl
     ? normalizeBaseUrl(existingConfig.baseUrl)
     : getConfiguredBaseUrl(currentConfig);
@@ -664,6 +664,8 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
       return 0;
     }
 
+    // Issue #3351: --yes --force should auto-overwrite without prompting
+    if (!yes || !force) {
     const prompter = createPrompter(io);
     try {
       const overwrite = await promptBoolean(prompter, io, `Overwrite ${displayConfigPath}?`, false);
@@ -686,6 +688,7 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
       }
     } finally {
       prompter.close();
+  }
     }
   }
 
@@ -710,6 +713,13 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   await authManager.load();
 
   if (generatedTokenRequested) {
+    // Issue #3351: --force should replace existing key, not crash
+    if (force) {
+      const existingKey = authManager.listKeys().find(k => k.name === 'ag-init-admin');
+      if (existingKey) {
+        await authManager.revokeKey(existingKey.id);
+      }
+    }
     const createdKey = await authManager.createKey('ag-init-admin', 100, undefined, 'admin');
     authToken = createdKey.key;
     createdKeyId = createdKey.id;


### PR DESCRIPTION
## Fix for #3351

### Problem
`ag init --force` crashes with `DUPLICATE_KEY_NAME` when an admin key from a previous init already exists.

### Root Cause
Two issues:
1. `createKey("ag-init-admin", ...)` always uses the same name — no cleanup of the old key
2. `--yes --force` still prompts "Overwrite config?" because the prompter block ran even when force=true
3. `createAdminToken` was `false` when existing token found, even with `--force`

### Fix
1. When `--force`, delete existing `ag-init-admin` key before creating new one
2. Skip interactive overwrite prompt when `--yes --force`
3. Set `createAdminToken = !existingToken || force`

### Verification
- `tsc --noEmit`: ✅ Zero errors
- `npm run build`: ✅ Success
- `vitest run src/__tests__/cli-init.test.ts`: ✅ 9/9 passed (including new regression test)

### Also Fixes
#3355 (same root cause — DUPLICATE_KEY_NAME with --force)