### PR TITLE
refactor(cli): DRY CliIO and writeLine — consolidate to cli-http.ts

### DIFF
--- a/src/cli-http.ts
+++ b/src/cli-http.ts
@@ -22,6 +22,11 @@ export function writeLine(stream: NodeJS.WritableStream, text: string = ''): voi
   stream.write(`${text}\n`);
 }
 
+/** Write text without trailing newline. */
+export function write(stream: NodeJS.WritableStream, text: string): void {
+  stream.write(text);
+}
+
 /** Resolve auth token from env, config, or legacy files. */
 export async function resolveAuthToken(): Promise<string> {
   const envToken = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -14,16 +14,7 @@ import { dirname } from 'node:path';
 import { findConfigFilePath, loadConfig, readConfigFile, serializeConfigFile, type Config } from '../config.js';
 import { getErrorMessage } from '../validation.js';
 import { getAuthTokenFilePath, persistAuthTokenFile, readAuthTokenFile } from '../utils/auth-token-path.js';
-
-interface CliIO {
-  stdin: NodeJS.ReadableStream;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-}
-
-function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
-  stream.write(`${text}\n`);
-}
+import { CliIO, writeLine } from '../cli-http.js';
 
 /**
  * Migrate clientAuthToken from config.yaml to the canonical auth-token file.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -19,6 +19,7 @@ import { AuthManager } from '../services/auth/index.js';
 import { buildEnvSchema, ENV_BYO_LLM_WHITELIST, getErrorMessage } from '../validation.js';
 import { persistAuthTokenFile, readAuthTokenFile } from '../utils/auth-token-path.js';
 import { isLocalhost } from '../utils/localhost.js';
+import { CliIO, writeLine, write } from '../cli-http.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -31,12 +32,6 @@ const BYO_ENV_FIELDS = [
   { key: 'ANTHROPIC_DEFAULT_FAST_MODEL', label: 'ANTHROPIC fast model' },
   { key: 'API_TIMEOUT_MS', label: 'API timeout (ms)' },
 ] as const;
-
-interface CliIO {
-  stdin: NodeJS.ReadableStream;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-}
 
 interface InitSummary {
   authToken: string;
@@ -83,14 +78,6 @@ interface Prompter {
 }
 
 // --- Shared utilities ---
-
-function write(stream: NodeJS.WritableStream, text: string): void {
-  stream.write(text);
-}
-
-function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
-  stream.write(`${text}\n`);
-}
 
 // --- Config path helpers ---
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -17,16 +17,7 @@ import {
   setStoredAuth,
   type StoredAuth,
 } from '../services/auth/token-store.js';
-
-interface CliIO {
-  stdin: NodeJS.ReadableStream;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-}
-
-function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
-  stream.write(`${text}\n`);
-}
+import { CliIO, writeLine } from '../cli-http.js';
 
 // ── RFC 8628 Device Flow ────────────────────────────────────────────
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -12,16 +12,7 @@ import {
   type StoredAuth,
 } from '../services/auth/token-store.js';
 import { parseOidcConfig, discoverOidcEndpoints, mergeDiscovery, type OidcConfig } from '../services/auth/oidc-config.js';
-
-interface CliIO {
-  stdin: NodeJS.ReadableStream;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-}
-
-function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
-  stream.write(`${text}\n`);
-}
+import { CliIO, writeLine } from '../cli-http.js';
 
 /** Attempt token revocation at the IdP (best-effort, does not block logout). */
 async function attemptRevocation(auth: StoredAuth, config: OidcConfig, fetchFn: typeof fetch): Promise<boolean> {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -22,19 +22,8 @@ import { getErrorMessage, parseIntSafe, validateEffort, validateModel } from '..
 import { generateSessionName } from '../utils/session-name.js';
 import { readAuthTokenFile } from '../utils/auth-token-path.js';
 
-interface CliIO {
-  stdin: NodeJS.ReadableStream;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-}
-
-
-
 import { isRateLimitError } from '../rate-limit.js';
-
-function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
-  stream.write(`${text}\n`);
-}
+import { CliIO, writeLine } from '../cli-http.js';
 
 async function resolveAuthToken(): Promise<string | undefined> {
   const envToken = process.env.AEGIS_AUTH_TOKEN || process.env.AEGIS_TOKEN;

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -10,16 +10,7 @@ import {
   type StoredAuth,
 } from '../services/auth/token-store.js';
 import { parseOidcConfig, discoverOidcEndpoints, mergeDiscovery, type OidcConfig } from '../services/auth/oidc-config.js';
-
-interface CliIO {
-  stdin: NodeJS.ReadableStream;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-}
-
-function writeLine(stream: NodeJS.WritableStream, text: string = ''): void {
-  stream.write(`${text}\n`);
-}
+import { CliIO, writeLine } from '../cli-http.js';
 
 /** Attempt to refresh an expired access token. */
 async function refreshToken(


### PR DESCRIPTION
## Summary

Closes #3675

Remove duplicate `CliIO` interface and `writeLine` function definitions from 6 command files (`auth.ts`, `init.ts`, `login.ts`, `logout.ts`, `run.ts`, `whoami.ts`). Replace with imports from the shared `cli-http.ts` module.

Also adds `write()` export to `cli-http.ts` (previously local to `init.ts` only).

**Pure refactor — no behavior change.**

### Changes
- `src/cli-http.ts`: Added `write()` export
- `src/commands/auth.ts`: Removed local `CliIO` + `writeLine`, added import
- `src/commands/init.ts`: Removed local `CliIO` + `writeLine` + `write`, added import
- `src/commands/login.ts`: Removed local `CliIO` + `writeLine`, added import
- `src/commands/logout.ts`: Removed local `CliIO` + `writeLine`, added import
- `src/commands/run.ts`: Removed local `CliIO` + `writeLine`, added import
- `src/commands/whoami.ts`: Removed local `CliIO` + `writeLine`, added import

### Verification
```
tsc --noEmit: ✅ (zero errors)
npm run build: ✅
npm test: ✅ 4612 passed (8 skipped)
```

Commit: b5d79344