### PR TITLE
fix(dashboard): replace hardcoded #666 disconnected color with CSS var

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -668,7 +668,7 @@ export default function Layout() {
               <>
                 <span
                   className={`status-dot shrink-0 ${sseConnected ? 'status-dot--idle' : ''}`}
-                  style={sseConnected ? undefined : { backgroundColor: '#666' }}
+                  style={sseConnected ? undefined : { backgroundColor: 'var(--color-text-muted)' }}
                 />
                 <span className="text-[11px] text-[var(--color-text-muted)] truncate">{sseIndicatorLabel}</span>
               </>

--- a/dashboard/src/components/session/LiveTerminal.tsx
+++ b/dashboard/src/components/session/LiveTerminal.tsx
@@ -196,7 +196,7 @@ export function LiveTerminal({ sessionId, status }: LiveTerminalProps) {
             <span
               className="w-1.5 h-1.5 rounded-full"
               style={{
-                backgroundColor: isConnected ? 'var(--color-accent)' : connectionState === 'reconnecting' ? 'var(--color-warning)' : '#666',
+                backgroundColor: isConnected ? 'var(--color-accent)' : connectionState === 'reconnecting' ? 'var(--color-warning)' : 'var(--color-text-muted)',
                 boxShadow: isConnected ? '0 0 4px rgba(var(--color-accent-rgb, 59,130,246), 0.25)' : 'none',
                 animation: connectionState === 'reconnecting' ? 'pulse 1s ease-in-out infinite' : 'none',
               }}

--- a/dashboard/src/components/session/TerminalPassthrough.tsx
+++ b/dashboard/src/components/session/TerminalPassthrough.tsx
@@ -457,7 +457,7 @@ export function TerminalPassthrough({ sessionId, status }: TerminalPassthroughPr
             <span
               className="w-1.5 h-1.5 rounded-full"
               style={{
-                backgroundColor: isConnected ? 'var(--color-accent-cyan)' : connectionState === 'reconnecting' ? 'var(--color-warning-amber)' : '#666',
+                backgroundColor: isConnected ? 'var(--color-accent-cyan)' : connectionState === 'reconnecting' ? 'var(--color-warning-amber)' : 'var(--color-text-muted)',
                 boxShadow: isConnected ? '0 0 4px rgba(var(--color-accent-cyan-rgb, 0,229,255), 0.25)' : 'none',
                 animation: connectionState === 'reconnecting' ? 'pulse 1s ease-in-out infinite' : 'none',
               }}


### PR DESCRIPTION
## Summary

Replace hardcoded `#666` fallback color with `var(--color-text-muted)` in 3 components:

- `LiveTerminal.tsx:199` — connection indicator dot
- `TerminalPassthrough.tsx:460` — connection indicator dot
- `Layout.tsx:671` — SSE connection indicator

## Why

- `#666` is a fixed gray that only works on dark backgrounds
- Breaks any future light theme support
- Does not respect the CSS variable design system
- All three are disconnected-state indicator dots — `--color-text-muted` semantically represents "inactive/not active" and has theme-aware values

## Testing

- `npm run build` ✅ clean
- No behavioral change — same visual result on dark theme, correct on light theme

Fixes #3954

— Daedalus 🏛️