### PR TITLE
feat(acp): add orphan action sweeper for stale leased actions (#4004)

### DIFF
--- a/src/__tests__/acp-action-sweeper.test.ts
+++ b/src/__tests__/acp-action-sweeper.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ActionSweeper, resolveSweeperConfig } from '../services/acp/action-sweeper.js';
+import {
+  createMemoryAcpLocalStorageProfile,
+  type AcpActionQueue,
+  type AcpControlActionInput,
+  type AcpSessionScope,
+} from '../services/acp/index.js';
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+function actionInput(overrides: Partial<AcpControlActionInput> = {}): AcpControlActionInput {
+  return {
+    ...scope,
+    sessionId: 'session-1',
+    actionId: `action-${Math.random().toString(36).slice(2, 8)}`,
+    type: 'prompt',
+    metadata: { text: 'hello' },
+    ...overrides,
+  };
+}
+
+describe('sweepOrphanedActions', () => {
+  it('recovers actions past their lease deadline', async () => {
+    const profile = createMemoryAcpLocalStorageProfile();
+    const queue = profile.actionQueue;
+
+    // Enqueue and lease an action
+    const action = await queue.enqueue(actionInput());
+    const leased = await queue.leaseNext(scope, {
+      leaseUntil: new Date(Date.now() + 5000),
+    });
+    expect(leased).not.toBeNull();
+    expect(leased!.actionId).toBe(action.actionId);
+    expect(leased!.status).toBe('leased');
+
+    // Sweep with now past the lease deadline
+    const now = new Date(Date.now() + 10000);
+    const recovered = await queue.sweepOrphanedActions(now);
+
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].actionId).toBe(action.actionId);
+    expect(recovered[0].status).toBe('failed');
+    expect(recovered[0].errorMetadata?.sweeper).toBe(true);
+    expect(recovered[0].errorMetadata?.reason).toBe('lease_expired');
+    expect(recovered[0].failedAt).toBeTruthy();
+  });
+
+  it('does not recover actions within their lease', async () => {
+    const profile = createMemoryAcpLocalStorageProfile();
+    const queue = profile.actionQueue;
+
+    await queue.enqueue(actionInput());
+    await queue.leaseNext(scope, {
+      leaseUntil: new Date(Date.now() + 60_000),
+    });
+
+    // Sweep with now BEFORE the lease deadline
+    const recovered = await queue.sweepOrphanedActions(new Date());
+
+    expect(recovered).toHaveLength(0);
+  });
+
+  it('does not recover queued or completed actions', async () => {
+    const profile = createMemoryAcpLocalStorageProfile();
+    const queue = profile.actionQueue;
+
+    // Enqueue a queued action (not leased)
+    await queue.enqueue(actionInput({ actionId: 'queued-action' }));
+
+    // Enqueue, lease, and complete another action
+    await queue.enqueue(actionInput({ actionId: 'completed-action' }));
+    const leased = await queue.leaseNext(scope, {
+      leaseUntil: new Date(Date.now() + 60_000),
+    });
+    expect(leased).not.toBeNull();
+    await queue.complete(leased!.actionId, scope, {});
+
+    // Sweep with future date
+    const recovered = await queue.sweepOrphanedActions(new Date(Date.now() + 120_000));
+
+    expect(recovered).toHaveLength(0);
+  });
+
+  it('recovers multiple orphaned actions', async () => {
+    const profile = createMemoryAcpLocalStorageProfile();
+    const queue = profile.actionQueue;
+
+    // Enqueue and lease 3 actions
+    for (let i = 1; i <= 3; i++) {
+      await queue.enqueue(actionInput({ actionId: `orphan-${i}` }));
+      await queue.leaseNext(scope, {
+        leaseUntil: new Date(Date.now() + 1000),
+      });
+    }
+
+    const recovered = await queue.sweepOrphanedActions(new Date(Date.now() + 5000));
+
+    expect(recovered).toHaveLength(3);
+    for (const r of recovered) {
+      expect(r.status).toBe('failed');
+      expect(r.errorMetadata?.sweeper).toBe(true);
+    }
+  });
+});
+
+describe('ActionSweeper', () => {
+  it('starts and stops the sweeper', () => {
+    const profile = createMemoryAcpLocalStorageProfile();
+    const sweeper = new ActionSweeper(
+      profile.actionQueue,
+      { enabled: true, intervalMs: 1000 },
+    );
+
+    sweeper.start();
+    sweeper.stop();
+    // No error means success
+  });
+
+  it('does not start when disabled', () => {
+    const profile = createMemoryAcpLocalStorageProfile();
+    // The sweeper itself doesn't check enabled — the caller does.
+    // But resolveSweeperConfig returns enabled=false when env says so.
+    const config = resolveSweeperConfig({ enabled: false });
+    expect(config.enabled).toBe(false);
+  });
+});
+
+describe('resolveSweeperConfig', () => {
+  const origEnabled = process.env.AEGIS_ACTION_SWEEPER_ENABLED;
+  const origInterval = process.env.AEGIS_ACTION_SWEEPER_INTERVAL_MS;
+
+  afterEach(() => {
+    if (origEnabled === undefined) {
+      delete process.env.AEGIS_ACTION_SWEEPER_ENABLED;
+    } else {
+      process.env.AEGIS_ACTION_SWEEPER_ENABLED = origEnabled;
+    }
+    if (origInterval === undefined) {
+      delete process.env.AEGIS_ACTION_SWEEPER_INTERVAL_MS;
+    } else {
+      process.env.AEGIS_ACTION_SWEEPER_INTERVAL_MS = origInterval;
+    }
+  });
+
+  it('returns defaults when no env or overrides', () => {
+    delete process.env.AEGIS_ACTION_SWEEPER_ENABLED;
+    delete process.env.AEGIS_ACTION_SWEEPER_INTERVAL_MS;
+    const config = resolveSweeperConfig();
+    expect(config).toEqual({ enabled: true, intervalMs: 60_000 });
+  });
+
+  it('reads enabled from env', () => {
+    process.env.AEGIS_ACTION_SWEEPER_ENABLED = 'false';
+    delete process.env.AEGIS_ACTION_SWEEPER_INTERVAL_MS;
+    const config = resolveSweeperConfig();
+    expect(config.enabled).toBe(false);
+  });
+
+  it('reads interval from env', () => {
+    delete process.env.AEGIS_ACTION_SWEEPER_ENABLED;
+    process.env.AEGIS_ACTION_SWEEPER_INTERVAL_MS = '30000';
+    const config = resolveSweeperConfig();
+    expect(config.intervalMs).toBe(30_000);
+  });
+
+  it('overrides take precedence over env', () => {
+    process.env.AEGIS_ACTION_SWEEPER_ENABLED = 'false';
+    process.env.AEGIS_ACTION_SWEEPER_INTERVAL_MS = '5000';
+    const config = resolveSweeperConfig({ enabled: true, intervalMs: 10_000 });
+    expect(config.enabled).toBe(true);
+    expect(config.intervalMs).toBe(10_000);
+  });
+});

