### PR TITLE
fix(run): session creation timeout configurable (#3904)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ playwright-report/
 test-results/
 wt/
 coverage/
+wt-last-updated

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -652,6 +652,8 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
 
   let sessionId: string;
   try {
+    // Session creation timeout — configurable via AEGIS_SESSION_CREATION_TIMEOUT_MS (ms)
+    const sessionCreationTimeoutMs = parseInt(process.env.AEGIS_SESSION_CREATION_TIMEOUT_MS ?? '', 10) || 120_000;
     const res = await fetch(`${baseUrl}/v1/sessions`, {
       method: 'POST',
       signal: AbortSignal.timeout(30_000),  // Issue #3243: session creation is now fast (prompt delivery is async)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -656,7 +656,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
     const sessionCreationTimeoutMs = parseInt(process.env.AEGIS_SESSION_CREATION_TIMEOUT_MS ?? '', 10) || 120_000;
     const res = await fetch(`${baseUrl}/v1/sessions`, {
       method: 'POST',
-      signal: AbortSignal.timeout(30_000),  // Issue #3243: session creation is now fast (prompt delivery is async)
+      signal: AbortSignal.timeout(sessionCreationTimeoutMs),  // Issue #3243: session creation is now fast (prompt delivery is async)
       headers,
       body: JSON.stringify({
         workDir: cwd,


### PR DESCRIPTION
Make session creation POST timeout configurable via AEGIS_SESSION_CREATION_TIMEOUT_MS (ms). Default: 120000ms. This prevents premature 30s session creation timeouts during slow server/LLM startup. See issue #3904.