### PR TITLE
feat(cli): friendlier session display names from prompt

### DIFF
--- a/src/__tests__/session-name.test.ts
+++ b/src/__tests__/session-name.test.ts
@@ -1,0 +1,74 @@
+/**
+ * session-name.test.ts — Tests for friendly session display names (#3489).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveSessionName, generateSessionName } from '../utils/session-name.js';
+
+describe('deriveSessionName', () => {
+  it('extracts verb-noun pair from prompt', () => {
+    expect(deriveSessionName('Build a REST API for user management')).toBe('build-rest-api');
+  });
+
+  it('extracts fix-verb phrases', () => {
+    expect(deriveSessionName('Fix the flaky test in SessionTable')).toBe('fix-flaky-test');
+  });
+
+  it('handles single-word prompts', () => {
+    expect(deriveSessionName('Hello')).toBe('hello');
+  });
+
+  it('handles prompts without recognized verbs', () => {
+    expect(deriveSessionName('user authentication flow')).toBe('user-authentication-flow');
+  });
+
+  it('handles empty string', () => {
+    expect(deriveSessionName('')).toBe('untitled');
+  });
+
+  it('handles whitespace-only string', () => {
+    expect(deriveSessionName('   ')).toBe('untitled');
+  });
+
+  it('strips punctuation', () => {
+    expect(deriveSessionName('Fix: the "bug" in /api/users')).toBe('fix-bug-api');
+  });
+
+  it('handles "refactor" verb', () => {
+    expect(deriveSessionName('Refactor the session manager to use Zustand')).toBe('refactor-session-manager');
+  });
+
+  it('handles "implement" verb', () => {
+    expect(deriveSessionName('Implement dark mode toggle for settings page')).toBe('implement-dark-mode');
+  });
+
+  it('handles "add" verb', () => {
+    expect(deriveSessionName('Add a logout button to the navbar')).toBe('add-logout-button');
+  });
+
+  it('handles "write" verb', () => {
+    expect(deriveSessionName('Write tests for the auth module')).toBe('write-tests-auth');
+  });
+
+  it('limits to 3 parts', () => {
+    expect(deriveSessionName('Build a full stack app with React and Node and PostgreSQL')).toBe('build-full-stack');
+  });
+
+  it('strips stop words', () => {
+    expect(deriveSessionName('The quick brown fox')).toBe('quick-brown-fox');
+  });
+});
+
+describe('generateSessionName', () => {
+  it('generates name with prefix', () => {
+    expect(generateSessionName('Build a login page')).toBe('cc-build-login-page');
+  });
+
+  it('generates name with session ID prefix', () => {
+    expect(generateSessionName('Fix the bug', 'a1b2')).toBe('cc-fix-bug-a1b2');
+  });
+
+  it('handles empty prompt', () => {
+    expect(generateSessionName('')).toBe('cc-untitled');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import {
   resolveClaudeAgentAcpBinary,
 } from './services/acp/binary-resolver.js';
 import { getErrorMessage, parseIntSafe, validateEffort } from './validation.js';
+import { generateSessionName } from './utils/session-name.js';
 import { setJsonLogsEnabled } from './logger.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -158,7 +159,7 @@ async function handleCreate(args: string[], io: CliIO): Promise<number> {
   const baseUrl = portOverride === null
     ? getConfiguredBaseUrl(config)
     : deriveBaseUrl('127.0.0.1', portOverride);
-  const sessionName = `cc-${brief.slice(0, 20).replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase()}`;
+  const sessionName = generateSessionName(brief);
   const authToken = await resolveAuthToken();
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (authToken) headers['Authorization'] = `Bearer ${authToken}`;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -19,6 +19,7 @@ import { deriveBaseUrl, getConfiguredBaseUrl, normalizeBaseUrl } from '../base-u
 import { AuthManager } from '../services/auth/index.js';
 import { findConfigFilePath, loadConfig, readConfigFile, writeConfigFile, serializeConfigFile, type Config } from '../config.js';
 import { getErrorMessage, parseIntSafe, validateEffort } from '../validation.js';
+import { generateSessionName } from '../utils/session-name.js';
 import { readAuthTokenFile } from '../utils/auth-token-path.js';
 
 interface CliIO {
@@ -423,7 +424,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
       body: JSON.stringify({
         workDir: cwd,
         prompt: brief,
-        name: `run-${brief.slice(0, 20).replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase()}`,
+        name: generateSessionName(brief),
         model,
         effort,
         ...(acceptPerms ? { permissionMode: 'bypassPermissions' } : {}),

--- a/src/utils/session-name.ts
+++ b/src/utils/session-name.ts
@@ -1,0 +1,71 @@
+/**
+ * utils/session-name.ts — Generate human-friendly session display names.
+ *
+ * Derives a short, readable name from the user's prompt by extracting
+ * the first verb-noun pair. Falls back to a slug of the first few words.
+ *
+ * Example:
+ *   "Build a REST API for user management" → "build-rest-api"
+ *   "Fix the flaky test in SessionTable"   → "fix-flaky-test"
+ *   "Hello"                                → "hello"
+ */
+
+// Common verbs to detect at the start of prompts
+const PROMPT_VERBS = new Set([
+  'build', 'create', 'make', 'implement', 'add', 'write', 'develop',
+  'fix', 'debug', 'resolve', 'repair', 'patch', 'solve',
+  'refactor', 'clean', 'remove', 'delete', 'replace', 'update',
+  'test', 'validate', 'verify', 'check',
+  'deploy', 'ship', 'release', 'publish',
+  'design', 'architect', 'plan', 'sketch',
+  'optimize', 'improve', 'enhance', 'speed',
+  'migrate', 'upgrade', 'port', 'convert',
+  'review', 'audit', 'analyze', 'investigate',
+  'setup', 'configure', 'install', 'init',
+  'document', 'explain', 'describe',
+]);
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'in', 'on', 'at', 'for', 'of', 'with', 'to',
+  'from', 'by', 'and', 'or', 'is', 'are', 'was', 'were', 'be',
+  'that', 'this', 'it', 'its', 'my', 'our', 'your', 'their',
+]);
+
+/**
+ * Extract a verb-noun phrase from a prompt and format as a session name.
+ * Returns a slug like "build-rest-api" or "fix-session-table".
+ * Falls back to the first 3 meaningful words if no verb is found.
+ */
+export function deriveSessionName(prompt: string): string {
+  if (!prompt || !prompt.trim()) return 'untitled';
+
+  // Lowercase, strip leading/trailing whitespace
+  const text = prompt.trim().toLowerCase();
+
+  // Tokenize: split on whitespace and punctuation, keep only alphanumeric
+  const tokens = text
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t.length > 0 && !STOP_WORDS.has(t));
+
+  if (tokens.length === 0) return 'untitled';
+
+  // If first token is a known verb, take verb + next 2 meaningful words
+  if (PROMPT_VERBS.has(tokens[0])) {
+    const parts = tokens.slice(0, 3); // verb + up to 2 nouns
+    return parts.join('-');
+  }
+
+  // Otherwise take first 3 meaningful words
+  return tokens.slice(0, 3).join('-');
+}
+
+/**
+ * Generate a full session name with prefix and short ID.
+ * Format: `cc-<derived-name>-<4-char-id>`
+ */
+export function generateSessionName(prompt: string, sessionIdPrefix?: string): string {
+  const base = deriveSessionName(prompt);
+  if (!sessionIdPrefix) return `cc-${base}`;
+  return `cc-${base}-${sessionIdPrefix}`;
+}


### PR DESCRIPTION
## Summary

Implements the unchecked `P2` item from #3489 — friendlier session display names.

### Before
```
cc-build-a-rest-api-for-u
run-fix-the-flaky-test-in-
```

### After
```
cc-build-rest-api
cc-fix-flaky-test
```

### What changed
- **`utils/session-name.ts`** — `deriveSessionName()` extracts verb-noun pair from the prompt. Recognizes 40+ dev verbs (build, fix, refactor, implement, deploy...). Strips stop words and punctuation. Falls back to first 3 meaningful words.
- **`cli.ts`** (`ag create`) — uses `generateSessionName(brief)` instead of raw slug
- **`run.ts`** (`ag run`) — same, consistent naming across both commands
- **16 unit tests** covering verbs, edge cases, punctuation, stop words, empty input

### Dashboard impact
Session names directly appear in the dashboard session table. Cleaner names = better UX for new users seeing their sessions for the first time.

Relates to #3489 (zero-config first-run epic)

— Daedalus 🏛️