### PR TITLE
test(api): add isolationMode redactSession tests (#3590)

### DIFF
--- a/src/__tests__/isolation-mode-3590.test.ts
+++ b/src/__tests__/isolation-mode-3590.test.ts
@@ -1,0 +1,65 @@
+/**
+ * isolation-mode-3590.test.ts — Verify isolationMode field on SessionInfo.
+ *
+ * Issue #3590: Expose bgIsolation mode on SessionInfo for dashboard.
+ * - isolationMode detected from CC settings or defaults to 'worktree'
+ * - Field preserved in redactSession (API response)
+ * - Backward compatible: sessions without field still work
+ */
+
+import { describe, it, expect } from 'vitest';
+import { redactSession } from '../routes/context.js';
+
+describe('Issue #3590 — isolationMode on SessionInfo', () => {
+  describe('redactSession preserves isolationMode', () => {
+    it('preserves isolationMode "none"', () => {
+      const redacted = redactSession({
+        id: 'test-id',
+        displayName: 'test',
+        isolationMode: 'none',
+        hookSecret: 'secret123',
+      });
+      expect(redacted.isolationMode).toBe('none');
+      expect(redacted.hookSecret).toBeUndefined();
+    });
+
+    it('preserves isolationMode "worktree"', () => {
+      const redacted = redactSession({
+        id: 'test-id',
+        displayName: 'test',
+        isolationMode: 'worktree',
+        hookSecret: 'secret123',
+      });
+      expect(redacted.isolationMode).toBe('worktree');
+      expect(redacted.hookSecret).toBeUndefined();
+    });
+
+    it('handles session without isolationMode (backward compat)', () => {
+      const redacted = redactSession({
+        id: 'test-id',
+        displayName: 'test',
+        hookSecret: 'secret123',
+      });
+      expect(redacted.isolationMode).toBeUndefined();
+      expect(redacted.hookSecret).toBeUndefined();
+    });
+
+    it('preserves isolationMode alongside other fields', () => {
+      const redacted = redactSession({
+        id: 'test-id',
+        displayName: 'test',
+        status: 'running',
+        model: 'claude-sonnet-4-6',
+        effort: 'high',
+        isolationMode: 'worktree',
+        hookSecret: 'secret',
+        hookSettingsFile: '/tmp/hooks.json',
+      });
+      expect(redacted.isolationMode).toBe('worktree');
+      expect(redacted.model).toBe('claude-sonnet-4-6');
+      expect(redacted.effort).toBe('high');
+      expect(redacted.hookSecret).toBeUndefined();
+      expect(redacted.hookSettingsFile).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression tests for the `isolationMode` field on `SessionInfo` (Issue #3590).

The backend implementation was already in place:
- `isolationMode?: "worktree" | "none"` on `SessionInfo` type (`session.ts`)
- Detection via `detectIsolationMode()` reading CC settings
- Default to `"worktree"` when not detected
- Zod validation (`validation.ts`)
- Passed through `redactSession()` for API responses

This PR adds 4 tests verifying:
1. `redactSession` preserves `isolationMode: "none"`
2. `redactSession` preserves `isolationMode: "worktree"`
3. Backward compat: session without `isolationMode` still works
4. `isolationMode` preserved alongside other fields (model, effort)

## Verification

```
tsc --noEmit: ✅ (1 pre-existing login.ts error)
npm run build: ✅
npm test: ✅ 4322 passed (24 skipped)
```

Closes #3590