### PR TITLE
docs: add --yes flag to ag run CLI reference

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,6 +42,7 @@ If the server is already running, `ag run` skips bootstrap and start — goes st
 | `--no-stream` | Don't stream output; print curl commands instead |
 | `--model <provider/model>` | Override the default model for this session |
 | `--name <name>` | Set a display name for the session |
+| `--yes` | Suppress all status messages for non-interactive/CI usage |
 | `--accept-permissions` / `-y` | Auto-approve all permission prompts (sets `permissionMode: bypassPermissions`) |
 
 > **Note:** `ag run --help` currently shows the general help. For `ag run` flags, refer to this table.

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -51,6 +51,7 @@ ag run "Build a REST API for managing tasks" --cwd .
 ag run "Fix the auth bug"                     # Uses current directory
 ag run "Refactor the utils" --no-stream       # Print curl commands instead of streaming
 ag run "Debug the tests" --port 3000          # Custom server port
+ag run "Fix CI" --yes                        # Non-interactive (CI-friendly)
 ```
 
 **What it does:**


### PR DESCRIPTION
## Summary\nDocuments the `--yes` flag added to `ag run` in PR #3478.\n\n## Changes\n- `docs/getting-started.md` — added `--yes` to the ag run flags table\n- `docs/integrations/cli.md` — added `--yes` usage example\n\n## Gap\nPR #3478 added `--yes` to suppress status messages for non-interactive/CI usage but did not update docs.