### PR TITLE
fix(cli): add timeouts to ag create session/send requests (#3424)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -156,6 +156,7 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
   let sessionId: string;
   try {
     const res = await fetch(`${baseUrl}/v1/sessions`, {
+      signal: AbortSignal.timeout(30_000),
       method: 'POST',
       headers,
       body: JSON.stringify({ workDir: cwd, name: sessionName, ...(acceptPerms ? { permissionMode: 'bypassPermissions' } : {}) }),
@@ -172,18 +173,24 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
     writeLine(io.stdout, `  ✅ Session created: ${session.displayName}`);
     writeLine(io.stdout, `     ID: ${sessionId}`);
   } catch (e: unknown) {
-    const cause = (e as { cause?: { code?: string } }).cause;
-    if (cause?.code === 'ECONNREFUSED') {
-      writeLine(io.stderr, `  ❌ Cannot connect to Aegis at ${baseUrl}.`);
-      writeLine(io.stderr, '     Start the server first: ag');
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      writeLine(io.stderr, '  ❌ Session creation timed out after 30s.');
+      writeLine(io.stderr, '     The server may be slow to respond. Try again or check server health.');
     } else {
-      writeLine(io.stderr, `  ❌ ${getErrorMessage(e)}`);
+      const cause = (e as { cause?: { code?: string } }).cause;
+      if (cause?.code === 'ECONNREFUSED') {
+        writeLine(io.stderr, `  ❌ Cannot connect to Aegis at ${baseUrl}.`);
+        writeLine(io.stderr, '     Start the server first: ag');
+      } else {
+        writeLine(io.stderr, `  ❌ ${getErrorMessage(e)}`);
+      }
     }
     return 1;
   }
 
   try {
     const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/send`, {
+      signal: AbortSignal.timeout(60_000),
       method: 'POST',
       headers,
       body: JSON.stringify({ text: brief }),


### PR DESCRIPTION
## Problem
`ag create` hangs silently when the server is slow or unresponsive. No timeout on fetch calls means the CLI waits forever with zero output.

## Root Cause
Two fetch calls in `handleCreate` (src/cli.ts) had no timeout:
- `POST /v1/sessions` — session creation (no timeout at all)
- `POST /v1/sessions/:id/send` — brief delivery (no timeout at all)

The preflight auth check had a 5s timeout, but the actual work didn't.

## Fix
- Added `AbortSignal.timeout(30_000)` to session creation
- Added `AbortSignal.timeout(60_000)` to brief delivery
- Added proper AbortError handling with actionable error message

## Verification
- `tsc --noEmit` — ✅ zero errors
- `npm run build` — ✅ success
- CLI tests (40 tests) — ✅ all pass

Closes #3424