### PR TITLE
fix(test): 3 tests fail when running npm test without prior npm run build

### DIFF
--- a/src/__tests__/acp-remove-tmux-rest-endpoints-2605.test.ts
+++ b/src/__tests__/acp-remove-tmux-rest-endpoints-2605.test.ts
@@ -10,20 +10,26 @@
 
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 describe('ACP-062: Remove legacy-specific REST endpoints', () => {
   let openapi: Record<string, unknown>;
+  let openapiAvailable: boolean;
 
   try {
     execFileSync('npm', ['run', 'build:openapi', '--silent'], { encoding: 'utf-8' });
     const distJson = readFileSync('./dist/openapi.json', 'utf-8');
     openapi = JSON.parse(distJson);
+    openapiAvailable = true;
   } catch {
     try {
       openapi = JSON.parse(readFileSync('./dist/openapi.json', 'utf-8'));
+      openapiAvailable = true;
     } catch {
+      // dist/openapi.json not available (fresh clone without build).
+      // Skip positive endpoint assertions — they require the OpenAPI spec.
       openapi = { paths: {} };
+      openapiAvailable = false;
     }
   }
 
@@ -42,12 +48,12 @@ describe('ACP-062: Remove legacy-specific REST endpoints', () => {
     expect(paths['/v1/sessions/{id}/discover-commands']).toBeUndefined();
   });
 
-  it('should still have /command endpoint (slash command, not legacy-specific)', () => {
+  it.skipIf(!openapiAvailable)('should still have /command endpoint (slash command, not legacy-specific)', () => {
     const paths = (openapi.paths || {}) as Record<string, unknown>;
     expect(paths['/v1/sessions/{id}/command']).toBeDefined();
   });
 
-  it('should still have /summary endpoint (session summary, not legacy-specific)', () => {
+  it.skipIf(!openapiAvailable)('should still have /summary endpoint (session summary, not legacy-specific)', () => {
     const paths = (openapi.paths || {}) as Record<string, unknown>;
     expect(paths['/v1/sessions/{id}/summary']).toBeDefined();
   });

--- a/src/__tests__/bin-resolution.test.ts
+++ b/src/__tests__/bin-resolution.test.ts
@@ -35,7 +35,9 @@ describe('package.json bin entries (#1929)', () => {
   });
 
   it('resolves both bins to the same existing CLI file', () => {
-    expect(existsSync(agBin)).toBe(true);
+    // Skip when dist/ has not been built (fresh clone without npm run build).
+    // CI always builds first, so this only affects local dev on bare clones.
+    if (!existsSync(agBin)) return;
     expect(existsSync(aegisBin)).toBe(true);
     expect(realpathSync(agBin)).toBe(realpathSync(aegisBin));
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
       '.worktrees/**',
       '.claude/worktrees/**',
       '.claude-internals/**',
+      // E2E requires build artifacts (dist/server.js) — use test:e2e script instead
+      'e2e/**',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Fix 3 tests that depend on dist/ build artifacts. e2e excluded from vitest, openapi/bin tests gracefully skip when dist missing. Closes #3573