### PR TITLE
test(cli): regression tests for ag run exit codes (#3838)

### DIFF
--- a/src/__tests__/commands/run-exit-code.test.ts
+++ b/src/__tests__/commands/run-exit-code.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Issue #3838: ag run exits 0 on error (empty prompt, missing args)
+ *
+ * Validates that handleRun returns non-zero exit codes for all validation failures.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleRun } from '../../commands/run.js';
+import type { CliIO } from '../../cli-http.js';
+
+function createMockIO(): CliIO {
+  return {
+    stdin: { on: vi.fn(), pipe: vi.fn() } as unknown as NodeJS.ReadableStream,
+    stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+    stderr: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+  };
+}
+
+describe('handleRun validation exit codes (#3838)', () => {
+  let io: CliIO;
+
+  beforeEach(() => {
+    io = createMockIO();
+  });
+
+  it('returns 1 for empty prompt ""', async () => {
+    const code = await handleRun([''], io);
+    expect(code).toBe(1);
+  });
+
+  it('returns 1 for no prompt (no args)', async () => {
+    const code = await handleRun([], io);
+    expect(code).toBe(1);
+  });
+
+  it('returns 1 for --model with no value (flag is last arg)', async () => {
+    const code = await handleRun(['--model'], io);
+    expect(code).toBe(1);
+  });
+
+  it('returns 1 for --model with flag-like value', async () => {
+    const code = await handleRun(['--model', '--other', 'build'], io);
+    expect(code).toBe(1);
+  });
+
+  it('returns 0 for --help', async () => {
+    const code = await handleRun(['--help'], io);
+    expect(code).toBe(0);
+  });
+
+  it('returns 0 for -h', async () => {
+    const code = await handleRun(['-h'], io);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3838

The validation error handling in `handleRun` already returns exit code 1 for all failure paths (empty prompt, missing prompt, --model without value). The bug was likely observed on the installed version which was broken by rebase conflicts on `main`.

This PR adds 6 regression tests to lock in the correct behavior:

| Test | Expected |
|------|----------|
| `ag run ""` | exit 1 |
| `ag run` (no args) | exit 1 |
| `ag run --model` (no value) | exit 1 |
| `ag run --model --other build` | exit 1 |
| `ag run --help` | exit 0 |
| `ag run -h` | exit 0 |

## Verification

```
npx tsc --noEmit: ✅
npm run build: ✅
npm test (new): 6/6 passed ✅
```