--- a/src/__tests__/acp-action-worker.test.ts
+++ b/src/__tests__/acp-action-worker.test.ts
@@ -266,6 +266,10 @@ class ScriptedActionQueue implements AcpActionQueue {
   async cancel(): Promise<AcpActionRecord | null> {
     throw new Error('not used by this test');
   }
+
+  async sweepOrphanedActions(): Promise<AcpActionRecord[]> {
+    return [];
+  }
 }
 
 class ThrowingLeaseQueue implements AcpActionQueue {
@@ -288,6 +292,10 @@ class ThrowingLeaseQueue implements AcpActionQueue {
   }
 
   async cancel(): Promise<AcpActionRecord | null> {
+    throw new Error('not used by this test');
+  }
+
+  async sweepOrphanedActions(): Promise<AcpActionRecord[]> {
     throw new Error('not used by this test');
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,6 +76,7 @@ import { AcpBackend } from './services/acp/backend.js';
 import { AcpSessionService } from './services/acp/session-service.js';
 import { AcpTerminalBridge } from './services/acp/terminal-bridge.js';
 import { createFileAcpLocalStorageProfile, type AcpLocalStorageProfile } from './services/acp/local-storage.js';
+import { ActionSweeper, resolveSweeperConfig } from './services/acp/action-sweeper.js';
 import { mapAcpJsonRpcNotificationToEvent } from './services/acp/event-mapper.js';
 import {
   registerHealthRoutes,
@@ -158,6 +159,7 @@ let acpSessionService: AcpSessionService | null = null;
 let acpBackend: AcpBackend | null = null;
 let acpTerminalBridge: AcpTerminalBridge | null = null;
 let acpPauseStore: import('./services/acp/pause-intervention.js').AcpPauseInterventionStore | null = null;
+let actionSweeper: ActionSweeper | null = null;
 
 // ── Inbound command handler ─────────────────────────────────────────
 
@@ -866,6 +868,28 @@ async function main(): Promise<void> {
   // Issue #3143: Wire ACP event store into session transcript reader
   sessions.setAcpEventStore(acpLocalProfile.eventStore);
 
+  // Issue #4004: Orphan action sweeper — recovers stale leased actions
+  const sweeperConfig = resolveSweeperConfig();
+  if (sweeperConfig.enabled) {
+    actionSweeper = new ActionSweeper(acpLocalProfile.actionQueue, sweeperConfig, {
+      onRecovered: (actions) => {
+        logger.info({
+          component: 'server',
+          operation: 'action_sweeper_recovered',
+          attributes: { count: actions.length, actionIds: actions.map(a => a.actionId) },
+        });
+      },
+      onError: (err) => {
+        logger.error({
+          component: 'server',
+          operation: 'action_sweeper_error',
+          errorCode: 'ACTION_SWEEPER_ERROR',
+          attributes: { error: err instanceof Error ? err.message : String(err) },
+        });
+      },
+    });
+  }
+
   // Memory bridge (Issue #783)
   if (config.memoryBridge?.enabled) {
     const persistPath = config.memoryBridge.persistPath ?? path.join(config.stateDir, 'memory.json');
@@ -1200,6 +1224,8 @@ async function main(): Promise<void> {
   const authSweepInterval = setInterval(() => auth.sweepStaleRateLimits(), 5 * 60_000);
   // #2452: Sweep expired quota usage entries every 5 minutes to prevent unbounded growth
   const quotaSweepInterval = setInterval(() => routeCtx.quotas.sweep(), 5 * 60_000);
+  // Issue #4004: Start orphan action sweeper
+  actionSweeper?.start();
   // #3227: Prune interval from StaticRateLimiter — assigned after registerDashboardStatic()
   let staticPruneInterval: ReturnType<typeof setInterval> | null = null;
   let pidFilePath = '';
@@ -1275,6 +1301,8 @@ async function main(): Promise<void> {
       clearInterval(authFailPruneInterval);
       clearInterval(authSweepInterval);
       clearInterval(quotaSweepInterval);
+      // Issue #4004: Stop orphan action sweeper
+      actionSweeper?.stop();
       if (staticPruneInterval) clearInterval(staticPruneInterval);
       rateLimiter.dispose();
 

--- a/src/services/acp/action-queue.ts
+++ b/src/services/acp/action-queue.ts
@@ -79,6 +79,12 @@ export interface AcpActionQueue {
     scope: AcpSessionScope,
     options?: AcpCancelActionOptions
   ): Promise<AcpActionRecord | null>;
+
+  /**
+   * Sweep all leased actions past their leasedUntil deadline, marking them as failed.
+   * Returns the list of recovered action records.
+   */
+  sweepOrphanedActions(now?: Date): Promise<AcpActionRecord[]>;
 }
 
 const MAX_ACTION_METADATA_KEYS = 20;

--- a/src/services/acp/action-sweeper.ts
+++ b/src/services/acp/action-sweeper.ts
@@ -1,0 +1,95 @@
+import type { AcpActionQueue, AcpActionRecord } from './action-queue.js';
+
+/** Configuration for the orphan action sweeper. */
+export interface ActionSweeperConfig {
+  /** Whether the sweeper is enabled. Default: true. */
+  enabled?: boolean;
+  /** Sweep interval in milliseconds. Default: 60_000. */
+  intervalMs?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const ENV_ENABLED = 'AEGIS_ACTION_SWEEPER_ENABLED';
+const ENV_INTERVAL_MS = 'AEGIS_ACTION_SWEEPER_INTERVAL_MS';
+
+/** Reads sweeper config from environment variables, with explicit overrides taking precedence. */
+export function resolveSweeperConfig(overrides: ActionSweeperConfig = {}): Required<ActionSweeperConfig> {
+  const envEnabled = process.env[ENV_ENABLED];
+  const envInterval = process.env[ENV_INTERVAL_MS];
+
+  let enabled = true;
+  if (overrides.enabled !== undefined) {
+    enabled = overrides.enabled;
+  } else if (envEnabled !== undefined) {
+    enabled = envEnabled !== 'false' && envEnabled !== '0';
+  }
+
+  let intervalMs = DEFAULT_INTERVAL_MS;
+  if (overrides.intervalMs !== undefined) {
+    intervalMs = overrides.intervalMs;
+  } else if (envInterval !== undefined) {
+    const parsed = Number.parseInt(envInterval, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      intervalMs = parsed;
+    }
+  }
+
+  return { enabled, intervalMs };
+}
+
+export interface ActionSweeperCallbacks {
+  onRecovered?: (actions: AcpActionRecord[]) => void;
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Periodically sweeps the action queue for orphaned (stale-leased) actions.
+ * Call `start()` to begin the sweep loop, `stop()` to end it.
+ */
+export class ActionSweeper {
+  private readonly queue: AcpActionQueue;
+  private readonly intervalMs: number;
+  private readonly callbacks: ActionSweeperCallbacks;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    queue: AcpActionQueue,
+    config: Required<ActionSweeperConfig>,
+    callbacks: ActionSweeperCallbacks = {}
+  ) {
+    this.queue = queue;
+    this.intervalMs = config.intervalMs;
+    this.callbacks = callbacks;
+  }
+
+  start(): void {
+    if (this.timer !== null) return;
+    this.timer = setInterval(() => {
+      void this.sweepOnce();
+    }, this.intervalMs);
+    // Prevent the timer from keeping the process alive
+    if (this.timer.unref) {
+      this.timer.unref();
+    }
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async sweepOnce(): Promise<void> {
+    try {
+      const recovered = await this.queue.sweepOrphanedActions();
+      if (recovered.length > 0 && this.callbacks.onRecovered) {
+        this.callbacks.onRecovered(recovered);
+      }
+    } catch (err) {
+      if (this.callbacks.onError) {
+        this.callbacks.onError(err);
+      }
+    }
+  }
+}

--- a/src/services/acp/index.ts
+++ b/src/services/acp/index.ts
@@ -63,6 +63,7 @@ export type {
   AcpLeaseActionOptions,
 } from './action-queue.js';
 export { normalizeAcpActionMetadata } from './action-queue.js';
+export { ActionSweeper, resolveSweeperConfig, type ActionSweeperConfig, type ActionSweeperCallbacks } from './action-sweeper.js';
 export {
   ACP_ACTION_WORKER_STALE_LEASE_RECOVERY_POLICY,
   AcpActionWorker,

--- a/src/services/acp/local-storage.ts
+++ b/src/services/acp/local-storage.ts
@@ -458,6 +458,31 @@ export class MemoryAcpActionQueue implements AcpActionQueue {
     this.state = state;
   }
 
+  async sweepOrphanedActions(now: Date = new Date()): Promise<AcpActionRecord[]> {
+    const recovered: AcpActionRecord[] = [];
+    for (const action of this.state.actions) {
+      if (
+        action.status === 'leased' &&
+        action.leasedUntil !== undefined &&
+        action.leasedUntil.getTime() <= now.getTime()
+      ) {
+        action.status = 'failed';
+        action.failedAt = new Date(now.getTime());
+        action.leasedUntil = undefined;
+        action.errorMetadata = {
+          sweeper: true,
+          reason: 'lease_expired',
+          recoveredAt: now.toISOString(),
+        };
+        recovered.push(cloneAction(action));
+      }
+    }
+    if (recovered.length > 0) {
+      await this.onMutation();
+    }
+    return recovered;
+  }
+
   private findByIdempotencyKey(
     input: AcpControlActionInput,
     idempotencyKey: string

--- a/src/services/acp/postgres-action-queue.ts
+++ b/src/services/acp/postgres-action-queue.ts
@@ -289,6 +289,27 @@ export class PostgresAcpActionQueue implements AcpActionQueue {
     return record;
   }
 
+  async sweepOrphanedActions(now: Date = new Date()): Promise<AcpActionRecord[]> {
+    const errorMetadata = {
+      sweeper: true,
+      reason: 'lease_expired',
+      recoveredAt: now.toISOString(),
+    };
+    const result = await this.requirePool().query<AcpActionRow>(
+      `UPDATE ${this.qt()}
+       SET status = 'failed',
+           failed_at = $1,
+           error_metadata = $2,
+           leased_until = NULL
+       WHERE status = 'leased'
+         AND leased_until IS NOT NULL
+         AND leased_until <= $1
+       RETURNING ${returningColumns()}`,
+      [now, errorMetadata]
+    );
+    return result.rows.map(rowToRecord);
+  }
+
   private async findByIdempotencyKey(
     tenantId: string,
     ownerKeyId: string,


### PR DESCRIPTION
## Summary

Implements #4004 — periodic sweeper that recovers orphaned (stale-leased) ACP actions.

When a worker crashes while holding a lease, the action stays in `leased` state forever. This sweeper periodically scans for leased actions past their `leasedUntil` deadline and marks them as `failed` with error metadata indicating sweeper recovery.

## Changes

- **`action-queue.ts`**: Add `sweepOrphanedActions(now?: Date)` to the `AcpActionQueue` interface
- **`local-storage.ts`**: Implement in `MemoryAcpActionQueue` — scans in-memory actions, marks expired leases as failed
- **`postgres-action-queue.ts`**: Implement in `PostgresAcpActionQueue` — single SQL UPDATE with RETURNING
- **`action-sweeper.ts`** (new): `ActionSweeper` class with `start()`/`stop()` lifecycle and configurable interval
- **`server.ts`**: Wire sweeper on startup, stop on graceful shutdown, log recovered actions
- **`acp-action-sweeper.test.ts`** (new): 10 tests covering sweep logic, config resolution, and lifecycle

## Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `AEGIS_ACTION_SWEEPER_ENABLED` | `true` | Enable/disable the sweeper |
| `AEGIS_ACTION_SWEEPER_INTERVAL_MS` | `60000` | Sweep interval in milliseconds |

## Verification

```
tsc --noEmit: ✓ 0 new errors (pre-existing test file errors only)
npm run build: ✓ success
npm test: ✓ 359 passed, 1 skipped, 4991 tests passed
```

## Files Changed

- `src/services/acp/action-queue.ts` — interface addition
- `src/services/acp/local-storage.ts` — memory implementation
- `src/services/acp/postgres-action-queue.ts` — postgres implementation
- `src/services/acp/action-sweeper.ts` — new utility
- `src/services/acp/index.ts` — exports
- `src/server.ts` — wiring
- `src/__tests__/acp-action-sweeper.test.ts` — new tests
- `src/__tests__/acp-action-worker.test.ts` — mock updates

Closes #4004