### PR TITLE
fix(api): transcript API returns full untruncated messages (#3863)

### DIFF
--- a/src/__tests__/fix-3863-transcript-truncation.test.ts
+++ b/src/__tests__/fix-3863-transcript-truncation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Issue #3863: Transcript API must return full (untruncated) assistant messages.
+ *
+ * Root cause: getCachedEntries() truncated text to MAX_CACHED_TEXT_LENGTH (2048 chars).
+ * Fix: readTranscript() and readTranscriptCursor() now use getFullEntries() which
+ * reads directly from JSONL without cache truncation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionTranscripts } from '../session-transcripts.js';
+import type { SessionInfo } from '../session.js';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const TEST_DIR = join(tmpdir(), 'aegis-test-3863');
+const JSONL_PATH = join(TEST_DIR, 'session.jsonl');
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    status: 'idle',
+    workDir: '/tmp/test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 120000,
+    permissionStallMs: 300000,
+    permissionMode: 'default',
+    settingsPatched: false,
+    ownerKeyId: 'test-key',
+    tenantId: '_system',
+    runnerName: 'claude-code',
+    isolationMode: 'worktree',
+    isolationPolicy: 'respect-cc',
+    jsonlPath: JSONL_PATH,
+    ...overrides,
+  } as SessionInfo;
+}
+
+// We mock readNewEntries but the actual code also checks existsSync
+// So we create real JSONL files and let the real readNewEntries work.
+// But for unit test isolation, let's mock readNewEntries and ensure the file exists.
+
+vi.mock('../transcript.js', () => ({
+  readNewEntries: vi.fn(),
+  findSessionFile: vi.fn().mockResolvedValue(null),
+  findSessionFileWithFanout: vi.fn().mockResolvedValue(null),
+}));
+
+import { readNewEntries } from '../transcript.js';
+const mockReadNewEntries = vi.mocked(readNewEntries);
+
+const LONG_TEXT = 'A'.repeat(5000);
+
+describe('#3863: getFullEntries returns untruncated text', () => {
+  let transcripts: SessionTranscripts;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(JSONL_PATH, ''); // Ensure existsSync passes
+    transcripts = new SessionTranscripts({
+      claudeProjectsDir: '/tmp/.claude/projects',
+      worktreeAwareContinuation: false,
+      worktreeSiblingDirs: [],
+    } as any);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('readTranscript returns full text (not truncated to 2048)', async () => {
+    mockReadNewEntries.mockResolvedValue({
+      entries: [
+        { role: 'assistant', contentType: 'text', text: LONG_TEXT, timestamp: '2026-05-20T00:00:00Z' },
+      ],
+      newOffset: 100,
+      raw: '',
+    });
+
+    const result = await transcripts.readTranscript(makeSession(), 1, 50);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe(LONG_TEXT);
+    expect(result.messages[0].text.length).toBe(5000);
+  });
+
+  it('readTranscriptCursor returns full text (not truncated to 2048)', async () => {
+    mockReadNewEntries.mockResolvedValue({
+      entries: [
+        { role: 'assistant', contentType: 'text', text: LONG_TEXT, timestamp: '2026-05-20T00:00:00Z' },
+      ],
+      newOffset: 100,
+      raw: '',
+    });
+
+    const result = await transcripts.readTranscriptCursor(makeSession(), undefined, 50);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe(LONG_TEXT);
+    expect(result.messages[0].text.length).toBe(5000);
+  });
+
+  it('readTranscript returns multiple untruncated entries', async () => {
+    const text1 = 'X'.repeat(3000);
+    const text2 = 'Y'.repeat(6000);
+
+    mockReadNewEntries.mockResolvedValue({
+      entries: [
+        { role: 'user', contentType: 'text', text: 'short query', timestamp: '2026-05-20T00:00:00Z' },
+        { role: 'assistant', contentType: 'text', text: text1, timestamp: '2026-05-20T00:00:01Z' },
+        { role: 'assistant', contentType: 'text', text: text2, timestamp: '2026-05-20T00:00:02Z' },
+      ],
+      newOffset: 300,
+      raw: '',
+    });
+
+    const result = await transcripts.readTranscript(makeSession(), 1, 50);
+
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[1].text).toBe(text1);
+    expect(result.messages[2].text).toBe(text2);
+  });
+
+  it('readTranscript with roleFilter preserves full text', async () => {
+    mockReadNewEntries.mockResolvedValue({
+      entries: [
+        { role: 'user', contentType: 'text', text: 'short', timestamp: '2026-05-20T00:00:00Z' },
+        { role: 'assistant', contentType: 'text', text: LONG_TEXT, timestamp: '2026-05-20T00:00:01Z' },
+      ],
+      newOffset: 200,
+      raw: '',
+    });
+
+    const result = await transcripts.readTranscript(makeSession(), 1, 50, 'assistant');
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe(LONG_TEXT);
+    expect(result.messages[0].text.length).toBe(5000);
+  });
+
+  it('falls back to empty array when JSONL read fails', async () => {
+    mockReadNewEntries.mockRejectedValue(new Error('ENOENT'));
+
+    const result = await transcripts.readTranscript(makeSession(), 1, 50);
+
+    expect(result.messages).toHaveLength(0);
+  });
+});

--- a/src/__tests__/fix-3863-transcript-truncation.test.ts
+++ b/src/__tests__/fix-3863-transcript-truncation.test.ts
@@ -77,7 +77,7 @@ describe('#3863: getFullEntries returns untruncated text', () => {
         { role: 'assistant', contentType: 'text', text: LONG_TEXT, timestamp: '2026-05-20T00:00:00Z' },
       ],
       newOffset: 100,
-      raw: '',
+      raw: [],
     });
 
     const result = await transcripts.readTranscript(makeSession(), 1, 50);
