### PR TITLE
fix(ux): ag init prompts readability + Ctrl+D handling (#3730)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -329,7 +329,8 @@ function createPrompter(io: CliIO): Prompter {
   return {
     close: () => {},
     async question(prompt: string): Promise<string> {
-      write(io.stdout, prompt);
+      // Non-TTY: add newline before each prompt for readable output
+      write(io.stdout, '\n' + prompt);
       const lines = await bufferedLinesPromise;
       const answer = lines[index] ?? '';
       index += 1;
@@ -618,6 +619,13 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
       baseUrl = await promptBaseUrl(prompter, io, baseUrl);
       byoEnv = await promptByoEnv(prompter, io, existingByoEnv);
       dashboardEnabled = await promptBoolean(prompter, io, 'Enable the bundled dashboard?', dashboardEnabled);
+    } catch (err: unknown) {
+      // Handle Ctrl+D / pipe exhaustion gracefully
+      if (err instanceof Error && (err.name === 'AbortError' || (err as NodeJS.ErrnoException).code === 'ABORT_ERR')) {
+        writeLine(io.stderr, '\n  ⚠️  Input ended — using defaults for remaining prompts.');
+      } else {
+        throw err;
+      }
     } finally {
       prompter.close();
     }


### PR DESCRIPTION
## What
Fixes two UX issues with `ag init` prompts:

### 1. Non-TTY prompts on single line
When `ag init` runs in non-interactive mode (piped stdin, scripts), all prompts rendered on one line. Now each prompt gets a leading newline for readability.

### 2. Ctrl+D crash
When stdin ends mid-prompt (Ctrl+D or pipe exhaustion), `ag init` crashed with an unhandled `AbortError` stack trace. Now it catches the error gracefully and falls back to defaults for remaining prompts.

## Verification
```
npx tsc --noEmit: ✅ 0 errors
npx vitest run src/__tests__/cli-init.test.ts: ✅ 14 passed
```

Closes #3730