### PR TITLE
fix(cli): prefix matching for ag kill and ag tail

### DIFF
--- a/src/__tests__/fix-3672-cli-kill-tail-prefix.test.ts
+++ b/src/__tests__/fix-3672-cli-kill-tail-prefix.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Issue #3672: ag kill and ag tail reject session ID prefixes while ag read accepts them.
+ *
+ * Tests:
+ * - handleKill with full UUID works
+ * - handleKill with prefix resolves and works
+ * - handleKill with ambiguous prefix returns error
+ * - handleKill with no match returns error
+ * - handleTail with full UUID works (resolves ID)
+ * - handleTail with prefix resolves
+ * - handleTail with ambiguous prefix returns error
+ * - handleTail with no match returns error
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockSessions = [
+  { id: 'a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5', displayName: 'test-1', status: 'idle' },
+  { id: 'b2854e13-91b4-4874-9189-b61fdd00a9c9', displayName: 'test-2', status: 'working' },
+];
+
+function createMockFetch(handlers: Record<string, () => Promise<Response>>): (url: string | URL | Request) => Promise<Response> {
+  return (url: string | URL | Request): Promise<Response> => {
+    const urlStr = url.toString();
+    if (urlStr.includes('/health')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'ok' }) } as Response);
+    }
+    if (urlStr.match(/\/v1\/sessions(\?|$)/) && !urlStr.includes('/sessions/')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions }),
+      } as Response);
+    }
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (urlStr.includes(pattern)) {
+        return handler();
+      }
+    }
+    return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({ error: 'not found' }) } as Response);
+  };
+}
+
+function createIO() {
+  const output: string[] = [];
+  return {
+    io: {
+      stdin: {} as any,
+      stdout: { write: (s: string) => { output.push(s); } } as any,
+      stderr: { write: (s: string) => { output.push(s); } } as any,
+    },
+    output,
+  };
+}
+
+describe('Issue #3672: ag kill prefix matching', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('handleKill with full UUID works', async () => {
+    globalThis.fetch = vi.fn(createMockFetch({
+      '/sessions/a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5': () => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      } as Response),
+    })) as any;
+
+    const { handleKill } = await import('../commands/kill.js');
+    const { io, output } = createIO();
+    const exitCode = await handleKill(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
+    expect(exitCode).toBe(0);
+    expect(output.join('')).toContain('killed');
+  });
+
+  it('handleKill with 8-char prefix resolves and works', async () => {
+    globalThis.fetch = vi.fn(createMockFetch({
+      '/sessions/a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5': () => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      } as Response),
+    })) as any;
+
+    const { handleKill } = await import('../commands/kill.js');
+    const { io, output } = createIO();
+    const exitCode = await handleKill(['a9e04f5e'], io);
+    expect(exitCode).toBe(0);
+    expect(output.join('')).toContain('killed');
+  });
+
+  it('handleKill with ambiguous prefix returns error', async () => {
+    // Override sessions to have ambiguous prefixes
+    const ambiguousMock = (url: string | URL | Request): Promise<Response> => {
+      const urlStr = url.toString();
+      if (urlStr.includes('/health')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'ok' }) } as Response);
+      }
+      if (urlStr.match(/\/v1\/sessions(\?|$)/) && !urlStr.includes('/sessions/')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: [
+              { id: 'a9e04f5e-aaaa-aaaa-aaaa-aaaaaaaaaaaa', status: 'idle' },
+              { id: 'a9e04f5e-bbbb-bbbb-bbbb-bbbbbbbbbbbb', status: 'idle' },
+            ],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({ error: 'not found' }) } as Response);
+    };
+    globalThis.fetch = vi.fn(ambiguousMock) as any;
+
+    // Need a fresh import to pick up new mock
+    vi.resetModules();
+    const { handleKill } = await import('../commands/kill.js');
+    const { io, output } = createIO();
+    const exitCode = await handleKill(['a9e04f5e'], io);
+    expect(exitCode).toBe(1);
+    expect(output.join('')).toContain('Ambiguous');
+  });
+
+  it('handleKill with no match returns error', async () => {
+    globalThis.fetch = vi.fn(createMockFetch({})) as any;
+
+    vi.resetModules();
+    const { handleKill } = await import('../commands/kill.js');
+    const { io, output } = createIO();
+    const exitCode = await handleKill(['zzzzzzzz'], io);
+    expect(exitCode).toBe(1);
+    expect(output.join('')).toContain('No session found');
+  });
+});
+
+describe('Issue #3672: ag tail prefix matching', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('handleTail with full UUID resolves ID', async () => {
+    globalThis.fetch = vi.fn(createMockFetch({
+      '/auth/sse-token': () => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ token: 'sse_test123' }),
+      } as Response),
+      '/events': () => Promise.resolve({
+        ok: true,
+        body: null,
+        json: () => Promise.resolve({}),
+      } as Response),
+    })) as any;
+
+    const { handleTail } = await import('../commands/tail.js');
+    const { io, output } = createIO();
+    const exitCode = await handleTail(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
+    // Will fail at "No response body" but should resolve the ID first
+    expect(output.join('')).toContain('a9e04f5e');
+  });
+
+  it('handleTail with 8-char prefix resolves', async () => {
+    globalThis.fetch = vi.fn(createMockFetch({
+      '/auth/sse-token': () => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ token: 'sse_test123' }),
+      } as Response),
+      '/events': () => Promise.resolve({
+        ok: true,
+        body: null,
+        json: () => Promise.resolve({}),
+      } as Response),
+    })) as any;
+
+    const { handleTail } = await import('../commands/tail.js');
+    const { io, output } = createIO();
+    const exitCode = await handleTail(['a9e04f5e'], io);
+    expect(output.join('')).toContain('a9e04f5e');
+  });
+
+  it('handleTail with ambiguous prefix returns error', async () => {
+    const ambiguousMock = (url: string | URL | Request): Promise<Response> => {
+      const urlStr = url.toString();
+      if (urlStr.includes('/health')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'ok' }) } as Response);
+      }
+      if (urlStr.match(/\/v1\/sessions(\?|$)/) && !urlStr.includes('/sessions/')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: [
+              { id: 'a9e04f5e-aaaa-aaaa-aaaa-aaaaaaaaaaaa', status: 'idle' },
+              { id: 'a9e04f5e-bbbb-bbbb-bbbb-bbbbbbbbbbbb', status: 'idle' },
+            ],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({ error: 'not found' }) } as Response);
+    };
+    globalThis.fetch = vi.fn(ambiguousMock) as any;
+
+    const { handleTail } = await import('../commands/tail.js');
+    const { io, output } = createIO();
+    const exitCode = await handleTail(['a9e04f5e'], io);
+    expect(exitCode).toBe(1);
+    expect(output.join('')).toContain('Ambiguous');
+  });
+
+  it('handleTail with no match returns error', async () => {
+    globalThis.fetch = vi.fn(createMockFetch({})) as any;
+
+    const { handleTail } = await import('../commands/tail.js');
+    const { io, output } = createIO();
+    const exitCode = await handleTail(['zzzzzzzz'], io);
+    expect(exitCode).toBe(1);
+    expect(output.join('')).toContain('No session found');
+  });
+});

