### PR TITLE
docs: add 'Why Aegis when CC has agents?' README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,59 @@ For troubleshooting, see [Windows Setup](docs/windows-setup.md).
 
 ---
 
+## Why Aegis when Claude Code has agents?
+
+Claude Code v2.1.141+ added `claude agents`, background sessions, a plugin marketplace, and agent teams. So why Aegis?
+
+**Short answer:** CC is a terminal REPL. Aegis is an API server. Different tools for different jobs.
+
+| | Claude Code Native | Aegis |
+|---|---|---|
+| **Interface** | Terminal (`claude agents`) | REST API, MCP, CLI, dashboard, Telegram |
+| **Open source** | ❌ Closed source | ✅ MIT, fully auditable |
+| **Approval from phone** | ❌ Terminal only | ✅ Telegram, Slack, web dashboard |
+| **Programmatic control** | `--json` flag | 65+ REST endpoints + 34 MCP tools |
+| **CI/CD integration** | Subprocess + exit codes | REST API, `ag run`, webhooks, pipelines |
+| **Cost analytics** | `/usage` in terminal | Dashboard analytics, per-session metrics, Prometheus |
+| **SSE event streaming** | ❌ | ✅ Per-session + global event streams |
+| **Multi-channel notifications** | Terminal only | Telegram, Slack, email, webhooks |
+| **Session templates** | ❌ | ✅ Reusable configs + pipeline orchestration |
+| **Cross-session memory** | Structured learnings (experimental) | Memory Bridge (REST key-value store) |
+| **RBAC / multi-user** | ❌ Single user | ✅ 3 roles, OIDC/SSO, per-key permissions |
+| **Audit trail** | ❌ | ✅ Hash-chained, immutable, exportable |
+| **Multi-agent** | Agent Teams (experimental) | Orchestrates multiple CC sessions via API (native team coordination not yet supported) |
+| **Session export** | ❌ | ✅ JSONL + markdown download |
+
+### When CC native is enough
+
+- You're a solo developer
+- You live in the terminal
+- You don't need phone approvals or CI/CD integration
+- One session at a time is fine
+
+### When you need Aegis
+
+- **Teams** — multiple people managing agents, RBAC, audit trails
+- **CI/CD** — `ag run` in GitHub Actions, webhook delivery, pipeline orchestration
+- **Phone approvals** — approve file writes and commands from Telegram/Slack
+- **Monitoring** — dashboard with cost analytics, SSE streams, Prometheus metrics
+- **Compliance** — immutable audit log, hash-chain integrity, GDPR/SOC2-ready
+- **Integration** — REST API + MCP server for custom tooling
+
+```
+Claude Code native:
+  You ← Terminal → CC sessions
+
+Aegis:
+  You ← Telegram/Slack/Dashboard/API → Aegis Server → CC sessions
+  CI/CD ← REST API ─────────────────────┘
+  Monitoring ← SSE/Prometheus/OTel ─────┘
+```
+
+CC handles the REPL. Aegis handles everything around it — routing, approvals, cost tracking, audit, and integration with your existing stack.
+
+---
+
 ## How It Works
 
 Aegis bridges Claude Code sessions through the Agent Client Protocol (ACP) and exposes everything through a unified API. No SDK dependency, no browser automation — just JSON-RPC over stdio.

--- a/docs/why-aegis.md
+++ b/docs/why-aegis.md
@@ -2,6 +2,45 @@
 
 Aegis is enterprise orchestration middleware for Claude Code. This page explains what makes Aegis different from developer tools and multi-agent frameworks — and why those differences matter for production deployments.
 
+## Aegis vs Claude Code Native
+
+Claude Code v2.1.141+ ships native orchestration features — `claude agents`, background sessions, a plugin marketplace, and agent teams. These are impressive for terminal-first workflows.
+
+**The key difference:** CC is a terminal REPL. Aegis is an API server.
+
+CC handles the conversation — prompts, tools, permissions, code generation. Aegis handles *everything around it*: routing prompts from any channel (Telegram, Slack, CI/CD), managing approvals from your phone, tracking costs across sessions, streaming events to monitoring systems, and maintaining an immutable audit trail.
+
+For a detailed feature-by-feature comparison, see the **[Why Aegis when CC has agents?](../README.md#why-aegis-when-claude-code-has-agents)** section in the README.
+
+### What CC native does well
+
+- **Terminal-first experience** — zero setup, instant start
+- **Background sessions** — sessions survive terminal close, can be resumed
+- **Plugin marketplace** — growing ecosystem of CC extensions
+- **Agent teams** — experimental multi-agent coordination within CC
+
+### What Aegis adds on top
+
+| Layer | What CC provides | What Aegis adds |
+|-------|-----------------|----------------|
+| **Access** | Terminal only | REST API, MCP server, Telegram, Slack, web dashboard |
+| **Approvals** | Terminal prompt | Phone approvals via Telegram/Slack, programmatic approve/reject |
+| **Observability** | `/usage` command | Prometheus metrics, OTel tracing, SSE event streams, per-session analytics |
+| **Compliance** | None | Hash-chained audit trail, RBAC, OIDC/SSO, immutable logs |
+| **Cost tracking** | Token count in terminal | Dashboard analytics, per-model breakdown, burn rate, budget enforcement |
+| **Integration** | `--json` flag | 65+ REST endpoints, 34 MCP tools, webhooks, session templates, pipelines |
+| **Security** | Local trust | API key management with roles, session isolation, workDir allowlists |
+
+### When to stay with CC native
+
+You're a solo developer who lives in the terminal, doesn't need CI/CD integration, and is happy approving everything on screen. CC native is a great experience for this.
+
+### When to add Aegis
+
+You need your agents reachable from *outside the terminal* — approvals from your phone, sessions triggered by CI/CD, costs tracked in a dashboard, events streamed to your monitoring stack, or an audit trail for compliance. That's the API server layer.
+
+---
+
 ## Aegis vs Developer Tools
 
 Some Claude Code wrappers focus on developer convenience — quick session management, browser-based UIs, and local-first workflows. Aegis is built for a different purpose: **production-grade orchestration at scale**.


### PR DESCRIPTION
Adds competitive positioning section to README addressing why someone would choose Aegis over native CC orchestration. Comparison table (14 rows), architecture diagram, honest 'when CC is enough' section. Addresses gap identified in #3884. Boss + Athena feedback incorporated.