@@ -93,7 +93,7 @@ describe('#3863: getFullEntries returns untruncated text', () => {
         { role: 'assistant', contentType: 'text', text: LONG_TEXT, timestamp: '2026-05-20T00:00:00Z' },
       ],
       newOffset: 100,
-      raw: '',
+      raw: [],
     });
 
     const result = await transcripts.readTranscriptCursor(makeSession(), undefined, 50);
@@ -114,7 +114,7 @@ describe('#3863: getFullEntries returns untruncated text', () => {
         { role: 'assistant', contentType: 'text', text: text2, timestamp: '2026-05-20T00:00:02Z' },
       ],
       newOffset: 300,
-      raw: '',
+      raw: [],
     });
 
     const result = await transcripts.readTranscript(makeSession(), 1, 50);
@@ -131,7 +131,7 @@ describe('#3863: getFullEntries returns untruncated text', () => {
         { role: 'assistant', contentType: 'text', text: LONG_TEXT, timestamp: '2026-05-20T00:00:01Z' },
       ],
       newOffset: 200,
-      raw: '',
+      raw: [],
     });
 
     const result = await transcripts.readTranscript(makeSession(), 1, 50, 'assistant');

--- a/src/session-transcripts.ts
+++ b/src/session-transcripts.ts
@@ -253,8 +253,8 @@ export class SessionTranscripts {
       }
     }
 
-    // #357: Use cached entries instead of re-reading from offset 0
-    let allEntries = await this.getCachedEntries(session);
+    // Issue #3863: Read full entries from disk for API transcript endpoints
+    let allEntries = await this.getFullEntries(session);
 
     if (roleFilter) {
       allEntries = allEntries.filter(e => e.role === roleFilter);
@@ -303,7 +303,7 @@ export class SessionTranscripts {
       }
     }
 
-    let allEntries = await this.getCachedEntries(session);
+    let allEntries = await this.getFullEntries(session);
 
     if (roleFilter) {
       allEntries = allEntries.filter(e => e.role === roleFilter);
@@ -546,6 +546,44 @@ export class SessionTranscripts {
       this.evictIfNeeded();
       return result.entries; // Return untruncated to callers
     } catch { /* JSONL read failed — return cached entries or empty */
+      return cached ? [...cached.entries] : [];
+    }
+  }
+
+
+  /**
+   * Issue #3863: Read full (untruncated) entries from JSONL for API transcript endpoints.
+   * Unlike getCachedEntries(), this reads directly from disk and does not truncate text,
+   * ensuring API consumers get complete assistant messages.
+   */
+  private async getFullEntries(session: SessionInfo): Promise<ParsedEntry[]> {
+    // Discover JSONL path if not yet known (Issue #884: worktree-aware)
+    if (!session.jsonlPath && session.claudeSessionId) {
+      const path = await this.findSessionFileMaybeWorktree(session.claudeSessionId);
+      if (path) {
+        session.jsonlPath = path;
+        session.byteOffset = 0;
+      }
+    }
+
+    if (!session.jsonlPath || !existsSync(session.jsonlPath)) {
+      // Issue #3143: Fall back to ACP event store for ACP sessions.
+      if (this.acpEventStore) {
+        try {
+          return await this.readFromAcpEvents(session);
+        } catch {
+          return [];
+        }
+      }
+      return [];
+    }
+
+    try {
+      const result = await readNewEntries(session.jsonlPath, 0);
+      return result.entries;
+    } catch {
+      // Fall back to cache (may be truncated, but better than nothing)
+      const cached = this.parsedEntriesCache.get(session.id);
       return cached ? [...cached.entries] : [];
     }
   }


### PR DESCRIPTION
## Summary
Fixes #3863 — `GET /v1/sessions/:id/transcript` truncated long assistant messages at ~2048 chars, making it impossible to retrieve full session output programmatically.

## Root Cause
`getCachedEntries()` in `session-transcripts.ts` truncated text to `MAX_CACHED_TEXT_LENGTH` (2048 chars) for memory efficiency (#3762). Both `readTranscript()` and `readTranscriptCursor()` used `getCachedEntries()`, so API responses contained truncated text.

## Fix
- Added `getFullEntries()` private method that reads directly from JSONL without cache truncation
- `readTranscript()` and `readTranscriptCursor()` now use `getFullEntries()` instead of `getCachedEntries()`
- `getCachedEntries()` is still used by `readMessages()` (monitoring/polling) where truncation is acceptable

## Files Changed
- `src/session-transcripts.ts`: +39 lines (new `getFullEntries()` method, 2 call-site changes)
- `src/__tests__/fix-3863-transcript-truncation.test.ts`: 5 new tests

## Verification
- `tsc --noEmit`: ✅ (0 errors)
- `npm run build`: OOM (pre-existing system memory issue, unrelated)
- Transcript tests: ✅ 45 passed
- New tests: ✅ 5 passed
- All tests verify 5000+ char messages returned untruncated

## Test Plan
- [x] Unit test: single 5000-char assistant message returned untruncated via readTranscript
- [x] Unit test: single 5000-char message returned untruncated via readTranscriptCursor
- [x] Unit test: multiple untruncated entries of varying lengths
- [x] Unit test: roleFilter preserves full text
- [x] Unit test: graceful fallback when JSONL read fails