### PR TITLE
fix(cli): ag run streaming output hangs — wrong response field names (#3368)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -170,16 +170,18 @@ async function streamOutput(baseUrl: string, sessionId: string, authToken: strin
       }
 
       const data = await res.json() as {
-        lines?: Array<{ text: string; role?: string }>;
-        transcript?: Array<{ text: string; role?: string }>;
+        messages?: Array<{ text: string; role?: string; contentType?: string }>;
         status?: string;
+        statusText?: string | null;
       };
 
-      // Support both `lines` and `transcript` response shapes
-      const entries = data.lines || data.transcript || [];
+      // #3368: Read endpoint returns `messages`, not `lines` or `transcript`
+      const entries = data.messages || [];
       if (entries.length > lastLineCount) {
         const newEntries = entries.slice(lastLineCount);
         for (const entry of newEntries) {
+          // Skip non-text content types (thinking, tool_use, tool_result, etc.)
+          if (entry.contentType && entry.contentType !== 'text') continue;
           const prefix = entry.role === 'user' ? '  👤 ' : entry.role === 'assistant' ? '  🤖 ' : '  ';
           writeLine(io.stdout, `${prefix}${entry.text.slice(0, 500)}`);
         }
@@ -188,9 +190,9 @@ async function streamOutput(baseUrl: string, sessionId: string, authToken: strin
       }
 
       // Check if session is done
-      if (data.status === 'completed' || data.status === 'error' || data.status === 'killed') {
+      if (data.status === 'completed' || data.status === 'error' || data.status === 'killed' || data.status === 'crashed') {
         writeLine(io.stdout);
-        writeLine(io.stdout, `  Session ended: ${data.status}`);
+        writeLine(io.stdout, `  ✅ Session ended: ${data.statusText || data.status}`);
         break;
       }
 


### PR DESCRIPTION
## Summary

Fixes #3368 — ag run streaming output never displays the answer.

## Root Cause

The `streamOutput()` function in `ag run` was looking for `data.lines` or `data.transcript` in the response from `/v1/sessions/:id/read`. But the endpoint actually returns `data.messages`. Since neither field existed, the CLI never received any entries and the stream appeared to hang indefinitely.

## Fix

- Changed response field from `lines/transcript` to `messages` (matching the actual API response)
- Skip non-text content types (thinking, tool_use, tool_result) — only show user/assistant text
- Added `crashed` to terminal status detection
- Show `statusText` when available for better end-of-session messages

## Verification

- tsc --noEmit: clean
- Response shape matches `readMessagesFromSession()` return type: `{ messages: ParsedEntry[], status: UIState, statusText, interactiveContent }`