### PR TITLE
docs: fix Session States table in README — align with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,14 @@ All endpoints under `/v1/`.
 |-------|---------|--------|
 | `working` | Actively generating | Wait or poll `/read` |
 | `idle` | Waiting for input | Send via `/send` |
-| `permission_prompt` | Awaiting approval | `/approve` or `/reject` |
-| `asking` | Claude asked a question | Read `/read`, respond `/send` |
+| `waiting_for_input` | Claude finished, awaiting user reply | Read `/read`, respond `/send` |
+| `permission_prompt` | Awaiting tool approval | `/approve` or `/reject` |
+| `bash_approval` | Awaiting bash command approval | `/approve` or `/reject` |
+| `ask_question` | Claude asked a question | Read `/read`, respond `/send` |
+| `plan_mode` | Claude is in plan mode | Review plan, respond |
+| `compacting` | Compressing context | Automatic, no action needed |
+| `context_warning` | Context window near limit | Consider starting a new session |
+| `settings` | Claude opened settings | Automatic, no action needed |
 | `pending` | Initial state, connecting to ACP runtime | Wait a moment and re-poll |
 | `error` | Session error | Check diagnostics, recreate |
 | `rate_limit` | Rate limited by provider | Wait and retry |


### PR DESCRIPTION
## Summary
Fixes an accuracy gap in the README Session States table found during docs review.

### Changes
- **Add 7 missing states:** `waiting_for_input`, `bash_approval`, `ask_question`, `plan_mode`, `compacting`, `context_warning`, `settings` — all exist in the codebase (`src/hooks.ts` UIState type) and api-reference.md
- **Remove stale `asking` state** — doesn't exist in the codebase (the actual state is `ask_question`)

### Before (11 states)
`working`, `idle`, `permission_prompt`, ~~`asking`~~, `pending`, `error`, `rate_limit`, `killed`, `completed`, `crashed`, `unknown`

### After (17 states)
`working`, `idle`, `waiting_for_input`, `permission_prompt`, `bash_approval`, `ask_question`, `plan_mode`, `compacting`, `context_warning`, `settings`, `pending`, `error`, `rate_limit`, `killed`, `completed`, `crashed`, `unknown`

Now matches the full list in `docs/api-reference.md` (line 1038).

Self-merge OK (docs-only).