### PR TITLE
chore(deps): remove unused OTel gRPC and Fastify instrumentation deps (#3604)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,8 +55,6 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
-        "@opentelemetry/instrumentation-fastify": "^0.57.0",
         "@opentelemetry/resources": "^2.7.1",
         "@opentelemetry/semantic-conventions": "^1.36.0",
         "ioredis": "^5.10.1",
@@ -1505,56 +1503,6 @@
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.218.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.57.0.tgz",
-      "integrity": "sha512-D+rwRtbiOediYocpKGvY/RQTpuLsLdCVwaOREyqWViwItJGibWI7O/wgd9xIV63pMP0D9IdSy27wnARfUaotKg==",
-      "deprecated": "Deprecated in favor of @fastify/otel, maintained by the Fastify authors.",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fastify/node_modules/@opentelemetry/api-logs": {
-      "version": "0.213.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
-      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fastify/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.213.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz",
-      "integrity": "sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.213.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/package.json
+++ b/package.json
@@ -132,8 +132,6 @@
     "vitest": "^4.1.5"
   },
   "optionalDependencies": {
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
-    "@opentelemetry/instrumentation-fastify": "^0.57.0",
     "@opentelemetry/resources": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.36.0",
     "ioredis": "^5.10.1",


### PR DESCRIPTION
## Summary
Removes two unused OpenTelemetry dependencies from `optionalDependencies`:

- `@opentelemetry/exporter-trace-otlp-grpc` — no import/require found in `src/`
- `@opentelemetry/instrumentation-fastify` — no import/require found in `src/`

The codebase uses the HTTP variant (`@opentelemetry/exporter-trace-otlp-http`) in `src/tracing.ts`, not gRPC. No Fastify OTel instrumentation is used.

## Why
- **SBOM bloat** — these appear in generated SBOMs as present dependencies
- **Audit noise** — future advisories on these packages trigger false-positive triage
- **Supply surface** — even optional deps are unnecessary attack surface

## Changes
- `package.json`: removed 2 entries from `optionalDependencies`
- `package-lock.json`: regenerated (net -2 packages, 540 → 538, zero vulnerabilities)

Closes #3604

## Verification
- `tsc --noEmit`: ✅
- `npm run build`: ✅
- `npm test`: ✅ 4418 passed (8 skipped)
- `grep -rn 'exporter-trace-otlp-grpc\|instrumentation-fastify' src/` → no results confirmed

## Dogfooding Note
Implemented via Aegis CC session `b9071459-fa36-48c4-b497-08e2b5104dc8`. Session completed successfully — CC removed deps, verified absence, and committed. Push and PR opened by Hep (read API returned 0 messages due to known monitorOffset bug, but JSONL confirmed 44 entries of clean work).