### PR TITLE
docs: document Claude Code auto-wiring during ag init (#3611)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,6 +73,8 @@ ag init
 > **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml` and regenerates auth keys. **You must restart the server** for the new keys to take effect — the running server does not hot-reload keys from disk. Without a restart, CLI commands will return `401 Unauthorized` with the new token.
 >
 > `ag init` now supports conversational onboarding with `--model` and `--name` flags for non-interactive setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session. Use `--force` to create a token even on localhost.
+>
+> **Claude Code auto-wiring:** If `claude` is on your PATH, `ag init` automatically offers to register Aegis as an MCP server in Claude Code. In `--yes` mode this happens automatically. You can verify with `claude mcp list`.
 
 ```bash
 ag

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -28,6 +28,8 @@ ag init --from-template code-reviewer
 
 The interactive flow is idempotent: if `.aegis/config.yaml` already exists, `ag init` keeps it unless you confirm an overwrite. In `--yes` mode, existing config is preserved by default — use `--force` (or `-f`) to allow overwriting.
 
+If Claude Code (`claude`) is detected on your PATH, `ag init` will automatically offer to wire the Aegis MCP server into Claude Code. This adds Aegis tools to your Claude Code session without manual setup. In `--yes` mode, MCP wiring happens automatically (skipped in CI/test environments).
+
 `ag init` also exposes the built-in starter gallery for Claude Code helpers:
 
 - `code-reviewer` (agent)


### PR DESCRIPTION
## Summary

Documents the new Claude Code auto-detection and MCP wiring feature from PR #3611.

### Changes
- **cli.md** ( section): Added paragraph explaining that  detects  on PATH and offers to wire Aegis MCP automatically. In `--yes` mode this happens without prompting.
- **getting-started.md** (Step 1): Added note about Claude Code auto-wiring in the `ag init` callout block.

### Why
PR #3611 merged with no docs update. Users need to know that `ag init` now auto-wires Claude Code MCP — this is a key zero-config UX improvement.

### Verification
- Read `src/commands/init.ts` — `offerClaudeCodeMcpWiring()` called after all init success paths
- Detects `claude` on PATH, checks if Aegis MCP already wired, uses project scope for `.aegis/` configs
- Skipped in CI/test environments