### PR TITLE
fix(dashboard): resilient session creation with fallback refetch

### DIFF
--- a/dashboard/src/__tests__/CreateSessionModal.test.tsx
+++ b/dashboard/src/__tests__/CreateSessionModal.test.tsx
@@ -11,6 +11,7 @@ const mockCreateSession = vi.fn();
 
 vi.mock('../api/client', () => ({
   createSession: (...args: unknown[]) => mockCreateSession(...args),
+  createSessionWithFallback: (...args: unknown[]) => mockCreateSession(...args),
   batchCreateSessions: (...args: unknown[]) => mockBatchCreateSessions(...args),
   getTemplates: (...args: unknown[]) => mockGetTemplates(...args),
 }));

--- a/dashboard/src/__tests__/NewSessionDrawer.test.tsx
+++ b/dashboard/src/__tests__/NewSessionDrawer.test.tsx
@@ -28,6 +28,7 @@ const mockGetTemplates = vi.fn();
 
 vi.mock('../api/client', () => ({
   createSession: (...args: unknown[]) => mockCreateSession(...args),
+  createSessionWithFallback: (...args: unknown[]) => mockCreateSession(...args),
   getTemplates: (...args: unknown[]) => mockGetTemplates(...args),
 }));
 

--- a/dashboard/src/__tests__/NewSessionPage.test.tsx
+++ b/dashboard/src/__tests__/NewSessionPage.test.tsx
@@ -13,6 +13,7 @@ const mockAddToast = vi.fn();
 
 vi.mock('../api/client', () => ({
   createSession: (...args: unknown[]) => mockCreateSession(...args),
+  createSessionWithFallback: (...args: unknown[]) => mockCreateSession(...args),
   getTemplates: (...args: unknown[]) => mockGetTemplates(...args),
 }));
 

--- a/dashboard/src/__tests__/createSessionWithFallback.test.ts
+++ b/dashboard/src/__tests__/createSessionWithFallback.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { createSessionWithFallback } from '../api/client';
+
+function mockJsonResponse(data: unknown, status = 201) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    headers: new Headers(),
+  } as Response;
+}
+
+const validSession = {
+  id: 'session-123',
+  displayName: 'test-session',
+  workDir: '/tmp',
+  status: 'idle',
+  createdAt: Date.now(),
+  lastActivity: Date.now(),
+  stallThresholdMs: 300000,
+  byteOffset: 0,
+  monitorOffset: 0,
+  permissionMode: 'default',
+};
+
+describe('createSessionWithFallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns session directly when API response is valid', async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(validSession));
+
+    const result = await createSessionWithFallback({ workDir: '/tmp' });
+
+    expect(result.id).toBe('session-123');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to session list when create response fails Zod validation', async () => {
+    // First call: create returns 201 but with malformed body → Zod throws
+    mockFetch.mockResolvedValueOnce(mockJsonResponse({ error: 'weird shape' }));
+    // Second call: getSessions returns valid session
+    mockFetch.mockResolvedValueOnce(
+      mockJsonResponse({
+        sessions: [validSession],
+        pagination: { page: 1, limit: 1, total: 1, totalPages: 1 },
+      }),
+    );
+
+    const result = await createSessionWithFallback({ workDir: '/tmp' });
+
+    expect(result.id).toBe('session-123');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws custom error when both create and list return nothing useful', async () => {
+    // Create returns malformed → validation error → fallback
+    mockFetch.mockResolvedValueOnce(mockJsonResponse({}));
+    // List returns empty
+    mockFetch.mockResolvedValueOnce(
+      mockJsonResponse({
+        sessions: [],
+        pagination: { page: 1, limit: 1, total: 0, totalPages: 0 },
+      }),
+    );
+
+    await expect(createSessionWithFallback({ workDir: '/tmp' })).rejects.toThrow(
+      'Session was created but session info could not be retrieved',
+    );
+  });
+
+  it('propagates HTTP 401 errors immediately (no fallback)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: () => Promise.resolve({ error: 'Unauthorized' }),
+      headers: new Headers(),
+    } as Response);
+
+    await expect(createSessionWithFallback({ workDir: '/tmp' })).rejects.toThrow('Unauthorized');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('propagates HTTP 500 errors immediately (no fallback)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ error: 'Internal Server Error' }),
+      headers: new Headers(),
+    } as Response);
+
+    await expect(createSessionWithFallback({ workDir: '/tmp' })).rejects.toThrow('Internal Server Error');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('propagates network errors immediately (no fallback)', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    await expect(createSessionWithFallback({ workDir: '/tmp' })).rejects.toThrow('Failed to fetch');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -408,6 +408,32 @@ export function createSession(opts: CreateSessionRequest & { signal?: AbortSigna
   });
 }
 
