### PR TITLE
fix(security): add auth guards to pipeline read and usage tiers endpoints

### DIFF
--- a/src/routes/pipelines.ts
+++ b/src/routes/pipelines.ts
@@ -5,7 +5,7 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { batchSessionSchema, pipelineSchema } from '../validation.js';
 import type { RouteContext } from './context.js';
-import { makePayload, registerWithLegacy, requirePermission, withValidation } from './context.js';
+import { makePayload, registerWithLegacy, requirePermission, requireRole, withValidation } from './context.js';
 import { cleanupTerminatedSessionState } from '../session-cleanup.js';
 
 const MAX_CONCURRENT_SESSIONS = 200;
@@ -71,11 +71,15 @@ export function registerPipelineRoutes(app: FastifyInstance, ctx: RouteContext):
 
   // Pipeline status
   registerWithLegacy(app, 'get', '/v1/pipelines/:id', async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+    if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
     const pipeline = pipelines.getPipeline(req.params.id);
     if (!pipeline) return reply.status(404).send({ error: 'Pipeline not found' });
     return pipeline;
   });
 
   // List pipelines
-  registerWithLegacy(app, 'get', '/v1/pipelines', async (_req: FastifyRequest, _reply: FastifyReply) => pipelines.listPipelines());
+  registerWithLegacy(app, 'get', '/v1/pipelines', async (req: FastifyRequest, reply: FastifyReply) => {
+    if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
+    return pipelines.listPipelines();
+  });
 }

--- a/src/routes/usage.ts
+++ b/src/routes/usage.ts
@@ -91,7 +91,8 @@ export function registerUsageRoutes(app: FastifyInstance, ctx: RouteContext): vo
   /**
    * GET /v1/usage/tiers — Current rate tier configuration.
    */
-  registerWithLegacy(app, 'get', '/v1/usage/tiers', async (_req: FastifyRequest, _reply: FastifyReply) => {
+  registerWithLegacy(app, 'get', '/v1/usage/tiers', async (req: FastifyRequest, reply: FastifyReply) => {
+    if (!requireRole(auth, req, reply, 'admin', 'operator', 'viewer')) return;
     return {
       schema_version: 1,
       tiers: metering.getRateTiers(),


### PR DESCRIPTION
## Summary

Adds missing authentication guards to three read endpoints that were missed during the auth sweep.

## Changes

### `src/routes/pipelines.ts`
- Added `requireRole` import
- `GET /v1/pipelines/:id` — now requires `admin`, `operator`, or `viewer` role
- `GET /v1/pipelines` — now requires `admin`, `operator`, or `viewer` role

### `src/routes/usage.ts`
- `GET /v1/usage/tiers` — now requires `admin`, `operator`, or `viewer` role

## Security Impact

Without these guards, anyone who can reach the Aegis API could:
- Enumerate all pipelines and their full configuration (workDir paths, prompts, dependencies, permissionMode)
- Read internal rate tier configuration (pricing, thresholds, billing structure)

Solo dev on localhost is unaffected. Risk applies when Aegis is network-accessible.

## Verification

```
npx tsc --noEmit ✅
npm run build    ✅
npm test         ✅ 4626 passed (8 skipped)
```

Closes #3689
Closes #3690