### PR TITLE
fix(ci): skip check-tag-freshness for tag-push events — unblocks CI release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,8 +394,14 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          # Recovery releases are always triggered by tag push — tag always exists.
-          # Skip freshness check for annotated tags containing 'recovery-release: true'.
+          # Tag-push events: GitHub already rejects pushes to existing tags (unless force-pushed,
+          # which branch protection blocks). The tag was just created — freshness is guaranteed.
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "::notice::Tag ${TAG} was just pushed — skipping freshness check for tag-push event."
+            exit 0
+          fi
+          # For workflow_dispatch: guard against accidentally re-running for an existing tag.
+          # Recovery releases skip this check (they always retag).
           if git cat-file -t "${TAG}" 2>/dev/null | grep -qx tag &&
              git cat-file tag "${TAG}" 2>/dev/null | grep -Fxq "recovery-release: true"; then
             echo "::notice::Tag ${TAG} is a recovery release — skipping freshness check."


### PR DESCRIPTION
Cherry-pick of 2e4b2887 onto main.

The `check-tag-freshness` job always fails for `push: tags` triggers because the tag is already on origin when CI runs. This fix skips the check for tag-push events (GitHub already guarantees freshness) and only runs it for `workflow_dispatch`.

This unlocks the full CI publish pipeline for v0.6.7 and all future releases.

Closes #3538

## Aegis version
**Developed with:** v0.6.7