### PR TITLE
docs: add isolation policy config and API docs (#3651)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -780,6 +780,8 @@ curl -X POST http://localhost:9100/v1/sessions \
 | `prd` | string | no | Product Requirements Document text (max 100k chars) |
 | `resumeSessionId` | string (UUID) | no | Resume an existing session by UUID |
 | `model` | string | no | Model name for analytics grouping and per-session model override (max 200 chars, `a-zA-Z0-9._/-` only, must start with alphanumeric). When set, passed to the CC session via `--model` flag. |
+| `effort` | string | no | Reasoning effort level: `low`, `medium`, `high`. When set, passed to the CC session via `--effort` flag. |
+| `isolationPolicy` | string | no | Override server-level isolation policy for this session: `respect-cc` (default), `enforce-worktree`, or `enforce-direct`. See [isolation policy](#isolation-policy) below. |
 | `claudeCommand` | string | no | Custom Claude Code CLI flags (max 500 chars, alphanumeric/safe chars only) |
 | `env` | object | no | Environment variables (subject to denylist) |
 | `stallThresholdMs` | number | no | Stall detection timeout (default: 300000, max: 3600000) |
@@ -808,6 +810,8 @@ curl -X POST http://localhost:9100/v1/sessions \
 ```
 
 > **Note:** The `model` and `effort` fields appear in the response when provided at creation time. The `isolationMode` field (`"worktree"` or `"none"`) is detected from Claude Code settings and indicates whether the session uses a git worktree or edits the project directly.
+>
+> **Isolation policy:** Control how Aegis handles worktree isolation via `isolationPolicy` (request body) or `AEGIS_ISOLATION_POLICY` (env/config). Values: `respect-cc` (default — follows CC settings), `enforce-worktree` (rejects sessions that would run without a worktree), `enforce-direct` (forces no worktree, edits project directly). Use `enforce-worktree` when multiple concurrent sessions share a repo to prevent file conflicts.
 
 **`promptDelivery` fields:**
 
@@ -829,6 +833,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 |--------|------|-----------|
 | 400 | — | Invalid request body, missing `workDir`, file path as `workDir`, empty `prompt`, disallowed characters in `name`/`label`/`model`, env denylist rejection |
 | 400 | `INVALID_WORKDIR` | workDir not in allowed directories. Default allows `$HOME` and server cwd. Set `allowedWorkDirs` in config to allow additional paths. Changes hot-reload. |
+| 400 | `ISOLATION_POLICY_VIOLATION` | Session rejected because isolation policy requires worktree but Claude Code settings would run without one. Fix: enable worktrees in Claude Code or change policy. |
 | 403 | `TENANT_WORKDIR_DENIED` | workDir outside tenant root |
 | 422 | `CC_VERSION_TOO_OLD` | Claude Code version below minimum |
 | 429 | `QUOTA_EXCEEDED` | Per-key session quota exceeded |

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -270,6 +270,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_ACP_BIN` | _(auto)_ | Path to the ACP binary (auto-detected if empty) |
 | `AEGIS_ACP_ENABLED` | `true` | Enable ACP backend for session creation and control actions |
 | `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (default 120s). Increase for slow BYO-LLM proxy setups (min: 1000) |
+| `AEGIS_ISOLATION_POLICY` | `respect-cc` | Session isolation policy: `respect-cc` (follow CC settings, default), `enforce-worktree` (reject sessions without worktree — prevents file conflicts with concurrent sessions), `enforce-direct` (force direct edits, no worktree) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Maximum concurrent sessions |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -344,6 +344,7 @@ Aegis is configured via environment variables:
 | `AEGIS_REDIS_KEY_PREFIX` | `aegis` | Redis key prefix |
 | `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC on protected endpoints even when auth is disabled |
 | `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (increase for slow BYO-LLM proxy setups) |
+| `AEGIS_ISOLATION_POLICY` | `respect-cc` | Session isolation policy: `respect-cc` (follow CC settings), `enforce-worktree` (reject non-worktree sessions), `enforce-direct` (force direct edits, no worktree) |
 
 See the [Enterprise Deployment Guide](enterprise.md#configuration-reference) for the complete environment variable reference (rate limiting, OIDC, hooks, notifications, alerting, and more).
 


### PR DESCRIPTION
## Summary

Documents the worktree isolation policy feature from PR #3651.

## Changes

- **api-reference.md**: Add `isolationPolicy` param to POST /v1/sessions request body table, add `ISOLATION_POLICY_VIOLATION` (400) error, add isolation policy note to response section
- **getting-started.md**: Add `AEGIS_ISOLATION_POLICY` to env var table
- **enterprise.md**: Add `AEGIS_ISOLATION_POLICY` to config env var table with all 3 values

## Feature being documented
- Config: `isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct'`
- Env: `AEGIS_ISOLATION_POLICY`
- Per-session override via request body `isolationPolicy` field
- Error: 400 `ISOLATION_POLICY_VIOLATION` when policy blocks session creation

## Verification
- [x] Values match `src/config.ts` Zod schema and env validation
- [x] Error code matches `src/routes/sessions.ts`