### PR TITLE
fix(ux): add remediation hint to workDir allowed-list error (#3729)

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -780,7 +780,9 @@ export async function validateWorkDir(
   const resolved = path.resolve(normalizedWorkDir);
   const preAllowed = candidateSafeDirs.some((dir) => isUnderOrEqual(resolved, dir));
   if (!preAllowed) {
-    const hint = windowsSuggestion ? ` Did you mean \`${windowsSuggestion}\`?` : '';
+    const hint = windowsSuggestion
+      ? ` Did you mean \`${windowsSuggestion}\`?`
+      : ' Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory.';
     return { error: `workDir ${resolved} is not in the allowed directories list.${hint}`, code: 'INVALID_WORKDIR' };
   }
 
@@ -796,7 +798,9 @@ export async function validateWorkDir(
   // Step 4: Canonical allowlist check after symlink resolution.
   const allowed = candidateSafeDirs.some((dir) => isUnderOrEqual(realPath, dir));
   if (!allowed) {
-    const hint = windowsSuggestion ? ` Did you mean \`${windowsSuggestion}\`?` : '';
+    const hint = windowsSuggestion
+      ? ` Did you mean \`${windowsSuggestion}\`?`
+      : ' Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory.';
     return { error: `workDir ${resolved} is not in the allowed directories list.${hint}`, code: 'INVALID_WORKDIR' };
   }
 


### PR DESCRIPTION
## What
When `ag run` is invoked from a directory outside the allowed list (e.g. `/tmp`), the error now tells the user how to fix it instead of just saying "not in the allowed directories list".

## Before
```
❌ Failed to create session: workDir /tmp/aegis-test is not in the allowed directories list.
```

## After
```
❌ Failed to create session: workDir /tmp/aegis-test is not in the allowed directories list. Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory.
```

## Verification
- `tsc --noEmit`: ✅ zero errors
- `npx vitest run src/__tests__/path-traversal-workdir-435.test.ts`: ✅ 26 passed

Closes #3729