### PR TITLE
fix(hooks): sync VALID_PERMISSION_MODES with Zod schema (#3577)

### DIFF
--- a/src/__tests__/fix-3577-permission-modes-sync.test.ts
+++ b/src/__tests__/fix-3577-permission-modes-sync.test.ts
@@ -1,0 +1,59 @@
+/**
+ * #3577 — VALID_PERMISSION_MODES must match the Zod schema in routes/sessions.ts
+ *
+ * The Zod schema accepts: default, bypassPermissions, plan, acceptEdits, dontAsk, auto
+ * hooks.ts VALID_PERMISSION_MODES must include all of them, or permission requests
+ * silently fall back to "default" and auto-approve never triggers.
+ */
+import { describe, it, expect } from 'vitest';
+
+// Re-extract VALID_PERMISSION_MODES from hooks.ts via dynamic import
+// We test the Set contents directly by checking the hook behavior
+
+// Read the source to verify consistency
+import fs from 'fs';
+import path from 'path';
+
+const hooksSource = fs.readFileSync(path.resolve(__dirname, '../hooks.ts'), 'utf-8');
+const sessionsSource = fs.readFileSync(path.resolve(__dirname, '../routes/sessions.ts'), 'utf-8');
+
+describe('#3577: VALID_PERMISSION_MODES matches Zod schema', () => {
+  const VALID_MODES_MATCH = hooksSource.match(
+    /VALID_PERMISSION_MODES\s*=\s*new\s+Set\(\[([^\]]+)\]\)/
+  );
+  const ZOD_ENUM_MATCH = sessionsSource.match(
+    /permissionMode:\s*z\.enum\(\[([^\]]+)\]\)/
+  );
+
+  it('should find VALID_PERMISSION_MODES in hooks.ts', () => {
+    expect(VALID_MODES_MATCH).not.toBeNull();
+  });
+
+  it('should find permissionMode z.enum in sessions.ts', () => {
+    expect(ZOD_ENUM_MATCH).not.toBeNull();
+  });
+
+  it('VALID_PERMISSION_MODES should contain all Zod enum values', () => {
+    if (!VALID_MODES_MATCH || !ZOD_ENUM_MATCH) return;
+
+    const parseValues = (s: string) =>
+      s.split(',')
+        .map(v => v.trim().replace(/['"]/g, ''))
+        .filter(Boolean);
+
+    const hookModes = parseValues(VALID_MODES_MATCH[1]);
+    const zodModes = parseValues(ZOD_ENUM_MATCH[1]);
+
+    for (const mode of zodModes) {
+      expect(hookModes).toContain(mode);
+    }
+  });
+
+  it('specifically includes auto, dontAsk, and acceptEdits', () => {
+    if (!VALID_MODES_MATCH) return;
+    const modes = VALID_MODES_MATCH[1];
+    expect(modes).toContain('auto');
+    expect(modes).toContain('dontAsk');
+    expect(modes).toContain('acceptEdits');
+  });
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -80,7 +80,7 @@ const HOOK_CIRCUIT_BREAKER_MAX = getCircuitBreakerMax();
 const HOOK_CIRCUIT_BREAKER_WINDOW_MS = getCircuitBreakerWindowMs();
 
 /** Valid permission_mode values accepted by Claude Code. */
-const VALID_PERMISSION_MODES = new Set(['default', 'plan', 'bypassPermissions']);
+const VALID_PERMISSION_MODES = new Set(['default', 'plan', 'bypassPermissions', 'acceptEdits', 'dontAsk', 'auto']);
 
 /** Valid CC hook event names (allow any for extensibility, but these are known). */
 const KNOWN_HOOK_EVENTS = new Set([


### PR DESCRIPTION
## Summary

Fixes #3577 — `VALID_PERMISSION_MODES` in `hooks.ts` only listed 3 values while the Zod schema in `routes/sessions.ts` accepts 6.

### The Bug
Sessions created with `permissionMode: "auto"`, `"dontAsk"`, or `"acceptEdits"` were silently downgraded to `"default"` at runtime, breaking auto-approve for those modes.

### The Fix
Synced `VALID_PERMISSION_MODES` to include all 6 values from the Zod enum:
- `default`, `plan`, `bypassPermissions` (existing)
- `acceptEdits`, `dontAsk`, `auto` (added)

### Regression Test
Added `fix-3577-permission-modes-sync.test.ts` that parses both `hooks.ts` and `routes/sessions.ts` source files and asserts every Zod enum value appears in the Set. Future drift will be caught immediately.

## Verification
- Commit: `44bb3d62`
- `tsc --noEmit`: ✅ zero errors
- `npm run build`: ✅ success
- `npm test`: ✅ 4339 passed (8 skipped)
- New tests: 4/4 passed

## Emergency Exception
Aegis server is DOWN. Direct implementation applied per SOUL.md rule 4 (dogfooding unavailable).