### PR TITLE
fix(cli): persist auth token to ~/.aegis/auth-token file (#3369)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,8 +6,9 @@
  * Also handles `--list-templates` and `--from-template`.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { copyFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
@@ -45,6 +46,23 @@ interface InitSummary {
   wroteConfig: boolean;
   identityScaffolded: boolean;
 }
+
+/**
+ * Persist the auth token to ~/.aegis/auth-token for easy access.
+ * File is created with 0600 permissions (owner read/write only).
+ * Non-fatal on failure — token remains in config.yaml as clientAuthToken.
+ */
+function persistAuthTokenFile(token: string): void {
+  const tokenDir = join(homedir(), '.aegis');
+  const tokenPath = join(tokenDir, 'auth-token');
+  try {
+    if (!existsSync(tokenDir)) mkdirSync(tokenDir, { recursive: true });
+    writeFileSync(tokenPath, token, { encoding: 'utf-8', mode: 0o600 });
+  } catch {
+    // Non-fatal — token is still in config.yaml as clientAuthToken
+  }
+}
+
 
 type TemplateType = 'agent' | 'skill' | 'slash-command';
 
@@ -783,6 +801,11 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
     } catch (error) {
       writeLine(io.stderr, `  ⚠️  Could not write identity file: ${getErrorMessage(error)}`);
     }
+  }
+
+  // #3369: Persist token to ~/.aegis/auth-token for easy scripting access
+  if (authToken) {
+    persistAuthTokenFile(authToken);
   }
 
   printInitSummary(io, {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -11,7 +11,7 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -31,7 +31,16 @@ function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
 }
 
 function resolveAuthToken(): string | undefined {
-  return process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN || undefined;
+  const envToken = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN;
+  if (envToken) return envToken;
+
+  // #3369: Check ~/.aegis/auth-token file as fallback
+  try {
+    const tokenPath = join(homedir(), '.aegis', 'auth-token');
+    return readFileSync(tokenPath, 'utf-8').trim() || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Closes #3369

`ag init` now persists the auth token to `~/.aegis/auth-token` (mode 0600) so users can easily retrieve it for scripting without scrolling terminal output.

`ag run` `resolveAuthToken()` now checks `~/.aegis/auth-token` as a fallback after env vars.

### Changes
- **init.ts**: Added `persistAuthTokenFile()` — writes token to `~/.aegis/auth-token` with 0600 permissions. Non-fatal on failure (token still in config.yaml).
- **run.ts**: `resolveAuthToken()` now falls back to reading `~/.aegis/auth-token` file.

### Verification
- `tsc --noEmit`: ✅ Zero errors
- `npm run build`: ✅ Success
- `npm test`: ✅ cli-init 13/13 passed (1 pre-existing flaky timeout on develop too)

```
Aegis API: unknown
Commit: 81f2cb9fa049dc5d0c84e1a8312a8f8772b5193b
Session: direct (prompt delivery regression #3271)
```