### PR TITLE
docs: document acpStrictValidation config + remove stale _validationWarnings (#3912)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2582,15 +2582,14 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/terminal/close \
 |--------|------------|
 | 501 | ACP terminal bridge not configured |
 
-### ACP Action Result Metadata
+### ACP Content Validation
 
-When ACP actions complete, the `resultMetadata` field on the action record contains key-value pairs extracted from the agent response. This metadata is stored as `Record<string, string | number | boolean | null>`.
+Aegis validates ACP prompt output for common hallucination signatures and malformed responses. Validation behavior is controlled by two config options:
 
-**Special fields:**
-
-| Key | Type | Description |
-|-----|------|-------------|
-| `_validationWarnings` | `string` (JSON) | Present when ACP content validation detects issues. Contains a JSON-encoded array of `{ code: string, message: string }` objects. Consumers must `JSON.parse()` to access structured data. |
+| Config Key | Env Var | Default | Description |
+|------------|---------|---------|-------------|
+| `acpStrictValidation` | `AEGIS_ACP_STRICT_VALIDATION` | `false` | When `true`, validation warnings cause the action to **fail** instead of logging a warning |
+| _(backend option)_ | — | `false` | `emitValidationWarnings`: emit `validation_warning` transition events for monitoring/alerting (opt-in) |
 
 **Validation warning codes:**
 
@@ -2600,7 +2599,7 @@ When ACP actions complete, the `resultMetadata` field on the action record conta
 | `hallucination_signature` | Output contains a known hallucination pattern (e.g. `[TRACE]`, `[THINKING]`, `<thinking>`, `[PROSE]`, `[INTERNAL_MONOLOGUE]`) |
 | `low_relevance` | Output has near-zero word overlap with the original prompt (<5%), indicating possible hallucination |
 
-> **Note:** The `_validationWarnings` field uses an underscore prefix to indicate it is system-generated metadata rather than agent output. This field is only present when validation warnings are detected — it is omitted when the output passes validation cleanly.
+> **Behavior:** By default (`acpStrictValidation: false`), validation warnings are logged to the server console and the action completes normally. Enable strict mode to enforce rejection of suspicious output — useful for production deployments requiring hallucination-free responses.
 
 ---
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -270,6 +270,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_ACP_BIN` | _(auto)_ | Path to the ACP binary (auto-detected if empty) |
 | `AEGIS_ACP_ENABLED` | `true` | Enable ACP backend for session creation and control actions |
 | `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (default 120s). Increase for slow BYO-LLM proxy setups (min: 1000) |
+| `AEGIS_ACP_STRICT_VALIDATION` | `false` | When `true`, ACP content validation warnings cause action failure instead of logging only. Useful for production deployments requiring hallucination-free output |
 | `AEGIS_ISOLATION_POLICY` | `respect-cc` | Session isolation policy: `respect-cc` (follow CC settings, default), `enforce-worktree` (reject sessions without worktree — prevents file conflicts with concurrent sessions), `enforce-direct` (force direct edits, no worktree) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |


### PR DESCRIPTION
## Summary

Updates docs for PR #3912 (ACP validation enforcement + structured warnings).

### Changes
- **enterprise.md**: Add `AEGIS_ACP_STRICT_VALIDATION` env var to config table
- **api-reference.md**: Replace `_validationWarnings` resultMetadata docs (field was **removed** in #3912) with new ACP Content Validation section documenting:
  - `acpStrictValidation` config + env var
  - `emitValidationWarnings` backend option
  - Updated validation behavior (strict vs. log-only)

### Why
PR #3912 removed `_validationWarnings` from resultMetadata and added config-driven validation. The old docs showed a field that no longer exists — accuracy regression from my PR #3902.