### PR TITLE
fix(server): config watcher accepts all fs.watch event types (#3905)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ playwright-report/
 test-results/
 wt/
 coverage/
+wt-last-updated

--- a/src/__tests__/config-watcher-hot-reload-3905.test.ts
+++ b/src/__tests__/config-watcher-hot-reload-3905.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Issue #3905: Config watcher should hot-reload allowedWorkDirs on all fs.watch event types.
+ *
+ * Editors use atomic saves (write-then-rename) which emit 'rename' events,
+ * not 'change'. The watcher must accept all event types.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { watch } from 'fs';
+import type { FSWatcher } from 'fs';
+
+// We test the watcher setup logic by verifying the event type filtering.
+// The actual setupConfigWatcher is deeply coupled to server state,
+// so we test the core pattern directly.
+
+describe('Config watcher event types (#3905)', () => {
+  it('should handle all fs.watch event types (not just "change")', () => {
+    // Track which event types trigger a reload
+    const triggeredEvents: (string | undefined)[] = [];
+
+    // Simulate the watcher callback pattern from server.ts
+    const watcherCallback = (_eventType: string) => {
+      // Before fix: if (eventType === 'change') { ... }
+      // After fix: accept all event types
+      triggeredEvents.push(_eventType);
+    };
+
+    // Simulate events that editors actually emit
+    watcherCallback('change');     // nano, some saves
+    watcherCallback('rename');     // vim, VS Code atomic saves
+    watcherCallback(undefined as unknown as string); // Windows, some NFS
+
+    // All three event types should have been accepted
+    expect(triggeredEvents).toHaveLength(3);
+    expect(triggeredEvents).toContain('change');
+    expect(triggeredEvents).toContain('rename');
+    expect(triggeredEvents).toContain(undefined);
+  });
+
+  it('old behavior: "rename" events were silently dropped', () => {
+    const triggeredEvents: string[] = [];
+
+    // OLD behavior (the bug)
+    const oldCallback = (eventType: string) => {
+      if (eventType === 'change') {
+        triggeredEvents.push(eventType);
+      }
+    };
+
+    oldCallback('change');
+    oldCallback('rename');
+    oldCallback(undefined as unknown as string);
+
+    // Only 'change' was handled — 'rename' (vim, VS Code) was ignored
+    expect(triggeredEvents).toHaveLength(1);
+    expect(triggeredEvents).not.toContain('rename');
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -729,14 +729,13 @@ function setupConfigWatcher(): void {
 
   // fs.watch for automatic detection
   try {
-    configWatcher = watch(configPath, (eventType) => {
-      if (eventType === 'change') {
-        // Debounce: FS events can fire multiple times for one save
+    configWatcher = watch(configPath, (_eventType) => {
+      // Accept all event types — editors emit rename (atomic save), change, or undefined.
+      // Debounce: FS events can fire multiple times for one save
         if (configReloadTimer) clearTimeout(configReloadTimer);
         configReloadTimer = setTimeout(() => {
           void handleConfigReload('file-change');
         }, 300);
-      }
     });
     configWatcher.on('error', () => {
       // Watcher failed (file deleted, permissions) — disable gracefully


### PR DESCRIPTION
## Issue
Fixes #3905 — `allowedWorkDirs` config changes require server restart.

## Root Cause
The `fs.watch` callback in `setupConfigWatcher()` only handled `eventType === 'change'`. Editors like vim and VS Code use atomic saves (write-then-rename) which emit `'rename'` events on Linux. These were silently dropped, so config hot-reload never triggered.

## Fix
Accept all event types from `fs.watch` (change, rename, undefined). Debouncing already coalesces rapid events.

## Changes
- `src/server.ts`: Remove `eventType === 'change'` guard, accept all event types
- `src/__tests__/config-watcher-hot-reload-3905.test.ts`: 2 tests documenting old vs new behavior

## Verification
- tsc --noEmit: ✅
- Tests: ✅ 2 passed