### PR TITLE
feat(dashboard): add CLI shortcuts panel with copy-to-clipboard (#3492)

### DIFF
--- a/dashboard/src/components/session/CliShortcutsPanel.tsx
+++ b/dashboard/src/components/session/CliShortcutsPanel.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { ChevronDown, Copy, Check } from 'lucide-react';
+import { useT } from '../../i18n/context.js';
+
+export interface CliShortcutsPanelProps {
+  sessionId: string;
+  createdAt?: number;
+}
+
+interface Command {
+  labelKey: string;
+  fullCmd: string;
+  displayCmd: string;
+}
+
+export function CliShortcutsPanel({ sessionId, createdAt }: CliShortcutsPanelProps) {
+  const t = useT();
+  const isNew = createdAt != null && Date.now() - createdAt < 60_000;
+  const [open, setOpen] = useState(isNew);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const shortId = sessionId.slice(0, 8);
+
+  const commands: Command[] = [
+    { labelKey: 'cliShortcuts.viewOutput',  fullCmd: `ag read ${sessionId}`,   displayCmd: `ag read ${shortId}`   },
+    { labelKey: 'cliShortcuts.streamLive',  fullCmd: `ag tail ${sessionId}`,   displayCmd: `ag tail ${shortId}`   },
+    { labelKey: 'cliShortcuts.checkStatus', fullCmd: `ag status ${sessionId}`, displayCmd: `ag status ${shortId}` },
+    { labelKey: 'cliShortcuts.killSession', fullCmd: `ag kill ${sessionId}`,   displayCmd: `ag kill ${shortId}`   },
+    { labelKey: 'cliShortcuts.listAll',     fullCmd: 'ag list',                displayCmd: 'ag list'              },
+  ];
+
+  const handleCopy = async (cmd: Command) => {
+    await navigator.clipboard.writeText(cmd.fullCmd);
+    setCopiedKey(cmd.labelKey);
+    setTimeout(() => setCopiedKey(null), 2000);
+  };
+
+  return (
+    <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-3 py-2.5 text-sm font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-surface-hover)]"
+        aria-expanded={open}
+        aria-label={t('cliShortcuts.title')}
+      >
+        <span>{t('cliShortcuts.title')}</span>
+        <ChevronDown
+          className={`h-4 w-4 text-[var(--color-text-muted)] transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="border-t border-[var(--color-void-lighter)] p-3 space-y-1">
+          {commands.map((cmd) => {
+            const isCopied = copiedKey === cmd.labelKey;
+            return (
+              <div key={cmd.labelKey} className="flex items-center gap-2 rounded px-1 py-1">
+                <span className="w-28 shrink-0 text-xs text-[var(--color-text-muted)]">
+                  {t(cmd.labelKey)}
+                </span>
+                <code
+                  className="flex-1 truncate rounded bg-[var(--color-void)] px-2 py-0.5 font-mono text-xs text-[var(--color-text-primary)]"
+                  title={cmd.fullCmd}
+                >
+                  {cmd.displayCmd}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => handleCopy(cmd)}
+                  aria-label={isCopied ? t('cliShortcuts.copied') : t('cliShortcuts.copy')}
+                  className="flex min-h-[28px] items-center justify-center gap-1 rounded px-1.5 text-xs text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)]"
+                >
+                  {isCopied ? (
+                    <>
+                      <Check className="h-3.5 w-3.5 text-[var(--color-success)]" />
+                      <span className="text-[var(--color-success)]">{t('cliShortcuts.copied')}</span>
+                    </>
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/session/__tests__/CliShortcutsPanel.test.tsx
+++ b/dashboard/src/components/session/__tests__/CliShortcutsPanel.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * CliShortcutsPanel.test.tsx — Tests for contextual CLI command shortcuts panel.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CliShortcutsPanel } from '../CliShortcutsPanel';
+
+const SESSION_ID = 'abcdef1234567890';
+const SHORT_ID = SESSION_ID.slice(0, 8); // 'abcdef12'
+
+describe('CliShortcutsPanel', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('renders all 5 commands with correct command text', () => {
+    render(<CliShortcutsPanel sessionId={SESSION_ID} />);
+
+    // expand the panel first (collapsed by default on "old" sessions)
+    const toggle = screen.getByRole('button', { name: /CLI Shortcuts/i });
+    fireEvent.click(toggle);
+
+    expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
+    expect(screen.getByText(`ag tail ${SHORT_ID}`)).toBeDefined();
+    expect(screen.getByText(`ag status ${SHORT_ID}`)).toBeDefined();
+    expect(screen.getByText(`ag kill ${SHORT_ID}`)).toBeDefined();
+    expect(screen.getByText('ag list')).toBeDefined();
+  });
+
+  it('copy button writes full session ID to clipboard and shows feedback', async () => {
+    render(<CliShortcutsPanel sessionId={SESSION_ID} />);
+
+    const toggle = screen.getByRole('button', { name: /CLI Shortcuts/i });
+    fireEvent.click(toggle);
+
+    const copyButtons = screen.getAllByRole('button', { name: /copy/i });
+    await act(async () => {
+      fireEvent.click(copyButtons[0]);
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`ag read ${SESSION_ID}`);
+    expect(screen.getByText('Copied!')).toBeDefined();
+  });
+
+  it('is collapsed by default when session is old', () => {
+    render(<CliShortcutsPanel sessionId={SESSION_ID} createdAt={Date.now() - 120_000} />);
+
+    // panel body should not be visible
+    expect(screen.queryByText(`ag read ${SHORT_ID}`)).toBeNull();
+  });
+
+  it('expands on header click', () => {
+    render(<CliShortcutsPanel sessionId={SESSION_ID} createdAt={Date.now() - 120_000} />);
+
+    expect(screen.queryByText(`ag read ${SHORT_ID}`)).toBeNull();
+
+    const toggle = screen.getByRole('button', { name: /CLI Shortcuts/i });
+    fireEvent.click(toggle);
+
+    expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
+  });
+
+  it('auto-expands when session is less than 60 seconds old', () => {
+    render(<CliShortcutsPanel sessionId={SESSION_ID} createdAt={Date.now() - 10_000} />);
+
+    // Should be expanded without any click
+    expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
+  });
+
+  it('displays truncated session ID (8 chars) in code but full ID in title attribute', () => {
+    render(<CliShortcutsPanel sessionId={SESSION_ID} />);
+
+    const toggle = screen.getByRole('button', { name: /CLI Shortcuts/i });
+    fireEvent.click(toggle);
+
+    const codeEl = screen.getByText(`ag read ${SHORT_ID}`);
+    expect(codeEl.closest('[title]')?.getAttribute('title')).toBe(`ag read ${SESSION_ID}`);
+  });
+});

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -668,6 +668,17 @@ export const en = {
     allSessions: 'All sessions',
     checkingAuth: 'Checking authentication',
   },
+
+  cliShortcuts: {
+    title: 'CLI Shortcuts',
+    viewOutput: 'View output',
+    streamLive: 'Stream live',
+    checkStatus: 'Check status',
+    killSession: 'Kill session',
+    listAll: 'List all sessions',
+    copied: 'Copied!',
+    copy: 'Copy',
+  },
 } as const;
 
 export type Messages = typeof en;

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -661,4 +661,15 @@ export const it = {
     allSessions: 'Tutte le sessioni',
     checkingAuth: 'Verifica autenticazione',
   },
+
+  cliShortcuts: {
+    title: 'Scorciatoie CLI',
+    viewOutput: 'Visualizza output',
+    streamLive: 'Stream in diretta',
+    checkStatus: 'Controlla stato',
+    killSession: 'Termina sessione',
+    listAll: 'Elenca tutte le sessioni',
+    copied: 'Copiato!',
+    copy: 'Copia',
+  },
 };

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -26,6 +26,7 @@ import { useSessionPolling } from '../hooks/useSessionPolling';
 import { useSessionIntervention } from '../hooks/useSessionIntervention';
 import { useSessionApproval } from '../hooks/useSessionApproval';
 import { SessionHeader } from '../components/session/SessionHeader';
+import { CliShortcutsPanel } from '../components/session/CliShortcutsPanel';
 import { PauseControlBar } from '../components/session/PauseControlBar';
 import { DriverControlBar } from '../components/session/DriverControlBar';
 import { useSessionParticipants } from '../hooks/useSessionParticipants';
@@ -806,6 +807,8 @@ export default function SessionDetailPage() {
               )}
             </AnimatePresence>
           </div>
+
+          <CliShortcutsPanel sessionId={s.id} createdAt={s.createdAt} />
 
           {/* Desktop session composer */}
           <div className="hidden rounded-b-lg border border-t-0 border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-3 sm:block animate-bento-reveal">


### PR DESCRIPTION
## F17 — Dashboard Next Steps alignment with CLI commands

Closes #3492

### What
Adds a collapsible `CliShortcutsPanel` component to the session detail page, showing contextual `ag` CLI commands with one-click copy.

### Commands displayed
- `ag read <session-id>` — View output
- `ag tail <session-id>` — Stream live
- `ag status <session-id>` — Check status
- `ag kill <session-id>` — Kill session
- `ag list` — List all sessions

### Features
- **Copy-to-clipboard** with visual "Copied!" feedback on each command
- **Session ID truncated** to 8 chars in display, full ID in `title` attribute for reference
- **Collapsible** — collapsed by default, auto-expands for new sessions (< 60s old)
- **i18n** — all strings in `en.ts` + `it.ts`
- **Accessible** — `aria-expanded`, `aria-label` on all interactive elements

### Files
- `dashboard/src/components/session/CliShortcutsPanel.tsx` — new component (90 lines)
- `dashboard/src/components/session/__tests__/CliShortcutsPanel.test.tsx` — 6 tests (82 lines)
- `dashboard/src/i18n/en.ts` — 8 new keys
- `dashboard/src/i18n/it.ts` — 8 new keys (Italian translations)
- `dashboard/src/pages/SessionDetailPage.tsx` — 3-line integration

### Quality gate
- ✅ TypeScript: no dashboard errors
- ✅ Tests: 6/6 passing
- ✅ Vite build: clean
- ✅ No new dependencies

— Daedalus 🏛️