### PR TITLE
fix: add 'pending' to UIStateEnum validation (#3756)

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -242,7 +242,7 @@ export function isValidUUID(id: string): boolean {
 const UIStateEnum = z.enum([
   'idle', 'working', 'compacting', 'context_warning', 'waiting_for_input',
   'permission_prompt', 'bash_approval', 'plan_mode', 'ask_question',
-  'settings', 'error', 'unknown',
+  'settings', 'error', 'pending', 'unknown',
 ]);
 
 /** Issue #700: Permission Policy Schema */


### PR DESCRIPTION
## Summary

Fixes #3756 — `GET /v1/sessions` returns 0 sessions when `state.json` contains sessions with `status: "pending"`.

### Root Cause
`pending` is a valid `UIState` (defined in `session.ts:37`) and sessions are created with `status: "pending"` by default (line 820). However, the Zod `UIStateEnum` in `validation.ts` did not include `"pending"`. When the server loads `state.json` on startup, `persistedStateSchema.safeParse()` rejects the entire state and boots with an empty sessions map.

### Fix
Add `"pending"` to the `UIStateEnum` z.enum union in `src/validation.ts`.

### Verification
```
$ npx tsc --noEmit   # ✅ pass
$ npm run build       # ✅ pass
$ npx vitest run      # ✅ 334 passed (1 pre-existing failure on #3078, unrelated)
```

### Impact
- Sessions with `status: "pending"` will now survive server restarts
- Dashboard will correctly show sessions after restart
- API consumers will see all sessions, not just non-pending ones
