### PR TITLE
fix(health): include session counts in unauthenticated response (#3739)

### DIFF
--- a/src/__tests__/health-auth-2458.test.ts
+++ b/src/__tests__/health-auth-2458.test.ts
@@ -227,24 +227,29 @@ describe('Issue #2458: GET /v1/health auth-gated info', () => {
     await app.close();
   });
 
-  it('unauthenticated request returns only { status }', async () => {
+  it('unauthenticated request returns status and session counts', async () => {
     const res = await app.inject({ method: 'GET', url: '/v1/health' });
 
     expect(res.statusCode).toBe(200);
     const body = res.json() as Record<string, unknown>;
     expect(body.status).toBe('ok');
-    // Must contain no additional fields
-    expect(Object.keys(body)).toEqual(['status']);
+    // Issue #3739: session counts are safe for unauthenticated callers
+    expect(body.sessions).toBeDefined();
+    expect(typeof (body.sessions as Record<string, unknown>).active).toBe('number');
+    expect(typeof (body.sessions as Record<string, unknown>).total).toBe('number');
+    // Must not contain sensitive fields
+    expect(Object.keys(body).sort()).toEqual(['sessions', 'status']);
   });
 
-  it('unauthenticated request does not leak version, uptime, sessions, or claude', async () => {
+  it('unauthenticated request does not leak version, uptime, or claude', async () => {
     const res = await app.inject({ method: 'GET', url: '/v1/health' });
     const body = res.json() as Record<string, unknown>;
 
     expect(body.version).toBeUndefined();
     expect(body.uptime).toBeUndefined();
     expect(body.platform).toBeUndefined();
-    expect(body.sessions).toBeUndefined();
+    // sessions is now included for unauthenticated callers (Issue #3739)
+    expect(body.sessions).toBeDefined();
     expect(body.claude).toBeUndefined();
     expect(body.timestamp).toBeUndefined();
   });
@@ -269,12 +274,13 @@ describe('Issue #2458: GET /v1/health auth-gated info', () => {
     expect(body.claude).toBeDefined();
   });
 
-  it('legacy GET /health also returns only { status } for unauthenticated callers', async () => {
+  it('legacy GET /health also returns status and session counts for unauthenticated callers', async () => {
     const res = await app.inject({ method: 'GET', url: '/health' });
 
     expect(res.statusCode).toBe(200);
     const body = res.json() as Record<string, unknown>;
     expect(body.status).toBe('ok');
-    expect(Object.keys(body)).toEqual(['status']);
+    expect(body.sessions).toBeDefined();
+    expect(Object.keys(body).sort()).toEqual(['sessions', 'status']);
   });
 });

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -321,12 +321,12 @@ describe('Server smoke test — full HTTP flow (Issue #1899)', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.status).toBe('ok');
-    // Issue #2458: unauthenticated callers must get only { status }
+    // Issue #3739: unauthenticated callers get status + session counts (but not sensitive fields)
     expect(body.version).toBeUndefined();
-    expect(body.sessions).toBeUndefined();
+    // sessions is now included (Issue #3739)
     expect(body.timestamp).toBeUndefined();
     expect(body.claude).toBeUndefined();
-    expect(Object.keys(body)).toEqual(['status']);
+    expect(Object.keys(body).sort()).toEqual(['sessions', 'status']);
   });
 
   it('GET /v1/health accepts dashboard session cookie for full data', async () => {

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -102,9 +102,9 @@ export function registerHealthRoutes(app: FastifyInstance, ctx: RouteContext): v
 
     const base = { status, timestamp: new Date().toISOString() };
 
-    // Unauthenticated: return only status (Issue #2458 — prevent info leak)
+    // Unauthenticated: return status + session counts (Issue #3739 — monitors need counts)
     if (!isAuthenticated) {
-      return { status };
+      return { status, sessions: { active: activeCount, total: totalCount } };
     }
 
     // Authenticated: return full health details


### PR DESCRIPTION
## Summary

Fixes #3739

The health endpoint at `GET /v1/health` was stripped to only `{status}` for unauthenticated callers (Issue #2458). This broke heartbeat scripts, watchdogs, and monitoring that depend on `sessions.active/total` counts.

Session counts are not sensitive — they are just numbers. This PR includes them in the unauthenticated response alongside status.

## Changes

- `src/routes/health.ts`: add `sessions: { active, total }` to the unauthenticated response branch
- `src/__tests__/health-auth-2458.test.ts`: updated assertions — session counts now expected in unauthenticated responses
- `src/__tests__/server-smoke.test.ts`: same assertion update

## Verification

```
npx tsc --noEmit: ✅
npm run build: ✅
npm test: ✅ 4774 passed (8 skipped) — 331 test files
```

## Security Consideration

`sessions.active` and `sessions.total` are non-sensitive counters. No version, uptime, platform, claude status, or other operational data is leaked to unauthenticated callers.

Commit: bc2c6abb
Issue: #3739