### PR TITLE
docs: add --passthrough flag to CLI reference and getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,7 @@ If the server is already running, `ag run` skips bootstrap and start — goes st
 | `--name <name>` | Set a display name for the session |
 | `--yes` | Suppress all status messages for non-interactive/CI usage |
 | `--accept-permissions` / `-y` | Auto-approve all permission prompts (sets `permissionMode: bypassPermissions`) |
+| `--passthrough` | Same as `--accept-permissions` — bypass all permissions (alias) |
 
 > **Note:** `ag run --help` currently shows the general help. For `ag run` flags, refer to this table.
 

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -70,6 +70,9 @@ If the server is already running, skips straight to session creation. Existing c
 |------|-------------|
 | `--cwd <path>` | Working directory (default: current directory) |
 | `--port <number>` | Server port override |
+| `--yes` | Suppress status messages for non-interactive/CI usage |
+| `--accept-permissions` / `-y` | Auto-approve all permission prompts |
+| `--passthrough` | Bypass all permissions (alias for `--accept-permissions`) |
 | `--no-stream` | Don't stream output; print curl commands instead |
 
 ### `ag` — Start Server


### PR DESCRIPTION
Documents the `--passthrough` CLI flag added in #3570.\n\n- `docs/integrations/cli.md`: adds `--passthrough`, `--yes`, `--accept-permissions` to ag run flags table\n- `docs/getting-started.md`: adds `--passthrough` as alias for `--accept-permissions`