### PR TITLE
fix(init): project-local stateDir for new configs (#3888)

### DIFF
--- a/src/__tests__/cli-init.test.ts
+++ b/src/__tests__/cli-init.test.ts
@@ -422,4 +422,58 @@ describe('ag init --model flag', () => {
       expect(config.clientAuthToken).toBeFalsy();
     });
   });
+
+  describe('#3888 — project-local stateDir for new configs', () => {
+    it('creates stateDir next to new config when no AEGIS_STATE_DIR env', async () => {
+      // Remove AEGIS_STATE_DIR so the fix activates
+      delete process.env.AEGIS_STATE_DIR;
+      process.env.AEGIS_HOST = '0.0.0.0'; // non-localhost to trigger token creation
+
+      const stdin = new PassThrough();
+      const stdout = new CaptureStream();
+      const stderr = new CaptureStream();
+      const runPromise = runCli(['init', '--yes', '--force'], { stdin, stdout, stderr });
+      setImmediate(() => stdin.end());
+      const code = await runPromise;
+      expect(code).toBe(0);
+
+      // Config at project-local .aegis/config.yaml
+      const configPath = join(projectDir, '.aegis', 'config.yaml');
+      expect(existsSync(configPath)).toBe(true);
+
+      // State dir should be project-local (.aegis/), not HOME
+      const config = parseYaml(readFileSync(configPath, 'utf-8')) as {
+        stateDir?: string;
+        clientAuthToken?: string;
+      };
+
+      // stateDir should be set to the .aegis/ directory under project
+      expect(config.stateDir).toBe(join(projectDir, '.aegis'));
+
+      // --force creates a new token, so keys.json should be in project-local .aegis/
+      const keysPath = join(projectDir, '.aegis', 'keys.json');
+      expect(existsSync(keysPath)).toBe(true);
+
+      // Verify the state directory message shows project-local path
+      expect(stdout.text()).toContain(join(projectDir, '.aegis'));
+    });
+
+    it('respects AEGIS_STATE_DIR env even for new configs', async () => {
+      // Set explicit state dir
+      process.env.AEGIS_STATE_DIR = stateDir;
+      process.env.AEGIS_HOST = '0.0.0.0';
+
+      const stdin = new PassThrough();
+      const stdout = new CaptureStream();
+      const stderr = new CaptureStream();
+      const runPromise = runCli(['init', '--yes'], { stdin, stdout, stderr });
+      setImmediate(() => stdin.end());
+      const code = await runPromise;
+      expect(code).toBe(0);
+
+      // Keys should be in the env-overridden state dir
+      const keysPath = join(stateDir, 'keys.json');
+      expect(existsSync(keysPath)).toBe(true);
+    });
+  });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -562,8 +562,12 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   const existingByoEnv = filterByoEnv(existingConfig?.defaultSessionEnv);
   const currentConfig = await loadConfig();
 
-  // Ensure state directory exists
-  const stateDir = currentConfig.stateDir;
+  // Issue #3888: For new configs, use project-local stateDir
+  // But respect explicit AEGIS_STATE_DIR env override.
+  const isNewConfig = existingConfigText === null;
+  const envStateDir = process.env.AEGIS_STATE_DIR || process.env.MANUS_STATE_DIR;
+  const localStateDir = isNewConfig && !envStateDir ? dirname(configPath) : currentConfig.stateDir;
+  const stateDir = localStateDir;
   await mkdir(stateDir, { recursive: true });
   writeLine(io.stdout, `  ✅ State directory: ${stateDir}`);
 
@@ -644,6 +648,10 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   const nextConfig: Partial<Config> = { ...(existingConfig ?? {}) };
   nextConfig.baseUrl = baseUrl;
   nextConfig.dashboardEnabled = dashboardEnabled;
+  // Issue #3888: Persist project-local stateDir for new configs
+  if (isNewConfig) {
+    nextConfig.stateDir = stateDir;
+  }
 
   if (byoEnv) {
     nextConfig.defaultSessionEnv = {
@@ -734,7 +742,7 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
   let authToken = existingToken;
   let tokenCreated = false;
   let createdKeyId: string | null = null;
-  const authManager = new AuthManager(join(currentConfig.stateDir, 'keys.json'), currentConfig.authToken);
+  const authManager = new AuthManager(join(stateDir, 'keys.json'), currentConfig.authToken);
   await authManager.load();
 
   if (generatedTokenRequested) {
@@ -818,9 +826,20 @@ export async function handleInit(args: string[], io: CliIO): Promise<number> {
     }
   }
 
-  // #3369: Persist token to ~/.aegis/auth-token for easy scripting access
+  // #3369 + #3888: Persist token to stateDir/auth-token
   if (authToken) {
-    persistAuthTokenFile(authToken);
+    if (isNewConfig) {
+      // Project-local: write directly to local stateDir
+      const tokenPath = join(stateDir, 'auth-token');
+      try {
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(tokenPath, authToken, { encoding: 'utf-8', mode: 0o600 });
+      } catch {
+        // Non-fatal — token is still in config.yaml as clientAuthToken
+      }
+    } else {
+      persistAuthTokenFile(authToken);
+    }
   }
 
   printInitSummary(io, {


### PR DESCRIPTION
## Summary

Fixes #3888 — `ag init --yes` now creates state (keys.json, auth-token) in the project-local `.aegis/` directory instead of always writing to `~/.aegis/`.

## Problem

When running `ag init --yes` in a project directory:
1. Config file → `cwd/.aegis/config.yaml` ✅ (already correct)
2. State directory → `~/.aegis/` ❌ (from global config fallback)
3. API keys → `~/.aegis/keys.json` ❌ (global, not project-local)

Multi-project users ended up sharing one global state store.

## Fix

When `ag init` creates a **new** config (no existing file at the resolved path):
- `stateDir` defaults to `dirname(configPath)` → `cwd/.aegis/`
- `keys.json` and `auth-token` are written project-local
- `stateDir` is persisted in the config for future runs

Guardrails:
- **Existing configs**: preserved — no behavior change
- **`AEGIS_STATE_DIR` env**: still respected (explicit override wins)
- **`MANUS_STATE_DIR` env**: still respected (backward compat)

## Files changed

- `src/commands/init.ts` — compute project-local stateDir for new configs; use it for AuthManager and token persistence
- `src/__tests__/cli-init.test.ts` — 2 new tests: project-local stateDir + env override respect

## Verification

```
npx tsc --noEmit     → zero errors
npm run build        → success
npm test             → 355 files, 4930 tests passed, 0 failed
```