### PR TITLE
docs: add GET /v1/settings/budget endpoint (#3830)

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -184,6 +184,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 |--------|------|------|---------|
 | `GET` | `/v1/cost/summary` | Bearer | Aggregate cost summary with burn rate |
 | `GET` | `/v1/cost/by-model` | Bearer | Cost grouped by model |
+| `GET` | `/v1/settings/budget` | Bearer | Server-side budget enforcement status |
 
 ## Metrics
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2635,6 +2635,45 @@ curl http://localhost:9100/v1/analytics/costs \
 
 ---
 
+### Get Budget Enforcement Status
+
+```
+GET /v1/settings/budget
+```
+
+Returns server-side budget enforcement status. Currently returns static values (no server-side enforcement). Forward-compatible: when budget enforcement is implemented, this endpoint will reflect real limits.
+
+| Role | Required |
+|------|----------|
+| admin, operator, viewer | Yes |
+
+```bash
+curl http://localhost:9100/v1/settings/budget \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "serverSideEnforcement": false,
+  "dailyLimitUsd": null,
+  "monthlyLimitUsd": null,
+  "hardStopEnabled": false,
+  "message": "Budget alerts are computed locally. Configure server-side limits in the Aegis configuration file."
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `serverSideEnforcement` | boolean | Whether server-side budget limits are active. Currently always `false`. |
+| `dailyLimitUsd` | number \| null | Configured daily spend limit in USD. `null` when not configured. |
+| `monthlyLimitUsd` | number \| null | Configured monthly spend limit in USD. `null` when not configured. |
+| `hardStopEnabled` | boolean | Whether sessions are killed when the budget is exceeded. Currently always `false`. |
+| `message` | string | Human-readable description of current enforcement state. |
+
+---
+
 ### Get Token Usage
 
 ```


### PR DESCRIPTION
Documents the new budget enforcement status endpoint added in #3830 (issue #3811).

### Changes
- **api-reference.md**: Added `GET /v1/settings/budget` section with endpoint description, RBAC role table, curl example, response example, and field reference table.
- **api-quick-ref.md**: Added row to Cost Tracking table.

### Context
PR #3830 added this endpoint but did not include docs. All other recently merged PRs (#3827–#3835) are dashboard batch fixes with no new API surface.