### PR TITLE
fix(dashboard): robust clipboard fallback for non-HTTPS mobile (#3525)

### DIFF
--- a/dashboard/src/__tests__/GettingStartedCard.test.tsx
+++ b/dashboard/src/__tests__/GettingStartedCard.test.tsx
@@ -9,11 +9,15 @@ import GettingStartedCard from '../components/shared/GettingStartedCard';
 const CLI_COMMAND = 'ag create "Build a hello world"';
 
 describe('GettingStartedCard', () => {
+  let mockExecCommand: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     localStorage.clear();
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+    mockExecCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = mockExecCommand as unknown as typeof document.execCommand;
   });
 
   it('renders when totalSessions < 3', () => {
@@ -77,44 +81,38 @@ describe('GettingStartedCard', () => {
     expect(screen.getByLabelText('Copied!')).toBeTruthy();
   });
 
-  // --- #3530: i18n coverage ---
+  // --- i18n coverage ---
 
   it('renders title via i18n key (not hardcoded)', () => {
     render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
-    // Title comes from t('gettingStarted.title') which resolves to 'Welcome to Aegis'
     expect(screen.getByText('Welcome to Aegis')).toBeTruthy();
   });
 
   it('renders description via i18n key', () => {
     render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
-    // Description from t('gettingStarted.description')
     expect(screen.getByText(/Create your first session to start managing Claude Code/)).toBeTruthy();
   });
 
   it('dismiss button aria-label uses i18n key', () => {
     render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
-    // aria-label={t('gettingStarted.dismiss')} resolves to 'Dismiss getting started card'
     const dismissBtn = screen.getByLabelText('Dismiss getting started card');
     expect(dismissBtn).toBeTruthy();
   });
 
   it('copy button aria-label uses i18n keys for default and copied states', async () => {
     render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
-    // Default: aria-label={t('gettingStarted.copyCommand')} = 'Copy command'
     const copyBtn = screen.getByLabelText('Copy command');
     expect(copyBtn).toBeTruthy();
 
-    // After copy: aria-label={t('gettingStarted.copied')} = 'Copied!'
     await act(async () => {
       fireEvent.click(copyBtn);
     });
     expect(screen.getByLabelText('Copied!')).toBeTruthy();
   });
 
-  // --- #3530: clipboard failure ---
+  // --- Clipboard fallback behavior ---
 
-  it('handles clipboard write failure gracefully without crashing', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('shows Copied! when clipboard API fails but textarea fallback succeeds', async () => {
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockRejectedValue(new DOMException('Not allowed', 'NotAllowedError')) },
     });
@@ -126,13 +124,42 @@ describe('GettingStartedCard', () => {
       fireEvent.click(copyBtn);
     });
 
-    // Should not crash — try-catch handles the rejection
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CLI_COMMAND);
-    // Card should still be rendered
+    // Textarea fallback should kick in
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+    expect(screen.getByLabelText('Copied!')).toBeTruthy();
+    // Card still rendered
     expect(screen.getByText('Welcome to Aegis')).toBeTruthy();
-    // Should NOT show copied state
-    expect(screen.queryByLabelText('Copied!')).toBeNull();
+  });
 
-    consoleError.mockRestore();
+  it('shows Copied! when navigator.clipboard is missing and textarea fallback succeeds', async () => {
+    // @ts-expect-error — testing missing clipboard API
+    delete navigator.clipboard;
+
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    const copyBtn = screen.getByLabelText('Copy command');
+
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+    expect(screen.getByLabelText('Copied!')).toBeTruthy();
+  });
+
+  it('does not show Copied! when both clipboard and textarea fallback fail', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('fail')) },
+    });
+    mockExecCommand.mockReturnValue(false);
+
+    render(<GettingStartedCard totalSessions={0} onCreateSession={vi.fn()} />);
+    const copyBtn = screen.getByLabelText('Copy command');
+
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    expect(screen.queryByLabelText('Copied!')).toBeNull();
+    expect(screen.getByText('Welcome to Aegis')).toBeTruthy();
   });
 });

--- a/dashboard/src/components/session/CliShortcutsPanel.tsx
+++ b/dashboard/src/components/session/CliShortcutsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronDown, Copy, Check } from 'lucide-react';
 import { useT } from '../../i18n/context.js';
