### PR TITLE
fix(api): call metering.start() to enable session lifecycle tracking (#3335)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -978,6 +978,7 @@ async function main(): Promise<void> {
   // Issue #3310: Load persisted metering records from previous runs.
   try {
     await metering.load();
+    metering.start();
   } catch (e) {
     logger.error({ component: 'server', operation: 'metering_load_failed', attributes: { error: e instanceof Error ? e.message : String(e) } });
   }


### PR DESCRIPTION
## Summary
Fixes #3335 — /v1/cost/summary returns zeros while /v1/analytics/costs has real data.

## Root Cause
`MeteringService.start()` was never called. This method subscribes to the session event bus for automatic recording of session lifecycle events. Without it, only JSONL-watcher-driven `recordTokenUsage()` calls worked during the current server run, and session events were never recorded.

## Fix
One-line: call `metering.start()` after `metering.load()` in server startup.

## Verification
- tsc --noEmit: clean
- MeteringService persistence pipeline already solid (5min auto-save, graceful shutdown save, atomic writes)