### PR TITLE
fix(ci): download artifacts before attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -979,6 +979,14 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: package
+          path: .
+      - uses: actions/download-artifact@v8
+        with:
+          name: helm-chart
+          path: deploy/helm/aegis
       - name: Generate build provenance attestation
         uses: actions/attest-build-provenance@v4
         with:


### PR DESCRIPTION
The `attest-build-provenance` job searched for `*.tgz` and `deploy/helm/aegis/*.tgz` in the runner's working directory but never downloaded those artifacts from previous jobs — so the glob always found nothing and the step failed.

Adds two `actions/download-artifact@v8` steps to fetch `package` (npm tarball) and `helm-chart` before the attestation runs.

Found during v0.6.7 CI run 25957844280 — this was the last remaining failure after fixing `check-tag-freshness` (#3538).

## Aegis version
**Developed with:** v0.6.7