### PR TITLE
fix(cli): stream timeout too aggressive for ag run (#3732)

### DIFF
--- a/src/__tests__/feat-3498-run-yes-timeout.test.ts
+++ b/src/__tests__/feat-3498-run-yes-timeout.test.ts
@@ -60,7 +60,7 @@ describe('Issue #3498: ag run --yes timeout', () => {
       expect(code).toBe(1);
       const allErrors = errors.join('');
       expect(allErrors).toContain('No output received');
-      expect(allErrors).toContain('30 seconds');
+      expect(allErrors).toContain('90 seconds');
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/__tests__/fix-3732-stream-timeout.test.ts
+++ b/src/__tests__/fix-3732-stream-timeout.test.ts
@@ -1,0 +1,256 @@
+/**
+ * fix-3732-stream-timeout.test.ts
+ * Tests for #3732: ag run stream interrupted timeout — no output shown for simple tasks.
+ *
+ * Key fixes:
+ * - Per-fetch timeout increased from 5s to 15s
+ * - --yes mode idle timeout increased from 30s to 90s
+ * - Retry on transient fetch errors (up to 3 attempts)
+ * - Clear idle timeout message instead of generic "Stream interrupted"
+ * - No-output exit code 1 for all modes (not just --yes)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock child_process to prevent spawning real processes
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({
+    on: vi.fn(),
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    unref: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
+
+// Mock claude-installer
+vi.mock('../utils/claude-installer.js', () => ({
+  checkClaudeInstalled: vi.fn().mockResolvedValue(true),
+  hasAnthropicCredentials: vi.fn().mockResolvedValue(true),
+}));
+
+describe('#3732 stream timeout fixes', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('retries on transient fetch errors before giving up', async () => {
+    const calls: string[] = [];
+    let callCount = 0;
+
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      callCount++;
+
+      if (urlStr.includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions/stats')) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions') && !urlStr.includes('/read')) {
+        // Session creation
+        return new Response(
+          JSON.stringify({
+            id: 'test-session-retry',
+            status: 'idle',
+            promptDelivery: { delivered: true, status: 'delivered', attempts: 1 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (urlStr.includes('/read')) {
+        calls.push(`read-${callCount}`);
+        // First 2 reads fail, 3rd succeeds with output
+        if (callCount <= 2) {
+          throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+        }
+        return new Response(
+          JSON.stringify({
+            messages: [
+              { role: 'user', text: 'hello', contentType: 'text' },
+              { role: 'assistant', text: 'world', contentType: 'text' },
+            ],
+            status: 'completed',
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof globalThis.fetch;
+
+    // Mock config/auth
+    vi.mock('../config.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../config.js')>();
+      return {
+        ...actual,
+        loadConfig: vi.fn().mockResolvedValue({}),
+        readConfigFile: vi.fn().mockResolvedValue({}),
+      };
+    });
+
+    // Need to reimport to get mocks
+    const { handleRun } = await import('../commands/run.js');
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const io = {
+      stdout: { write: (s: string) => stdout.push(s) } as any,
+      stderr: { write: (s: string) => stderr.push(s) } as any,
+      stdin: process.stdin as any,
+    };
+
+    const result = await handleRun(['hello', '--yes'], io);
+    expect(result).toBe(0); // Session completed with output
+    expect(stdout.join('')).toContain('world');
+  });
+
+  it('shows idle timeout message with dynamic timeout value', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+
+      if (urlStr.includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions/stats')) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions') && !urlStr.includes('/read')) {
+        return new Response(
+          JSON.stringify({
+            id: 'test-session-idle',
+            status: 'idle',
+            promptDelivery: { delivered: true, status: 'delivered', attempts: 1 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (urlStr.includes('/read')) {
+        // Always return 0 messages, session still running — simulates idle timeout
+        return new Response(
+          JSON.stringify({ messages: [], status: 'running' }),
+          { status: 200 },
+        );
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const { handleRun } = await import('../commands/run.js');
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const io = {
+      stdout: { write: (s: string) => stdout.push(s) } as any,
+      stderr: { write: (s: string) => stderr.push(s) } as any,
+      stdin: process.stdin as any,
+    };
+
+    // Run with a short timeout by using --yes (90s) — we advance timers
+    const runPromise = handleRun(['hello', '--yes'], io);
+
+    // Advance time past 90s idle timeout
+    await vi.advanceTimersByTimeAsync(95_000);
+
+    const result = await runPromise;
+    expect(result).toBe(1); // Exit code 1 when no output
+    const errors = stderr.join('');
+    expect(errors).toContain('90 seconds');
+  });
+
+  it('gives up after 3 consecutive fetch errors', async () => {
+    let callCount = 0;
+
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      callCount++;
+
+      if (urlStr.includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions/stats')) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions') && !urlStr.includes('/read')) {
+        return new Response(
+          JSON.stringify({
+            id: 'test-session-errors',
+            status: 'idle',
+            promptDelivery: { delivered: true, status: 'delivered', attempts: 1 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (urlStr.includes('/read')) {
+        // All reads fail with timeout
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const { handleRun } = await import('../commands/run.js');
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const io = {
+      stdout: { write: (s: string) => stdout.push(s) } as any,
+      stderr: { write: (s: string) => stderr.push(s) } as any,
+      stdin: process.stdin as any,
+    };
+
+    const result = await handleRun(['hello', '--yes'], io);
+    expect(result).toBe(1);
+    const errors = stderr.join('');
+    expect(errors).toContain('3 attempts');
+    expect(errors).toContain('aborted');
+  });
+
+  it('returns exit code 1 for no output in non-yes mode too', async () => {
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+
+      if (urlStr.includes('/v1/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions/stats')) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      if (urlStr.includes('/v1/sessions') && !urlStr.includes('/read')) {
+        return new Response(
+          JSON.stringify({
+            id: 'test-session-noyes',
+            status: 'idle',
+            promptDelivery: { delivered: true, status: 'delivered', attempts: 1 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (urlStr.includes('/read')) {
+        // All reads fail — simulate persistent error
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const { handleRun } = await import('../commands/run.js');
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const io = {
+      stdout: { write: (s: string) => stdout.push(s) } as any,
+      stderr: { write: (s: string) => stderr.push(s) } as any,
+      stdin: process.stdin as any,
+    };
+
+    // Note: no --yes flag
+    const result = await handleRun(['hello'], io);
+    expect(result).toBe(1);
+  });
+});

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -280,7 +280,7 @@ async function pollUntilComplete(baseUrl: string, sessionId: string, authToken: 
 }
 
 /** Stream session transcript/output to terminal using polling.
- *  @param maxIdleMs Maximum idle time before timing out (default 120s). Set to 30_000 for --yes mode.
+ *  @param maxIdleMs Maximum idle time before timing out (default 120s). Set to 90_000 for --yes mode.
  *  @returns true if output was received, false if timed out without output. */
 async function streamOutput(baseUrl: string, sessionId: string, authToken: string | undefined, io: CliIO, maxIdleMs: number = 120_000): Promise<boolean> {
   const headers: Record<string, string> = {};
@@ -294,11 +294,16 @@ async function streamOutput(baseUrl: string, sessionId: string, authToken: strin
   writeLine(io.stdout, '  📡 Streaming session output (Ctrl+C to stop)...');
   writeLine(io.stdout);
 
-  try {
-    while (Date.now() - lastActivity < maxIdleMs) {
+  // #3732: Increased from 5s to 15s — read endpoint may block waiting for CC output
+  const FETCH_TIMEOUT_MS = 15_000;
+  const MAX_CONSECUTIVE_ERRORS = 3;
+  let consecutiveErrors = 0;
+
+  while (Date.now() - lastActivity < maxIdleMs) {
+    try {
       const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/read`, {
         headers,
-        signal: AbortSignal.timeout(5000),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
 
       if (!res.ok) {
@@ -313,6 +318,9 @@ async function streamOutput(baseUrl: string, sessionId: string, authToken: strin
         status?: string;
         statusText?: string | null;
       };
+
+      // Reset error counter on successful fetch
+      consecutiveErrors = 0;
 
       // #3368: Read endpoint returns `messages`, not `lines` or `transcript`
       const entries = data.messages || [];
@@ -366,9 +374,24 @@ async function streamOutput(baseUrl: string, sessionId: string, authToken: strin
       }
 
       await new Promise((r) => setTimeout(r, 1500));
+    } catch (e) {
+      // #3732: Retry on transient fetch errors instead of aborting immediately
+      consecutiveErrors++;
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        writeLine(io.stderr, `  ⚠️  Stream fetch failed after ${MAX_CONSECUTIVE_ERRORS} attempts: ${getErrorMessage(e)}`);
+        break;
+      }
+      // Transient error — retry after brief pause
+      await new Promise((r) => setTimeout(r, 2000));
     }
-  } catch (e) {
-    writeLine(io.stderr, `  ⚠️  Stream interrupted: ${getErrorMessage(e)}`);
+  }
+
+  // #3732: Clear idle timeout message (replaces generic "Stream interrupted")
+  if (!receivedAnyOutput && Date.now() - lastActivity >= maxIdleMs) {
+    writeLine(io.stderr);
+    writeLine(io.stderr, `  ⏱️  No output received within ${Math.round(maxIdleMs / 1000)}s idle timeout.`);
+    writeLine(io.stderr, '  The session may still be running. Check with:');
+    writeLine(io.stderr, `    ag read ${sessionId}`);
   }
 
   // Return whether we received any output (for --yes timeout detection)
@@ -658,14 +681,14 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
   }
 
   // Stream output
-  // Issue #3498: Use 30s idle timeout in --yes mode for fast failure
-  const streamTimeoutMs = skipPrompts ? 30_000 : 120_000;
+  // Issue #3732: Use 90s idle timeout in --yes mode (CC often needs 30-60s to produce first output)
+  const streamTimeoutMs = skipPrompts ? 90_000 : 120_000;
   const receivedOutput = await streamOutput(baseUrl, sessionId, authToken, io, streamTimeoutMs);
 
-  // Issue #3498: If --yes mode timed out without output, show actionable error
-  if (!receivedOutput && skipPrompts) {
+  // Issue #3732: If timed out without output, show actionable error (all modes)
+  if (!receivedOutput) {
     writeLine(io.stderr);
-    writeLine(io.stderr, '  ⚠️  No output received within 30 seconds.');
+    writeLine(io.stderr, `  ⚠️  No output received within ${Math.round(streamTimeoutMs / 1000)} seconds.`);
     writeLine(io.stderr, '  This usually means Claude Code could not start or is not responding.');
     writeLine(io.stderr);
     writeLine(io.stderr, '  Possible causes:');


### PR DESCRIPTION
## Fix for #3732

### Problem
`ag run "simple task" --yes` shows "Stream interrupted: The operation was aborted due to timeout" even though the CC session completes successfully. The streaming output never shows the assistant response.

### Root Cause
1. **Per-fetch timeout (5s)** too short — read endpoint may block waiting for CC output
2. **`--yes` idle timeout (30s)** too aggressive — CC often needs 30-60s to produce first output
3. **Catch block swallows all errors** — no retry on transient fetch failures
4. **Exit code 0** even when stream times out without showing output

### Changes
- Increased per-fetch timeout from 5s → 15s
- Increased `--yes` idle timeout from 30s → 90s
- Retry on transient fetch errors (up to 3 consecutive attempts)
- Clear "⏱️ idle timeout" message instead of generic "Stream interrupted"
- Exit code 1 for no output in all modes (not just `--yes`)
- Removed try/catch wrapping of the entire while loop — individual fetch errors are caught and retried

### Files
- `src/commands/run.ts`: Core fix (streamOutput function + handleRun timeout)
- `src/__tests__/fix-3732-stream-timeout.test.ts`: 4 new tests
- `src/__tests__/feat-3498-run-yes-timeout.test.ts`: Updated "30s" → "90s" expectation

### Verification
```
npx tsc --noEmit: ✅ 0 errors
npm run build (tsc + openapi + dashboard copy): ✅
npm test: ✅ 4771 passed (8 skipped)
```

Commit: 6398b088
Session: direct implementation (Aegis server OOM crash during CC session)