### PR TITLE
fix(api): add POST /v1/sessions/:id/prompt route (#3331)

### DIFF
--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -83,6 +83,10 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
   // Issue #2461: /input alias for /send
   registerWithLegacy(app, 'post', '/v1/sessions/:id/input', sendHandler);
 
+
+  // Issue #3331: /prompt alias for /send (referenced in getting-started.md)
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/prompt', sendHandler);
+
   // Issue #702: GET children sessions
   registerWithLegacy(app, 'get', '/v1/sessions/:id/children', withOwnership(sessions, async (_req, _reply, session) => {
     const children = (session.children ?? []).map(id => {


### PR DESCRIPTION
## Problem
POST /v1/sessions/:id/prompt returns 404 Not Found. The endpoint is referenced in docs/getting-started.md but was never registered.

## Fix
Add /prompt as an alias for /send in session-actions.ts, using the same handler with full ownership checks, quota enforcement, ACP delivery, and stall tracking.

## Verification
- tsc --noEmit: zero errors
- npm run build: success
- npm test: 4211 passed (10 pre-existing failures on develop)

## Affected
- src/routes/session-actions.ts

Fixes #3331

---
Hephaestus 🔨