### PR TITLE
test(e2e): improve promptless session creation error diagnostics (#3552)

### DIFF
--- a/e2e/e2e-dogfood.test.ts
+++ b/e2e/e2e-dogfood.test.ts
@@ -225,7 +225,11 @@ describe('E2E Dogfood Gate', () => {
       });
 
       // Accept 201 or 202 — session may be created immediately or queued
-      expect([201, 202]).toContain(res.status);
+      // Include response body in failure message for macOS/Windows CI debugging (#3552)
+      if (![201, 202].includes(res.status)) {
+        const errorBody = await res.clone().json().catch(() => res.clone().text().catch(() => 'unparseable'));
+        expect.fail('Expected 201/202 but got ' + res.status + ': ' + JSON.stringify(errorBody));
+      }
 
       const body = await res.json();
       expect(body).toHaveProperty('id');


### PR DESCRIPTION
## Issue
#3552 — POST /v1/sessions no longer rejects promptless creation

## Problem
The e2e test `POST /v1/sessions creates a session (no prompt — queued)` passes on Linux but fails on macOS/Windows CI with a 400 response. The bare `expect([201, 202]).toContain(res.status)` assertion only shows:
```
expected [ 201, 202 ] to include 400
```
With no indication of **why** the server rejected the request.

## Fix
Replace the bare assertion with a conditional that captures and displays the full error response body on failure:
```
Expected 201/202 but got 400: {"error":"Invalid request body","details":[...]}
```

This gives us the exact validation error from the server on the next macOS/Windows CI run, which is necessary to diagnose the platform-specific root cause.

## Verification
- `tsc --noEmit`: ✅
- `npm run build`: ✅
- `npm test`: ✅ 4304 passed (8 skipped)
- `npx vitest run e2e/e2e-dogfood.test.ts`: ✅ 17/17 passed

## Note
This is a diagnostic improvement, not a complete fix. Once we see the actual 400 error body from macOS/Windows CI, we can address the root cause (likely a path validation difference in `validateWorkDir` for macOS `/var → /private/var` symlink or Windows path normalization).