### PR TITLE
fix(dashboard): light theme contrast — amber-200, bg-white, border-white invisible on light backgrounds

### DIFF
--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -584,6 +584,58 @@ body::before {
 [data-theme="light-aaa"] .text-amber-400 {
   color: var(--color-warning) !important;
 }
+/* ------------------------------------------------------------------
+ * Light-mode overrides for amber-200 (warning text) and white/opacity
+ * utilities used as backgrounds and borders in dark mode.
+ * amber-200 (#fde68a) has ~1.4:1 contrast on white — fails WCAG AA.
+ * bg-white/5 and border-white/5 are invisible on light backgrounds.
+ * ------------------------------------------------------------------ */
+[data-theme="light"] .text-amber-200,
+[data-theme="light-paper"] .text-amber-200,
+[data-theme="light-aaa"] .text-amber-200 {
+  color: var(--color-warning) !important;
+}
+[data-theme="light"] .text-amber-200\/80,
+[data-theme="light-paper"] .text-amber-200\/80,
+[data-theme="light-aaa"] .text-amber-200\/80 {
+  color: var(--color-warning) !important;
+}
+[data-theme="light"] .border-amber-500\/20,
+[data-theme="light"] .border-amber-500\/30,
+[data-theme="light-paper"] .border-amber-500\/20,
+[data-theme="light-paper"] .border-amber-500\/30,
+[data-theme="light-aaa"] .border-amber-500\/20,
+[data-theme="light-aaa"] .border-amber-500\/30 {
+  border-color: color-mix(in srgb, var(--color-warning) 30%, transparent) !important;
+}
+[data-theme="light"] .bg-amber-500\/5,
+[data-theme="light"] .bg-amber-500\/10,
+[data-theme="light-paper"] .bg-amber-500\/5,
+[data-theme="light-paper"] .bg-amber-500\/10,
+[data-theme="light-aaa"] .bg-amber-500\/5,
+[data-theme="light-aaa"] .bg-amber-500\/10 {
+  background-color: color-mix(in srgb, var(--color-warning) 8%, transparent) !important;
+}
+[data-theme="light"] .bg-white\/5,
+[data-theme="light-paper"] .bg-white\/5,
+[data-theme="light-aaa"] .bg-white\/5 {
+  background-color: var(--color-void-light) !important;
+}
+[data-theme="light"] .bg-white\/10,
+[data-theme="light-paper"] .bg-white\/10,
+[data-theme="light-aaa"] .bg-white\/10 {
+  background-color: var(--color-void-lighter) !important;
+}
+[data-theme="light"] .border-white\/5,
+[data-theme="light-paper"] .border-white\/5,
+[data-theme="light-aaa"] .border-white\/5 {
+  border-color: var(--color-void-lighter) !important;
+}
+[data-theme="light"] .border-white\/10,
+[data-theme="light-paper"] .border-white\/10,
+[data-theme="light-aaa"] .border-white\/10 {
+  border-color: var(--color-void-lighter) !important;
+}
 
 /* ------------------------------------------------------------------
  * Light-mode readability shim for rose/red/sky utility classes (issue #2378).


### PR DESCRIPTION
Closes #3372

## Problem

30+ instances of hardcoded dark-mode colors are invisible or nearly invisible on light backgrounds:

- `text-amber-200` (#fde68a) on white: **1.4:1 contrast ratio** — fails WCAG AA (4.5:1 required)
- `bg-white/5`, `bg-white/10`: invisible on white/near-white backgrounds
- `border-white/5`, `border-white/10`: invisible borders
- `border-amber-500/20`, `bg-amber-500/5`: warning containers invisible in light

## Solution

Added CSS-only light theme overrides in `index.css` using the existing pattern (same approach as the `text-slate-*` and `text-rose-*` overrides already in the file). No component changes needed — all fixes are CSS-level.

### New overrides

| Dark-mode utility | Light theme override |
|---|---|
| `text-amber-200` | `var(--color-warning)` |
| `text-amber-200/80` | `var(--color-warning)` |
| `bg-white/5` | `var(--color-void-light)` |
| `bg-white/10` | `var(--color-void-lighter)` |
| `border-white/5`, `border-white/10` | `var(--color-void-lighter)` |
| `border-amber-500/20`, `/30` | `color-mix(in srgb, var(--color-warning) 30%, transparent)` |
| `bg-amber-500/5`, `/10` | `color-mix(in srgb, var(--color-warning) 8%, transparent)` |

### Why CSS-only?

The existing codebase already uses this pattern (lines 525–575 in index.css). Converting 30+ components to CSS custom properties would be a larger refactor — this PR fixes the visual bug immediately with zero risk of regressions.

### Components fixed (30+ instances)

- SettingsPage, MetricsPage, AnalyticsPage, CostPage, TemplatesPage — error/warning alerts
- SessionTable — loading skeleton, error message, empty state
- MetricCards — error banner
- LiveAuditStream — filter container, empty state
- Layout — search bar, keyboard shortcuts
- CommandPalette — keyboard hints, active item highlight
- TerminalPassthrough — status bar
- VirtualizedSessionList — hover states
- HomeStatusPanel — status icons
- ActivityStream — avatar placeholders
- NewSessionDrawer — hover states

## Verification

- ✅ TypeScript strict: 0 errors
- ✅ Vitest: 1300 tests passed, 0 failed (133 files)
- ✅ CSS braces balanced
- ✅ Only `dashboard/src/index.css` touched
- ✅ `color-mix()` supported in all modern browsers (Chrome 111+, Firefox 113+, Safari 16.2+)

— Daedalus 🏛️