### PR TITLE
docs: document AEGIS_SESSION_CREATION_TIMEOUT_MS env var

### DIFF
--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -91,6 +91,7 @@ If the server is already running, skips straight to session creation. Existing c
 | Variable | Description |
 |----------|------------|
 | `AEGIS_RUN_TIMEOUT` | Default timeout for `ag run` in seconds (default: 300) |
+| `AEGIS_SESSION_CREATION_TIMEOUT_MS` | Timeout in ms for the session creation POST during `ag run` (default: 120000). Increase for slow server/LLM startup |
 
 ### `ag` — Start Server
 


### PR DESCRIPTION
Documents the new CLI env var added in #3909.\n\n- Adds `AEGIS_SESSION_CREATION_TIMEOUT_MS` to the `ag run` env vars table in `docs/integrations/cli.md`\n- Default: 120000ms (configurable, replaces the old hardcoded 30s timeout)\n\nCovers the accuracy gap from PR #3909.