### PR TITLE
fix(api): record session completion from hooks, make metrics idempotent (#3427)

### DIFF
--- a/src/__tests__/session-stats-3427.test.ts
+++ b/src/__tests__/session-stats-3427.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Issue #3427: Session stats show 0% completion rate
+ *
+ * Root cause: metrics.sessionCompleted() was only called from monitor's
+ * checkStopSignals, never from the hook event handler. If the monitor
+ * didn't detect the stop signal (e.g., ACP mode), completed stayed 0.
+ *
+ * Fix: metrics.sessionCompleted/sessionFailed are now called from hooks
+ * AND are idempotent (won't double-count if both paths fire).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MetricsCollector } from '../metrics.js';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('Issue #3427: session stats completion tracking', () => {
+  let metrics: MetricsCollector;
+
+  beforeEach(() => {
+    metrics = new MetricsCollector(join(tmpdir(), `test-metrics-${Date.now()}.json`));
+  });
+
+  it('should count sessionCompleted when called', () => {
+    metrics.sessionCreated('s1');
+    metrics.sessionCompleted('s1');
+
+    const result = metrics.getGlobalMetrics(1);
+    expect(result.sessions.completed).toBe(1);
+    expect(result.sessions.failed).toBe(0);
+  });
+
+  it('should count sessionFailed when called', () => {
+    metrics.sessionCreated('s2');
+    metrics.sessionFailed('s2');
+
+    const result = metrics.getGlobalMetrics(1);
+    expect(result.sessions.completed).toBe(0);
+    expect(result.sessions.failed).toBe(1);
+  });
+
+  it('should be idempotent — sessionCompleted called twice counts once', () => {
+    metrics.sessionCreated('s3');
+    metrics.sessionCompleted('s3');
+    metrics.sessionCompleted('s3'); // duplicate (e.g., hooks + monitor both fire)
+
+    const result = metrics.getGlobalMetrics(1);
+    expect(result.sessions.completed).toBe(1);
+  });
+
+  it('should be idempotent — sessionFailed called twice counts once', () => {
+    metrics.sessionCreated('s4');
+    metrics.sessionFailed('s4');
+    metrics.sessionFailed('s4'); // duplicate
+
+    const result = metrics.getGlobalMetrics(1);
+    expect(result.sessions.failed).toBe(1);
+  });
+
+  it('should not count both completed and failed for same session', () => {
+    metrics.sessionCreated('s5');
+    metrics.sessionCompleted('s5');
+    metrics.sessionFailed('s5'); // conflicting — first one wins
+
+    const result = metrics.getGlobalMetrics(1);
+    expect(result.sessions.completed).toBe(1);
+    expect(result.sessions.failed).toBe(0);
+  });
+
+  it('should count multiple different sessions correctly', () => {
+    metrics.sessionCreated('s6');
+    metrics.sessionCreated('s7');
+    metrics.sessionCreated('s8');
+    metrics.sessionCompleted('s6');
+    metrics.sessionCompleted('s7');
+    metrics.sessionFailed('s8');
+
+    const result = metrics.getGlobalMetrics(0);
+    expect(result.sessions.completed).toBe(2);
+    expect(result.sessions.failed).toBe(1);
+  });
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -378,7 +378,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
             deps.eventBus.emitStatus(sessionId, 'idle', 'Claude finished (hook: Stop)');
           }
           // Issue #3427: Record session completion in metrics from hook path
-          deps.metrics?.sessionCompleted(sessionId);
+          if (typeof deps.metrics?.sessionCompleted === "function") deps.metrics.sessionCompleted(sessionId);
           break;
         }
         case 'PreToolUse': {
@@ -445,9 +445,9 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
 
     // Issue #3427: Record metrics for completion/failure hook events not handled above
     if (eventName === 'TaskCompleted' || eventName === 'SessionEnd') {
-      deps.metrics?.sessionCompleted(sessionId);
+      if (typeof deps.metrics?.sessionCompleted === "function") deps.metrics.sessionCompleted(sessionId);
     } else if (eventName === 'StopFailure') {
-      deps.metrics?.sessionFailed(sessionId);
+      if (typeof deps.metrics?.sessionFailed === "function") deps.metrics.sessionFailed(sessionId);
     }
 
     // Decision events need a response body that CC uses

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -377,6 +377,8 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
           } else {
             deps.eventBus.emitStatus(sessionId, 'idle', 'Claude finished (hook: Stop)');
           }
+          // Issue #3427: Record session completion in metrics from hook path
+          deps.metrics?.sessionCompleted(sessionId);
           break;
         }
         case 'PreToolUse': {
@@ -439,6 +441,13 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
             hookBody.permission_prompt || 'Permission requested (hook)');
           break;
       }
+    }
+
+    // Issue #3427: Record metrics for completion/failure hook events not handled above
+    if (eventName === 'TaskCompleted' || eventName === 'SessionEnd') {
+      deps.metrics?.sessionCompleted(sessionId);
+    } else if (eventName === 'StopFailure') {
+      deps.metrics?.sessionFailed(sessionId);
     }
 
     // Decision events need a response body that CC uses

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -112,6 +112,8 @@ export class MetricsCollector {
   private perSession = new Map<string, SessionMetrics>();
   private latency = new Map<string, SessionLatency>();
   private sessionStartTimes = new Map<string, number>();
+  /** Issue #3427: Track settled sessions to avoid double-counting. */
+  private readonly settledSessions = new Set<string>();
   private startTime = Date.now();
 
   /** Maximum samples per latency type per session (rolling window). */
@@ -176,12 +178,18 @@ export class MetricsCollector {
   }
 
   sessionCompleted(sessionId: string): void {
+    // Issue #3427: Idempotent — only count once per session
+    if (this.settledSessions.has(sessionId)) return;
+    this.settledSessions.add(sessionId);
     this.global.sessionsCompleted++;
     sessionsCompletedTotal.inc();
     this.finalizeSessionDuration(sessionId);
   }
 
   sessionFailed(sessionId: string): void {
+    // Issue #3427: Idempotent — only count once per session
+    if (this.settledSessions.has(sessionId)) return;
+    this.settledSessions.add(sessionId);
     this.global.sessionsFailed++;
     sessionsFailedTotal.inc();
     this.finalizeSessionDuration(sessionId);


### PR DESCRIPTION
## Issue
Fixes #3427

## Root Cause
`metrics.sessionCompleted()` and `metrics.sessionFailed()` were only called from the monitor's `checkStopSignals()` method. The hook event handler (`src/hooks.ts`) never recorded completion metrics, so sessions that completed via hooks (Stop, TaskCompleted, SessionEnd events) — especially in ACP mode — never incremented the completed counter.

## Fix
1. **hooks.ts**: Call `metrics.sessionCompleted()` on Stop/TaskCompleted/SessionEnd events and `metrics.sessionFailed()` on StopFailure events
2. **metrics.ts**: Make `sessionCompleted()` and `sessionFailed()` idempotent via a `settledSessions` Set — prevents double-counting when both the monitor and hooks detect the same completion

## Verification
- `tsc --noEmit`: ✅
- `npm run build`: ✅
- `npm test` (new test file): ✅ 6/6 passed
- Commit: 48aaf158

## New Tests
`src/__tests__/session-stats-3427.test.ts` — 6 tests covering:
- Basic completion/failure counting
- Idempotency (double-call counts once)
- Conflict resolution (completed wins over failed if called first)
- Multiple sessions counted correctly