### PR TITLE
fix(cli): ag run --help shows run-specific flags instead of generic help

### DIFF
--- a/src/__tests__/run-help-3796.test.ts
+++ b/src/__tests__/run-help-3796.test.ts
@@ -1,0 +1,52 @@
+/**
+ * run-help-3796.test.ts — Tests for Issue #3796.
+ *
+ * `ag run --help` should show run-specific help, not generic ag help.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCli, CliIO } from '../cli.js';
+
+function makeIo(lines: string[]): CliIO {
+  return {
+    stdin: process.stdin,
+    stdout: { write: (s: string) => { lines.push(s); }, end: () => {} } as any,
+    stderr: { write: () => {}, end: () => {} } as any,
+  };
+}
+
+describe('Issue #3796: ag run --help shows run-specific flags', () => {
+  it('shows run-specific help for "ag run --help"', async () => {
+    const lines: string[] = [];
+    const exitCode = await runCli(['run', '--help'], makeIo(lines));
+    const output = lines.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('ag run');
+    expect(output).toContain('--cwd');
+    expect(output).toContain('--model');
+    expect(output).toContain('--no-stream');
+    // Should NOT contain generic ag commands like 'ag init' or 'ag list'
+    expect(output).not.toContain('ag init');
+    expect(output).not.toContain('ag list');
+  });
+
+  it('shows run-specific help for "ag run -h"', async () => {
+    const lines: string[] = [];
+    const exitCode = await runCli(['run', '-h'], makeIo(lines));
+    const output = lines.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('ag run');
+    expect(output).toContain('--cwd');
+  });
+
+  it('shows generic help for "ag --help" (no subcommand)', async () => {
+    const lines: string[] = [];
+    const exitCode = await runCli(['--help'], makeIo(lines));
+    const output = lines.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Usage:');
+    expect(output).toContain('ag run');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -368,7 +368,11 @@ ${authBlock}  Flags:
 
 /** Main CLI entry point that dispatches subcommands and bootstraps the server. */
 export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO = defaultCliIO): Promise<number> {
-  if (argv.includes('--help') || argv.includes('-h')) {
+  // Issue #3796: Only show generic help if no subcommand is provided.
+  // Subcommands like 'run' handle their own --help with command-specific flags.
+  const knownCommands = ['mcp', 'init', 'doctor', 'create', 'login', 'logout', 'whoami', 'run', 'list', 'read', 'status', 'kill', 'sessions', 'stop', 'send', 'version', 'setup'];
+  const hasKnownCommand = argv.length > 0 && knownCommands.includes(argv[0]);
+  if ((argv.includes('--help') || argv.includes('-h')) && !hasKnownCommand) {
     printHelp(io);
     return 0;
   }


### PR DESCRIPTION
## Summary
Fixes #3796

`ag run --help` now shows run-specific options (--cwd, --model, --timeout, etc.) instead of the generic `ag` help.

### Before
```
$ ag run --help
Usage: ag <command> [options]
Commands:
  run       Create session and stream output
  init      Initialize Aegis config
  ...
```

### After
```
$ ag run --help

  ag run <prompt> [options]

  Create a session, deliver a brief, and stream output.

  Arguments:
    <prompt>              Task description for Claude

  Options:
    --cwd <path>          Working directory (default: current directory)
    --model <model>       Set Claude model
    --no-stream           Don't stream output
    ...
```

### Root Cause
The top-level `--help` check in `cli.ts` intercepted ALL `--help` flags before subcommand handlers could process them.

### Fix
Generic help only triggers when no known subcommand is provided. Subcommands with their own `--help` handling (currently `run`) now get to process it first.

### Changes
- `src/cli.ts`: Skip generic help when a known subcommand is present; let the subcommand handle `--help`
- `src/__tests__/run-help-3796.test.ts`: 3 tests (run --help, run -h, ag --help still works)

### Verification
```
tsc --noEmit: ✅
npm run build: ✅
Tests: ✅ 3/3 passed
```