### PR TITLE
fix(cli): prevent EADDRINUSE when server already running (#3346)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -62,13 +62,43 @@ async function verifyAuth(baseUrl: string, authToken: string | undefined): Promi
   }
 }
 
-/** Check if the server is healthy at the given base URL. */
+/** Check if the server is healthy at the given base URL.
+ *  #3346: Also checks PID file as a fallback when the health endpoint times out.
+ *  If the PID file exists and the process is alive, assume the server is running. */
 async function isServerHealthy(baseUrl: string, authToken?: string): Promise<boolean> {
   try {
     const headers: Record<string, string> = {};
     if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
     const res = await fetch(`${baseUrl}/v1/health`, { headers, signal: AbortSignal.timeout(3000) });
-    return res.ok;
+    if (res.ok) return true;
+    // Non-401 error or network issue — fall through to PID file check
+  } catch {
+    // Network error — fall through to PID file check
+  }
+
+  // #3346: Fallback — check if an Aegis server PID file exists with a live process
+  try {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const stateDir = process.env.AEGIS_STATE_DIR || join(homedir(), '.aegis');
+    const pidFile = join(stateDir, 'aegis.pid');
+    if (existsSync(pidFile)) {
+      const pid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+      if (pid > 0 && pidExists(pid)) {
+        return true;
+      }
+    }
+  } catch {
+    // Ignore
+  }
+
+  return false;
+}
+
+/** Check if a process with the given PID is alive. */
+function pidExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
   } catch {
     return false;
   }

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -168,8 +168,11 @@ export async function listenWithRetry(
       console.error(`EADDRINUSE on port ${port} - attempting recovery (attempt ${attempt + 1}/${maxRetries})`);
       const killed = await killStalePortHolder(port, stateDir);
       if (!killed) {
-        console.error(`EADDRINUSE recovery failed: no stale process found on port ${port}`);
-        throw err;
+        // #3346: Better error message when a peer Aegis is already running
+        console.error(`EADDRINUSE: another Aegis server is already running on port ${port}`);
+        console.error(`  If you want to use the running server, no action needed — just connect to it.`);
+        console.error(`  If you want to restart it, stop the existing server first: ag stop`);
+        process.exit(1);
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #3346 — ag run fails with EADDRINUSE when server already running.

## Changes

1. **CLI health check fallback** (src/commands/run.ts): When the health endpoint times out or returns a non-OK status, falls back to checking the Aegis PID file. If a live process exists, assumes the server is running and skips bootstrap/start.

2. **Server EADDRINUSE message** (src/startup.ts): When a peer Aegis is detected on the port (already fixed by Hermes in a prior commit on this branch), exits with a clear message instead of a raw stack trace.

## Verification

- tsc --noEmit: clean
- PID file check uses process.kill(pid, 0) for zero-cost liveness check
- Graceful fallback: if PID file doesn't exist or process is dead, returns false (existing behavior)