### PR TITLE
docs: add ag auth migrate CLI reference (#3516)

### DIFF
--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -125,6 +125,23 @@ claude mcp add aegis -- ag mcp
 
 For other MCP hosts (Cursor, Windsurf), see the [Cursor integration](./cursor.md) or [Windsurf integration](./windsurf.md).
 
+### `ag auth migrate` — Migrate Auth Token
+
+Migrate a `clientAuthToken` from `config.yaml` to the canonical auth-token file (single source of truth).
+
+```bash
+ag auth migrate
+```
+
+**What it does:**
+
+1. Reads `clientAuthToken` from `.aegis/config.yaml`
+2. Writes the token to the canonical auth-token path
+3. Removes `clientAuthToken` from config.yaml
+4. Reports what was migrated
+
+Run this after upgrading from a version that stored tokens in config. If the token is already in the canonical location, it reports that and exits cleanly.
+
 ### `ag list` — List Sessions
 
 List active and recent sessions.


### PR DESCRIPTION
Documents `ag auth migrate` introduced in #3516.

- Adds CLI reference section to `docs/integrations/cli.md`
- Explains migration from config.yaml to canonical auth-token file

Accuracy gap found during heartbeat scan.