### PR TITLE
fix(deploy): add ExecStartPre build step to aegis.service (#3480)

### DIFF
--- a/deploy/systemd/aegis.service
+++ b/deploy/systemd/aegis.service
@@ -33,6 +33,9 @@ User=aegis
 Group=aegis
 WorkingDirectory=/opt/aegis
 
+# Build fresh dist/ before starting (prevents stale code after merges)
+ExecStartPre=/bin/bash -c 'cd /opt/aegis && npm run build 2>&1 | while read line; do echo "build: $line"; done'
+
 # Server
 ExecStart=/usr/bin/node dist/server.js
 # Wait for health endpoint to respond (max 15s) before marking service as active
@@ -54,7 +57,7 @@ ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes
 NoNewPrivileges=yes
-ReadWritePaths=/opt/aegis/state /opt/aegis/logs
+ReadWritePaths=/opt/aegis/state /opt/aegis/logs /opt/aegis/dist
 
 # Logging
 StandardOutput=journal


### PR DESCRIPTION
## Problem
The Aegis systemd service does not run `npm run build` before starting. After merging PRs to `develop`, a `systemctl restart aegis` runs stale compiled `dist/` code.

## Fix
- Added `ExecStartPre` to run `npm run build` before the server starts
- Added `/opt/aegis/dist` to `ReadWritePaths` (required under `ProtectSystem=strict`)

## Verification
- `tsc --noEmit`: ✅ (no TS changes)
- `npm run build`: ✅
- Commit: 37dc0374

Closes #3480