### PR TITLE
test(dashboard): add tests for EmptyState, CopyButton, StatusDot

### DIFF
--- a/dashboard/src/components/overview/__tests__/StatusDot.test.tsx
+++ b/dashboard/src/components/overview/__tests__/StatusDot.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * StatusDot.test.tsx — Tests for StatusDot component.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatusDot from '../StatusDot';
+
+describe('StatusDot', () => {
+  it('renders for idle status', () => {
+    render(<StatusDot status="idle" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Idle');
+  });
+
+  it('renders for working status with pulse animation', () => {
+    render(<StatusDot status="working" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Working');
+    expect(dot.style.animation).toContain('pulse');
+  });
+
+  it('renders for killed status without pulse', () => {
+    render(<StatusDot status="killed" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Killed');
+    expect(dot.style.animation).toBe('');
+  });
+
+  it('renders for completed status', () => {
+    render(<StatusDot status="completed" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Completed');
+  });
+
+  it('renders health=stall with override color and slower pulse', () => {
+    render(<StatusDot status="idle" health="stall" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Stalled');
+    expect(dot.style.animation).toContain('2s');
+  });
+
+  it('renders health=dead label override', () => {
+    render(<StatusDot status="idle" health="dead" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Dead');
+  });
+
+  it('renders for permission_prompt with pulse', () => {
+    render(<StatusDot status="permission_prompt" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Permission prompt');
+    expect(dot.style.animation).toContain('pulse');
+  });
+
+  it('renders for error status', () => {
+    render(<StatusDot status="error" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Error');
+  });
+
+  it('renders for unknown status as fallback', () => {
+    render(<StatusDot status="unknown" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('aria-label')).toBe('Status: Unknown');
+  });
+
+  it('has title attribute matching label', () => {
+    render(<StatusDot status="idle" />);
+    const dot = screen.getByRole('img');
+    expect(dot.getAttribute('title')).toBe('Idle');
+  });
+});

--- a/dashboard/src/components/shared/__tests__/CopyButton.test.tsx
+++ b/dashboard/src/components/shared/__tests__/CopyButton.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * CopyButton.test.tsx — Tests for shared CopyButton component.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// Mock useCopy hook
+const mockCopy = vi.fn();
+vi.mock('../../../hooks/useCopy', () => ({
+  useCopy: (_value: string, _label?: string) => ({
+    copied: false,
+    copy: mockCopy,
+  }),
+}));
+
+// Must import after mock
+import { CopyButton } from '../CopyButton';
+
+describe('CopyButton', () => {
+  it('renders a button', () => {
+    render(<CopyButton value="test-value" />);
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  it('has aria-label with label text', () => {
+    render(<CopyButton value="abc" label="session ID" />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toContain('session ID');
+  });
+
+  it('has default aria-label when label omitted', () => {
+    render(<CopyButton value="abc" />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toContain('Copy');
+  });
+
+  it('has title attribute for tooltip', () => {
+    render(<CopyButton value="abc" />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('title')).toBe('Copy');
+  });
+
+  it('accepts className', () => {
+    render(<CopyButton value="abc" className="custom-class" />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('custom-class');
+  });
+});

--- a/dashboard/src/components/shared/__tests__/EmptyState.test.tsx
+++ b/dashboard/src/components/shared/__tests__/EmptyState.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * EmptyState.test.tsx — Tests for shared EmptyState component.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import EmptyState from '../EmptyState';
+
+describe('EmptyState', () => {
+  it('renders title', () => {
+    render(<EmptyState title="No sessions found" />);
+    expect(screen.getByText('No sessions found')).toBeTruthy();
+  });
+
+  it('renders description when provided', () => {
+    render(<EmptyState title="Empty" description="Create a session to get started" />);
+    expect(screen.getByText('Create a session to get started')).toBeTruthy();
+  });
+
+  it('does not render description when omitted', () => {
+    const { container } = render(<EmptyState title="Empty" />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('renders icon when provided', () => {
+    render(<EmptyState title="Empty" icon={<span data-testid="icon">X</span>} />);
+    expect(screen.getByTestId('icon')).toBeTruthy();
+  });
+
+  it('does not render icon element when omitted', () => {
+    const { container } = render(<EmptyState title="Empty" />);
+    // The icon wrapper div should not exist
+    const iconWrappers = container.querySelectorAll('.rounded-full.p-3');
+    expect(iconWrappers.length).toBe(0);
+  });
+
+  it('renders action slot', () => {
+    render(<EmptyState title="Empty" action={<button>Create New</button>} />);
+    expect(screen.getByText('Create New')).toBeTruthy();
+  });
+
+  it('has role="status" and aria-label', () => {
+    render(<EmptyState title="No data" />);
+    const el = screen.getByRole('status');
+    expect(el.getAttribute('aria-label')).toBe('No data');
+  });
+
+  it('applies error variant styles', () => {
+    render(<EmptyState title="Error" variant="empty-error" />);
+    const container = screen.getByRole('status');
+    expect(container.className).toContain('border');
+  });
+
+  it('applies custom className', () => {
+    render(<EmptyState title="Test" className="my-custom" />);
+    const container = screen.getByRole('status');
+    expect(container.className).toContain('my-custom');
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for 3 shared dashboard components that had zero coverage.

### New tests
- **EmptyState** (9 tests): title, description, icon, action, variants, a11y attributes, className
- **CopyButton** (5 tests): render, aria-label with/without label, title attribute, className
- **StatusDot** (10 tests): all status types, health overrides (stall/dead), pulse animation, labels

### Coverage impact
- 24 new tests across 3 files
- All test rendering, accessibility attributes, and variant behavior
- No production code changes

Relates to #3575 (coverage gaps)

— Daedalus 🏛️