### PR TITLE
fix(cli): hide killed/completed/crashed sessions from ag list by default (#3731)

### DIFF
--- a/src/__tests__/commands/list.test.ts
+++ b/src/__tests__/commands/list.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for commands/list.ts — Issue #3731
+ * Verify that killed/completed/crashed sessions are hidden by default
+ * and shown with --all.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock cli-http so we don't need a running server
+const mockWriteLine = vi.fn();
+const mockStdout = { write: vi.fn() };
+const mockStderr = { write: vi.fn() };
+const mockIO = { stdout: mockStdout, stderr: mockStderr };
+
+let mockFetchResponse: { ok: boolean; status: number; statusText: string; json: () => Promise<any> };
+
+vi.mock('../../cli-http.js', () => ({
+  resolveBaseUrl: vi.fn().mockResolvedValue('http://localhost:9100'),
+  resolveAuthToken: vi.fn().mockResolvedValue('test-token'),
+  buildHeaders: vi.fn().mockReturnValue({ Authorization: 'Bearer test-token' }),
+  requireServer: vi.fn().mockResolvedValue(true),
+  writeLine: (...args: any[]) => mockWriteLine(...args),
+}));
+
+// Mock global fetch
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWriteLine.mockImplementation((stream: any, text: string) => {
+    // writeLine(io.stdout, text) or writeLine(io.stderr, text)
+  });
+});
+
+async function importList() {
+  return import('../../commands/list.js');
+}
+
+function makeFetchResponse(sessions: any[]) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ sessions }),
+  };
+}
+
+describe('handleList', () => {
+  it('hides killed sessions by default', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([
+      { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'idle', displayName: 'alive-session' },
+      { id: '11111111-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'killed', displayName: 'dead-session' },
+      { id: '22222222-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'completed', displayName: 'done-session' },
+      { id: '33333333-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'crashed', displayName: 'crash-session' },
+    ])) as any;
+
+    const { handleList } = await importList();
+    const exitCode = await handleList([], mockIO as any);
+
+    expect(exitCode).toBe(0);
+    // Should mention only the idle session
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const sessionLines = calls.filter((l: string) => l && l.includes('aaaaaaaa'));
+    expect(sessionLines.length).toBe(1);
+    // Should NOT include killed/completed/crashed
+    const deadLines = calls.filter((l: string) => l && (l.includes('dead-session') || l.includes('done-session') || l.includes('crash-session')));
+    expect(deadLines.length).toBe(0);
+    // Tip should mention --all
+    const tipCalls = calls.filter((l: string) => l && l.includes('--all'));
+    expect(tipCalls.length).toBe(1);
+  });
+
+  it('shows all sessions with --all flag', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([
+      { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'idle', displayName: 'alive-session' },
+      { id: '11111111-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'killed', displayName: 'dead-session' },
+    ])) as any;
+
+    const { handleList } = await importList();
+    const exitCode = await handleList(['--all'], mockIO as any);
+
+    expect(exitCode).toBe(0);
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const aliveLines = calls.filter((l: string) => l && l.includes('alive-session'));
+    const deadLines = calls.filter((l: string) => l && l.includes('dead-session'));
+    expect(aliveLines.length).toBe(1);
+    expect(deadLines.length).toBe(1);
+  });
+
+  it('shows helpful empty message when no active sessions', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([
+      { id: '11111111-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'killed', displayName: 'dead-session' },
+    ])) as any;
+
+    const { handleList } = await importList();
+    const exitCode = await handleList([], mockIO as any);
+
+    expect(exitCode).toBe(0);
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const emptyMsg = calls.find((l: string) => l && l.includes('--all'));
+    expect(emptyMsg).toBeDefined();
+  });
+
+  it('still passes --status filter to server', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([])) as any;
+
+    const { handleList } = await importList();
+    await handleList(['--status', 'idle'], mockIO as any);
+
+    const fetchUrl = (globalThis.fetch as any).mock.calls[0][0] as string;
+    expect(fetchUrl).toContain('status=idle');
+  });
+
+  it('--all does not add --all tip', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([
+      { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'idle', displayName: 'alive-session' },
+    ])) as any;
+
+    const { handleList } = await importList();
+    await handleList(['--all'], mockIO as any);
+
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const allTip = calls.filter((l: string) => l && l.includes('--all'));
+    expect(allTip.length).toBe(0);
+  });
+});
+
+// Restore fetch after all tests
+import { afterAll } from 'vitest';
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,9 +3,13 @@
  *
  * Wraps GET /v1/sessions with optional status and project (`--cwd`) filters.
  * Issue #3633: Add --full-ids and --json flags for better CLI workflow.
