### PR TITLE
fix(cli): retry SSE token on ag tail  (#3566)

### DIFF
--- a/src/__tests__/tail-sse-retry.test.ts
+++ b/src/__tests__/tail-sse-retry.test.ts
@@ -1,0 +1,288 @@
+/**
+ * tail-sse-retry.test.ts — Tests for #3566: SSE token retry flow in `ag tail`.
+ *
+ * Covers:
+ * 1. Initial 401 → fetch SSE token → reconnect → successful stream
+ * 2. SSE token fetch failure (bearer token invalid) → clear error
+ * 3. Successful first connection (no SSE token needed — e.g. localhost no-auth mode)
+ * 4. SSE token fetch returns 401 → clear error message
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We test the handleTail function directly by mocking fetch.
+// Since tail.ts uses node:readline and platform-specific logic,
+// we focus on the HTTP retry behavior by testing fetchSSEToken
+// and the overall flow through handleTail with controlled mocks.
+
+import { Writable } from 'node:stream';
+
+// Helper to create a mock CliIO
+function createMockIO() {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const stdout = new Writable({ write: (chunk, _enc, cb) => { stdoutChunks.push(chunk.toString()); cb(); } });
+  const stderr = new Writable({ write: (chunk, _enc, cb) => { stderrChunks.push(chunk.toString()); cb(); } });
+  return {
+    io: {
+      stdin: process.stdin,
+      stdout,
+      stderr,
+    },
+    getStdout: () => stdoutChunks.join(''),
+    getStderr: () => stderrChunks.join(''),
+  };
+}
+
+// Mock modules before importing
+vi.mock('../cli-http.js', () => ({
+  resolveBaseUrl: vi.fn().mockResolvedValue('http://localhost:9100'),
+  resolveAuthToken: vi.fn().mockResolvedValue('test-bearer-token'),
+  buildHeaders: vi.fn().mockReturnValue({ Authorization: 'Bearer test-bearer-token' }),
+  requireServer: vi.fn().mockResolvedValue(true),
+  writeLine: (stream: NodeJS.WritableStream, text: string = '') => {
+    stream.write(`${text}\n`);
+  },
+}));
+
+// Import after mocks
+import { handleTail } from '../commands/tail.js';
+
+describe('ag tail — SSE token retry flow (#3566)', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch SSE token and reconnect when initial SSE request returns 401', async () => {
+    const { io, getStdout, getStderr } = createMockIO();
+
+    const sseEventsUrl = 'http://localhost:9100/v1/sessions/test-session/events';
+    const sseTokenUrl = 'http://localhost:9100/v1/auth/sse-token';
+    const sseTokenWithQuery = 'http://localhost:9100/v1/sessions/test-session/events?token=sse_test-token-123';
+
+    let fetchCallCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      fetchCallCount++;
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+      // First call: SSE endpoint with bearer token → 401
+      if (urlStr === sseEventsUrl && fetchCallCount === 1) {
+        return new Response(JSON.stringify({ error: 'Unauthorized — SSE token required for event streams' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Second call: POST /v1/auth/sse-token → success
+      if (urlStr === sseTokenUrl && init?.method === 'POST') {
+        return new Response(JSON.stringify({ token: 'sse_test-token-123', expiresAt: Date.now() + 300_000 }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Third call: SSE endpoint with ?token= → success with stream
+      if (urlStr === sseTokenWithQuery) {
+        const encoder = new TextEncoder();
+        const events = [
+          'data: {"type":"assistant","content":"Hello"}\n\n',
+          'data: [DONE]\n\n',
+        ];
+        const body = new ReadableStream({
+          start(controller) {
+            for (const event of events) {
+              controller.enqueue(encoder.encode(event));
+            }
+            controller.close();
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      }
+
+      return new Response('Not Found', { status: 404 });
+    });
+
+    const result = await handleTail(['test-session'], io);
+
+    expect(result).toBe(0);
+    expect(fetchCallCount).toBe(3);
+    expect(getStdout()).toContain('SSE token required');
+    expect(getStdout()).toContain('🤖 Hello');
+  });
+
+  it('should show clear error when SSE token fetch fails (401)', async () => {
+    const { io, getStdout, getStderr } = createMockIO();
+
+    const sseEventsUrl = 'http://localhost:9100/v1/sessions/test-session/events';
+    const sseTokenUrl = 'http://localhost:9100/v1/auth/sse-token';
+
+    let fetchCallCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      fetchCallCount++;
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+      // First call: SSE endpoint → 401
+      if (urlStr === sseEventsUrl && fetchCallCount === 1) {
+        return new Response(JSON.stringify({ error: 'Unauthorized — SSE token required for event streams' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Second call: POST /v1/auth/sse-token → 401 (invalid bearer)
+      if (urlStr === sseTokenUrl && init?.method === 'POST') {
+        return new Response(JSON.stringify({ error: 'Unauthorized — invalid API key' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response('Not Found', { status: 404 });
+    });
+
+    const result = await handleTail(['test-session'], io);
+
+    expect(result).toBe(1);
+    expect(fetchCallCount).toBe(2);
+    expect(getStderr()).toContain('Failed to obtain SSE token');
+    expect(getStderr()).toContain('ag login');
+  });
+
+  it('should succeed without SSE token when first request succeeds (no-auth localhost)', async () => {
+    const { io, getStdout, getStderr } = createMockIO();
+
+    const sseEventsUrl = 'http://localhost:9100/v1/sessions/test-session/events';
+
+    let fetchCallCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL | Request) => {
+      fetchCallCount++;
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+      if (urlStr === sseEventsUrl) {
+        const encoder = new TextEncoder();
+        const events = [
+          'data: {"type":"assistant","content":"Direct hello"}\n\n',
+        ];
+        const body = new ReadableStream({
+          start(controller) {
+            for (const event of events) {
+              controller.enqueue(encoder.encode(event));
+            }
+            controller.close();
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      }
+
+      return new Response('Not Found', { status: 404 });
+    });
+
+    const result = await handleTail(['test-session'], io);
+
+    expect(result).toBe(0);
+    expect(fetchCallCount).toBe(1);
+    expect(getStdout()).toContain('🤖 Direct hello');
+    expect(getStdout()).not.toContain('SSE token required');
+  });
+
+  it('should show clear error when SSE reconnect also fails with 401', async () => {
+    const { io, getStdout, getStderr } = createMockIO();
+
+    const sseEventsUrl = 'http://localhost:9100/v1/sessions/test-session/events';
+    const sseTokenUrl = 'http://localhost:9100/v1/auth/sse-token';
+    const sseTokenWithQuery = 'http://localhost:9100/v1/sessions/test-session/events?token=sse_expired-token';
+
+    let fetchCallCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      fetchCallCount++;
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+      // First call: SSE endpoint → 401
+      if (urlStr === sseEventsUrl && fetchCallCount === 1) {
+        return new Response(JSON.stringify({ error: 'Unauthorized — SSE token required for event streams' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Second call: POST /v1/auth/sse-token → success
+      if (urlStr === sseTokenUrl && init?.method === 'POST') {
+        return new Response(JSON.stringify({ token: 'sse_expired-token', expiresAt: Date.now() + 300_000 }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Third call: SSE endpoint with ?token= → still 401 (token expired)
+      if (urlStr === sseTokenWithQuery) {
+        return new Response(JSON.stringify({ error: 'Unauthorized — SSE token invalid or expired' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response('Not Found', { status: 404 });
+    });
+
+    const result = await handleTail(['test-session'], io);
+
+    expect(result).toBe(1);
+    expect(fetchCallCount).toBe(3);
+    expect(getStderr()).toContain('Unauthorized');
+    expect(getStderr()).toContain('SSE token authentication failed');
+  });
+
+  it('should return error when no session ID is provided', async () => {
+    const { io, getStderr } = createMockIO();
+
+    const result = await handleTail([], io);
+
+    expect(result).toBe(1);
+    expect(getStderr()).toContain('Missing session ID');
+  });
+
+  it('should handle SSE token fetch network error gracefully', async () => {
+    const { io, getStderr } = createMockIO();
+
+    const sseEventsUrl = 'http://localhost:9100/v1/sessions/test-session/events';
+
+    let fetchCallCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL | Request) => {
+      fetchCallCount++;
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+      // First call: SSE endpoint → 401
+      if (urlStr === sseEventsUrl && fetchCallCount === 1) {
+        return new Response(JSON.stringify({ error: 'Unauthorized — SSE token required for event streams' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Second call: POST /v1/auth/sse-token → network error (null return)
+      if (urlStr.includes('sse-token')) {
+        throw new Error('Network error');
+      }
+
+      return new Response('Not Found', { status: 404 });
+    });
+
+    const result = await handleTail(['test-session'], io);
+
+    expect(result).toBe(1);
+    expect(fetchCallCount).toBe(2);
+    expect(getStderr()).toContain('Failed to obtain SSE token');
+  });
+});

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -49,7 +49,7 @@ export async function handleRead(args: string[], io: CliIO): Promise<number> {
 
   for (const msg of messages) {
     const role = msg.role ?? 'unknown';
-    const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+    const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content ?? null) ?? '';
     const prefix = role === 'assistant' ? '🤖' : role === 'user' ? '👤' : '⚙️';
     // Truncate long messages for terminal readability
     const lines = content.split('\n');

--- a/src/commands/tail.ts
+++ b/src/commands/tail.ts
@@ -4,6 +4,10 @@
  * Connects to GET /v1/sessions/:id/events SSE stream and prints events.
  * Uses SIGINT on Unix and a readline keypress fallback on Windows for Ctrl+C.
  * Includes a 30-minute max-duration safeguard so the process never hangs forever.
+ *
+ * #3566: On SSE routes, the server requires short-lived SSE tokens (prefixed `sse_`).
+ * If the initial SSE request returns 401, the CLI fetches an SSE token via
+ * POST /v1/auth/sse-token and reconnects with ?token=<sse-token>.
  */
 
 import { platform } from 'node:os';
@@ -12,6 +16,34 @@ import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLin
 
 /** Maximum tail duration before auto-disconnect (30 minutes). */
 const MAX_TAIL_DURATION_MS = 30 * 60 * 1000;
+
+/**
+ * #3566: Fetch a short-lived SSE token from the server.
+ * The caller must provide a valid bearer token (already authenticated).
+ * Returns the SSE token string, or null if the request fails.
+ */
+async function fetchSSEToken(
+  baseUrl: string,
+  bearerToken: string,
+  signal?: AbortSignal,
+): Promise<{ token: string; expiresAt: number } | null> {
+  try {
+    const res = await fetch(`${baseUrl}/v1/auth/sse-token`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${bearerToken}`,
+        'Content-Type': 'application/json',
+      },
+      signal,
+    });
+    if (!res.ok) {
+      return null;
+    }
+    return await res.json() as { token: string; expiresAt: number };
+  } catch {
+    return null;
+  }
+}
 
 export async function handleTail(args: string[], io: CliIO): Promise<number> {
   const sessionId = args.find(a => !a.startsWith('-'));
@@ -73,9 +105,13 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
   // Don't prevent Node.js from exiting naturally.
   maxDurationTimer.unref();
 
+  // #3566: Build SSE URL — optionally includes ?token= for SSE-token auth.
+  let sseUrl = `${baseUrl}/v1/sessions/${sessionId}/events`;
+  let usedSSEToken = false;
+
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/events`, {
+    res = await fetch(sseUrl, {
       headers,
       signal: abortController.signal,
     });
@@ -87,16 +123,60 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
     throw e;
   }
 
+  // #3566: If 401 and we haven't tried SSE token yet, fetch one and retry.
+  if (res.status === 401 && !usedSSEToken && authToken) {
+    writeLine(io.stdout, '  🔑 SSE token required — fetching…');
+
+    const sseTokenResult = await fetchSSEToken(baseUrl, authToken, abortController.signal);
+    if (!sseTokenResult) {
+      writeLine(io.stderr, '  ❌ Failed to obtain SSE token — your bearer token may be invalid or expired.');
+      writeLine(io.stderr, '     Run `ag login` to refresh your credentials.');
+      clearTimeout(maxDurationTimer);
+      process.removeListener('SIGINT', onSigInt);
+      keypressCleanup?.();
+      return 1;
+    }
+
+    // Reconnect with ?token=<sse-token> query param
+    sseUrl = `${baseUrl}/v1/sessions/${sessionId}/events?token=${encodeURIComponent(sseTokenResult.token)}`;
+    usedSSEToken = true;
+
+    try {
+      res = await fetch(sseUrl, {
+        headers: { 'Accept': 'text/event-stream' },
+        signal: abortController.signal,
+      });
+    } catch (e: unknown) {
+      if ((e as Error).name === 'AbortError') {
+        clearTimeout(maxDurationTimer);
+        return 0;
+      }
+      throw e;
+    }
+  }
+
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
+    const errMsg = ((err as { error?: string }).error) || res.statusText;
+
+    // #3566: Surface specific guidance for SSE-related 401 errors
+    if (res.status === 401) {
+      writeLine(io.stderr, `  ❌ Unauthorized — ${errMsg}`);
+      writeLine(io.stderr, '     SSE token authentication failed. Run `ag login` to refresh credentials.');
+    } else {
+      writeLine(io.stderr, `  ❌ ${errMsg}`);
+    }
     clearTimeout(maxDurationTimer);
+    process.removeListener('SIGINT', onSigInt);
+    keypressCleanup?.();
     return 1;
   }
 
   if (!res.body) {
     writeLine(io.stderr, '  ❌ No response body — SSE not supported.');
     clearTimeout(maxDurationTimer);
+    process.removeListener('SIGINT', onSigInt);
+    keypressCleanup?.();
     return 1;
   }
 


### PR DESCRIPTION
## Summary

Fixes the `ag tail` command failing when the server enforces SSE-only token authentication on event-stream routes.

When the initial SSE request returns 401, the CLI now:
1. **Fetches an SSE token** via `POST /v1/auth/sse-token` using the existing bearer token
2. **Reconnects** to the SSE endpoint with `?token=<sse-token>` query parameter
3. **Surfaces clear errors** when the SSE token fetch fails (invalid/expired bearer token)

## Changes

- `src/commands/tail.ts` — Added `fetchSSEToken()` helper and retry logic on initial 401 response
- `src/__tests__/tail-sse-retry.test.ts` — 6 new tests covering:
  - Initial 401 → SSE token fetch → successful stream
  - SSE token fetch failure (invalid bearer) → clear error
  - Direct success without SSE token (no-auth localhost)
  - SSE reconnect still fails with 401 → clear error
  - Missing session ID → usage error
  - Network error during token fetch → graceful handling

## Verification

```
$ npx tsc --noEmit
# Exit code 0 — zero TypeScript errors

$ npm run build
# Build OK ✓

$ npm test
# 294 test files passed | 4310 tests passed | 8 skipped
# Exit code 0
```

## References

Closes #3566
Refs #297 #408
