### PR TITLE
docs: add terminal/content endpoint + fix kill response format

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -36,7 +36,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `POST` | `/v1/sessions/{id}/escape` | Bearer | Send Escape key |
 | `POST` | `/v1/sessions/{id}/interrupt` | Bearer | Send Ctrl+C (interrupt) |
 | `DELETE` | `/v1/sessions/{id}` | Bearer | Kill session |
-| `GET` | `/v1/sessions/{id}/pane` | Bearer | Capture raw terminal pane (tmux only — returns 501 in ACP mode) |
+| `GET` | `/v1/sessions/{id}/terminal/content` | Bearer | Get terminal content snapshot (ACP terminal bridge; graceful empty when unavailable) |
 | `GET` | `/v1/sessions/{id}/children` | Bearer | Get child sessions |
 | `POST` | `/v1/sessions/{id}/spawn` | Bearer | Spawn a child session |
 | `POST` | `/v1/sessions/{id}/fork` | Bearer | Fork the session |
@@ -72,6 +72,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 
 | Method | Path | Auth | Summary |
 |--------|------|------|--------|
+| `GET` | `/v1/sessions/{id}/terminal/content` | Bearer | Get terminal content snapshot (ACP terminal bridge) |
 | `POST` | `/v1/sessions/{id}/terminal/open` | Bearer | Open terminal session |
 | `POST` | `/v1/sessions/{id}/terminal/input` | Bearer | Send terminal input |
 | `POST` | `/v1/sessions/{id}/terminal/resize` | Bearer | Resize terminal |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1499,7 +1499,7 @@ curl -X DELETE http://localhost:9100/v1/sessions/abc123 \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-**Response:** `{ "ok": true }`
+**Response:** `{ "ok": true, "status": "killed" }`
 
 | Status | Error |
 |--------|-------|
@@ -2354,6 +2354,52 @@ When ACP backend is not configured: `{ "driver": null, "observers": [], "activeC
 
 ACP terminal debug endpoints for programmatic terminal access (open, input, resize, reconnect, close).
 These complement the WebSocket terminal streaming documented in the WebSocket section below.
+
+#### Get Terminal Content
+
+```
+GET /v1/sessions/:id/terminal/content
+```
+
+Returns a snapshot of terminal content for a session. When a `terminalId` query param is provided and the ACP terminal bridge is active, returns the current terminal output. Otherwise returns a graceful empty response.
+
+```bash
+curl http://localhost:9100/v1/sessions/abc123/terminal/content?terminalId=term-1 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `terminalId` | string | no | Terminal session ID. If omitted, returns empty content. |
+
+**Response:**
+
+```json
+{
+  "content": "...terminal output...",
+  "terminalId": "term-1",
+  "columns": 120,
+  "rows": 40,
+  "source": "terminal_bridge"
+}
+```
+
+When no terminal bridge or no `terminalId`:
+
+```json
+{
+  "content": "",
+  "source": "unavailable"
+}
+```
+
+**Errors:**
+
+| Status | Condition |
+|--------|------------|
+| 404 | Session not found |
 
 #### Open Terminal
 


### PR DESCRIPTION
## Accuracy fixes from PR scan

Found 2 gaps in recent merged PRs:

### 1. GET /v1/sessions/:id/terminal/content (PR #3448)
New endpoint completely undocumented in api-reference.md. Added:
- Full endpoint docs with query params, response schema, error table
- Entry in api-quick-ref.md
- Replaced stale `/pane` reference with `/terminal/content`

### 2. Kill response format (PR #3441)
Response now returns `{ "ok": true, "status": "killed" }` but docs showed `{ "ok": true }`. Fixed.

### Other PRs checked (no gaps)
- #3456, #3455, #3454, #3451 — dashboard refactor/docs
- #3447 — ACP inFlightPrompts fix (internal)
- #3446 — OpenAPI path fix (internal)
- #3445 — --port propagation (already documented)
- #3444, #3439 — internal fixes