### PR TITLE
chore: sync main→develop (release pipeline hardening)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -963,7 +963,16 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
-          npx clawhub@latest publish skill/ --slug onestep-aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration"
+          set +e
+          OUTPUT=$(npx clawhub@latest publish skill/ --slug onestep-aegis --name "Aegis Bridge" --version "$VERSION" --changelog "Release v$VERSION - HTTP/MCP Claude Code orchestration" 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ $STATUS -ne 0 ] && echo "$OUTPUT" | grep -qi "already exists"; then
+            echo "::notice::ClawHub version $VERSION already exists — skipping."
+          elif [ $STATUS -ne 0 ]; then
+            exit $STATUS
+          fi
 
   # H1: SLSA build provenance attestation.
   # Generates machine-readable provenance for every release artifact.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,8 +394,14 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          # Recovery releases are always triggered by tag push — tag always exists.
-          # Skip freshness check for annotated tags containing 'recovery-release: true'.
+          # Tag-push events: GitHub already rejects pushes to existing tags (unless force-pushed,
+          # which branch protection blocks). The tag was just created — freshness is guaranteed.
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "::notice::Tag ${TAG} was just pushed — skipping freshness check for tag-push event."
+            exit 0
+          fi
+          # For workflow_dispatch: guard against accidentally re-running for an existing tag.
+          # Recovery releases skip this check (they always retag).
           if git cat-file -t "${TAG}" 2>/dev/null | grep -qx tag &&
              git cat-file tag "${TAG}" 2>/dev/null | grep -Fxq "recovery-release: true"; then
             echo "::notice::Tag ${TAG} is a recovery release — skipping freshness check."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -979,6 +979,14 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: package
+          path: .
+      - uses: actions/download-artifact@v8
+        with:
+          name: helm-chart
+          path: deploy/helm/aegis
       - name: Generate build provenance attestation
         uses: actions/attest-build-provenance@v4
         with:


### PR DESCRIPTION
## Sync main → develop

Backport of release workflow fixes from the v0.6.7 release run.

### Changes

1. **fix(ci): skip check-tag-freshness for tag-push events** — avoids double-trigger when a tag push creates the release
2. **fix(ci): download artifacts before attest-build-provenance** — SLSA provenance step needs artifacts present
3. **fix(ci): skip ClawHub publish gracefully when version already exists** — idempotent publish guard

### Verification
- CI green on all checks (ubuntu test, lint, helm-smoke, sdk-drift)
- macOS/Windows test-matrix failures are pre-existing platform issues
- GitGuardian, Trivy, CodeQL all clean