### PR TITLE
feat(dashboard): global approval notifications — badge, toast, store

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from './shared/ErrorBoundary';
 import { useTheme } from '../hooks/useTheme';
 import CommandPalette from './shared/CommandPalette';
 import LiveAuditStream from './shared/LiveAuditStream';
+import { ApprovalNotification, ApprovalBadge } from './approvals/ApprovalNotification';
 import { NewSessionDrawer } from './NewSessionDrawer';
 import { Sun, Moon, Plus, Search } from 'lucide-react';
 import {
@@ -558,6 +559,9 @@ export default function Layout() {
                 PREVIEW
               </span>
 
+              {/* Pending approvals badge */}
+              <ApprovalBadge />
+
               {/* New Session button */}
               <button
                 type="button"
@@ -701,6 +705,7 @@ export default function Layout() {
       <ConnectionBanner />
       {/* Command Palette */}
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+      <ApprovalNotification />
       {/* New Session Drawer */}
       <NewSessionDrawer />
     </div>

--- a/dashboard/src/components/approvals/ApprovalNotification.tsx
+++ b/dashboard/src/components/approvals/ApprovalNotification.tsx
@@ -20,16 +20,18 @@ import { useToastStore } from "../../store/useToastStore";
  * Place this once in the app root or Layout.
  */
 export function ApprovalNotification() {
-  const list = useApprovalStore((s) => s.list());
-  const count = list.length;
+  // Subscribe to the Map (stable reference) — NOT s.list() which creates new arrays
+  const pending = useApprovalStore((s) => s.pending);
+  const count = pending.size;
   const addToast = useToastStore((s) => s.addToast);
   const navigate = useNavigate();
   const previousCount = useRef(count);
-  const knownIds = useRef(new Set(list.map((a) => a.sessionId)));
+  const knownIds = useRef(new Set<string>());
 
   // Show toast when new approval arrives
   useEffect(() => {
     if (count > previousCount.current) {
+      const list = Array.from(pending.values());
       for (const approval of list) {
         if (!knownIds.current.has(approval.sessionId)) {
           knownIds.current.add(approval.sessionId);
@@ -45,11 +47,11 @@ export function ApprovalNotification() {
     previousCount.current = count;
 
     // Clean up known IDs for removed approvals
-    const currentIds = new Set(list.map((a) => a.sessionId));
+    const currentIds = new Set(pending.keys());
     for (const id of knownIds.current) {
       if (!currentIds.has(id)) knownIds.current.delete(id);
     }
-  }, [count, list, addToast, navigate]);
+  }, [count, pending, addToast, navigate]);
 
   return null;
 }
@@ -59,7 +61,8 @@ export function ApprovalNotification() {
  * Place in the header toolbar.
  */
 export function ApprovalBadge() {
-  const count = useApprovalStore((s) => s.count());
+  // Subscribe to pending Map size (primitive, no re-render loop)
+  const count = useApprovalStore((s) => s.pending.size);
 
   if (count === 0) return null;
 

--- a/dashboard/src/components/approvals/ApprovalNotification.tsx
+++ b/dashboard/src/components/approvals/ApprovalNotification.tsx
@@ -1,0 +1,76 @@
+/**
+ * ApprovalNotification — global toast + sidebar badge for pending approvals.
+ *
+ * Shows a toast when a new approval_request arrives, and a badge
+ * in the header with the count of pending approvals.
+ *
+ * Related: #3622 Tier 1
+ */
+
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
+import { useApprovalStore } from "../../store/useApprovalStore";
+import { useToastStore } from "../../store/useToastStore";
+
+/**
+ * ApprovalNotification — invisible component that watches for new
+ * pending approvals and shows toasts.
+ *
+ * Place this once in the app root or Layout.
+ */
+export function ApprovalNotification() {
+  const list = useApprovalStore((s) => s.list());
+  const count = list.length;
+  const addToast = useToastStore((s) => s.addToast);
+  const navigate = useNavigate();
+  const previousCount = useRef(count);
+  const knownIds = useRef(new Set(list.map((a) => a.sessionId)));
+
+  // Show toast when new approval arrives
+  useEffect(() => {
+    if (count > previousCount.current) {
+      for (const approval of list) {
+        if (!knownIds.current.has(approval.sessionId)) {
+          knownIds.current.add(approval.sessionId);
+          addToast(
+            "warning",
+            `Permission required: ${approval.sessionName}`,
+            "Click the session to review and approve",
+            { duration: 15_000 },
+          );
+        }
+      }
+    }
+    previousCount.current = count;
+
+    // Clean up known IDs for removed approvals
+    const currentIds = new Set(list.map((a) => a.sessionId));
+    for (const id of knownIds.current) {
+      if (!currentIds.has(id)) knownIds.current.delete(id);
+    }
+  }, [count, list, addToast, navigate]);
+
+  return null;
+}
+
+/**
+ * ApprovalBadge — renders the pending count badge.
+ * Place in the header toolbar.
+ */
+export function ApprovalBadge() {
+  const count = useApprovalStore((s) => s.count());
+
+  if (count === 0) return null;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-amber-500/20 border border-amber-500/30 px-2 py-0.5 text-xs font-bold text-amber-400 cursor-pointer"
+      aria-label={`${count} pending approval${count > 1 ? "s" : ""}`}
+      title={`${count} session${count > 1 ? "s" : ""} awaiting approval`}
+    >
+      <AlertTriangle className="h-3 w-3" />
+      {count}
+    </span>
+  );
+}

--- a/dashboard/src/components/approvals/index.ts
+++ b/dashboard/src/components/approvals/index.ts
@@ -1,0 +1,3 @@
+export { ApprovalNotification, ApprovalBadge } from "./ApprovalNotification";
+export { useApprovalStore } from "../../store/useApprovalStore";
+export type { PendingApproval } from "../../store/useApprovalStore";

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -28,6 +28,7 @@ import {
 import { useSseAwarePolling } from '../../hooks/useSseAwarePolling';
 import { useToastStore } from '../../store/useToastStore';
 import { useStore } from '../../store/useStore';
+import { useApprovalStore } from '../../store/useApprovalStore';
 import type { RowHealth, SessionStatusCounts, SessionStatusFilter } from '../../types';
 import { ConfirmDialog } from '../ConfirmDialog';
 import RealtimeBadge from './RealtimeBadge';
@@ -223,6 +224,8 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
       }
 
       setSessionsAndHealth(filteredSessions, nextHealthMap);
+      // Sync pending approvals to global store
+      useApprovalStore.getState().setFromSessions(filteredSessions);
       setStatusCounts(counts);
       setSearchCapped(isSearching && list.pagination.total > list.sessions.length);
       setLoadError(null);

--- a/dashboard/src/store/__tests__/useApprovalStore.test.ts
+++ b/dashboard/src/store/__tests__/useApprovalStore.test.ts
@@ -1,0 +1,92 @@
+/**
+ * useApprovalStore tests.
+ * Related: #3622 Tier 1
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useApprovalStore } from "../useApprovalStore";
+
+describe("useApprovalStore", () => {
+  beforeEach(() => {
+    useApprovalStore.setState({ pending: new Map() });
+  });
+
+  it("starts empty", () => {
+    expect(useApprovalStore.getState().count()).toBe(0);
+    expect(useApprovalStore.getState().list()).toEqual([]);
+  });
+
+  it("addApproval adds an entry", () => {
+    useApprovalStore.getState().addApproval({
+      sessionId: "abc",
+      sessionName: "test-session",
+      startedAt: Date.now(),
+    });
+    expect(useApprovalStore.getState().count()).toBe(1);
+    const entry = useApprovalStore.getState().list()[0];
+    expect(entry.sessionId).toBe("abc");
+    expect(entry.sessionName).toBe("test-session");
+  });
+
+  it("removeApproval removes the entry", () => {
+    useApprovalStore.getState().addApproval({
+      sessionId: "abc",
+      sessionName: "test-session",
+      startedAt: Date.now(),
+    });
+    useApprovalStore.getState().removeApproval("abc");
+    expect(useApprovalStore.getState().count()).toBe(0);
+  });
+
+  it("setFromSessions filters permission_prompt sessions", () => {
+    useApprovalStore.getState().setFromSessions([
+      {
+        id: "s1",
+        displayName: "waiting",
+        status: "permission_prompt",
+        pendingPermission: { toolName: "bash", startedAt: 1000, expiresAt: 2000 },
+      },
+      {
+        id: "s2",
+        displayName: "working",
+        status: "working",
+        pendingPermission: null,
+      },
+      {
+        id: "s3",
+        displayName: "another-waiting",
+        status: "permission_prompt",
+        pendingPermission: { startedAt: 3000 },
+      },
+    ]);
+    expect(useApprovalStore.getState().count()).toBe(2);
+    const ids = useApprovalStore.getState().list().map((a) => a.sessionId);
+    expect(ids).toContain("s1");
+    expect(ids).toContain("s3");
+  });
+
+  it("setFromSessions replaces all existing entries", () => {
+    useApprovalStore.getState().addApproval({
+      sessionId: "old",
+      sessionName: "old-session",
+      startedAt: Date.now(),
+    });
+    useApprovalStore.getState().setFromSessions([]);
+    expect(useApprovalStore.getState().count()).toBe(0);
+  });
+
+  it("addApproval updates existing entry for same session", () => {
+    useApprovalStore.getState().addApproval({
+      sessionId: "abc",
+      sessionName: "first",
+      startedAt: 1000,
+    });
+    useApprovalStore.getState().addApproval({
+      sessionId: "abc",
+      sessionName: "updated",
+      startedAt: 2000,
+    });
+    expect(useApprovalStore.getState().count()).toBe(1);
+    expect(useApprovalStore.getState().list()[0].sessionName).toBe("updated");
+  });
+});

--- a/dashboard/src/store/useApprovalStore.ts
+++ b/dashboard/src/store/useApprovalStore.ts
@@ -1,0 +1,85 @@
+/**
+ * store/useApprovalStore.ts — Global pending approval state.
+ *
+ * Tracks sessions with pending permission prompts across the dashboard.
+ * Populated from session list API polling + SSE events.
+ * Used by: ApprovalNotification, sidebar badge, session table indicators.
+ *
+ * Related: #3622 Tier 1 (Permission Approval Flow UI)
+ */
+
+import { create } from "zustand";
+
+export interface PendingApproval {
+  sessionId: string;
+  sessionName: string;
+  toolName?: string;
+  prompt?: string;
+  startedAt: number;
+  expiresAt?: number;
+}
+
+export interface ApprovalStoreState {
+  /** Map of sessionId → pending approval. */
+  pending: Map<string, PendingApproval>;
+
+  /** Add or update a pending approval (from SSE or polling). */
+  addApproval: (approval: PendingApproval) => void;
+
+  /** Remove a pending approval (approved/rejected/expired). */
+  removeApproval: (sessionId: string) => void;
+
+  /** Bulk-set from session list API response. */
+  setFromSessions: (sessions: Array<{
+    id: string;
+    displayName: string;
+    status: string;
+    pendingPermission?: { toolName?: string; prompt?: string; startedAt: number; expiresAt?: number } | null;
+  }>) => void;
+
+  /** Count of pending approvals. */
+  count: () => number;
+
+  /** Get all pending approvals as array. */
+  list: () => PendingApproval[];
+}
+
+export const useApprovalStore = create<ApprovalStoreState>((set, get) => ({
+  pending: new Map(),
+
+  addApproval: (approval) =>
+    set((state) => {
+      const next = new Map(state.pending);
+      next.set(approval.sessionId, approval);
+      return { pending: next };
+    }),
+
+  removeApproval: (sessionId) =>
+    set((state) => {
+      const next = new Map(state.pending);
+      next.delete(sessionId);
+      return { pending: next };
+    }),
+
+  setFromSessions: (sessions) =>
+    set(() => {
+      const next = new Map<string, PendingApproval>();
+      for (const s of sessions) {
+        if (s.status === "permission_prompt" && s.pendingPermission) {
+          next.set(s.id, {
+            sessionId: s.id,
+            sessionName: s.displayName,
+            toolName: s.pendingPermission.toolName,
+            prompt: s.pendingPermission.prompt,
+            startedAt: s.pendingPermission.startedAt,
+            expiresAt: s.pendingPermission.expiresAt,
+          });
+        }
+      }
+      return { pending: next };
+    }),
+
+  count: () => get().pending.size,
+
+  list: () => Array.from(get().pending.values()),
+}));


### PR DESCRIPTION
## Summary

Tier 1 item #2 from #3622 — **Permission Approval Flow UI**: global notification when sessions need approval.

### Problem
When an agent session hits a permission prompt, the dashboard shows the prompt only inside the session detail page. There is no global indicator — users must manually check each session. This undermines Aegis's core "human in the loop" positioning.

### What Shipped

**New Store:**
- `useApprovalStore` — Zustand store tracking pending approvals across all sessions
  - `setFromSessions()` — bulk sync from session list API data
  - `addApproval()` / `removeApproval()` — for future SSE event integration
  - `count()` / `list()` — for badge and notification consumers

**New Components:**
- `ApprovalNotification` — invisible component (place in root) that shows warning toasts when new permission prompts arrive
  - Dedup tracking — only fires once per session ID
  - 15-second toast duration (longer than normal — approvals are important)
- `ApprovalBadge` — amber count badge for header toolbar showing pending approval count

**Integration:**
- `SessionTable` syncs `permission_prompt` sessions to approval store on every poll cycle
- `Layout` adds `ApprovalNotification` in root + `ApprovalBadge` in header toolbar

### How It Works Today

No backend changes needed. Uses existing API data:
- Sessions with `status: "permission_prompt"` + `pendingPermission` data
- Synced on every poll cycle (already happens in SessionTable)
- Badge appears in header, toast fires on new approvals

### Future Enhancements (when SSE/ACP lands)
- Subscribe to `session_approval` global SSE event for instant notifications
- Add approval action buttons directly in the toast/notification
- Sound notification option

### Tests

6 passing — store: add, remove, setFromSessions, replace, update, idempotency.

### CI

- ✅ `tsc --noEmit` — 0 errors
- ⏳ Full suite + build — running

### Related

- #3622 — ACP competitive intel (dashboard differentiation)
- #3684 — Agent badges (Tier 1 item #1)

— Daedalus 🏛️