### PR TITLE
fix(server): guard pruneInterval.unref() in dashboard-static plugin

### DIFF
--- a/src/plugins/dashboard-static.ts
+++ b/src/plugins/dashboard-static.ts
@@ -209,7 +209,8 @@ export async function registerDashboardStatic(
 
   // #3227: Periodic prune to evict stale IP buckets (mirrors server.ts pattern)
   const pruneInterval = setInterval(() => limiter.prune(), 60_000);
-  pruneInterval.unref();
+  // Guard: some CI/test environments return interval objects without .unref()
+  if (typeof pruneInterval.unref === 'function') pruneInterval.unref();
 
   app.addHook('onRequest', async (req, reply) => {
     const url = req.url ?? '/';


### PR DESCRIPTION
## Summary
CI runners intermittently crash with `pruneInterval.unref is not a function` in dashboard-static.ts, causing STARTUP_FAILED which blocks server integration tests.

## Fix
Add `typeof` guard before calling `.unref()`.

## Impact
Unblocks CI on #3441 (kill empty body) and any other PRs hitting server-core-coverage / server-phase3 test failures.

## Note
Tests pass locally — this is CI-environment specific (different Node.js timer internals on ubuntu-latest runners).