### PR TITLE
docs: add 500 error for approve/reject when no permission pending

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1951,6 +1951,7 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/approval/approve \
 
 | Status | Condition |
 |--------|------------|
+| 500 | No pending permission request for the given approval ID |
 | 501 | ACP backend not configured |
 
 #### Reject Permission
@@ -1981,6 +1982,7 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/approval/reject \
 
 | Status | Condition |
 |--------|------------|
+| 500 | No pending permission request for the given approval ID |
 | 501 | ACP backend not configured |
 
 #### Get Pending Approvals


### PR DESCRIPTION
PR #3469 (fix #3428) changed `approve()` and `reject()` to throw when no permission request is pending. The route handler catches this and returns 500.\n\nThis PR adds the 500 error row to both approve and reject endpoint tables in `api-reference.md`.