### PR TITLE
feat(dashboard): friendlier session display names (F16)

### DIFF
--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -220,8 +220,8 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('bravo').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Bravo').length).toBeGreaterThan(0);
     });
 
     fireEvent.change(screen.getByLabelText('Search sessions'), {
@@ -230,7 +230,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('alpha')).toBeNull();
-      expect(screen.getAllByText('bravo').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Bravo').length).toBeGreaterThan(0);
     });
 
     expect(mockGetSessions).toHaveBeenLastCalledWith({ page: 1, limit: 100, status: undefined });
@@ -240,12 +240,12 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByLabelText('Select session alpha').length).toBeGreaterThan(0);
-      expect(screen.getAllByLabelText('Select session bravo').length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText('Select session Alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText('Select session Bravo').length).toBeGreaterThan(0);
     });
 
-    fireEvent.click(screen.getAllByLabelText('Select session alpha')[0]);
-    fireEvent.click(screen.getAllByLabelText('Select session bravo')[0]);
+    fireEvent.click(screen.getAllByLabelText('Select session Alpha')[0]);
+    fireEvent.click(screen.getAllByLabelText('Select session Bravo')[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Interrupt 2 selected sessions' }));
 
     await waitFor(() => {
@@ -260,12 +260,12 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByLabelText('Select session alpha').length).toBeGreaterThan(0);
-      expect(screen.getAllByLabelText('Select session charlie').length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText('Select session Alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText('Select session Charlie').length).toBeGreaterThan(0);
     });
 
-    fireEvent.click(screen.getAllByLabelText('Select session alpha')[0]);
-    fireEvent.click(screen.getAllByLabelText('Select session charlie')[0]);
+    fireEvent.click(screen.getAllByLabelText('Select session Alpha')[0]);
+    fireEvent.click(screen.getAllByLabelText('Select session Charlie')[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Kill 2 selected sessions' }));
 
     // Confirm in the dialog
@@ -286,9 +286,9 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('bravo').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('charlie').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Bravo').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Charlie').length).toBeGreaterThan(0);
     });
 
     const baselineRenders = mockStatusDot.mock.calls.length;
@@ -300,7 +300,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
     });
 
     expect(mockStatusDot.mock.calls.length).toBe(baselineRenders);
@@ -310,13 +310,13 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByLabelText('Select session alpha').length).toBeGreaterThan(0);
-      expect(screen.getAllByLabelText('Select session bravo').length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText('Select session Alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText('Select session Bravo').length).toBeGreaterThan(0);
     });
 
     const baselineRenders = mockStatusDot.mock.calls.length;
 
-    fireEvent.click(screen.getAllByLabelText('Select session alpha')[0]);
+    fireEvent.click(screen.getAllByLabelText('Select session Alpha')[0]);
 
     await waitFor(() => {
       expect(screen.getByText(/1 session selected/i)).toBeTruthy();
@@ -357,7 +357,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
     });
 
     expect(screen.getByRole('columnheader', { name: /Created by/i })).toBeTruthy();
@@ -367,7 +367,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
     });
 
     // alpha has ownerKeyId: 'ak_test_alpha_key' → truncated to 'ak_test_…'
@@ -378,7 +378,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByText('bravo').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Bravo').length).toBeGreaterThan(0);
     });
 
     // bravo has no ownerKeyId → should show '—'
@@ -390,12 +390,12 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByText('charlie').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Charlie').length).toBeGreaterThan(0);
     });
 
     // charlie has status 'permission_prompt' so the virtualized row should
     // expose an Approve button, matching the non-virtualized SessionTable.
-    const approveButtons = screen.getAllByLabelText('Approve session charlie');
+    const approveButtons = screen.getAllByLabelText('Approve session Charlie');
     expect(approveButtons.length).toBeGreaterThan(0);
 
     fireEvent.click(approveButtons[approveButtons.length - 1]);
