### PR TITLE
chore(deps): bump ts-morph to ^28.0.0 (issue #3667)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "async-mutex": "^0.5.0",
         "fastify": "^5.8.5",
         "nodemailer": "^8.0.7",
-        "open": "11.0.0",
         "openid-client": "^6.8.4",
         "prom-client": "^15.1.3",
         "yaml": "^2.9.0",
@@ -46,7 +45,7 @@
         "eslint-config-prettier": "^10.1.8",
         "lockfile-lint": "5.0.0",
         "prettier": "^3.8.1",
-        "ts-morph": "^27.0.2",
+        "ts-morph": "^28.0.0",
         "typedoc": "^0.28.18",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.0",
@@ -2669,9 +2668,9 @@
       "license": "MIT"
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
-      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.29.0.tgz",
+      "integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7483,13 +7482,13 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
-      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-28.0.0.tgz",
+      "integrity": "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ts-morph/common": "~0.28.1",
+        "@ts-morph/common": "~0.29.0",
         "code-block-writer": "^13.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "eslint-config-prettier": "^10.1.8",
     "lockfile-lint": "5.0.0",
     "prettier": "^3.8.1",
-    "ts-morph": "^27.0.2",
+    "ts-morph": "^28.0.0",
     "typedoc": "^0.28.18",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",


### PR DESCRIPTION
Bumps devDependency ts-morph to ^28.0.0 and updates package-lock.json.\n\nRun: npm ci && npm run build to validate.\n\nRefs: #3667