### PR TITLE
fix(ci): remove unused actions:write from create-release-branch (#3920)

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -34,7 +34,6 @@ on:
         type: string
 
 permissions:
-  actions: write
   contents: write
 
 jobs:


### PR DESCRIPTION
## Summary

Removes `actions: write` permission from `create-release-branch.yml` GITHUB_TOKEN scope.

**Root cause:** All `gh` CLI commands in this workflow (`gh workflow run`, `gh issue view`) use the GitHub App token (`GH_TOKEN` env var), not the default `GITHUB_TOKEN`. The `actions: write` permission on `GITHUB_TOKEN` was therefore unused.

**Only `contents: write` remains** — needed by `git push origin HEAD:release/...` which authenticates via the `GITHUB_TOKEN` configured by `actions/checkout`.

### Audit of other flagged workflows

| Workflow | Permissions | Verdict |
|----------|-------------|---------|
| `graduation-check.yml` | `contents: write` + `pull-requests: write` + `issues: read` + `actions: read` | ✅ All needed (`peter-evans/create-pull-request` needs contents+PR write; queries need read) |
| `sdk-sync.yml` | `contents: write` + `pull-requests: write` | ✅ All needed (`git push` + `gh pr create`) |

Closes #3920