### PR TITLE
fix(dashboard): dark: prefix cleanup, shadow tokens, z-index management

### DIFF
--- a/dashboard/src/components/NewSessionDrawer.tsx
+++ b/dashboard/src/components/NewSessionDrawer.tsx
@@ -118,7 +118,7 @@ export function NewSessionDrawer() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-[150] bg-black/50 backdrop-blur-sm"
+            className="fixed inset-0 z-[var(--z-drawer-overlay)] bg-black/50 backdrop-blur-sm"
             onClick={closeNewSession}
             aria-hidden="true"
           />
@@ -134,7 +134,7 @@ export function NewSessionDrawer() {
             animate={{ x: 0 }}
             exit={{ x: '100%' }}
             transition={{ duration: 0.25, ease: [0.2, 0.8, 0.2, 1] }}
-            className="fixed right-0 top-0 bottom-0 z-[151] w-full md:w-[480px] bg-[var(--color-surface)] border-l border-white/5 shadow-2xl flex flex-col overflow-y-auto"
+            className="fixed right-0 top-0 bottom-0 z-[var(--z-drawer)] w-full md:w-[480px] bg-[var(--color-surface)] border-l border-white/5 shadow-2xl flex flex-col overflow-y-auto"
           >
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-5 border-b border-white/5 shrink-0">

--- a/dashboard/src/components/brand/OnboardingScreen.tsx
+++ b/dashboard/src/components/brand/OnboardingScreen.tsx
@@ -92,7 +92,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
                 damping: 20,
               }}
             >
-              <ShieldLogoMark size="xl" className="drop-shadow-[0_0_24px_rgba(34,197,94,0.8)]" />
+              <ShieldLogoMark size="xl" className="drop-shadow-[var(--shadow-brand-success-lg)]" />
             </motion.div>
           )}
         </AnimatePresence>

