### PR TITLE
fix(cli): ag read crash + ag tail unauthorized + auth-token file desync

### DIFF
--- a/src/__tests__/fix-3565-read-crash.test.ts
+++ b/src/__tests__/fix-3565-read-crash.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Issue #3565: ag read crashes with TypeError on split of undefined.
+ *
+ * The /read endpoint returns ParsedEntry objects with { text } not { content }.
+ * handleRead must handle both formats without crashing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../cli-http.js', () => ({
+  resolveBaseUrl: vi.fn(async () => 'http://localhost:9100'),
+  resolveAuthToken: vi.fn(async () => 'test-token'),
+  buildHeaders: vi.fn(() => ({ Authorization: 'Bearer test-token' })),
+  requireServer: vi.fn(async () => true),
+  writeLine: vi.fn(),
+}));
+
+import { handleRead } from '../commands/read.js';
+import { writeLine } from '../cli-http.js';
+
+function makeIO() {
+  return {
+    stdin: process.stdin as any,
+    stdout: { write: vi.fn() } as any,
+    stderr: { write: vi.fn() } as any,
+  };
+}
+
+describe('ag read (#3565)', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns error when session ID is missing', async () => {
+    const io = makeIO();
+    const exitCode = await handleRead([], io);
+    expect(exitCode).toBe(1);
+    expect(writeLine).toHaveBeenCalledWith(io.stderr, expect.stringContaining('Missing session ID'));
+  });
+
+  it('handles ParsedEntry format (text field) without crashing', async () => {
+    // #3565: /read returns { text } not { content }
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        messages: [
+          { role: 'user', contentType: 'text', text: 'Say hello', timestamp: '2026-05-16T00:00:00Z' },
+          { role: 'assistant', contentType: 'text', text: 'Hello!', timestamp: '2026-05-16T00:00:01Z' },
+        ],
+        status: 'idle',
+      }),
+    })) as any;
+
+    const io = makeIO();
+    const exitCode = await handleRead(['abc123'], io);
+    expect(exitCode).toBe(0);
+    expect(writeLine).toHaveBeenCalledWith(io.stdout, expect.stringContaining('👤 Say hello'));
+    expect(writeLine).toHaveBeenCalledWith(io.stdout, expect.stringContaining('🤖 Hello!'));
+  });
+
+  it('handles empty messages without crashing', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ messages: [], status: 'idle' }),
+    })) as any;
+
+    const io = makeIO();
+    const exitCode = await handleRead(['abc123'], io);
+    expect(exitCode).toBe(0);
+    expect(writeLine).toHaveBeenCalledWith(io.stdout, expect.stringContaining('No messages'));
+  });
+
+  it('handles mixed content and text fields', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        messages: [
+          { role: 'user', content: 'Old format message' },
+          { role: 'assistant', text: 'New format response' },
+          { role: 'system', text: 'System message' },
+        ],
+        status: 'idle',
+      }),
+    })) as any;
+
+    const io = makeIO();
+    const exitCode = await handleRead(['abc123'], io);
+    expect(exitCode).toBe(0);
+    expect(writeLine).toHaveBeenCalledWith(io.stdout, expect.stringContaining('👤 Old format message'));
+    expect(writeLine).toHaveBeenCalledWith(io.stdout, expect.stringContaining('🤖 New format response'));
+    expect(writeLine).toHaveBeenCalledWith(io.stdout, expect.stringContaining('⚙️ System message'));
+  });
+
+  it('handles messages with undefined text and content', async () => {
+    // Edge case: msg has neither text nor content
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        messages: [
+          { role: 'assistant' },
+        ],
+        status: 'idle',
+      }),
+    })) as any;
+
+    const io = makeIO();
+    // Should NOT crash with TypeError
+    const exitCode = await handleRead(['abc123'], io);
+    expect(exitCode).toBe(0);
+  });
+
+  it('handles server error response', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: 'Invalid token' }),
+    })) as any;
+
+    const io = makeIO();
+    const exitCode = await handleRead(['abc123'], io);
+    expect(exitCode).toBe(1);
+    expect(writeLine).toHaveBeenCalledWith(io.stderr, expect.stringContaining('Invalid token'));
+  });
+});

