### PR TITLE
fix(dashboard): add aria-labels to remaining icon-only buttons

### DIFF
--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -212,6 +212,7 @@ export default function ActivityStream({
             {/* Clear filters */}
             {(filterSession || filterType) && (
               <button type="button"
+                aria-label="Clear filters"
                 onClick={() => { setFilterSession(null); setFilterType(null); }}
                 className="min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
               >

--- a/dashboard/src/components/session/TranscriptView.tsx
+++ b/dashboard/src/components/session/TranscriptView.tsx
@@ -256,6 +256,7 @@ export function TranscriptView({ sessionId }: TranscriptViewProps) {
       {showScrollBtn && (
         <button type="button"
           onClick={scrollToBottom}
+          aria-label="Scroll to bottom"
           className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-accent)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
           title="Scroll to bottom"
         >

--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -92,6 +92,7 @@ export default function NewSessionPage() {
       {/* Header */}
       <div className="flex items-center gap-3 sm:gap-4 mb-4 sm:mb-6">
         <button type="button"
+          aria-label="Go back"
           onClick={() => navigate(-1)}
           className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded hover:bg-[var(--color-void-lighter)] transition-colors text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
           title={t('newSession.goBack')}


### PR DESCRIPTION
## Summary

Fixes #3688 — adds missing `aria-label` attributes to the remaining icon-only buttons in the dashboard.

## Changes

After a comprehensive scan of all dashboard components, only **3 icon-only buttons** were still missing `aria-label` attributes (most were already fixed in previous PRs):

| File | Button | aria-label added |
|------|--------|-----------------|
| `NewSessionPage.tsx` | Back button (ArrowLeft icon) | `"Go back"` |
| `ActivityStream.tsx` | Clear filters (X icon) | `"Clear filters"` |
| `TranscriptView.tsx` | Scroll to bottom (↓) | `"Scroll to bottom"` |

## Audit Note

The issue originally listed 7 components, but most buttons already had `aria-label` or visible text content. The remaining gaps were:
- Icon-only buttons that had `title` but not `aria-label` (screen readers do not always announce `title` consistently)
- A newly added back button in NewSessionPage

## Quality Gate

- ✅ `tsc --noEmit`: 0 errors
- ✅ `vitest run`: all tests pass (all suites green)
- ✅ No new dependencies
- ✅ 3 lines added, 0 changed — minimal, safe change

— Daedalus 🏛️