### PR TITLE
docs: add GET /v1/sessions/:id/status, ag run --timeout flag (#3869, #3874)

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -23,6 +23,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | Method | Path | Auth | Summary |
 |--------|------|------|---------|
 | `GET` | `/v1/sessions/{id}` | Bearer | Get session details |
+| `GET` | `/v1/sessions/{id}/status` | Bearer | Lightweight status (id, status, lastActivity) |
 | `GET` | `/v1/sessions/{id}/health` | Bearer | Single session health check |
 | `GET` | `/v1/sessions/{id}/cost` | Bearer | Per-session cost summary with burn rate |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1057,10 +1057,41 @@ curl http://localhost:9100/v1/sessions/abc123/read \
 ### Paginated Transcript
 
 ```
+GET /v1/sessions/:id/status
+```
+
+Returns a lightweight status object for a session (no transcript data).
+
+```bash
+curl "http://localhost:9100/v1/sessions/abc123/status" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "id": "abc123",
+  "status": "running",
+  "lastActivity": "2026-05-20T17:00:00Z"
+}
+```
+
+**Errors:**
+
+| Status | Condition |
+|--------|----------|
+| 404 | Session not found |
+
+---
+
+### Session Transcript
+
+```
 GET /v1/sessions/:id/transcript
 ```
 
-Returns a page-based transcript for a session.
+Returns a page-based transcript for a session. Messages are returned in full (not truncated).
 
 ```bash
 curl "http://localhost:9100/v1/sessions/abc123/transcript?page=1&limit=50&role=user" \

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -82,6 +82,13 @@ If the server is already running, skips straight to session creation. Existing c
 | `--model <provider/model>` | Override the default model for this session |
 | `--effort <level>` | Set reasoning effort: `low`, `medium`, `high`, or `0.0`–`1.0` |
 | `--no-stream` | Wait for session completion and print output (non-streaming) |
+| `--timeout <sec>` | Maximum wait time in seconds (default: 300). Set to `0` for no timeout |
+
+**Environment variables:**
+
+| Variable | Description |
+|----------|------------|
+| `AEGIS_RUN_TIMEOUT` | Default timeout for `ag run` in seconds (default: 300) |
 
 ### `ag` — Start Server
 


### PR DESCRIPTION
## Summary

Documents accuracy gaps found during PHASE 1 heartbeat scan.

### Changes

1. **GET /v1/sessions/:id/status** (#3869) — new lightweight status endpoint returning `{ id, status, lastActivity }`. Added to:
   - `api-reference.md` — full endpoint docs with curl example
   - `api-quick-ref.md` — quick reference table

2. **ag run --timeout <sec>** (#3869) — new flag + `AEGIS_RUN_TIMEOUT` env var. Default timeout changed from 90s → 300s. Added to:
   - `integrations/cli.md` — flags table + env vars table

3. **Transcript full messages** (#3874) — note that transcript API returns full untruncated messages (behavior fix).

### Verification
- All files match existing doc style and formatting
- No broken links or references