### PR TITLE
feat(cli): --passthrough flag (bypassPermissions) (#3544)

### DIFF
--- a/src/__tests__/feat-3544-passthrough.test.ts
+++ b/src/__tests__/feat-3544-passthrough.test.ts
@@ -1,0 +1,134 @@
+/**
+ * feat-3544-passthrough.test.ts
+ *
+ * Issue #3544: --passthrough CLI flag should pass permissionMode='bypassPermissions'
+ * to POST /v1/sessions in both `ag run` and `ag create`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+
+// ── Helpers ──
+
+function createMockIO() {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  return {
+    io: {
+      stdin: { on: vi.fn(), resume: vi.fn() } as unknown as NodeJS.ReadableStream,
+      stdout: { write: (t: string) => { stdoutChunks.push(t); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: (t: string) => { stderrChunks.push(t); } } as unknown as NodeJS.WritableStream,
+    },
+    getStdout: () => stdoutChunks.join(''),
+    getStderr: () => stderrChunks.join(''),
+  };
+}
+
+// ── Unit tests for flag parsing ──
+
+describe('Issue #3544: --passthrough flag', () => {
+  describe('run.ts flag parsing', () => {
+    it('--passthrough should be recognized in acceptPerms check', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const source = fs.readFileSync(
+        path.join(import.meta.dirname ?? __dirname, '..', 'commands', 'run.ts'),
+        'utf-8',
+      );
+      // Verify the line that sets acceptPerms includes --passthrough
+      expect(source).toMatch(/args\.includes\(['"]--passthrough['"]\)/);
+      // Verify permissionMode: 'bypassPermissions' is used when acceptPerms is true
+      expect(source).toMatch(/permissionMode:\s*['"]bypassPermissions['"]/);
+    });
+
+    it('run.ts help text mentions --passthrough', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const source = fs.readFileSync(
+        path.join(import.meta.dirname ?? __dirname, '..', 'commands', 'run.ts'),
+        'utf-8',
+      );
+      expect(source).toMatch(/--passthrough/);
+    });
+  });
+
+  describe('cli.ts handleCreate flag parsing', () => {
+    it('--passthrough should be recognized in acceptPerms check in handleCreate', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const source = fs.readFileSync(
+        path.join(import.meta.dirname ?? __dirname, '..', 'cli.ts'),
+        'utf-8',
+      );
+      expect(source).toMatch(/args\.includes\(['"]--passthrough['"]\)/);
+    });
+
+    it('cli.ts help text mentions --passthrough', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const source = fs.readFileSync(
+        path.join(import.meta.dirname ?? __dirname, '..', 'cli.ts'),
+        'utf-8',
+      );
+      // Help text should document --passthrough
+      const helpSection = source.match(/Create:[\s\S]*?Doctor:/)?.[0] ?? '';
+      expect(helpSection).toContain('--passthrough');
+    });
+  });
+
+  describe('cli.ts handleCreate --passthrough behavior via mocked fetch', () => {
+    let originalFetch: typeof globalThis.fetch;
+    let fetchCalls: Array<{ url: string; options?: RequestInit }>;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      fetchCalls = [];
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, options?: RequestInit) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+        fetchCalls.push({ url: urlStr, options });
+
+        if (urlStr.includes('/v1/sessions/stats')) {
+          return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } });
+        }
+        if (urlStr.includes('/v1/sessions') && options?.method === 'POST') {
+          return new Response(JSON.stringify({
+            id: 'test-session-id',
+            displayName: 'test-session',
+          }), { status: 200, headers: { 'content-type': 'application/json' } });
+        }
+        if (urlStr.includes('/send')) {
+          return new Response(JSON.stringify({ delivered: true, attempts: 1 }), { status: 200, headers: { 'content-type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }) as unknown as typeof globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('handleCreate sends permissionMode=bypassPermissions when --passthrough is set', async () => {
+      const { runCli } = await import('../cli.js');
+      const { io } = createMockIO();
+      await runCli(['create', 'test brief', '--passthrough'], io);
+
+      const postCall = fetchCalls.find(c => c.url.includes('/v1/sessions') && c.options?.method === 'POST');
+      expect(postCall).toBeDefined();
+
+      const body = JSON.parse(postCall!.options!.body as string);
+      expect(body.permissionMode).toBe('bypassPermissions');
+    });
+
+    it('handleCreate does NOT send permissionMode when --passthrough is absent', async () => {
+      const { runCli } = await import('../cli.js');
+      const { io } = createMockIO();
+      await runCli(['create', 'test brief'], io);
+
+      const postCall = fetchCalls.find(c => c.url.includes('/v1/sessions') && c.options?.method === 'POST');
+      expect(postCall).toBeDefined();
+
+      const body = JSON.parse(postCall!.options!.body as string);
+      expect(body.permissionMode).toBeUndefined();
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,7 +136,7 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
     }
   }
 
-  const acceptPerms = args.includes('--accept-permissions') || args.includes('-y');
+  const acceptPerms = args.includes('--accept-permissions') || args.includes('-y') || args.includes('--passthrough');
 
   if (!brief) {
     writeLine(io.stderr, '  ❌ Missing brief. Usage: ag create "Build a login page"');
@@ -262,6 +262,7 @@ function printHelp(io: CliIO): void {
   Create:
     ag create "Build a login page" --cwd /path/to/project
     ag create "Fix the tests"      (uses current directory)
+    ag create "..." --passthrough   Bypass all permissions
 
   Doctor:
     ag doctor              Validate starter templates here, otherwise run local diagnostics

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -271,6 +271,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
     writeLine(io.stdout, '    --port <number>       Server port override (default: 9100)');
     writeLine(io.stdout, '    --no-stream           Don\'t stream output; print status only');
     writeLine(io.stdout, '    --accept-permissions  Auto-approve tool permissions (-y)');
+    writeLine(io.stdout, '    --passthrough          Run session with all permissions bypassed');
     writeLine(io.stdout, '    --model <model>       Override default Claude model');
     writeLine(io.stdout, '    -h, --help            Show this help message');
     writeLine(io.stdout);
@@ -295,7 +296,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
 
   const noStream = args.includes('--no-stream');
   const skipPrompts = args.includes('--yes');
-  const acceptPerms = args.includes('--accept-permissions') || args.includes('-y');
+  const acceptPerms = args.includes('--accept-permissions') || args.includes('-y') || args.includes('--passthrough');
 
   writeLine(io.stdout, `  🚀 ag run: ${brief.slice(0, 60)}${brief.length > 60 ? '...' : ''}`);
 


### PR DESCRIPTION
## Summary

Implements `--passthrough` CLI flag for `ag run` and `ag create` that passes `permissionMode='bypassPermissions'` to the session creation API.

Closes #3544

## Changes

- **`src/commands/run.ts`**: Accept `--passthrough` alongside `--accept-permissions`/`-y`, triggering `permissionMode: 'bypassPermissions'` in POST /v1/sessions
- **`src/cli.ts` (handleCreate)**: Same `--passthrough` support for `ag create`
- **Help text**: Updated in both `ag run --help` and main `ag --help` to document the flag
- **Tests**: `src/__tests__/feat-3544-passthrough.test.ts` — 6 tests covering source-level flag parsing, help text documentation, integration test with mocked fetch, and negative test

## Verification

```
$ npx tsc --noEmit
# ✅ Zero errors

$ npm run build
# ✅ Build succeeded

$ npx vitest run src/__tests__/feat-3544-passthrough.test.ts
# ✅ 6 tests passed (907ms)

$ npm test
# ✅ 4334 passed, 0 new failures (pre-existing flaky e2e tests unrelated to this change)
```

## Usage

```bash
# Bypass all permissions in a run session
ag run "Fix the tests" --passthrough

# Bypass all permissions in a create session
ag create "Build a REST API" --passthrough
```
