### PR TITLE
fix(ci): skip ClawHub publish gracefully when version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -963,7 +963,16 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest publish skill/ --slug onestep-aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"
+          set +e
+          OUTPUT=$(npx clawhub@latest publish skill/ --slug onestep-aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration" 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ $STATUS -ne 0 ] && echo "$OUTPUT" | grep -qi "already exists"; then
+            echo "::notice::ClawHub version $VERSION already exists — skipping."
+          elif [ $STATUS -ne 0 ]; then
+            exit $STATUS
+          fi
 
   # H1: SLSA build provenance attestation.
   # Generates machine-readable provenance for every release artifact.


### PR DESCRIPTION
Mirrors the same already-exists pattern used by `publish-npm`: captures stdout, checks for `"already exists"` in the output, emits a `::notice` and exits 0 instead of propagating the error.

Found as the last remaining failure after fixing `check-tag-freshness` (#3538) and `attest-build-provenance` (#3550) — this was previously hidden because the run never got this far.

## Aegis version
**Developed with:** v0.6.7