### PR TITLE
fix(ci): add npm audit + lockfile-lint to local gate (#3918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Security audit
-        run: npm audit --audit-level=high
-      - name: Lockfile lint
-        run: npx lockfile-lint --type npm --path package-lock.json --validate-https
+      - name: Supply chain security
+        run: npm run audit-check
       - name: TypeScript check
         run: npx tsc --noEmit
       - name: Build
@@ -287,10 +285,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Security audit
-        run: npm audit --audit-level=high
-      - name: Lockfile lint
-        run: npx lockfile-lint --type npm --path package-lock.json --validate-https
+      - name: Supply chain security
+        run: npm run audit-check
       - name: TypeScript check
         run: npx tsc --noEmit
       - name: Build

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postinstall": "node scripts/postinstall-verify.cjs",
     "hooks:install": "git config core.hooksPath .githooks",
     "docs": "typedoc",
-    "gate": "npm run hygiene-check && npm run security-check && npm run dashboard:tokens:gate && npm run dashboard:clickable:gate && npx tsc --noEmit && npm run build && npm test",
+    "gate": "npm run hygiene-check && npm run security-check && npm run audit-check && npm run dashboard:tokens:gate && npm run dashboard:clickable:gate && npx tsc --noEmit && npm run build && npm test",
     "start": "node dist/cli.js",
     "dev": "tsc && node dist/cli.js",
     "prepublishOnly": "bash scripts/check-merge-conflicts.sh && npm run build",
@@ -62,7 +62,8 @@
     "dashboard:icons:audit": "node scripts/dashboard-icons-audit.cjs",
     "dashboard:a11y:check": "cd dashboard && npm run a11y:check",
     "test:e2e": "vitest run e2e/e2e-dogfood.test.ts",
-    "test:e2e:ci": "vitest run e2e/e2e-dogfood.test.ts --reporter=verbose"
+    "test:e2e:ci": "vitest run e2e/e2e-dogfood.test.ts --reporter=verbose",
+    "audit-check": "bash scripts/audit-check.sh"
   },
   "keywords": [
     "claude",

--- a/scripts/audit-check.sh
+++ b/scripts/audit-check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Supply chain security gate — npm audit + lockfile lint
+set -euo pipefail
+
+echo "🔍 npm audit (--audit-level=high)..."
+npm audit --audit-level=high
+
+echo "🔒 lockfile-lint..."
+npx lockfile-lint --type npm --path package-lock.json --validate-https
+
+echo "✅ Supply chain checks passed"


### PR DESCRIPTION
## Problem
`npm run gate` did not include `npm audit` or `lockfile-lint` — vulnerable dependencies or tampered lockfiles passed local gate but failed CI.

## Fix
- **New:** `scripts/audit-check.sh` — runs `npm audit --audit-level=high` + `npx lockfile-lint`
- **Gate:** Added `npm run audit-check` to `npm run gate` (after security-check, before dashboard gates)
- **CI:** Replaced 2× inline audit + lockfile steps with `npm run audit-check`

## Files
| File | Change |
|------|--------|
| `scripts/audit-check.sh` | New — shared supply chain security gate |
| `package.json` | Added `audit-check` script + wired into `gate` |
| `.github/workflows/ci.yml` | Replaced 4 inline steps (2 per job) with 2 `npm run audit-check` calls |

## Verification
```
npm run audit-check: ✅ (0 vulnerabilities, lockfile valid)
tsc --noEmit: ✅
npm run build: ✅
```

Closes #3918