--- a/src/__tests__/fix-3567-auth-token-desync.test.ts
+++ b/src/__tests__/fix-3567-auth-token-desync.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #3567: auth-token file desyncs from config.yaml authToken on restart.
+ *
+ * The server should auto-repair the auth-token file when it detects
+ * the file token doesn't match any registered key.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('../utils/auth-token-path.js', () => ({
+  getAuthTokenFilePath: vi.fn(() => '/home/test/.aegis/auth-token'),
+  persistAuthTokenFile: vi.fn(),
+  readAuthTokenFile: vi.fn(() => null),
+}));
+
+import { AuthManager } from '../services/auth/AuthManager.js';
+
+describe('AuthManager #3567 — getMasterToken', () => {
+  const tmpDir = `/tmp/test-auth-3567-${Date.now()}`;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty string when no master token is set', () => {
+    const auth = new AuthManager(`${tmpDir}/keys.json`, '', '_system');
+    expect(auth.getMasterToken()).toBe('');
+  });
+
+  it('returns the master token when set', () => {
+    const auth = new AuthManager(`${tmpDir}/keys.json`, 'aegis_test_master_token', '_system');
+    expect(auth.getMasterToken()).toBe('aegis_test_master_token');
+  });
+});

--- a/src/__tests__/tail-sigint-windows-3512.test.ts
+++ b/src/__tests__/tail-sigint-windows-3512.test.ts
@@ -1,5 +1,6 @@
 /**
  * Regression tests for #3512 — ag tail SIGINT handler unreliable on Windows.
+ * Updated for #3566 — SSE token acquisition before connecting to events stream.
  *
  * Verifies:
  * 1. On Windows (platform() === 'win32'), readline keypress listener is used as fallback
@@ -7,6 +8,7 @@
  * 3. 30-minute max-duration timer is always set
  * 4. Cleanup happens correctly on abort (SIGINT, keypress, or timeout)
  * 5. Missing session ID returns error
+ * 6. #3566: SSE token is obtained before connecting to event stream
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -42,6 +44,27 @@ function makeIO() {
   };
 }
 
+/**
+ * #3566: Create a mock fetch that handles the two-step SSE flow:
+ * 1st call: POST /v1/auth/sse-token → { token: 'sse_test_token' }
+ * 2nd call: GET /v1/sessions/:id/events → SSE stream
+ */
+function createSSEMockFetch(streamResponse: { ok: boolean; body?: ReadableStream; json?: () => Promise<any> }) {
+  let callCount = 0;
+  return vi.fn(async (url: string, opts?: any) => {
+    callCount++;
+    // First call: SSE token endpoint
+    if (callCount === 1 && typeof url === 'string' && url.includes('/sse-token')) {
+      return {
+        ok: true,
+        json: async () => ({ token: 'sse_test_token' }),
+      };
+    }
+    // Second call: events stream
+    return streamResponse;
+  });
+}
+
 describe('tail SIGINT handling (#3512)', () => {
   const originalIsTTY = process.stdin.isTTY;
 
@@ -73,11 +96,11 @@ describe('tail SIGINT handling (#3512)', () => {
       },
     });
 
-    const mockFetch = vi.fn(async () => ({
+    const mockFetch = createSSEMockFetch({
       ok: true,
       body: fakeStream,
       json: async () => ({}),
-    }));
+    });
 
     const originalGlobalFetch = globalThis.fetch;
     globalThis.fetch = mockFetch as any;
@@ -103,11 +126,11 @@ describe('tail SIGINT handling (#3512)', () => {
       },
     });
 
-    const mockFetch = vi.fn(async () => ({
+    const mockFetch = createSSEMockFetch({
       ok: true,
       body: fakeStream,
       json: async () => ({}),
-    }));
+    });
 
     const originalGlobalFetch = globalThis.fetch;
     globalThis.fetch = mockFetch as any;
@@ -123,13 +146,43 @@ describe('tail SIGINT handling (#3512)', () => {
     }
   });
 
-  it('handles server returning non-OK response', async () => {
+  it('handles SSE token fetch failure', async () => {
+    // SSE token endpoint returns failure
     const mockFetch = vi.fn(async () => ({
       ok: false,
-      status: 404,
-      statusText: 'Not Found',
-      json: async () => ({ error: 'Session not found' }),
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: 'Invalid token' }),
     }));
+
+    const originalGlobalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch as any;
+
+    try {
+      const io = makeIO();
+      const exitCode = await handleTail(['abc123'], io);
+      expect(exitCode).toBe(1);
+      expect(writeLine).toHaveBeenCalledWith(io.stderr, expect.stringContaining('SSE token'));
+    } finally {
+      globalThis.fetch = originalGlobalFetch;
+    }
+  });
+
+  it('handles events stream returning non-OK response', async () => {
+    // First call succeeds (SSE token), second fails (stream)
+    let callCount = 0;
+    const mockFetch = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, json: async () => ({ token: 'sse_test_token' }) };
+      }
+      return {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({ error: 'Session not found' }),
+      };
+    });
 
     const originalGlobalFetch = globalThis.fetch;
     globalThis.fetch = mockFetch as any;
