### PR TITLE
feat(dashboard): add pagination to SessionBoard with load-more button

### DIFF
--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -7,6 +7,7 @@
  *
  * Columns: Running | Waiting | Idle | Other
  * Each card shows: session name, model, status, last activity.
+ * Pagination: "Load X more" button when sessions exceed page size.
  */
 
 import { useState, useMemo, useCallback } from 'react';
@@ -15,7 +16,9 @@ import type { SessionInfo, UIState } from '../../types';
 import StatusDot from './StatusDot';
 import { useStore } from '../../store/useStore';
 import { useSseAwarePolling } from '../../hooks/useSseAwarePolling';
-import { Loader2, Columns3 } from 'lucide-react';
+import { Loader2, Columns3, ChevronDown } from 'lucide-react';
+
+const PAGE_SIZE = 100;
 
 const FALLBACK_POLL_INTERVAL_MS = 5_000;
 const SSE_HEALTHY_POLL_INTERVAL_MS = 30_000;
@@ -167,13 +170,18 @@ export function SessionBoard() {
   const latestActivity = useStore((s) => s.activities[0] ?? null);
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [totalCount, setTotalCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
 
   const fetchSessions = useCallback(async () => {
     try {
       setError(null);
-      const result = await getSessions({ limit: 100 });
+      const result = await getSessions({ limit: PAGE_SIZE, page: 1 });
       setSessions(result.sessions);
+      setTotalCount(result.pagination.total);
+      setCurrentPage(1);
       setLoading(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load sessions');
@@ -188,6 +196,24 @@ export function SessionBoard() {
     fallbackPollIntervalMs: FALLBACK_POLL_INTERVAL_MS,
     healthyPollIntervalMs: SSE_HEALTHY_POLL_INTERVAL_MS,
   });
+
+  const loadMore = useCallback(async () => {
+    const nextPage = currentPage + 1;
+    try {
+      setLoadingMore(true);
+      const result = await getSessions({ limit: PAGE_SIZE, page: nextPage });
+      setSessions((prev) => [...prev, ...result.sessions]);
+      setTotalCount(result.pagination.total);
+      setCurrentPage(nextPage);
+    } catch {
+      // Silently fail — user can retry
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [currentPage]);
+
+  const hasMore = sessions.length < totalCount;
+  const remaining = totalCount - sessions.length;
 
   const columns = useMemo(() => {
     const grouped = new Map<string, SessionInfo[]>();
@@ -210,7 +236,7 @@ export function SessionBoard() {
     return { grouped, hasOther: (grouped.get('other')?.length ?? 0) > 0 };
   }, [sessions]);
 
-  const totalSessions = sessions.length;
+  const loadedSessions = sessions.length;
   const runningCount = sessions.filter(s => BOARD_COLUMNS[0].statuses.includes(s.status)).length;
   const waitingCount = sessions.filter(s => BOARD_COLUMNS[1].statuses.includes(s.status)).length;
 
@@ -236,7 +262,7 @@ export function SessionBoard() {
       {/* Board header with stats */}
       <div className="flex items-center gap-4 text-xs text-[var(--color-text-muted)]">
         <Columns3 className="h-4 w-4" />
-        <span>{totalSessions} sessions</span>
+        <span>{totalCount} sessions{hasMore ? ` (${loadedSessions} loaded)` : ''}</span>
         <span className="flex items-center gap-1">
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
           {runningCount} running
@@ -284,6 +310,31 @@ export function SessionBoard() {
           </div>
         )}
       </div>
+
+      {/* Load more */}
+      {hasMore && (
+        <div className="flex justify-center py-2">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loadingMore}
+            className="flex items-center gap-2 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label={`Load ${remaining} more sessions`}
+          >
+            {loadingMore ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading...
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-4 w-4" />
+                Load {remaining} more
+              </>
+            )}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/dashboard/src/components/overview/__tests__/SessionBoard.test.tsx
+++ b/dashboard/src/components/overview/__tests__/SessionBoard.test.tsx
@@ -5,7 +5,7 @@
  * session card data rendering, sorting, accessibility roles.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import { SessionBoard } from '../SessionBoard';
 
 vi.mock('../../../api/client', () => ({
@@ -326,3 +326,141 @@ describe('SessionBoard', () => {
     });
   });
 });
+
+  // ── #3996: Pagination ─────────────────────────────────────────────
+
+  it('shows "Load more" button when total exceeds loaded sessions', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'working' }),
+        makeSession({ id: 's2', status: 'idle' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 216, totalPages: 3 },
+    });
+
+    render(<SessionBoard />);
+
+    const loadMoreBtn = await screen.findByRole('button', { name: /Load 214 more/ });
+    expect(loadMoreBtn).not.toBeNull();
+  });
+
+  it('does not show "Load more" when all sessions are loaded', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [makeSession({ id: 's1' })],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 sessions')).not.toBeNull();
+    });
+    expect(screen.queryByRole('button', { name: /Load.*more/ })).toBeNull();
+  });
+
+  it('shows total count in header when there are unloaded sessions', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [makeSession({ id: 's1' })],
+      pagination: { page: 1, limit: 100, total: 50, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    await waitFor(() => {
+      // Shows total (50) not just loaded count (1)
+      expect(screen.getByText(/50 sessions/)).not.toBeNull();
+    });
+  });
+
+  it('shows loaded/total breakdown when hasMore', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [makeSession({ id: 's1' }), makeSession({ id: 's2' })],
+      pagination: { page: 1, limit: 100, total: 216, totalPages: 3 },
+    });
+
+    render(<SessionBoard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/216 sessions \(2 loaded\)/)).not.toBeNull();
+    });
+  });
+
+  it('does not show loaded breakdown when all sessions fit in one page', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [makeSession({ id: 's1' }), makeSession({ id: 's2' })],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    await waitFor(() => {
+      // Just "2 sessions" without loaded breakdown
+      expect(screen.getByText('2 sessions')).not.toBeNull();
+    });
+    expect(screen.queryByText(/loaded\)/)).toBeNull();
+  });
+
+  it('appends sessions when "Load more" is clicked', async () => {
+    // First page
+    mockGetSessions.mockResolvedValueOnce({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's1', status: 'working', displayName: 'first-page' }),
+      ],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 2 },
+    });
+
+    // Second page
+    mockGetSessions.mockResolvedValueOnce({
+      ...emptyResponse,
+      sessions: [
+        makeSession({ id: 's2', status: 'idle', displayName: 'second-page' }),
+      ],
+      pagination: { page: 2, limit: 100, total: 2, totalPages: 2 },
+    });
+
+    render(<SessionBoard />);
+
+    // Wait for first page
+    await screen.findByText('first-page');
+
+    // Click load more
+    const loadMoreBtn = screen.getByRole('button', { name: /Load 1 more/ });
+    fireEvent.click(loadMoreBtn);
+
+    // Both sessions should be visible
+    await waitFor(() => {
+      expect(screen.getByText('first-page')).not.toBeNull();
+      expect(screen.getByText('second-page')).not.toBeNull();
+    });
+
+    // "Load more" button should disappear
+    expect(screen.queryByRole('button', { name: /Load.*more/ })).toBeNull();
+  });
+
+  it('shows loading spinner on "Load more" button while fetching', async () => {
+    // First page resolves immediately
+    mockGetSessions.mockResolvedValueOnce({
+      ...emptyResponse,
+      sessions: [makeSession({ id: 's1' })],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 2 },
+    });
+
+    // Second page hangs
+    mockGetSessions.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<SessionBoard />);
+
+    const loadMoreBtn = await screen.findByRole('button', { name: /Load 1 more/ });
+    fireEvent.click(loadMoreBtn);
+
+    // Button should show loading state
+    await waitFor(() => {
+      expect(screen.getByText('Loading...')).not.toBeNull();
+    });
+  });


### PR DESCRIPTION
## Summary
Closes #3996

Adds pagination to the Kanban board so sessions beyond the initial page are no longer silently missing.

### Changes
- Page-based fetching: initial load fetches page 1, "Load more" fetches next page and appends
- **"Load X more" button** — shows remaining count (e.g. "Load 116 more") per design spec
- Header shows total + loaded count: "216 sessions (100 loaded)" when there are unloaded sessions
- Button shows spinner + "Loading..." while fetching, disabled during in-flight requests
- Button disappears once all sessions are loaded

### Design decisions
- "Load more" over infinite scroll — simplest, mobile-friendly, no virtual scroll complexity (per Athena)
- Remaining count visible — prevents "wait, is that everything?" confusion (per Argus audit)
- PAGE_SIZE = 100, same as previous hard cap — no behavior change for small deployments

### Testing
- 25 tests pass (18 existing + 7 new pagination tests)
- tsc clean
- 2 files changed, 194 additions

— Daedalus 🏛️