### PR TITLE
fix(sessions): return 422 NO_RUNNER_AVAILABLE when prompt has no runner

### DIFF
--- a/src/__tests__/no-runner-prompt-3797.test.ts
+++ b/src/__tests__/no-runner-prompt-3797.test.ts
@@ -1,0 +1,187 @@
+/**
+ * no-runner-prompt-3797.test.ts — Tests for Issue #3797.
+ *
+ * When acpEnabled=false and no runner is available, the API must not
+ * silently return 201 with promptDelivery.delivered=false. It must
+ * return 422 with NO_RUNNER_AVAILABLE.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import { registerSessionRoutes } from '../routes/sessions.js';
+import type { RouteContext } from '../routes/context.js';
+import type { SessionInfo } from '../session.js';
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'test-session-id',
+    displayName: 'test-session',
+    workDir: '/tmp/test-project',
+    status: 'idle',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    ownerKeyId: null,
+    tenantId: '_system',
+    ...overrides,
+  } as SessionInfo;
+}
+
+function buildApp(opts: { acpEnabled?: boolean; sendInitialPromptDelivered?: boolean } = {}) {
+  const sessionMap = new Map<string, SessionInfo>();
+
+  const sessions = {
+    getSession: vi.fn((id: string) => sessionMap.get(id)),
+    listSessions: vi.fn(() => Array.from(sessionMap.values())),
+    killSession: vi.fn(async () => {}),
+    save: vi.fn(async () => {}),
+    createSession: vi.fn(async (o: any) => {
+      const s = makeSession({ id: `new-${Date.now()}`, ...o });
+      sessionMap.set(s.id, s);
+      return s;
+    }),
+    findIdleSessionByWorkDir: vi.fn(async () => null),
+    sendInitialPrompt: vi.fn(async () => ({
+      delivered: opts.sendInitialPromptDelivered ?? false,
+      attempts: 0,
+    })),
+    releaseSessionClaim: vi.fn(),
+    getHealth: vi.fn(async () => ({ alive: false, claudeRunning: false, status: 'idle', hasTranscript: false, lastActivity: 0, lastActivityAgo: 0, sessionAge: 0, details: 'OK' })),
+    getSummary: vi.fn(async () => ({ summary: '', sessionId: '' })),
+    getLatencyMetrics: vi.fn(() => ({})),
+    readTranscript: vi.fn(async () => ({ messages: [], total: 0, page: 1, limit: 50, hasMore: false })),
+    readTranscriptCursor: vi.fn(async () => ({ messages: [], hasMore: false, nextCursorId: null })),
+    getPendingPermissionInfo: vi.fn(() => null),
+    getPendingQuestionInfo: vi.fn(() => null),
+  };
+
+  const ctx = {
+    sessions,
+    auth: {
+      authEnabled: false,
+      getKey: vi.fn(() => ({ role: 'admin', permissions: ['create', 'kill'] })),
+      check: vi.fn(() => ({ valid: true, keyId: null, permission: 'create' })),
+      getPermissions: vi.fn(() => ['create', 'kill']),
+      getRole: vi.fn(() => 'admin'),
+    },
+    config: { sseIdleMs: 30000, sseClientTimeoutMs: 60000, acpEnabled: opts.acpEnabled ?? false, envDenylist: [], envAdminAllowlist: [] },
+    quotas: { checkSessionQuota: vi.fn(() => ({ allowed: true })) },
+    metrics: { sessionCreated: vi.fn(), sessionCompleted: vi.fn(), sessionFailed: vi.fn(), promptSent: vi.fn(), getGlobalMetrics: vi.fn(() => ({})), getSessionMetrics: vi.fn(() => ({})), getSessionLatency: vi.fn(() => ({})), recordPermissionResponse: vi.fn(), cleanupSession: vi.fn() },
+    monitor: { removeSession: vi.fn() },
+    eventBus: { subscribe: vi.fn(() => vi.fn()), emitStatus: vi.fn(), emitVerification: vi.fn(), emitApproval: vi.fn(), emitEnded: vi.fn(), getEventsSince: vi.fn(() => []) },
+    channels: { sessionCreated: vi.fn(async () => {}), sessionEnded: vi.fn(async () => {}), statusChange: vi.fn(async () => {}) },
+    toolRegistry: { getSessionTools: vi.fn(() => []), processEntries: vi.fn(), cleanupSession: vi.fn(), getToolDefinitions: vi.fn(() => []) },
+    sseLimiter: { acquire: vi.fn(() => ({ allowed: true })), release: vi.fn(), unregisterWriter: vi.fn() },
+    memoryBridge: null,
+    validateWorkDir: vi.fn(async (dir: string) => dir),
+    getAuditLogger: vi.fn(() => ({ log: vi.fn(async () => {}), query: vi.fn(async () => []) })),
+    alertManager: {},
+    jsonlWatcher: {} as any,
+    pipelines: {} as any,
+    requestKeyMap: new Map(),
+    serverState: { draining: false },
+    metering: {} as any,
+    metricsCache: {} as any,
+    acpBackend: null,
+    eventStore: { list: vi.fn(async () => []) },
+  } as unknown as RouteContext;
+
+  const app = Fastify({ logger: false });
+  app.addHook('onRequest', async (req: any) => {
+    req.authKeyId = null;
+    req.tenantId = '_system';
+    req.matchedPermission = 'create';
+  });
+
+  registerSessionRoutes(app, ctx);
+
+  return { app, sessions, ctx };
+}
+
+describe('Issue #3797: NO_RUNNER_AVAILABLE when no runner and prompt provided', () => {
+  let app: ReturnType<typeof buildApp>['app'];
+  let sessions: ReturnType<typeof buildApp>['sessions'];
+
+  beforeEach(async () => {
+    ({ app, sessions } = buildApp({ acpEnabled: false }));
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 422 NO_RUNNER_AVAILABLE on create path when ACP disabled', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      payload: {
+        workDir: '/tmp/test-project',
+        prompt: 'Hello, do something',
+      },
+    });
+
+    expect(response.statusCode).toBe(422);
+    const body = response.json();
+    expect(body.error).toBe('NO_RUNNER_AVAILABLE');
+    expect(body.message).toContain('no agent runner available');
+  });
+
+  it('returns 422 NO_RUNNER_AVAILABLE on reuse path when ACP disabled', async () => {
+    // Create a pre-existing idle session so reuse path triggers
+    const existing = makeSession({ id: 'idle-1', workDir: '/tmp/test-project', status: 'idle' });
+    sessions.createSession = vi.fn(async (o: any) => {
+      const s = makeSession({ id: 'idle-1', ...o });
+      return s;
+    });
+    sessions.findIdleSessionByWorkDir = vi.fn(async () => existing) as any;
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      payload: {
+        workDir: '/tmp/test-project',
+        prompt: 'Reuse and fail',
+      },
+    });
+
+    expect(response.statusCode).toBe(422);
+    const body = response.json();
+    expect(body.error).toBe('NO_RUNNER_AVAILABLE');
+  });
+
+  it('creates session without prompt when ACP disabled (no runner needed)', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      payload: {
+        workDir: '/tmp/test-project',
+      },
+    });
+
+    // Without a prompt, no runner is needed — session should be created normally
+    expect(response.statusCode).toBe(201);
+  });
+
+  it('allows prompt delivery when ACP is enabled', async () => {
+    const { app: acpApp } = buildApp({ acpEnabled: true, sendInitialPromptDelivered: false });
+    // When ACP is enabled, the ACP backend handles delivery — we skip the 422 check
+    // (the ACP path is separate and handled by acpBackend.sendPrompt)
+    await acpApp.ready();
+
+    const response = await acpApp.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      payload: {
+        workDir: '/tmp/test-project',
+        prompt: 'Hello with ACP',
+      },
+    });
+
+    // With ACP enabled but no acpBackend, it goes to createSession (non-ACP else branch)
+    // then sendInitialPrompt returns false — but since acpEnabled is true, it should NOT 422
+    // Actually: acpEnabled=true but acpBackend=null means it goes to the else branch (no ACP backend)
+    // and sendInitialPrompt returns false. The check is !ctx.config.acpEnabled — since it's true,
+    // the 422 should NOT trigger. The session will be created with delivered=false but no 422.
+    expect(response.statusCode).toBe(201);
+    await acpApp.close();
+  });
+});

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -428,6 +428,13 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           : await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
+        // Issue #3797: Fail loudly when prompt delivery fails due to no runner
+        if (prompt && promptDelivery && !promptDelivery.delivered && !ctx.config.acpEnabled) {
+          return reply.status(422).send({
+            error: 'NO_RUNNER_AVAILABLE',
+            message: 'Prompt not delivered: no agent runner available. Enable ACP by setting AEGIS_ACP_ENABLED=true or adding "acpEnabled": true to .aegis/config.yaml.',
+          });
+        }
         return reply.status(200).send({ ...redactSession(existing as unknown as Record<string, unknown>), reused: true, promptDelivery });
       } finally {
         sessions.releaseSessionClaim(existing.id);
@@ -513,12 +520,19 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       }
     }
 
-    // Issue #3068: Warn when ACP is disabled — sessions are created but no agent runs
-    const acpWarning = prompt && !ctx.config.acpEnabled && promptDelivery && !promptDelivery.delivered
-      ? 'Session created but prompt not delivered: ACP is disabled. Set AEGIS_ACP_ENABLED=true or add "acpEnabled": true to config to enable Claude Code sessions.'
-      : undefined;
+    // Issue #3797: When prompt provided but no runner available, return 422 instead of 201 with silent failure.
+    // This prevents the API from returning promptDelivery.delivered=false while looking successful.
+    if (prompt && promptDelivery && !promptDelivery.delivered && !ctx.config.acpEnabled) {
+      await sessions.killSession(session.id);
+      cleanupTerminatedSessionState(session.id, { monitor, metrics, toolRegistry });
+      return reply.status(422).send({
+        error: 'NO_RUNNER_AVAILABLE',
+        message: 'Session not created: no agent runner available to execute the prompt. Enable ACP by setting AEGIS_ACP_ENABLED=true or adding "acpEnabled": true to .aegis/config.yaml.',
+        hint: 'The session was created then cleaned up because no runner could deliver the prompt.',
+      });
+    }
 
-    return reply.status(201).send({ ...redactSession(session as unknown as Record<string, unknown>), promptDelivery, ...(acpWarning ? { warning: acpWarning } : {}) });
+    return reply.status(201).send({ ...redactSession(session as unknown as Record<string, unknown>), promptDelivery });
   }
   registerWithLegacy(app, 'post', '/v1/sessions', {
     config: {


### PR DESCRIPTION
## Summary
Fixes #3797

When `acpEnabled: false` and no agent runner is available, creating a session with a prompt now returns **422 NO_RUNNER_AVAILABLE** instead of 201 with a silent `promptDelivery.delivered=false`.

### Before
```json
HTTP 201
{ "id": "...", "status": "idle", "promptDelivery": { "delivered": false, "attempts": 0 }, "warning": "..." }
```
User sees "session created" but nothing runs. The warning is buried in the response.

### After
```json
HTTP 422
{ "error": "NO_RUNNER_AVAILABLE", "message": "Session not created: no agent runner available...", "hint": "..." }
```
Clear, immediate error. Session is cleaned up — no zombie sessions.

### Changes
- `src/routes/sessions.ts`:
  - **Create path**: When prompt delivery fails and ACP is disabled, kill the session, clean up state, return 422
  - **Reuse path**: Same 422 check when reusing an idle session
  - Sessions without a prompt still create normally (no runner needed)
- `src/__tests__/no-runner-prompt-3797.test.ts`: 4 tests
  - 422 on create path with ACP disabled
  - 422 on reuse path with ACP disabled
  - 201 on create without prompt (no runner needed)
  - 201 with ACP enabled (ACP handles delivery)

### Verification
```
tsc --noEmit: ✅ (0 errors)
npm run build: ✅
Tests: ✅ 4/4 new + 43/43 existing session-route tests
```

### Session
Direct implementation (CC sessions stall — recurring MCP tool delivery bug).