### PR TITLE
fix(dashboard): flaky TemplatesPage delete test on Node 20

### DIFF
--- a/dashboard/src/__tests__/TemplatesPage.test.tsx
+++ b/dashboard/src/__tests__/TemplatesPage.test.tsx
@@ -103,20 +103,20 @@ describe('TemplatesPage', () => {
       expect(screen.getByText('React Scaffold')).toBeDefined();
     });
 
-    // There should be at least 2 "Delete" buttons (one per template card)
-    // The first template's Delete button should trigger the confirm dialog
-    const allDeleteBtns = screen.getAllByText('Delete');
-    expect(allDeleteBtns.length).toBeGreaterThanOrEqual(2);
+    // Find delete buttons by accessible name (aria-label)
+    const deleteButtons = screen.getAllByRole('button', { name: /Delete template/ });
+    expect(deleteButtons.length).toBeGreaterThanOrEqual(2);
 
-    // Click the first Delete button
-    await act(async () => {
-      fireEvent.click(allDeleteBtns[0]);
-    });
+    // Click the first Delete button to open confirmation
+    fireEvent.click(deleteButtons[0]);
 
-    // The confirm dialog should render - check for the dialog heading
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Delete Template' })).toBeDefined();
-    }, { timeout: 3000 });
+    // Use findByRole which auto-waits — avoids timeout flakiness on Node 20 CI
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 });
+    expect(dialog).toBeDefined();
+
+    // Verify the heading is rendered inside the dialog
+    const heading = screen.getByRole('heading', { name: 'Delete Template' });
+    expect(heading).toBeDefined();
 
     // Verify deleteTemplate was NOT called yet (confirmation needed)
     expect(client.deleteTemplate).not.toHaveBeenCalled();

--- a/dashboard/src/__tests__/TemplatesPage.test.tsx
+++ b/dashboard/src/__tests__/TemplatesPage.test.tsx
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import { act } from 'react';
+
 import TemplatesPage from '../pages/TemplatesPage';
 import { I18nProvider } from '../i18n/context';
 import * as client from '../api/client';

--- a/dashboard/src/components/session/__tests__/ApprovalBanner.test.tsx
+++ b/dashboard/src/components/session/__tests__/ApprovalBanner.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * ApprovalBanner.test.tsx — Tests for permission prompt banner.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ApprovalBanner } from '../ApprovalBanner';
+
+// Mock framer-motion to avoid animation overhead in tests
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    span: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+    button: ({ children, onClick, ...props }: any) => (
+      <button type="button" onClick={onClick} {...props}>{children}</button>
+    ),
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}));
+
+describe('ApprovalBanner', () => {
+  it('renders permission prompt', () => {
+    render(<ApprovalBanner prompt="Allow file write to /src/index.ts?" />);
+    expect(screen.getByText('Permission Required')).toBeTruthy();
+    expect(screen.getByText('Allow file write to /src/index.ts?')).toBeTruthy();
+  });
+
+  it('renders APPROVE and REJECT buttons', () => {
+    render(<ApprovalBanner prompt="Allow?" />);
+    expect(screen.getByText('APPROVE')).toBeTruthy();
+    expect(screen.getByText('REJECT')).toBeTruthy();
+  });
+
+  it('calls onApprove when approve clicked', () => {
+    const onApprove = vi.fn();
+    render(<ApprovalBanner prompt="Allow?" onApprove={onApprove} />);
+    fireEvent.click(screen.getByText('APPROVE'));
+    expect(onApprove).toHaveBeenCalledOnce();
+  });
+
+  it('calls onReject when reject clicked', () => {
+    const onReject = vi.fn();
+    render(<ApprovalBanner prompt="Allow?" onReject={onReject} />);
+    fireEvent.click(screen.getByText('REJECT'));
+    expect(onReject).toHaveBeenCalledOnce();
+  });
+
+  it('shows auto-approved state for bypassPermissions', () => {
+    render(<ApprovalBanner prompt="Allow?" permissionMode="bypassPermissions" />);
+    expect(screen.getByText(/Auto-approved/)).toBeTruthy();
+    expect(screen.queryByText('APPROVE')).toBeNull();
+  });
+
+  it('shows auto-approved state for dontAsk', () => {
+    render(<ApprovalBanner prompt="Allow?" permissionMode="dontAsk" />);
+    expect(screen.getByText(/Auto-approved/)).toBeTruthy();
+  });
+
+  it('shows normal prompt for default permission mode', () => {
+    render(<ApprovalBanner prompt="Allow?" permissionMode="default" />);
+    expect(screen.getByText('APPROVE')).toBeTruthy();
+  });
+
+  it('renders countdown label when provided', () => {
+    render(<ApprovalBanner prompt="Allow?" countdownLabel="2m 30s" />);
+    expect(screen.getByText('TTL 2m 30s')).toBeTruthy();
+  });
+
+  it('does not render countdown label when omitted', () => {
+    render(<ApprovalBanner prompt="Allow?" />);
+    expect(screen.queryByText(/TTL/)).toBeNull();
+  });
+
+  it('toggles prompt expansion on click', () => {
+    const { container } = render(<ApprovalBanner prompt="Short prompt" />);
+    const promptEl = screen.getByText('Short prompt');
+    expect(promptEl.className).toContain('truncate');
+    fireEvent.click(promptEl);
+    expect(promptEl.className).toContain('break-words');
+  });
+});

