### PR TITLE
test(dashboard): expand Kanban board + tab routing coverage

### DIFF
--- a/dashboard/src/components/overview/__tests__/SessionBoard.test.tsx
+++ b/dashboard/src/components/overview/__tests__/SessionBoard.test.tsx
@@ -1,8 +1,11 @@
 /**
- * SessionBoard tests.
+ * SessionBoard tests — expanded coverage for #3991.
+ *
+ * Covers: column grouping logic, "Other" column, running/waiting counts,
+ * session card data rendering, sorting, accessibility roles.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { SessionBoard } from '../SessionBoard';
 
 vi.mock('../../../api/client', () => ({
@@ -37,6 +40,8 @@ describe('SessionBoard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  // ── Original tests ────────────────────────────────────────────────
 
   it('renders loading state', () => {
     mockGetSessions.mockReturnValue(new Promise(() => {}));
@@ -136,5 +141,176 @@ describe('SessionBoard', () => {
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /Session board/ })).not.toBeNull();
     });
+  });
+
+  // ── #3991: Column grouping logic ──────────────────────────────────
+
+  it('groups working sessions into the Running column', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's-running', status: 'working', displayName: 'runner' }),
+        makeSession({ id: 's-idle', status: 'idle', displayName: 'sleeper' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const runningRegion = await screen.findByRole('region', { name: /Running sessions/ });
+    expect(within(runningRegion).getByText('runner')).not.toBeNull();
+
+    const idleRegion = await screen.findByRole('region', { name: /Idle sessions/ });
+    expect(within(idleRegion).getByText('sleeper')).not.toBeNull();
+  });
+
+  it('groups permission_prompt into the Waiting column', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's-wait', status: 'permission_prompt', displayName: 'waiter' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const waitingRegion = await screen.findByRole('region', { name: /Waiting sessions/ });
+    expect(within(waitingRegion).getByText('waiter')).not.toBeNull();
+  });
+
+  it('groups unknown statuses into Other column', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's-unknown', status: 'some_new_status' as string, displayName: 'mystery' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const otherRegion = await screen.findByRole('region', { name: /Other sessions/ });
+    expect(within(otherRegion).getByText('mystery')).not.toBeNull();
+  });
+
+  it('does not render Other column when no sessions have unknown status', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'working' }),
+        makeSession({ id: 's2', status: 'idle' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    await screen.findByRole('region', { name: /Session board/ });
+    expect(screen.queryByRole('region', { name: /Other sessions/ })).toBeNull();
+  });
+
+  it('shows correct running and waiting counts in header', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'working' }),
+        makeSession({ id: 's2', status: 'compacting' }),
+        makeSession({ id: 's3', status: 'permission_prompt' }),
+        makeSession({ id: 's4', status: 'idle' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 4, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 running/)).not.toBeNull();
+      expect(screen.getByText(/1 waiting/)).not.toBeNull();
+      expect(screen.getByText('4 sessions')).not.toBeNull();
+    });
+  });
+
+  it('renders session card aria-label with name and status', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'working', displayName: 'my-session' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const card = await screen.findByRole('article', { name: /my-session.*working/ });
+    expect(card).not.toBeNull();
+  });
+
+  it('renders compacting status in Running column', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'compacting', displayName: 'compactor' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const runningRegion = await screen.findByRole('region', { name: /Running sessions/ });
+    expect(within(runningRegion).getByText('compactor')).not.toBeNull();
+  });
+
+  it('renders ask_question status in Waiting column', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'ask_question', displayName: 'questioner' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const waitingRegion = await screen.findByRole('region', { name: /Waiting sessions/ });
+    expect(within(waitingRegion).getByText('questioner')).not.toBeNull();
+  });
+
+  it('sorts sessions within a column by lastActivity descending', async () => {
+    const now = Date.now();
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's-old', status: 'working', displayName: 'older-session', lastActivity: now - 60000 }),
+        makeSession({ id: 's-new', status: 'working', displayName: 'newer-session', lastActivity: now - 10000 }),
+      ],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const runningRegion = await screen.findByRole('region', { name: /Running sessions/ });
+    const cards = within(runningRegion).getAllByRole('listitem');
+    expect(within(cards[0]).getByText('newer-session')).not.toBeNull();
+    expect(within(cards[1]).getByText('older-session')).not.toBeNull();
+  });
+
+  it('renders all Waiting sub-statuses in Waiting column', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'bash_approval', displayName: 'bash-approval' }),
+        makeSession({ id: 's2', status: 'context_warning', displayName: 'context-warn' }),
+        makeSession({ id: 's3', status: 'waiting_for_input', displayName: 'wait-input' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 3, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const waitingRegion = await screen.findByRole('region', { name: /Waiting sessions/ });
+    expect(within(waitingRegion).getByText('bash-approval')).not.toBeNull();
+    expect(within(waitingRegion).getByText('context-warn')).not.toBeNull();
+    expect(within(waitingRegion).getByText('wait-input')).not.toBeNull();
   });
 });

--- a/dashboard/src/pages/__tests__/SessionsPage.test.tsx
+++ b/dashboard/src/pages/__tests__/SessionsPage.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * SessionsPage tab routing tests — #3991.
+ *
+ * Verifies tab switching renders the correct panel content.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SessionsPage from '../SessionsPage';
+
+// Mock SessionBoard
+vi.mock('../../components/overview/SessionBoard', () => ({
+  SessionBoard: () => <div data-testid="session-board">Board View</div>,
+}));
+
+// Mock SessionTable
+vi.mock('../../components/overview/SessionTable', () => ({
+  __esModule: true,
+  default: () => <div data-testid="session-table">Active Table</div>,
+}));
+
+// Mock SessionHistoryPage (lazy loaded)
+vi.mock('../SessionHistoryPage', () => ({
+  __esModule: true,
+  default: () => <div data-testid="session-history">History Page</div>,
+}));
+
+// Mock ErrorBoundary
+vi.mock('../../components/shared/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock Skeleton
+vi.mock('../../components/shared/Skeleton', () => ({
+  SkeletonTable: () => <div>Loading skeleton</div>,
+}));
+
+// Mock i18n
+vi.mock('../../i18n/context', () => ({
+  useT: () => (key: string) => key,
+}));
+
+function renderWithRouter(initialPath: string = '/sessions') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/sessions" element={<SessionsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('SessionsPage tab routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to Active tab when no tab param', () => {
+    renderWithRouter('/sessions');
+
+    expect(screen.getByTestId('session-table')).not.toBeNull();
+    const activeTab = screen.getByRole('tab', { name: 'Active' });
+    expect(activeTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('renders Board tab panel when ?tab=board', () => {
+    renderWithRouter('/sessions?tab=board');
+
+    expect(screen.getByTestId('session-board')).not.toBeNull();
+    const boardTab = screen.getByRole('tab', { name: 'Board' });
+    expect(boardTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('renders All tab panel when ?tab=all', async () => {
+    renderWithRouter('/sessions?tab=all');
+
+    // SessionHistoryPage is lazy loaded
+    await waitFor(() => {
+      expect(screen.getByTestId('session-history')).not.toBeNull();
+    });
+    const allTab = screen.getByRole('tab', { name: 'All' });
+    expect(allTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('switches to Board tab on click', async () => {
+    renderWithRouter('/sessions');
+
+    // Starts on Active tab
+    expect(screen.getByTestId('session-table')).not.toBeNull();
+
+    // Click Board tab
+    fireEvent.click(screen.getByRole('tab', { name: 'Board' }));
+
+    // Board panel should appear
+    await waitFor(() => {
+      expect(screen.getByTestId('session-board')).not.toBeNull();
+    });
+  });
+
+  it('switches to All tab on click', async () => {
+    renderWithRouter('/sessions');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'All' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-history')).not.toBeNull();
+    });
+  });
+
+  it('falls back to Active tab for unknown tab param', () => {
+    renderWithRouter('/sessions?tab=nonexistent');
+
+    expect(screen.getByTestId('session-table')).not.toBeNull();
+    const activeTab = screen.getByRole('tab', { name: 'Active' });
+    expect(activeTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('renders all three tabs in the tablist', () => {
+    renderWithRouter('/sessions');
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(3);
+    expect(tabs.map(t => t.textContent)).toEqual(['Active', 'Board', 'All']);
+  });
+});

--- a/dashboard/src/pages/__tests__/SessionsPage.test.tsx
+++ b/dashboard/src/pages/__tests__/SessionsPage.test.tsx
@@ -2,43 +2,41 @@
  * SessionsPage tab routing tests — #3991.
  *
  * Verifies tab switching renders the correct panel content.
+ * SessionBoard and SessionHistoryPage are lazy-loaded via React.lazy,
+ * so all board/all assertions must use waitFor for Suspense resolution.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import SessionsPage from '../SessionsPage';
 
-// Mock SessionBoard
 vi.mock('../../components/overview/SessionBoard', () => ({
+  __esModule: true,
   SessionBoard: () => <div data-testid="session-board">Board View</div>,
 }));
 
-// Mock SessionTable
 vi.mock('../../components/overview/SessionTable', () => ({
   __esModule: true,
   default: () => <div data-testid="session-table">Active Table</div>,
 }));
 
-// Mock SessionHistoryPage (lazy loaded)
 vi.mock('../SessionHistoryPage', () => ({
   __esModule: true,
   default: () => <div data-testid="session-history">History Page</div>,
 }));
 
-// Mock ErrorBoundary
 vi.mock('../../components/shared/ErrorBoundary', () => ({
   ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-// Mock Skeleton
 vi.mock('../../components/shared/Skeleton', () => ({
-  SkeletonTable: () => <div>Loading skeleton</div>,
+  SkeletonTable: () => <div data-testid="skeleton">Loading skeleton</div>,
 }));
 
-// Mock i18n
 vi.mock('../../i18n/context', () => ({
   useT: () => (key: string) => key,
 }));
+
+import SessionsPage from '../SessionsPage';
 
 function renderWithRouter(initialPath: string = '/sessions') {
   return render(
@@ -63,10 +61,13 @@ describe('SessionsPage tab routing', () => {
     expect(activeTab.getAttribute('aria-selected')).toBe('true');
   });
 
-  it('renders Board tab panel when ?tab=board', () => {
+  it('renders Board tab panel when ?tab=board', async () => {
     renderWithRouter('/sessions?tab=board');
 
-    expect(screen.getByTestId('session-board')).not.toBeNull();
+    // SessionBoard is lazy-loaded via React.lazy — needs waitFor
+    await waitFor(() => {
+      expect(screen.getByTestId('session-board')).not.toBeNull();
+    });
     const boardTab = screen.getByRole('tab', { name: 'Board' });
     expect(boardTab.getAttribute('aria-selected')).toBe('true');
   });
@@ -74,7 +75,6 @@ describe('SessionsPage tab routing', () => {
   it('renders All tab panel when ?tab=all', async () => {
     renderWithRouter('/sessions?tab=all');
 
-    // SessionHistoryPage is lazy loaded
     await waitFor(() => {
       expect(screen.getByTestId('session-history')).not.toBeNull();
     });
@@ -91,7 +91,7 @@ describe('SessionsPage tab routing', () => {
     // Click Board tab
     fireEvent.click(screen.getByRole('tab', { name: 'Board' }));
 
-    // Board panel should appear
+    // Board is lazy — wait for Suspense to resolve
     await waitFor(() => {
       expect(screen.getByTestId('session-board')).not.toBeNull();
     });


### PR DESCRIPTION
## Summary
Closes #3991

### SessionBoard.test.tsx — 10 new tests (18 total)
- **Column grouping**: working/compacting → Running, permission_prompt/ask_question/bash_approval/context_warning/waiting_for_input → Waiting, idle → Idle
- **Other column**: unknown status → conditional Other column render
- **Header counts**: running/waiting count badges verified
- **Session card aria-label**: name + status in accessible label
- **Sort order**: sessions sorted by lastActivity descending within columns

### SessionsPage.test.tsx — 7 new tab routing tests
- Default to Active tab (no URL param)
- `?tab=board` renders SessionBoard
- `?tab=all` renders SessionHistoryPage (lazy)
- Click-based tab switching (Active → Board, Active → All)
- Unknown tab param fallback to Active
- Tablist renders all 3 tabs with correct names

## Verification
- 25 tests pass (18 + 7)
- `tsc --noEmit` clean
- No production code changes — test files only

— Daedalus 🏛️