--- a/src/__tests__/tail-sigint-windows-3512.test.ts
+++ b/src/__tests__/tail-sigint-windows-3512.test.ts
@@ -107,7 +107,7 @@ describe('tail SIGINT handling (#3512)', () => {
 
     try {
       const io = makeIO();
-      const exitCode = await handleTail(['abc123'], io);
+      const exitCode = await handleTail(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
 
       expect(readline.emitKeypressEvents).toHaveBeenCalledWith(process.stdin);
       expect(exitCode).toBe(0);
@@ -137,7 +137,7 @@ describe('tail SIGINT handling (#3512)', () => {
 
     try {
       const io = makeIO();
-      const exitCode = await handleTail(['abc123'], io);
+      const exitCode = await handleTail(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
 
       expect(readline.emitKeypressEvents).not.toHaveBeenCalled();
       expect(exitCode).toBe(0);
@@ -160,7 +160,7 @@ describe('tail SIGINT handling (#3512)', () => {
 
     try {
       const io = makeIO();
-      const exitCode = await handleTail(['abc123'], io);
+      const exitCode = await handleTail(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
       expect(exitCode).toBe(1);
       expect(writeLine).toHaveBeenCalledWith(io.stderr, expect.stringContaining('SSE token'));
     } finally {
@@ -189,7 +189,7 @@ describe('tail SIGINT handling (#3512)', () => {
 
     try {
       const io = makeIO();
-      const exitCode = await handleTail(['abc123'], io);
+      const exitCode = await handleTail(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
       expect(exitCode).toBe(1);
       expect(writeLine).toHaveBeenCalledWith(io.stderr, expect.stringContaining('Session not found'));
     } finally {
@@ -217,7 +217,7 @@ describe('tail SIGINT handling (#3512)', () => {
 
     try {
       const io = makeIO();
-      const exitCode = await handleTail(['abc123'], io);
+      const exitCode = await handleTail(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
       expect(exitCode).toBe(0);
       // Should have printed the assistant message
       expect(writeLine).toHaveBeenCalledWith(io.stdout, expect.stringContaining('🤖 hello'));
@@ -252,7 +252,7 @@ describe('tail SIGINT handling (#3512)', () => {
 
       try {
         const io = makeIO();
-        await handleTail(['abc123'], io);
+        await handleTail(['a9e04f5e-ba93-4ec7-b0d6-76648b4a33e5'], io);
         expect(onceSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
         expect(removeListenerSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
       } finally {

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -2,9 +2,11 @@
  * commands/kill.ts — `ag kill <id>` — Terminate a session.
  *
  * Wraps DELETE /v1/sessions/:id.
+ * Issue #3672: Support prefix matching for session IDs via resolveSessionId.
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+import { resolveSessionId } from './read.js';
 
 export async function handleKill(args: string[], io: CliIO): Promise<number> {
   const sessionId = args.find(a => !a.startsWith('-'));
@@ -18,7 +20,12 @@ export async function handleKill(args: string[], io: CliIO): Promise<number> {
   if (!(await requireServer(baseUrl, authToken, io))) return 1;
 
   const headers = buildHeaders(authToken);
-  const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}`, {
+
+  // Issue #3672: Resolve prefix to full UUID
+  const resolvedId = await resolveSessionId(sessionId, baseUrl, headers, io);
+  if (!resolvedId) return 1;
+
+  const res = await fetch(`${baseUrl}/v1/sessions/${resolvedId}`, {
     method: 'DELETE',
     headers,
     signal: AbortSignal.timeout(15_000),
@@ -30,6 +37,6 @@ export async function handleKill(args: string[], io: CliIO): Promise<number> {
     return 1;
   }
 
-  writeLine(io.stdout, `  ✅ Session ${sessionId.slice(0, 8)}… killed.`);
+  writeLine(io.stdout, `  ✅ Session ${resolvedId.slice(0, 8)}… killed.`);
   return 0;
 }

--- a/src/commands/tail.ts
+++ b/src/commands/tail.ts
@@ -4,6 +4,7 @@
  * Connects to GET /v1/sessions/:id/events SSE stream and prints events.
  * Issue #3566: SSE endpoints require short-lived sse_ tokens.
  * The CLI first obtains an SSE token via POST /v1/auth/sse-token, then connects.
+ * Issue #3672: Support prefix matching for session IDs via resolveSessionId.
  *
  * Uses SIGINT on Unix and a readline keypress fallback on Windows for Ctrl+C.
  * Includes a 30-minute max-duration safeguard so the process never hangs forever.
@@ -12,6 +13,7 @@
 import { platform } from 'node:os';
 import * as readline from 'node:readline';
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+import { resolveSessionId } from './read.js';
 
 /** Maximum tail duration before auto-disconnect (30 minutes). */
 const MAX_TAIL_DURATION_MS = 30 * 60 * 1000;
@@ -46,6 +48,12 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
   const authToken = await resolveAuthToken();
   if (!(await requireServer(baseUrl, authToken, io))) return 1;
 
+  const headers = buildHeaders(authToken);
+
+  // Issue #3672: Resolve prefix to full UUID
+  const resolvedId = await resolveSessionId(sessionId, baseUrl, headers, io);
+  if (!resolvedId) return 1;
+
   // Issue #3566: Obtain SSE token before connecting to the event stream.
   const sseToken = await obtainSSEToken(baseUrl, authToken);
   if (!sseToken) {
@@ -53,10 +61,10 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
     return 1;
   }
 
-  const headers = buildHeaders(sseToken);
-  headers['Accept'] = 'text/event-stream';
+  const sseHeaders = buildHeaders(sseToken);
+  sseHeaders['Accept'] = 'text/event-stream';
 
-  writeLine(io.stdout, `  Tailing session ${sessionId.slice(0, 8)}… (Ctrl+C to stop)`);
+  writeLine(io.stdout, `  Tailing session ${resolvedId.slice(0, 8)}… (Ctrl+C to stop)`);
 
   const abortController = new AbortController();
   const onSigInt = () => {
@@ -104,8 +112,8 @@ export async function handleTail(args: string[], io: CliIO): Promise<number> {
 
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/events`, {
-      headers,
+    res = await fetch(`${baseUrl}/v1/sessions/${resolvedId}/events`, {
+      headers: sseHeaders,
       signal: abortController.signal,
     });
   } catch (e: unknown) {


### PR DESCRIPTION
## Summary

Fixes #3672 — `ag kill` and `ag tail` now accept session ID prefixes (e.g. `5070c990`), matching the behavior of `ag read` and `ag status`.

## Problem

- `ag read 5070c990` → ✅ works (prefix matching)
- `ag kill 5070c990` → ❌ "Invalid session ID — must be a UUID"
- `ag tail 5070c990` → starts connecting then ❌ "Invalid session ID"

The `tail` case is worst: it prints "Tailing session 5070c990…" suggesting acceptance, then fails.

## Fix

Import and call `resolveSessionId` (from `read.ts`) in both `kill.ts` and `tail.ts`, following the pattern already established in `status.ts`.

### Files changed
- `src/commands/kill.ts` — import + call `resolveSessionId` before DELETE fetch
- `src/commands/tail.ts` — import + call `resolveSessionId` before SSE token + event stream
- `src/__tests__/fix-3672-cli-kill-tail-prefix.test.ts` — 8 new tests (full UUID, prefix resolve, ambiguous, no-match — for both commands)
- `src/__tests__/tail-sigint-windows-3512.test.ts` — use full UUID to avoid prefix resolution in existing SIGINT tests

## Verification

```
npx tsc --noEmit  → ✅ (no new errors)
npm run build     → ✅
npm test          → ✅ 317 passed | 0 failed | 1 skipped | 4598 tests
```

Commit: a031c387
Branch: fix/3672-cli-kill-tail-prefix → develop