### PR TITLE
docs: add /prompt alias for /send, remove stale note

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1413,9 +1413,9 @@ POST /v1/sessions/:id/send
 
 Sends a text message to the Claude Code session.
 
-**Alias:** `POST /v1/sessions/:id/input` — identical behavior.
+**Aliases:** `POST /v1/sessions/:id/input` and `POST /v1/sessions/:id/prompt` — identical behavior.
 
-> **Note:** There is no `/v1/sessions/:id/prompt` endpoint. Session creation accepts a `prompt` field for the initial message; for follow-up messages, use `/send` or `/input` with the `text` field.
+> **Note:** Session creation accepts a `prompt` field for the initial message; for follow-up messages, use `/send`, `/input`, or `/prompt` with the `text` field.
 
 ```bash
 curl -X POST http://localhost:9100/v1/sessions/abc123/send \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -207,7 +207,7 @@ curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN"
 
 ## 6. Send a Follow-Up
 
-> **Endpoint note:** Follow-up messages use `/send` (or `/input` alias) with a `text` field. There is no `/prompt` endpoint — `prompt` is only a field during session creation.
+> **Endpoint note:** Follow-up messages use `/send`, `/input`, or `/prompt` with a `text` field. The `prompt` field is only for the initial message during session creation.
 
 ```bash
 curl -X POST http://localhost:9100/v1/sessions/a1b2c3d4/send \


### PR DESCRIPTION
## Accuracy Fix

PR #3420 added `POST /v1/sessions/:id/prompt` as an alias for `/send`, but docs in two files still stated 'There is no /prompt endpoint.'

### Changes
- **api-reference.md**: `/prompt` listed as alias alongside `/input`; removed stale note
- **getting-started.md**: Updated endpoint note to include `/prompt`

### Affected PRs
- #3420 (added /prompt route)

---
Scribe 📝