+import { copyToClipboard } from '../../utils/clipboard.js';
 
 export interface CliShortcutsPanelProps {
   sessionId: string;
@@ -30,12 +31,10 @@ export function CliShortcutsPanel({ sessionId, createdAt }: CliShortcutsPanelPro
   ];
 
   const handleCopy = async (cmd: Command) => {
-    try {
-      await navigator.clipboard.writeText(cmd.fullCmd);
+    const ok = await copyToClipboard(cmd.fullCmd);
+    if (ok) {
       setCopiedKey(cmd.labelKey);
       setTimeout(() => setCopiedKey(null), 2000);
-    } catch {
-      // Clipboard API unavailable (non-HTTPS mobile) — fail silently
     }
   };
 

--- a/dashboard/src/components/session/__tests__/CliShortcutsPanel.test.tsx
+++ b/dashboard/src/components/session/__tests__/CliShortcutsPanel.test.tsx
@@ -10,10 +10,14 @@ const SESSION_ID = 'abcdef1234567890';
 const SHORT_ID = SESSION_ID.slice(0, 8); // 'abcdef12'
 
 describe('CliShortcutsPanel', () => {
+  let mockExecCommand: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+    mockExecCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = mockExecCommand as unknown as typeof document.execCommand;
   });
 
   it('renders all 5 commands with correct command text', () => {
@@ -80,8 +84,7 @@ describe('CliShortcutsPanel', () => {
     expect(codeEl.closest('[title]')?.getAttribute('title')).toBe(`ag read ${SESSION_ID}`);
   });
 
-  it('handles clipboard write failure gracefully without crashing', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('shows Copied! feedback when clipboard API fails but textarea fallback succeeds', async () => {
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockRejectedValue(new DOMException('Not allowed', 'NotAllowedError')) },
     });
@@ -96,18 +99,14 @@ describe('CliShortcutsPanel', () => {
       fireEvent.click(copyButtons[0]);
     });
 
-    // Should not crash — try-catch handles the rejection
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`ag read ${SESSION_ID}`);
-    // Should NOT show "Copied!" feedback on failure
-    expect(screen.queryByText('Copied!')).toBeNull();
-    // Panel should still be rendered and functional
+    // Should have fallen back to textarea copy and show feedback
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+    expect(screen.getByText('Copied!')).toBeDefined();
+    // Panel still functional
     expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
-
-    consoleError.mockRestore();
   });
 
-  it('handles missing navigator.clipboard without crashing', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('shows Copied! feedback when navigator.clipboard is missing and textarea fallback succeeds', async () => {
     // @ts-expect-error — testing missing clipboard API
     delete navigator.clipboard;
 
@@ -121,9 +120,30 @@ describe('CliShortcutsPanel', () => {
       fireEvent.click(copyButtons[0]);
     });
 
-    // Should not crash — try-catch handles missing clipboard
-    expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
+    // Textarea fallback should succeed
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+    expect(screen.getByText('Copied!')).toBeDefined();
+  });
 
-    consoleError.mockRestore();
+  it('does not show Copied! when both clipboard API and textarea fallback fail', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('fail')) },
+    });
+    mockExecCommand.mockReturnValue(false);
+
+    render(<CliShortcutsPanel sessionId={SESSION_ID} />);
+
+    const toggle = screen.getByRole('button', { name: /CLI Shortcuts/i });
+    fireEvent.click(toggle);
+
+    const copyButtons = screen.getAllByRole('button', { name: /copy/i });
+    await act(async () => {
+      fireEvent.click(copyButtons[0]);
+    });
+
+    // Should NOT show "Copied!" when both paths fail
+    expect(screen.queryByText('Copied!')).toBeNull();
+    // Panel still functional
+    expect(screen.getByText(`ag read ${SHORT_ID}`)).toBeDefined();
   });
 });

--- a/dashboard/src/components/shared/GettingStartedCard.tsx
+++ b/dashboard/src/components/shared/GettingStartedCard.tsx
@@ -9,6 +9,7 @@
 import { useState } from 'react';
 import { useT } from '../../i18n/context.js';
 import { Rocket, X, ArrowRight, Copy, Check } from 'lucide-react';
+import { copyToClipboard } from '../../utils/clipboard.js';
 
 interface GettingStartedCardProps {
   totalSessions: number;
@@ -34,12 +35,10 @@ export default function GettingStartedCard({ totalSessions, onCreateSession }: G
   };
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(CLI_COMMAND);
+    const ok = await copyToClipboard(CLI_COMMAND);
+    if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API unavailable (non-HTTPS mobile)
     }
   };
 

