### PR TITLE
fix(dashboard): Batch B dogfooding fixes (#3815, #3816, #3810, #3820)

### DIFF
--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -527,7 +527,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
 
           {/* Error */}
           {error && (
-            <div className="text-xs text-[var(--color-danger)] bg-[var(--color-danger)]/10 border border-[var(--color-danger)]/20 rounded px-3 py-2">
+            <div className="text-xs text-[var(--color-error)] bg-[var(--color-error)]/10 border border-[var(--color-error)]/20 rounded px-3 py-2">
               {error}
             </div>
           )}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -245,13 +245,16 @@ export default function Layout() {
 
     const mediaQuery = window.matchMedia(MOBILE_SIDEBAR_QUERY);
     let wasMobileViewport = mediaQuery.matches;
+    let hasAutoOpened = false;
 
     const handleViewportChange = () => {
       const nextIsMobileViewport = mediaQuery.matches;
       setIsMobileViewport(nextIsMobileViewport);
 
-      if (!wasMobileViewport && nextIsMobileViewport) {
+      // Only auto-open once on the first desktop→mobile transition (fixes #3820)
+      if (!hasAutoOpened && !wasMobileViewport && nextIsMobileViewport) {
         setMobileOpen(true);
+        hasAutoOpened = true;
       }
 
       wasMobileViewport = nextIsMobileViewport;

--- a/dashboard/src/components/overview/StatusDot.tsx
+++ b/dashboard/src/components/overview/StatusDot.tsx
@@ -18,11 +18,11 @@ const STATUS_COLORS: Record<UIState, string> = {
   compacting: 'var(--color-warning)',
   context_warning: 'var(--color-warning)',
   waiting_for_input: 'var(--color-warning)',
-  pending: '#f0ad4e',  // amber — visually distinct from unknown gray
-  unknown: '#666',
-  killed: '#888',
-  completed: '#4CAF50',
-  crashed: '#F44336',
+  pending: 'var(--color-dot-pending)',
+  unknown: 'var(--color-dot-unknown)',
+  killed: 'var(--color-dot-killed)',
+  completed: 'var(--color-dot-completed)',
+  crashed: 'var(--color-dot-crashed)',
 };
 
 const HEALTH_COLORS: Record<SessionHealthState, string> = {

--- a/dashboard/src/hooks/useSwipeGesture.ts
+++ b/dashboard/src/hooks/useSwipeGesture.ts
@@ -6,20 +6,37 @@ interface SwipeGestureOptions {
   onSwipe: (direction: SwipeDirection, touchPoint: { x: number; y: number }) => void;
   threshold?: number;
   enabled?: boolean;
+  /** Attach to a specific element instead of window */
+  elementRef?: React.RefObject<HTMLElement | null>;
+  /** Ignore swipes starting within N px of screen edge (default: 30) */
+  edgeExclusion?: number;
 }
 
 export function useSwipeGesture({
   onSwipe,
   threshold = 50,
   enabled = true,
+  elementRef,
+  edgeExclusion = 30,
 }: SwipeGestureOptions) {
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
 
+    const target = elementRef?.current ?? window;
+
     const handleTouchStart = (e: TouchEvent) => {
       const touch = e.touches[0];
+      // Ignore edge swipes that could conflict with browser back gesture
+      if (
+        touch.clientX < edgeExclusion ||
+        touch.clientX > window.innerWidth - edgeExclusion ||
+        touch.clientY < edgeExclusion ||
+        touch.clientY > window.innerHeight - edgeExclusion
+      ) {
+        return;
+      }
       touchStartRef.current = { x: touch.clientX, y: touch.clientY };
     };
 
@@ -45,12 +62,12 @@ export function useSwipeGesture({
       touchStartRef.current = null;
     };
 
-    window.addEventListener('touchstart', handleTouchStart, { passive: true });
-    window.addEventListener('touchend', handleTouchEnd, { passive: true });
+    (target as Window & HTMLElement).addEventListener('touchstart', handleTouchStart as EventListener, { passive: true });
+    (target as Window & HTMLElement).addEventListener('touchend', handleTouchEnd as EventListener, { passive: true });
 
     return () => {
-      window.removeEventListener('touchstart', handleTouchStart);
-      window.removeEventListener('touchend', handleTouchEnd);
+      (target as Window & HTMLElement).removeEventListener('touchstart', handleTouchStart as EventListener);
+      (target as Window & HTMLElement).removeEventListener('touchend', handleTouchEnd as EventListener);
     };
-  }, [onSwipe, threshold, enabled]);
+  }, [onSwipe, threshold, enabled, elementRef, edgeExclusion]);
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -66,6 +66,13 @@
   --color-success-rgb: 34, 197, 94;
   --color-warning: #f59e0b;
   --color-warning-rgb: 245, 158, 11;
+  --color-dot-pending: #f0ad4e;
+  --color-dot-unknown: #666;
+  --color-dot-killed: #888;
+  --color-dot-completed: #4CAF50;
+  --color-dot-crashed: #F44336;
+  --color-dot-orange: #f97316;
+  --color-dot-red: #ef4444;
   --color-info: #3b82f6;
 
   /* Chart & Metrics */


### PR DESCRIPTION
## Summary
Closes #3815, #3816, #3810, #3820

### #3815 — Error color tokens inconsistent
CreateSessionModal template mode used `--color-danger` (destructive action) for error display. Changed to `--color-error` to match single/batch modes.

### #3816 — StatusDot hardcoded hex → CSS variables
5 statuses (pending, unknown, killed, completed, crashed) used raw hex colors. Added `--color-dot-*` CSS variables to index.css. StatusDot now references these tokens exclusively.

### #3810 — Mobile swipe conflicts with browser back
`useSwipeGesture` now ignores swipes starting within 30px of screen edges, preventing conflicts with iOS/Chrome browser back gesture. Also added optional `elementRef` prop for scoped attachment.

### #3820 — Mobile sidebar auto-opens on resize
Sidebar auto-opened on every desktop→mobile viewport transition (e.g. resizing browser window). Now auto-opens only once via `hasAutoOpened` guard.

## Test evidence
- `tsc --noEmit` clean
- 40/40 tests pass (CreateSessionModal + client)

— Daedalus