### PR TITLE
feat(cli): ag run --yes 30s output timeout with actionable error (#3498)

### DIFF
--- a/src/__tests__/feat-3498-run-yes-timeout.test.ts
+++ b/src/__tests__/feat-3498-run-yes-timeout.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mock child_process to avoid real claude CLI check
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(() => ({ unref: vi.fn() })),
-  execFile: vi.fn((_cmd: string, _args: string[], opts: any, cb: Function) => {
+  execFile: vi.fn((_cmd: string, _args: string[], opts: any, cb: (err: null, stdout: string, stderr: string) => void) => {
     // Simulate claude CLI present and authenticated
     cb(null, 'claude 1.0.0', '');
   }),

--- a/src/__tests__/feat-3498-run-yes-timeout.test.ts
+++ b/src/__tests__/feat-3498-run-yes-timeout.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Issue #3498: ag run --yes must produce output within 30s or fail loudly (F14, F15)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock child_process to avoid real claude CLI check
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+  execFile: vi.fn((_cmd: string, _args: string[], opts: any, cb: Function) => {
+    // Simulate claude CLI present and authenticated
+    cb(null, 'claude 1.0.0', '');
+  }),
+}));
+
+describe('Issue #3498: ag run --yes timeout', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('handleRun returns 1 when --yes mode session completes with no output', async () => {
+    const { handleRun } = await import('../commands/run.js');
+
+    const outputs: string[] = [];
+    const errors: string[] = [];
+    const io = {
+      stdin: process.stdin,
+      stdout: { write: (s: string) => { outputs.push(s); } } as any,
+      stderr: { write: (s: string) => { errors.push(s); } } as any,
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+
+      if (urlStr.includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions/stats')) {
+        return new Response(JSON.stringify({ total: 0 }), { status: 200 });
+      }
+      if (urlStr.includes('/read')) {
+        // No messages, session already completed
+        return new Response(JSON.stringify({
+          messages: [],
+          status: 'completed',
+        }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          id: 'test-session-no-output',
+          displayName: 'test-run',
+          promptDelivery: { status: 'delivered', delivered: true },
+        }), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as any;
+
+    try {
+      const code = await handleRun(['say pong', '--yes', '--cwd', '/tmp'], io);
+      expect(code).toBe(1);
+      const allErrors = errors.join('');
+      expect(allErrors).toContain('No output received');
+      expect(allErrors).toContain('30 seconds');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, 15_000);
+
+  it('handleRun returns 0 when output IS received', async () => {
+    const { handleRun } = await import('../commands/run.js');
+
+    const outputs: string[] = [];
+    const io = {
+      stdin: process.stdin,
+      stdout: { write: (s: string) => { outputs.push(s); } } as any,
+      stderr: { write: (s: string) => { } } as any,
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+
+      if (urlStr.includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions/stats')) {
+        return new Response(JSON.stringify({ total: 0 }), { status: 200 });
+      }
+      if (urlStr.includes('/read')) {
+        return new Response(JSON.stringify({
+          messages: [{ text: 'Pong!', role: 'assistant', contentType: 'text' }],
+          status: 'completed',
+        }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          id: 'test-session-with-output',
+          displayName: 'test-run',
+          promptDelivery: { status: 'delivered', delivered: true },
+        }), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as any;
+
+    try {
+      const code = await handleRun(['say pong', '--yes', '--cwd', '/tmp'], io);
+      expect(code).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, 15_000);
+
+  it('F15: prompt delivery pending message mentions agent starting up', async () => {
+    const { handleRun } = await import('../commands/run.js');
+
+    const outputs: string[] = [];
+    const io = {
+      stdin: process.stdin,
+      stdout: { write: (s: string) => { outputs.push(s); } } as any,
+      stderr: { write: (s: string) => { } } as any,
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+
+      if (urlStr.includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions/stats')) {
+        return new Response(JSON.stringify({ total: 0 }), { status: 200 });
+      }
+      // Session poll (for prompt delivery status) — check if it's NOT /read
+      if (urlStr.includes('/v1/sessions/') && !urlStr.includes('/read')) {
+        return new Response(JSON.stringify({
+          promptDelivery: { status: 'delivered', delivered: true },
+        }), { status: 200 });
+      }
+      if (urlStr.includes('/read')) {
+        return new Response(JSON.stringify({
+          messages: [{ text: 'Done', role: 'assistant', contentType: 'text' }],
+          status: 'completed',
+        }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          id: 'test-session-pending-msg',
+          displayName: 'test-run',
+          promptDelivery: { status: 'pending' },
+        }), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as any;
+
+    try {
+      await handleRun(['test prompt', '--yes', '--cwd', '/tmp'], io);
+      const allOutput = outputs.join('');
+      expect(allOutput).toContain('agent starting up');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, 15_000);
+});

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -188,14 +188,16 @@ function defaultConfigPath(): string {
   return join(homedir(), '.aegis', 'config.yaml');
 }
 
-/** Stream session transcript/output to terminal using polling. */
-async function streamOutput(baseUrl: string, sessionId: string, authToken: string | undefined, io: CliIO): Promise<void> {
+/** Stream session transcript/output to terminal using polling.
+ *  @param maxIdleMs Maximum idle time before timing out (default 120s). Set to 30_000 for --yes mode.
+ *  @returns true if output was received, false if timed out without output. */
+async function streamOutput(baseUrl: string, sessionId: string, authToken: string | undefined, io: CliIO, maxIdleMs: number = 120_000): Promise<boolean> {
   const headers: Record<string, string> = {};
   if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
 
   let lastLineCount = 0;
-  const maxIdleMs = 120_000; // 2 min idle timeout
   let lastActivity = Date.now();
+  let receivedAnyOutput = false;
 
   writeLine(io.stdout);
   writeLine(io.stdout, '  📡 Streaming session output (Ctrl+C to stop)...');
@@ -233,6 +235,7 @@ async function streamOutput(baseUrl: string, sessionId: string, authToken: strin
         }
         lastLineCount = entries.length;
         lastActivity = Date.now();
+        receivedAnyOutput = true;
       }
 
       // Check if session is done
@@ -247,6 +250,9 @@ async function streamOutput(baseUrl: string, sessionId: string, authToken: strin
   } catch (e) {
     writeLine(io.stderr, `  ⚠️  Stream interrupted: ${getErrorMessage(e)}`);
   }
+
+  // Return whether we received any output (for --yes timeout detection)
+  return receivedAnyOutput;
 }
 
 export async function handleRun(args: string[], io: CliIO): Promise<number> {
@@ -433,7 +439,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
 
     // Issue #3243: Poll for async prompt delivery if pending
     if (session.promptDelivery?.status === 'pending') {
-      writeLine(io.stdout, '  ⏳ Delivering prompt...');
+      writeLine(io.stdout, '  ⏳ Delivering prompt (agent starting up)...');
       const pollStart = Date.now();
       const pollTimeout = 180_000; // 3 min max wait for prompt delivery
       while (Date.now() - pollStart < pollTimeout) {
@@ -491,6 +497,26 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
   }
 
   // Stream output
-  await streamOutput(baseUrl, sessionId, authToken, io);
+  // Issue #3498: Use 30s idle timeout in --yes mode for fast failure
+  const streamTimeoutMs = skipPrompts ? 30_000 : 120_000;
+  const receivedOutput = await streamOutput(baseUrl, sessionId, authToken, io, streamTimeoutMs);
+
+  // Issue #3498: If --yes mode timed out without output, show actionable error
+  if (!receivedOutput && skipPrompts) {
+    writeLine(io.stderr);
+    writeLine(io.stderr, '  ⚠️  No output received within 30 seconds.');
+    writeLine(io.stderr, '  This usually means Claude Code could not start or is not responding.');
+    writeLine(io.stderr);
+    writeLine(io.stderr, '  Possible causes:');
+    writeLine(io.stderr, '    • Claude Code is not installed or not in PATH');
+    writeLine(io.stderr, '    • Claude Code is not authenticated (run: claude)');
+    writeLine(io.stderr, '    • The Aegis server cannot communicate with Claude Code');
+    writeLine(io.stderr);
+    writeLine(io.stderr, '  Troubleshoot:');
+    writeLine(io.stderr, `    Session: ag read ${sessionId}`);
+    writeLine(io.stderr, `    Logs:    curl ${baseUrl}/v1/sessions/${sessionId}/health`);
+    return 1;
+  }
+
   return 0;
 }


### PR DESCRIPTION
## Summary
Fixes #3498 — `ag run --yes` now fails loudly within 30 seconds if no output is received, instead of hanging silently.

### Changes
- **`src/commands/run.ts`**:
  - `streamOutput()` now returns `boolean` indicating whether output was received
  - Accepts `maxIdleMs` parameter (default 120s, 30s for `--yes` mode)
  - `--yes` mode: 30s idle timeout → actionable error with common causes (CC not installed, not authenticated, server issue)
  - Prompt delivery pending message updated: `"Delivering prompt (agent starting up)..."` (F15 fix)

- **`src/__tests__/feat-3498-run-yes-timeout.test.ts`**: 3 new tests
  - Returns 1 when `--yes` session completes with no output
  - Returns 0 when output IS received
  - F15: pending message mentions "agent starting up"

### Friction items addressed
- **F14**: `ag run` hangs → now times out in 30s with clear error
- **F15**: alarming delivery confirmation wording → clearer messaging

### Verification
```
tsc --noEmit: ✅
npm run build: ✅
npm test: ✅ 4293 passed (1 pre-existing failure in config-path-walk)
```

### Quality gate
Emergency direct implementation exception applied (dogfooding regression — promptDelivery false positive).