### PR TITLE
fix(dashboard): discoverable keyboard shortcut help

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -679,6 +679,18 @@ export default function Layout() {
             Command palette
           </button>
 
+          <span className="hidden md:inline text-[11px] text-[var(--color-text-muted)]">·</span>
+
+          <button
+            type="button"
+            className="hidden md:inline-flex items-center gap-1 text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+            title="Keyboard shortcuts"
+            onClick={() => window.dispatchEvent(new KeyboardEvent('keydown', { key: '?', shiftKey: true }))}
+          >
+            <kbd className="font-mono text-[10px] border border-white/10 bg-white/5 rounded px-1.5 text-[var(--color-text-primary)]">?</kbd>
+            Shortcuts
+          </button>
+
           {/* Mobile: compact version on the right */}
           <span className="sm:hidden text-[11px] text-[var(--color-text-muted)] font-mono truncate">v{aegisVersion}</span>
         </footer>


### PR DESCRIPTION
## Changes
- Add visible `?` Shortcuts button in footer next to `⌘K` hint
- Desktop-only (hidden on mobile/touch devices)
- Clicking triggers the KeyboardShortcutsHelp overlay
- Solves the circular discovery problem: shortcuts were only findable through the command palette, which itself needed a shortcut

Fixes #3642

Test plan:
- [x] TypeScript clean
- [x] Build clean
- [x] 1497 tests pass

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>