### PR TITLE
feat(dashboard): add last-updated indicator and stale-data UX (#3809)

### DIFF
--- a/dashboard/src/components/shared/LastUpdatedIndicator.tsx
+++ b/dashboard/src/components/shared/LastUpdatedIndicator.tsx
@@ -1,0 +1,32 @@
+/**
+ * components/shared/LastUpdatedIndicator.tsx — Displays "Last updated: Xs ago" text.
+ * Shows an amber pulse when data is stale (>30s since last update).
+ */
+
+interface LastUpdatedIndicatorProps {
+  relativeTime: string;
+  isStale: boolean;
+}
+
+export function LastUpdatedIndicator({ relativeTime, isStale }: LastUpdatedIndicatorProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-xs tabular-nums transition-colors ${
+        isStale
+          ? 'text-amber-400'
+          : 'text-[var(--color-text-muted)]'
+      }`}
+      role="status" aria-live="polite"
+      aria-label={`Last updated ${relativeTime}`}
+    >
+      <span
+        className={`inline-block h-1.5 w-1.5 rounded-full ${
+          isStale
+            ? 'bg-amber-400 animate-pulse'
+            : 'bg-emerald-400'
+        }`}
+      />
+      Updated {relativeTime}
+    </span>
+  );
+}

--- a/dashboard/src/components/shared/StaleDataBanner.tsx
+++ b/dashboard/src/components/shared/StaleDataBanner.tsx
@@ -1,0 +1,25 @@
+/**
+ * components/shared/StaleDataBanner.tsx — Warning banner shown when SSE is disconnected.
+ * Displayed on SessionDetailPage when sseError is truthy.
+ */
+
+import { AlertTriangle } from 'lucide-react';
+
+interface StaleDataBannerProps {
+  error: string;
+}
+
+export function StaleDataBanner({ error }: StaleDataBannerProps) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-2.5 text-sm text-amber-300"
+      role="alert"
+      aria-label="Live updates disconnected — data may be stale"
+    >
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+      <span>
+        Live updates disconnected — data may be stale. {error}
+      </span>
+    </div>
+  );
+}

--- a/dashboard/src/components/shared/__tests__/LastUpdatedIndicator.test.tsx
+++ b/dashboard/src/components/shared/__tests__/LastUpdatedIndicator.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LastUpdatedIndicator } from '../LastUpdatedIndicator';
+
+describe('LastUpdatedIndicator', () => {
+  it('renders relative time text', () => {
+    render(<LastUpdatedIndicator relativeTime="12s ago" isStale={false} />);
+    expect(screen.getByText(/12s ago/)).toBeTruthy();
+  });
+
+  it('shows stale styling when isStale is true', () => {
+    const { container } = render(<LastUpdatedIndicator relativeTime="45s ago" isStale={true} />);
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('shows normal styling when fresh', () => {
+    const { container } = render(<LastUpdatedIndicator relativeTime="just now" isStale={false} />);
+    expect(container.querySelector('.animate-pulse')).toBeNull();
+  });
+
+  it('has role=status for accessibility', () => {
+    render(<LastUpdatedIndicator relativeTime="5s ago" isStale={false} />);
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+});

--- a/dashboard/src/components/shared/__tests__/StaleDataBanner.test.tsx
+++ b/dashboard/src/components/shared/__tests__/StaleDataBanner.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StaleDataBanner } from '../StaleDataBanner';
+
+describe('StaleDataBanner', () => {
+  it('renders the warning message', () => {
+    render(<StaleDataBanner error="Connection lost" />);
+    expect(screen.getByText(/Live updates disconnected/)).toBeTruthy();
+    expect(screen.getByText(/Connection lost/)).toBeTruthy();
+  });
+
+  it('has role=alert for accessibility', () => {
+    render(<StaleDataBanner error="SSE error" />);
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+});

--- a/dashboard/src/hooks/__tests__/useLastUpdated.test.ts
+++ b/dashboard/src/hooks/__tests__/useLastUpdated.test.ts
@@ -1,0 +1,81 @@
+/**
+ * hooks/__tests__/useLastUpdated.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLastUpdated } from '../useLastUpdated';
+
+describe('useLastUpdated', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" initially', () => {
+    const { result } = renderHook(() => useLastUpdated());
+    expect(result.current.relativeTime).toBe('just now');
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it('updates relative time as time passes', () => {
+    const { result } = renderHook(() => useLastUpdated());
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(result.current.relativeTime).toBe('10s ago');
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it('marks stale after 30 seconds', () => {
+    const { result } = renderHook(() => useLastUpdated());
+
+    act(() => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.relativeTime).toBe('31s ago');
+  });
+
+  it('markUpdated resets the timer', () => {
+    const { result } = renderHook(() => useLastUpdated());
+
+    act(() => {
+      vi.advanceTimersByTime(45_000);
+    });
+
+    expect(result.current.isStale).toBe(true);
+
+    act(() => {
+      result.current.markUpdated();
+    });
+
+    expect(result.current.relativeTime).toBe('just now');
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it('shows minutes for >= 60s', () => {
+    const { result } = renderHook(() => useLastUpdated());
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(result.current.relativeTime).toBe('2m ago');
+  });
+
+  it('shows hours for >= 3600s', () => {
+    const { result } = renderHook(() => useLastUpdated());
+
+    act(() => {
+      vi.advanceTimersByTime(7200_000);
+    });
+
+    expect(result.current.relativeTime).toBe('2h ago');
+  });
+});

--- a/dashboard/src/hooks/useLastUpdated.ts
+++ b/dashboard/src/hooks/useLastUpdated.ts
@@ -1,0 +1,46 @@
+/**
+ * hooks/useLastUpdated.ts — Tracks the last successful data refresh timestamp.
+ *
+ * Returns a human-readable relative time string (e.g. "12s ago", "2m ago")
+ * that updates every second. Call `markUpdated()` on every successful SSE event
+ * or poll completion.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+export function useLastUpdated() {
+  const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [, forceUpdate] = useState(0);
+
+  // Tick every second to refresh relative time display
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      forceUpdate((n) => n + 1);
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const markUpdated = useCallback(() => {
+    setLastUpdated(Date.now());
+  }, []);
+
+  const secondsAgo = Math.floor((Date.now() - lastUpdated) / 1000);
+
+  let relativeTime: string;
+  if (secondsAgo < 5) {
+    relativeTime = 'just now';
+  } else if (secondsAgo < 60) {
+    relativeTime = `${secondsAgo}s ago`;
+  } else if (secondsAgo < 3600) {
+    relativeTime = `${Math.floor(secondsAgo / 60)}m ago`;
+  } else {
+    relativeTime = `${Math.floor(secondsAgo / 3600)}h ago`;
+  }
+
+  const isStale = secondsAgo > 30;
+
+  return { relativeTime, isStale, markUpdated, lastUpdated };
+}

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -16,6 +16,8 @@ import HomeStatusPanel from '../components/overview/HomeStatusPanel';
 import SessionTable from '../components/overview/SessionTable';
 import CreateSessionModal from '../components/CreateSessionModal';
 import LiveStatusIndicator from '../components/shared/LiveStatusIndicator';
+import { useLastUpdated } from '../hooks/useLastUpdated';
+import { LastUpdatedIndicator } from '../components/shared/LastUpdatedIndicator';
 import { KPIBanner } from '../components/analytics/KPIBanner';
 import type { KPIItem } from '../components/analytics/KPIBanner';
 import { ModelDistributionBar } from '../components/analytics/ModelDistributionBar';
@@ -60,10 +62,14 @@ export default function OverviewPage() {
   // Real-time SSE updates
   useSessionRealtimeUpdates();
 
+  // Track last data refresh time
+  const { relativeTime, isStale, markUpdated } = useLastUpdated();
+
   const fetchAnalytics = useCallback(async () => {
     try {
       const data = await getAnalyticsSummary();
       setAnalytics(data);
+      markUpdated();
       
     } catch (e) {
       /* analytics fetch failed — non-critical */
@@ -299,6 +305,9 @@ export default function OverviewPage() {
         >
           Recent Sessions
         </h3>
+        <div className="flex items-center justify-between">
+          <LastUpdatedIndicator relativeTime={relativeTime} isStale={isStale} />
+        </div>
         <div aria-labelledby="recent-sessions-heading"><SessionTable maxRows={5} /></div>
       </div>
 

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -22,6 +22,7 @@ import {
   forkSession,
 } from '../api/client';
 import { useToastStore } from '../store/useToastStore';
+import { useStore } from '../store/useStore';
 import { useSessionPolling } from '../hooks/useSessionPolling';
 import { useSessionIntervention } from '../hooks/useSessionIntervention';
 import { useSessionApproval } from '../hooks/useSessionApproval';
@@ -37,6 +38,7 @@ const SessionMetricsPanel = lazy(() => import('../components/session/SessionMetr
 import { LatencyPanel } from '../components/metrics/LatencyPanel';
 const AuditTrailPanel = lazy(() => import('../components/session/AuditTrailPanel').then(m => ({ default: m.AuditTrailPanel })));
 import { ApprovalBanner } from '../components/session/ApprovalBanner';
+import { StaleDataBanner } from '../components/shared/StaleDataBanner';
 import { AcpApprovalModal } from '../components/session/AcpApprovalModal';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PendingQuestionCard } from '../components/session/PendingQuestionCard';
@@ -153,6 +155,7 @@ export default function SessionDetailPage() {
   const handleSendRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const handleInterruptRef = useRef<() => void>(() => {});
   const addToast = useToastStore((t_store) => t_store.addToast);
+  const sseError = useStore((s) => s.sseError);
 
   function getVisibleMessageInput(): HTMLInputElement | null {
     const candidates = [desktopMsgInputRef.current, mobileMsgInputRef.current].filter(
@@ -573,6 +576,8 @@ export default function SessionDetailPage() {
             onKill={() => { void handleKill(); }}
             onSaveTemplate={() => setSaveTemplateModalOpen(true)}
           />
+
+          {sseError && <StaleDataBanner error={sseError} />}
 
           <PauseControlBar
             sessionStatus={s.status}


### PR DESCRIPTION
## Summary

Implements #3809 — users can now tell if dashboard data is fresh or stale.

### Changes
- **useLastUpdated hook** — tracks last successful data refresh, returns relative time string (e.g. "12s ago") that ticks every second, marks stale after 30s
- **LastUpdatedIndicator** — subtle "Updated Xs ago" display with green/amber dot near Recent Sessions on OverviewPage
- **StaleDataBanner** — amber warning banner on SessionDetailPage when SSE is disconnected (sseError is truthy)
- **Session completion toast** — already present in develop (c9ded322), fires success toast when working→idle

### Files
- `dashboard/src/hooks/useLastUpdated.ts` — new hook
- `dashboard/src/components/shared/LastUpdatedIndicator.tsx` — new component
- `dashboard/src/components/shared/StaleDataBanner.tsx` — new component
- `dashboard/src/pages/OverviewPage.tsx` — integrated LastUpdatedIndicator
- `dashboard/src/pages/SessionDetailPage.tsx` — integrated StaleDataBanner
- 3 new test files (12 tests total)

### Quality
- `tsc --noEmit` ✅ clean
- 12 new Vitest tests ✅ all pass
- aria-live + role=status for accessibility
- Dark theme compatible (CSS vars)

— Daedalus 🏛️