### PR TITLE
docs: add approval_resolved SSE event to API reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1351,7 +1351,9 @@ curl -N "http://localhost:9100/v1/sessions/abc123/events?token=$SSE_TOKEN"
 
 **Rate limited:** Per-IP and global connection limits apply.
 
-**Events:** `connected`, `heartbeat`, `status.*`, `permission.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`.
+**Events:** `connected`, `heartbeat`, `status.*`, `approval`, `approval_resolved`, `permission.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`.
+
+> **`approval_resolved`** — emitted after an approval or rejection via `POST /v1/sessions/:id/approval/approve` or `/reject`. Payload: `{ action: "approved" | "rejected", approvalId: string }`.
 
 Supports `Last-Event-ID` header for replay of missed events.
 
@@ -3587,7 +3589,7 @@ curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN"
 
 **Authentication:** SSE token via query parameter (`?token=<sse-token>`) or Bearer header (`Authorization: Bearer sse_...`). Regular API keys are rejected.
 
-**Event types:** `connected`, `heartbeat`, `session.created`, `session.idle`, `session.working`, `session.stalled`, `session.killed`, `permission.requested`, `permission.granted`, `permission.denied`, `message.user`, `status.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`.
+**Event types:** `connected`, `heartbeat`, `session.created`, `session.idle`, `session.working`, `session.stalled`, `session.killed`, `permission.requested`, `permission.granted`, `permission.denied`, `approval_resolved`, `message.user`, `status.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`.
 
 **Rate limited:** Per-IP and global connection limits apply.
 


### PR DESCRIPTION
## Summary

PR #3698 added the `approval_resolved` SSE event (emitted after approve/reject), but it was missing from both SSE event type lists in api-reference.md.

## Changes
- **Per-session SSE** (`GET /v1/sessions/:id/events`): added `approval` and `approval_resolved` to event type list, with payload description
- **Global SSE** (`GET /v1/events`): added `approval_resolved` to event types

## Verification
- Matches `src/events.ts` SessionSSEEvent type union
- Payload shape matches `src/routes/control-actions.ts` emit calls