### PR TITLE
fix(acp): sendPrompt uses request() with 5s ack timeout instead of notify() (#3479)

### DIFF
--- a/src/__tests__/acp-backend.test.ts
+++ b/src/__tests__/acp-backend.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  AcpJsonRpcTimeoutError,
   AcpBackend,
   AcpSessionNotFoundError,
   hasLoadSessionCapability,
@@ -619,6 +620,70 @@ describe('AcpBackend session lifecycle', () => {
     const result = await backend.sendPrompt('session-1', 'test', scope);
     expect(result.error).toBe('no_acp_runtime');
   });
+
+  it('sendPrompt uses request() with short ack timeout (#3479)', async () => {
+    const service = new FakeSessionService();
+    const client = new FakeBackendClient();
+    client.setResult('initialize', {});
+    client.setResult('session/new', { sessionId: 'acp-agent-session-1' });
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    await backend.createSession({ ...scope, cwd });
+    const result = await backend.sendPrompt('session-1', 'hello', scope);
+
+    // Should have used request() not notify()
+    expect(result.delivered).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(client.requests.some(r => r.method === 'session/prompt')).toBe(true);
+    const promptReq = client.requests.find(r => r.method === 'session/prompt');
+    expect(promptReq?.params).toEqual({
+      sessionId: 'acp-agent-session-1',
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+  });
+
+  it('sendPrompt treats ack timeout as delivered (#3479)', async () => {
+    const service = new FakeSessionService();
+    const client = new FakeTimeoutClient();
+    client.setResult('initialize', {});
+    client.setResult('session/new', { sessionId: 'acp-agent-session-1' });
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    await backend.createSession({ ...scope, cwd });
+    const result = await backend.sendPrompt('session-1', 'hello', scope);
+
+    // Timeout is acceptable — CC likely received the prompt
+    expect(result.delivered).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('sendPrompt surfaces -32601 Method not found errors (#3479)', async () => {
+    const service = new FakeSessionService();
+    const client = new FakeErrorClient(new Error('Method not found: session/prompt'));
+    client.setResult('initialize', {});
+    client.setResult('session/new', { sessionId: 'acp-agent-session-1' });
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    await backend.createSession({ ...scope, cwd });
+    const result = await backend.sendPrompt('session-1', 'hello', scope);
+
+    // Actual errors must be surfaced (not silently swallowed)
+    expect(result.delivered).toBe(false);
+    expect(result.error).toContain('Method not found');
+  });
 });
 
 class FakeBackendClient implements AcpBackendClient {
@@ -868,4 +933,47 @@ async function waitForCondition(predicate: () => boolean): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 0));
   }
   throw new Error('condition was not met');
+}
+
+class FakeTimeoutClient extends FakeBackendClient {
+  async request<T = AcpJsonValue>(
+    method: string,
+    params?: AcpJsonValue,
+    _options?: AcpJsonRpcRequestOptions
+  ): Promise<AcpJsonRpcSuccess<T>> {
+    this.requests.push({ method, params });
+    // Simulate timeout for session/prompt
+    if (method === 'session/prompt') {
+      const err = new AcpJsonRpcTimeoutError({ id: 'test', method, timeoutMs: 5000 });
+      throw err;
+    }
+    return {
+      jsonrpc: '2.0',
+      id: `${method}-request`,
+      result: this.results.get(method) as T,
+    };
+  }
+}
+
+class FakeErrorClient extends FakeBackendClient {
+  private readonly error: Error;
+  constructor(error: Error) {
+    super();
+    this.error = error;
+  }
+  async request<T = AcpJsonValue>(
+    method: string,
+    params?: AcpJsonValue,
+    _options?: AcpJsonRpcRequestOptions
+  ): Promise<AcpJsonRpcSuccess<T>> {
+    this.requests.push({ method, params });
+    if (method === 'session/prompt') {
+      throw this.error;
+    }
+    return {
+      jsonrpc: '2.0',
+      id: `${method}-request`,
+      result: this.results.get(method) as T,
+    };
+  }
 }

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -34,6 +34,7 @@ import type {
 
 const DEFAULT_PROTOCOL_VERSION = 1;
 const ACP_PROMPT_REQUEST_TIMEOUT_MS = 60_000;
+const ACP_PROMPT_ACK_TIMEOUT_MS = 5_000;
 const PACKAGE_VERSION = readPackageVersion();
 
 export interface AcpBackendClient {
@@ -425,19 +426,35 @@ export class AcpBackend {
         return { delivered: false, attempts: 0, error: 'no_agent_session' };
       }
 
-      // #3423: Use notify (fire-and-forget) instead of request.
-      // request() blocks until Claude finishes responding (up to 60s timeout),
-      // causing /v1/sessions/:id/send to hang with an empty response body.
-      await runtime.client.notify('session/prompt', {
-        sessionId: acpSessionId,
-        prompt: [{ type: 'text', text }],
-      });
+      // #3479: Revert notify() back to request() with a short ack timeout.
+      // #3423's notify() fix silently swallowed CC's -32601 "Method not found"
+      // error because JSON-RPC notifications have no response. Using request()
+      // with a 5s timeout: if CC acks within 5s → confirmed delivered. If it
+      // times out → CC likely received it but hasn't responded yet → mark as
+      // delivered (same behavior as notify, but with a chance to catch errors).
+      // If CC returns an actual error (e.g. -32601) → surface it properly.
+      try {
+        await runtime.client.request('session/prompt', {
+          sessionId: acpSessionId,
+          prompt: [{ type: 'text', text }],
+        }, { timeoutMs: ACP_PROMPT_ACK_TIMEOUT_MS });
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AcpJsonRpcTimeoutError') {
+          // Timeout is acceptable — CC likely received the prompt but hasn't
+          // responded yet. Log and continue as delivered.
+          console.warn(`[ACP prompt ack timeout] session=${sessionId} — treating as delivered`);
+        } else {
+          // Actual error (e.g. -32601 Method not found) — surface it
+          throw err;
+        }
+      }
       return { delivered: true, attempts: 1 };
     } catch (err) {
-      // Issue #3223: Log timeout details for BYO-LLM proxy diagnosis
-      if (err instanceof Error && err.message.includes('timed out')) {
-        console.warn(`[ACP prompt timeout] session=${sessionId} method=session/prompt notify=true`);
+      if (err instanceof Error && err.name === 'AcpJsonRpcTimeoutError') {
+        // Handled above — should not reach here, but defensive
+        return { delivered: true, attempts: 1 };
       }
+      console.warn(`[ACP prompt error] session=${sessionId} method=session/prompt error=${(err as Error).message}`);
       return { delivered: false, attempts: 1, error: (err as Error).message };
     } finally {
       this.inFlightPrompts.delete(sessionId);


### PR DESCRIPTION
## Problem
PR #3437 changed `sendPrompt()` from `request()` to `notify()` (fire-and-forget JSON-RPC) to fix #3423 (`/send` hanging 60s). However, `notify()` silently swallowed CC's `-32601 "Method not found"` error because JSON-RPC notifications have no response. This caused `promptDelivery.delivered = true` even when CC never received the prompt.

**Impact:** ALL CC sessions broken. Sessions create but never execute. Zero Claude output.

## Fix
Revert to `request()` with a **5s ack timeout** (`ACP_PROMPT_ACK_TIMEOUT_MS`):
- If CC acks within 5s → confirmed delivered
- If timeout → CC likely received it → mark as delivered (same behavior as `notify()`)
- If CC returns an error (e.g. `-32601`) → surface it as `delivered: false`

This fixes both #3423 (no 60s hang) and #3479 (errors no longer silently swallowed).

## Changes
- `src/services/acp/backend.ts`:
  - Added `ACP_PROMPT_ACK_TIMEOUT_MS = 5_000` constant
  - Changed `sendPrompt()` from `notify()` → `request()` with 5s timeout
  - Added inner try/catch to handle `AcpJsonRpcTimeoutError` gracefully (treat as delivered)
  - Actual errors (e.g. `-32601`) now surface as `delivered: false` with error message
  - Added warn log for both ack timeouts and actual errors

## Verification
- `tsc --noEmit`: ✅ zero errors
- `npm run build`: ✅
- Tests: 17/17 passed (14 existing + 3 new regression tests)

### New Tests
1. `sendPrompt uses request() with short ack timeout (#3479)` — verifies `request()` is used (not `notify()`)
2. `sendPrompt treats ack timeout as delivered (#3479)` — verifies timeout → `delivered: true`
3. `sendPrompt surfaces -32601 Method not found errors (#3479)` — verifies errors → `delivered: false`

## Related
- Fixes #3479
- Supersedes #3437 (which introduced the regression)
- Original fix for #3423 (preserved — no 60s hang)
