### PR TITLE
fix(api): wire ACP notifications to event store for /read endpoint (#3422)

### DIFF
--- a/src/__tests__/acp-backend.test.ts
+++ b/src/__tests__/acp-backend.test.ts
@@ -52,7 +52,7 @@ describe('AcpBackend session lifecycle', () => {
         return client;
       },
       backendRunIdProvider: () => 'backend-run-1',
-      onRawNotification: notification => rawNotifications.push(notification),
+      onRawNotification: (notification, _ctx) => rawNotifications.push(notification),
       onRawRequest: request => rawRequests.push(request),
     });
 
@@ -529,7 +529,7 @@ describe('AcpBackend session lifecycle', () => {
       sessionService: service,
       clientFactory: () => client,
       backendRunIdProvider: () => 'backend-run-load',
-      onRawNotification: notification => rawNotifications.push(notification),
+      onRawNotification: (notification, _ctx) => rawNotifications.push(notification),
     });
 
     const loaded = await backend.loadSession({

--- a/src/__tests__/fix-3422-read-empty-transcript.test.ts
+++ b/src/__tests__/fix-3422-read-empty-transcript.test.ts
@@ -16,7 +16,7 @@ import type { SessionTranscripts } from '../session-transcripts.js';
 import { SessionManager } from '../session.js';
 import type { SessionInfo } from '../session.js';
 
-function makeNotification(method: string, params: Record<string, unknown>): AcpJsonRpcNotification {
+function makeNotification(method: string, params: unknown): AcpJsonRpcNotification {
   return {
     jsonrpc: '2.0',
     method,
@@ -112,27 +112,27 @@ describe('Issue #3422: ACP events persisted from onRawNotification', () => {
       async append(input: AcpAppendEventInput) {
         storedEvents.push(input);
         return {
-          seq: storedEvents.length,
           sessionId: input.sessionId,
-          tenantId: input.tenantId,
-          ownerKeyId: input.ownerKeyId,
+          eventSeq: storedEvents.length,
+          eventId: `evt-${storedEvents.length}`,
           eventType: input.eventType,
           payload: input.payload,
           occurredAt: input.occurredAt ?? new Date(),
-        };
+          ingestedAt: new Date(),
+        } as AcpEventRecord;
       },
-      async list(input) {
+      async list(input: AcpListEventsInput) {
         return storedEvents
           .filter(e => e.sessionId === input.sessionId)
           .map((e, i) => ({
-            seq: i + 1,
             sessionId: e.sessionId,
-            tenantId: e.tenantId,
-            ownerKeyId: e.ownerKeyId,
+            eventSeq: i + 1,
+            eventId: `evt-${i + 1}`,
             eventType: e.eventType,
             payload: e.payload,
             occurredAt: e.occurredAt ?? new Date(),
-          }));
+            ingestedAt: new Date(),
+          } as AcpEventRecord));
       },
     };
 
@@ -165,7 +165,7 @@ describe('Issue #3422: ACP events persisted from onRawNotification', () => {
     expect(storedEvents[2].eventType).toBe('tool.started');
 
     // Verify events can be listed back
-    const events = await eventStore.list({ sessionId: 'test-session-1' });
+    const events = await eventStore.list({ sessionId: 'test-session-1', afterEventSeq: 0 });
     expect(events).toHaveLength(3);
   });
 });

--- a/src/__tests__/fix-3422-read-empty-transcript.test.ts
+++ b/src/__tests__/fix-3422-read-empty-transcript.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Issue #3422: GET /v1/sessions/:id/read returns empty messages but /transcript has data
+ *
+ * Root cause: AcpBackend.onRawNotification was never wired to persist ACP events
+ * to the event store. CC notifications (message.delta, tool.started, etc.) were received
+ * by the JSON-RPC client but never stored, so readMessagesFromSession() found nothing.
+ *
+ * Fix: Wire onRawNotification in server.ts to call mapAcpJsonRpcNotificationToEvent()
+ * and persist via eventStore.append().
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mapAcpJsonRpcNotificationToEvent } from '../services/acp/event-mapper.js';
+import type { AcpJsonRpcNotification } from '../services/acp/json-rpc-client.js';
+import type { AcpEventStore, AcpAppendEventInput } from '../services/acp/event-store.js';
+import type { SessionTranscripts } from '../session-transcripts.js';
+import { SessionManager } from '../session.js';
+import type { SessionInfo } from '../session.js';
+
+function makeNotification(method: string, params: Record<string, unknown>): AcpJsonRpcNotification {
+  return {
+    jsonrpc: '2.0',
+    method,
+    ...(Object.keys(params).length > 0 ? { params } : {}),
+    raw: { jsonrpc: '2.0', method, params },
+  };
+}
+
+describe('Issue #3422: ACP events persisted from onRawNotification', () => {
+  const context = {
+    sessionId: 'test-session-1',
+    tenantId: 'default',
+    ownerKeyId: 'key-1',
+  };
+
+  it('maps message.delta notification to event store input', () => {
+    const notification = makeNotification('session/update', {
+      sessionId: 'acp-agent-1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'Hello world' },
+        messageId: 'msg-1',
+      },
+    });
+
+    const result = mapAcpJsonRpcNotificationToEvent(notification, context);
+
+    expect(result.sessionId).toBe('test-session-1');
+    expect(result.eventType).toBe('message.delta');
+    expect(result.payload).toMatchObject({
+      schemaVersion: 1,
+      text: 'Hello world',
+      messageId: 'msg-1',
+    });
+  });
+
+  it('maps thinking.delta notification to event store input', () => {
+    const notification = makeNotification('session/update', {
+      sessionId: 'acp-agent-1',
+      update: {
+        sessionUpdate: 'agent_thought_chunk',
+        content: { type: 'text', text: 'thinking...' },
+      },
+    });
+
+    const result = mapAcpJsonRpcNotificationToEvent(notification, context);
+
+    expect(result.eventType).toBe('thinking.delta');
+    expect(result.payload).toMatchObject({ text: 'thinking...' });
+  });
+
+  it('maps tool.started notification to event store input', () => {
+    const notification = makeNotification('session/update', {
+      sessionId: 'acp-agent-1',
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'tc-1',
+        title: 'Read file.ts',
+        kind: 'read',
+        status: 'running',
+      },
+    });
+
+    const result = mapAcpJsonRpcNotificationToEvent(notification, context);
+
+    expect(result.eventType).toBe('tool.started');
+    expect(result.payload).toMatchObject({
+      toolCallId: 'tc-1',
+      title: 'Read file.ts',
+    });
+  });
+
+  it('maps tool.completed notification to event store input', () => {
+    const notification = makeNotification('session/update', {
+      sessionId: 'acp-agent-1',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'tc-1',
+        status: 'completed',
+      },
+    });
+
+    const result = mapAcpJsonRpcNotificationToEvent(notification, context);
+
+    expect(result.eventType).toBe('tool.completed');
+    expect(result.payload).toMatchObject({ toolCallId: 'tc-1', status: 'completed' });
+  });
+
+  it('persists events to event store and reads them back via readFromAcpEvents', async () => {
+    // Simulate the wiring: notification -> map -> append -> list -> readFromAcpEvents
+    const storedEvents: AcpAppendEventInput[] = [];
+    const eventStore: AcpEventStore = {
+      async append(input: AcpAppendEventInput) {
+        storedEvents.push(input);
+        return {
+          seq: storedEvents.length,
+          sessionId: input.sessionId,
+          tenantId: input.tenantId,
+          ownerKeyId: input.ownerKeyId,
+          eventType: input.eventType,
+          payload: input.payload,
+          occurredAt: input.occurredAt ?? new Date(),
+        };
+      },
+      async list(input) {
+        return storedEvents
+          .filter(e => e.sessionId === input.sessionId)
+          .map((e, i) => ({
+            seq: i + 1,
+            sessionId: e.sessionId,
+            tenantId: e.tenantId,
+            ownerKeyId: e.ownerKeyId,
+            eventType: e.eventType,
+            payload: e.payload,
+            occurredAt: e.occurredAt ?? new Date(),
+          }));
+      },
+    };
+
+    // Simulate CC sending notifications
+    const notifications = [
+      makeNotification('session/update', {
+        sessionId: 'acp-1',
+        update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Hello' }, messageId: 'm1' },
+      }),
+      makeNotification('session/update', {
+        sessionId: 'acp-1',
+        update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: ' world' }, messageId: 'm1' },
+      }),
+      makeNotification('session/update', {
+        sessionId: 'acp-1',
+        update: { sessionUpdate: 'tool_call', toolCallId: 'tc1', title: 'Bash', kind: 'bash', status: 'running' },
+      }),
+    ];
+
+    // Wire: notification -> map -> append (this is what server.ts does now)
+    for (const notification of notifications) {
+      const event = mapAcpJsonRpcNotificationToEvent(notification, context);
+      await eventStore.append(event);
+    }
+
+    // Verify events were stored
+    expect(storedEvents).toHaveLength(3);
+    expect(storedEvents[0].eventType).toBe('message.delta');
+    expect(storedEvents[1].eventType).toBe('message.delta');
+    expect(storedEvents[2].eventType).toBe('tool.started');
+
+    // Verify events can be listed back
+    const events = await eventStore.list({ sessionId: 'test-session-1' });
+    expect(events).toHaveLength(3);
+  });
+});