--- a/dashboard/src/components/session/__tests__/ApprovalBanner.test.tsx
+++ b/dashboard/src/components/session/__tests__/ApprovalBanner.test.tsx
@@ -72,7 +72,7 @@ describe('ApprovalBanner', () => {
   });
 
   it('toggles prompt expansion on click', () => {
-    const { container } = render(<ApprovalBanner prompt="Short prompt" />);
+    render(<ApprovalBanner prompt="Short prompt" />);
     const promptEl = screen.getByText('Short prompt');
     expect(promptEl.className).toContain('truncate');
     fireEvent.click(promptEl);

--- a/dashboard/src/components/shared/__tests__/ErrorBoundary.test.tsx
+++ b/dashboard/src/components/shared/__tests__/ErrorBoundary.test.tsx
@@ -2,8 +2,8 @@
  * ErrorBoundary.test.tsx — Tests for error boundary with fallback UI.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { ErrorBoundary } from '../ErrorBoundary';
 
 // Component that throws on demand

--- a/dashboard/src/components/shared/__tests__/ErrorBoundary.test.tsx
+++ b/dashboard/src/components/shared/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * ErrorBoundary.test.tsx — Tests for error boundary with fallback UI.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+// Component that throws on demand
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('Test error message');
+  return <div>All good</div>;
+}
+
+describe('ErrorBoundary', () => {
+  // Suppress console.error from React error boundary in test output
+  const originalError = console.error;
+  beforeEach(() => {
+    console.error = (...args: unknown[]) => {
+      if (typeof args[0] === 'string' && args[0].includes('Test error')) return;
+      if (typeof args[0] === 'string' && args[0].includes('The above error occurred')) return;
+      originalError.call(console, ...args);
+    };
+  });
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('All good')).toBeTruthy();
+  });
+
+  it('renders fallback UI when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/Something went wrong/)).toBeTruthy();
+  });
+
+  it('displays error message', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Test error message')).toBeTruthy();
+  });
+
+  it('renders custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={<div>Custom error</div>}>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Custom error')).toBeTruthy();
+    expect(screen.queryByText(/Something went wrong/)).toBeNull();
+  });
+
+  it('has try again button', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Try again')).toBeTruthy();
+  });
+
+  it('has aria-live="assertive" for accessibility', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    const alert = screen.getByRole('alert');
+    expect(alert.getAttribute('aria-live')).toBe('assertive');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the flaky "deletes a template after confirmation" test that times out on Node 20 CI. Also adds test coverage for 2 more critical components.

### Flaky Test Fix (Closes #3599)
Three issues combining on slower CI:
1. `fireEvent.click` wrapped in unnecessary `act()` — creates extra microtask flush
2. `waitFor(() => getByRole(...))` with only 3s timeout — tight for Node 20 CI
3. `getAllByText("Delete")` — ambiguous, matches multiple button types

Fix: `findByRole("alertdialog", timeout: 5000)` auto-waits, precise aria-label targeting, no unnecessary `act()`.

### New Test Coverage (Relates to #3575)
- **ApprovalBanner**: 10 tests (permission prompt, approve/reject callbacks, auto-approved modes for bypassPermissions/dontAsk, countdown label, expansion toggle)
- **ErrorBoundary**: 6 tests (normal render, error fallback, custom fallback, error message display, Try again button, aria-live accessibility)

### Testing
- All tests pass locally
- Flaky test pattern follows Testing Library best practices

— Daedalus 🏛️