### PR TITLE
docs: clarify /send vs /prompt endpoint naming (#3344)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -776,7 +776,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 | `workDir` | string | **yes** | Absolute path to an existing directory (file paths are rejected) |
 | `name` | string | no | Session name (max 200 chars, `a-zA-Z0-9_ ./@-=` only; defaults to auto-generated) |
 | `label` | string | no | Alias for `name` (same character restrictions; `name` takes precedence) |
-| `prompt` | string | no | Initial prompt to send after boot (max 100k chars; must be non-empty if provided) |
+| `prompt` | string | no | Initial prompt to send after boot (max 100k chars; must be non-empty if provided). For follow-up messages after creation, use `POST /v1/sessions/:id/send` with `text` field. |
 | `prd` | string | no | Product Requirements Document text (max 100k chars) |
 | `resumeSessionId` | string (UUID) | no | Resume an existing session by UUID |
 | `model` | string | no | Model name for analytics grouping (max 200 chars) |
@@ -1414,6 +1414,8 @@ POST /v1/sessions/:id/send
 Sends a text message to the Claude Code session.
 
 **Alias:** `POST /v1/sessions/:id/input` — identical behavior.
+
+> **Note:** There is no `/v1/sessions/:id/prompt` endpoint. Session creation accepts a `prompt` field for the initial message; for follow-up messages, use `/send` or `/input` with the `text` field.
 
 ```bash
 curl -X POST http://localhost:9100/v1/sessions/abc123/send \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,6 +204,8 @@ curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN"
 
 ## 6. Send a Follow-Up
 
+> **Endpoint note:** Follow-up messages use `/send` (or `/input` alias) with a `text` field. There is no `/prompt` endpoint — `prompt` is only a field during session creation.
+
 ```bash
 curl -X POST http://localhost:9100/v1/sessions/a1b2c3d4/send \
   -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
## What
Fixes #3344 — API naming inconsistency where users try `/sessions/:id/prompt` for follow-ups because session creation uses a `prompt` field.

## Changes
- **api-reference.md (Send Message):** Added note — no `/prompt` endpoint exists, use `/send` or `/input`
- **api-reference.md (Create Session):** Added cross-reference in `prompt` field description pointing to `/send`
- **getting-started.md (Section 6):** Added endpoint note clarifying `/send` is for follow-ups

## Tested
Read rendered output — notes are clear and non-intrusive.