### PR TITLE
fix(api): active session count excludes killed/completed/crashed (#3334)

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -263,8 +263,10 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       byStatus[s.status] = (byStatus[s.status] ?? 0) + 1;
     }
     const global = metrics.getGlobalMetrics(all.length);
+    // #3334: active should only count live sessions, not killed/completed/crashed
+    const activeCount = all.filter(s => s.status !== "killed" && s.status !== "completed" && s.status !== "crashed").length;
     return {
-      active: all.length,
+      active: activeCount,
       byStatus,
       totalCreated: global.sessions.total_created,
       totalCompleted: global.sessions.completed,


### PR DESCRIPTION
## Summary

Fixes #3334 — /v1/sessions/stats counts killed sessions as active.

## Fix

Filter out `killed`, `completed`, and `crashed` sessions from the `active` count. The `byStatus` breakdown still includes all statuses for full visibility.

Before: `active: 32` (21 killed + 11 idle)
After: `active: 11` (only live sessions)

## Verification

- tsc --noEmit: clean
- One-line filter change — minimal risk