### PR TITLE
fix(cli): ag init crashes with DUPLICATE_KEY_NAME when key exists (#3876)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -738,18 +738,26 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   await authManager.load();
 
   if (generatedTokenRequested) {
-    // Issue #3351: --force should replace existing key, not crash
-    if (force) {
-      const existingKey = authManager.listKeys().find(k => k.name === 'ag-init-admin');
+    const existingKey = authManager.listKeys().find(k => k.name === 'ag-init-admin');
+    if (existingKey && !force) {
+      // Issue #3876: reuse existing key instead of crashing with DUPLICATE_KEY_NAME
+      // Key hash is stored, not plaintext — cannot recover original token.
+      // Skip key creation; the existing key remains valid.
+      writeLine(io.stderr, "  ⚠️  Admin key 'ag-init-admin' already exists, skipping key creation.");
+      writeLine(io.stderr, "     Your existing key is still valid. Use --force to replace it.");
+      // Do not update clientAuthToken — keep whatever was in the existing config
+      tokenCreated = false;
+    } else {
+      // Issue #3351: --force replaces existing key
       if (existingKey) {
         await authManager.revokeKey(existingKey.id);
       }
+      const createdKey = await authManager.createKey('ag-init-admin', 100, undefined, 'admin');
+      authToken = createdKey.key;
+      createdKeyId = createdKey.id;
+      nextConfig.clientAuthToken = createdKey.key;
+      tokenCreated = true;
     }
-    const createdKey = await authManager.createKey('ag-init-admin', 100, undefined, 'admin');
-    authToken = createdKey.key;
-    createdKeyId = createdKey.id;
-    nextConfig.clientAuthToken = createdKey.key;
-    tokenCreated = true;
   }
 
   const finalConfigText = serializeConfigFile(nextConfig, configPath);

--- a/tests/commands/fix-3876-duplicate-key.test.ts
+++ b/tests/commands/fix-3876-duplicate-key.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Issue #3876: ag init crashes with DUPLICATE_KEY_NAME when key already exists.
+ *
+ * Integration tests verify:
+ * 1. First run succeeds and creates key
+ * 2. Second run succeeds without crash (either reuses token or skips creation)
+ * 3. --force replaces the key
+ *
+ * The duplicate key guard (in the `generatedTokenRequested` block) is tested
+ * by the --force test — it exercises both branches of the fix.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough, Writable } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/utils/claude-installer.js', () => ({
+  ensureClaudeInstalled: vi.fn(),
+  checkClaudeInstalled: vi.fn(() => Promise.resolve({ installed: true })),
+  installClaudeCli: vi.fn(() => Promise.resolve(true)),
+}));
+
+import { runCli } from '../../src/cli.js';
+
+class CaptureStream extends Writable {
+  private chunks: string[] = [];
+  override _write(chunk: string | Buffer, _enc: BufferEncoding, cb: (error?: Error | null) => void) {
+    this.chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
+    cb();
+  }
+  text() { return this.chunks.join(''); }
+}
+
+describe('Issue #3876: ag init duplicate key handling', () => {
+  let originalCwd: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalEnv = { ...process.env };
+    projectDir = mkdtempSync(join(tmpdir(), 'aegis-3876-'));
+    stateDir = join(projectDir, 'state');
+    process.chdir(projectDir);
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('AEGIS_') || key.startsWith('MANUS_')) delete process.env[key];
+    }
+    process.env.AEGIS_STATE_DIR = stateDir;
+    process.env.AEGIS_HOST = '0.0.0.0';
+    process.env.AEGIS_PORT = '9100';
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env = originalEnv;
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  async function runInit(argv: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+    const stdin = new PassThrough();
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    const runPromise = runCli(argv, { stdin, stdout, stderr });
+    setImmediate(() => stdin.end());
+    const code = await runPromise;
+    return { code, stdout: stdout.text(), stderr: stderr.text() };
+  }
+
+  it('should succeed on first run', async () => {
+    const { code, stderr } = await runInit(['init', '--yes']);
+    expect(code).toBe(0);
+    expect(stderr).not.toContain('DUPLICATE_KEY_NAME');
+  });
+
+  it('should not crash on repeated runs', async () => {
+    const r1 = await runInit(['init', '--yes']);
+    expect(r1.code).toBe(0);
+
+    // Second run — must not crash with DUPLICATE_KEY_NAME
+    const r2 = await runInit(['init', '--yes']);
+    expect(r2.code).toBe(0);
+    expect(r2.stderr).not.toContain('DUPLICATE_KEY_NAME');
+  });
+
+  it('should not crash on repeated runs with --force', async () => {
+    const r1 = await runInit(['init', '--yes']);
+    expect(r1.code).toBe(0);
+
+    const r2 = await runInit(['init', '--yes', '--force']);
+    expect(r2.code).toBe(0);
+    expect(r2.stderr).not.toContain('DUPLICATE_KEY_NAME');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3876

`ag init` crashes with `DUPLICATE_KEY_NAME` when the `ag-init-admin` API key already exists in `keys.json` (from a previous run in any project sharing the same state directory).

## Root Cause

The `--force` path handled existing keys (revoke + recreate), but the default path called `createKey()` unconditionally — crashing when the key already existed.

## Fix

Before calling `createKey()`, check if `ag-init-admin` already exists:
- **No `--force`**: skip key creation, warn user the key already exists, suggest `--force` to replace
- **With `--force`**: revoke existing key, then recreate (unchanged behavior)
- **No existing key**: create as before (unchanged)

## Files Changed

- `src/commands/init.ts` — check for existing key before createKey, warn + skip if found
- `tests/commands/fix-3876-duplicate-key.test.ts` — 3 integration tests

## Verification

```
tsc --noEmit: ✅
npm test (init tests): ✅ 14 passed + 3 new = 17 total
```