--- a/dashboard/src/components/brand/ShieldLogo.tsx
+++ b/dashboard/src/components/brand/ShieldLogo.tsx
@@ -70,7 +70,7 @@ export function ShieldWordmark({ size = 'md', className = '', collapsed = false 
 
   return (
     <div className={`flex items-center gap-3 ${className}`}>
-      <ShieldLogoMark size={size} className="shrink-0 drop-shadow-[0_0_8px_rgba(34,197,94,0.6)]" />
+      <ShieldLogoMark size={size} className="shrink-0 drop-shadow-[var(--shadow-brand-success)]" />
       {!collapsed && (
         <span
           className={`${text} font-bold tracking-tight whitespace-nowrap`}

--- a/dashboard/src/components/overview/HomeStatusPanel.tsx
+++ b/dashboard/src/components/overview/HomeStatusPanel.tsx
@@ -63,7 +63,7 @@ function StatusCard({ label, value, detail, tone, icon, actionButton }: StatusCa
   return (
     <article
       aria-label={`${label}: ${value}`}
-      className={`relative overflow-hidden card-glass card-glass-interactive animate-bento-reveal px-5 py-4 flex items-center justify-between shadow-[0_20px_40px_-15px_rgba(0,0,0,0.7)] ${toneStyles[tone].border}`}
+      className={`relative overflow-hidden card-glass card-glass-interactive animate-bento-reveal px-5 py-4 flex items-center justify-between shadow-[var(--shadow-panel)] ${toneStyles[tone].border}`}
     >
       {/* Critical Alert Glowing Underlay */}
       {isCritical && (

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -481,7 +481,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
 
   return (
     <div className="space-y-6 relative">
-      <div className="card-glass w-full animate-bento-reveal shadow-[0_8px_30px_rgb(0,0,0,0.4)]">
+      <div className="card-glass w-full animate-bento-reveal shadow-[var(--shadow-card)]">
         <div className="flex flex-col gap-4 border-b border-white/5 bg-white/5 p-4 backdrop-blur-md xl:flex-row xl:items-start xl:justify-between">
           <div className="flex-1 space-y-3">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
@@ -657,7 +657,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
           <div className="absolute top-0 left-1/2 -translate-x-1/2 w-64 h-px bg-gradient-to-r from-transparent via-cyan-500/30 to-transparent" />
 
           {/* Icon diamond */}
-          <div className="relative z-10 w-20 h-20 mb-6 rounded-2xl bg-white/5 border border-white/10 flex items-center justify-center shadow-[0_0_30px_rgba(6,182,212,0.12)] transform rotate-45">
+          <div className="relative z-10 w-20 h-20 mb-6 rounded-2xl bg-white/5 border border-white/10 flex items-center justify-center shadow-[var(--shadow-accent-cyan)] transform rotate-45">
             <span className="text-2xl transform -rotate-45 block text-[var(--color-text-muted)]">⌘</span>
           </div>
 

--- a/dashboard/src/components/shared/CommandPalette.tsx
+++ b/dashboard/src/components/shared/CommandPalette.tsx
@@ -191,7 +191,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
-            className="fixed inset-0 z-[200] md:bg-black/60 md:backdrop-blur-sm bg-[var(--color-void)]"
+            className="fixed inset-0 z-[var(--z-cmd-overlay)] md:bg-black/60 md:backdrop-blur-sm bg-[var(--color-void)]"
             style={{ backgroundImage: 'var(--palette-backdrop)' }}
             onClick={onClose}
           />
@@ -206,7 +206,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
             aria-modal="true"
             aria-label={t("aria.commandPalette")}
             ref={trapRef as React.Ref<HTMLDivElement>}
-            className="fixed left-1/2 top-[20vh] z-[201] w-full max-w-xl -translate-x-1/2"
+            className="fixed left-1/2 top-[20vh] z-[var(--z-cmd)] w-full max-w-xl -translate-x-1/2"
           >
             <div className="card-glass overflow-hidden shadow-palette">
               {/* Search input */}

--- a/dashboard/src/design/tokens.ts
+++ b/dashboard/src/design/tokens.ts
@@ -130,6 +130,12 @@ export const tokens = {
       '0 30px 60px -15px rgba(0, 0, 0, 0.9), 0 12px 40px -4px rgba(0, 0, 0, 0.5), 0 0 25px rgba(6, 182, 212, 0.15), inset 0 1px 0 rgba(255,255,255,0.05)',
     terminal: 'inset 0 2px 15px rgba(0,0,0,0.5)',
     statusGlow: '0 0 10px currentColor',
+    /** Cyan accent glow (used in SessionTable hero). */
+    accentCyan: '0 0 30px rgba(6, 182, 212, 0.12)',
+    /** Success brand glow (used in ShieldLogo, OnboardingScreen). */
+    brandSuccess: '0 0 8px rgba(34, 197, 94, 0.6)',
+    /** Success brand glow — large (OnboardingScreen hero). */
+    brandSuccessLg: '0 0 24px rgba(34, 197, 94, 0.8)',
     cardLight:
       '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06), 0 20px 40px -10px rgba(0,0,0,0.08), inset 0 1px 0 rgba(255,255,255,1)',
     cardLightHover:
@@ -142,6 +148,11 @@ export const tokens = {
    */
   zIndex: {
     base: 0,
+    drawerOverlay: 150,
+    drawer: 151,
+    commandPaletteOverlay: 200,
+    commandPalette: 201,
+    tour: 300,
     dropdown: 1000,
     sticky: 1100,
     overlay: 1200,

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -83,6 +83,21 @@
   --duration-slow: 320ms;
   --duration-cinematic: 480ms;
 
+  /* Shadow tokens */
+  --shadow-card: 0 8px 30px rgb(0, 0, 0, 0.4);
+  --shadow-panel: 0 20px 40px -15px rgba(0, 0, 0, 0.7);
+  --shadow-accent-cyan: 0 0 30px rgba(6, 182, 212, 0.12);
+  --shadow-brand-success: 0 0 8px rgba(34, 197, 94, 0.6);
+  --shadow-brand-success-lg: 0 0 24px rgba(34, 197, 94, 0.8);
+
+  /* Z-index layers */
+  --z-drawer-overlay: 150;
+  --z-drawer: 151;
+  --z-cmd-overlay: 200;
+  --z-cmd: 201;
+  --z-tour: 300;
+  --z-toast: 400;
+
   --ease-standard: cubic-bezier(0.2, 0, 0, 1);
   --ease-emphasis-in: cubic-bezier(0.3, 0, 0.8, 0.15);
   --ease-emphasis-out: cubic-bezier(0.05, 0.7, 0.1, 1);

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -141,7 +141,7 @@ function actionBadgeClass(action: string): string {
   if (action.includes('create') || action.includes('authenticated')) {
     return 'border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 text-cyan-300';
   }
-  return 'border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)]/40 text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)]';
+  return 'border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)]/40 text-[var(--color-text-primary)]';
 }
 
 function truncateHash(hash: string, len = 8): string {
@@ -178,7 +178,7 @@ function AuditRow({ record, index, onClick }: { record: AuditRecord; index: numb
       onClick={onClick}
       className="border-b border-[var(--color-void-lighter)] transition-colors hover:bg-[var(--color-void-light)]/40 cursor-pointer"
     >
-      <td className="whitespace-nowrap px-4 py-3 text-sm text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)]">
+      <td className="whitespace-nowrap px-4 py-3 text-sm text-[var(--color-text-muted)]">
         {formatTimestamp(record.ts)}
       </td>
       <td className="max-w-[120px] truncate px-4 py-3 font-mono text-sm text-[var(--color-text-primary)]" title={record.actor}>
@@ -189,10 +189,10 @@ function AuditRow({ record, index, onClick }: { record: AuditRecord; index: numb
           {record.action}
         </span>
       </td>
-      <td className="max-w-[140px] truncate px-4 py-3 font-mono text-sm text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)]" title={record.sessionId ?? ''}>
+      <td className="max-w-[140px] truncate px-4 py-3 font-mono text-sm text-[var(--color-text-primary)]" title={record.sessionId ?? ''}>
         {record.sessionId ? truncateHash(record.sessionId, 12) : '—'}
       </td>
-      <td className="px-4 py-3 font-mono text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)]" title={record.hash}>
+      <td className="px-4 py-3 font-mono text-xs text-[var(--color-text-muted)]" title={record.hash}>
         {truncateHash(record.hash)}
       </td>
     </motion.tr>
@@ -368,7 +368,7 @@ function DetailDrawer({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
-          className="fixed inset-0 z-[150] bg-black/50 backdrop-blur-sm"
+          className="fixed inset-0 z-[var(--z-drawer-overlay)] bg-black/50 backdrop-blur-sm"
           onClick={onClose}
         />
         {/* Panel */}
@@ -381,7 +381,7 @@ function DetailDrawer({
           animate={{ x: 0 }}
           exit={{ x: '100%' }}
           transition={{ duration: 0.25, ease: [0.2, 0.8, 0.2, 1] }}
-          className="fixed right-0 top-0 bottom-0 z-[151] w-full md:w-[480px] overflow-y-auto border-l border-white/10 bg-[var(--color-void)] shadow-2xl"
+          className="fixed right-0 top-0 bottom-0 z-[var(--z-drawer)] w-full md:w-[480px] overflow-y-auto border-l border-white/10 bg-[var(--color-void)] shadow-2xl"
         >
           <div className="flex items-center justify-between border-b border-[var(--color-void-lighter)] px-6 py-4">
             <div className="flex items-center gap-2">
@@ -390,7 +390,7 @@ function DetailDrawer({
             </div>
             <button type="button"
               onClick={onClose}
-              className="rounded p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-muted)] dark:hover:text-[var(--color-text-primary)] transition-colors"
+              className="rounded p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
               aria-label={t("aria.closeDetailDrawer")}
             >
               <X className="h-4 w-4" />
@@ -448,7 +448,7 @@ function DetailDrawer({
                   {copied === 'json' ? 'Copied' : 'Copy'}
                 </button>
               </div>
-              <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-all font-mono text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)]">
+              <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-all font-mono text-xs text-[var(--color-text-primary)]">
                 {JSON.stringify(record, null, 2)}
               </pre>
             </div>
@@ -724,8 +724,8 @@ export default function AuditPage() {
 
       <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)]/50 p-4">
         <div className="mb-3 flex items-center gap-2">
-          <Filter className="h-4 w-4 text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)]" />
-          <span className="text-sm font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)]">Filters</span>
+          <Filter className="h-4 w-4 text-[var(--color-text-muted)]" />
+          <span className="text-sm font-medium text-[var(--color-text-primary)]">Filters</span>
         </div>
 
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
@@ -738,7 +738,7 @@ export default function AuditPage() {
               value={filters.actor}
               onChange={(event) => setFilters((current) => ({ ...current, actor: event.target.value }))}
               onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
-              className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
 
@@ -752,7 +752,7 @@ export default function AuditPage() {
               value={filters.action}
               onChange={(event) => setFilters((current) => ({ ...current, action: event.target.value }))}
               onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
-              className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
             <datalist id="audit-action-suggestions">
               {ACTION_SUGGESTIONS.map((action) => (
@@ -770,7 +770,7 @@ export default function AuditPage() {
               value={filters.sessionId}
               onChange={(event) => setFilters((current) => ({ ...current, sessionId: event.target.value }))}
               onKeyDown={(event) => { if (event.key === 'Enter') applyFilters(); }}
-              className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-gray-400 dark:placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+              className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] placeholder-zinc-600 focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
             />
           </div>
 
@@ -806,7 +806,7 @@ export default function AuditPage() {
           </button>
           <button type="button"
             onClick={clearFilters}
-            className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-void-lighter)]"
+            className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-void-lighter)]"
           >
             Clear
           </button>
@@ -908,7 +908,7 @@ export default function AuditPage() {
                   setPageSize(Number(event.target.value));
                   setPage(1);
                 }}
-                className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
+                className="min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-primary)] focus:border-[var(--color-accent-cyan)]/50 focus:outline-none"
               >
                 {PAGE_SIZE_OPTIONS.map((size) => (
                   <option key={size} value={size}>{size} / page</option>
@@ -923,7 +923,7 @@ export default function AuditPage() {
               <button type="button"
                 onClick={() => setPage((current) => Math.max(1, current - 1))}
                 disabled={page <= 1}
-                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label={t("aria.prevPage")}
               >
                 <ChevronLeft className="h-3.5 w-3.5" />
@@ -931,7 +931,7 @@ export default function AuditPage() {
               <button type="button"
                 onClick={() => setPage((current) => current + 1)}
                 disabled={!hasMore || page >= totalPages}
-                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1 text-xs text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label={t("aria.nextPage")}
               >
                 <ChevronRight className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Three UX cleanup fixes from dashboard UAT, closing 3 issues in one PR.

### #3655 — Remove redundant `dark:` prefixes in AuditPage
The dashboard is dark-theme-only (per SOUL.md). All `dark:` variant classes are redundant — they match the default rendering. Removed 13 instances:
- `text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)]` → `text-[var(--color-text-muted)]`
- `text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)]` → `text-[var(--color-text-primary)]`
- `placeholder-gray-400 dark:placeholder-zinc-600` → `placeholder-zinc-600`

### #3656 — Replace hardcoded shadow values with design tokens
Added 3 new shadow tokens + CSS vars:
- `tokens.shadow.accentCyan` / `--shadow-accent-cyan` — cyan glow
- `tokens.shadow.brandSuccess` / `--shadow-brand-success` — success glow
- `tokens.shadow.brandSuccessLg` / `--shadow-brand-success-lg` — large success glow

Replaced in 4 components:
- `SessionTable.tsx` — card depth shadow + cyan glow
- `HomeStatusPanel.tsx` — panel depth shadow
- `ShieldLogo.tsx` — success brand glow
- `OnboardingScreen.tsx` — success brand glow (large)

### #3658 — Centralized z-index management
Extended existing `tokens.zIndex` scale with overlay-specific layers:
- `drawerOverlay: 150`, `drawer: 151`
- `commandPaletteOverlay: 200`, `commandPalette: 201`
- `tour: 300`

Added matching CSS vars (`--z-drawer-overlay`, etc.) and replaced hardcoded `z-[150]`/`z-[200]` in:
- `NewSessionDrawer.tsx`
- `AuditPage.tsx`
- `CommandPalette.tsx`

### Verification
- `tsc --noEmit`: 0 errors
- `vitest`: 154 files, 1497 passed
- `tokens-gate`: OK (0 violations)
- `npm run build`: clean

Closes #3655, Closes #3656, Closes #3658