### PR TITLE
fix(dashboard): approval SSE sync + aria-labels on icon buttons

### DIFF
--- a/dashboard/src/components/session/ApprovalBanner.tsx
+++ b/dashboard/src/components/session/ApprovalBanner.tsx
@@ -76,6 +76,7 @@ export function ApprovalBanner({
         <button
           type="button"
           onClick={() => setExpanded((current) => !current)}
+          aria-label="Toggle approval details"
           className={`mt-3 w-full cursor-pointer text-left font-mono text-sm text-[var(--color-text-primary)] hover:text-white transition-colors ${
             expanded ? 'break-words max-h-48 overflow-y-auto' : 'truncate'
           }`}

--- a/dashboard/src/components/session/TranscriptBubble.tsx
+++ b/dashboard/src/components/session/TranscriptBubble.tsx
@@ -265,6 +265,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
                 copyMessage();
               }}
               className="p-1 rounded hover:bg-[var(--color-void)]/10 transition-colors"
+              aria-label="Copy message"
               title="Copy message"
             >
               <Icon name="Copy" size={16} className={isUser ? 'text-[var(--color-void)]' : 'text-[var(--color-text-muted)]'} />
@@ -276,6 +277,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
                 copyUpToHere();
               }}
               className="p-1 rounded hover:bg-[var(--color-void)]/10 transition-colors"
+              aria-label="Copy transcript up to here"
               title="Copy transcript up to here"
             >
               <Icon name="FileText" size={16} className={isUser ? 'text-[var(--color-void)]' : 'text-[var(--color-text-muted)]'} />
@@ -287,6 +289,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
                 copyPermalink();
               }}
               className="p-1 rounded hover:bg-[var(--color-void)]/10 transition-colors"
+              aria-label="Copy permalink"
               title="Copy permalink"
             >
               <Icon name="Link" size={16} className={isUser ? 'text-[var(--color-void)]' : 'text-[var(--color-text-muted)]'} />

--- a/dashboard/src/hooks/useAcpApproval.ts
+++ b/dashboard/src/hooks/useAcpApproval.ts
@@ -14,6 +14,7 @@ import {
   getPendingApproval,
 } from '../api/acp-approval-client.js';
 import type { AcpApprovalRequest } from '../types/acp-approval';
+import { useApprovalStore } from '../store/useApprovalStore';
 
 export interface UseAcpApprovalOptions {
   sessionId: string;
@@ -100,6 +101,8 @@ export function useAcpApproval({
           setApproval(null);
           setCountdown(null);
           setIsExpired(false);
+          // Also clear the global approval badge
+          useApprovalStore.getState().removeApproval(sessionId);
         }
       } catch {
         // Ignore malformed events
@@ -168,6 +171,7 @@ export function useAcpApproval({
       setApproval(null);
       setCountdown(null);
       setIsExpired(false);
+      useApprovalStore.getState().removeApproval(sessionId);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -188,6 +192,7 @@ export function useAcpApproval({
       setApproval(null);
       setCountdown(null);
       setIsExpired(false);
+      useApprovalStore.getState().removeApproval(sessionId);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/dashboard/src/hooks/useSessionRealtimeUpdates.ts
+++ b/dashboard/src/hooks/useSessionRealtimeUpdates.ts
@@ -10,6 +10,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useStore } from '../store/useStore';
+import { useApprovalStore } from '../store/useApprovalStore';
 import type { UIState, SessionHealthState } from '../types';
 
 const SESSION_RELEVANT_EVENTS: ReadonlySet<string> = new Set([
@@ -18,6 +19,7 @@ const SESSION_RELEVANT_EVENTS: ReadonlySet<string> = new Set([
   'session_created',
   'session_stall',
   'session_dead',
+  'session_approval',
 ]);
 
 /**
@@ -54,8 +56,10 @@ export function useSessionRealtimeUpdates(): void {
       if (!SESSION_RELEVANT_EVENTS.has(event.event)) continue;
       if (event.sessionId === 'global') continue;
 
+      // Extract status for use in multiple handlers below
+      let newStatus: UIState | undefined;
       if (event.event === 'session_status_change') {
-        const newStatus = event.data?.status as UIState | undefined;
+        newStatus = event.data?.status as UIState | undefined;
         if (!newStatus) continue;
 
         const idx = updatedSessions.findIndex((s) => s.id === event.sessionId);
@@ -86,6 +90,23 @@ export function useSessionRealtimeUpdates(): void {
         if (!existing || existing.health !== 'dead') {
           updatedHealthMap[event.sessionId!] = { alive: false, loading: false, health: 'dead' as SessionHealthState };
           healthChanged = true;
+        }
+      }
+
+      // Sync approval store: remove from pending when status changes away from permission_prompt
+      if (event.event === 'session_status_change' && newStatus && newStatus !== 'permission_prompt') {
+        const pending = useApprovalStore.getState().pending;
+        if (pending.has(event.sessionId!)) {
+          useApprovalStore.getState().removeApproval(event.sessionId!);
+        }
+      }
+
+      // Forward-compatible: handle session_approval SSE event (#3697)
+      if (event.event === 'session_approval') {
+        const approvalData = event.data as { action?: string } | undefined;
+        const action = approvalData?.action;
+        if (action && useApprovalStore.getState().pending.has(event.sessionId!)) {
+          useApprovalStore.getState().removeApproval(event.sessionId!);
         }
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to merged #3692. Three changes:

### 1. Approval store SSE sync (#3697 dashboard half)

`useSessionRealtimeUpdates` removes sessions from the global approval store when status changes away from `permission_prompt`. Also handles `session_approval` global SSE event (forward-compat for #3698).

### 2. Per-session approval_resolved wiring (#3698 consumer)

`useAcpApproval` now calls `useApprovalStore.removeApproval(sessionId)` on:
- Per-session SSE `approval_resolved` event
- Successful approve/reject API response

Three redundant clear paths ensure the badge always disappears instantly.

### 3. aria-labels on icon-only buttons (#3688 partial)

- TranscriptBubble: Copy message, Copy up to here, Copy permalink
- ApprovalBanner: Toggle approval details

### Files changed
- `dashboard/src/hooks/useSessionRealtimeUpdates.ts` — global SSE sync
- `dashboard/src/hooks/useAcpApproval.ts` — per-session SSE + API sync
- `dashboard/src/components/session/TranscriptBubble.tsx` — aria-labels
- `dashboard/src/components/session/ApprovalBanner.tsx` — aria-label

### Tests
1517 passed, 157 files, 0 failures.

— Daedalus 🏛️