--- a/dashboard/src/utils/__tests__/clipboard.test.ts
+++ b/dashboard/src/utils/__tests__/clipboard.test.ts
@@ -1,0 +1,111 @@
+/**
+ * clipboard.test.ts — Tests for robust copy-to-clipboard utility.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { copyToClipboard } from '../clipboard';
+
+describe('copyToClipboard', () => {
+  let mockExecCommand: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Default: modern clipboard API available
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    // Mock document.execCommand for jsdom (not available by default)
+    mockExecCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = mockExecCommand as unknown as typeof document.execCommand;
+  });
+
+  afterEach(() => {
+    mockExecCommand.mockRestore?.();
+  });
+
+  it('uses navigator.clipboard.writeText when available', async () => {
+    const result = await copyToClipboard('hello');
+    expect(result).toBe(true);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
+    expect(mockExecCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns true when navigator.clipboard.writeText succeeds', async () => {
+    const result = await copyToClipboard('test-command');
+    expect(result).toBe(true);
+  });
+
+  it('falls back to textarea execCommand when clipboard API rejects', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new DOMException('Not allowed')) },
+    });
+
+    const result = await copyToClipboard('fallback-text');
+    expect(result).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('falls back to textarea execCommand when navigator.clipboard is missing', async () => {
+    // @ts-expect-error — testing missing clipboard API
+    delete navigator.clipboard;
+
+    const result = await copyToClipboard('no-api-text');
+    expect(result).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('returns false when both clipboard API and execCommand fail', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('fail')) },
+    });
+    mockExecCommand.mockReturnValue(false);
+
+    const result = await copyToClipboard('double-fail');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when clipboard API missing and execCommand throws', async () => {
+    // @ts-expect-error — testing missing clipboard API
+    delete navigator.clipboard;
+    mockExecCommand.mockImplementation(() => { throw new Error('no exec'); });
+
+    const result = await copyToClipboard('exec-throws');
+    expect(result).toBe(false);
+  });
+
+  it('creates and removes temporary textarea during fallback', async () => {
+    // @ts-expect-error — testing missing clipboard API
+    delete navigator.clipboard;
+
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const removeSpy = vi.spyOn(document.body, 'removeChild');
+
+    await copyToClipboard('cleanup-test');
+
+    // Should have appended and removed a textarea
+    const appended = appendSpy.mock.calls[0]?.[0] as HTMLTextAreaElement;
+    expect(appended?.tagName).toBe('TEXTAREA');
+    expect(appended?.value).toBe('cleanup-test');
+    expect(removeSpy).toHaveBeenCalledWith(appended);
+
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it('textarea fallback sets value correctly before copy', async () => {
+    // @ts-expect-error — testing missing clipboard API
+    delete navigator.clipboard;
+
+    let capturedValue = '';
+    mockExecCommand.mockImplementation(() => {
+      const allTa = document.querySelectorAll('textarea');
+      if (allTa.length > 0 && allTa[0]) {
+        capturedValue = (allTa[0] as HTMLTextAreaElement).value;
+      }
+      return true;
+    });
+
+    await copyToClipboard('verify-value');
+    expect(capturedValue).toBe('verify-value');
+  });
+});

--- a/dashboard/src/utils/clipboard.ts
+++ b/dashboard/src/utils/clipboard.ts
@@ -1,0 +1,51 @@
+/**
+ * clipboard.ts — Robust copy-to-clipboard with textarea fallback.
+ *
+ * Uses `navigator.clipboard.writeText` when available (HTTPS / localhost).
+ * Falls back to programmatic textarea selection + execCommand("copy")
+ * for older browsers and insecure contexts (e.g. plain HTTP on mobile).
+ */
+
+/**
+ * Copy `text` to the system clipboard.
+ * Returns `true` if the copy succeeded, `false` otherwise.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  // Try modern Clipboard API first
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // NotAllowedError or other failure — fall through to textarea fallback
+    }
+  }
+
+  // Textarea fallback for insecure contexts / old browsers
+  return textareaCopy(text);
+}
+
+function textareaCopy(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+
+  // Position off-screen to avoid visual flash
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  textarea.style.top = '-9999px';
+  textarea.style.opacity = '0';
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch {
+    success = false;
+  }
+
+  document.body.removeChild(textarea);
+  return success;
+}


### PR DESCRIPTION
## Summary

Closes #3525

Replaces silent clipboard failure with a robust textarea-based fallback that works on:
- Non-HTTPS mobile browsers (insecure context)
- Older browsers without `navigator.clipboard`
- Any environment where Clipboard API throws `NotAllowedError`

## Changes

### New: `copyToClipboard` utility (`dashboard/src/utils/clipboard.ts`)
- Tries `navigator.clipboard.writeText` first (modern API)
- Falls back to programmatic textarea selection + `document.execCommand("copy")`
- Returns `boolean` so callers know if copy succeeded

### Updated: `CliShortcutsPanel`
- Uses `copyToClipboard` instead of bare try-catch
- Shows "Copied!" feedback even when falling back to textarea method
- No feedback when both methods fail (graceful degradation)

### Updated: `GettingStartedCard`
- Same pattern: `copyToClipboard` utility, feedback on fallback success

## Tests (33 total)

- **8 new** utility tests (`clipboard.test.ts`) — modern API, rejection fallback, missing API, double-failure, DOM cleanup, value verification
- **9 updated** CliShortcutsPanel tests — added 3 fallback scenarios (API reject → textarea success, missing API → textarea success, both fail)
- **16 updated** GettingStartedCard tests — added 3 fallback scenarios (same pattern)

## Quality Gate
- [x] `tsc --noEmit` — clean (dashboard)
- [x] `vite build` — success
- [x] `vitest run` — 33/33 passing
- [x] No bundle size regression (utility is tiny, tree-shaken)