+/**
+ * Resilient session creation: wraps createSession with a fallback.
+ * If the API returns a malformed response (Zod validation failure) or a
+ * response missing a session ID, refetches the sessions list and returns
+ * the most recently created session.
+ * Defensive fix for #3738.
+ */
+export async function createSessionWithFallback(opts: CreateSessionRequest & { signal?: AbortSignal }): Promise<SessionInfo> {
+  try {
+    const session = await createSession(opts);
+    if (session?.id) return session;
+  } catch (err) {
+    // Only attempt fallback on validation errors or missing-id responses.
+    // Re-throw auth errors, network errors, and HTTP 4xx/5xx immediately.
+    const msg = err instanceof Error ? err.message : '';
+    const isValidation = msg.includes('API response validation failed');
+    const isNoId = msg.includes('session info could not be retrieved');
+    if (!isValidation && !isNoId) throw err;
+  }
+  // Fallback: refetch sessions list and return the newest
+  const list = await getSessions({ limit: 1 });
+  if (list.sessions.length > 0) return list.sessions[0];
+  throw new Error('Session was created but session info could not be retrieved');
+}
+
+
 export function killSession(id: string): Promise<OkResponse> {
   return request(`/v1/sessions/${encodeURIComponent(id)}`, {
     method: 'DELETE',

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useNavigate } from 'react-router-dom';
 import { X, Loader2, Plus, Trash2 } from 'lucide-react';
-import { createSession, batchCreateSessions, getTemplates } from '../api/client';
+import { createSessionWithFallback, batchCreateSessions, getTemplates } from '../api/client';
 import type { SessionTemplate } from '../types';
 import { useT } from '../i18n/context';
 
@@ -164,7 +164,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
     const controller = new AbortController();
     abortRef.current = controller;
     try {
-      const session = await createSession({
+      const session = await createSessionWithFallback({
         workDir: workDir.trim(),
         name: name.trim() || undefined,
         prompt: prompt.trim() || undefined,
@@ -476,7 +476,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
           abortRef.current = controller;
 
           try {
-            const session = await createSession({
+            const session = await createSessionWithFallback({
               workDir: template.workDir,
               prompt: template.prompt,
               claudeCommand: template.claudeCommand,

--- a/dashboard/src/components/NewSessionDrawer.tsx
+++ b/dashboard/src/components/NewSessionDrawer.tsx
@@ -9,7 +9,7 @@ import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, Plus, X } from 'lucide-react';
 import { Drawer } from './shared/Drawer';
-import { createSession, getTemplates } from '../api/client';
+import { createSessionWithFallback, getTemplates } from '../api/client';
 import type { SessionTemplate } from '../types';
 import { useToastStore } from '../store/useToastStore';
 import { useDrawerStore } from '../store/useDrawerStore';
@@ -86,7 +86,7 @@ export function NewSessionDrawer() {
 
     setLoading(true);
     try {
-      const session = await createSession({
+      const session = await createSessionWithFallback({
         workDir: workDir.trim(),
         name: name.trim() || undefined,
         claudeCommand: claudeCommand.trim() || undefined,

--- a/dashboard/src/components/tour/FirstRunTour.tsx
+++ b/dashboard/src/components/tour/FirstRunTour.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { X, PlayCircle, CheckCircle2, Shield, Trash2, Lightbulb } from 'lucide-react';
-import { createSession, approve, killSession, getSessions } from '../../api/client';
+import { createSessionWithFallback, approve, killSession, getSessions } from '../../api/client';
 import { useToastStore } from '../../store/useToastStore';
 import type { SessionInfo } from '../../types';
 import { useT } from '../../i18n/context';
@@ -43,7 +43,7 @@ export function FirstRunTour({ onComplete }: FirstRunTourProps) {
     setError(null);
     
     try {
-      const result = await createSession({
+      const result = await createSessionWithFallback({
         workDir: SANDBOX_DIR,
         name: 'aegis-tour',
         prompt: 'This is a tutorial session. Say "Hello from the tour!"',

--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -5,7 +5,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FileText, Loader2, Plus, ArrowLeft, Star, Clock, X } from 'lucide-react';
-import { createSession, getTemplates } from '../api/client';
+import { createSessionWithFallback, getTemplates } from '../api/client';
 import type { SessionTemplate } from '../types';
 import { useToastStore } from '../store/useToastStore';
 import { useRecentDirs } from '../hooks/useRecentDirs';
@@ -61,7 +61,7 @@ export default function NewSessionPage() {
 
     setLoading(true);
     try {
-      const session = await createSession({
+      const session = await createSessionWithFallback({
         workDir: workDir.trim(),
         name: name.trim() || undefined,
         claudeCommand: claudeCommand.trim() || undefined,


### PR DESCRIPTION
## Summary
Fixes #3738

The dashboard's `createSession()` relied on POST /v1/sessions returning a valid `SessionInfo` object. When the API returned a malformed response (Zod validation failure), the UI would break silently — the session was created but the user couldn't navigate to it.

## Changes
- **New `createSessionWithFallback()`** in `api/client.ts`: wraps `createSession` with a try/catch that catches Zod validation errors and falls back to refetching the session list. Auth errors, network errors, and HTTP 4xx/5xx propagate immediately.
- **Updated 4 UI components** to use the resilient variant: `CreateSessionModal`, `NewSessionDrawer`, `NewSessionPage`, `FirstRunTour`
- **6 new unit tests** covering happy path, fallback on validation failure, empty list error, and error propagation (401/500/network)

## Test evidence
- `tsc --noEmit` clean
- 38/38 tests pass (createSessionWithFallback + CreateSessionModal + NewSessionDrawer + NewSessionPage)
- 30/30 client.test.ts tests pass (unchanged)

— Daedalus
