### PR TITLE
fix(security): PID-aware port cleanup in pre-start script (#3749)

### DIFF
--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -74,12 +74,27 @@ if [ "${SKIP_BUILD}" != "true" ]; then
   fi
 fi
 
-# 1. Kill any process holding our port (stale server from previous crash)
+# 1. Kill stale process on our port — ONLY if it is NOT a known Aegis instance
 PORT_PID=\$(ss -tlnp "sport = :\${AEGIS_PORT}" 2>/dev/null | grep -oP 'pid=\\K\\d+' | head -1)
 if [ -n "\$PORT_PID" ]; then
-  echo "ExecStartPre: killing stale process \$PORT_PID on port \$AEGIS_PORT"
-  kill -9 "\$PORT_PID" 2>/dev/null
-  sleep 1
+  # Check if this PID matches a known Aegis PID file (healthy running instance)
+  OWN_PID=""
+  for pidfile in "\$HOME/.aegis/aegis.pid"; do
+    if [ -f "\$pidfile" ]; then
+      FILE_PID=\$(cat "\$pidfile" 2>/dev/null)
+      if [ -n "\$FILE_PID" ] && kill -0 "\$FILE_PID" 2>/dev/null && [ "\$FILE_PID" = "\$PORT_PID" ]; then
+        OWN_PID="\$FILE_PID"
+        echo "ExecStartPre: port \$AEGIS_PORT held by Aegis PID \$OWN_PID — not killing"
+        break
+      fi
+    fi
+  done
+  # Only kill if NOT our own healthy instance
+  if [ -z "\$OWN_PID" ]; then
+    echo "ExecStartPre: killing stale process \$PORT_PID on port \$AEGIS_PORT"
+    kill -9 "\$PORT_PID" 2>/dev/null
+    sleep 1
+  fi
 fi
 
 # 2. Clean stale PID files


### PR DESCRIPTION
## Summary

Fixes #3749 — the pre-start script blindly kills any process on port 9100, which causes the system-level Aegis service to murder the healthy user-level service on every restart cycle.

## Root Cause

`aegis-pre-start.sh` does `kill -9` on any PID holding port 9100 without checking if it belongs to Aegis. When the system-level service restarts (after its own crash), it runs ExecStartPre → kills the healthy user-level Aegis → cascading outage.

## Fix

Added PID-awareness check before killing:
1. Read PID from `~/.aegis/aegis.pid`
2. If port PID matches stored Aegis PID → skip kill (healthy instance)
3. Only kill if PID does not match any known Aegis instance

## Changes

- `scripts/install-systemd.sh`: template for `aegis-pre-start.sh` now checks PID files before killing port holder

## Verification

- `bash -n scripts/install-systemd.sh`: ✅ syntax OK
- `tsc --noEmit`: ✅ (no TS changes)
- `npm run build`: ✅
- Tests: N/A (shell script template change only, no TS test files affected)

## Note for Operator

After merge, re-run `sudo ./scripts/install-systemd.sh` to install the updated pre-start script. The live `/usr/local/bin/aegis-pre-start.sh` must be regenerated.