### PR TITLE
fix(cli): add --accept-permissions flag to ag run and ag create (#3336, #3337)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,6 +120,8 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
     }
   }
 
+  const acceptPerms = args.includes('--accept-permissions') || args.includes('-y');
+
   if (!brief) {
     writeLine(io.stderr, '  ❌ Missing brief. Usage: ag create "Build a login page"');
     return 1;
@@ -156,7 +158,7 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
     const res = await fetch(`${baseUrl}/v1/sessions`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ workDir: cwd, name: sessionName }),
+      body: JSON.stringify({ workDir: cwd, name: sessionName, ...(acceptPerms ? { permissionMode: 'bypassPermissions' } : {}) }),
     });
 
     if (!res.ok) {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -261,6 +261,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
   const portOverride = portIdx !== -1 ? parseIntSafe(args[portIdx + 1], 9100) : null;
 
   const noStream = args.includes('--no-stream');
+  const acceptPerms = args.includes('--accept-permissions') || args.includes('-y');
 
   writeLine(io.stdout, `  🚀 ag run: ${brief.slice(0, 60)}${brief.length > 60 ? '...' : ''}`);
 
@@ -366,6 +367,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
         workDir: cwd,
         prompt: brief,
         name: `run-${brief.slice(0, 20).replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase()}`,
+        ...(acceptPerms ? { permissionMode: 'bypassPermissions' } : {}),
       }),
     });
 


### PR DESCRIPTION
## Summary
Fixes #3336 and #3337 — sessions stall on permission-gated tasks.

## Problem
`ag run` and `ag create` don't pass `permissionMode` to the server. When Claude tries to write files, the session hits the permission gate and stalls indefinitely. `ag run` times out; `ag create` leaves zombie sessions.

## Fix
New flag: `--accept-permissions` / `-y`
- Sets `permissionMode: 'bypassPermissions'` on session creation
- Both `ag run` and `ag create` support it
- Backward compatible: without the flag, behavior is unchanged

## Usage
```bash
ag run "Create a file" --accept-permissions
ag create "Build a login page" -y
```

## Verification
- tsc --noEmit: clean
- Minimal change: flag parse + spread into request body