### PR TITLE
feat(cli): add ag list, read, kill, status, tail subcommands (#3499)

### DIFF
--- a/src/__tests__/cli-subcommands-3499.test.ts
+++ b/src/__tests__/cli-subcommands-3499.test.ts
@@ -1,0 +1,93 @@
+/**
+ * cli-subcommands-3499.test.ts — Tests for Issue #3499:
+ * CLI subcommands: ag list, ag read, ag kill, ag status, ag tail.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runCli } from '../cli.js';
+
+function mockIO() {
+  return {
+    stdin: { pipe: vi.fn() } as unknown as NodeJS.ReadableStream,
+    stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+    stderr: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+  };
+}
+
+function getStdout(io: ReturnType<typeof mockIO>): string {
+  const write = io.stdout.write as unknown as ReturnType<typeof vi.fn>;
+  return write.mock.calls.map((c: string[]) => c.join('')).join('');
+}
+
+function getStderr(io: ReturnType<typeof mockIO>): string {
+  const write = io.stderr.write as unknown as ReturnType<typeof vi.fn>;
+  return write.mock.calls.map((c: string[]) => c.join('')).join('');
+}
+
+describe('CLI subcommands (#3499)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ag read', () => {
+    it('should error without session ID', async () => {
+      const io = mockIO();
+      const code = await runCli(['read'], io);
+      expect(code).toBe(1);
+      expect(getStderr(io)).toContain('Missing session ID');
+    });
+  });
+
+  describe('ag kill', () => {
+    it('should error without session ID', async () => {
+      const io = mockIO();
+      const code = await runCli(['kill'], io);
+      expect(code).toBe(1);
+      expect(getStderr(io)).toContain('Missing session ID');
+    });
+  });
+
+  describe('ag tail', () => {
+    it('should error without session ID', async () => {
+      const io = mockIO();
+      const code = await runCli(['tail'], io);
+      expect(code).toBe(1);
+      expect(getStderr(io)).toContain('Missing session ID');
+    });
+  });
+
+  describe('ag status', () => {
+    it('should not reject as unknown command', async () => {
+      const io = mockIO();
+      const code = await runCli(['status'], io);
+      // Server may or may not be running — either way, not "Unknown command"
+      const stderr = getStderr(io);
+      expect(stderr).not.toContain('Unknown command: "status"');
+      // If server is running, should succeed (0); if not, should fail (1)
+      expect([0, 1]).toContain(code);
+    });
+  });
+
+  describe('ag list', () => {
+    it('should not reject as unknown command', async () => {
+      const io = mockIO();
+      const code = await runCli(['list'], io);
+      const stderr = getStderr(io);
+      expect(stderr).not.toContain('Unknown command: "list"');
+      expect([0, 1]).toContain(code);
+    });
+  });
+
+  describe('--help includes new subcommands', () => {
+    it('should list all new subcommands in help output', async () => {
+      const io = mockIO();
+      await runCli(['--help'], io);
+      const help = getStdout(io);
+      expect(help).toContain('ag list');
+      expect(help).toContain('ag read');
+      expect(help).toContain('ag kill');
+      expect(help).toContain('ag tail');
+      expect(help).toContain('ag status');
+    });
+  });
+});

--- a/src/__tests__/cli-unknown-command-3079.test.ts
+++ b/src/__tests__/cli-unknown-command-3079.test.ts
@@ -1,9 +1,11 @@
 /**
  * cli-unknown-command-3079.test.ts — Tests for Issue #3079:
  * Unknown CLI commands should error instead of silently creating sessions.
+ *
+ * Updated for #3499: `status` and `list` are now valid subcommands.
  */
 
-import { describe, it, expect, vi, type Mock } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { runCli } from '../cli.js';
 
 function mockIO() {
@@ -17,23 +19,11 @@ function mockIO() {
 describe('CLI unknown command rejection (#3079)', () => {
   it('should reject unknown single-word commands', async () => {
     const io = mockIO();
-    const code = await runCli(['status'], io);
-    expect(code).toBe(1);
-    const stderrWrite = io.stderr.write as unknown as Mock;
-    const stderr = stderrWrite.mock.calls.map((c: string[]) => c.join('')).join('');
-    expect(stderr).toContain('Unknown command: "status"');
-  });
-
-  it('should reject "ag health"', async () => {
-    const io = mockIO();
     const code = await runCli(['health'], io);
     expect(code).toBe(1);
-  });
-
-  it('should reject "ag list"', async () => {
-    const io = mockIO();
-    const code = await runCli(['list'], io);
-    expect(code).toBe(1);
+    const stderrWrite = io.stderr.write as unknown as ReturnType<typeof vi.fn>;
+    const stderr = stderrWrite.mock.calls.map((c: string[]) => c.join('')).join('');
+    expect(stderr).toContain('Unknown command: "health"');
   });
 
   it('should reject "ag version"', async () => {
@@ -64,5 +54,24 @@ describe('CLI unknown command rejection (#3079)', () => {
     const io = mockIO();
     const code = await runCli(['--version'], io);
     expect(code).toBe(0);
+  });
+
+  // #3499: status and list are now valid subcommands
+  it('should route "ag status" to handleStatus (not reject)', async () => {
+    const io = mockIO();
+    const code = await runCli(['status'], io);
+    const stderrWrite = io.stderr.write as unknown as ReturnType<typeof vi.fn>;
+    const stderr = stderrWrite.mock.calls.map((c: string[]) => c.join('')).join('');
+    expect(stderr).not.toContain('Unknown command: "status"');
+    expect([0, 1]).toContain(code);
+  });
+
+  it('should route "ag list" to handleList (not reject)', async () => {
+    const io = mockIO();
+    const code = await runCli(['list'], io);
+    const stderrWrite = io.stderr.write as unknown as ReturnType<typeof vi.fn>;
+    const stderr = stderrWrite.mock.calls.map((c: string[]) => c.join('')).join('');
+    expect(stderr).not.toContain('Unknown command: "list"');
+    expect([0, 1]).toContain(code);
   });
 });

--- a/src/cli-http.ts
+++ b/src/cli-http.ts
@@ -1,0 +1,85 @@
+/**
+ * cli-http.ts — Shared HTTP helpers for CLI subcommands.
+ *
+ * Centralises baseUrl resolution, auth token lookup, and common request
+ * patterns so that `ag list`, `ag read`, `ag kill`, `ag status`, and
+ * `ag tail` don't duplicate boilerplate.
+ */
+
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { deriveBaseUrl, getConfiguredBaseUrl } from './base-url.js';
+import { loadConfig } from './config.js';
+import { parseIntSafe } from './validation.js';
+
+export interface CliIO {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+export function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
+  stream.write(`${text}\n`);
+}
+
+/** Resolve auth token from env, config, or legacy files. */
+export async function resolveAuthToken(): Promise<string> {
+  const envToken = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN;
+  if (envToken) return envToken;
+
+  // ~/.aegis/auth-token file
+  try {
+    const tokenPath = join(homedir(), '.aegis', 'auth-token');
+    const token = readFileSync(tokenPath, 'utf-8').trim();
+    if (token) return token;
+  } catch { /* not found */ }
+
+  try {
+    const config = await loadConfig();
+    if (config.clientAuthToken) return config.clientAuthToken;
+    if (config.authToken) return config.authToken;
+  } catch { /* no config */ }
+
+  return '';
+}
+
+/** Resolve base URL from --port flag or config. */
+export async function resolveBaseUrl(args: string[]): Promise<string> {
+  const portIdx = args.indexOf('--port');
+  if (portIdx !== -1 && args[portIdx + 1]) {
+    return deriveBaseUrl('127.0.0.1', parseIntSafe(args[portIdx + 1], 9100));
+  }
+  const config = await loadConfig();
+  return getConfiguredBaseUrl(config);
+}
+
+/** Build headers with optional auth. */
+export function buildHeaders(authToken: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+  return headers;
+}
+
+/** Check if the server is reachable. */
+export async function isServerHealthy(baseUrl: string, authToken?: string): Promise<boolean> {
+  try {
+    const headers: Record<string, string> = {};
+    if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+    const res = await fetch(`${baseUrl}/v1/health`, { headers, signal: AbortSignal.timeout(3000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Ensure the server is reachable, printing an error and returning false if not. */
+export async function requireServer(baseUrl: string, authToken: string, io: CliIO): Promise<boolean> {
+  if (!(await isServerHealthy(baseUrl, authToken))) {
+    writeLine(io.stderr, `  ❌ Cannot connect to Aegis at ${baseUrl}.`);
+    writeLine(io.stderr, '     Start the server first: ag');
+    return false;
+  }
+  return true;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,11 @@ import { handleLogin } from './commands/login.js';
 import { handleLogout } from './commands/logout.js';
 import { handleWhoami } from './commands/whoami.js';
 import { handleRun } from './commands/run.js';
+import { handleList } from './commands/list.js';
+import { handleRead } from './commands/read.js';
+import { handleKill } from './commands/kill.js';
+import { handleStatus } from './commands/status.js';
+import { handleTail } from './commands/tail.js';
 import {
   AcpBinaryResolutionError,
   resolveClaudeAgentAcpBinary,
@@ -210,12 +215,12 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
   }
 
   writeLine(io.stdout);
-  // Issue #2996: Include auth header in curl output when auth is configured.
-  const curlAuth = authToken ? ` -H "Authorization: Bearer ${authToken}"` : '';
+  writeLine(io.stdout);
   writeLine(io.stdout, '  Next steps:');
-  writeLine(io.stdout, `    Status:   curl${curlAuth} ${baseUrl}/v1/sessions/${sessionId}/health`);
-  writeLine(io.stdout, `    Read:     curl${curlAuth} ${baseUrl}/v1/sessions/${sessionId}/read`);
-  writeLine(io.stdout, `    Kill:     curl -X DELETE${curlAuth} ${baseUrl}/v1/sessions/${sessionId}`);
+  writeLine(io.stdout, `    Status:   ag status`);
+  writeLine(io.stdout, `    Read:     ag read ${sessionId}`);
+  writeLine(io.stdout, `    Tail:     ag tail ${sessionId}`);
+  writeLine(io.stdout, `    Kill:     ag kill ${sessionId}`);
   return 0;
 }
 
@@ -257,6 +262,15 @@ function printHelp(io: CliIO): void {
     ag mcp                 Start MCP stdio server
     ag mcp --port 3000     Custom Aegis API port
     claude mcp add aegis -- ag mcp
+
+  Sessions:
+    ag list                 List active sessions
+    ag list --status active  Filter by status
+    ag read <id>            Read session output
+    ag tail <id>            Follow session output in real-time
+    ag kill <id>            Terminate a session
+    ag status               Show server health + session summary
+
 
   Auth (OAuth2 device flow):
     ag login               Authenticate via your IdP (requires OIDC config)
@@ -344,8 +358,25 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
     return handleRun(argv.slice(1), io);
   }
 
-  // Issue #3079: Reject single-word args that look like unknown commands.
-  // Known subcommands are handled above; single-word non-flag args are likely
+  if (argv[0] === 'list') {
+    return handleList(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'read') {
+    return handleRead(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'kill') {
+    return handleKill(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'status') {
+    return handleStatus(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'tail') {
+    return handleTail(argv.slice(1), io);
+  }
   // typos (e.g. "ag status", "ag health") rather than intentional prompts.
   // Multi-word args or quoted strings are treated as prompts (backward compat).
   if (argv.length === 1 && !argv[0].startsWith('-') && !argv[0].includes(' ')) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -215,7 +215,6 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
   }
 
   writeLine(io.stdout);
-  writeLine(io.stdout);
   writeLine(io.stdout, '  Next steps:');
   writeLine(io.stdout, `    Status:   ag status`);
   writeLine(io.stdout, `    Read:     ag read ${sessionId}`);

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -26,7 +26,7 @@ export async function handleKill(args: string[], io: CliIO): Promise<number> {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
     return 1;
   }
 

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -1,0 +1,35 @@
+/**
+ * commands/kill.ts — `ag kill <id>` — Terminate a session.
+ *
+ * Wraps DELETE /v1/sessions/:id.
+ */
+
+import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+
+export async function handleKill(args: string[], io: CliIO): Promise<number> {
+  const sessionId = args.find(a => !a.startsWith('-'));
+  if (!sessionId) {
+    writeLine(io.stderr, '  ❌ Missing session ID. Usage: ag kill <session-id>');
+    return 1;
+  }
+
+  const baseUrl = await resolveBaseUrl(args);
+  const authToken = await resolveAuthToken();
+  if (!(await requireServer(baseUrl, authToken, io))) return 1;
+
+  const headers = buildHeaders(authToken);
+  const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}`, {
+    method: 'DELETE',
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    return 1;
+  }
+
+  writeLine(io.stdout, `  ✅ Session ${sessionId.slice(0, 8)}… killed.`);
+  return 0;
+}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,0 +1,47 @@
+/**
+ * commands/list.ts — `ag list` — List active sessions.
+ *
+ * Wraps GET /v1/sessions with optional status filter.
+ */
+
+import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+
+export async function handleList(args: string[], io: CliIO): Promise<number> {
+  const baseUrl = await resolveBaseUrl(args);
+  const authToken = await resolveAuthToken();
+  if (!(await requireServer(baseUrl, authToken, io))) return 1;
+
+  const headers = buildHeaders(authToken);
+  const params = new URLSearchParams();
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--status' && args[i + 1]) {
+      params.set('status', args[++i]!);
+    }
+  }
+
+  const url = `${baseUrl}/v1/sessions${params.toString() ? '?' + params : ''}`;
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(10_000) });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    return 1;
+  }
+
+  const body = await res.json() as { sessions?: any[]; data?: any[] };
+  const sessions = body.sessions ?? body.data ?? [];
+
+  if (sessions.length === 0) {
+    writeLine(io.stdout, '  No sessions found.');
+    return 0;
+  }
+
+  writeLine(io.stdout, `  Sessions (${sessions.length}):`);
+  for (const s of sessions) {
+    const id = (s.id as string).slice(0, 8);
+    const name = s.displayName ?? s.name ?? 'unnamed';
+    const status = s.status ?? 'unknown';
+    writeLine(io.stdout, `    ${id}…  ${status.padEnd(12)}  ${name}`);
+  }
+  return 0;
+}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -24,7 +24,7 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
     return 1;
   }
 
@@ -38,7 +38,7 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
 
   writeLine(io.stdout, `  Sessions (${sessions.length}):`);
   for (const s of sessions) {
-    const id = (s.id as string).slice(0, 8);
+    const id = (s.id as string)?.slice(0, 8) ?? "????????";
     const name = s.displayName ?? s.name ?? 'unnamed';
     const status = s.status ?? 'unknown';
     writeLine(io.stdout, `    ${id}…  ${status.padEnd(12)}  ${name}`);

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -1,0 +1,70 @@
+/**
+ * commands/read.ts — `ag read <id>` — Read session output.
+ *
+ * Wraps GET /v1/sessions/:id/read with optional pagination.
+ */
+
+import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+
+export async function handleRead(args: string[], io: CliIO): Promise<number> {
+  const sessionId = args.find(a => !a.startsWith('-'));
+  if (!sessionId) {
+    writeLine(io.stderr, '  ❌ Missing session ID. Usage: ag read <session-id>');
+    return 1;
+  }
+
+  const baseUrl = await resolveBaseUrl(args);
+  const authToken = await resolveAuthToken();
+  if (!(await requireServer(baseUrl, authToken, io))) return 1;
+
+  const headers = buildHeaders(authToken);
+
+  // Parse optional flags
+  let page = 1;
+  let limit = 200;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--page' && args[i + 1]) page = parseInt(args[++i]!, 10) || 1;
+    if (args[i] === '--limit' && args[i + 1]) limit = parseInt(args[++i]!, 10) || 200;
+  }
+
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+  const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/read?${params}`, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    return 1;
+  }
+
+  const body = await res.json() as { messages?: any[]; data?: any[]; page?: number; totalPages?: number };
+  const messages = body.messages ?? body.data ?? [];
+
+  if (messages.length === 0) {
+    writeLine(io.stdout, '  No messages yet.');
+    return 0;
+  }
+
+  for (const msg of messages) {
+    const role = msg.role ?? 'unknown';
+    const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+    const prefix = role === 'assistant' ? '🤖' : role === 'user' ? '👤' : '⚙️';
+    // Truncate long messages for terminal readability
+    const lines = content.split('\n');
+    const displayLines = lines.slice(0, 50);
+    for (const line of displayLines) {
+      writeLine(io.stdout, `  ${prefix} ${line}`);
+    }
+    if (lines.length > 50) {
+      writeLine(io.stdout, `  ${prefix} ... (${lines.length - 50} more lines)`);
+    }
+  }
+
+  if (body.totalPages && body.page && body.totalPages > body.page) {
+    writeLine(io.stdout, `\n  Page ${body.page}/${body.totalPages}. Use --page ${body.page + 1} for more.`);
+  }
+
+  return 0;
+}

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -35,7 +35,7 @@ export async function handleRead(args: string[], io: CliIO): Promise<number> {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
     return 1;
   }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,51 @@
+/**
+ * commands/status.ts — `ag status` — Show server health and session summary.
+ *
+ * Wraps GET /v1/health and GET /v1/sessions/stats.
+ */
+
+import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+
+export async function handleStatus(args: string[], io: CliIO): Promise<number> {
+  const baseUrl = await resolveBaseUrl(args);
+  const authToken = await resolveAuthToken();
+  if (!(await requireServer(baseUrl, authToken, io))) return 1;
+
+  const headers = buildHeaders(authToken);
+
+  // Fetch health
+  const healthRes = await fetch(`${baseUrl}/v1/health`, { headers, signal: AbortSignal.timeout(5000) });
+  if (!healthRes.ok) {
+    writeLine(io.stderr, `  ❌ Health check failed: ${healthRes.statusText}`);
+    return 1;
+  }
+  const health = await healthRes.json() as Record<string, any>;
+
+  writeLine(io.stdout, '  Aegis Status');
+  writeLine(io.stdout, '  ────────────');
+  writeLine(io.stdout, `  Version:   ${health.version ?? 'unknown'}`);
+  writeLine(io.stdout, `  Status:    ${health.status ?? 'unknown'}`);
+  writeLine(io.stdout, `  Uptime:    ${health.uptime != null ? formatUptime(health.uptime) : 'unknown'}`);
+  if (health.port) writeLine(io.stdout, `  Port:      ${health.port}`);
+
+  // Fetch session stats
+  try {
+    const statsRes = await fetch(`${baseUrl}/v1/sessions/stats`, { headers, signal: AbortSignal.timeout(5000) });
+    if (statsRes.ok) {
+      const stats = await statsRes.json() as Record<string, any>;
+      writeLine(io.stdout, `  Sessions:  ${stats.active ?? stats.running ?? 0} active / ${stats.total ?? 0} total`);
+    }
+  } catch {
+    // Stats endpoint may not exist — skip
+  }
+
+  return 0;
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}

--- a/src/commands/tail.ts
+++ b/src/commands/tail.ts
@@ -1,0 +1,94 @@
+/**
+ * commands/tail.ts — `ag tail <id>` — Follow session output in real-time.
+ *
+ * Connects to GET /v1/sessions/:id/events SSE stream and prints events.
+ */
+
+import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+
+export async function handleTail(args: string[], io: CliIO): Promise<number> {
+  const sessionId = args.find(a => !a.startsWith('-'));
+  if (!sessionId) {
+    writeLine(io.stderr, '  ❌ Missing session ID. Usage: ag tail <session-id>');
+    return 1;
+  }
+
+  const baseUrl = await resolveBaseUrl(args);
+  const authToken = await resolveAuthToken();
+  if (!(await requireServer(baseUrl, authToken, io))) return 1;
+
+  const headers = buildHeaders(authToken);
+  headers['Accept'] = 'text/event-stream';
+
+  writeLine(io.stdout, `  Tailing session ${sessionId.slice(0, 8)}… (Ctrl+C to stop)`);
+
+  const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/events`, {
+    headers,
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    return 1;
+  }
+
+  if (!res.body) {
+    writeLine(io.stderr, '  ❌ No response body — SSE not supported.');
+    return 1;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          const data = line.slice(6).trim();
+          if (!data || data === '[DONE]') continue;
+          try {
+            const event = JSON.parse(data);
+            printEvent(event, io);
+          } catch {
+            writeLine(io.stdout, `  ${data}`);
+          }
+        }
+      }
+    }
+  } catch (e: unknown) {
+    if ((e as any).name !== 'AbortError') {
+      writeLine(io.stderr, `  Connection closed.`);
+    }
+  }
+
+  return 0;
+}
+
+function printEvent(event: Record<string, any>, io: CliIO): void {
+  const type = event.type ?? event.event ?? 'message';
+
+  if (type === 'assistant' || type === 'message') {
+    const content = event.content ?? event.text ?? event.delta ?? '';
+    if (content) writeLine(io.stdout, `  🤖 ${content}`);
+  } else if (type === 'tool_use' || type === 'tool_result') {
+    const name = event.name ?? event.toolName ?? 'tool';
+    writeLine(io.stdout, `  🔧 ${type}: ${name}`);
+  } else if (type === 'thinking') {
+    writeLine(io.stdout, `  💭 thinking...`);
+  } else if (type === 'error') {
+    writeLine(io.stderr, `  ❌ ${event.message ?? event.error ?? 'error'}`);
+  } else {
+    // Generic — show type and any text
+    const text = event.text ?? event.content ?? event.message;
+    if (text) writeLine(io.stdout, `  [${type}] ${text}`);
+  }
+}

--- a/src/commands/tail.ts
+++ b/src/commands/tail.ts
@@ -22,14 +22,29 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
 
   writeLine(io.stdout, `  Tailing session ${sessionId.slice(0, 8)}… (Ctrl+C to stop)`);
 
-  const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/events`, {
-    headers,
-    signal: AbortSignal.timeout(30_000),
-  });
+  // Use SIGINT-wired AbortController instead of fixed timeout.
+  // tail is meant to follow long-running sessions until the user hits Ctrl+C.
+  const abortController = new AbortController();
+  const onSigInt = () => {
+    abortController.abort();
+    writeLine(io.stdout, '\n  Stopped.');
+  };
+  process.once('SIGINT', onSigInt);
+
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/events`, {
+      headers,
+      signal: abortController.signal,
+    });
+  } catch (e: unknown) {
+    if ((e as Error).name === 'AbortError') return 0;
+    throw e;
+  }
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    writeLine(io.stderr, `  ❌ ${((err as any).error) || res.statusText}`);
+    writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
     return 1;
   }
 
@@ -65,9 +80,11 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
       }
     }
   } catch (e: unknown) {
-    if ((e as any).name !== 'AbortError') {
+    if ((e as Error).name !== 'AbortError') {
       writeLine(io.stderr, `  Connection closed.`);
     }
+  } finally {
+    process.removeListener('SIGINT', onSigInt);
   }
 
   return 0;


### PR DESCRIPTION
## Issue
#3499 — CLI subcommands (F17, F19)

## What
Adds 5 new CLI subcommands wrapping the REST API:

| Command | Endpoint |
|---------|----------|
| `ag list` | `GET /v1/sessions` |
| `ag read <id>` | `GET /v1/sessions/:id/read` |
| `ag kill <id>` | `DELETE /v1/sessions/:id` |
| `ag status` | `GET /v1/health` + `/v1/sessions/stats` |
| `ag tail <id>` | `GET /v1/sessions/:id/events` (SSE) |

Also:
- Updates `ag create` "Next steps" footer to use native commands instead of `curl`
- Adds `src/cli-http.ts` shared helper for auth/baseUrl resolution
- Updates `--help` with new Sessions section
- Updates `cli-unknown-command-3079` test: `status`/`list` are now valid

## Acceptance
- [x] All 5 subcommands work end-to-end
- [x] `ag create` footer shows native commands, not curl
- [x] `ag --help` lists all new subcommands

## Verification
```
tsc --noEmit: ✅
npm run build: ✅
Tests: 14 passed (cli-subcommands-3499 + cli-unknown-command-3079)
Commit: 2b710be1
```

## Files changed
- `src/cli-http.ts` (new) — shared HTTP helpers
- `src/commands/list.ts` (new)
- `src/commands/read.ts` (new)
- `src/commands/kill.ts` (new)
- `src/commands/status.ts` (new)
- `src/commands/tail.ts` (new)
- `src/cli.ts` — wire subcommands + update help + update create footer
- `src/__tests__/cli-subcommands-3499.test.ts` (new)
- `src/__tests__/cli-unknown-command-3079.test.ts` — updated
