### PR TITLE
fix(dashboard): Batch F dogfooding fixes (#3824, #3825, #3818)

### DIFF
--- a/dashboard/src/components/session/TranscriptViewer.tsx
+++ b/dashboard/src/components/session/TranscriptViewer.tsx
@@ -37,6 +37,7 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
   const [showScrollBtn, setShowScrollBtn] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
+  const unreadCountRef = useRef(0);
   const seenKeys = useRef<Set<string>>(new Set());
 
   // Fetch initial messages via API client
@@ -149,9 +150,15 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
     const el = containerRef.current;
     if (!el) return;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    if (atBottom) {
+      unreadCountRef.current = 0;
+    } else if (!userScrolledRef.current) {
+      // User just scrolled up — capture current count as baseline
+      unreadCountRef.current = filteredMessages.length;
+    }
     userScrolledRef.current = !atBottom;
     setShowScrollBtn(!atBottom);
-  }, []);
+  }, [filteredMessages.length]);
 
   const scrollToBottom = useCallback(() => {
     userScrolledRef.current = false;
@@ -244,6 +251,11 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
           title="Scroll to bottom"
         >
           ↓
+          {unreadCountRef.current > 0 && (
+            <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-[var(--color-accent-cyan)] text-[10px] font-bold text-[var(--color-void-dark)] px-1">
+              {filteredMessages.length - unreadCountRef.current}
+            </span>
+          )}
         </button>
       )}
     </div>

--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -83,6 +83,11 @@ export default function NewSessionPage() {
   }, [workDir, name, claudeCommand, prompt, permissionMode, addToast, navigate, addRecentDir, t]);
 
   function applyTemplate(template: SessionTemplate): void {
+    // Warn if form already has content that would be overwritten
+    const isDirty = name || workDir || prompt || claudeCommand;
+    if (isDirty && !window.confirm('Applying this template will overwrite all current form fields. Continue?')) {
+      return;
+    }
     setName(template.name);
     setWorkDir(template.workDir);
     setPrompt(template.prompt ?? '');

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '../hooks/useTheme';
 import type { Theme } from '../hooks/useTheme';
 import { useReadingFont, type ReadingFont } from '../stores/readingFontStore';
 import { useLocale } from '../i18n/context';
+import { useToastStore } from '../store/useToastStore';
 import { useT } from '../i18n/context';
 
 const STORAGE_KEY = 'aegis-dashboard-settings';
@@ -112,6 +113,7 @@ function SettingsSwitch({ checked, label, onClick }: SettingsSwitchProps) {
 
 export default function SettingsPage() {
   const handleRestartOnboarding = () => { try { localStorage.removeItem('aegis:onboarded'); sessionStorage.removeItem('aegis:onboarded'); } catch {} window.location.reload(); };
+  const addToast = useToastStore((s) => s.addToast);
   const [settings, setSettings] = useState<Settings>(loadSettings);
   const [saveError, setSaveError] = useState<string | null>(null);
   const { theme, resolvedTheme, toggleTheme, setTheme } = useTheme();
@@ -144,16 +146,34 @@ export default function SettingsPage() {
     setSettings((prev) => ({ ...prev, [key]: value }));
   };
 
+  const resetToDefaults = () => {
+    if (window.confirm('Reset all settings to their default values?')) {
+      setSettings(DEFAULT_SETTINGS);
+      setTheme('dark');
+      setReadingFont('default');
+      setLocale('en');
+      addToast('info', 'Settings reset to defaults');
+    }
+  };
+
   const isLight = resolvedTheme !== 'dark';
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-3">
         <Settings className="h-6 w-6 text-[var(--color-accent-cyan)]" />
-        <div>
+        <div className="flex-1">
           <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">{t('settings.title')}</h1>
           <p className="mt-1 text-sm text-[var(--color-text-muted)]">{t('settings.subtitle')}</p>
         </div>
+        <button
+          type="button"
+          onClick={resetToDefaults}
+          className="shrink-0 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-xs font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-void-lighter)] transition-colors"
+          aria-label="Reset all settings to defaults"
+        >
+          Reset to defaults
+        </button>
       </div>
 
       {saveError && (


### PR DESCRIPTION
## Summary
Closes #3824, #3825, #3818

### #3824 — Template apply silently overwrites form fields
Added browser confirm dialog when applying a template on NewSessionPage if any form fields already have content. Prevents accidental data loss.

### #3825 — Settings page has no 'Reset to defaults'
Added 'Reset to defaults' button in the Settings page header. Resets all settings, theme, reading font, and locale to defaults with confirmation dialog.

### #3818 — Transcript scroll-to-bottom has no unread count
Scroll-to-bottom button now shows an unread count badge (blue pill with number) when new messages arrive while the user has scrolled up.

## Test evidence
- `tsc --noEmit` clean
- 32/32 tests pass

— Daedalus