### PR TITLE
fix(init): MCP wiring scope detection always returned project scope (#3614)

### DIFF
--- a/src/__tests__/init-cc-mcp-3501.test.ts
+++ b/src/__tests__/init-cc-mcp-3501.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { execFile } from 'node:child_process';
+import { describe, it, expect } from 'vitest';
+import { join, resolve, dirname } from 'node:path';
+import { homedir } from 'node:os';
 
 // #3501: Test Claude Code MCP auto-wiring detection
 // We test the detection logic by mocking execFile
@@ -25,12 +26,26 @@ other: npx other-mcp`;
     expect(output.includes('aegis')).toBe(false);
   });
 
-  it('should use project scope for .aegis config paths', () => {
-    const configPath = '/home/user/projects/myapp/.aegis/config.yaml';
-    const configDir = configPath.substring(0, configPath.lastIndexOf('/'));
-    const isProjectConfig = !configPath.includes('/home/user/') === false && configPath.includes('.aegis');
-    // Project config: includes .aegis
-    expect(configPath.includes('.aegis')).toBe(true);
+  // Issue #3614: Scope detection must distinguish global (~/.aegis/) from project configs
+  it('should use GLOBAL scope for ~/.aegis/config.yaml (global config)', () => {
+    const configPath = join(homedir(), '.aegis', 'config.yaml');
+    const globalAegisDir = join(homedir(), '.aegis');
+    const isProjectConfig = !resolve(configPath).startsWith(globalAegisDir);
+    expect(isProjectConfig).toBe(false); // global scope
+  });
+
+  it('should use project scope for ~/projects/myapp/.aegis/config.yaml', () => {
+    const configPath = join(homedir(), 'projects', 'myapp', '.aegis', 'config.yaml');
+    const globalAegisDir = join(homedir(), '.aegis');
+    const isProjectConfig = !resolve(configPath).startsWith(globalAegisDir);
+    expect(isProjectConfig).toBe(true); // project scope
+  });
+
+  it('should use project scope for /opt/aegis/config.yaml (non-home dir)', () => {
+    const configPath = '/opt/aegis/config.yaml';
+    const globalAegisDir = join(homedir(), '.aegis');
+    const isProjectConfig = !resolve(configPath).startsWith(globalAegisDir);
+    expect(isProjectConfig).toBe(true); // project scope
   });
 
   it('should build correct wire args for project scope', () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -940,9 +940,12 @@ async function offerClaudeCodeMcpWiring(args: string[], io: CliIO, configPath: s
     return;
   }
 
-  // Determine scope: project-level if configPath is local, global otherwise
+  // Determine scope: project-level if configPath is NOT under ~/.aegis/, global otherwise.
+  // Issue #3614: Previous logic used includes('.aegis') which matched ALL Aegis config paths,
+  // making isProjectConfig always true. Now checks if config is under the default global dir.
   const configDir = dirname(configPath);
-  const isProjectConfig = !configPath.includes(homedir()) || configPath.includes('.aegis');
+  const globalAegisDir = join(homedir(), '.aegis');
+  const isProjectConfig = !resolve(configPath).startsWith(globalAegisDir);
 
   const wireArgs = isProjectConfig
     ? ['mcp', 'add', '--scope', 'project', 'aegis', '--', 'ag', 'mcp']


### PR DESCRIPTION
## Summary

Fixes #3614 — scope detection bug in `offerClaudeCodeMcpWiring()`.

### The Bug

```typescript
const isProjectConfig = !configPath.includes(homedir()) || configPath.includes("".aegis"");
```

`isProjectConfig` was **always true** because every Aegis config path contains `.aegis`. This caused MCP wiring to always use `--scope project` even for global configs (`~/.aegis/config.yaml`).

### Impact

- MCP wiring always wrote to project-scoped `.claude/settings.json` instead of global CC settings
- If the project-scoped settings file was committed, other contributors who clone the repo would get a stale MCP config pointing at `ag mcp` on the original author's machine
- No tokens or secrets leak — `ag mcp` is a local binary — but confusing for new contributors

### Fix

```typescript
const globalAegisDir = join(homedir(), .aegis);
const isProjectConfig = !resolve(configPath).startsWith(globalAegisDir);
```

Now correctly identifies:
- `~/.aegis/config.yaml` → global scope (isProjectConfig = false)
- `~/projects/myapp/.aegis/config.yaml` → project scope (isProjectConfig = true)
- `/opt/aegis/config.yaml` → project scope (isProjectConfig = true)

### Tests

Updated `init-cc-mcp-3501.test.ts` with 3 new scope detection tests (replaced the old broken one). All 8 tests pass.

### Security note

Found during security audit of PR #3611. Not a security vulnerability — the MCP server being wired is always `ag mcp` (hardcoded, no injection). This is a functional + hygiene fix.

— Themis 🛡️