### PR TITLE
docs: project-local stateDir for new ag init configs (#3901)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ playwright-report/
 test-results/
 wt/
 coverage/
+wt-last-updated

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ ag init
 >
 > **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml` and regenerates auth keys. **You must restart the server** for the new keys to take effect — the running server does not hot-reload keys from disk. Without a restart, CLI commands will return `401 Unauthorized` with the new token.
 >
-> `ag init` now supports conversational onboarding with `--model` and `--name` flags for non-interaction setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session. Use `--force` to create a token even on localhost.
+> `ag init` now supports conversational onboarding with `--model` and `--name` flags for non-interactive setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session. Use `--force` to create a token even on localhost.
 >
 > **Project-local state:** For new configs, `ag init` stores state (keys, auth-token) in the project `.aegis/` directory alongside `config.yaml`, not in the global `~/.aegis/`. This keeps each project isolated. Override with `AEGIS_STATE_DIR`.
 >

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,9 @@ ag init
 >
 > **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml` and regenerates auth keys. **You must restart the server** for the new keys to take effect — the running server does not hot-reload keys from disk. Without a restart, CLI commands will return `401 Unauthorized` with the new token.
 >
-> `ag init` now supports conversational onboarding with `--model` and `--name` flags for non-interactive setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session. Use `--force` to create a token even on localhost.
+> `ag init` now supports conversational onboarding with `--model` and `--name` flags for non-interaction setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session. Use `--force` to create a token even on localhost.
+>
+> **Project-local state:** For new configs, `ag init` stores state (keys, auth-token) in the project `.aegis/` directory alongside `config.yaml`, not in the global `~/.aegis/`. This keeps each project isolated. Override with `AEGIS_STATE_DIR`.
 >
 > **Claude Code auto-wiring:** If `claude` is on your PATH, `ag init` automatically offers to register Aegis as an MCP server in Claude Code. In `--yes` mode this happens automatically. You can verify with `claude mcp list`.
 

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -28,6 +28,8 @@ ag init --from-template code-reviewer
 
 The interactive flow is idempotent: if `.aegis/config.yaml` already exists, `ag init` keeps it unless you confirm an overwrite. In `--yes` mode, existing config is preserved by default — use `--force` (or `-f`) to allow overwriting.
 
+**Project-local state:** When `ag init` creates a **new** config (no existing file), state (keys, auth-token) is stored in the project-local `.aegis/` directory alongside `config.yaml`, not in the global `~/.aegis/`. Existing configs are unaffected. You can override this with `AEGIS_STATE_DIR`.
+
 If Claude Code (`claude`) is detected on your PATH, `ag init` will automatically offer to wire the Aegis MCP server into Claude Code. This adds Aegis tools to your Claude Code session without manual setup. In `--yes` mode, MCP wiring happens automatically (skipped in CI/test environments).
 
 **Claude CLI auto-install:** If `claude` is not found on your PATH and `ANTHROPIC_API_KEY` is not set, `ag init` will prompt you to install Claude Code (`curl -fsSL https://claude.ai/install.sh | bash`). In `--yes` mode, installation proceeds automatically. On Windows, the CLI provides `npm install -g @anthropic-ai/claude-code` guidance instead. If `ANTHROPIC_API_KEY` is already set, the install step is skipped (ACP can authenticate without the CLI).
@@ -124,7 +126,7 @@ AEGIS_AUTH_TOKEN=secret ag
 | `AEGIS_HOST` | `127.0.0.1` | Bind address |
 | `AEGIS_AUTH_TOKEN` | _(none)_ | Bearer token (required for production) |
 | `AEGIS_DASHBOARD_ENABLED` | `true` | Serve the bundled dashboard |
-| `AEGIS_STATE_DIR` | `~/.aegis` | Session state directory |
+| `AEGIS_STATE_DIR` | `~/.aegis` (global) or `.aegis/` (project-local) | Session state directory. `ag init` defaults new configs to project-local |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Max concurrent sessions |
 | `AEGIS_IDLE_TIMEOUT_MS` | `600000` | Idle timeout (10 min) |
 | `AEGIS_STALL_THRESHOLD_MS` | `120000` | Stall threshold (2 min) |


### PR DESCRIPTION
## Summary

Updates docs to reflect PR #3901 — `ag init` now creates project-local stateDir (`.aegis/` in cwd) for new configs instead of always using `~/.aegis/`.

## Changes

- **cli.md**: Added project-local state note to `ag init` section + updated `AEGIS_STATE_DIR` default in env var table
- **getting-started.md**: Added project-local state note after `ag init` block

## Verification

Read-only docs change. No code affected.