### PR TITLE
fix(ci): skip check-tag-freshness for tag-push events — unblocks CI release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,8 +394,14 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          # Recovery releases are always triggered by tag push — tag always exists.
-          # Skip freshness check for annotated tags containing 'recovery-release: true'.
+          # Tag-push events: GitHub already rejects pushes to existing tags (unless force-pushed,
+          # which branch protection blocks). The tag was just created — freshness is guaranteed.
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "::notice::Tag ${TAG} was just pushed — skipping freshness check for tag-push event."
+            exit 0
+          fi
+          # For workflow_dispatch: guard against accidentally re-running for an existing tag.
+          # Recovery releases skip this check (they always retag).
           if git cat-file -t "${TAG}" 2>/dev/null | grep -qx tag &&
              git cat-file tag "${TAG}" 2>/dev/null | grep -Fxq "recovery-release: true"; then
             echo "::notice::Tag ${TAG} is a recovery release — skipping freshness check."


### PR DESCRIPTION
## Problem

`check-tag-freshness` always fails when the release workflow is triggered by `push: tags: v*`.

The check uses `git ls-remote` to verify the tag doesn't exist on origin. But since the workflow was triggered by pushing the tag, the tag always exists by the time CI runs — so the check always fails, and `publish-npm` never runs.

**Evidence:** Every release CI run shows `failure` (run IDs: 25956859298, 25520243371, 25478332701...). All npm publishes have been done manually, without provenance.

## Root cause

The check was designed for a `workflow_dispatch` scenario where someone could accidentally re-run the release workflow for an existing tag. It was never updated when the trigger changed to `push: tags`.

## Fix

When triggered by a tag push (`GITHUB_EVENT_NAME == push`), skip the freshness check early — GitHub already guarantees the tag is new (branch protection prevents force-push). Only run the check for `workflow_dispatch` where re-triggering is possible.

```diff
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "::notice::Tag ${TAG} was just pushed — skipping freshness check."
+            exit 0
+          fi
```

## Impact after fix

- Release CI will complete successfully for tag pushes
- npm publish will happen via CI (with `--provenance`)
- TypeScript SDK + Python SDK + Helm chart will be auto-published
- Manual `npm publish` workaround no longer needed

## Aegis version

**Developed with:** v0.6.7 (npm latest)

Closes #3538