### PR TITLE
docs: model validation format + CHANGELOG updates for recent merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dashboard: isolation mode badge** — bgIsolation sessions show visual indicator ([#3539](https://github.com/OneStepAt4time/aegis/pull/3539))
 - **Dashboard: workDir filter** — filter session table by project directory ([#3537](https://github.com/OneStepAt4time/aegis/pull/3537))
 - **Dashboard: CLI shortcuts panel** — inline CLI hints on Getting Started card
+- **CC auto-wiring during ag init** — detect Claude Code on PATH and offer MCP registration ([#3501](https://github.com/OneStepAt4time/aegis/pull/3501))
 
 ### Bug Fixes
 
@@ -30,6 +31,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Auth-token file desync** — resolve client/server token mismatch
 - **Dashboard clipboard fallback** — robust handling for non-HTTPS mobile contexts ([#3525](https://github.com/OneStepAt4time/aegis/pull/3525))
 - **Config-path-walk test isolation** — isolate from host ~/.aegis/ state ([#3548](https://github.com/OneStepAt4time/aegis/pull/3548))
+- **Model string validation** — reject malformed model names on --model flag and API schema ([#3606](https://github.com/OneStepAt4time/aegis/pull/3606))
+- **MCP scope detection** — fix global configs incorrectly wired as project-scoped ([#3614](https://github.com/OneStepAt4time/aegis/pull/3614))
+- **Unused OTel deps removed** — strip gRPC and Fastify instrumentation deps ([#3605](https://github.com/OneStepAt4time/aegis/pull/3605))
+
+### Test Coverage
+
+- Route-level tests for session-data, session-actions, templates ([#3575](https://github.com/OneStepAt4time/aegis/pull/3575))
+- AuthManager and JsonFileStore direct tests ([#3575](https://github.com/OneStepAt4time/aegis/pull/3575))
+- Session-transcripts, session-discovery, rate-limiter tests ([#3575](https://github.com/OneStepAt4time/aegis/pull/3575))
+- CommandPalette component tests ([#3620](https://github.com/OneStepAt4time/aegis/pull/3620))
+- Model validation regression tests ([#3606](https://github.com/OneStepAt4time/aegis/pull/3606))
+- MCP scope detection tests ([#3614](https://github.com/OneStepAt4time/aegis/pull/3614))
 
 ### Documentation
 
@@ -40,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add 25 missing env vars to enterprise.md config reference
 - Add review gate rule for non-trivial PRs ([#3557](https://github.com/OneStepAt4time/aegis/pull/3557))
 - CC v2.1.141–143 competitive intel update ([#3561](https://github.com/OneStepAt4time/aegis/pull/3561))
+- Document CC auto-wiring in getting-started and cli reference ([#3612](https://github.com/OneStepAt4time/aegis/pull/3612))
+- ccusage-dashboard competitive research — cache pricing TTL-split gap identified ([#3236](https://github.com/OneStepAt4time/aegis/issues/3236))
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -779,7 +779,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 | `prompt` | string | no | Initial prompt to send after boot (max 100k chars; must be non-empty if provided). For follow-up messages after creation, use `POST /v1/sessions/:id/send` with `text` field. |
 | `prd` | string | no | Product Requirements Document text (max 100k chars) |
 | `resumeSessionId` | string (UUID) | no | Resume an existing session by UUID |
-| `model` | string | no | Model name for analytics grouping and per-session model override (max 200 chars). When set, passed to the CC session via `--model` flag. |
+| `model` | string | no | Model name for analytics grouping and per-session model override (max 200 chars, `a-zA-Z0-9._/-` only, must start with alphanumeric). When set, passed to the CC session via `--model` flag. |
 | `claudeCommand` | string | no | Custom Claude Code CLI flags (max 500 chars, alphanumeric/safe chars only) |
 | `env` | object | no | Environment variables (subject to denylist) |
 | `stallThresholdMs` | number | no | Stall detection timeout (default: 300000, max: 3600000) |
@@ -827,7 +827,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 
 | Status | Code | Condition |
 |--------|------|-----------|
-| 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, disallowed characters in `name`/`label`, env denylist rejection |
+| 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, disallowed characters in `name`/`label`/`model`, env denylist rejection |
 | 400 | `INVALID_WORKDIR` | workDir not in allowed directories. Default allows `$HOME` and server cwd. Set `allowedWorkDirs` in config to allow additional paths. Changes hot-reload. |
 | 403 | `TENANT_WORKDIR_DENIED` | workDir outside tenant root |
 | 422 | `CC_VERSION_TOO_OLD` | Claude Code version below minimum |


### PR DESCRIPTION
## Summary
Docs updates for recent merges since #3601 (CHANGELOG).

### api-reference.md
- Add `model` field format restriction: `a-zA-Z0-9._/-` only, must start with alphanumeric (from #3606 validateModel)
- Add `model` to 400 error "disallowed characters" list

### CHANGELOG.md
Added to [Unreleased]:
- **Bug Fixes:** model string validation (#3606), MCP scope detection fix (#3614), unused OTel deps (#3605)
- **Features:** CC auto-wiring during ag init (#3501)
- **Test Coverage:** new section with 6 entries (#3575, #3620, #3606, #3614)
- **Documentation:** CC auto-wiring docs (#3612), ccusage competitive research (#3236)

### Verification
- Model format matches `src/validation.ts` regex: `^[a-zA-Z0-9][a-zA-Z0-9._\/-]{0,199}$`
- All PR numbers verified against merge log

Clean branch from latest develop. Docs-only.