### PR TITLE
feat(dashboard): add inline CLI hint to GettingStartedCard (#3526)

### DIFF
--- a/dashboard/src/__tests__/GettingStartedCard.test.tsx
+++ b/dashboard/src/__tests__/GettingStartedCard.test.tsx
@@ -3,12 +3,17 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import GettingStartedCard from '../components/shared/GettingStartedCard';
+
+const CLI_COMMAND = 'ag create "Build a hello world"';
 
 describe('GettingStartedCard', () => {
   beforeEach(() => {
     localStorage.clear();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
   });
 
   it('renders when totalSessions < 3', () => {
@@ -55,5 +60,20 @@ describe('GettingStartedCard', () => {
 
     rerender(<GettingStartedCard totalSessions={2} onCreateSession={vi.fn()} />);
     expect(screen.getByText('Welcome to Aegis')).toBeTruthy();
+  });
+
+  it('renders inline CLI command hint', () => {
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    expect(screen.getByText(CLI_COMMAND)).toBeTruthy();
+  });
+
+  it('copies CLI command to clipboard on copy button click', async () => {
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    const copyBtn = screen.getByLabelText('Copy command');
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CLI_COMMAND);
+    expect(screen.getByLabelText('Copied!')).toBeTruthy();
   });
 });

--- a/dashboard/src/components/shared/GettingStartedCard.tsx
+++ b/dashboard/src/components/shared/GettingStartedCard.tsx
@@ -1,14 +1,14 @@
 /**
  * components/shared/GettingStartedCard.tsx — Welcome card for new users.
  *
- * Shows when total sessions < 3 and user hasn't dismissed it.
- * CTA opens the CreateSessionModal.
+ * Shows when totalSessions < 3 and user hasn't dismissed it.
+ * CTA opens the CreateSessionModal. Includes inline CLI hint for zero-config flow.
  * Uses design tokens for dark/light theme compatibility.
  */
 
 import { useState } from 'react';
 import { useT } from '../../i18n/context.js';
-import { Rocket, X, ArrowRight } from 'lucide-react';
+import { Rocket, X, ArrowRight, Copy, Check } from 'lucide-react';
 
 interface GettingStartedCardProps {
   totalSessions: number;
@@ -16,12 +16,14 @@ interface GettingStartedCardProps {
 }
 
 const DISMISS_KEY = 'aegis-getting-started-dismissed';
+const CLI_COMMAND = 'ag create "Build a hello world"';
 
 export default function GettingStartedCard({ totalSessions, onCreateSession }: GettingStartedCardProps) {
   const t = useT();
   const [dismissed, setDismissed] = useState(() => {
     return localStorage.getItem(DISMISS_KEY) === 'true';
   });
+  const [copied, setCopied] = useState(false);
 
   // Auto-hide: if user has 3+ sessions, never show
   if (totalSessions >= 3 || dismissed) return null;
@@ -29,6 +31,16 @@ export default function GettingStartedCard({ totalSessions, onCreateSession }: G
   const handleDismiss = () => {
     localStorage.setItem(DISMISS_KEY, 'true');
     setDismissed(true);
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(CLI_COMMAND);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (non-HTTPS mobile)
+    }
   };
 
   return (
@@ -61,6 +73,25 @@ export default function GettingStartedCard({ totalSessions, onCreateSession }: G
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">
             {t('gettingStarted.description')}
           </p>
+
+          {/* Inline CLI hint */}
+          <div className="mt-2.5 inline-flex items-center gap-1.5 rounded-md bg-[var(--color-void)] px-2.5 py-1">
+            <code className="font-mono text-xs text-[var(--color-text-primary)]">
+              {CLI_COMMAND}
+            </code>
+            <button
+              type="button"
+              onClick={handleCopy}
+              aria-label={copied ? t('gettingStarted.copied') : t('gettingStarted.copyCommand')}
+              className="flex items-center justify-center rounded p-0.5 text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
+            >
+              {copied ? (
+                <Check className="h-3 w-3 text-[var(--color-success)]" />
+              ) : (
+                <Copy className="h-3 w-3" />
+              )}
+            </button>
+          </div>
         </div>
 
         {/* CTA */}

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -684,6 +684,8 @@ export const en = {
     description: 'Create your first session to start managing Claude Code with audit logs, permissions, and real-time monitoring. Or run ag create in your terminal.',
     createFirstSession: 'Create First Session',
     dismiss: 'Dismiss getting started card',
+    copyCommand: 'Copy command',
+    copied: 'Copied!',
   },
 } as const;
 

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -678,5 +678,7 @@ export const it = {
     description: 'Crea la tua prima sessione per gestire Claude Code con log di audit, permessi e monitoraggio in tempo reale. Oppure esegui ag create nel terminale.',
     createFirstSession: 'Crea prima sessione',
     dismiss: 'Chiudi guida introduttiva',
+    copyCommand: 'Copia comando',
+    copied: 'Copiato!',
   },
 };


### PR DESCRIPTION
## Add inline `ag create` command hint to GettingStartedCard

Closes #3526

### What
Adds an inline terminal-style CLI hint below the welcome card description, showing `ag create "Build a hello world"` with a copy-to-clipboard button.

### Changes
- **GettingStartedCard**: New inline `<code>` block with the `ag create` command + copy button (with try-catch for non-HTTPS mobile)
- **i18n**: Added `gettingStarted.copyCommand` and `gettingStarted.copied` keys (EN + IT)
- **Tests**: 2 new tests — renders CLI command, copies to clipboard with feedback

### Before
Card showed "Create your first session..." text with a "Create First Session" button.

### After
Same card, but now also shows an inline `ag create "Build a hello world"` snippet users can copy and run in their terminal — bridging the zero-config flow directly into the dashboard.

### Quality Gate
- ✅ TypeScript: no dashboard errors
- ✅ Tests: 9/9 passing
- ✅ Vite build: clean

— Daedalus 🏛️