### PR TITLE
feat(dashboard): surface model per session in table and detail page

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -207,6 +207,7 @@ export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
     url: z.string(),
     description: z.string(),
   })).optional(),
+  model: z.string().optional(),
 });
 
 // ── SessionsListResponse ────────────────────────────────────────

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -200,7 +200,7 @@ function VirtualizedRow(props: {
         >
           {formatSessionName(session.displayName, session.id.slice(0, 8))}
         </Link>
-        <ModelBadge model={(session as ExtendedSessionInfo).model} />
+        <ModelBadge model={session.model} />
         <EffortIndicator effort={(session as ExtendedSessionInfo).effort} />
       </div>
       <div className="flex items-center max-w-[150px] truncate px-3 font-mono text-xs text-[var(--color-text-muted)]" title={session.workDir}>

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -181,7 +181,7 @@ export function SessionHeader({
           {truncateMiddle(session.id, 16)}
           <CopyButton value={session.id} label="session ID" size={16} />
         </span>
-        <ModelBadge model={(session as ExtendedSessionInfo).model} className="hidden sm:inline-flex" />
+        <ModelBadge model={session.model} className="hidden sm:inline-flex" />
         <EffortIndicator effort={(session as ExtendedSessionInfo).effort} className="hidden sm:inline-flex" />
         {session.ownerKeyId && (
           <span className="group hidden font-mono sm:inline-flex items-center gap-1">

--- a/dashboard/src/types/session-extensions.ts
+++ b/dashboard/src/types/session-extensions.ts
@@ -10,8 +10,6 @@
 import type { SessionInfo } from './index';
 
 export interface ExtendedSessionInfo extends SessionInfo {
-  /** AI model used for this session (e.g. "claude-opus-4.7"). Undefined for older sessions. */
-  model?: string;
   /** Effort level for this session (e.g. "high", "medium", "low", "0.8"). Undefined for older sessions. */
   effort?: string;
 }

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -71,6 +71,7 @@ export interface SessionInfo {
   }>;
   ownerKeyId?: string;
   tenantId?: string;
+  model?: string;
 }
 
 export interface SessionHealth {


### PR DESCRIPTION
## Summary

Surface the `model` field from the Aegis API in the dashboard UI.

### Changes
- **`src/api-contracts.ts`**: Add `model?: string` to `SessionInfo` interface
- **`dashboard/src/api/schemas.ts`**: Add `model` to `SessionInfoSchema` (Zod)
- **`SessionHeader.tsx`**: Remove `ExtendedSessionInfo` cast for model, use `session.model` directly
- **`VirtualizedSessionList.tsx`**: Same cleanup
- **`session-extensions.ts`**: Remove `model` from extension (now in base type)

### What this does
- Model badge now reads from the typed API response instead of an unsafe cast
- Graceful degradation: `ModelBadge` renders nothing when model is `undefined` (older sessions)
- `EffortIndicator` still uses `ExtendedSessionInfo` cast — backend does not store effort yet

### What this does NOT do
- Does not add `effort` to API contracts (backend does not store it)
- Does not modify `ModelBadge` or `EffortIndicator` components (they already work)
- Does not touch backend session logic

### Verification
- `tsc --noEmit`: ✅ zero errors
- `npm run build`: ✅ clean build
- `npm test`: ✅ 1402 tests pass (142 files, 2 skipped)

Closes #3560

— Daedalus 🏛️