### PR TITLE
fix(dashboard): mobile overflow — responsive min-widths and grid columns

### DIFF
--- a/dashboard/src/components/session/ApprovalBanner.tsx
+++ b/dashboard/src/components/session/ApprovalBanner.tsx
@@ -91,7 +91,7 @@ export function ApprovalBanner({
           whileTap={{ scale: 0.95 }}
           type="button"
           onClick={onApprove}
-          className="min-h-[44px] min-w-[90px] rounded-lg border border-[var(--color-success)]/40 bg-[var(--color-success)]/20 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-success)] transition-colors hover:bg-[var(--color-success)]/30 hover:border-[var(--color-success)]/60 shadow-[0_0_15px_rgba(34,197,94,0.15)] hover:shadow-[0_0_20px_rgba(34,197,94,0.3)]"
+          className="min-h-[44px] rounded-lg border border-[var(--color-success)]/40 bg-[var(--color-success)]/20 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-success)] transition-colors hover:bg-[var(--color-success)]/30 hover:border-[var(--color-success)]/60 shadow-[0_0_15px_rgba(34,197,94,0.15)] hover:shadow-[0_0_20px_rgba(34,197,94,0.3)]"
         >
           APPROVE
         </motion.button>
@@ -100,7 +100,7 @@ export function ApprovalBanner({
           whileTap={{ scale: 0.95 }}
           type="button"
           onClick={onReject}
-          className="min-h-[44px] min-w-[90px] rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 text-xs font-semibold tracking-wide text-red-400 transition-colors hover:bg-red-500/20 hover:border-red-500/50"
+          className="min-h-[44px] rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 text-xs font-semibold tracking-wide text-red-400 transition-colors hover:bg-red-500/20 hover:border-red-500/50"
         >
           REJECT
         </motion.button>

--- a/dashboard/src/components/shared/NLFilterBar.tsx
+++ b/dashboard/src/components/shared/NLFilterBar.tsx
@@ -230,7 +230,7 @@ export function NLFilterBar({ onFilter, placeholder = 'Filter: "active sessions 
         onKeyDown={handleKeyDown}
         onBlur={() => { if (inputValue.trim()) commitInput(); }}
         placeholder={chips.length === 0 ? placeholder : 'Add filter…'}
-        className="min-h-8 min-w-[200px] flex-1 bg-transparent text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none"
+        className="min-h-8 flex-1 sm:min-w-[200px] bg-transparent text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none"
         aria-label={t("aria.naturalLanguageFilter")}
       />
       {(chips.length > 0 || inputValue) && (

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -160,7 +160,7 @@ export default function PipelinesPage() {
           placeholder={t("pipelines.searchPlaceholder")} aria-label={t("aria.searchPipelines")}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="min-h-[44px] flex-1 min-w-[200px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent-cyan)]"
+          className="min-h-[44px] flex-1 sm:min-w-[200px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent-cyan)]"
         />
         <select aria-label={t("aria.filterByStatus")}
           value={statusFilter}

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -967,7 +967,7 @@ export default function SessionDetailPage() {
               onKill={handleKillRequest}
             />
           ) : (
-            <div className="grid grid-cols-3 gap-2 rounded-2xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 rounded-2xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-2">
               <button
                 type="button"
                 onClick={handleInterrupt}


### PR DESCRIPTION
## Summary

Batch fix for 4 mobile responsiveness issues (375px viewport):

- **#3401** — PipelinesPage search input `min-w-[200px]` → `sm:min-w-[200px]`
- **#3402** — SessionDetailPage metrics grid `grid-cols-3` → `grid-cols-1 sm:grid-cols-3`
- **#3403** — ApprovalBanner buttons: removed `min-w-[90px]` (flex-wrap handles mobile stacking)
- **#3404** — NLFilterBar search input `min-w-[200px]` → `sm:min-w-[200px]`

## Changes
4 files, 5 lines changed (pure CSS class adjustments, no logic changes).

## Quality Gate
- ✅ TypeScript: no new errors
- ✅ Build: passes
- ✅ Tests: 133 files, 1300 passed, 2 skipped

Closes #3401, Closes #3402, Closes #3403, Closes #3404

— Daedalus 🏛️