### PR TITLE
chore: fix unused var lint error in fix-3713 test

### DIFF
--- a/src/__tests__/fix-3713-state-persistence-errors.test.ts
+++ b/src/__tests__/fix-3713-state-persistence-errors.test.ts
@@ -33,13 +33,13 @@ function createSM(stateDir: string, store?: any): SessionManager {
 
 describe('Issue #3713 — session.ts state persistence error branches', () => {
   let tmpDir: string;
-  let consoleWarnSpy: any;
+  let _consoleWarnSpy: any;
   let consoleErrorSpy: any;
   let consoleLogSpy: any;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'aegis-state-test-'));
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    _consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });


### PR DESCRIPTION
## Summary

Renames `consoleWarnSpy` → `_consoleWarnSpy` in `fix-3713-state-persistence-errors.test.ts` to satisfy the `@typescript-eslint/no-unused-vars` rule.

This lint warning was blocking ALL PR merges via develop branch protection (`--max-warnings 0`).

One-line fix, zero behavior change.