### PR TITLE
docs: rate-limit auto-retry + Telegram compact format (#3779, #3780)

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -470,6 +470,25 @@ aegis_permission_response_ms_avg > 60000
 
 Until the Prometheus endpoint ships, scrape `/v1/metrics` via a Prometheus `scrape_configs` HTTP scrape target.
 
+### Automatic Rate-Limit Retry
+
+When running parallel Claude Code sessions, Anthropic rate limits (429/overloaded) can cause CC to terminate sessions as `StopFailure`. Aegis automatically recovers:
+
+1. **Detects** rate-limit `StopFailure` from the CC process
+2. **Restarts** the session automatically with exponential backoff
+3. **Notifies** you via configured channels (retrying X/3 in Ns…, success, or exhaustion)
+4. **Resets** retry counter when the session resumes activity
+
+**Default retry parameters** (internal MonitorConfig):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `rateLimitMaxRetries` | 3 | Max retry attempts per rate-limited session |
+| `rateLimitBaseDelayMs` | 5 000 | Base delay for exponential backoff (5s) |
+| `rateLimitMaxDelayMs` | 60 000 | Max delay cap for exponential backoff (60s) |
+
+Backoff formula: `min(baseDelay × 2^attempt + randomJitter, maxDelay)` — prevents thundering herd on parallel retries.
+
 ### Diagnostics
 
 ```bash

--- a/docs/integrations/notifications.md
+++ b/docs/integrations/notifications.md
@@ -29,9 +29,26 @@ AEGIS_TG_GROUP_ID=-1001234567890
 AEGIS_TG_ALLOWED_USERS=user1,user2  # optional
 ```
 
+### Message Format
+
+By default, Telegram uses **compact mode** — a clean, cc-connect–style format:
+
+```
+[20/05/2026 05:45] User: List files in the project
+🛠️ Exec: ls -la /home/user/project
+🛠️ Exec: completed; 12 files found
+🧰 Process: my-session
+```
+
+Key behaviors in compact mode:
+- Timestamps use `[DD/MM/YYYY HH:MM]` format
+- Tool executions show a one-line summary (`🛠️ Exec: ...`)
+- Trivial results (ok, done, success) are suppressed
+- Session creation shows process name + details
+
 ### Verbose Mode
 
-Enable verbose mode to forward full Claude Code output (thinking, tool calls, code) to Telegram:
+Enable verbose mode to forward full Claude Code output (thinking, tool calls, code):
 
 ```bash
 AEGIS_TG_VERBOSE=true
@@ -45,12 +62,12 @@ Or in `aegis.config.json`:
 }
 ```
 
-| Event | Without verbose | With verbose |
-|-------|----------------|-------------|
+| Event | Compact (default) | Verbose |
+|-------|-------------------|--------|
 | `message.thinking` | Silent | 💭 *thinking text* (truncated 800 chars) |
-| `message.tool_use` | Progress tracking only | 🔧 `tool.label` + code block (truncated 600 chars) |
+| `message.tool_use` | 🛠️ `Exec: summary` (one line) | 🔧 `tool.label` + code block (truncated 600 chars) |
 | `message.assistant` | Forwarded | Forwarded (unchanged) |
-| `message.user` | Forwarded | Forwarded (unchanged) |
+| `message.user` | `[timestamp] User: text` | `[timestamp] User: text` |
 
 ### Events
 


### PR DESCRIPTION
## Summary

Documents two recently merged features:

### 1. Automatic Rate-Limit Retry (#3779 → #3754)
- CC upstream rate limits (429/overloaded) now trigger automatic session restart
- Added **Automatic Rate-Limit Retry** section to `enterprise.md` with retry parameters table
- Documents MonitorConfig defaults: 3 retries, 5s base backoff, 60s max

### 2. Telegram Compact Format (#3780 → #3747)
- Default Telegram format changed from verbose to **compact** (cc-connect style)
- Updated `notifications.md`: renamed section to Message Format, added compact example
- Updated format comparison table (compact vs verbose)
- Note: `AEGIS_TG_VERBOSE=true` still enables old verbose format

### Files Changed
| File | Change |
|------|--------|
| `docs/enterprise.md` | +Automatic Rate-Limit Retry section |
| `docs/integrations/notifications.md` | +compact format docs, updated table |