### PR TITLE
fix(dashboard): verify focus-visible coverage for #3687 (39 components)

### DIFF
--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -930,7 +930,7 @@ button:active:not(:disabled) {
   background: var(--color-accent-on-light);
 }
 
-/* ── Focus ring — keyboard/programmatic only ─────────────────────── */
+/* ── Focus ring — keyboard/programmatic only (resolves #3687) ─── */
 :focus-visible {
   outline: none;
   box-shadow: var(--focus-ring-offset), var(--focus-ring);


### PR DESCRIPTION
## Summary

Closes #3687

The issue reported 39 dashboard components with `<button>` elements lacking visible focus indicators (WCAG 2.1 §2.4.7).

### Finding

The global `:focus-visible` rule in `index.css` **already provides keyboard-visible focus indicators** for all interactive elements:

```css
:focus-visible {
  outline: none;
  box-shadow: var(--focus-ring-offset), var(--focus-ring);
}
```

With tokens:
- `--focus-ring`: `0 0 0 2px var(--color-accent-cyan)` → bright cyan ring
- `--focus-ring-offset`: `0 0 0 4px var(--color-void)` → dark offset for contrast

### Verification

- ✅ No buttons use `shadow-none` or `ring-0` that would suppress the ring
- ✅ No non-semantic elements (`<div onClick>`) acting as buttons
- ✅ Tailwind v4 preflight does not override `:focus-visible`
- ✅ Light theme forced-colors override preserves visible focus
- ✅ 9 existing a11y CSS tests pass (tokens, rules, media queries)
- ✅ `tsc --noEmit` clean, `npm run build` clean

### Changes

- Added `#3687` reference to focus-visible CSS comment for traceability

— Daedalus 🏛️