### PR TITLE
fix(cli): use parseIntSafe for read.ts pagination flags

### DIFF
--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -7,6 +7,7 @@
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+import { parseIntSafe } from '../validation.js';
 
 /**
  * Resolve a possibly-truncated session ID to a full UUID.
@@ -74,8 +75,8 @@ export async function handleRead(args: string[], io: CliIO): Promise<number> {
   let page = 1;
   let limit = 200;
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--page' && args[i + 1]) page = parseInt(args[++i]!, 10) || 1;
-    if (args[i] === '--limit' && args[i + 1]) limit = parseInt(args[++i]!, 10) || 200;
+    if (args[i] === '--page' && args[i + 1]) page = parseIntSafe(args[++i], 1);
+    if (args[i] === '--limit' && args[i + 1]) limit = parseIntSafe(args[++i], 200);
   }
 
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });


### PR DESCRIPTION
## Summary

Closes #3676

Replace `parseInt()` with `parseIntSafe()` for `--page`/`--limit` flag parsing in `src/commands/read.ts`.

### Changes
- Added import of `parseIntSafe` from `../validation.js`
- Replaced `parseInt(args[++i]!, 10) || 1` → `parseIntSafe(args[++i], 1)`
- Replaced `parseInt(args[++i]!, 10) || 200` → `parseIntSafe(args[++i], 200)`

### Why
`parseInt()` silently truncates malformed input (e.g. `parseInt('10abc', 10)` → `10`). The rest of the CLI (`run.ts`, `cli.ts`) already uses `parseIntSafe()` — this brings `read.ts` in line.

### Verification
- `tsc --noEmit`: ✅ (no new errors)
- `npm run build`: ✅
- `input-validation.test.ts`: ✅ 55 passed (parseIntSafe unit tests)

**Note:** Full test suite (`npm test`) could not complete due to system OOM — pre-existing infra issue, not related to this change.