### PR TITLE
docs: update --no-stream description after behavior change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ memory/
 /.test-scratch/
 playwright-report/
 test-results/
+wt/

--- a/docs/five-minute-setup.md
+++ b/docs/five-minute-setup.md
@@ -103,7 +103,7 @@ Now Claude can create sessions, read transcripts, and manage Aegis directly thro
 | `-y` | Auto-approve all permission prompts |
 | `--model <model>` | Override the model for this session |
 | `--effort <level>` | Reasoning effort: `low`, `medium`, `high` |
-| `--no-stream` | Print curl commands instead of streaming |
+| `--no-stream` | Wait for session completion and print output (non-streaming) |
 
 ## Troubleshooting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ If the server is already running, `ag run` skips bootstrap and start — goes st
 |------|-------------|
 | `--cwd <path>` | Working directory (default: current directory) |
 | `--port <number>` | Server port override |
-| `--no-stream` | Don't stream output; print curl commands instead |
+| `--no-stream` | Wait for session completion and print output (non-streaming) |
 | `--model <provider/model>` | Override the default model for this session |
 | `--name <name>` | Set a display name for the session |
 | `--yes` | Suppress all status messages for non-interactive/CI usage |

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -53,7 +53,7 @@ Bootstrap config, start the server, create a session, and stream output — all 
 ```bash
 ag run "Build a REST API for managing tasks" --cwd .
 ag run "Fix the auth bug"                     # Uses current directory
-ag run "Refactor the utils" --no-stream       # Print curl commands instead of streaming
+ag run "Refactor the utils" --no-stream       # Wait for completion and print output
 ag run "Debug the tests" --port 3000          # Custom server port
 ag run "Fix CI" --yes                        # Non-interactive (CI-friendly)
 ```
@@ -81,7 +81,7 @@ If the server is already running, skips straight to session creation. Existing c
 | `--passthrough` | Bypass all permissions (alias for `--accept-permissions`) |
 | `--model <provider/model>` | Override the default model for this session |
 | `--effort <level>` | Set reasoning effort: `low`, `medium`, `high`, or `0.0`–`1.0` |
-| `--no-stream` | Don't stream output; print curl commands instead |
+| `--no-stream` | Wait for session completion and print output (non-streaming) |
 
 ### `ag` — Start Server
 


### PR DESCRIPTION
## Summary

Updates `--no-stream` flag description across 3 docs files to reflect the new behavior from #3704.

### What changed
PR #3704 changed `--no-stream` from "print curl commands and exit" to "poll until completion and print output".

### Files updated
- `docs/integrations/cli.md` — example + flags table
- `docs/getting-started.md` — flags table
- `docs/five-minute-setup.md` — flags table

### Test plan
- [x] No broken links
- [x] Descriptions match actual CLI behavior