### PR TITLE
fix(validation): trim inputs and reject whitespace-only prompts/names (fixes #3956 #3957)

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -41,17 +41,17 @@ export const MAX_INPUT_LENGTH = 10_000;
 
 /** POST /v1/sessions/:id/send */
 export const sendMessageSchema = z.object({
-  text: z.string().min(1).max(MAX_INPUT_LENGTH),
+  text: z.preprocess((v) => (typeof v === "string" ? v.trim() : v), z.string().min(1).max(MAX_INPUT_LENGTH)),
 }).strict();
 
 /** POST /v1/sessions/:id/command */
 export const commandSchema = z.object({
-  command: z.string().min(1).max(MAX_INPUT_LENGTH),
+  command: z.preprocess((v) => (typeof v === "string" ? v.trim() : v), z.string().min(1).max(MAX_INPUT_LENGTH)),
 }).strict();
 
 /** POST /v1/sessions/:id/bash */
 export const bashSchema = z.object({
-  command: z.string().min(1).max(MAX_INPUT_LENGTH),
+  command: z.preprocess((v) => (typeof v === "string" ? v.trim() : v), z.string().min(1).max(MAX_INPUT_LENGTH)),
 }).strict();
 
 /** POST /v1/sessions/:id/screenshot */


### PR DESCRIPTION
This clean PR contains only the validation trim changes to reject whitespace-only prompts and names.\n\nFiles changed: src/validation.ts (preprocess trims for prompts/names/commands).\n\nRationale: closes #3956 and #3957.\n\nNotes: I audited the earlier large PR and removed unrelated files; this PR targets 'develop' as required by the release process.