### PR TITLE
chore: bundle hygiene — direct ACP imports + shared backoff (#3781)

### DIFF
--- a/src/__tests__/rate-limit-retry-3754.test.ts
+++ b/src/__tests__/rate-limit-retry-3754.test.ts
@@ -270,8 +270,9 @@ describe('Issue #3754: Rate-limit retry logic', () => {
     const match = msg.match(/in (\d+)s…/);
     expect(match).not.toBeNull();
     const delaySec = parseInt(match![1], 10);
-    // Base is 10s, cap is 15s — first attempt should be 10s (+ up to 1s jitter)
-    expect(delaySec).toBeGreaterThanOrEqual(10);
-    expect(delaySec).toBeLessThanOrEqual(15);
+    // Base is 10s, cap is 15s — computeDelayMs uses multiplicative jitter (0.5–1.0x)
+    // First attempt: 10000 * [0.5..1.0] = 5000–10000ms → 5–10s
+    expect(delaySec).toBeGreaterThanOrEqual(5);
+    expect(delaySec).toBeLessThanOrEqual(10);
   });
 });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -27,6 +27,7 @@ import { type AlertManager } from './alerting.js';
 import { type MetricsCollector } from './metrics.js';
 import { startToolSpan, setToolResult, spanOk } from './tracing.js';
 import type { Span } from '@opentelemetry/api';
+import { computeDelayMs } from './retry.js';
 
 /** Stub: parse "Cogitated for Xm Ys" from status text. Returns duration in ms or null. */
 function parseCogitatedDuration(_statusText: string): number | null {
@@ -495,9 +496,8 @@ export class SessionMonitor {
     if (this.acpBackend && retryAttempt <= maxRetries) {
       const baseDelay = this.config.rateLimitBaseDelayMs;
       const maxDelay = this.config.rateLimitMaxDelayMs;
-      // Exponential backoff with jitter: min(base * 2^attempt + jitter, max)
-      const jitter = Math.floor(Math.random() * 1000);
-      const delayMs = Math.min(baseDelay * Math.pow(2, retryAttempt - 1) + jitter, maxDelay);
+      // Exponential backoff with jitter (shared computeDelayMs from retry.ts)
+      const delayMs = computeDelayMs(retryAttempt, baseDelay, maxDelay);
       this.rateLimitRetryAttempts.set(session.id, retryAttempt);
       await this.channels.statusChange(
         this.makePayload('status.rate_limited', session,

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -21,7 +21,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function computeDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+export function computeDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
   const exponential = Math.min(baseDelayMs * (2 ** (attempt - 1)), maxDelayMs);
   const jitterMultiplier = 0.5 + (Math.random() * 0.5);
   return Math.round(exponential * jitterMultiplier);

--- a/src/server.ts
+++ b/src/server.ts
@@ -72,14 +72,11 @@ import { AlertManager } from './alerting.js';
 import { InMemoryPauseInterventionStore } from './services/acp/in-memory-pause-intervention-store.js';
 import { isWindowsShutdownMessage, parseShutdownTimeoutMs } from './shutdown-utils.js';
 import { ServiceContainer } from './container.js';
-import {
-  AcpBackend,
-  AcpSessionService,
-  AcpTerminalBridge,
-  createFileAcpLocalStorageProfile,
-  mapAcpJsonRpcNotificationToEvent,
-  type AcpLocalStorageProfile,
-} from './services/acp/index.js';
+import { AcpBackend } from './services/acp/backend.js';
+import { AcpSessionService } from './services/acp/session-service.js';
+import { AcpTerminalBridge } from './services/acp/terminal-bridge.js';
+import { createFileAcpLocalStorageProfile, type AcpLocalStorageProfile } from './services/acp/local-storage.js';
+import { mapAcpJsonRpcNotificationToEvent } from './services/acp/event-mapper.js';
 import {
   registerHealthRoutes,
   registerAuthRoutes,


### PR DESCRIPTION
## Summary

Implements Priorities 1 and 3 from #3781 (bundle hygiene audit).

### Priority 1: Eliminate barrel-driven eager loading (~158KB / 7.4%)
- `server.ts` previously imported 6 symbols from `services/acp/index.js` (the barrel)
- The barrel re-exports ALL 25+ ACP sub-modules including deferred Phase 4 modules
- Node.js eagerly loads all re-exported modules at import time
- **Fix:** Replace barrel import with 5 direct submodule imports
- Result: Postgres stores, Redis coordination, fanout, action-worker, action-queue no longer loaded at server startup

### Priority 3: Unify backoff logic
- `monitor.ts` had inline exponential backoff: `min(base * 2^attempt + jitter, max)`
- `retry.ts` has `computeDelayMs()` using multiplicative jitter: `exponential * (0.5 + random * 0.5)`
- **Fix:** Export `computeDelayMs` from `retry.ts`, use it in `monitor.ts`
- The full-jitter strategy is superior to additive jitter for thundering herd avoidance

### Files changed
| File | Change |
|------|--------|
| `src/server.ts` | Barrel → 5 direct imports |
| `src/retry.ts` | Export `computeDelayMs` |
| `src/monitor.ts` | Use `computeDelayMs` from retry.ts |
| `src/__tests__/rate-limit-retry-3754.test.ts` | Update jitter expectations |

## Verification

```
tsc --noEmit: ✅
npm run build: ✅
npm test (server + acp + monitor): ✅ 539 passed (2 skipped)
```

> Note: Full `npm test` OOM-killed on this host (pre-existing system memory issue). All affected test suites verified individually.

Fixes #3781