### PR TITLE
fix(dashboard): clipboard error handling + i18n GettingStartedCard

### DIFF
--- a/dashboard/src/components/session/CliShortcutsPanel.tsx
+++ b/dashboard/src/components/session/CliShortcutsPanel.tsx
@@ -30,9 +30,13 @@ export function CliShortcutsPanel({ sessionId, createdAt }: CliShortcutsPanelPro
   ];
 
   const handleCopy = async (cmd: Command) => {
-    await navigator.clipboard.writeText(cmd.fullCmd);
-    setCopiedKey(cmd.labelKey);
-    setTimeout(() => setCopiedKey(null), 2000);
+    try {
+      await navigator.clipboard.writeText(cmd.fullCmd);
+      setCopiedKey(cmd.labelKey);
+      setTimeout(() => setCopiedKey(null), 2000);
+    } catch {
+      // Clipboard API unavailable (non-HTTPS mobile) — fail silently
+    }
   };
 
   return (

--- a/dashboard/src/components/shared/GettingStartedCard.tsx
+++ b/dashboard/src/components/shared/GettingStartedCard.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState } from 'react';
+import { useT } from '../../i18n/context.js';
 import { Rocket, X, ArrowRight } from 'lucide-react';
 
 interface GettingStartedCardProps {
@@ -17,6 +18,7 @@ interface GettingStartedCardProps {
 const DISMISS_KEY = 'aegis-getting-started-dismissed';
 
 export default function GettingStartedCard({ totalSessions, onCreateSession }: GettingStartedCardProps) {
+  const t = useT();
   const [dismissed, setDismissed] = useState(() => {
     return localStorage.getItem(DISMISS_KEY) === 'true';
   });
@@ -27,10 +29,6 @@ export default function GettingStartedCard({ totalSessions, onCreateSession }: G
   const handleDismiss = () => {
     localStorage.setItem(DISMISS_KEY, 'true');
     setDismissed(true);
-  };
-
-  const handleCreate = () => {
-    onCreateSession();
   };
 
   return (
@@ -44,7 +42,7 @@ export default function GettingStartedCard({ totalSessions, onCreateSession }: G
         type="button"
         onClick={handleDismiss}
         className="absolute right-3 top-3 rounded-md p-1 text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] hover:bg-[var(--color-void-lighter)]"
-        aria-label="Dismiss getting started card"
+        aria-label={t('gettingStarted.dismiss')}
       >
         <X className="h-4 w-4" />
       </button>
@@ -58,20 +56,20 @@ export default function GettingStartedCard({ totalSessions, onCreateSession }: G
         {/* Content */}
         <div className="flex-1 min-w-0">
           <h2 className="text-base font-semibold text-[var(--color-text-primary)]">
-            Welcome to Aegis
+            {t('gettingStarted.title')}
           </h2>
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">
-            Create your first session to start managing Claude Code with audit logs, permissions, and real-time monitoring.
+            {t('gettingStarted.description')}
           </p>
         </div>
 
         {/* CTA */}
         <button
           type="button"
-          onClick={handleCreate}
+          onClick={onCreateSession}
           className="inline-flex min-h-[44px] shrink-0 items-center justify-center gap-2 rounded-lg border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 px-5 py-2.5 text-sm font-semibold text-[var(--color-accent-cyan)] transition-all hover:bg-[var(--color-accent-cyan)]/20 hover:border-[var(--color-accent-cyan)]/50"
         >
-          Create First Session
+          {t('gettingStarted.createFirstSession')}
           <ArrowRight className="h-4 w-4" />
         </button>
       </div>

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -679,6 +679,12 @@ export const en = {
     copied: 'Copied!',
     copy: 'Copy',
   },
+  gettingStarted: {
+    title: 'Welcome to Aegis',
+    description: 'Create your first session to start managing Claude Code with audit logs, permissions, and real-time monitoring. Or run ag create in your terminal.',
+    createFirstSession: 'Create First Session',
+    dismiss: 'Dismiss getting started card',
+  },
 } as const;
 
 export type Messages = typeof en;

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -672,4 +672,11 @@ export const it = {
     copied: 'Copiato!',
     copy: 'Copia',
   },
+
+  gettingStarted: {
+    title: 'Benvenuto in Aegis',
+    description: 'Crea la tua prima sessione per gestire Claude Code con log di audit, permessi e monitoraggio in tempo reale. Oppure esegui ag create nel terminale.',
+    createFirstSession: 'Crea prima sessione',
+    dismiss: 'Chiudi guida introduttiva',
+  },
 };


### PR DESCRIPTION
## Dashboard Zero-Config Audit Fixes

Findings from post-sprint dashboard competitive audit.

### Fix 1: Clipboard Error Handling
`CliShortcutsPanel` `handleCopy` called `navigator.clipboard.writeText()` without try-catch. On non-HTTPS mobile (or when Clipboard API is denied), this caused unhandled promise rejections.

**Fix:** Wrapped in try-catch with silent failure — consistent with the non-critical nature of copy-to-clipboard.

### Fix 2: GettingStartedCard i18n + Zero-Config
The GettingStartedCard had hardcoded English strings and no mention of the new `ag create` CLI shortcut from the zero-config sprint.

**Fix:**
- Extracted all user-facing strings to i18n (`gettingStarted.title`, `.description`, `.createFirstSession`, `.dismiss`)
- Added Italian translations
- Updated description to mention `ag create` as an alternative to the UI CTA

### Quality Gate
- ✅ TypeScript: no dashboard errors
- ✅ Tests: 13/13 passing (7 GettingStartedCard + 6 CliShortcutsPanel)
- ✅ Vite build: clean

— Daedalus 🏛️