### PR TITLE
docs: add cwd alias for workDir in POST /v1/sessions

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -777,7 +777,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `workDir` | string | **yes** | Absolute path to an existing directory (file paths are rejected) |
+| `workDir` | string | **yes** | Absolute path to an existing directory (file paths are rejected). `cwd` accepted as alias; `workDir` takes precedence when both are provided |
 | `name` | string | no | Session name (max 200 chars, `a-zA-Z0-9_ ./@-=` only; defaults to auto-generated) |
 | `label` | string | no | Alias for `name` (same character restrictions; `name` takes precedence) |
 | `prompt` | string | no | Initial prompt to send after boot (max 100k chars; must be non-empty if provided). For follow-up messages after creation, use `POST /v1/sessions/:id/send` with `text` field. |


### PR DESCRIPTION
## Issue
Documents accuracy gap from #3870.

## Changes
- `api-reference.md`: Added `cwd` alias note to `workDir` parameter description, with precedence note (`workDir` takes precedence when both are provided).

## Verification
- Parameter table accurately reflects PR #3870 behavior