### PR TITLE
docs: add --session-id flag to ag create (#3771)

### DIFF
--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -256,6 +256,7 @@ ag create "Fix the failing tests"                     # Uses current directory
 | `--cwd <dir>` | Working directory for the session |
 | `--model <provider/model>` | Override the default model for this session |
 | `--effort <level>` | Set reasoning effort: `low`, `medium`, `high`, or `0.0`–`1.0` |
+| `--session-id <id>` | Send the brief to an existing session instead of creating a new one |
 | `--port <port>` | Aegis API port (default: `AEGIS_PORT` or `9100`) |
 
 This is a convenience wrapper that:


### PR DESCRIPTION
Documents the `--session-id` flag added to `ag create` by #3771 (fixes #3760).\n\nWhen `--session-id <id>` is provided, the brief is sent to the existing session instead of creating a new one.\n\n**Files changed:**\n- `docs/integrations/cli.md` — added `--session-id` to ag create options table