### PR TITLE
docs: update health unauthenticated response + telegramTopicId

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,7 +32,7 @@ Returns server health, version, uptime, and Claude CLI status.
 
 | Role | Required | Notes |
 |------|----------|-------|
-| None | — | Unauthenticated callers receive only `{ "status": "ok" }` to prevent information leakage |
+| None | — | Unauthenticated callers receive `{ "status": "ok", "sessions": { "active": N, "total": N } }` — version, uptime, and Claude CLI status are excluded |
 | admin | Yes | Full response with version, uptime, sessions, Claude CLI status |
 
 ```bash
@@ -63,7 +63,11 @@ curl http://localhost:9100/v1/health
 
 ```json
 {
-  "status": "ok"
+  "status": "ok",
+  "sessions": {
+    "active": 3,
+    "total": 42
+  }
 }
 ```
 
@@ -858,7 +862,7 @@ curl http://localhost:9100/v1/sessions/abc123 \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-**Response:** Session object with `actionHints` for current interactive state.
+**Response:** Session object with `actionHints` for current interactive state. When a Telegram topic is linked, the response includes `telegramTopicId`.
 
 **Errors:**
 


### PR DESCRIPTION
## Accuracy Fixes

- **Health endpoint** (#3750): Unauthenticated response now includes `sessions.active` and `sessions.total` — updated description, example, and role table
- **Session detail** (#3761): `GET /v1/sessions/:id` returns `telegramTopicId` when a Telegram topic is linked — added to response description

No other docs gaps found in recent merged PRs (#3750–#3767).