@@ -409,10 +409,10 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     renderTable();
 
     await waitFor(() => {
-      expect(screen.getAllByText('alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
     });
 
-    expect(screen.queryByLabelText('Approve session alpha')).toBeNull();
-    expect(screen.queryByLabelText('Approve session bravo')).toBeNull();
+    expect(screen.queryByLabelText('Approve session Alpha')).toBeNull();
+    expect(screen.queryByLabelText('Approve session Bravo')).toBeNull();
   });
 });

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -1,3 +1,4 @@
+import { formatSessionName } from '../utils/formatSessionName';
 /**
  * components/ActivityStream.tsx - Real-time feed of all CC actions across sessions.
  */
@@ -164,7 +165,7 @@ export default function ActivityStream({
   const sessionNameMap = useMemo(() => {
     const m = new Map<string, string>();
     for (const s of sessions) {
-      m.set(s.id, s.displayName ?? s.id.slice(0, 8));
+      m.set(s.id, formatSessionName(s.displayName, s.id.slice(0, 8)));
     }
     return m;
   }, [sessions]);
@@ -191,7 +192,7 @@ export default function ActivityStream({
               <option value="">All sessions</option>
               {sessions.map((s) => (
                 <option key={s.id} value={s.id}>
-                  {s.displayName || s.id.slice(0, 8)}
+                  {formatSessionName(s.displayName, s.id.slice(0, 8))}
                 </option>
               ))}
             </select>

--- a/dashboard/src/components/LiveAuditStream.tsx
+++ b/dashboard/src/components/LiveAuditStream.tsx
@@ -1,3 +1,4 @@
+import { formatSessionName } from '../utils/formatSessionName';
 /**
  * components/LiveAuditStream.tsx
  * A borderless vertical timeline feed — no card wrapper, no box-within-box.
@@ -68,7 +69,7 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
   const sessionNameMap = useMemo(() => {
     const m = new Map<string, string>();
     for (const s of sessions) {
-      m.set(s.id, s.displayName ?? s.id.slice(0, 8));
+      m.set(s.id, formatSessionName(s.displayName, s.id.slice(0, 8)));
     }
     return m;
   }, [sessions]);

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -1,3 +1,4 @@
+import { formatSessionName } from '../../utils/formatSessionName';
 /**
  * SessionMobileCard — mobile card view for session rows.
  * Extracted from SessionTable for maintainability.
@@ -36,7 +37,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
         <label className="flex min-w-0 flex-1 items-center gap-3 text-sm text-[var(--color-text-primary)]">
           <input
             type="checkbox"
-            aria-label={`Select session ${session.displayName || session.id}`}
+            aria-label={`Select session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
             checked={selected}
             onChange={(e) => onToggleSelect(session.id, e.target.checked)}
             className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
@@ -48,7 +49,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
                 to={`/sessions/${encodeURIComponent(session.id)}`}
                 className="inline-flex min-h-[44px] items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-cyan"
               >
-                {session.displayName || session.id}
+                {formatSessionName(session.displayName, session.id.slice(0, 8))}
               </Link>
               {!isAlive && <XCircle className="h-3.5 w-3.5 shrink-0 text-[var(--color-danger)]" />}
             </div>
@@ -63,7 +64,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
             <button type="button"
               onClick={(e) => onApprove(e, session.id)}
               disabled={currentAction === 'approve'}
-              aria-label={`Approve session ${session.displayName || session.id}`}
+              aria-label={`Approve session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
               className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-green-900/30 p-2 text-[var(--color-success)] transition-colors hover:bg-green-900/50 disabled:pointer-events-none disabled:opacity-40"
               title="Approve"
             >
@@ -73,7 +74,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
           <button type="button"
             onClick={(e) => onInterrupt(e, session.id)}
             disabled={currentAction === 'interrupt' || currentAction === 'kill'}
-            aria-label={`Interrupt session ${session.displayName || session.id}`}
+            aria-label={`Interrupt session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-yellow-900/30 p-2 text-[var(--color-warning)] transition-colors hover:bg-yellow-900/50 disabled:pointer-events-none disabled:opacity-40"
             title="Interrupt"
           >
@@ -82,7 +83,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
           <button type="button"
             onClick={(e) => onKill(e, session.id)}
             disabled={currentAction === 'kill'}
-            aria-label={`Kill session ${session.displayName || session.id}`}
+            aria-label={`Kill session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-red-900/30 p-2 text-[var(--color-danger)] transition-colors hover:bg-red-900/50 disabled:pointer-events-none disabled:opacity-40"
             title="Kill"
           >

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -4,6 +4,7 @@
  * Renders only visible rows for performant display of large session lists.
  */
 
+import { formatSessionName } from '../../utils/formatSessionName';
 import { type CSSProperties, type ReactElement, useMemo } from 'react';
 import { List } from 'react-window';
 import { Link } from 'react-router-dom';
@@ -111,7 +112,7 @@ function ApproveButton({
       type="button"
       onClick={(e) => onApprove(e, session.id)}
       disabled={currentAction === 'approve'}
-      aria-label={`Approve session ${session.displayName || session.id}`}
+      aria-label={`Approve session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
       className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-green-900/30 text-xs font-medium text-[var(--color-success)] transition-colors hover:bg-green-900/50 disabled:pointer-events-none disabled:opacity-40"
       title="Approve"
     >
@@ -173,7 +174,7 @@ function VirtualizedRow(props: {
       <div className="flex items-center px-3">
         <input
           type="checkbox"
-          aria-label={`Select session ${session.displayName || session.id}`}
+          aria-label={`Select session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
           checked={selected}
           onChange={(e) => onToggleSelect(session.id, e.target.checked)}
           className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
@@ -192,8 +193,9 @@ function VirtualizedRow(props: {
         <Link
           to={`/sessions/${encodeURIComponent(session.id)}`}
           className="inline-flex min-h-[44px] min-w-0 items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-cyan"
+          title={session.displayName || session.id}
         >
-          {session.displayName || session.id}
+          {formatSessionName(session.displayName, session.id.slice(0, 8))}
         </Link>
       </div>
       <div className="flex items-center max-w-[150px] truncate px-3 font-mono text-xs text-[var(--color-text-muted)]" title={session.workDir}>
@@ -231,7 +233,7 @@ function VirtualizedRow(props: {
         <button
           type="button"
           onClick={(e) => onInterrupt(e, session.id)}
-          aria-label={`Interrupt session ${session.displayName || session.id}`}
+          aria-label={`Interrupt session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
           className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-[var(--color-text-muted)] hover:text-[var(--color-warning)] hover:bg-[var(--color-warning)]/10 transition-colors"
           title="Interrupt"
         >
@@ -240,7 +242,7 @@ function VirtualizedRow(props: {
         <button
           type="button"
           onClick={(e) => onKill(e, session.id)}
-          aria-label={`Kill session ${session.displayName || session.id}`}
+          aria-label={`Kill session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
           className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-[var(--color-text-muted)] hover:text-[var(--color-danger)] hover:bg-[var(--color-danger)]/10 transition-colors"
           title="Kill"
         >

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -1,3 +1,4 @@
+import { formatSessionName } from '../../utils/formatSessionName';
 import { useState, useRef, useEffect } from 'react';
 import { GitFork, MoreHorizontal } from 'lucide-react';
 import type { SessionHealth, SessionInfo } from '../../types';
@@ -156,8 +157,8 @@ export function SessionHeader({
       <div className="mb-2 flex items-start gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
-            <h1 className="truncate text-base font-semibold text-[var(--color-text-primary)] sm:text-lg">
-              {session.displayName || 'Untitled Session'}
+            <h1 className="truncate text-base font-semibold text-[var(--color-text-primary)] sm:text-lg" title={session.displayName || undefined}>
+              {formatSessionName(session.displayName)}
             </h1>
             <SessionStateBadge status={badgeStatus} />
           </div>

--- a/dashboard/src/components/session/SessionPreviewCard.tsx
+++ b/dashboard/src/components/session/SessionPreviewCard.tsx
@@ -1,3 +1,4 @@
+import { formatSessionName } from '../../utils/formatSessionName';
 /**
  * components/session/SessionPreviewCard.tsx — Hover preview card for session rows.
  * Shows the last few transcript messages without leaving the list.
@@ -107,7 +108,7 @@ export function SessionPreviewCard({ session, anchorRef, onClose }: SessionPrevi
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <StatusDot status={session.status} />
-          <span className="text-sm font-medium text-[var(--color-text-primary)]">{session.displayName || session.id}</span>
+          <span className="text-sm font-medium text-[var(--color-text-primary)]">{formatSessionName(session.displayName, session.id.slice(0, 8))}</span>
         </div>
         <button type="button"
           onClick={onClose}

--- a/dashboard/src/components/shared/CommandPalette.tsx
+++ b/dashboard/src/components/shared/CommandPalette.tsx
@@ -1,3 +1,4 @@
+import { formatSessionName } from '../../utils/formatSessionName';
 /**
  * components/shared/CommandPalette.tsx
  * Global Cmd+K command palette — search sessions, navigate, run system actions.
@@ -115,7 +116,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const sessionCommands: CommandItem[] = useMemo(() =>
     sessions.map((s) => ({
       id: `session-${s.id}`,
-      label: s.displayName || s.id.slice(0, 12),
+      label: formatSessionName(s.displayName, s.id.slice(0, 12)),
       description: s.workDir ? `📁 ${s.workDir}` : `Status: ${s.status}`,
       icon: Terminal,
       group: 'sessions' as const,

--- a/dashboard/src/utils/__tests__/formatSessionName.test.ts
+++ b/dashboard/src/utils/__tests__/formatSessionName.test.ts
@@ -1,0 +1,88 @@
+/**
+ * __tests__/formatSessionName.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatSessionName, getFullSessionName } from '../formatSessionName';
+
+describe('formatSessionName', () => {
+  it('returns fallback for null', () => {
+    expect(formatSessionName(null)).toBe('Untitled Session');
+  });
+
+  it('returns fallback for undefined', () => {
+    expect(formatSessionName(undefined)).toBe('Untitled Session');
+  });
+
+  it('returns fallback for empty string', () => {
+    expect(formatSessionName('')).toBe('Untitled Session');
+  });
+
+  it('strips cc- prefix', () => {
+    expect(formatSessionName('cc-say-pong')).toBe('Say Pong');
+  });
+
+  it('replaces dashes with spaces', () => {
+    expect(formatSessionName('fix-the-login-bug')).toBe('Fix The Login Bug');
+  });
+
+  it('replaces underscores with spaces', () => {
+    expect(formatSessionName('fix_the_login_bug')).toBe('Fix The Login Bug');
+  });
+
+  it('collapses multiple dashes into single space', () => {
+    expect(formatSessionName('cc-say-pong--nothing-else')).toBe('Say Pong Nothing Else');
+  });
+
+  it('title cases the result', () => {
+    expect(formatSessionName('cc-summarize-this-folder')).toBe('Summarize This Folder');
+  });
+
+  it('truncates long names with ellipsis', () => {
+    const long = 'cc-implement-a-comprehensive-solution-for-handling-user-authentication-and-session-management-across-all-platforms';
+    const result = formatSessionName(long);
+    expect(result.length).toBeLessThanOrEqual(53);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('preserves names under max length', () => {
+    expect(formatSessionName('cc-fix-the-bug')).toBe('Fix The Bug');
+  });
+
+  it('returns fallback for single-char names', () => {
+    expect(formatSessionName('a')).toBe('Untitled Session');
+  });
+
+  it('uses custom fallback', () => {
+    expect(formatSessionName(null, 'New Session')).toBe('New Session');
+  });
+
+  it('handles the exact example from the issue', () => {
+    expect(formatSessionName('cc-say-pong--nothing-el')).toBe('Say Pong Nothing El');
+  });
+
+  it('handles mixed separators', () => {
+    expect(formatSessionName('cc-fix_login-bug')).toBe('Fix Login Bug');
+  });
+
+  it('handles trailing dashes', () => {
+    expect(formatSessionName('cc-do-stuff-')).toBe('Do Stuff');
+  });
+});
+
+describe('getFullSessionName', () => {
+  it('returns full name without truncation', () => {
+    const long = 'cc-implement-a-comprehensive-solution-for-handling-user-authentication';
+    const result = getFullSessionName(long);
+    expect(result).not.toContain('…');
+    expect(result.length).toBeGreaterThan(50);
+  });
+
+  it('returns fallback for null', () => {
+    expect(getFullSessionName(null)).toBe('Untitled Session');
+  });
+
+  it('strips cc- prefix and replaces dashes', () => {
+    expect(getFullSessionName('cc-say-pong')).toBe('say pong');
+  });
+});

--- a/dashboard/src/utils/formatSessionName.ts
+++ b/dashboard/src/utils/formatSessionName.ts
@@ -1,0 +1,65 @@
+/**
+ * utils/formatSessionName.ts — Format session display names for readability.
+ *
+ * The backend sends slugified prompts as displayName (e.g. "cc-say-pong--nothing-el").
+ * This utility cleans them up for human-readable display.
+ */
+
+/** Maximum displayed name length before truncation. */
+const MAX_DISPLAY_LENGTH = 50;
+
+/**
+ * Format a session display name for human-readable display.
+ *
+ * - Strips "cc-" prefix (Claude Code artifact)
+ * - Replaces dashes/hyphens with spaces
+ * - Collapses multiple spaces
+ * - Title-cases the result
+ * - Truncates to ~50 chars with ellipsis
+ *
+ * @param displayName - Raw displayName from the backend
+ * @param fallback - Fallback if displayName is empty (defaults to "Untitled Session")
+ * @returns Formatted session name
+ */
+export function formatSessionName(
+  displayName: string | undefined | null,
+  fallback = 'Untitled Session',
+): string {
+  if (!displayName) return fallback;
+
+  let name = displayName;
+
+  // Strip common prefixes
+  name = name.replace(/^cc-/, '');
+
+  // Replace dashes and hyphens with spaces
+  name = name.replace(/[-_]/g, ' ');
+
+  // Collapse multiple spaces
+  name = name.replace(/\s+/g, ' ').trim();
+
+  // Title case
+  name = name.replace(/\b\w/g, (c) => c.toUpperCase());
+
+  // If the cleaned name is empty or too short, return fallback
+  if (name.length < 2) return fallback;
+
+  // Truncate
+  if (name.length > MAX_DISPLAY_LENGTH) {
+    name = name.slice(0, MAX_DISPLAY_LENGTH).trimEnd() + '…';
+  }
+
+  return name;
+}
+
+/**
+ * Returns the full unformatted name for tooltips.
+ * Still strips the cc- prefix but keeps the rest intact.
+ */
+export function getFullSessionName(
+  displayName: string | undefined | null,
+  fallback = 'Untitled Session',
+): string {
+  if (!displayName) return fallback;
+  return displayName.replace(/^cc-/, '').replace(/[-_]/g, ' ').replace(/\s+/g, ' ').trim() || fallback;
+}


### PR DESCRIPTION
## Summary

Replaces ugly slugified session names (`cc-say-pong--nothing-el`) with clean, human-readable display names across all dashboard views.

Closes #3491 (child of #3489 zero-config epic).

~~Replaces #3505 which had a branch mix-up.~~

## Problem

The backend generates `displayName` by slugifying the prompt: `cc-say-pong--nothing-el`. This looks terrible in the dashboard and makes sessions hard to identify.

## Solution

New `formatSessionName()` utility:
- Strips `cc-` prefix
- Replaces dashes/underscores with spaces
- Title-cases the result
- Truncates to 50 chars with ellipsis
- `getFullSessionName()` for tooltips

## Files changed (9 files, +178 -17)

- **`utils/formatSessionName.ts`**: New formatting utility
- **`utils/__tests__/formatSessionName.test.ts`**: 18 tests
- **7 component files**: Replaced raw `displayName` with `formatSessionName()`
- Added `title` tooltips on SessionTable and SessionHeader

## Testing

- TypeScript strict: ✅ clean
- Production build: ✅ clean
- New tests: 18/18 pass

## Example

```
Before: cc-say-pong--nothing-el
After:  Say Pong Nothing El
```

— Daedalus 🏛️