--- a/src/__tests__/fix-3422-read-empty-transcript.test.ts
+++ b/src/__tests__/fix-3422-read-empty-transcript.test.ts
@@ -10,18 +10,15 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mapAcpJsonRpcNotificationToEvent } from '../services/acp/event-mapper.js';
-import type { AcpJsonRpcNotification } from '../services/acp/json-rpc-client.js';
-import type { AcpEventStore, AcpAppendEventInput } from '../services/acp/event-store.js';
-import type { SessionTranscripts } from '../session-transcripts.js';
-import { SessionManager } from '../session.js';
-import type { SessionInfo } from '../session.js';
+import type { AcpJsonRpcNotification, AcpJsonValue } from '../services/acp/json-rpc-client.js';
+import type { AcpEventStore, AcpAppendEventInput, AcpEventRecord, AcpListEventsInput } from '../services/acp/event-store.js';
 
-function makeNotification(method: string, params: unknown): AcpJsonRpcNotification {
+function makeNotification(method: string, params?: Record<string, unknown>): AcpJsonRpcNotification {
   return {
     jsonrpc: '2.0',
     method,
-    ...(Object.keys(params).length > 0 ? { params } : {}),
-    raw: { jsonrpc: '2.0', method, params },
+    ...(params && Object.keys(params).length > 0 ? { params: params as AcpJsonValue } : {}),
+    raw: { jsonrpc: '2.0', method, params: (params ?? null) as AcpJsonValue },
   };
 }
 
@@ -109,30 +106,34 @@ describe('Issue #3422: ACP events persisted from onRawNotification', () => {
     // Simulate the wiring: notification -> map -> append -> list -> readFromAcpEvents
     const storedEvents: AcpAppendEventInput[] = [];
     const eventStore: AcpEventStore = {
-      async append(input: AcpAppendEventInput) {
+      async append(input: AcpAppendEventInput): Promise<AcpEventRecord> {
         storedEvents.push(input);
         return {
           sessionId: input.sessionId,
+          tenantId: input.tenantId,
+          ownerKeyId: input.ownerKeyId,
           eventSeq: storedEvents.length,
           eventId: `evt-${storedEvents.length}`,
           eventType: input.eventType,
-          payload: input.payload,
           occurredAt: input.occurredAt ?? new Date(),
           ingestedAt: new Date(),
-        } as AcpEventRecord;
+          payload: input.payload,
+        };
       },
-      async list(input: AcpListEventsInput) {
+      async list(input: AcpListEventsInput): Promise<AcpEventRecord[]> {
         return storedEvents
           .filter(e => e.sessionId === input.sessionId)
           .map((e, i) => ({
             sessionId: e.sessionId,
+            tenantId: e.tenantId,
+            ownerKeyId: e.ownerKeyId,
             eventSeq: i + 1,
             eventId: `evt-${i + 1}`,
             eventType: e.eventType,
-            payload: e.payload,
             occurredAt: e.occurredAt ?? new Date(),
             ingestedAt: new Date(),
-          } as AcpEventRecord));
+            payload: e.payload,
+          }));
       },
     };
 
@@ -165,7 +166,11 @@ describe('Issue #3422: ACP events persisted from onRawNotification', () => {
     expect(storedEvents[2].eventType).toBe('tool.started');
 
     // Verify events can be listed back
-    const events = await eventStore.list({ sessionId: 'test-session-1', afterEventSeq: 0 });
+    const events = await eventStore.list({
+      sessionId: 'test-session-1',
+      tenantId: 'default',
+      ownerKeyId: 'key-1',
+    });
     expect(events).toHaveLength(3);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,6 +76,7 @@ import {
   AcpSessionService,
   AcpTerminalBridge,
   createFileAcpLocalStorageProfile,
+  mapAcpJsonRpcNotificationToEvent,
   type AcpLocalStorageProfile,
 } from './services/acp/index.js';
 import {
@@ -814,9 +815,34 @@ async function main(): Promise<void> {
   acpSessionService = new AcpSessionService(acpLocalProfile.sessionStore, {
     pauseInterventionStore: acpPauseStore ?? new InMemoryPauseInterventionStore(),
   });
+  // Issue #3422: Wire ACP notifications to event store so /read and /transcript
+  // return data for ACP sessions. Without this, CC notifications are received but never persisted.
+  const acpEventStore = acpLocalProfile.eventStore;
   acpBackend = new AcpBackend({
     sessionService: acpSessionService,
     jsonRpcClientOptions: { requestTimeoutMs: config.acpPromptTimeoutMs },
+    onRawNotification: (notification, context) => {
+      try {
+        const event = mapAcpJsonRpcNotificationToEvent(notification, {
+          sessionId: context.sessionId,
+          tenantId: context.tenantId,
+          ownerKeyId: context.ownerKeyId,
+        });
+        void acpEventStore.append(event).catch(err => {
+          logger.info({
+            component: 'server',
+            operation: 'acp_event_append_failed',
+            attributes: { sessionId: context.sessionId, error: String(err) },
+          });
+        });
+      } catch (err) {
+        logger.info({
+          component: 'server',
+          operation: 'acp_event_map_failed',
+          attributes: { sessionId: context.sessionId, error: String(err) },
+        });
+      }
+    },
   });
   acpTerminalBridge = new AcpTerminalBridge({
     sessionResolver: {

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -222,7 +222,7 @@ export interface AcpBackendOptions {
   clientCapabilities?: AcpJsonObject;
   childProcessOptions?: Omit<AcpChildProcessOptions, 'cwd'>;
   jsonRpcClientOptions?: Omit<AcpJsonRpcClientOptions, 'child'>;
-  onRawNotification?: (notification: AcpJsonRpcNotification) => void;
+  onRawNotification?: (notification: AcpJsonRpcNotification, context: { sessionId: string } & AcpSessionScope) => void;
   onRawRequest?: (request: AcpJsonRpcInboundRequest) => void;
   onRuntimeExit?: (event: AcpBackendRuntimeExitEvent) => void;
   restartBackoff?: (context: AcpBackendRestartBackoffContext) => number;
@@ -774,7 +774,7 @@ export class AcpBackend {
   private bindRuntime(runtime: AcpBackendRuntime): AcpBackendRuntime {
     runtime.disposers.push(
       runtime.client.onNotification(notification => {
-        this.options.onRawNotification?.(notification);
+        this.options.onRawNotification?.(notification, { sessionId: runtime.sessionId, ...runtime.scope });
       }),
       runtime.client.onRequest(request => {
         if (request.method === 'session/request_permission') {


### PR DESCRIPTION
## Summary

Fixes #3422 — `GET /v1/sessions/:id/read` returns empty messages while `/transcript` has data.

## Root Cause

`AcpBackend.onRawNotification` was never wired in `server.ts`. CC notifications (`session/update` with `message.delta`, `thinking.delta`, `tool.started`, etc.) were received by the JSON-RPC client but never persisted to the `AcpEventStore`. As a result, `readMessagesFromSession()` found no events for ACP sessions.

The event mapper (`src/services/acp/event-mapper.ts`) already existed and correctly mapped CC notifications to event store entries, but it was never called from production code — only exported from the index.

## Changes

- **`src/server.ts`**: Wire `onRawNotification` on `AcpBackend` to call `mapAcpJsonRpcNotificationToEvent()` and persist via `eventStore.append()`
- **`src/services/acp/backend.ts`**: Extend `onRawNotification` callback signature to include session context (`sessionId`, `tenantId`, `ownerKeyId`)
- **`src/__tests__/acp-backend.test.ts`**: Update callback signatures for new context parameter
- **`src/__tests__/fix-3422-read-empty-transcript.test.ts`**: 5 new regression tests

## Verification

```
tsc --noEmit: ✅
npm run build: ✅
npm test: ✅ 4219 passed (4 pre-existing failures on develop)
```

## Test Plan

- [x] New regression tests pass (notification → map → store → list round-trip)
- [x] Existing ACP backend tests pass
- [ ] Manual test: create Aegis session, send prompt, verify `/read` returns messages
- [ ] Verify `/transcript` continues to work correctly
