### PR TITLE
docs: fix orphaned code fence and remove unreleased effort field (#3578)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -802,13 +802,11 @@ curl -X POST http://localhost:9100/v1/sessions \
   "status": "working",
   "createdAt": 1712650800000,
   "promptDelivery": { "delivered": true, "attempts": 1, "status": "delivered" },
-  "model": "opus-4.7",
-  "effort": "high"
+  "model": "opus-4.7"
 }
 ```
 
-> **Note:** `model` and `effort` fields appear in the response when provided at creation time. Both are optional. When the backend implementation lands (#3560), these will also be populated from CC session metadata.
-```
+> **Note:** The `model` field appears in the response when provided at creation time. The `effort` field is accepted at creation but not yet returned in responses — it will be added once the backend implementation lands (#3560).
 
 **`promptDelivery` fields:**
 


### PR DESCRIPTION
## Summary
Fixes #3578 — two docs accuracy issues found in Argus post-merge audit of PR #3562.

## Changes
- **Remove orphaned closing code fence** after the Note block in `api-reference.md` (~line 812). This trailing \`\`\` broke markdown rendering — everything after it until the next fence became a code block.
- **Remove `effort` from response example** — the backend does not yet return this field (proposed, #3560). Including it misleads API consumers who try the example and don't get `effort` back.
- **Update Note** to accurately reflect current state: `model` is returned in responses, `effort` is accepted at creation but not yet in responses.

## Files
- `docs/api-reference.md` — 2 insertions, 4 deletions

## Severity
P2 docs accuracy — not blocking, but the orphaned fence was breaking the API reference rendering.

Self-merge OK (docs-only, no code changes).