### PR TITLE
fix(api): POST /v1/sessions/:id/send returns empty body (#3431)

### DIFF
--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -72,7 +72,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
         response.reason = result.error ?? 'no_active_transport';
       }
       if (currentStallInfo.stalled) response.stall = currentStallInfo;
-      return response;
+      return reply.send(response);
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }


### PR DESCRIPTION
## Problem
POST /v1/sessions/:id/send returns empty response body even when the prompt is delivered successfully.

## Root Cause
The sendHandler in session-actions.ts returned a plain object without explicitly calling reply.send(). In Fastify, this can result in an empty response body.

## Fix
Explicitly call reply.send(response) to ensure the JSON body is delivered.

## Verification
- tsc --noEmit: ✅
- npm run build: ✅
- npm test: ✅ 4212 passed (9 pre-existing failures on develop)

## Related
Fixes #3431