### PR TITLE
feat(init): zero-config default — no token on localhost (#3496)

### DIFF
--- a/src/__tests__/cli-init.test.ts
+++ b/src/__tests__/cli-init.test.ts
@@ -124,7 +124,7 @@ describe('ag init', () => {
     expect(result.stdout).toContain(config.clientAuthToken!);
   });
 
-  it('supports non-interactive --yes bootstrap', async () => {
+  it('supports non-interactive --yes bootstrap (zero-config on localhost)', async () => {
     const result = await runInit(['init', '--yes']);
     const configPath = join(projectDir, '.aegis', 'config.yaml');
     const config = parseYaml(readFileSync(configPath, 'utf-8')) as {
@@ -137,9 +137,10 @@ describe('ag init', () => {
     expect(result.code).toBe(0);
     expect(config.baseUrl).toBe('http://127.0.0.1:9100');
     expect(config.dashboardEnabled).toBe(true);
-    expect(config.clientAuthToken?.startsWith('aegis_')).toBe(true);
+    // #3496: localhost defaults to zero-config — no token created
+    expect(config.clientAuthToken).toBeFalsy();
     expect(config.defaultSessionEnv).toBeUndefined();
-    expect(result.stdout).toContain('Created admin API token');
+    expect(result.stdout).toContain('zero-config');
   });
 
   it('does not overwrite an existing config without confirmation', async () => {
@@ -296,11 +297,11 @@ describe('ag init --model flag', () => {
   });
 
   it('replaces existing admin key on --force (issue #3351)', async () => {
-    // First init creates a key
+    // First init with --force creates a key (even on localhost)
     let stdin = new PassThrough();
     let stdout = new CaptureStream();
     let stderr = new CaptureStream();
-    let runPromise = runCli(['init', '--yes'], { stdin, stdout, stderr });
+    let runPromise = runCli(['init', '--yes', '--force'], { stdin, stdout, stderr });
     setImmediate(() => stdin.end());
     let code = await runPromise;
     expect(code).toBe(0);
@@ -325,5 +326,94 @@ describe('ag init --model flag', () => {
     const token2 = config2.clientAuthToken;
     expect(token2).toBeTruthy();
     expect(token2).not.toBe(token1);
+  });
+
+  describe('#3496 — zero-config localhost', () => {
+    it('skips token creation on localhost with --yes (zero-config)', async () => {
+      process.env.AEGIS_HOST = '127.0.0.1';
+      const stdin = new PassThrough();
+      const stdout = new CaptureStream();
+      const stderr = new CaptureStream();
+      const runPromise = runCli(['init', '--yes'], { stdin, stdout, stderr });
+      setImmediate(() => stdin.end());
+      const code = await runPromise;
+      expect(code).toBe(0);
+
+      const out = stdout.text();
+      // Should show zero-config message
+      expect(out).toContain('zero-config');
+      // Should NOT have created a token
+      const configPath = join(projectDir, '.aegis', 'config.yaml');
+      const config = parseYaml(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+      expect(config.clientAuthToken).toBeFalsy();
+      // No auth-token file
+      const authTokenPath = join(
+        process.env.HOME || '/tmp',
+        '.aegis',
+        'auth-token',
+      );
+      // (auth-token file may exist from other tests, so we don't assert its absence globally)
+    });
+
+    it('creates token on public host with --yes', async () => {
+      process.env.AEGIS_HOST = '0.0.0.0';
+      const stdin = new PassThrough();
+      const stdout = new CaptureStream();
+      const stderr = new CaptureStream();
+      const runPromise = runCli(['init', '--yes'], { stdin, stdout, stderr });
+      setImmediate(() => stdin.end());
+      const code = await runPromise;
+      expect(code).toBe(0);
+
+      const configPath = join(projectDir, '.aegis', 'config.yaml');
+      const config = parseYaml(readFileSync(configPath, 'utf-8')) as { clientAuthToken: string };
+      expect(config.clientAuthToken).toBeTruthy();
+    });
+
+    it('creates token on localhost with --force (explicit override)', async () => {
+      process.env.AEGIS_HOST = '127.0.0.1';
+      const stdin = new PassThrough();
+      const stdout = new CaptureStream();
+      const stderr = new CaptureStream();
+      const runPromise = runCli(['init', '--yes', '--force'], { stdin, stdout, stderr });
+      setImmediate(() => stdin.end());
+      const code = await runPromise;
+      expect(code).toBe(0);
+
+      const configPath = join(projectDir, '.aegis', 'config.yaml');
+      const config = parseYaml(readFileSync(configPath, 'utf-8')) as { clientAuthToken: string };
+      // --force should still create a token even on localhost
+      expect(config.clientAuthToken).toBeTruthy();
+    });
+
+    it('skips token creation on localhost with hostname "localhost"', async () => {
+      process.env.AEGIS_HOST = 'localhost';
+      const stdin = new PassThrough();
+      const stdout = new CaptureStream();
+      const stderr = new CaptureStream();
+      const runPromise = runCli(['init', '--yes'], { stdin, stdout, stderr });
+      setImmediate(() => stdin.end());
+      const code = await runPromise;
+      expect(code).toBe(0);
+
+      const configPath = join(projectDir, '.aegis', 'config.yaml');
+      const config = parseYaml(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+      expect(config.clientAuthToken).toBeFalsy();
+    });
+
+    it('skips token creation on IPv6 localhost ::1', async () => {
+      process.env.AEGIS_HOST = '::1';
+      const stdin = new PassThrough();
+      const stdout = new CaptureStream();
+      const stderr = new CaptureStream();
+      const runPromise = runCli(['init', '--yes'], { stdin, stdout, stderr });
+      setImmediate(() => stdin.end());
+      const code = await runPromise;
+      expect(code).toBe(0);
+
+      const configPath = join(projectDir, '.aegis', 'config.yaml');
+      const config = parseYaml(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+      expect(config.clientAuthToken).toBeFalsy();
+    });
   });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -64,6 +64,16 @@ function persistAuthTokenFile(token: string): void {
 }
 
 
+
+
+/**
+ * #3496: Check if a host address is a localhost interface.
+ * Mirrors AuthManager.isLocalhostBinding logic.
+ */
+function isLocalhostHost(host: string): boolean {
+  return host === '127.0.0.1' || host === '::1' || host === 'localhost';
+}
+
 type TemplateType = 'agent' | 'skill' | 'slash-command';
 
 interface TemplateManifestEntry {
@@ -603,7 +613,12 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
     return 1;
   }
 
-  let createAdminToken = !existingToken || force;
+  // #3496: On localhost, default to no token creation (zero-config).
+  const isLocal = isLocalhostHost(currentConfig.host);
+  if (isLocal && !existingToken && !force) {
+    writeLine(io.stdout, '  ℹ️  Localhost detected — skipping auth setup (zero-config mode).');
+  }
+  let createAdminToken = (!isLocal && !existingToken) || force;
   let baseUrl = existingConfig?.baseUrl
     ? normalizeBaseUrl(existingConfig.baseUrl)
     : getConfiguredBaseUrl(currentConfig);
@@ -618,13 +633,15 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
       writeLine(io.stdout, `  Bootstrap config: ${displayConfigPath}`);
       writeLine(io.stdout);
       userName = await promptLine(prompter, 'Your name (for agent identity)', '');
+      // #3496: On localhost, default to NOT creating a token (zero-config).
+      const tokenPromptDefault = isLocal ? false : !existingToken;
       createAdminToken = await promptBoolean(
         prompter,
         io,
         existingToken
           ? 'Create a fresh admin API token for dashboard + CLI access?'
           : 'Create an admin API token for dashboard + CLI access?',
-        !existingToken,
+        tokenPromptDefault,
       );
       baseUrl = await promptBaseUrl(prompter, io, baseUrl);
       byoEnv = await promptByoEnv(prompter, io, existingByoEnv);


### PR DESCRIPTION
## What

When running `ag init` on localhost (127.0.0.1, ::1, or `localhost`), skip admin token creation entirely. The server already bypasses auth for localhost when no tokens are configured.

Fixes #3496

## Changes

- **`src/commands/init.ts`**: Added `isLocalhostHost()` helper. On localhost, `createAdminToken` defaults to `false` (zero-config). Interactive prompt defaults to "no" for token creation on localhost. `--force` still creates a token as explicit override. Public hosts (`0.0.0.0`, etc.) keep existing behavior.
- **`src/__tests__/cli-init.test.ts`**: 5 new tests — localhost IPv4, IPv6, hostname, public host, and `--force` override. Updated 2 existing tests for the new zero-config default.

## Why

The 95% use case (solo dev, localhost) should require zero prompts and zero tokens. The `AuthManager.validate()` localhost bypass (lines 498–506) and `isNoAuthLocalhost` check in server.ts already handle this at runtime — `ag init` was the last piece always creating an unnecessary token.

## Acceptance Criteria

- [x] `ag init` on localhost: zero prompts (with `--yes`), zero tokens, server starts with auth bypassed
- [x] `ag init --force` on localhost: still creates token (explicit override)
- [x] `ag init` on `--host 0.0.0.0`: creates token (current behavior preserved)
- [x] Existing `AuthManager.validate()` localhost bypass preserved (no changes to auth manager)
- [x] Tests: 14/14 pass in `cli-init.test.ts`

## Verification

```
npx tsc --noEmit: ✅ 0 errors
npm run build: ✅
npm test: ✅ 4281 passed (4 pre-existing failures, 8 skipped)
```

## Security Notes

- No change to runtime auth behavior — the localhost bypass already existed
- `--force` provides explicit escape hatch for localhost users who want auth
- Public interface behavior unchanged (always prompts for auth)