### PR TITLE
docs: remove stale /approve and /reject endpoint paths

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1507,43 +1507,7 @@ curl -X DELETE http://localhost:9100/v1/sessions/abc123 \
 
 ---
 
-### Approve Permission Request
 
-```
-POST /v1/sessions/:id/approve
-```
-
-Approves a pending permission request from Claude Code.
-
-```bash
-curl -X POST http://localhost:9100/v1/sessions/abc123/approve \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"permissionId": "perm-1"}'
-```
-
-**Response:** `{ "ok": true }`
-
----
-
-### Reject Permission Request
-
-```
-POST /v1/sessions/:id/reject
-```
-
-Rejects a pending permission request from Claude Code.
-
-```bash
-curl -X POST http://localhost:9100/v1/sessions/abc123/reject \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"permissionId": "perm-1"}'
-```
-
-**Response:** `{ "ok": true }`
-
----
 
 ### Answer Pending Question
 


### PR DESCRIPTION
## Summary

Removes duplicate, stale endpoint paths from `api-reference.md`:

- `POST /v1/sessions/:id/approve` (removed)
- `POST /v1/sessions/:id/reject` (removed)

The correct paths (`POST /v1/sessions/:id/approval/approve` and `/approval/reject`) were already documented further down in the same file (unchanged). The stale entries used paths that do not match actual route registrations — the OpenAPI spec was corrected in PR #3446 but the docs still had the wrong paths.

## Related
- #3446 — fixed OpenAPI spec paths for approve/reject
- #3428 — original issue

## Checklist
- [x] No code changes — docs only
- [x] Correct `/approval/approve` and `/approval/reject` entries preserved