### PR TITLE
feat(dashboard): add ModelBadge and EffortIndicator components (#3560)

### DIFF
--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -5,6 +5,9 @@
  */
 
 import { formatSessionName } from '../../utils/formatSessionName';
+import { ModelBadge } from '../shared/ModelBadge';
+import { EffortIndicator } from '../shared/EffortIndicator';
+import type { ExtendedSessionInfo } from '../../types/session-extensions';
 import { type CSSProperties, type ReactElement, useMemo } from 'react';
 import { List } from 'react-window';
 import { Link } from 'react-router-dom';
@@ -197,6 +200,8 @@ function VirtualizedRow(props: {
         >
           {formatSessionName(session.displayName, session.id.slice(0, 8))}
         </Link>
+        <ModelBadge model={(session as ExtendedSessionInfo).model} />
+        <EffortIndicator effort={(session as ExtendedSessionInfo).effort} />
       </div>
       <div className="flex items-center max-w-[150px] truncate px-3 font-mono text-xs text-[var(--color-text-muted)]" title={session.workDir}>
         {truncateDir(session.workDir)}

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -7,6 +7,9 @@ import { HoldButton } from '../shared/HoldButton';
 import { CopyButton } from '../shared/CopyButton';
 import { TimelineScrubber, type TimelineEvent } from './TimelineScrubber';
 import { useT } from '../../i18n/context';
+import { ModelBadge } from '../shared/ModelBadge';
+import { EffortIndicator } from '../shared/EffortIndicator';
+import type { ExtendedSessionInfo } from '../../types/session-extensions';
 
 interface SessionHeaderProps {
   session: SessionInfo;
@@ -178,6 +181,8 @@ export function SessionHeader({
           {truncateMiddle(session.id, 16)}
           <CopyButton value={session.id} label="session ID" size={16} />
         </span>
+        <ModelBadge model={(session as ExtendedSessionInfo).model} className="hidden sm:inline-flex" />
+        <EffortIndicator effort={(session as ExtendedSessionInfo).effort} className="hidden sm:inline-flex" />
         {session.ownerKeyId && (
           <span className="group hidden font-mono sm:inline-flex items-center gap-1">
             Owner: {session.ownerKeyId.slice(0, 8)}

--- a/dashboard/src/components/shared/EffortIndicator.tsx
+++ b/dashboard/src/components/shared/EffortIndicator.tsx
@@ -1,0 +1,57 @@
+/**
+ * components/shared/EffortIndicator.tsx — Compact effort level indicator.
+ *
+ * Shows a small colored dot + label for the session's effort level.
+ * Renders nothing when effort is undefined/null (graceful degradation).
+ *
+ * Effort levels (from CC convention):
+ *   high   → Orange (max thinking)
+ *   medium → Yellow (default)
+ *   low    → Green (fast mode)
+ */
+
+const EFFORT_STYLES: Record<string, { color: string; label: string }> = {
+  high: { color: 'var(--color-warning)', label: 'High' },
+  medium: { color: 'var(--color-accent-cyan)', label: 'Med' },
+  low: { color: 'var(--color-success)', label: 'Low' },
+};
+
+function getEffortStyle(effort: string): { color: string; label: string } {
+  const lower = effort.toLowerCase();
+  if (EFFORT_STYLES[lower]) return EFFORT_STYLES[lower];
+
+  // Handle numeric effort (0.0–1.0)
+  const num = parseFloat(effort);
+  if (!isNaN(num)) {
+    if (num >= 0.7) return EFFORT_STYLES.high;
+    if (num >= 0.3) return EFFORT_STYLES.medium;
+    return EFFORT_STYLES.low;
+  }
+
+  return { color: 'var(--color-text-muted)', label: effort };
+}
+
+export interface EffortIndicatorProps {
+  /** Effort level (e.g. "high", "medium", "low", "0.8"). When undefined, renders nothing. */
+  effort?: string | null;
+  className?: string;
+}
+
+export function EffortIndicator({ effort, className = '' }: EffortIndicatorProps) {
+  if (!effort) return null;
+
+  const { color, label } = getEffortStyle(effort);
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[10px] leading-none text-[var(--color-text-muted)] ${className}`}
+      title={`Effort: ${effort}`}
+    >
+      <span
+        className="inline-block h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      {label}
+    </span>
+  );
+}

--- a/dashboard/src/components/shared/ModelBadge.tsx
+++ b/dashboard/src/components/shared/ModelBadge.tsx
@@ -1,0 +1,53 @@
+/**
+ * components/shared/ModelBadge.tsx — Compact model name badge.
+ *
+ * Color-coded per CCMeter convention (shared with ModelDistributionBar):
+ *   Opus   → Purple
+ *   Sonnet → Blue
+ *   Haiku  → Green
+ *   Other  → Muted
+ *
+ * Renders nothing when model is undefined/null (graceful degradation
+ * for sessions created before the model field was added to the API).
+ */
+
+
+const MODEL_STYLES: Record<string, { color: string; label: string }> = {
+  opus: { color: 'var(--color-accent-purple)', label: 'Opus' },
+  sonnet: { color: 'var(--color-accent)', label: 'Sonnet' },
+  haiku: { color: 'var(--color-success)', label: 'Haiku' },
+};
+
+function getModelStyle(model: string): { color: string; label: string } {
+  const lower = model.toLowerCase();
+  for (const [key, style] of Object.entries(MODEL_STYLES)) {
+    if (lower.includes(key)) return style;
+  }
+  return { color: 'var(--color-text-muted)', label: model };
+}
+
+export interface ModelBadgeProps {
+  /** Raw model identifier (e.g. "claude-opus-4.7"). When undefined, renders nothing. */
+  model?: string | null;
+  className?: string;
+}
+
+export function ModelBadge({ model, className = '' }: ModelBadgeProps) {
+  if (!model) return null;
+
+  const { color, label } = getModelStyle(model);
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold leading-none ${className}`}
+      style={{
+        backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)`,
+        color,
+        border: `1px solid color-mix(in srgb, ${color} 30%, transparent)`,
+      }}
+      title={model}
+    >
+      {label}
+    </span>
+  );
+}

--- a/dashboard/src/components/shared/__tests__/EffortIndicator.test.tsx
+++ b/dashboard/src/components/shared/__tests__/EffortIndicator.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * EffortIndicator.test.tsx — Tests for the effort level indicator.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EffortIndicator } from '../EffortIndicator';
+
+describe('EffortIndicator', () => {
+  it('renders nothing when effort is undefined', () => {
+    const { container } = render(<EffortIndicator />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when effort is null', () => {
+    const { container } = render(<EffortIndicator effort={null} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders High for high effort', () => {
+    render(<EffortIndicator effort="high" />);
+    expect(screen.getByText('High')).toBeTruthy();
+  });
+
+  it('renders Med for medium effort', () => {
+    render(<EffortIndicator effort="medium" />);
+    expect(screen.getByText('Med')).toBeTruthy();
+  });
+
+  it('renders Low for low effort', () => {
+    render(<EffortIndicator effort="low" />);
+    expect(screen.getByText('Low')).toBeTruthy();
+  });
+
+  it('maps numeric 0.8 to High', () => {
+    render(<EffortIndicator effort="0.8" />);
+    expect(screen.getByText('High')).toBeTruthy();
+  });
+
+  it('maps numeric 0.5 to Med', () => {
+    render(<EffortIndicator effort="0.5" />);
+    expect(screen.getByText('Med')).toBeTruthy();
+  });
+
+  it('maps numeric 0.1 to Low', () => {
+    render(<EffortIndicator effort="0.1" />);
+    expect(screen.getByText('Low')).toBeTruthy();
+  });
+
+  it('renders raw value for unknown effort', () => {
+    render(<EffortIndicator effort="turbo" />);
+    expect(screen.getByText('turbo')).toBeTruthy();
+  });
+
+  it('shows effort in title attribute', () => {
+    render(<EffortIndicator effort="high" />);
+    const indicator = screen.getByText('High');
+    expect(indicator.closest('[title]')?.getAttribute('title')).toBe('Effort: high');
+  });
+});

--- a/dashboard/src/components/shared/__tests__/ModelBadge.test.tsx
+++ b/dashboard/src/components/shared/__tests__/ModelBadge.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * ModelBadge.test.tsx — Tests for the model name badge component.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ModelBadge } from '../ModelBadge';
+
+describe('ModelBadge', () => {
+  it('renders nothing when model is undefined', () => {
+    const { container } = render(<ModelBadge />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when model is null', () => {
+    const { container } = render(<ModelBadge model={null} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders Opus label for opus model', () => {
+    render(<ModelBadge model="claude-opus-4.7" />);
+    expect(screen.getByText('Opus')).toBeTruthy();
+  });
+
+  it('renders Sonnet label for sonnet model', () => {
+    render(<ModelBadge model="claude-sonnet-4.6" />);
+    expect(screen.getByText('Sonnet')).toBeTruthy();
+  });
+
+  it('renders Haiku label for haiku model', () => {
+    render(<ModelBadge model="claude-haiku-3.5" />);
+    expect(screen.getByText('Haiku')).toBeTruthy();
+  });
+
+  it('renders raw model name for unknown models', () => {
+    render(<ModelBadge model="gpt-5" />);
+    expect(screen.getByText('gpt-5')).toBeTruthy();
+  });
+
+  it('shows full model in title attribute', () => {
+    render(<ModelBadge model="claude-opus-4.7-20250515" />);
+    const badge = screen.getByText('Opus');
+    expect(badge.closest('[title]')?.getAttribute('title')).toBe('claude-opus-4.7-20250515');
+  });
+});

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -689,6 +689,10 @@ export const en = {
     copyCommand: 'Copy command',
     copied: 'Copied!',
   },
+  modelBadge: {
+    title: 'Model',
+    effortTitle: 'Effort',
+  },
 } as const;
 
 export type Messages = typeof en;

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -683,4 +683,9 @@ export const it = {
     copyCommand: 'Copia comando',
     copied: 'Copiato!',
   },
+
+  modelBadge: {
+    title: 'Modello',
+    effortTitle: 'Sforzo',
+  },
 };

--- a/dashboard/src/types/session-extensions.ts
+++ b/dashboard/src/types/session-extensions.ts
@@ -1,0 +1,17 @@
+/**
+ * types/session-extensions.ts — Forward-compatible extensions to SessionInfo.
+ *
+ * These optional fields will be provided by the backend API in a future update.
+ * Until then, they default to undefined and UI components degrade gracefully.
+ *
+ * Usage: cast SessionInfo to ExtendedSessionInfo where model/effort is needed.
+ */
+
+import type { SessionInfo } from './index';
+
+export interface ExtendedSessionInfo extends SessionInfo {
+  /** AI model used for this session (e.g. "claude-opus-4.7"). Undefined for older sessions. */
+  model?: string;
+  /** Effort level for this session (e.g. "high", "medium", "low", "0.8"). Undefined for older sessions. */
+  effort?: string;
+}


### PR DESCRIPTION
## Model + Effort UI Shell (Forward-Compatible)

Implements the dashboard side of #3560. Ready for when backend exposes `model` and `effort` fields on `SessionInfo`.

### New Components
- **`ModelBadge`** — Color-coded model badge (Opus=purple, Sonnet=blue, Haiku=green, Other=muted). Reuses the same model style map as `ModelDistributionBar`.
- **`EffortIndicator`** — Compact dot + label for effort level. Supports both text (`high`/`medium`/`low`) and numeric (`0.8`) values.

### Integration
- **VirtualizedSessionList** — ModelBadge + EffortIndicator appear next to session name in the table row
- **SessionHeader** — ModelBadge + EffortIndicator appear in the metadata row (hidden on mobile)

### Forward Compatibility
- **`ExtendedSessionInfo`** type — extends `SessionInfo` with optional `model?` and `effort?` fields
- Both components render **nothing** when their prop is undefined — graceful degradation for sessions created before the backend adds these fields
- No backend changes required — pure UI shell

### Tests
- **ModelBadge**: 7 tests (null/undefined, Opus/Sonnet/Haiku/unknown, title attribute)
- **EffortIndicator**: 10 tests (null/undefined, high/med/low, numeric mapping, unknown, title attribute)
- **17/17 passing**

### Quality Gate
- ✅ TypeScript: no dashboard errors
- ✅ Tests: 17/17 passing
- ✅ Vite build: clean
- ✅ No new dependencies

### Next Steps (backend)
When `SessionInfo` gains `model` and `effort` fields, remove the `ExtendedSessionInfo` cast — everything else works automatically.

— Daedalus 🏛️