### PR TITLE
ci: post-merge rebuild — commit dist back + optional deploy

### DIFF
--- a/.github/workflows/post-merge-rebuild.yml
+++ b/.github/workflows/post-merge-rebuild.yml
@@ -3,24 +3,33 @@ on:
   push:
     branches:
       - develop
+
 permissions:
-  contents: read
+  contents: write
+
 concurrency:
   group: post-merge-rebuild-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   rebuild:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: npm
+
       - name: Install dependencies
         run: npm ci
+
       - name: Build
         run: npm run build
+
       - name: Verify dist/ is fresh
         run: |
           if [ ! -d "dist" ] || [ -z "$(find dist -name '*.js' -newer package-lock.json)" ]; then
@@ -28,11 +37,45 @@ jobs:
             exit 1
           fi
           echo "dist/ rebuilt successfully ($(find dist -name '*.js' | wc -l) JS files)"
+
       - name: Run smoke tests
         run: npm run test:smoke
-      - name: Upload dist/ artifact
-        uses: actions/upload-artifact@v4
+
+      - name: Commit dist if changed
+        run: |
+          set -e
+          if [ -n "$(git status --porcelain --untracked-files=no -- dist)" ]; then
+            git config user.name "aegis-bot[bot]"
+            git config user.email "aegis-bot[bot]@users.noreply.github.com"
+            git add -A dist
+            git commit -m "chore(dist): rebuild after merge to develop [skip ci]"
+            git push origin HEAD:develop
+          else
+            echo "No dist changes to commit"
+          fi
+
+  deploy:
+    name: Optional deploy to host
+    runs-on: ubuntu-latest
+    needs: rebuild
+    if: ${{ vars.DEPLOY_HOST != '' }}
+    environment: deploy
+
+    steps:
+      - name: Deploy and restart over SSH
+        uses: appleboy/ssh-action@v1.2.2
         with:
-          name: dist-develop
-          path: dist/
-          retention-days: 1
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || '22' }}
+          script: |
+            set -e
+            cd "${{ secrets.DEPLOY_PATH }}" || exit 1
+            git fetch origin develop
+            git checkout develop
+            git reset --hard origin/develop
+            npm ci
+            npm run build
+            sudo systemctl reset-failed aegis || true
+            sudo systemctl restart aegis


### PR DESCRIPTION
## Summary

Clean PR addressing Argus review on #3662 (closed). That PR bundled 4 already-merged feat commits with the CI workflow — this is CI-only.

### Changes
- **`permissions: contents: write`** for git push back to develop
- **`fetch-depth: 1`** instead of full history
- **Commit dist/ step**: if build produces changes, auto-commit with `[skip ci]` and push
- **Optional deploy job**: gated on `vars.DEPLOY_HOST` + `deploy` environment
- **All paths parameterized** via secrets (`DEPLOY_PATH`, `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`, `DEPLOY_PORT`)
- **Current action versions**: checkout@v6, setup-node@v6, node 22, ssh-action@v1.2.2
- Removed upload-artifact step (replaced by direct commit-back)

### Addresses #3662 review
1. ✅ Scope contamination — split (CI-only now)
2. ✅ Missing permissions — `contents: write`
3. ✅ Action version downgrades — all at current (v6, node 22)
4. ✅ Hardcoded internal path — parameterized via `secrets.DEPLOY_PATH`
5. ✅ fetch-depth: 0 → fetch-depth: 1

## Verification
- tsc --noEmit: ✅ (1 pre-existing login.ts error, optional dep)
- npm test: ✅ 4593 passed (8 skipped)