### PR TITLE
docs: add --accept-permissions flag and clarify active session count

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -980,7 +980,7 @@ curl "http://localhost:9100/v1/sessions/history?page=1&limit=20&status=active" \
 GET /v1/sessions/stats
 ```
 
-Returns aggregated session statistics. Non-admin keys see only their own.
+Returns aggregated session statistics. Non-admin keys see only their own. The `active` count **excludes terminal sessions** (`killed`, `completed`, `crashed`); use `byStatus` for a full breakdown.
 
 ```bash
 curl http://localhost:9100/v1/sessions/stats \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,6 +42,7 @@ If the server is already running, `ag run` skips bootstrap and start — goes st
 | `--no-stream` | Don't stream output; print curl commands instead |
 | `--model <provider/model>` | Override the default model for this session |
 | `--name <name>` | Set a display name for the session |
+| `--accept-permissions` / `-y` | Auto-approve all permission prompts (sets `permissionMode: bypassPermissions`) |
 
 > **Note:** `ag run --help` currently shows the general help. For `ag run` flags, refer to this table.
 


### PR DESCRIPTION
## Summary
Documents 2 accuracy gaps found during PHASE 1 heartbeat scan:

1. **PR #3416** — `--accept-permissions` / `-y` flag for `ag run` and `ag create` was undocumented. Added to CLI flag table in `getting-started.md`.

2. **PR #3396** — `GET /v1/sessions/stats` `active` count now excludes terminal sessions (`killed`, `completed`, `crashed`). Added clarification note in `api-reference.md`.

## Files changed
- `docs/getting-started.md` — added `--accept-permissions` / `-y` row to CLI flag table
- `docs/api-reference.md` — clarified that `active` excludes terminal states