### PR TITLE
fix(api): add GET /v1/sessions/:id/status lightweight endpoint (#3860)

### DIFF
--- a/src/__tests__/fix-3860-status-route.test.ts
+++ b/src/__tests__/fix-3860-status-route.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Issue #3860: GET /v1/sessions/:id/status returns 404 for all sessions
+ *
+ * Simple integration test: verify /v1/sessions/:id/status route exists
+ * and returns expected shape.
+ */
+import { describe, it, expect } from 'vitest';
+
+const BASE = 'http://localhost:9100';
+const TOKEN = process.env.AEGIS_TOKEN || '';
+
+describe('GET /v1/sessions/:id/status (#3860)', () => {
+  const headers = {
+    Authorization: `Bearer ${TOKEN}`,
+    'Content-Type': 'application/json',
+  };
+
+  it('returns 200 with {id, status, lastActivity} for existing session', async () => {
+    // Create a session
+    const createRes = await fetch(`${BASE}/v1/sessions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ workDir: '/home/bubuntu/projects/aegis' }),
+    });
+    expect(createRes.status).toBe(201);
+    const { id } = await createRes.json() as any;
+
+    // Hit the status endpoint
+    const statusRes = await fetch(`${BASE}/v1/sessions/${id}/status`, { headers: { Authorization: `Bearer ${TOKEN}` } });
+    expect(statusRes.status).toBe(200);
+    const body = await statusRes.json() as any;
+    expect(body.id).toBe(id);
+    expect(typeof body.status).toBe('string');
+    expect(typeof body.lastActivity).toBe('number');
+
+    // Cleanup
+    await fetch(`${BASE}/v1/sessions/${id}`, { method: 'DELETE', headers: { Authorization: `Bearer ${TOKEN}` } });
+  });
+
+  it('returns 404 for non-existent session', async () => {
+    const res = await fetch(`${BASE}/v1/sessions/00000000-0000-4000-8000-000000009999/status`, { headers: { Authorization: `Bearer ${TOKEN}` } });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3860

`GET /v1/sessions/:id/status` was returning 404 for all sessions because the route was never registered. Users expected a lightweight status-only endpoint (documented in some places as "Get session status").

### Fix
Added `GET /v1/sessions/:id/status` route in `src/routes/sessions.ts` that returns:
```json
{ "id": "...", "status": "idle", "lastActivity": 1779285343066 }
```

Uses the existing `withOwnership` middleware for auth/key scoping.

### Changes
- `src/routes/sessions.ts`: Added route registration (4 lines)
- `src/__tests__/fix-3860-status-route.test.ts`: Integration tests (2 tests)

## Verification
```
npx tsc --noEmit: ✅
```