### PR TITLE
fix(validation): include allowed directories in INVALID_WORKDIR error

### DIFF
--- a/src/__tests__/allowed-dirs-hint-3798.test.ts
+++ b/src/__tests__/allowed-dirs-hint-3798.test.ts
@@ -1,0 +1,64 @@
+/**
+ * allowed-dirs-hint-3798.test.ts — Tests for Issue #3798.
+ *
+ * When workDir is rejected, the error message must include
+ * the list of allowed directories so the user knows what's permitted.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateWorkDir } from '../validation.js';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+
+const tmpBase = path.join(os.tmpdir(), `aegis-test-3798-${process.pid}`);
+
+beforeEach(async () => {
+  await fs.mkdir(tmpBase, { recursive: true });
+});
+
+describe('Issue #3798: error message includes allowed directories', () => {
+  it('includes allowed dirs in rejection message (default safe dirs)', async () => {
+    // /tmp is not in default safe dirs (homedir + cwd)
+    const result = await validateWorkDir('/tmp');
+    expect(typeof result).toBe('object');
+    if (typeof result === 'object') {
+      expect(result.code).toBe('INVALID_WORKDIR');
+      // Must mention "Allowed:" with at least homedir
+      expect(result.error).toContain('Allowed:');
+      expect(result.error).toContain(os.homedir());
+    }
+  });
+
+  it('includes custom allowed dirs in rejection message', async () => {
+    const allowedDir = path.join(tmpBase, 'project-a');
+    const rejectedDir = path.join(tmpBase, 'project-b');
+    await fs.mkdir(allowedDir, { recursive: true });
+    await fs.mkdir(rejectedDir, { recursive: true });
+
+    const result = await validateWorkDir(rejectedDir, [allowedDir]);
+    expect(typeof result).toBe('object');
+    if (typeof result === 'object') {
+      expect(result.code).toBe('INVALID_WORKDIR');
+      expect(result.error).toContain('Allowed:');
+      expect(result.error).toContain(allowedDir);
+    }
+  });
+
+  it('includes multiple allowed dirs when configured', async () => {
+    const dir1 = path.join(tmpBase, 'alpha');
+    const dir2 = path.join(tmpBase, 'beta');
+    const rejectedDir = path.join(tmpBase, 'gamma');
+    await fs.mkdir(dir1, { recursive: true });
+    await fs.mkdir(dir2, { recursive: true });
+    await fs.mkdir(rejectedDir, { recursive: true });
+
+    const result = await validateWorkDir(rejectedDir, [dir1, dir2]);
+    expect(typeof result).toBe('object');
+    if (typeof result === 'object') {
+      expect(result.code).toBe('INVALID_WORKDIR');
+      expect(result.error).toContain('Allowed:');
+      expect(result.error).toContain(dir1);
+      expect(result.error).toContain(dir2);
+    }
+  });
+});

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -782,7 +782,7 @@ export async function validateWorkDir(
   if (!preAllowed) {
     const hint = windowsSuggestion
       ? ` Did you mean \`${windowsSuggestion}\`?`
-      : ' Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory.';
+      : ` Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory. Allowed: ${candidateSafeDirs.join(", ")}`;
     return { error: `workDir ${resolved} is not in the allowed directories list.${hint}`, code: 'INVALID_WORKDIR' };
   }
 
@@ -800,7 +800,7 @@ export async function validateWorkDir(
   if (!allowed) {
     const hint = windowsSuggestion
       ? ` Did you mean \`${windowsSuggestion}\`?`
-      : ' Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory.';
+      : ` Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory. Allowed: ${candidateSafeDirs.join(", ")}`;
     return { error: `workDir ${resolved} is not in the allowed directories list.${hint}`, code: 'INVALID_WORKDIR' };
   }
 


### PR DESCRIPTION
## Summary
Fixes #3798

When `workDir` is rejected for not being in `allowedWorkDirs`, the error message now includes the list of currently allowed directories so users know what paths are permitted.

### Before
```
workDir /tmp is not in the allowed directories list. Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory.
```

### After
```
workDir /tmp is not in the allowed directories list. Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory. Allowed: /home/user, /home/user/projects
```

### Changes
- `src/validation.ts`: Updated both INVALID_WORKDIR rejection messages (pre-allowlist check + canonical check) to append `Allowed: <dirs>` to the hint
- `src/__tests__/allowed-dirs-hint-3798.test.ts`: 3 new tests verifying the "Allowed:" string appears in error messages for default and custom configs

### Verification
```
tsc --noEmit: ✅ (0 errors)
npm run build: ✅
Tests: ✅ 44 passed (4 test files: allowed-dirs-hint + template-workdir + workdir-not-found + path-traversal)
```

### Session
Direct implementation (CC session f5b78e59 stalled after Skill tool invocation — recurring MCP stall pattern).