### PR TITLE
docs(readme): finalize Quick Start for post-epic flow (#3489)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ npx --package=@onestepat4time/aegis ag run "Build a login page" --cwd ./my-pro
   Aegis v0.7.0
   ✓ Claude Code found
   ✓ Server started → http://127.0.0.1:9100/dashboard
-  ✓ Session created: cc-build-a-login-page
+  ✓ Session created: my-project
 
   [Claude] I'll build a login page with email and password fields...
   [Claude] ├── Creating src/components/LoginForm.tsx

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,7 +119,9 @@ Then include the token in every request:
 curl -H "Authorization: Bearer your-secret-token" http://localhost:9100/v1/sessions
 ```
 
-**Option B: OIDC / SSO (enterprise)**
+**Option B: OIDC / SSO (enterprise — Phase 4)**
+
+> OIDC/SSO is a Phase 4 feature, currently hidden from CLI help. Enable with `AEGIS_FEATURE_OIDC=1`.
 
 For IdP-based authentication, configure OIDC and use the CLI:
 


### PR DESCRIPTION
## What

Final docs updates for the **last unchecked item** on #3489 — README Quick Start rewrite (P3).

## Changes

**README.md**
- Updated session display name in example output: `cc-build-a-login-page` → `my-project`
- Matches the new `basename(workDir)` default from #3654 (friendlier display names)

**docs/getting-started.md**
- Flagged OIDC / `ag login` section as **Phase 4** with `AEGIS_FEATURE_OIDC=1` note
- These commands are now hidden from `--help` (#3654) — docs should reflect that

## Context

The Quick Start was already rewritten around `ag run` in a previous PR (#3509). This PR handles the remaining accuracy updates after #3654 (Ema's friendlier names + OIDC hide) landed.

**Closes #3489** (11/11 child items done → epic complete).

## Checklist
- [x] No code changes
- [x] Examples match current develop behavior
- [x] No sensitive data in examples