### PR TITLE
fix(security): add AEGIS_AUTH_TOKEN to ENV_DENYLIST (#3852)

### DIFF
--- a/src/__tests__/env-denylist-1392.test.ts
+++ b/src/__tests__/env-denylist-1392.test.ts
@@ -66,6 +66,9 @@ describe('Env var denylist — live Zod schema (Issues #1392 + #1908)', () => {
     it('rejects AEGIS_SECRET', () => {
       expectRejection({ AEGIS_SECRET: 'super-secret' }, 'denylisted');
     });
+    it('rejects AEGIS_AUTH_TOKEN (#3852)', () => {
+      expectRejection({ AEGIS_AUTH_TOKEN: 'aegis_deadbeef1234' }, 'denylisted');
+    });
 
     it('rejects DATABASE_URL', () => {
       expectRejection({ DATABASE_URL: 'postgres://...' }, 'denylisted');
@@ -313,6 +316,7 @@ describe('Env var denylist — live Zod schema (Issues #1392 + #1908)', () => {
       expect(ENV_DENYLIST).toContain('LD_LIBRARY_PATH');
       expect(ENV_DENYLIST).toContain('ANTHROPIC_API_KEY');
       expect(ENV_DENYLIST).toContain('AEGIS_OIDC_CLIENT_SECRET');
+    expect(ENV_DENYLIST).toContain('AEGIS_AUTH_TOKEN');
       expect(ENV_DENYLIST).toContain('COMSPEC');
       expect(ENV_DENYLIST).toContain('DYLD_FRAMEWORK_PATH');
     });

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -457,7 +457,7 @@ export const ENV_DENYLIST: readonly string[] = [
   'GOOGLE_AI_API_KEY', 'MISTRAL_API_KEY', 'DEEPSEEK_API_KEY',
   // Application secrets — prevent privilege escalation
   'AEGIS_SECRET', 'DATABASE_URL', 'SECRET_KEY', 'JWT_SECRET',
-  'SESSION_SECRET', 'ENCRYPTION_KEY', 'AEGIS_OIDC_CLIENT_SECRET',
+  'SESSION_SECRET', 'ENCRYPTION_KEY', 'AEGIS_OIDC_CLIENT_SECRET', 'AEGIS_AUTH_TOKEN',
   // Home / user identity
   'HOME', 'USER', 'LOGNAME', 'USERNAME',
   // Windows-specific


### PR DESCRIPTION
## Summary

Closes #3852

Adds `AEGIS_AUTH_TOKEN` to the `ENV_DENYLIST` in `src/validation.ts`, preventing it from being passed to Claude Code sessions via the `env` field.

### Changes
- `src/validation.ts`: Added `AEGIS_AUTH_TOKEN` to Application secrets section
- `src/__tests__/env-denylist-1392.test.ts`: Added test for denylist membership + schema rejection

### Why
Defense-in-depth: even though the attack surface is currently limited, the auth token should never be injected into CC session environments.

## Verification
```
npx tsc --noEmit: ✅
Tests: 67/67 passed ✅
```