### PR TITLE
fix(auth): resolve auth token discovery mismatch between CLI and server (#3340)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -30,7 +30,7 @@ function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
   stream.write(`${text}\n`);
 }
 
-function resolveAuthToken(): string | undefined {
+async function resolveAuthToken(): Promise<string | undefined> {
   const envToken = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN;
   if (envToken) return envToken;
 
@@ -38,6 +38,17 @@ function resolveAuthToken(): string | undefined {
   try {
     const tokenPath = join(homedir(), '.aegis', 'auth-token');
     return readFileSync(tokenPath, 'utf-8').trim() || undefined;
+  } catch {
+    // File doesn't exist — continue to config search
+  }
+
+  // #3340: Search config files for clientAuthToken/authToken as last resort.
+  // Covers the case where ag init wrote the token to a config but the
+  // auth-token file is missing (e.g., partial state, file deleted).
+  try {
+    const { loadConfig } = await import('../config.js');
+    const config = await loadConfig();
+    return config.clientAuthToken || config.authToken || undefined;
   } catch {
     return undefined;
   }
@@ -262,7 +273,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
     : getConfiguredBaseUrl(config);
 
   // Check if server is running
-  let authToken = resolveAuthToken() || config.authToken || config.clientAuthToken || undefined;
+  let authToken = await resolveAuthToken() || config.authToken || config.clientAuthToken || undefined;
   let serverRunning = await isServerHealthy(baseUrl, authToken);
 
   if (!serverRunning) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -833,8 +833,10 @@ async function main(): Promise<void> {
 
   const container = new ServiceContainer();
   // #1644: Derive hook-secret encryption key from master auth token (non-empty only)
-  if (config.authToken) {
-    sessions.setEncryptionKey(config.authToken);
+  // #3340: Also check clientAuthToken
+  const encryptionKey = config.authToken || config.clientAuthToken;
+  if (encryptionKey) {
+    sessions.setEncryptionKey(encryptionKey);
   }
 
   // Issue #3143: Wire ACP event store into session transcript reader
@@ -861,7 +863,9 @@ async function main(): Promise<void> {
   registerChannels(config);
 
   // Setup auth (Issue #39: multi-key + backward compat)
-  auth = new AuthManager(path.join(config.stateDir, 'keys.json'), config.authToken, config.defaultTenantId);
+  // #3340: Fall back to clientAuthToken when authToken is not set
+  const masterToken = config.authToken || config.clientAuthToken || undefined;
+  auth = new AuthManager(path.join(config.stateDir, 'keys.json'), masterToken, config.defaultTenantId);
   auth.setHost(config.host);  // #1080: needed for auth bypass security check
 
   // #1419: Initialize audit logger and wire into auth


### PR DESCRIPTION
## Summary

Fixes #3340 — auth token discovery regression blocking new users.

## Root Cause

`ag init --yes` writes tokens to `clientAuthToken` in config, but the server only reads `authToken`. The CLI's `resolveAuthToken()` checks env vars and the auth-token file, but doesn't fall back to config file fields. Result: new users hit 401 immediately after init.

## Fix

**CLI** (`src/commands/run.ts`):
- `resolveAuthToken()` now falls back to searching config files for `clientAuthToken`/`authToken` when the auth-token file is missing

**Server** (`src/server.ts`):
- AuthManager uses `clientAuthToken` as master token fallback when `authToken` is empty
- Session encryption key also checks `clientAuthToken`

## Verification
- tsc --noEmit: clean
- Backward compatible: existing setups with `authToken` are unaffected

## Related
- #3356 (auth-token file disappearing) — assigned to Ema, not addressed here
- #3369 (persist auth-token file) — already merged, provides the primary fix path