### PR TITLE
feat: enforce worktree isolation policy per session (#3613)

### DIFF
--- a/src/__tests__/isolation-policy-3613.test.ts
+++ b/src/__tests__/isolation-policy-3613.test.ts
@@ -1,0 +1,238 @@
+/**
+ * isolation-policy-3613.test.ts — Tests for Issue #3613.
+ *
+ * Session isolation policy enforcement:
+ *   - "respect-cc": use detected isolation mode as-is (default, no behavior change)
+ *   - "enforce-worktree": reject session creation when bgIsolation="none"
+ *   - "enforce-direct": force isolationMode to "none" regardless of CC settings
+ *
+ * Also tests per-session override via isolationPolicy in createSession opts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SessionManager, SessionCreationError } from '../session.js';
+import type { Config } from '../config.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+
+function makeMockConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    port: 9100,
+    host: '127.0.0.1',
+    authToken: '',
+    stateDir: join(tmpdir(), `aegis-test-3613-${Date.now()}`),
+    claudeProjectsDir: '/tmp/.claude/projects',
+    maxSessionAgeMs: 7200000,
+    reaperIntervalMs: 300000,
+    continuationPointerTtlMs: 300000,
+    tgBotToken: '',
+    tgGroupId: '',
+    tgAllowedUsers: [],
+    tgTopicTtlMs: 300000,
+    webhooks: [],
+    defaultSessionEnv: {},
+    defaultPermissionMode: 'default',
+    stallThresholdMs: 300000,
+    sseMaxConnections: 100,
+    sseMaxPerIp: 10,
+    allowedWorkDirs: [],
+    hookSecretHeaderOnly: false,
+    memoryBridge: { enabled: false },
+    worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+    ...overrides,
+  } as unknown as Config;
+}
+
+/**
+ * Create a temp directory with a .claude/settings.json that sets bgIsolation.
+ */
+function createWorkdirWithIsolation(bgIsolation: 'none' | 'worktree'): string {
+  const workDir = mkdtempSync(join(tmpdir(), 'aegis-wd-3613-'));
+  const claudeDir = join(workDir, '.claude');
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(
+    join(claudeDir, 'settings.json'),
+    JSON.stringify({ worktree: { bgIsolation } }),
+  );
+  return workDir;
+}
+
+/**
+ * Create a temp workdir WITHOUT any .claude settings (defaults to worktree).
+ */
+function createDefaultWorkdir(): string {
+  return mkdtempSync(join(tmpdir(), 'aegis-wd-3613-'));
+}
+
+describe('Issue #3613 — Isolation policy enforcement', () => {
+  let config: Config;
+  let sm: SessionManager;
+  const cleanup: string[] = [];
+
+  beforeEach(() => {
+    config = makeMockConfig({ isolationPolicy: 'respect-cc' });
+    sm = new SessionManager(config);
+  });
+
+  afterEach(() => {
+    for (const dir of cleanup) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+    cleanup.length = 0;
+  });
+
+  describe('respect-cc (default)', () => {
+    it('allows session with bgIsolation="none" when policy is respect-cc', async () => {
+      const workDir = createWorkdirWithIsolation('none');
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'respect-cc';
+
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-respect-none',
+      });
+
+      expect(session.isolationMode).toBe('none');
+      expect(session.id).toBeDefined();
+    });
+
+    it('allows session with bgIsolation="worktree" when policy is respect-cc', async () => {
+      const workDir = createWorkdirWithIsolation('worktree');
+      cleanup.push(workDir, config.stateDir);
+
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-respect-worktree',
+      });
+
+      expect(session.isolationMode).toBe('worktree');
+    });
+
+    it('defaults to worktree when no CC settings exist', async () => {
+      const workDir = createDefaultWorkdir();
+      cleanup.push(workDir, config.stateDir);
+
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-respect-default',
+      });
+
+      expect(session.isolationMode).toBe('worktree');
+    });
+  });
+
+  describe('enforce-worktree', () => {
+    it('rejects session when bgIsolation="none" and policy is enforce-worktree', async () => {
+      const workDir = createWorkdirWithIsolation('none');
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'enforce-worktree';
+
+      await expect(
+        sm.createSession({ workDir, name: 'test-reject' }),
+      ).rejects.toThrow(SessionCreationError);
+
+      await expect(
+        sm.createSession({ workDir, name: 'test-reject' }),
+      ).rejects.toThrow(/enforce-worktree/);
+    });
+
+    it('allows session when bgIsolation="worktree" and policy is enforce-worktree', async () => {
+      const workDir = createWorkdirWithIsolation('worktree');
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'enforce-worktree';
+
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-allow',
+      });
+
+      expect(session.isolationMode).toBe('worktree');
+    });
+
+    it('allows session when no CC settings exist and policy is enforce-worktree', async () => {
+      const workDir = createDefaultWorkdir();
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'enforce-worktree';
+
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-default-allow',
+      });
+
+      // No settings → defaults to 'worktree' → allowed
+      expect(session.isolationMode).toBe('worktree');
+    });
+  });
+
+  describe('enforce-direct', () => {
+    it('forces isolationMode to "none" regardless of CC settings', async () => {
+      const workDir = createWorkdirWithIsolation('worktree');
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'enforce-direct';
+
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-force-direct',
+      });
+
+      // Even though CC settings say worktree, enforce-direct forces none
+      expect(session.isolationMode).toBe('none');
+    });
+
+    it('forces isolationMode to "none" when no CC settings exist', async () => {
+      const workDir = createDefaultWorkdir();
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'enforce-direct';
+
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-force-direct-default',
+      });
+
+      expect(session.isolationMode).toBe('none');
+    });
+  });
+
+  describe('per-session override', () => {
+    it('allows per-session override of global policy', async () => {
+      const workDir = createWorkdirWithIsolation('none');
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'enforce-worktree';
+
+      // Global policy would reject, but per-session override allows
+      const session = await sm.createSession({
+        workDir,
+        name: 'test-override',
+        isolationPolicy: 'respect-cc',
+      });
+
+      expect(session.isolationMode).toBe('none');
+    });
+
+    it('per-session enforce-worktree overrides global respect-cc', async () => {
+      const workDir = createWorkdirWithIsolation('none');
+      cleanup.push(workDir, config.stateDir);
+      config.isolationPolicy = 'respect-cc';
+
+      // Global policy would allow, but per-session override rejects
+      await expect(
+        sm.createSession({
+          workDir,
+          name: 'test-override-reject',
+          isolationPolicy: 'enforce-worktree',
+        }),
+      ).rejects.toThrow(SessionCreationError);
+    });
+  });
+
+  describe('SessionCreationError', () => {
+    it('has correct name property', () => {
+      const err = new SessionCreationError('test');
+      expect(err.name).toBe('SessionCreationError');
+      expect(err.message).toBe('test');
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -169,6 +169,12 @@ export interface Config {
   acpEnabled: boolean;
   /** ACP JSON-RPC request timeout in ms (default: 60000). Issue #3223. */
   acpPromptTimeoutMs: number;
+  /** Session isolation policy (Issue #3613).
+   *  "respect-cc": read bgIsolation from CC settings (current behavior, default)
+   *  "enforce-worktree": reject sessions where isolation would be "none"
+   *  "enforce-direct": force bgIsolation "none" (niche, single-session workdirs)
+   */
+  isolationPolicy?: "respect-cc" | "enforce-worktree" | "enforce-direct";
 }
 
 /** Compute stall threshold from env var or default (Issue #392).
@@ -233,6 +239,7 @@ const defaults: Config = {
   rateLimit: { enabled: true, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
   acpEnabled: true,
   acpPromptTimeoutMs: 120_000, // Issue #3243: 120s default for BYO-LLM proxy setups
+  isolationPolicy: 'respect-cc', // Issue #3613: safe default, no behavior change
 };
 
 /** Parse CLI args for --config flag */
@@ -465,6 +472,7 @@ function applyEnvOverrides(config: Config): Config {
     { aegis: 'AEGIS_STRICT_RBAC', manus: '', key: 'strictRBAC' },
     { aegis: 'AEGIS_ACP_ENABLED', manus: '', key: 'acpEnabled' },
     { aegis: 'AEGIS_ACP_PROMPT_TIMEOUT_MS', manus: '', key: 'acpPromptTimeoutMs' },
+    { aegis: 'AEGIS_ISOLATION_POLICY', manus: '', key: 'isolationPolicy' },
   ];
 
   for (const { aegis, manus, key } of envMappings) {
@@ -527,6 +535,14 @@ function applyEnvOverrides(config: Config): Config {
       case 'tgGroupId':
       case 'defaultTenantId':
         config[key] = value;
+        break;
+      // Issue #3613: isolationPolicy with validation
+      case 'isolationPolicy':
+        if (value === 'respect-cc' || value === 'enforce-worktree' || value === 'enforce-direct') {
+          config.isolationPolicy = value as Config['isolationPolicy'];
+        } else {
+          console.warn(`Invalid AEGIS_ISOLATION_POLICY: "${value}". Must be respect-cc, enforce-worktree, or enforce-direct.`);
+        }
         break;
       default:
         // Skip complex types (Record<string,string>) that can't be set from a single env var

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -11,6 +11,7 @@ import { SYSTEM_TENANT } from '../config.js';
 import { filterByTenant } from '../utils/tenant-filter.js';
 import { validateWorkdirPath } from '../tenant-workdir.js';
 import { cleanupTerminatedSessionState } from '../session-cleanup.js';
+import { SessionCreationError } from '../session.js';
 import {
   type RouteContext,
   requirePermission,
@@ -54,6 +55,8 @@ function buildCreateSessionSchema(ctx: RouteContext) {
     effort: z.string().max(20).optional(),
     // Issue #2913: per-session custom system prompt (cc-connect parity).
     systemPrompt: z.string().max(100_000).optional(),
+    // Issue #3613: per-session isolation policy override.
+    isolationPolicy: z.enum(['respect-cc', 'enforce-worktree', 'enforce-direct']).optional(),
   }).strict();
 }
 
@@ -354,7 +357,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
    */
   async function createSessionHandler(req: FastifyRequest, reply: FastifyReply, data: z.infer<typeof createSessionSchema>): Promise<unknown> {
     if (!requirePermission(auth, req, reply, 'create')) return;
-    const { workDir, prompt, prd, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId, memoryKeys, model, systemPrompt, effort } = data;
+    const { workDir, prompt, prd, resumeSessionId, claudeCommand, env, stallThresholdMs, permissionMode, autoApprove, parentId, memoryKeys, model, systemPrompt, effort, isolationPolicy } = data;
     // Issue #2530: `label` is an alias for `name`; normalise so downstream only sees `name`.
     const name = data.name ?? data.label;
     if (!workDir) return reply.status(400).send({ error: 'workDir is required' });
@@ -451,7 +454,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         return reply.status(500).send({ error: 'ACP runtime failed to start — check claude CLI availability and ACP configuration', details: acpErr });
       }
       try {
-        session = await sessions.createSession({ id: acpResult.session.id, workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env: env as Record<string, string> | undefined, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId, tenantId: req.tenantId, model, effort });
+        session = await sessions.createSession({ id: acpResult.session.id, workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env: env as Record<string, string> | undefined, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId, tenantId: req.tenantId, model, effort, isolationPolicy });
         // Issue #3135: Sync ACP session status to local session state
         // The ACP backend tracks agent status independently; mirror it here.
         const acpToUIState: Record<string, import('../session.js').UIState> = { idle: 'idle', running: 'working', paused: 'idle', intervening: 'working', closing: 'idle', closed: 'idle', failed: 'error' };
@@ -465,7 +468,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         throw e;
       }
     } else {
-      session = await sessions.createSession({ workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env: env as Record<string, string> | undefined, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId, tenantId: req.tenantId, model, effort });
+      session = await sessions.createSession({ workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env: env as Record<string, string> | undefined, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId, tenantId: req.tenantId, model, effort, isolationPolicy });
     }
     metrics.sessionCreated(session.id);
 
@@ -544,7 +547,14 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         }
         return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
       }
-      return createSessionHandler(req, reply, parsed.data);
+      try {
+        return await createSessionHandler(req, reply, parsed.data);
+      } catch (e: unknown) {
+        if (e instanceof SessionCreationError) {
+          return reply.status(400).send({ error: 'ISOLATION_POLICY_VIOLATION', message: e.message, code: 'isolation_policy_violation' });
+        }
+        throw e;
+      }
     },
   });
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -118,6 +118,7 @@ export interface SessionInfo {
   lastHookEventAt?: number;      // Unix timestamp from the hook payload (CC's timestamp)
   model?: string;                // Issue #89 L25: Model name from hook payload (e.g. "claude-sonnet-4-6")
   effort?: string;               // Issue #3545: Reasoning effort level
+    /** Issue #3613: Per-session isolation policy override. */    isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
   /** Issue #3590: Session isolation mode — whether CC runs in a worktree or directly edits the project. */
   isolationMode?: 'worktree' | 'none';
   lastDeadAt?: number;           // Unix timestamp when session was detected as dead (Issue #283)
@@ -293,6 +294,14 @@ export type { PermissionDecision };
  * Coordinates session lifecycle, persistence, transcript discovery, and
  * interactive approval/question flows for all managed Claude Code sessions.
  */
+/** Issue #3613: Error thrown when session creation is rejected by isolation policy. */
+export class SessionCreationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionCreationError';
+  }
+}
+
 export class SessionManager {
   private state: SessionState = { sessions: Object.create(null) as Record<string, SessionInfo> };
   private stateFile: string;
@@ -604,6 +613,7 @@ export class SessionManager {
     initialStatus?: UIState;
     model?: string;
     effort?: string;
+    /** Issue #3613: Per-session isolation policy override. */    isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
   }): Promise<SessionInfo> {
     const id = opts.id ?? crypto.randomUUID();
     const createSpan = startSessionSpan('create', id, { workDir: opts.workDir });
@@ -689,7 +699,20 @@ export class SessionManager {
     // Issue #169 Phase 2: Generate HTTP hook settings for this session.
     // Detect isolation mode from project/global Claude settings (Issue #3590)
     const detectedIsolation = await detectIsolationMode(opts.workDir).catch(() => undefined);
-    const isolationMode = detectedIsolation ?? 'worktree';
+    let isolationMode: 'worktree' | 'none' = detectedIsolation ?? 'worktree';
+
+    // Issue #3613: Enforce isolation policy
+    const policy = opts.isolationPolicy ?? this.config.isolationPolicy;
+    if (policy === 'enforce-worktree' && isolationMode === 'none') {
+      throw new SessionCreationError(
+        `Session rejected: isolation policy is 'enforce-worktree' but CC settings have bgIsolation="none". ` +
+        `Set worktree.bgIsolation to "worktree" in .claude/settings.json or change the server isolation policy.`
+      );
+    }
+    if (policy === 'enforce-direct') {
+      isolationMode = 'none';
+    }
+    // policy === 'respect-cc' → use detected isolationMode as-is
 
     // Writes a temp file with hooks pointing to Aegis's hook receiver.
       // Issue #936: Clean stale session hooks from settings.local.json before writing new hooks.

--- a/src/session.ts
+++ b/src/session.ts
@@ -118,7 +118,8 @@ export interface SessionInfo {
   lastHookEventAt?: number;      // Unix timestamp from the hook payload (CC's timestamp)
   model?: string;                // Issue #89 L25: Model name from hook payload (e.g. "claude-sonnet-4-6")
   effort?: string;               // Issue #3545: Reasoning effort level
-    /** Issue #3613: Per-session isolation policy override. */    isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
+    /** Issue #3613: Per-session isolation policy override. */
+  isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
   /** Issue #3590: Session isolation mode — whether CC runs in a worktree or directly edits the project. */
   isolationMode?: 'worktree' | 'none';
   lastDeadAt?: number;           // Unix timestamp when session was detected as dead (Issue #283)
@@ -613,7 +614,8 @@ export class SessionManager {
     initialStatus?: UIState;
     model?: string;
     effort?: string;
-    /** Issue #3613: Per-session isolation policy override. */    isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
+    /** Issue #3613: Per-session isolation policy override. */
+  isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
   }): Promise<SessionInfo> {
     const id = opts.id ?? crypto.randomUUID();
     const createSpan = startSessionSpan('create', id, { workDir: opts.workDir });
@@ -704,12 +706,16 @@ export class SessionManager {
     // Issue #3613: Enforce isolation policy
     const policy = opts.isolationPolicy ?? this.config.isolationPolicy;
     if (policy === 'enforce-worktree' && isolationMode === 'none') {
+      console.warn(`Session ${id}: enforce-worktree policy rejecting session with detected bgIsolation="none"`);
       throw new SessionCreationError(
         `Session rejected: isolation policy is 'enforce-worktree' but CC settings have bgIsolation="none". ` +
         `Set worktree.bgIsolation to "worktree" in .claude/settings.json or change the server isolation policy.`
       );
     }
     if (policy === 'enforce-direct') {
+      if (isolationMode !== 'none') {
+        console.warn(`Session ${id}: enforce-direct policy overriding detected worktree isolation to none`);
+      }
       isolationMode = 'none';
     }
     // policy === 'respect-cc' → use detected isolationMode as-is
@@ -781,6 +787,7 @@ export class SessionManager {
       model: opts.model,
       effort: opts.effort,
       isolationMode: isolationMode,
+      isolationPolicy: policy,
     };
 
     this.state.sessions[id] = session;


### PR DESCRIPTION
## Summary

Implements #3613 — session isolation policy enforcement to prevent file conflicts when multiple CC sessions share a working copy.

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Default policy | `respect-cc` | No behavior change, safest default |
| Enforcement mode | `reject` | Explicit > implicit — returns 400 with clear error |
| Phase-3 prep | Config surface + enforcement + tests now | Dashboard follows (Daedalus) |

If Ema disagrees with any default, swap in one config line — `respect-cc` is backward compatible.

## Changes

### Config surface (`src/config.ts`)
- New field: `isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct'`
- Default: `'respect-cc'` (no behavior change)
- Env: `AEGIS_ISOLATION_POLICY` with runtime validation

### Enforcement logic (`src/session.ts`)
- `SessionCreationError` — new error class for policy violations
- Between `detectIsolationMode()` and session storage:
  - `enforce-worktree` + detected `none` → reject with clear error
  - `enforce-direct` → force `isolationMode = 'none'`
  - `respect-cc` → passthrough (current behavior)
- Per-session override via `isolationPolicy` in createSession opts

### API (`src/routes/sessions.ts`)
- `POST /v1/sessions` accepts optional `isolationPolicy` field
- `SessionCreationError` → 400 `{ error: 'ISOLATION_POLICY_VIOLATION', message, code }`
- Zod schema: `z.enum(['respect-cc', 'enforce-worktree', 'enforce-direct']).optional()`

### Tests (`src/__tests__/isolation-policy-3613.test.ts`)
11 new tests:
- `respect-cc`: allows `none`, allows `worktree`, defaults to `worktree`
- `enforce-worktree`: rejects `none`, allows `worktree`, allows default
- `enforce-direct`: forces `none` regardless of CC settings
- Per-session override: override global policy in either direction
- `SessionCreationError` class properties

## Verification

```
npx tsc --noEmit  ✓  (0 new errors)
npm run build      ✓  Success
npx vitest run     ✓  315 files, 4593 tests passed
```

## Dashboard (follow-up)
- Show enforced policy in project settings
- Badge when enforcement is active
- Warning banner when policy conflicts with CC settings
→ Daedalus territory, tracked in #3539

Closes #3613
