### PR TITLE
fix(ci): add eslint to npm run gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postinstall": "node scripts/postinstall-verify.cjs",
     "hooks:install": "git config core.hooksPath .githooks",
     "docs": "typedoc",
-    "gate": "npm run hygiene-check && npm run security-check && npm run audit-check && npm run dashboard:tokens:gate && npm run dashboard:clickable:gate && npx tsc --noEmit && npm run build && npm test",
+    "gate": "npm run hygiene-check && npm run security-check && npm run audit-check && npm run lint && npm run dashboard:tokens:gate && npm run dashboard:clickable:gate && npx tsc --noEmit && npm run build && npm test",
     "start": "node dist/cli.js",
     "dev": "tsc && node dist/cli.js",
     "prepublishOnly": "bash scripts/check-merge-conflicts.sh && npm run build",


### PR DESCRIPTION
## What
Add `npm run lint` (eslint) to `npm run gate` so local gate parity matches CI.

## Why
Closes #3917 — developers can currently push code that passes `npm run gate` locally but fails CI lint. This wastes CI minutes and causes context switching.

## Change
One-line edit to `package.json` — inserts `npm run lint` after `npm run audit-check` in the gate script.

## Verification
```
$ npm run lint
✖ 427 problems (0 errors, 427 warnings)
→ 0 errors, exit 0

$ npm run hygiene-check && npm run security-check && npm run audit-check && npm run lint
✅ All passed
```

Note: `dashboard:tokens:gate` has pre-existing violations (11 across 4 files) unrelated to this change — same failure exists on develop HEAD.

Aegis server version: v0.6.7
Commit: a139010a
Session: direct implementation (Aegis session failed to start)