### PR TITLE
fix(dashboard): Batch D dogfooding fixes (#3808, #3812, #3813, #3814)

### DIFF
--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -508,16 +508,15 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
           abortRef.current = controller;
 
           try {
-            // Validate workDir before submit
-      const dirError = validateWorkDir(workDir);
-      if (dirError) {
-        setWorkDirError(dirError);
-        workDirRef.current?.focus();
-        return;
-      }
-      setWorkDirError(null);
+            // Validate workDir before submit (batch uses template.workDir)
+            const dirError = validateWorkDir(template.workDir);
+            if (dirError) {
+              setError(dirError);
+              setLoading(false);
+              return;
+            }
 
-      const session = await createSessionWithFallback({
+            const session = await createSessionWithFallback({
               workDir: template.workDir,
               prompt: template.prompt,
               claudeCommand: template.claudeCommand,

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -9,7 +9,7 @@ import { X, Loader2, Plus, Trash2 } from 'lucide-react';
 import { createSessionWithFallback, batchCreateSessions, getTemplates } from '../api/client';
 import type { SessionTemplate } from '../types';
 import { useT } from '../i18n/context';
-import { PERMISSION_MODES } from '../utils/sessionCreation';
+import { PERMISSION_MODES, validateWorkDir } from '../utils/sessionCreation';
 
 interface CreateSessionModalProps {
   open: boolean;
@@ -68,6 +68,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
   const [workDir, setWorkDir] = useState('');
   const [name, setName] = useState('');
   const [claudeCommand, setClaudeCommand] = useState('');
+  const [workDirError, setWorkDirError] = useState<string | null>(null);
   const [prompt, setPrompt] = useState('');
   const [permissionMode, setPermissionMode] = useState('default');
   const [loading, setLoading] = useState(false);
@@ -167,6 +168,15 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
     const controller = new AbortController();
     abortRef.current = controller;
     try {
+      // Validate workDir before submit
+      const dirError = validateWorkDir(workDir);
+      if (dirError) {
+        setWorkDirError(dirError);
+        workDirRef.current?.focus();
+        return;
+      }
+      setWorkDirError(null);
+
       const session = await createSessionWithFallback({
         workDir: workDir.trim(),
         name: name.trim() || undefined,
@@ -261,7 +271,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               type="text"
               ref={workDirRef}
               value={workDir}
-              onChange={(e) => setWorkDir(e.target.value)}
+              onChange={(e) => { setWorkDir(e.target.value); setWorkDirError(null); }}
               placeholder="/home/user/project"
               className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-gray-400 dark:placeholder-gray-600 focus-visible:outline-none focus:border-[var(--color-accent)] font-mono"
             />
@@ -279,6 +289,9 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               placeholder="my-session"
               className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-gray-400 dark:placeholder-gray-600 focus-visible:outline-none focus:border-[var(--color-accent)]"
             />
+            {workDirError && (
+              <p className="mt-1 text-xs text-[var(--color-error)]">{workDirError}</p>
+            )}
           </div>
 
           {/* Claude Command */}
@@ -491,7 +504,16 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
           abortRef.current = controller;
 
           try {
-            const session = await createSessionWithFallback({
+            // Validate workDir before submit
+      const dirError = validateWorkDir(workDir);
+      if (dirError) {
+        setWorkDirError(dirError);
+        workDirRef.current?.focus();
+        return;
+      }
+      setWorkDirError(null);
+
+      const session = await createSessionWithFallback({
               workDir: template.workDir,
               prompt: template.prompt,
               claudeCommand: template.claudeCommand,

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -580,11 +580,12 @@ export default function Layout() {
               <button
                 type="button"
                 onClick={() => setPaletteOpen(true)}
-                className="hidden min-h-[44px] sm:inline-flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] bg-white px-3 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-slate-50 hover:text-[var(--color-text-primary)] dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10 transition-all"
+                className="min-h-[44px] inline-flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] bg-white px-3 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-slate-50 hover:text-[var(--color-text-primary)] dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10 transition-all"
+                aria-label="Open command palette"
               >
                 <Search className="h-3 w-3" />
-                <span>Search…</span>
-                <kbd className="ml-1 font-mono text-[10px] text-[var(--color-text-primary)] border border-white/10 rounded px-1">⌘K</kbd>
+                <span className="hidden sm:inline">Search…</span>
+                <kbd className="hidden sm:inline ml-1 font-mono text-[10px] text-[var(--color-text-primary)] border border-white/10 rounded px-1">⌘K</kbd>
               </button>
 
               {/* Version + theme toggle */}

--- a/dashboard/src/components/NewSessionDrawer.tsx
+++ b/dashboard/src/components/NewSessionDrawer.tsx
@@ -15,7 +15,7 @@ import { useToastStore } from '../store/useToastStore';
 import { useDrawerStore } from '../store/useDrawerStore';
 import { useConfetti } from '../hooks/useConfetti';
 import { useT } from '../i18n/context';
-import { PERMISSION_MODES } from '../utils/sessionCreation';
+import { PERMISSION_MODES, validateWorkDir } from '../utils/sessionCreation';
 
 
 
@@ -31,6 +31,7 @@ export function NewSessionDrawer() {
   const [claudeCommand, setClaudeCommand] = useState('');
   const [prompt, setPrompt] = useState('');
   const [permissionMode, setPermissionMode] = useState('default');
+  const [workDirError, setWorkDirError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [templates, setTemplates] = useState<SessionTemplate[]>([]);
 
@@ -55,6 +56,7 @@ export function NewSessionDrawer() {
     } else {
       // Reset form on close
       setName('');
+      setWorkDirError(null);
       setWorkDir('');
       setClaudeCommand('');
       setPrompt('');
@@ -76,6 +78,13 @@ export function NewSessionDrawer() {
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
+    const dirError = validateWorkDir(workDir);
+    if (dirError) {
+      setWorkDirError(dirError);
+      return;
+    }
+    setWorkDirError(null);
+
     if (!workDir.trim()) {
       addToast('error', 'Missing work directory', 'Work directory is required');
       return;
@@ -139,12 +148,15 @@ export function NewSessionDrawer() {
                   id="drawer-workDir"
                   type="text"
                   value={workDir}
-                  onChange={(e) => setWorkDir(e.target.value)}
+                  onChange={(e) => { setWorkDir(e.target.value); setWorkDirError(null); }}
                   placeholder="/home/user/projects/myapp"
                   required
                   className="w-full rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent-cyan)]"
                 />
                 <p className="mt-1 text-xs text-[var(--color-text-muted)]">Absolute path where the session will run</p>
+                {workDirError && (
+                  <p className="mt-1 text-xs text-[var(--color-error)]">{workDirError}</p>
+                )}
               </div>
 
               {/* Session Name */}
@@ -211,9 +223,33 @@ export function NewSessionDrawer() {
               </div>
 
               {templates.length > 0 && (
-                <p className="text-xs text-[var(--color-text-muted)]">
-                  {templates.length} template{templates.length !== 1 ? 's' : ''} available — use the Overview page to create from template
-                </p>
+                <div>
+                  <label htmlFor="drawer-template-select" className="block text-xs font-medium text-[var(--color-text-muted)] mb-1.5">
+                    Quick fill from template
+                  </label>
+                  <select
+                    id="drawer-template-select"
+                    value=""
+                    onChange={(e) => {
+                      const tpl = templates[Number(e.target.value)];
+                      if (!tpl) return;
+                      if (tpl.name) setName(tpl.name);
+                      if (tpl.workDir) setWorkDir(tpl.workDir);
+                      if (tpl.prompt) setPrompt(tpl.prompt);
+                      if (tpl.permissionMode) setPermissionMode(tpl.permissionMode);
+                      if (tpl.claudeCommand) setClaudeCommand(tpl.claudeCommand);
+                      useToastStore.getState().addToast('info', `Applied template: ${tpl.name || 'Untitled'}`, undefined, { duration: 2000 });
+                    }}
+                    className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+                  >
+                    <option value="" disabled>
+                      {templates.length} template{templates.length !== 1 ? 's' : ''} available…
+                    </option>
+                    {templates.map((t, i) => (
+                      <option key={t.id} value={i}>{t.name || 'Untitled'}</option>
+                    ))}
+                  </select>
+                </div>
               )}
 
               {/* Actions */}

--- a/dashboard/src/components/mobile/MobilePermissionPrompt.tsx
+++ b/dashboard/src/components/mobile/MobilePermissionPrompt.tsx
@@ -93,6 +93,7 @@ export function MobilePermissionPrompt({
     },
     threshold: 80,
     enabled: !showContextMenu,
+    elementRef: containerRef,
   });
 
   const handleTouchStart = (e: React.TouchEvent) => {

--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -11,6 +11,7 @@ import { useToastStore } from '../store/useToastStore';
 import { useRecentDirs } from '../hooks/useRecentDirs';
 import { sanitizeErrorMessage } from '../utils/sanitizeErrorMessage';
 import { useT } from '../i18n/context';
+import { validateWorkDir } from '../utils/sessionCreation';
 
 export default function NewSessionPage() {
   const navigate = useNavigate();
@@ -57,6 +58,12 @@ export default function NewSessionPage() {
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
+    const dirError = validateWorkDir(workDir);
+    if (dirError) {
+      addToast('error', dirError);
+      return;
+    }
+
     if (!workDir.trim()) {
       addToast('error', t('newSession.missingWorkDir'), t('newSession.missingWorkDirDescription'));
       return;

--- a/dashboard/src/utils/sessionCreation.ts
+++ b/dashboard/src/utils/sessionCreation.ts
@@ -17,3 +17,30 @@ export const PERMISSION_MODES = [
 ] as const;
 
 export type PermissionMode = (typeof PERMISSION_MODES)[number]['value'];
+
+/**
+ * Validate that a working directory path looks like a valid absolute path.
+ * Allows: /foo, /foo/bar, /foo/../bar, C:\foo (Windows)
+ * Rejects: empty, relative paths without leading /, common mistakes
+ */
+export function validateWorkDir(path: string): string | null {
+  const trimmed = path.trim();
+  if (!trimmed) return 'Working directory is required';
+
+  // Must start with / (Unix) or drive letter (Windows)
+  if (!trimmed.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(trimmed)) {
+    return 'Working directory must be an absolute path (e.g. /home/user/project)';
+  }
+
+  // Reject obviously wrong patterns
+  if (trimmed.includes('  ')) {
+    return 'Path contains multiple consecutive spaces';
+  }
+
+  // Reject control characters
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) {
+    return 'Path contains invalid characters';
+  }
+
+  return null; // valid
+}


### PR DESCRIPTION
## Summary
Closes #3808, #3812, #3813, #3814

### #3808 — Command palette not accessible on mobile
Removed `hidden sm:` from the search trigger button. On small screens: icon-only button with aria-label. On sm+: full text + ⌘K shortcut hint. Keyboard shortcut still disabled on touch devices (no Cmd+K on phones).

### #3812 — useSwipeGesture conflicts with horizontal scroll
MobilePermissionPrompt now passes `elementRef: containerRef` to useSwipeGesture, scoping swipe detection to the prompt container instead of window. Previously swiping in any scrollable content could trigger approve/reject.

### #3813 — NewSessionDrawer template dead-end
Replaced the dead-end text ("use the Overview page to create from template") with a template picker dropdown. Selecting a template fills name, workDir, prompt, permissionMode, and claudeCommand fields.

### #3814 — No client-side validation for working directory
Added `validateWorkDir()` in `utils/sessionCreation.ts`: checks absolute path format (starts with / or drive letter), rejects control characters and double spaces. Wired into all 3 entry points with inline error display (Modal/Drawer) and toast (Page).

## Test evidence
- `tsc --noEmit` clean (pre-existing i18n type error in context.tsx excluded)
- 38/38 tests pass

— Daedalus