### PR TITLE
fix(cli): ag list shows partial ID tip (#3894)

### DIFF
--- a/src/__tests__/commands/fix-3894-partial-id-tip.test.ts
+++ b/src/__tests__/commands/fix-3894-partial-id-tip.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for Issue #3894 — ag list mentions partial ID support in tips.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockWriteLine = vi.fn();
+const mockStdout = { write: vi.fn() };
+const mockStderr = { write: vi.fn() };
+const mockIO = { stdout: mockStdout, stderr: mockStderr };
+
+vi.mock('../../cli-http.js', () => ({
+  resolveBaseUrl: vi.fn().mockResolvedValue('http://localhost:9100'),
+  resolveAuthToken: vi.fn().mockResolvedValue('test-token'),
+  buildHeaders: vi.fn().mockReturnValue({ Authorization: 'Bearer test-token' }),
+  requireServer: vi.fn().mockResolvedValue(true),
+  writeLine: (...args: any[]) => mockWriteLine(...args),
+}));
+
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWriteLine.mockImplementation(() => {});
+});
+
+async function importList() {
+  return import('../../commands/list.js');
+}
+
+function makeSessions(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `${String(i).padStart(8, '0')}-aaaa-bbbb-cccc-dddddddddddd`,
+    status: 'idle',
+    displayName: `session-${i}`,
+  }));
+}
+
+describe('ag list partial ID tip (#3894)', () => {
+  it('shows partial ID tip when sessions exist', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ sessions: makeSessions(2) }),
+    }) as any;
+
+    const { handleList } = await importList();
+    await handleList([], mockIO as any);
+
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const partialTip = calls.find((l: string) => l && l.includes('Partial IDs'));
+    expect(partialTip).toBeDefined();
+    expect(partialTip).toContain('ag read');
+  });
+
+  it('shows partial ID tip even with --all', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ sessions: makeSessions(1) }),
+    }) as any;
+
+    const { handleList } = await importList();
+    await handleList(['--all'], mockIO as any);
+
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const partialTip = calls.find((l: string) => l && l.includes('Partial IDs'));
+    expect(partialTip).toBeDefined();
+  });
+
+  it('does not show partial ID tip when no sessions', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ sessions: [] }),
+    }) as any;
+
+    const { handleList } = await importList();
+    await handleList([], mockIO as any);
+
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const partialTip = calls.find((l: string) => l && l.includes('Partial IDs'));
+    expect(partialTip).toBeUndefined();
+  });
+});
+
+import { afterAll } from 'vitest';
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,6 +4,7 @@
  * Wraps GET /v1/sessions with optional status and project (`--cwd`) filters.
  * Issue #3633: Add --full-ids and --json flags for better CLI workflow.
  * Issue #3731: Hide killed/completed/crashed by default; --all shows everything.
+ * Issue #3894: Mention partial ID support in tips.
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
@@ -81,6 +82,7 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
   if (tips.length > 0) {
     writeLine(io.stdout, '');
     writeLine(io.stdout, `  Tip: use ${tips.join(', ')}, or pipe with --json.`);
+    writeLine(io.stdout, '  Partial IDs (e.g. ag read 786d9a13) are supported by read, kill, tail, and status.');
   }
 
   return 0;


### PR DESCRIPTION
## Issue
#3894 — `ag list` truncates IDs but `ag read` requires full UUID

## Root Cause
Prefix matching was already implemented in #3633 (read), #3672 (kill/tail), and #3674 (status). However, the published npm package (v0.6.7) predates these fixes, so users hitting the issue were on an outdated version.

## Fix
Add a discoverability tip in `ag list` output so users know partial IDs work:
```
  Partial IDs (e.g. ag read 786d9a13) are supported by read, kill, tail, and status.
```

## Changes
- `src/commands/list.ts`: Add partial ID tip line after existing tips
- `src/__tests__/commands/fix-3894-partial-id-tip.test.ts`: 3 tests for tip visibility

## Verification
- tsc --noEmit: ✅
- Tests: ✅ 8 passed (5 existing + 3 new)

## Note
The core fix (prefix matching) is already on develop. This PR only improves discoverability. The real resolution for users is a new npm release that includes #3633, #3672, #3674.

---
Hephaestus 🔨