### PR TITLE
docs: add --effort flag, ag list --cwd, remove proposed effort status

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -787,7 +787,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 | `autoApprove` | boolean | no | Skip permission prompts (= `permissionMode: bypassPermissions`) |
 | `parentId` | string (UUID) | no | Set parent session — child appears in parent's `/children` |
 | `memoryKeys` | string[] | no | Pre-load memory entries into session (max 50) |
-| `effort` | string | no | Reasoning effort level: `low`, `medium`, or `high`. Passed to the CC session via `--effort` flag. *(Proposed — awaiting backend implementation, #3560)* |
+| `effort` | string | no | Reasoning effort level: `low`, `medium`, or `high`. Passed to the CC session via `--effort` flag. |
 | `systemPrompt` | string | no | Per-session custom system prompt passed via ACP `_meta.systemPrompt` (max 100k chars; ACP only) |
 
 > **Multi-tenancy:** Sessions inherit `tenantId` from the creating API key.
@@ -806,7 +806,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 }
 ```
 
-> **Note:** The `model` field appears in the response when provided at creation time. The `effort` field is accepted at creation but not yet returned in responses — it will be added once the backend implementation lands (#3560).
+> **Note:** The `model` and `effort` fields appear in the response when provided at creation time.
 
 **`promptDelivery` fields:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,7 @@ If the server is already running, `ag run` skips bootstrap and start — goes st
 | `--name <name>` | Set a display name for the session |
 | `--yes` | Suppress all status messages for non-interactive/CI usage |
 | `--accept-permissions` / `-y` | Auto-approve all permission prompts (sets `permissionMode: bypassPermissions`) |
+| `--effort <level>` | Set reasoning effort: `low`, `medium`, `high`, or `0.0`–`1.0` |
 | `--passthrough` | Same as `--accept-permissions` — bypass all permissions (alias) |
 
 > **Note:** `ag run --help` shows the general help (which includes `ag run` in the usage section). For the full list of `ag run` flags, refer to the table above.
@@ -190,6 +191,29 @@ Next steps:
 Save the `id` — you'll need it for follow-up commands.
 
 > **Note:** `workDir` must be under an allowed directory. By default, Aegis allows `$HOME` and the server's current working directory. System temp dirs (`/tmp`, `/var/tmp`) are intentionally excluded for security. To allow additional directories, set `allowedWorkDirs` in `.aegis/config.yaml` (or `aegis.config.json`). Changes are hot-reloaded without restart.
+
+### CLI: List Sessions
+
+```bash
+ag list                           # List all sessions
+ag list --cwd /path/to/project    # Filter by working directory
+ag list --status working          # Filter by status
+```
+
+| Flag | Description |
+|------|-------------|
+| `--cwd <path>` | Filter sessions by working directory |
+| `--status <state>` | Filter by status (`working`, `idle`, `completed`, etc.) |
+| `--port <number>` | Server port override |
+
+Other useful CLI commands:
+
+```bash
+ag status <session-id>   # Get session status
+ag read <session-id>     # Read session output
+ag tail <session-id>     # Stream session output live
+ag kill <session-id>     # Kill a running session
+```
 
 ## 5. Monitor Progress
 


### PR DESCRIPTION
## Summary

Docs accuracy fixes for recently merged features:

### Gaps fixed
1. **`--effort` flag missing** from getting-started.md flags table (PR #3587 added it to ag create/run)
2. **`ag list --cwd` undocumented** (PR #3586 added the flag)
3. **api-reference.md `effort` field** still marked "Proposed — awaiting backend implementation" but #3587 implements it
4. **Response note stale** — said effort not yet returned, but it is now

### Changes
- `getting-started.md`: Added `--effort` to flags table, added ag list section with --cwd/--status, added CLI subcommands reference (status, read, tail, kill)
- `api-reference.md`: Removed "Proposed" from effort field, updated response note

### Related PRs
- #3587 (feat: --model and --effort flags)
- #3586 (feat: --cwd flag for ag list)
- #3562 (docs: speculative model/effort fields — now realized)