### PR TITLE
fix(auth): proactive keys.json reload + orphan auth-token detection

### DIFF
--- a/src/__tests__/fix-3367-auth-recovery.test.ts
+++ b/src/__tests__/fix-3367-auth-recovery.test.ts
@@ -44,17 +44,16 @@ describe('Issue #3367: Auth state recovery after state directory loss', () => {
     const { key: newKey } = await newAuth.createKey('new-key', 100, undefined, 'admin');
     await newAuth.save();
 
-    // Step 5: Old key still works (in-memory), new key doesn't
-    expect(auth.validate(oldKey).valid).toBe(true);
-    expect(auth.validate(newKey).valid).toBe(false);
-
-    // Step 6: Reload should pick up new keys
-    const reloaded = await auth.reload();
-    expect(reloaded).toBe(true);
-
-    // Step 7: New key should now work, old key should not
+    // Step 5: With proactive reload (#3484), the very first validate() call
+    // after newAuth recreated keys.json already picks up the new state.
+    // The new key works; the old key no longer matches any registered hash.
     expect(auth.validate(newKey).valid).toBe(true);
     expect(auth.validate(oldKey).valid).toBe(false);
+
+    // Step 6: An explicit reload() is now a no-op because validate()
+    // already advanced lastKeysMtime.
+    const reloaded = await auth.reload();
+    expect(reloaded).toBe(false);
   });
 
   it('reload() does nothing if keys.json has not changed', async () => {

--- a/src/__tests__/fix-3484-auth-state-sync.test.ts
+++ b/src/__tests__/fix-3484-auth-state-sync.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Issue #3484: AuthManager state synchronization fixes.
+ *
+ *  1. validate() should proactively reload keys.json when its mtime advances,
+ *     so a freshly-added key activates on the first request rather than after
+ *     a wasted 401 wakes up the post-fail async reload.
+ *
+ *  2. checkClientToken() should detect when a plaintext token (e.g. from
+ *     ~/.aegis/auth-token) is orphaned — i.e. does not match any registered
+ *     key nor the master token.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { AuthManager } from '../services/auth/AuthManager.js';
+
+describe('Issue #3484: AuthManager proactive reload + orphan detection', () => {
+  let tmpDir: string;
+  let keysFile: string;
+  let auth: AuthManager;
+
+  beforeEach(async () => {
+    tmpDir = join('/tmp', `test-3484-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tmpDir, { recursive: true });
+    keysFile = join(tmpDir, 'keys.json');
+    auth = new AuthManager(keysFile, '');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('reloadSyncIfChanged()', () => {
+    it('returns false when keys.json has not been modified since last load', async () => {
+      await auth.createKey('initial', 100, undefined, 'admin');
+      // save() updates lastKeysMtime; immediate check sees no change.
+      expect(auth.reloadSyncIfChanged()).toBe(false);
+    });
+
+    it('picks up an externally appended key without an explicit reload() call', async () => {
+      // Seed with one key via the normal API
+      const { key: existing } = await auth.createKey('existing', 100, undefined, 'admin');
+      expect(auth.validate(existing).valid).toBe(true);
+
+      // Simulate another writer (e.g. a future SSO provisioner) appending a key
+      const raw = await readFile(keysFile, 'utf-8');
+      const store = JSON.parse(raw) as { keys: unknown[] };
+      // Use AuthManager.hashKey to mirror the production hashing rule.
+      const newKeyPlaintext = 'aegis_' + 'a'.repeat(60);
+      store.keys.push({
+        id: 'externalfeed1234',
+        name: 'externally-added',
+        hash: AuthManager.hashKey(newKeyPlaintext),
+        createdAt: Date.now(),
+        lastUsedAt: 0,
+        rateLimit: 100,
+        expiresAt: null,
+        role: 'admin',
+        permissions: ['create', 'send', 'approve', 'reject', 'kill'],
+        tenantId: '_system',
+      });
+      await writeFile(keysFile, JSON.stringify(store, null, 2));
+      // Force a strictly-newer mtime since some filesystems have second-level granularity.
+      const future = new Date(Date.now() + 5_000);
+      utimesSync(keysFile, future, future);
+
+      // First call to validate() must already honor the new key — no warm-up 401.
+      const result = auth.validate(newKeyPlaintext);
+      expect(result.valid).toBe(true);
+      expect(result.keyId).toBe('externalfeed1234');
+    });
+
+    it('leaves in-memory keys intact when keys.json becomes corrupt', async () => {
+      const { key } = await auth.createKey('survivor', 100, undefined, 'admin');
+      expect(auth.validate(key).valid).toBe(true);
+
+      await writeFile(keysFile, '{ not valid json');
+      const future = new Date(Date.now() + 5_000);
+      utimesSync(keysFile, future, future);
+
+      // validate() must not throw and must still recognize the in-memory key.
+      const r = auth.validate(key);
+      expect(r.valid).toBe(true);
+    });
+  });
+
+  describe('checkClientToken()', () => {
+    it('returns matched=false for the empty string', () => {
+      expect(auth.checkClientToken('')).toEqual({ matched: false, via: null });
+    });
+
+    it('returns matched=true with via=key for a registered plaintext token', async () => {
+      const { key } = await auth.createKey('registered', 100, undefined, 'admin');
+      expect(auth.checkClientToken(key)).toEqual({ matched: true, via: 'key' });
+    });
+
+    it('returns matched=true with via=master when the token equals the master token', () => {
+      const master = 'aegis_master_test_token';
+      const a = new AuthManager(keysFile, master);
+      expect(a.checkClientToken(master)).toEqual({ matched: true, via: 'master' });
+    });
+
+    it('returns matched=false for an orphaned plaintext token', async () => {
+      await auth.createKey('only-real-key', 100, undefined, 'admin');
+      const orphan = 'aegis_' + 'b'.repeat(60);
+      expect(auth.checkClientToken(orphan)).toEqual({ matched: false, via: null });
+    });
+
+    it('trims surrounding whitespace before comparing', async () => {
+      const { key } = await auth.createKey('whitespace', 100, undefined, 'admin');
+      expect(auth.checkClientToken(`  ${key}\n`)).toEqual({ matched: true, via: 'key' });
+    });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,8 @@
 import Fastify, { type FastifyRequest, type FastifyReply } from 'fastify';
 import fastifyRateLimit from '@fastify/rate-limit';
 import fs from 'node:fs/promises';
-import { watch, type FSWatcher } from 'node:fs';
+import { existsSync, readFileSync, watch, type FSWatcher } from 'node:fs';
+import { homedir } from 'node:os';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyCors from '@fastify/cors';
 import crypto from 'node:crypto';
@@ -930,6 +931,23 @@ async function main(): Promise<void> {
   container.register('authManager', auth, {
     start: async () => {
       await auth.load();
+      // #3356/#3484: Detect an orphaned ~/.aegis/auth-token whose content no
+      // longer matches any registered key. CLI usage via that file will fail
+      // silently otherwise.
+      const clientTokenFile = path.join(homedir(), '.aegis', 'auth-token');
+      if (existsSync(clientTokenFile)) {
+        try {
+          const fileToken = readFileSync(clientTokenFile, 'utf-8').trim();
+          if (fileToken && !auth.checkClientToken(fileToken).matched) {
+            console.warn(
+              `[auth] ${clientTokenFile} contains a token that does not match any registered key — ` +
+              `CLI auth via that file will fail. Run 'ag init' to refresh or delete the file.`,
+            );
+          }
+        } catch {
+          // Unreadable — ignore, the CLI will surface its own auth error.
+        }
+      }
     },
     stop: async () => {},
     health: async () => ({ healthy: auth.isHealthy(), details: auth.isHealthy() ? undefined : "keys.json missing — state dir may have been wiped" }),

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -10,7 +10,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import { timingSafeStringEqual } from '../../crypto-utils.js';
 import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 import { authStoreSchema } from '../../validation.js';
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { secureFilePermissions } from '../../file-utils.js';
 import { SYSTEM_TENANT } from '../../config.js';
@@ -495,6 +495,11 @@ export class AuthManager {
    * Issue #1944: tenantId is set from the API key (admin/master = undefined = bypass).
    */
   validate(token: string): { valid: boolean; keyId: string | null; rateLimited: boolean; reason?: AuthRejectReason; tenantId?: string } {
+    // #3484: Proactively pick up external edits to keys.json before the lookup.
+    // Without this, a key freshly appended to keys.json only activates after
+    // an initial 401 wakes up the post-fail async reload.
+    this.reloadSyncIfChanged();
+
     // No auth configured and no keys → allow all
     if (!this.masterToken && this.store.keys.length === 0) {
       // #1080: SECURITY FIX — when binding to a non-localhost interface without auth,
@@ -644,6 +649,61 @@ export class AuthManager {
     } finally {
       this.reloading = false;
     }
+  }
+
+  /**
+   * #3484: Synchronous reload when keys.json mtime has advanced.
+   * Called from validate() to guarantee freshly-written keys activate on the
+   * first request, instead of needing a wasted 401 to trigger the post-fail
+   * async reload. Returns true when keys were refreshed.
+   *
+   * Mirrors the validation/normalization done by load() but skips the
+   * normalize-induced save — the next async save() (createKey, revoke,
+   * lastUsedAt sweep) will persist any cleanups.
+   */
+  reloadSyncIfChanged(): boolean {
+    if (this.reloading) return false;
+    if (!existsSync(this.keysFile)) return false;
+    if (!this._keysFileChanged()) return false;
+    try {
+      const raw = readFileSync(this.keysFile, 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      const storeParsed = authStoreSchema.safeParse(parsed);
+      if (storeParsed.success) {
+        this.store = {
+          keys: storeParsed.data.keys.map((key) => this.normalizeStoredKey(key).key),
+        };
+      }
+      if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { graceKeys?: unknown }).graceKeys)) {
+        const now = Date.now();
+        this.graceKeys = ((parsed as { graceKeys: GraceKeyEntry[] }).graceKeys).filter(
+          (entry) => entry.graceExpiresAt > now,
+        );
+      }
+      return true;
+    } catch {
+      // Corrupted or unreadable — keep in-memory keys, retry on next mtime bump.
+      return false;
+    }
+  }
+
+  /**
+   * #3356/#3484: Compare a plaintext token (e.g. from ~/.aegis/auth-token)
+   * against the in-memory key store and the master token. Used by server
+   * startup to detect orphaned client-token files that no longer correspond
+   * to any registered key.
+   */
+  checkClientToken(token: string): { matched: boolean; via: 'master' | 'key' | null } {
+    const trimmed = token.trim();
+    if (!trimmed) return { matched: false, via: null };
+    if (this.masterToken && timingSafeStringEqual(trimmed, this.masterToken)) {
+      return { matched: true, via: 'master' };
+    }
+    const hash = AuthManager.hashKey(trimmed);
+    if (this.store.keys.some((k) => k.hash === hash)) {
+      return { matched: true, via: 'key' };
+    }
+    return { matched: false, via: null };
   }
 
   /** #3367: Check if keys.json mtime has changed. */


### PR DESCRIPTION
## Summary

Two small AuthManager state-sync improvements I found while verifying the #3479 fix end-to-end on bubuntu earlier today.

- **`validate()` now reloads `keys.json` proactively** when its mtime advances. Previously, the #3367 async-on-fail reload required a wasted 401 to wake up before a freshly-added key would activate. Live repro on bubuntu: appending a new admin entry to `keys.json` and `touch`-ing it → first request returned 401, second succeeded.
- **`checkClientToken()` helper + startup warning** for the orphan variant of #3356, where `~/.aegis/auth-token` exists but its content matches no registered key (observed live: the file persisted across a key rotation while `keys.json` no longer contained the corresponding hash).

The existing #3367 reload-on-failure path is preserved as a fallback for the case where `validate()` is never called between mtime bumps.

## Aegis version

**Developed with:** v0.6.7-preview.1   ← `curl -s http://localhost:9100/v1/health` returned `{"status":"ok"}` on bubuntu after the #3479 fix landed; the version field is not exposed in the public response, but the build that surfaced these bugs is the develop tip as of `d94e7efa`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] New: `src/__tests__/fix-3484-auth-state-sync.test.ts` — 8/8 pass (reloadSyncIfChanged + checkClientToken)
- [x] Existing: `src/__tests__/fix-3367-auth-recovery.test.ts` — 8/8 pass (step 5 of the wipe-and-recreate test updated to match the new proactive semantics: the explicit `reload()` is now a no-op because `validate()` already advanced `lastKeysMtime`).
- [x] Full suite: only pre-existing failures unrelated to auth (Windows chmod tests, dashboard token gate violations) — confirmed identical on `develop` baseline.
- [ ] CI on develop

## Changes

| File | Δ | What |
|------|---|------|
| `src/services/auth/AuthManager.ts` | +63 / -1 | `readFileSync` import, `reloadSyncIfChanged()`, `checkClientToken()`, call site in `validate()` |
| `src/server.ts` | +18 / -1 | imports `homedir`/`existsSync`/`readFileSync`, orphan-token warning in the `authManager` container start callback |
| `src/__tests__/fix-3484-auth-state-sync.test.ts` | +118 / 0 | new test file |
| `src/__tests__/fix-3367-auth-recovery.test.ts` | +5 / -9 | step 5 updated for proactive-reload semantics |

204 insertions, 11 deletions across 4 files. Well under the 500-line PR cap.

## Notes

- The orphan check on startup is observability-only — it logs `[auth] ...` to console.warn. No behavior change beyond the warning, so it is safe to ship without flag gating.
- `reloadSyncIfChanged()` skips the normalize-induced save() that `load()` performs. The next async save (createKey / revoke / lastUsedAt sweep) will persist any cleanups. The trade-off: one extra normalize on the next sweep vs. a synchronous write in the hot path of `validate()`.
- `npm run gate` fails on `dashboard:tokens:gate` with 25 pre-existing violations — same failure on `develop` baseline. Not introduced by this PR.

Closes #3484
Refs #3356

Generated by Hephaestus (Aegis dev agent)