@@ -153,11 +206,11 @@ describe('tail SIGINT handling (#3512)', () => {
       },
     });
 
-    const mockFetch = vi.fn(async () => ({
+    const mockFetch = createSSEMockFetch({
       ok: true,
       body: fakeStream,
       json: async () => ({}),
-    }));
+    });
 
     const originalGlobalFetch = globalThis.fetch;
     globalThis.fetch = mockFetch as any;
@@ -185,11 +238,11 @@ describe('tail SIGINT handling (#3512)', () => {
         },
       });
 
-      const mockFetch = vi.fn(async () => ({
+      const mockFetch = createSSEMockFetch({
         ok: true,
         body: fakeStream,
         json: async () => ({}),
-      }));
+      });
 
       const originalGlobalFetch = globalThis.fetch;
       globalThis.fetch = mockFetch as any;

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -2,6 +2,7 @@
  * commands/read.ts — `ag read <id>` — Read session output.
  *
  * Wraps GET /v1/sessions/:id/read with optional pagination.
+ * Issue #3565: Handle both legacy msg.content and ParsedEntry msg.text fields.
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
@@ -49,7 +50,10 @@ export async function handleRead(args: string[], io: CliIO): Promise<number> {
 
   for (const msg of messages) {
     const role = msg.role ?? 'unknown';
-    const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+    // #3565: /read returns ParsedEntry { text } not { content }.
+    // Handle both formats with null safety.
+    const raw = msg.text ?? msg.content;
+    const content = typeof raw === 'string' ? raw : JSON.stringify(raw ?? '') ?? '';
     const prefix = role === 'assistant' ? '🤖' : role === 'user' ? '👤' : '⚙️';
     // Truncate long messages for terminal readability
     const lines = content.split('\n');

--- a/src/commands/tail.ts
+++ b/src/commands/tail.ts
@@ -2,6 +2,9 @@
  * commands/tail.ts — `ag tail <id>` — Follow session output in real-time.
  *
  * Connects to GET /v1/sessions/:id/events SSE stream and prints events.
+ * Issue #3566: SSE endpoints require short-lived sse_ tokens.
+ * The CLI first obtains an SSE token via POST /v1/auth/sse-token, then connects.
+ *
  * Uses SIGINT on Unix and a readline keypress fallback on Windows for Ctrl+C.
  * Includes a 30-minute max-duration safeguard so the process never hangs forever.
  */
@@ -12,6 +15,25 @@ import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLin
 
 /** Maximum tail duration before auto-disconnect (30 minutes). */
 const MAX_TAIL_DURATION_MS = 30 * 60 * 1000;
+
+/**
+ * Issue #3566: Obtain a short-lived SSE token via POST /v1/auth/sse-token.
+ * SSE endpoints reject long-lived bearer tokens — only sse_ prefixed tokens are accepted.
+ */
+async function obtainSSEToken(baseUrl: string, authToken: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${baseUrl}/v1/auth/sse-token`, {
+      method: 'POST',
+      headers: buildHeaders(authToken),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) return null;
+    const body = await res.json() as { token?: string };
+    return body.token ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export async function handleTail(args: string[], io: CliIO): Promise<number> {
   const sessionId = args.find(a => !a.startsWith('-'));
@@ -24,7 +46,14 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
   const authToken = await resolveAuthToken();
   if (!(await requireServer(baseUrl, authToken, io))) return 1;
 
-  const headers = buildHeaders(authToken);
+  // Issue #3566: Obtain SSE token before connecting to the event stream.
+  const sseToken = await obtainSSEToken(baseUrl, authToken);
+  if (!sseToken) {
+    writeLine(io.stderr, '  ❌ Failed to obtain SSE token. Check your auth credentials.');
+    return 1;
+  }
+
+  const headers = buildHeaders(sseToken);
   headers['Accept'] = 'text/event-stream';
 
   writeLine(io.stdout, `  Tailing session ${sessionId.slice(0, 8)}… (Ctrl+C to stop)`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ import Fastify, { type FastifyRequest, type FastifyReply } from 'fastify';
 import fastifyRateLimit from '@fastify/rate-limit';
 import fs from 'node:fs/promises';
 import { existsSync, readFileSync, watch, type FSWatcher } from 'node:fs';
-import { getAuthTokenFilePath } from './utils/auth-token-path.js';
+import { getAuthTokenFilePath, persistAuthTokenFile } from './utils/auth-token-path.js';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyCors from '@fastify/cors';
 import crypto from 'node:crypto';
@@ -932,21 +932,27 @@ async function main(): Promise<void> {
   container.register('authManager', auth, {
     start: async () => {
       await auth.load();
-      // #3356/#3484: Detect an orphaned ~/.aegis/auth-token whose content no
-      // longer matches any registered key. CLI usage via that file will fail
-      // silently otherwise.
+      // #3356/#3484/#3567: Detect and auto-repair an orphaned ~/.aegis/auth-token
+      // whose content no longer matches any registered key. Auto-repair by
+      // persisting the current master token so the CLI keeps working after restarts.
       const clientTokenFile = getAuthTokenFilePath();
-      if (existsSync(clientTokenFile)) {
+      const currentMaster = auth.getMasterToken();
+      if (currentMaster) {
         try {
-          const fileToken = readFileSync(clientTokenFile, 'utf-8').trim();
-          if (fileToken && !auth.checkClientToken(fileToken).matched) {
-            console.warn(
-              `[auth] ${clientTokenFile} contains a token that does not match any registered key — ` +
-              `CLI auth via that file will fail. Run 'ag init' to refresh or delete the file.`,
-            );
+          const fileToken = existsSync(clientTokenFile)
+            ? readFileSync(clientTokenFile, 'utf-8').trim()
+            : '';
+          if (!fileToken || !auth.checkClientToken(fileToken).matched) {
+            persistAuthTokenFile(currentMaster);
+            if (fileToken) {
+              console.warn(
+                `[auth] ${clientTokenFile} desynced from config — auto-repaired with current master token.`,
+              );
+            }
           }
         } catch {
-          // Unreadable — ignore, the CLI will surface its own auth error.
+          // Unreadable — try to persist anyway
+          persistAuthTokenFile(currentMaster);
         }
       }
     },

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -729,6 +729,11 @@ export class AuthManager {
     return true;
   }
 
+  /** #3567: Expose master token for auth-token file auto-repair. */
+  getMasterToken(): string {
+    return this.masterToken;
+  }
+
   /** Hash a key with SHA-256. */
   static hashKey(key: string): string {
     return createHash('sha256').update(key).digest('hex');


### PR DESCRIPTION
## Summary

Fixes three dogfood-found CLI bugs from v0.6.7:

### #3565 — `ag read` crashes with TypeError on split of undefined
**Root cause:** `/read` endpoint returns `ParsedEntry` objects with `{ text }` field, but `handleRead` accessed `msg.content` which is undefined. `JSON.stringify(undefined)` returns `undefined` (not a string), causing the `.split()` crash.

**Fix:** Check `msg.text` (ParsedEntry format) before `msg.content` (legacy), with null safety via `?? ''`.

### #3566 — `ag tail` returns Unauthorized — SSE token required
**Root cause:** SSE endpoints (`/v1/sessions/:id/events`) require short-lived `sse_` prefixed tokens. The CLI passed the long-lived `aegis_` API key directly, which was rejected by `classifyBearerTokenForRoute()`.

**Fix:** `handleTail` now calls `POST /v1/auth/sse-token` to obtain a short-lived SSE token before connecting to the events stream.

### #3567 — auth-token file desyncs from config.yaml authToken on restart
**Root cause:** When the server restarts and `config.yaml` gets a new `authToken`, the `~/.aegis/auth-token` file still has the old one. CLI commands fail with "Unauthorized" until manually synced.

**Fix:** Server auth startup now auto-repairs the auth-token file when it detects the file token doesn't match any registered key. Added `AuthManager.getMasterToken()` for the repair path.

## Verification

```
tsc --noEmit: ✅
npm run build: ✅
npm test: ✅ 4329 passed (8 skipped)
```

- 6 new tests for `ag read` (ParsedEntry format, null safety, mixed formats)
- 7 tests for `ag tail` (updated for SSE token flow + new failure case)
- 2 new tests for `AuthManager.getMasterToken()`

## Files Changed

| File | Change |
|------|--------|
| `src/commands/read.ts` | Handle `msg.text` before `msg.content` with null safety |
| `src/commands/tail.ts` | Obtain SSE token before connecting to events stream |
| `src/server.ts` | Auto-repair auth-token file on startup desync |
| `src/services/auth/AuthManager.ts` | Add `getMasterToken()` method |
| `src/__tests__/fix-3565-read-crash.test.ts` | New: 6 tests for read crash fix |
| `src/__tests__/fix-3567-auth-token-desync.test.ts` | New: 2 tests for auth desync |
| `src/__tests__/tail-sigint-windows-3512.test.ts` | Updated: SSE token mock flow |