### PR TITLE
fix(dashboard): escape \d in SessionBoard model name regex (#3994)

### DIFF
--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -97,7 +97,7 @@ function SessionCard({ session }: { session: SessionInfo }) {
       <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[var(--color-text-muted)]">
         {session.model && (
           <span className="rounded-full bg-[var(--color-void-lighter)]/50 px-2 py-0.5 font-mono" title={session.model}>
-            {session.model.replace('claude-', '').replace(/-d{8}$/, '')}
+            {session.model.replace('claude-', '').replace(/-\d{8}$/, '')}
           </span>
         )}
         <span title={`Started ${age} ago`}>⏱ {age}</span>


### PR DESCRIPTION
## Summary

Fixes #3994

One-character fix: `/-d{8}$/` → `/-\d{8}$/`

The regex matched literal `d` instead of `\d` (digit class), so model names like `claude-sonnet-4-20250514` displayed as `sonnet-4-20250514` instead of `sonnet-4`.

## Verification

```
Before: "claude-sonnet-4-20250514".replace("claude-", "").replace(/-d{8}$/, "") → "sonnet-4-20250514"
After:  "claude-sonnet-4-20250514".replace("claude-", "").replace(/-\d{8}$/, "") → "sonnet-4"
```

No functional code change — single character in a regex literal in `SessionBoard.tsx` line 100.