### PR TITLE
docs(readme): remove 🚧 Upcoming notice from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 
 ## Quick Start
 
-> 🚧 **Upcoming** — This flow tracks [#3489](https://github.com/OneStepAt4time/aegis/issues/3489) (Zero-Config Epic). See the [current getting-started guide](docs/getting-started.md) for the step-by-step setup that works today.
 
 One command. Zero config. Claude Code responds in your terminal.
 


### PR DESCRIPTION
Removes the `🚧 Upcoming` notice from Quick Start per Argus review on #3504.

The zero-config `ag run` flow is live and working — no need to redirect to the old getting-started guide.

One-line deletion. No other changes.