### PR TITLE
feat(dashboard): add workDir filter to session table (#3537)

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -15,6 +15,7 @@ import {
   FolderOpen,
   Search,
   Sparkles,
+  Filter,
 } from 'lucide-react';
 import {
   approve,
@@ -103,7 +104,17 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
   const navigate = useNavigate();
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [groupByDir, setGroupByDir] = useState(true);
+  const [workDirFilter, setWorkDirFilter] = useState<string>('all');
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+
+  const uniqueWorkDirs = useMemo(() => {
+    const dirs = new Map<string, string>();
+    for (const s of sessions) {
+      const key = extractDirKey(s.workDir);
+      if (!dirs.has(key)) dirs.set(key, s.workDir);
+    }
+    return Array.from(dirs.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  }, [sessions]);
 
   // Keyboard shortcuts: arrows navigate, Enter opens, Delete kills
   useEffect(() => {
@@ -392,7 +403,11 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
     : '';
 
   const rowViewModels = useMemo<SessionRowViewModel[]>(() => {
-    const baseSessions = maxRows ? sessions.slice(0, maxRows) : sessions;
+    let source = sessions;
+    if (workDirFilter !== 'all') {
+      source = source.filter((s) => extractDirKey(s.workDir) === workDirFilter || s.workDir === workDirFilter);
+    }
+    const baseSessions = maxRows ? source.slice(0, maxRows) : source;
     return baseSessions.map((session, idx) => {
       const health = healthMap[session.id];
       return {
@@ -404,7 +419,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
         isFocused: idx === focusedIndex,
       };
     });
-  }, [actionLoading, healthMap, selectedIdSet, sessions, focusedIndex, maxRows]);
+  }, [actionLoading, healthMap, selectedIdSet, sessions, focusedIndex, maxRows, workDirFilter]);
 
   const groupedRowModels = useMemo(() => {
     if (!groupByDir) return null;
@@ -515,6 +530,28 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                 <FolderOpen className="h-3.5 w-3.5" />
                 {groupByDir ? 'Ungroup' : 'By Directory'}
               </button>
+
+              {uniqueWorkDirs.length > 1 && (
+                <label className="flex items-center gap-2 text-sm text-[var(--color-text-muted)]">
+                  <Filter className="h-3.5 w-3.5" />
+                  <select
+                    value={workDirFilter}
+                    onChange={(e) => {
+                      setWorkDirFilter(e.target.value);
+                      setPage(1);
+                    }}
+                    aria-label={t("aria.filterByDirectory")}
+                    className="min-h-[36px] rounded-md border border-void-lighter bg-void px-2 py-1 text-xs text-[var(--color-text-primary)] outline-none focus:border-cyan max-w-[180px]"
+                  >
+                    <option value="all">{t("aria.allDirectories")} ({sessions.length})</option>
+                    {uniqueWorkDirs.map(([key, full]) => (
+                      <option key={key} value={key} title={full}>
+                        {key}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
             </div>
 
             <div className="flex flex-wrap gap-2" role="group" aria-label={t("aria.filterByStatusGroup")}>

--- a/dashboard/src/components/overview/__tests__/SessionTable.workDirFilter.test.tsx
+++ b/dashboard/src/components/overview/__tests__/SessionTable.workDirFilter.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * SessionTable.workDirFilter.test.tsx — Tests for workDir filtering in session table.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SessionTable from '../SessionTable';
+import type { SessionStatusCounts } from '../../../types';
+
+const mockGetSessions = vi.fn();
+const mockGetSessionStatusCounts = vi.fn();
+const mockGetAllSessionsHealth = vi.fn();
+
+vi.mock('../../../api/client', () => ({
+  getSessions: (...args: unknown[]) => mockGetSessions(...args),
+  getSessionStatusCounts: (...args: unknown[]) => mockGetSessionStatusCounts(...args),
+  getAllSessionsHealth: (...args: unknown[]) => mockGetAllSessionsHealth(...args),
+  approve: vi.fn(),
+  interrupt: vi.fn(),
+  killSession: vi.fn(),
+}));
+
+vi.mock('../../../store/useToastStore', () => ({
+  useToastStore: (selector: (state: { addToast: () => void }) => unknown) =>
+    selector({ addToast: vi.fn() }),
+}));
+
+const counts: SessionStatusCounts = {
+  all: 3, idle: 2, working: 1, compacting: 0, context_warning: 0,
+  waiting_for_input: 0, permission_prompt: 0, plan_mode: 0, ask_question: 0,
+  bash_approval: 0, settings: 0, error: 0, rate_limit: 0, pending: 0,
+  unknown: 0, killed: 0, completed: 0, crashed: 0,
+};
+
+const multiDirSessions = {
+  sessions: [
+    { id: 's1', displayName: 'project-a', workDir: '/home/user/projects/a', status: 'idle', createdAt: Date.now() - 1000, lastActivity: Date.now() },
+    { id: 's2', displayName: 'project-b', workDir: '/home/user/projects/b', status: 'working', createdAt: Date.now() - 1000, lastActivity: Date.now() },
+    { id: 's3', displayName: 'project-a-2', workDir: '/home/user/projects/a', status: 'idle', createdAt: Date.now() - 1000, lastActivity: Date.now() },
+  ],
+  pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+};
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('SessionTable workDir filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessions.mockResolvedValue(multiDirSessions);
+    mockGetSessionStatusCounts.mockResolvedValue(counts);
+    mockGetAllSessionsHealth.mockResolvedValue({});
+  });
+
+  it('shows workDir filter when sessions have multiple directories', async () => {
+    renderWithRouter(<SessionTable />);
+    const filterSelect = await screen.findByLabelText('Filter by directory');
+    expect(filterSelect).toBeTruthy();
+    const options = within(filterSelect as HTMLElement).getAllByRole('option');
+    expect(options.length).toBe(3); // All + a + b
+  });
+
+  it('does not show workDir filter when all sessions share one directory', async () => {
+    mockGetSessions.mockResolvedValue({
+      sessions: [
+        { id: 's1', displayName: 'only-project', workDir: '/home/user/project', status: 'idle', createdAt: Date.now(), lastActivity: Date.now() },
+      ],
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    });
+
+    renderWithRouter(<SessionTable />);
+
+    // Wait for loading to finish (look for any element from the loaded table)
+    await waitFor(() => {
+      expect(mockGetSessions).toHaveBeenCalled();
+    });
+
+    // Filter should NOT appear — only 1 unique directory
+    expect(screen.queryByLabelText('Filter by directory')).toBeNull();
+  });
+});

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -570,6 +570,8 @@ export const en = {
     searchSessions: 'Search sessions',
     searchPipelines: 'Search pipelines',
     filterByStatus: 'Filter by status',
+    filterByDirectory: 'Filter by directory',
+    allDirectories: 'All directories',
     filterByStatusGroup: 'Filter sessions by status',
     bulkActions: 'Bulk actions',
     clearSelection: 'Clear selection',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -567,6 +567,8 @@ export const it = {
     searchSessions: 'Cerca sessioni',
     searchPipelines: 'Cerca pipeline',
     filterByStatus: 'Filtra per stato',
+    filterByDirectory: 'Filtra per cartella',
+    allDirectories: 'Tutte le cartelle',
     filterByStatusGroup: 'Filtra sessioni per stato',
     bulkActions: 'Azioni collettive',
     clearSelection: 'Cancella selezione',


### PR DESCRIPTION
## Add directory filter to session table

Implements the dashboard side of #3537.

### What
Adds a workDir filter dropdown to the session table that appears when sessions span multiple working directories. Allows users to scope the session list to a specific project directory.

### Changes
- **SessionTable**: New `workDirFilter` state + `uniqueWorkDirs` computed from sessions
- Client-side filtering in `rowViewModels` memo (no API change needed)
- Filter dropdown appears only when `uniqueWorkDirs.length > 1` (auto-hides when unnecessary)
- Uses `extractDirKey` for display names, full path in `title` attribute
- i18n: `aria.filterByDirectory` + `aria.allDirectories` (EN + IT)
- **Tests**: 2 tests — filter appears with multiple dirs, hidden with single dir

### Notes
- **Session detail page**: workDir already displayed in SessionHeader (line 166). No change needed.
- **CLI side** (`ag list --cwd`): Backend territory, needs separate PR from Hephaestus.

### Quality Gate
- ✅ TypeScript: no dashboard errors
- ✅ Tests: 2/2 passing
- ✅ Vite build: clean
- ✅ No new dependencies

— Daedalus 🏛️