+ * Issue #3731: Hide killed/completed/crashed by default; --all shows everything.
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+
+/** Statuses considered "terminal" — hidden from `ag list` unless --all is passed. */
+const TERMINAL_STATUSES = new Set(['killed', 'completed', 'crashed']);
 
 export async function handleList(args: string[], io: CliIO): Promise<number> {
   const baseUrl = await resolveBaseUrl(args);
@@ -17,6 +21,7 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
 
   let fullIds = false;
   let jsonOutput = false;
+  let showAll = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--status' && args[i + 1]) {
@@ -28,6 +33,8 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
       fullIds = true;
     } else if (args[i] === '--json') {
       jsonOutput = true;
+    } else if (args[i] === '--all') {
+      showAll = true;
     }
   }
 
@@ -41,7 +48,12 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
   }
 
   const body = await res.json() as { sessions?: any[]; data?: any[] };
-  const sessions = body.sessions ?? body.data ?? [];
+  let sessions = body.sessions ?? body.data ?? [];
+
+  // #3731: Filter terminal statuses unless --all
+  if (!showAll) {
+    sessions = sessions.filter(s => !TERMINAL_STATUSES.has(s.status));
+  }
 
   if (jsonOutput) {
     // Machine-readable JSON output — include full IDs
@@ -50,7 +62,7 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
   }
 
   if (sessions.length === 0) {
-    writeLine(io.stdout, '  No sessions found.');
+    writeLine(io.stdout, showAll ? '  No sessions found.' : '  No active sessions. Use --all to include killed/completed/crashed.');
     return 0;
   }
 
@@ -63,9 +75,12 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
     writeLine(io.stdout, `    ${id}${suffix}  ${status.padEnd(12)}  ${name}`);
   }
 
-  if (!fullIds) {
+  const tips: string[] = [];
+  if (!fullIds) tips.push('--full-ids to show full UUIDs');
+  if (!showAll) tips.push('--all to include killed/completed/crashed');
+  if (tips.length > 0) {
     writeLine(io.stdout, '');
-    writeLine(io.stdout, '  Tip: use --full-ids to show full UUIDs, or pipe with --json.');
+    writeLine(io.stdout, `  Tip: use ${tips.join(', ')}, or pipe with --json.`);
   }
 
   return 0;


### PR DESCRIPTION
## Issue
Closes #3731

## Problem
After `ag kill <id>`, killed sessions persist in `ag list` output. Over time the list fills with dead sessions, looking broken to new users.

## Solution
- Filter terminal statuses (`killed`, `completed`, `crashed`) from default `ag list` output
- `--all` flag shows everything (backward compatible for scripts)
- Empty state message suggests `--all` when only dead sessions exist
- Tip line updated to mention `--all`

## Changes
- `src/commands/list.ts`: Added `TERMINAL_STATUSES` filter + `--all` flag
- `src/__tests__/commands/list.test.ts`: 5 new tests

## Verification
- `tsc --noEmit`: ✅ zero errors
- `npm run build`: OOM killed (pre-existing system memory issue — dashboard build; TS compilation succeeds)
- Tests: ✅ 5/5 passed (list), 4771+ total suite passed earlier today