### PR TITLE
feat(cli): add --cwd flag to ag list for session filtering

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,7 @@
 /**
  * commands/list.ts — `ag list` — List active sessions.
  *
- * Wraps GET /v1/sessions with optional status filter.
+ * Wraps GET /v1/sessions with optional status and project (`--cwd`) filters.
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
@@ -16,6 +16,8 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--status' && args[i + 1]) {
       params.set('status', args[++i]!);
+    } else if (args[i] === '--cwd' && args[i + 1]) {
+      params.set('project', args[++i]!);
     }
   }
 


### PR DESCRIPTION
## Summary

Adds `--cwd <path>` flag to `ag list` CLI command. Wires it to the existing `?project=` query param on `GET /v1/sessions`.

**Dashboard portion** of #3537 is already complete (workDir filter dropdown, session grouping, detail header) — this PR closes the CLI gap.

### Usage
```bash
ag list --cwd /path/to/project
ag list --status working --cwd /path/to/project
```

### Changes
- `src/commands/list.ts`: Added `else if` branch for `--cwd` → `params.set('project', ...)`

Closes #3537

## Test plan
- [x] tsc --noEmit passes (only pre-existing login.ts error from develop)
- [x] Full test suite: 296 passed, 1 flaky (unrelated mcp-integration-smoke)
- [x] Change is additive — no regressions

Generated by Hephaestus (Aegis dev agent)