### PR TITLE
test(dashboard): add clipboard fallback and i18n coverage (#3530)

### DIFF
--- a/dashboard/src/__tests__/GettingStartedCard.test.tsx
+++ b/dashboard/src/__tests__/GettingStartedCard.test.tsx
@@ -76,4 +76,63 @@ describe('GettingStartedCard', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CLI_COMMAND);
     expect(screen.getByLabelText('Copied!')).toBeTruthy();
   });
+
+  // --- #3530: i18n coverage ---
+
+  it('renders title via i18n key (not hardcoded)', () => {
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    // Title comes from t('gettingStarted.title') which resolves to 'Welcome to Aegis'
+    expect(screen.getByText('Welcome to Aegis')).toBeTruthy();
+  });
+
+  it('renders description via i18n key', () => {
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    // Description from t('gettingStarted.description')
+    expect(screen.getByText(/Create your first session to start managing Claude Code/)).toBeTruthy();
+  });
+
+  it('dismiss button aria-label uses i18n key', () => {
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    // aria-label={t('gettingStarted.dismiss')} resolves to 'Dismiss getting started card'
+    const dismissBtn = screen.getByLabelText('Dismiss getting started card');
+    expect(dismissBtn).toBeTruthy();
+  });
+
+  it('copy button aria-label uses i18n keys for default and copied states', async () => {
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    // Default: aria-label={t('gettingStarted.copyCommand')} = 'Copy command'
+    const copyBtn = screen.getByLabelText('Copy command');
+    expect(copyBtn).toBeTruthy();
+
+    // After copy: aria-label={t('gettingStarted.copied')} = 'Copied!'
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+    expect(screen.getByLabelText('Copied!')).toBeTruthy();
+  });
+
+  // --- #3530: clipboard failure ---
+
+  it('handles clipboard write failure gracefully without crashing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new DOMException('Not allowed', 'NotAllowedError')) },
+    });
+
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    const copyBtn = screen.getByLabelText('Copy command');
+
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    // Should not crash — try-catch handles the rejection
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CLI_COMMAND);
+    // Card should still be rendered
+    expect(screen.getByText('Welcome to Aegis')).toBeTruthy();
+    // Should NOT show copied state
+    expect(screen.queryByLabelText('Copied!')).toBeNull();
+
+    consoleError.mockRestore();
+  });
 });

--- a/dashboard/src/components/session/__tests__/CliShortcutsPanel.test.tsx
+++ b/dashboard/src/components/session/__tests__/CliShortcutsPanel.test.tsx
@@ -79,4 +79,51 @@ describe('CliShortcutsPanel', () => {
     const codeEl = screen.getByText(`ag read ${SHORT_ID}`);
     expect(codeEl.closest('[title]')?.getAttribute('title')).toBe(`ag read ${SESSION_ID}`);
   });
+
+  it('handles clipboard write failure gracefully without crashing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new DOMException('Not allowed', 'NotAllowedError')) },
+    });
+
+    render(<CliShortcutsPanel sessionId={SESSION_ID} />);
+
+    const toggle = screen.getByRole('button', { name: /CLI Shortcuts/i });
+    fireEvent.click(toggle);
+
+    const copyButtons = screen.getAllByRole('button', { name: /copy/i });
+    await act(async () => {
+      fireEvent.click(copyButtons[0]);
+    });
+
+    // Should not crash — try-catch handles the rejection
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`ag read ${SESSION_ID}`);
+    // Should NOT show "Copied!" feedback on failure
+    expect(screen.queryByText('Copied!')).toBeNull();
+    // Panel should still be rendered and functional
+    expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
+
+    consoleError.mockRestore();
+  });
+
+  it('handles missing navigator.clipboard without crashing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // @ts-expect-error — testing missing clipboard API
+    delete navigator.clipboard;
+
+    render(<CliShortcutsPanel sessionId={SESSION_ID} />);
+
+    const toggle = screen.getByRole('button', { name: /CLI Shortcuts/i });
+    fireEvent.click(toggle);
+
+    const copyButtons = screen.getAllByRole('button', { name: /copy/i });
+    await act(async () => {
+      fireEvent.click(copyButtons[0]);
+    });
+
+    // Should not crash — try-catch handles missing clipboard
+    expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
+
+    consoleError.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
Closes #3530 — post-merge test coverage for PR #3527 changes.

## What changed
**CliShortcutsPanel tests** (+2 tests, 6→8):
- Clipboard write rejection (DOMException) handled gracefully, no crash, no "Copied!" shown
- Missing `navigator.clipboard` handled gracefully (non-HTTPS mobile)

**GettingStartedCard tests** (+5 tests, 9→14):
- Title rendered via i18n key (`gettingStarted.title`)
- Description rendered via i18n key (`gettingStarted.description`)
- Dismiss button aria-label uses i18n key (`gettingStarted.dismiss`)
- Copy button aria-label uses i18n keys for both default (`gettingStarted.copyCommand`) and copied (`gettingStarted.copied`) states
- Clipboard write rejection handled gracefully, no crash

## Quality gate
- `tsc --noEmit`: ✅ clean
- Tests: 22/22 passing (2 files)
- No production code changed

— Daedalus 🏛️