### PR TITLE
feat(dashboard): isolation mode badge for bgIsolation sessions

### DIFF
--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -8,6 +8,8 @@ import { formatSessionName } from '../../utils/formatSessionName';
 import { ModelBadge } from '../shared/ModelBadge';
 import { EffortIndicator } from '../shared/EffortIndicator';
 import type { ExtendedSessionInfo } from '../../types/session-extensions';
+import { IsolationModeBadge } from '../shared/IsolationModeBadge';
+import type { IsolationSessionInfo } from '../../types/session-isolation';
 import { type CSSProperties, type ReactElement, useMemo } from 'react';
 import { List } from 'react-window';
 import { Link } from 'react-router-dom';
@@ -202,6 +204,7 @@ function VirtualizedRow(props: {
         </Link>
         <ModelBadge model={session.model} />
         <EffortIndicator effort={(session as ExtendedSessionInfo).effort} />
+        <IsolationModeBadge isolationMode={(session as IsolationSessionInfo).isolationMode} />
       </div>
       <div className="flex items-center max-w-[150px] truncate px-3 font-mono text-xs text-[var(--color-text-muted)]" title={session.workDir}>
         {truncateDir(session.workDir)}

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -10,6 +10,8 @@ import { useT } from '../../i18n/context';
 import { ModelBadge } from '../shared/ModelBadge';
 import { EffortIndicator } from '../shared/EffortIndicator';
 import type { ExtendedSessionInfo } from '../../types/session-extensions';
+import { IsolationModeBadge } from '../shared/IsolationModeBadge';
+import type { IsolationSessionInfo } from '../../types/session-isolation';
 
 interface SessionHeaderProps {
   session: SessionInfo;
@@ -183,6 +185,7 @@ export function SessionHeader({
         </span>
         <ModelBadge model={session.model} className="hidden sm:inline-flex" />
         <EffortIndicator effort={(session as ExtendedSessionInfo).effort} className="hidden sm:inline-flex" />
+        <IsolationModeBadge isolationMode={(session as IsolationSessionInfo).isolationMode} className="hidden sm:inline-flex" />
         {session.ownerKeyId && (
           <span className="group hidden font-mono sm:inline-flex items-center gap-1">
             Owner: {session.ownerKeyId.slice(0, 8)}

--- a/dashboard/src/components/shared/IsolationModeBadge.tsx
+++ b/dashboard/src/components/shared/IsolationModeBadge.tsx
@@ -1,0 +1,55 @@
+/**
+ * components/shared/IsolationModeBadge.tsx — Isolation mode indicator.
+ *
+ * Shows a small badge indicating whether a session uses worktree isolation
+ * or direct (none) mode.
+ *
+ * - worktree → green (safe, isolated)
+ * - none     → amber warning (shared working copy)
+ * - undefined → renders nothing (graceful degradation)
+ *
+ * Related: #3539 (bgIsolation), #3590 (backend field)
+ */
+
+const MODE_STYLES: Record<string, { color: string; label: string; title: string }> = {
+  worktree: {
+    color: 'var(--color-success)',
+    label: 'Worktree',
+    title: 'Session uses isolated worktree (safe)',
+  },
+  none: {
+    color: 'var(--color-warning)',
+    label: 'Direct',
+    title: 'Session edits working copy directly — concurrent sessions may conflict',
+  },
+};
+
+export interface IsolationModeBadgeProps {
+  /** Isolation mode. When undefined, renders nothing. */
+  isolationMode?: string | null;
+  className?: string;
+}
+
+export function IsolationModeBadge({ isolationMode, className = '' }: IsolationModeBadgeProps) {
+  if (!isolationMode) return null;
+
+  const style = MODE_STYLES[isolationMode] ?? {
+    color: 'var(--color-text-muted)',
+    label: isolationMode,
+    title: `Isolation: ${isolationMode}`,
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold leading-none ${className}`}
+      style={{
+        backgroundColor: `color-mix(in srgb, ${style.color} 15%, transparent)`,
+        color: style.color,
+        border: `1px solid color-mix(in srgb, ${style.color} 30%, transparent)`,
+      }}
+      title={style.title}
+    >
+      {style.label}
+    </span>
+  );
+}

--- a/dashboard/src/components/shared/__tests__/IsolationModeBadge.test.tsx
+++ b/dashboard/src/components/shared/__tests__/IsolationModeBadge.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * IsolationModeBadge.test.tsx — Tests for #3539.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IsolationModeBadge } from '../IsolationModeBadge';
+
+describe('IsolationModeBadge (#3539)', () => {
+  it('renders nothing when isolationMode is undefined', () => {
+    const { container } = render(<IsolationModeBadge />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when isolationMode is null', () => {
+    const { container } = render(<IsolationModeBadge isolationMode={null} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders worktree badge with green styling', () => {
+    const { container, getByTitle } = render(<IsolationModeBadge isolationMode="worktree" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe('Worktree');
+    expect(getByTitle(/isolated worktree/i)).toBeTruthy();
+  });
+
+  it('renders none badge with warning styling', () => {
+    const { container, getByTitle } = render(<IsolationModeBadge isolationMode="none" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe('Direct');
+    expect(getByTitle(/directly/i)).toBeTruthy();
+  });
+
+  it('renders unknown mode with muted styling', () => {
+    const { container, getByTitle } = render(<IsolationModeBadge isolationMode="custom" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe('custom');
+    expect(getByTitle(/Isolation: custom/)).toBeTruthy();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<IsolationModeBadge isolationMode="worktree" className="hidden sm:inline-flex" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('hidden');
+  });
+});

--- a/dashboard/src/types/session-isolation.ts
+++ b/dashboard/src/types/session-isolation.ts
@@ -1,0 +1,18 @@
+/**
+ * types/session-isolation.ts — Forward-compatible isolation mode extension.
+ *
+ * CC v2.1.143 added `worktree.bgIsolation: "none"` — sessions can edit the
+ * working copy directly. Aegis needs to surface this in the dashboard.
+ *
+ * These optional fields will be provided by the backend API after #3590 lands.
+ * Until then, they default to undefined and UI components degrade gracefully.
+ */
+
+import type { SessionInfo } from './index';
+
+export type IsolationMode = 'worktree' | 'none';
+
+export interface IsolationSessionInfo extends SessionInfo {
+  /** Session isolation mode. Undefined = not yet detected (assume worktree). */
+  isolationMode?: IsolationMode;
+}

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -263,7 +263,6 @@ export async function handleLogin(args: string[], io: CliIO, fetchFn: typeof fet
     // Try to open browser (best-effort, silently ignore failure)
     if (!noOpen && deviceAuth.verification_uri_complete) {
       try {
-        // @ts-expect-error - 'open' is an optional dependency; handle at runtime
         const { default: open } = await import('open');
         await open(deviceAuth.verification_uri_complete);
       } catch {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -263,6 +263,7 @@ export async function handleLogin(args: string[], io: CliIO, fetchFn: typeof fet
     // Try to open browser (best-effort, silently ignore failure)
     if (!noOpen && deviceAuth.verification_uri_complete) {
       try {
+        // @ts-expect-error - 'open' is an optional dependency; handle at runtime
         const { default: open } = await import('open');
         await open(deviceAuth.verification_uri_complete);
       } catch {

--- a/src/session.ts
+++ b/src/session.ts
@@ -118,6 +118,8 @@ export interface SessionInfo {
   lastHookEventAt?: number;      // Unix timestamp from the hook payload (CC's timestamp)
   model?: string;                // Issue #89 L25: Model name from hook payload (e.g. "claude-sonnet-4-6")
   effort?: string;               // Issue #3545: Reasoning effort level
+  /** Issue #3590: Session isolation mode — whether CC runs in a worktree or directly edits the project. */
+  isolationMode?: 'worktree' | 'none';
   lastDeadAt?: number;           // Unix timestamp when session was detected as dead (Issue #283)
   ccPid?: number;                // PID of the Claude Code process (Issue #353: swarm parent matching)
   parentId?: string;             // Issue #702: Parent session ID for sub-agent hierarchy

--- a/src/session.ts
+++ b/src/session.ts
@@ -188,6 +188,34 @@ function normalizeApprovalLabel(label: string): string {
   return label.toLowerCase().replace(/[^a-z0-9]+/g, '');
 }
 
+/** Detect session isolation mode from project or global Claude Code settings. */
+async function detectIsolationMode(workDir: string): Promise<'worktree' | 'none' | undefined> {
+  const candidates = [
+    join(workDir, '.claude', 'settings.local.json'),
+    join(workDir, '.claude', 'settings.json'),
+    join(homedir(), '.claude', 'settings.local.json'),
+    join(homedir(), '.claude', 'settings.json'),
+  ];
+
+  for (const p of candidates) {
+    try {
+      if (!existsSync(p)) continue;
+      const raw = await readFile(p, { encoding: 'utf8' }).catch(() => undefined);
+      if (!raw) continue;
+      let obj: any;
+      try { obj = JSON.parse(raw); } catch { continue; }
+      const val = obj?.worktree?.bgIsolation ?? obj?.worktree?.bgIsolation ?? undefined;
+      if (typeof val === 'string') {
+        if (val === 'none') return 'none';
+        if (val === 'worktree') return 'worktree';
+      }
+    } catch (_) {
+      // ignore and continue
+    }
+  }
+  return undefined;
+}
+
 function pickNumberedApprovalOption(
   options: NumberedApprovalOption[],
   action: 'approve' | 'reject',
@@ -657,6 +685,10 @@ export class SessionManager {
     const hookSecret = randomBytes(32).toString('hex');
 
     // Issue #169 Phase 2: Generate HTTP hook settings for this session.
+    // Detect isolation mode from project/global Claude settings (Issue #3590)
+    const detectedIsolation = await detectIsolationMode(opts.workDir).catch(() => undefined);
+    const isolationMode = detectedIsolation ?? 'worktree';
+
     // Writes a temp file with hooks pointing to Aegis's hook receiver.
       // Issue #936: Clean stale session hooks from settings.local.json before writing new hooks.
       // This prevents CC from loading dead hook URLs on restart.
@@ -723,6 +755,7 @@ export class SessionManager {
       // before the first hook event arrives. Hooks may override this later.
       model: opts.model,
       effort: opts.effort,
+      isolationMode: isolationMode,
     };
 
     this.state.sessions[id] = session;

--- a/src/session.ts
+++ b/src/session.ts
@@ -206,7 +206,7 @@ async function detectIsolationMode(workDir: string): Promise<'worktree' | 'none'
       if (!raw) continue;
       let obj: any;
       try { obj = JSON.parse(raw); } catch { continue; }
-      const val = obj?.worktree?.bgIsolation ?? obj?.worktree?.bgIsolation ?? undefined;
+      const val = obj?.worktree?.bgIsolation;
       if (typeof val === 'string') {
         if (val === 'none') return 'none';
         if (val === 'worktree') return 'worktree';

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -302,6 +302,9 @@ export const persistedStateSchema = z.record(
     lastHookReceivedAt: z.number().optional(),
     lastHookEventAt: z.number().optional(),
     model: z.string().optional(),
+    effort: z.string().optional(),
+    /** Issue #3590: Session isolation mode */
+    isolationMode: z.enum(['worktree','none']).optional(),
     lastDeadAt: z.number().optional(),
     ccPid: z.number().optional(),
     parentId: z.string().uuid().optional(),


### PR DESCRIPTION
## Summary

Dashboard surface for #3539 (bgIsolation modes). Depends on backend `isolationMode` field from #3590.

### What this does
- **`IsolationModeBadge` component**: Shows green "Worktree" badge for isolated sessions, amber "Direct" badge for non-isolated sessions
- **`session-isolation.ts`**: Forward-compatible type extension (`IsolationSessionInfo`)
- **`SessionHeader.tsx`**: Shows isolation mode badge in metadata row
- **`VirtualizedSessionList.tsx`**: Shows isolation mode badge in session table
- **6 unit tests**: Render nothing, worktree mode, none mode, unknown mode, className

### Graceful degradation
When `isolationMode` is undefined (sessions created before the field existed), the badge renders nothing — no layout shift, no broken UI.

### Backend dependency
Hep already added `isolationMode` to `SessionInfo` and session detection in the same branch. This PR includes both backend and dashboard changes.

Closes #3539
Related: #3590

— Daedalus 🏛️