### PR TITLE
fix(cli): ag status respects session-id argument (#3673)

### DIFF
--- a/src/__tests__/commands/status.test.ts
+++ b/src/__tests__/commands/status.test.ts
@@ -1,0 +1,256 @@
+/**
+ * status.test.ts — Tests for `ag status [session-id]` (#3673)
+ *
+ * Covers:
+ * - Server health path (no session ID)
+ * - Session detail path (session ID provided)
+ * - 404 / non-OK from GET /v1/sessions/:id → error + return 1
+ * - resolveSessionId failure → return 1
+ * - Cost display from /v1/sessions/:id/metrics
+ * - formatUptime and formatRelativeTime helper logic
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../cli-http.js', () => ({
+  resolveBaseUrl: vi.fn(async () => 'http://127.0.0.1:9100'),
+  resolveAuthToken: vi.fn(async () => ''),
+  buildHeaders: vi.fn(() => ({})),
+  requireServer: vi.fn(async () => true),
+  writeLine: vi.fn((stream: NodeJS.WritableStream, text: string = '') => stream.write(`${text}\n`)),
+}));
+
+vi.mock('../../commands/read.js', () => ({
+  resolveSessionId: vi.fn(),
+  handleRead: vi.fn(),
+}));
+
+import { handleStatus } from '../../commands/status.js';
+import { resolveSessionId } from '../../commands/read.js';
+import { writeLine } from '../../cli-http.js';
+
+function makeIO() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    io: {
+      stdin: process.stdin as unknown as NodeJS.ReadableStream,
+      stdout: { write: (s: string) => { out.push(s); return true; } } as unknown as NodeJS.WritableStream,
+      stderr: { write: (s: string) => { err.push(s); return true; } } as unknown as NodeJS.WritableStream,
+    },
+    getOut: () => out.join(''),
+    getErr: () => err.join(''),
+  };
+}
+
+const mockResolveSessionId = resolveSessionId as ReturnType<typeof vi.fn>;
+const mockWriteLine = writeLine as ReturnType<typeof vi.fn>;
+
+describe('ag status — server health (no session ID)', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+    mockWriteLine.mockImplementation((stream: NodeJS.WritableStream, text: string = '') => stream.write(`${text}\n`));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns 0 and prints health info', async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes('/v1/health')) {
+        return { ok: true, json: async () => ({ version: '2.5.0', status: 'healthy', uptime: 3661, port: 9100 }) };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof fetch;
+
+    const { io, getOut } = makeIO();
+    const code = await handleStatus([], io);
+    expect(code).toBe(0);
+    const output = getOut();
+    expect(output).toContain('2.5.0');
+    expect(output).toContain('healthy');
+    expect(output).toContain('1h 1m');
+    expect(output).toContain('9100');
+  });
+
+  it('shows session count from stats endpoint', async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes('/v1/health')) {
+        return { ok: true, json: async () => ({ version: '1.0.0', status: 'ok', uptime: 10 }) };
+      }
+      if (String(url).includes('/v1/sessions/stats')) {
+        return { ok: true, json: async () => ({ active: 3, total: 10 }) };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof fetch;
+
+    const { io, getOut } = makeIO();
+    const code = await handleStatus([], io);
+    expect(code).toBe(0);
+    expect(getOut()).toContain('3 active / 10 total');
+  });
+
+  it('returns 1 when health check fails', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      statusText: 'Service Unavailable',
+    })) as unknown as typeof fetch;
+
+    const { io, getErr } = makeIO();
+    const code = await handleStatus([], io);
+    expect(code).toBe(1);
+    expect(getErr()).toContain('Health check failed');
+  });
+});
+
+describe('ag status <session-id> — session detail', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+    mockWriteLine.mockImplementation((stream: NodeJS.WritableStream, text: string = '') => stream.write(`${text}\n`));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('displays session info when found', async () => {
+    mockResolveSessionId.mockResolvedValue('abc-full-uuid-123');
+    const now = Date.now();
+    const createdAt = now - 90_000; // 1m 30s ago
+    const lastActivity = now - 10_000; // 10s ago
+
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes('/v1/sessions/abc-full-uuid-123/metrics')) {
+        return { ok: true, json: async () => ({ tokenUsage: { estimatedCostUsd: 0.0123 } }) };
+      }
+      if (String(url).includes('/v1/sessions/abc-full-uuid-123')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 'abc-full-uuid-123',
+            status: 'running',
+            model: 'claude-opus-4-5',
+            createdAt,
+            lastActivity,
+          }),
+        };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof fetch;
+
+    const { io, getOut } = makeIO();
+    const code = await handleStatus(['abc'], io);
+    expect(code).toBe(0);
+    const output = getOut();
+    expect(output).toContain('abc-full-uuid-123');
+    expect(output).toContain('running');
+    expect(output).toContain('claude-opus-4-5');
+    expect(output).toContain('$0.0123');
+    expect(output).toContain('1m');
+    expect(output).toContain('10s ago');
+  });
+
+  it('returns 1 and prints error when session not found (404)', async () => {
+    mockResolveSessionId.mockResolvedValue('ghost-session-id');
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    })) as unknown as typeof fetch;
+
+    const { io, getErr } = makeIO();
+    const code = await handleStatus(['ghost'], io);
+    expect(code).toBe(1);
+    expect(getErr()).toContain('Session not found');
+  });
+
+  it('returns 1 when resolveSessionId fails (ambiguous prefix)', async () => {
+    mockResolveSessionId.mockResolvedValue(null);
+
+    const { io } = makeIO();
+    const code = await handleStatus(['am'], io);
+    expect(code).toBe(1);
+  });
+
+  it('shows "n/a" cost when metrics endpoint unavailable', async () => {
+    mockResolveSessionId.mockResolvedValue('session-xyz');
+    const now = Date.now();
+
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes('/metrics')) {
+        return { ok: false, status: 404 };
+      }
+      if (String(url).includes('/v1/sessions/session-xyz')) {
+        return {
+          ok: true,
+          json: async () => ({ id: 'session-xyz', status: 'idle', createdAt: now - 5000, lastActivity: now - 1000 }),
+        };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof fetch;
+
+    const { io, getOut } = makeIO();
+    const code = await handleStatus(['session-xyz'], io);
+    expect(code).toBe(0);
+    expect(getOut()).toContain('n/a');
+  });
+
+  it('omits Model line when session has no model field', async () => {
+    mockResolveSessionId.mockResolvedValue('sess-no-model');
+    const now = Date.now();
+
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes('/metrics')) return { ok: false, status: 404 };
+      if (String(url).includes('/v1/sessions/sess-no-model')) {
+        return {
+          ok: true,
+          json: async () => ({ id: 'sess-no-model', status: 'completed', createdAt: now - 1000, lastActivity: now }),
+        };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof fetch;
+
+    const { io, getOut } = makeIO();
+    await handleStatus(['sess-no-model'], io);
+    expect(getOut()).not.toContain('Model:');
+  });
+});
+
+describe('formatUptime (via server health output)', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+    mockWriteLine.mockImplementation((stream: NodeJS.WritableStream, text: string = '') => stream.write(`${text}\n`));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it.each([
+    [30, '30s'],
+    [90, '1m 30s'],
+    [3665, '1h 1m'],
+  ])('uptime %ds → "%s"', async (uptime: number, expected: string) => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes('/v1/health')) {
+        return { ok: true, json: async () => ({ version: '1.0', status: 'ok', uptime }) };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof fetch;
+
+    const { io, getOut } = makeIO();
+    await handleStatus([], io);
+    expect(getOut()).toContain(expected);
+  });
+});

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -13,7 +13,7 @@ import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLin
  * If the ID looks like a full UUID, return it as-is.
  * Otherwise, fetch the session list and find a unique match.
  */
-async function resolveSessionId(sessionId: string, baseUrl: string, headers: Record<string, string>, io: CliIO): Promise<string | null> {
+export async function resolveSessionId(sessionId: string, baseUrl: string, headers: Record<string, string>, io: CliIO): Promise<string | null> {
   // Full UUID — no resolution needed
   if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {
     return sessionId;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,43 +1,104 @@
 /**
- * commands/status.ts — `ag status` — Show server health and session summary.
+ * commands/status.ts — `ag status [session-id]` — Show server health or session details.
  *
- * Wraps GET /v1/health and GET /v1/sessions/stats.
+ * Without a session ID: wraps GET /v1/health and GET /v1/sessions/stats.
+ * With a session ID:    wraps GET /v1/sessions/:id (+ optional metrics).
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+import { resolveSessionId } from './read.js';
 
 export async function handleStatus(args: string[], io: CliIO): Promise<number> {
+  const sessionId = args.find(a => !a.startsWith('-'));
   const baseUrl = await resolveBaseUrl(args);
   const authToken = await resolveAuthToken();
   if (!(await requireServer(baseUrl, authToken, io))) return 1;
-
   const headers = buildHeaders(authToken);
 
-  // Fetch health
+  if (sessionId) {
+    return handleSessionStatus(sessionId, baseUrl, headers, io);
+  }
+
+  // Server health (no session ID)
   const healthRes = await fetch(`${baseUrl}/v1/health`, { headers, signal: AbortSignal.timeout(5000) });
   if (!healthRes.ok) {
     writeLine(io.stderr, `  ❌ Health check failed: ${healthRes.statusText}`);
     return 1;
   }
-  const health = await healthRes.json() as Record<string, any>;
+  const health = await healthRes.json() as Record<string, unknown>;
 
   writeLine(io.stdout, '  Aegis Status');
   writeLine(io.stdout, '  ────────────');
   writeLine(io.stdout, `  Version:   ${health.version ?? 'unknown'}`);
   writeLine(io.stdout, `  Status:    ${health.status ?? 'unknown'}`);
-  writeLine(io.stdout, `  Uptime:    ${health.uptime != null ? formatUptime(health.uptime) : 'unknown'}`);
+  writeLine(io.stdout, `  Uptime:    ${health.uptime != null ? formatUptime(health.uptime as number) : 'unknown'}`);
   if (health.port) writeLine(io.stdout, `  Port:      ${health.port}`);
 
-  // Fetch session stats
   try {
     const statsRes = await fetch(`${baseUrl}/v1/sessions/stats`, { headers, signal: AbortSignal.timeout(5000) });
     if (statsRes.ok) {
-      const stats = await statsRes.json() as Record<string, any>;
+      const stats = await statsRes.json() as Record<string, unknown>;
       writeLine(io.stdout, `  Sessions:  ${stats.active ?? stats.running ?? 0} active / ${stats.total ?? 0} total`);
     }
   } catch {
     // Stats endpoint may not exist — skip
   }
+
+  return 0;
+}
+
+async function handleSessionStatus(
+  sessionId: string,
+  baseUrl: string,
+  headers: Record<string, string>,
+  io: CliIO,
+): Promise<number> {
+  const resolvedId = await resolveSessionId(sessionId, baseUrl, headers, io);
+  if (!resolvedId) return 1;
+
+  const res = await fetch(`${baseUrl}/v1/sessions/${resolvedId}`, {
+    headers,
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      writeLine(io.stderr, `  ❌ Session not found: ${sessionId}`);
+    } else {
+      writeLine(io.stderr, `  ❌ Failed to fetch session: ${res.statusText}`);
+    }
+    return 1;
+  }
+
+  const session = await res.json() as Record<string, unknown>;
+
+  let costDisplay = 'n/a';
+  try {
+    const metricsRes = await fetch(`${baseUrl}/v1/sessions/${resolvedId}/metrics`, {
+      headers,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (metricsRes.ok) {
+      const m = await metricsRes.json() as { tokenUsage?: { estimatedCostUsd?: number } };
+      if (m.tokenUsage?.estimatedCostUsd != null) {
+        costDisplay = `$${m.tokenUsage.estimatedCostUsd.toFixed(4)}`;
+      }
+    }
+  } catch {
+    // Metrics may not be available
+  }
+
+  const createdAt = typeof session.createdAt === 'number' ? session.createdAt : null;
+  const lastActivity = typeof session.lastActivity === 'number' ? session.lastActivity : null;
+  const now = Date.now();
+
+  writeLine(io.stdout, `  Session: ${resolvedId}`);
+  writeLine(io.stdout, '  ─────────────────────────────────────');
+  writeLine(io.stdout, `  Status:        ${session.status ?? 'unknown'}`);
+  if (session.model) writeLine(io.stdout, `  Model:         ${session.model}`);
+  writeLine(io.stdout, `  Cost:          ${costDisplay}`);
+  writeLine(io.stdout, `  Duration:      ${createdAt != null ? formatUptime((now - createdAt) / 1000) : 'unknown'}`);
+  writeLine(io.stdout, `  Last activity: ${lastActivity != null ? formatRelativeTime(lastActivity, now) : 'unknown'}`);
 
   return 0;
 }
@@ -48,4 +109,14 @@ function formatUptime(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   return `${h}h ${m}m`;
+}
+
+function formatRelativeTime(ts: number, now: number): string {
+  const diffSec = Math.floor((now - ts) / 1000);
+  if (diffSec < 0) return 'just now';
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  return `${diffHr}h ${diffMin % 60}m ago`;
 }


### PR DESCRIPTION
## Fix #3673 — `ag status` ignores session-id argument

### Problem
`ag status <session-id>` ignores the session ID entirely and always returns server health info.

### Solution
- Modified `src/commands/status.ts` to accept an optional session-id argument
- When a session ID is provided:
  - Resolves via prefix matching (reusing `resolveSessionId` from `read.ts`)
  - Fetches session details from `GET /v1/sessions/:id`
  - Fetches cost metrics from `GET /v1/sessions/:id/metrics`
  - Displays: session ID, status, model, cost, duration, last activity
- When no session ID provided: keeps current server health behavior
- Exported `resolveSessionId` from `read.ts` for reuse

### Changes
- `src/commands/status.ts` — added `handleSessionStatus()` with session-specific display
- `src/commands/read.ts` — exported `resolveSessionId` (was already used internally)
- `src/__tests__/commands/status.test.ts` — new test file (256 lines, 11 tests)

### Verification
```
Aegis API: v0.6.7
Commit: b036254e
Session: 6ef48e3c-da37-4175-b838-b9f03d05ddb5

tsc --noEmit: ✅ (zero errors)
npm run build: ✅
npm test: ✅ 316 test files, 4604 tests passed (8 skipped)
```

Closes #3673