### PR TITLE
fix(init): MCP wiring scoping — global config no longer treated as project (#3614)

### DIFF
--- a/src/__tests__/init-cc-mcp-3501.test.ts
+++ b/src/__tests__/init-cc-mcp-3501.test.ts
@@ -25,12 +25,26 @@ other: npx other-mcp`;
     expect(output.includes('aegis')).toBe(false);
   });
 
-  it('should use project scope for .aegis config paths', () => {
+  // #3614 regression: isProjectConfig must distinguish global vs project config
+  it('should identify global ~/.aegis/config.yaml as NOT project config', () => {
+    const configPath = '/home/user/.aegis/config.yaml';
+    const globalAegisDir = '/home/user/.aegis';
+    const isProjectConfig = !configPath.startsWith(globalAegisDir);
+    expect(isProjectConfig).toBe(false);
+  });
+
+  it('should identify project-local .aegis/config.yaml as project config', () => {
     const configPath = '/home/user/projects/myapp/.aegis/config.yaml';
-    const configDir = configPath.substring(0, configPath.lastIndexOf('/'));
-    const isProjectConfig = !configPath.includes('/home/user/') === false && configPath.includes('.aegis');
-    // Project config: includes .aegis
-    expect(configPath.includes('.aegis')).toBe(true);
+    const globalAegisDir = '/home/user/.aegis';
+    const isProjectConfig = !configPath.startsWith(globalAegisDir);
+    expect(isProjectConfig).toBe(true);
+  });
+
+  it('should identify non-home-dir config as project config', () => {
+    const configPath = '/opt/projects/myapp/.aegis/config.yaml';
+    const globalAegisDir = '/home/user/.aegis';
+    const isProjectConfig = !configPath.startsWith(globalAegisDir);
+    expect(isProjectConfig).toBe(true);
   });
 
   it('should build correct wire args for project scope', () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -942,7 +942,8 @@ async function offerClaudeCodeMcpWiring(args: string[], io: CliIO, configPath: s
 
   // Determine scope: project-level if configPath is local, global otherwise
   const configDir = dirname(configPath);
-  const isProjectConfig = !configPath.includes(homedir()) || configPath.includes('.aegis');
+  const globalAegisDir = join(homedir(), '.aegis');
+  const isProjectConfig = !configPath.startsWith(globalAegisDir);
 
   const wireArgs = isProjectConfig
     ? ['mcp', 'add', '--scope', 'project', 'aegis', '--', 'ag', 'mcp']


### PR DESCRIPTION
## Fix for #3614

### Bug
`isProjectConfig` used `configPath.includes(.aegis)` which matched **every** Aegis config path, making it always `true`. MCP wiring always used `--scope project`, even for global configs (`~/.aegis/config.yaml`).

### Fix
Replace with `configPath.startsWith(join(homedir(), .aegis))` to correctly identify the global `~/.aegis/` directory.

| Config path | Before | After |
|---|---|---|
| `~/.aegis/config.yaml` | project ❌ | global ✅ |
| `~/projects/myapp/.aegis/config.yaml` | project ✅ | project ✅ |
| `/opt/app/.aegis/config.yaml` | project ✅ | project ✅ |

### Regression Tests (3 new)
- Global `~/.aegis/config.yaml` → NOT project config
- Project-local inside home dir → project config
- Project-local outside home dir → project config

### Verification
```
tsc --noEmit: ✅
npm run build: ✅
npm test: ✅ 4531 passed (8 skipped)
```

Spotted by Themis during security audit of #3611.