### PR TITLE
fix(dashboard): responsive layout for NewSessionPage

### DIFF
--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -88,12 +88,12 @@ export default function NewSessionPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-2xl mx-auto px-4 sm:px-0">
       {/* Header */}
-      <div className="flex items-center gap-4 mb-6">
+      <div className="flex items-center gap-3 sm:gap-4 mb-4 sm:mb-6">
         <button type="button"
           onClick={() => navigate(-1)}
-          className="p-2 rounded hover:bg-[var(--color-void-lighter)] transition-colors text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+          className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded hover:bg-[var(--color-void-lighter)] transition-colors text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
           title={t('newSession.goBack')}
         >
           <ArrowLeft className="h-5 w-5" />
@@ -290,7 +290,7 @@ export default function NewSessionPage() {
         )}
 
         {/* Submit */}
-        <div className="flex gap-3 pt-2">
+        <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row">
           <button
             type="submit"
             disabled={loading || !workDir.trim()}


### PR DESCRIPTION
## Changes
- Add horizontal padding on mobile (px-4, removes on sm+)
- Back button meets 44px touch target minimum
- Header gap tighter on mobile
- Submit buttons stack on mobile (primary action at bottom)

Fixes #3640

Test plan:
- [x] TypeScript clean
- [x] Build clean
- [x] 1497 tests pass

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>