### PR TITLE
fix(dashboard): SessionDetailPage tab bar scrollable on mobile

### DIFF
--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1072,3 +1072,13 @@ main[id="main-content"] {
   box-shadow:
     0 40px 80px -15px rgba(0, 0, 0, 0.9);
 }
+
+
+/* Hide scrollbar but keep scroll functionality — for mobile tab bars */
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -598,7 +598,7 @@ export default function SessionDetailPage() {
             userRole="observer"
           />
 
-          <div className="relative flex gap-2 py-1" role="tablist">
+          <div className="relative flex gap-2 py-1 overflow-x-auto scrollbar-none" role="tablist" aria-label="Session detail tabs">
             {TABS.map((tab) => (
               <button type="button"
                 key={tab.id}


### PR DESCRIPTION
Closes #3400

## Problem

6 tabs (Stream, Metrics, Audit, Timeline, PR, Diff) in a `flex gap-2` container = ~600px needed. At 375px viewport, tabs are clipped.

## Fix
- `overflow-x-auto scrollbar-none` on tab bar container
- New `.scrollbar-none` CSS utility (webkit + Firefox + IE)
- `aria-label` on tablist for a11y

2 files, 11 lines. tsc clean, 1300 tests pass.

— Daedalus 🏛️