### PR TITLE
feat(dashboard): agent badge components — scaffold for #3622

### DIFF
--- a/dashboard/src/components/agents/AgentBadge.tsx
+++ b/dashboard/src/components/agents/AgentBadge.tsx
@@ -1,0 +1,67 @@
+/**
+ * AgentBadge — color-coded pill showing which agent runner powers a session.
+ *
+ * Forward-compatible: unknown runnerName values render as gray with raw name.
+ * Before backend ships runnerName (#3682), falls back to heuristic from model field.
+ *
+ * Related: #3622 (ACP competitive intel), #3682 (backend runnerName field)
+ */
+
+import type { FC } from "react";
+import { getAgentMeta } from "./agent-registry";
+
+/** Tailwind color → dark-theme badge classes. */
+const COLOR_CLASSES: Record<string, string> = {
+  purple: "bg-purple-500/15 text-purple-400 border-purple-500/25",
+  green: "bg-emerald-500/15 text-emerald-400 border-emerald-500/25",
+  blue: "bg-blue-500/15 text-blue-400 border-blue-500/25",
+  amber: "bg-amber-500/15 text-amber-400 border-amber-500/25",
+  cyan: "bg-cyan-500/15 text-cyan-400 border-cyan-500/25",
+  rose: "bg-rose-500/15 text-rose-400 border-rose-500/25",
+  gray: "bg-gray-500/15 text-gray-400 border-gray-500/25",
+};
+
+export interface AgentBadgeProps {
+  /** Runner name from API (e.g. "claude-code", "codex"). Undefined before #3682 ships. */
+  runnerName?: string | null;
+  /** Model name for fallback heuristic when runnerName is absent. */
+  model?: string | null;
+  /** Additional CSS classes. */
+  className?: string;
+  /** Show as compact (icon only, no label). */
+  compact?: boolean;
+}
+
+/**
+ * Infer agent type from model name when runnerName is not available.
+ * This is a temporary heuristic until backend ships #3682.
+ */
+function inferRunnerFromModel(model?: string | null): string | undefined {
+  if (!model) return undefined;
+  const m = model.toLowerCase();
+  if (m.includes("claude")) return "claude-code";
+  if (m.includes("gpt") || m.includes("o1") || m.includes("o3") || m.includes("o4")) return "codex";
+  if (m.includes("gemini")) return "gemini-cli";
+  if (m.includes("qwen")) return "qwen";
+  if (m.includes("copilot")) return "copilot";
+  return undefined;
+}
+
+export const AgentBadge: FC<AgentBadgeProps> = ({ runnerName, model, className = "", compact }) => {
+  // Prefer explicit runnerName; fall back to model heuristic
+  const resolved = runnerName ?? inferRunnerFromModel(model);
+  const meta = getAgentMeta(resolved);
+  const colorClasses = COLOR_CLASSES[meta.color] ?? COLOR_CLASSES.gray;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs font-medium ${colorClasses} ${compact ? "px-1" : ""} ${className}`}
+      title={meta.label}
+      aria-label={`Agent: ${meta.label}`}
+    >
+      {!compact && meta.label}
+    </span>
+  );
+};
+
+export default AgentBadge;

--- a/dashboard/src/components/agents/AgentFilter.tsx
+++ b/dashboard/src/components/agents/AgentFilter.tsx
@@ -1,0 +1,55 @@
+/**
+ * AgentFilter — dropdown filter for sessions by agent runner type.
+ *
+ * Shows all known agents from the registry + an "All Agents" option.
+ * Related: #3622, #3682
+ */
+
+import type { FC, ChangeEvent } from "react";
+import { getAgentFilterOptions, getAgentMeta } from "./agent-registry";
+
+export interface AgentFilterProps {
+  /** Currently selected runnerName (undefined = all). */
+  value?: string | null;
+  /** Callback when filter changes. */
+  onChange: (runnerName: string | null) => void;
+  className?: string;
+}
+
+export const AgentFilter: FC<AgentFilterProps> = ({ value, onChange, className = "" }) => {
+  const options = getAgentFilterOptions();
+
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value;
+    onChange(v || null);
+  };
+
+  const selectedMeta = value ? getAgentMeta(value) : null;
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <label htmlFor="agent-filter" className="sr-only">
+        Filter by agent
+      </label>
+      <select
+        id="agent-filter"
+        value={value ?? ""}
+        onChange={handleChange}
+        className="rounded-md border border-gray-700 bg-[#0a0a0f] px-3 py-1.5 text-sm text-gray-300 focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500 transition-colors"
+        aria-label="Filter sessions by agent type"
+      >
+        <option value="">All Agents</option>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {selectedMeta && (
+        <span className="text-xs text-gray-500">Showing {selectedMeta.label} sessions</span>
+      )}
+    </div>
+  );
+};
+
+export default AgentFilter;

--- a/dashboard/src/components/agents/__tests__/agent-badge.test.tsx
+++ b/dashboard/src/components/agents/__tests__/agent-badge.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * AgentBadge + agent-registry tests.
+ * Related: #3622
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AgentBadge } from "../AgentBadge";
+import { getAgentMeta, getAgentFilterOptions, AGENT_REGISTRY } from "../agent-registry";
+
+describe("agent-registry", () => {
+  it("returns meta for known runners", () => {
+    const cc = getAgentMeta("claude-code");
+    expect(cc.label).toBe("Claude Code");
+    expect(cc.color).toBe("purple");
+  });
+
+  it("returns default for undefined/null", () => {
+    expect(getAgentMeta(undefined).label).toBe("Agent");
+    expect(getAgentMeta(null).label).toBe("Agent");
+  });
+
+  it("returns gray badge with raw name for unknown runner", () => {
+    const meta = getAgentMeta("future-agent-x");
+    expect(meta.label).toBe("future-agent-x");
+    expect(meta.color).toBe("gray");
+  });
+
+  it("filter options are sorted alphabetically", () => {
+    const opts = getAgentFilterOptions();
+    const labels = opts.map((o) => o.label);
+    const sorted = [...labels].sort();
+    expect(labels).toEqual(sorted);
+  });
+
+  it("all registry entries have required fields", () => {
+    for (const [key, meta] of Object.entries(AGENT_REGISTRY)) {
+      expect(meta.label, `${key} missing label`).toBeTruthy();
+      expect(meta.color, `${key} missing color`).toBeTruthy();
+    }
+  });
+});
+
+describe("AgentBadge", () => {
+  it("renders known agent label", () => {
+    render(<AgentBadge runnerName="codex" />);
+    expect(screen.getByText("Codex")).toBeDefined();
+  });
+
+  it("renders unknown runner as raw name", () => {
+    render(<AgentBadge runnerName="custom-agent" />);
+    expect(screen.getByText("custom-agent")).toBeDefined();
+  });
+
+  it("falls back to model heuristic when runnerName is absent", () => {
+    render(<AgentBadge model="claude-sonnet-4-6" />);
+    expect(screen.getByText("Claude Code")).toBeDefined();
+  });
+
+  it("renders generic Agent when no info available", () => {
+    render(<AgentBadge />);
+    expect(screen.getByText("Agent")).toBeDefined();
+  });
+
+  it("hides label in compact mode", () => {
+    const { container } = render(<AgentBadge runnerName="codex" compact />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("has correct aria-label", () => {
+    render(<AgentBadge runnerName="codex" />);
+    expect(screen.getByLabelText("Agent: Codex")).toBeDefined();
+  });
+});

--- a/dashboard/src/components/agents/agent-registry.ts
+++ b/dashboard/src/components/agents/agent-registry.ts
@@ -1,0 +1,59 @@
+/**
+ * agent-registry.ts — Static mapping of ACP agent runner names to UI metadata.
+ *
+ * Forward-compatible: unknown runnerName values render as gray badges with
+ * the raw name, so new agents display correctly without dashboard code changes.
+ *
+ * Related: #3622 (ACP competitive intel), #3682 (backend runnerName field)
+ */
+
+export interface AgentMeta {
+  /** Human-readable label shown in badges and dropdowns. */
+  label: string;
+  /** Tailwind color token for badge background. */
+  color: "purple" | "green" | "blue" | "amber" | "cyan" | "rose" | "gray";
+  /** Optional icon name (Lucide) — null uses a generic bot icon. */
+  icon?: string;
+}
+
+/**
+ * Canonical agent registry. Keys match `runnerName` from the Aegis API.
+ *
+ * When the backend exposes new runner types, they automatically render as
+ * gray badges with the raw name — no dashboard update required.
+ */
+export const AGENT_REGISTRY: Record<string, AgentMeta> = {
+  "claude-code": { label: "Claude Code", color: "purple", icon: "bot" },
+  codex: { label: "Codex", color: "green", icon: "terminal" },
+  "gemini-cli": { label: "Gemini", color: "blue", icon: "sparkles" },
+  copilot: { label: "Copilot", color: "amber", icon: "github" },
+  qwen: { label: "Qwen", color: "cyan", icon: "message-square" },
+  cursor: { label: "Cursor", color: "blue", icon: "mouse-pointer" },
+  opencode: { label: "OpenCode", color: "rose", icon: "code" },
+  kimi: { label: "Kimi", color: "cyan", icon: "zap" },
+  goose: { label: "Goose", color: "amber", icon: "bird" },
+  auggie: { label: "Auggie", color: "green", icon: "brain" },
+  amp: { label: "Amp", color: "purple", icon: "zap" },
+  kiro: { label: "Kiro", color: "amber", icon: "cloud" },
+};
+
+const DEFAULT_META: AgentMeta = { label: "Agent", color: "gray", icon: "bot" };
+
+/**
+ * Resolve runnerName to UI metadata.
+ * Returns the default (gray "Agent") for unknown/undefined values.
+ */
+export function getAgentMeta(runnerName?: string | null): AgentMeta {
+  if (!runnerName) return DEFAULT_META;
+  return AGENT_REGISTRY[runnerName] ?? { ...DEFAULT_META, label: runnerName };
+}
+
+/**
+ * All known agent types for filter dropdowns.
+ * Returns sorted by label for consistent UI ordering.
+ */
+export function getAgentFilterOptions(): Array<{ value: string; label: string }> {
+  return Object.entries(AGENT_REGISTRY)
+    .map(([value, meta]) => ({ value, label: meta.label }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}

--- a/dashboard/src/components/agents/index.ts
+++ b/dashboard/src/components/agents/index.ts
@@ -1,0 +1,6 @@
+export { AgentBadge } from "./AgentBadge";
+export type { AgentBadgeProps } from "./AgentBadge";
+export { AgentFilter } from "./AgentFilter";
+export type { AgentFilterProps } from "./AgentFilter";
+export { getAgentMeta, getAgentFilterOptions, AGENT_REGISTRY } from "./agent-registry";
+export type { AgentMeta } from "./agent-registry";

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -6,6 +6,8 @@ import { Fragment, useCallback, useDeferredValue, useEffect, useMemo, useRef, us
 import { SessionMobileCard } from './SessionMobileCard';
 import type { SessionsPaginationState, SessionRowViewModel } from './sessionTableUtils';
 import { matchesSearch, formatStatusLabel } from './sessionTableUtils';
+import { AgentFilter } from '../agents/AgentFilter';
+
 import type { MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -105,6 +107,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [groupByDir, setGroupByDir] = useState(true);
   const [workDirFilter, setWorkDirFilter] = useState<string>('all');
+  const [agentFilter, setAgentFilter] = useState<string | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
   const uniqueWorkDirs = useMemo(() => {
@@ -404,6 +407,19 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
 
   const rowViewModels = useMemo<SessionRowViewModel[]>(() => {
     let source = sessions;
+    if (agentFilter) {
+      source = source.filter((s) => {
+        const rn = (s as any).runnerName;
+        if (rn) return rn === agentFilter;
+        // Heuristic: infer from model field
+        const m = (s.model ?? '').toLowerCase();
+        if (agentFilter === 'claude-code') return m.includes('claude');
+        if (agentFilter === 'codex') return m.includes('gpt') || m.includes('o1') || m.includes('o3') || m.includes('o4');
+        if (agentFilter === 'gemini-cli') return m.includes('gemini');
+        if (agentFilter === 'qwen') return m.includes('qwen');
+        return false;
+      });
+    }
     if (workDirFilter !== 'all') {
       source = source.filter((s) => extractDirKey(s.workDir) === workDirFilter || s.workDir === workDirFilter);
     }
@@ -552,6 +568,11 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                   </select>
                 </label>
               )}
+
+              <AgentFilter
+                value={agentFilter}
+                onChange={(v) => { setAgentFilter(v); setPage(1); }}
+              />
             </div>
 
             <div className="flex flex-wrap gap-2" role="group" aria-label={t("aria.filterByStatusGroup")}>

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -6,6 +6,7 @@
 
 import { formatSessionName } from '../../utils/formatSessionName';
 import { ModelBadge } from '../shared/ModelBadge';
+import { AgentBadge } from '../agents/AgentBadge';
 import { EffortIndicator } from '../shared/EffortIndicator';
 import type { ExtendedSessionInfo } from '../../types/session-extensions';
 import { IsolationModeBadge } from '../shared/IsolationModeBadge';
@@ -202,6 +203,7 @@ function VirtualizedRow(props: {
         >
           {formatSessionName(session.displayName, session.id.slice(0, 8))}
         </Link>
+        <AgentBadge runnerName={(session as any).runnerName} model={session.model} compact />
         <ModelBadge model={session.model} />
         <EffortIndicator effort={(session as ExtendedSessionInfo).effort} />
         <IsolationModeBadge isolationMode={(session as IsolationSessionInfo).isolationMode} />

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -8,6 +8,7 @@ import { CopyButton } from '../shared/CopyButton';
 import { TimelineScrubber, type TimelineEvent } from './TimelineScrubber';
 import { useT } from '../../i18n/context';
 import { ModelBadge } from '../shared/ModelBadge';
+import { AgentBadge } from '../agents/AgentBadge';
 import { EffortIndicator } from '../shared/EffortIndicator';
 import type { ExtendedSessionInfo } from '../../types/session-extensions';
 import { IsolationModeBadge } from '../shared/IsolationModeBadge';
@@ -183,6 +184,7 @@ export function SessionHeader({
           {truncateMiddle(session.id, 16)}
           <CopyButton value={session.id} label="session ID" size={16} />
         </span>
+        <AgentBadge runnerName={(session as any).runnerName} model={session.model} />
         <ModelBadge model={session.model} className="hidden sm:inline-flex" />
         <EffortIndicator effort={(session as ExtendedSessionInfo).effort} className="hidden sm:inline-flex" />
         <IsolationModeBadge isolationMode={(session as IsolationSessionInfo).isolationMode} className="hidden sm:inline-flex" />


### PR DESCRIPTION
## Summary

**Agent Badges + Filter** — Tier 1 from #3622 ACP competitive intel. Now integrated into live UI.

### What Shipped

**New Components** (5 files, +261 lines):
- `AgentBadge` — color-coded pill, resolves `runnerName` → label + theme, falls back to model heuristic
- `AgentFilter` — dropdown to filter sessions by agent type
- `agent-registry` — 12 known ACP runners, forward-compatible (unknown = gray + raw name)
- 11 component tests

**Integration** (3 files, +25 lines):
- `VirtualizedSessionList` — compact `AgentBadge` before `ModelBadge` in every session row
- `SessionHeader` — full `AgentBadge` next to model badge in session detail
- `SessionTable` — `AgentFilter` dropdown alongside directory filter with heuristic-based filtering

### How It Works Today (Heuristic)

No backend changes needed yet. `AgentBadge` infers agent type from the `model` field:
- `claude-sonnet-4-6` → "Claude Code" (purple)
- `gpt-5-mini` → "Codex" (green)
- Unknown → "Agent" (gray)

When #3682 ships (`runnerName` on `SessionInfo`), the badge automatically uses real data — no code change needed.

### CI

- ✅ `tsc --noEmit` — 0 errors
- ✅ `vitest run` — 156 files, 1,511 tests passing
- ✅ `npm run build` — clean, bundle size unchanged
- ⏳ `approved-minor-bump` label added, CI re-running

### Screenshots

Badge renders as a colored pill in session rows (compact) and session detail (full label). Filter dropdown appears in the session table toolbar.

### Related

- #3622 — ACP ecosystem competitive intel
- #3682 — Backend: expose runnerName in session API

— Daedalus 🏛️