### PR TITLE
fix(session): carry over model/effort on resume; add missing API contract fields (#3948)

### DIFF
--- a/src/__tests__/resume-model-persist-3948.test.ts
+++ b/src/__tests__/resume-model-persist-3948.test.ts
@@ -1,0 +1,189 @@
+/**
+ * resume-model-persist-3948.test.ts
+ *
+ * Tests that when a session is resumed via resumeSessionId, the model and
+ * effort fields are carried over from the original session.
+ *
+ * Issue #3948: ensure per-session model persistence on resume.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+// Mock tmux backend before importing SessionManager
+vi.mock('../tmux.js', () => ({
+  TmuxRunner: vi.fn().mockImplementation(() => ({
+    ensureSession: vi.fn().mockResolvedValue(undefined),
+    listWindows: vi.fn().mockResolvedValue([]),
+    createWindow: vi.fn().mockResolvedValue({ windowId: '@1', displayName: 'mock', freshSessionId: 'mock-cc' }),
+    capturePane: vi.fn().mockResolvedValue(''),
+    capturePaneDirect: vi.fn().mockResolvedValue(''),
+    listPanePid: vi.fn().mockResolvedValue(12345),
+    isPidAlive: vi.fn().mockResolvedValue(true),
+    getWindowHealth: vi.fn().mockResolvedValue({ windowExists: true, paneCommand: null, claudeRunning: false, paneDead: false }),
+    windowExists: vi.fn().mockResolvedValue(true),
+    sendKeys: vi.fn().mockResolvedValue({ success: true }),
+    sendKeysVerified: vi.fn().mockResolvedValue({ delivered: true, attempts: 1 }),
+    sendSpecialKey: vi.fn().mockResolvedValue({ success: true }),
+    killWindow: vi.fn().mockResolvedValue({ success: true }),
+    killSession: vi.fn().mockResolvedValue({ success: true }),
+    isServerHealthy: vi.fn().mockResolvedValue({ healthy: true, error: null }),
+    isTmuxServerError: vi.fn().mockReturnValue(false),
+  })),
+}));
+
+// Mock hook settings writing
+vi.mock('../hooks.js', async () => {
+  const actual = await vi.importActual('../hooks.js');
+  return {
+    ...actual,
+    writeHookSettingsFile: vi.fn().mockResolvedValue('/tmp/fake-hooks.json'),
+    cleanupStaleSessionHooks: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { SessionManager } from '../session.js';
+import type { Config } from '../config.js';
+
+function makeConfig(stateDir: string): Config {
+  return {
+    port: 0, host: '127.0.0.1', authToken: 'test-token',
+    stateDir,
+    claudeProjectsDir: join(stateDir, 'projects'),
+    maxSessionAgeMs: 2 * 60 * 60 * 1000, reaperIntervalMs: 60 * 60 * 1000,
+    continuationPointerTtlMs: 24 * 60 * 60 * 1000,
+    tgBotToken: '', tgGroupId: '', tgAllowedUsers: [], tgTopicTtlMs: 0,
+    tgTopicAutoDelete: true, tgVerbose: false, tgTopicTTLHours: 0,
+    stallThresholdMs: 5 * 60 * 1000, defaultPermissionMode: 'default',
+    allowedWorkDirs: [], defaultSessionEnv: {}, metricsToken: '',
+    hookSecretHeaderOnly: false, pipelineStageTimeoutMs: 30_000,
+    webhooks: [], sseMaxConnections: 100, sseMaxPerIp: 10,
+    memoryBridge: { enabled: false }, worktreeAwareContinuation: false,
+    worktreeSiblingDirs: [],
+    verificationProtocol: { autoVerifyOnStop: false, criticalOnly: false },
+    alerting: { webhooks: [], failureThreshold: 5, cooldownMs: 600_000 },
+    envDenylist: [], envAdminAllowlist: [], enforceSessionOwnership: false,
+    strictRBAC: false,
+    sseIdleMs: 60_000, sseClientTimeoutMs: 300_000, hookTimeoutMs: 10_000,
+    shutdownGraceMs: 15_000, keyRotationGraceSeconds: 3600, shutdownHardMs: 20_000,
+    acpPromptTimeoutMs: 120_000,
+    rateLimit: { enabled: false, sessionsMax: 100, generalMax: 30, timeWindowSec: 60 },
+    stateStore: 'file', postgresUrl: '', defaultTenantId: 'default', acpEnabled: false,
+    tenantWorkdirs: {},
+  } satisfies Config;
+}
+
+describe('Resume session model persistence (#3948)', () => {
+  let tmpDir: string;
+  let sessions: SessionManager;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aegis-resume-3948-'));
+    sessions = new SessionManager(makeConfig(tmpDir));
+    await sessions.load();
+  });
+
+  afterEach(() => {
+    try { rmSync(tmpDir, { recursive: true }); } catch {}
+  });
+
+  it('carries over model from original session on resume', async () => {
+    // Create original session with explicit model
+    const original = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'original',
+      model: 'claude-sonnet-4-20250514',
+    });
+
+    // Resume without specifying model
+    const resumed = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'resumed',
+      resumeSessionId: original.id,
+    });
+
+    expect(resumed.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('carries over effort from original session on resume', async () => {
+    const original = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'original',
+      model: 'claude-opus-4',
+      effort: 'high',
+    });
+
+    const resumed = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'resumed',
+      resumeSessionId: original.id,
+    });
+
+    expect(resumed.model).toBe('claude-opus-4');
+    expect(resumed.effort).toBe('high');
+  });
+
+  it('explicit model override wins over resume carry-over', async () => {
+    const original = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'original',
+      model: 'claude-sonnet-4-20250514',
+    });
+
+    const resumed = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'resumed',
+      resumeSessionId: original.id,
+      model: 'claude-haiku-3.5',
+    });
+
+    // Explicit override should win
+    expect(resumed.model).toBe('claude-haiku-3.5');
+  });
+
+  it('explicit effort override wins over resume carry-over', async () => {
+    const original = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'original',
+      model: 'claude-sonnet-4',
+      effort: 'high',
+    });
+
+    const resumed = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'resumed',
+      resumeSessionId: original.id,
+      effort: 'low',
+    });
+
+    expect(resumed.model).toBe('claude-sonnet-4'); // carried over
+    expect(resumed.effort).toBe('low'); // explicit override
+  });
+
+  it('uses detected model when no resume and no explicit model', async () => {
+    // No model, no resume — should use whatever detectedModel returns (undefined in test)
+    const session = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'fresh',
+    });
+
+    // detectedModel will be undefined in test (no CC settings files)
+    // so model should be undefined
+    expect(session.model).toBeUndefined();
+  });
+
+  it('handles resume of non-existent session gracefully', async () => {
+    const fakeId = '00000000-0000-0000-0000-000000000000';
+    const session = await sessions.createSession({
+      workDir: tmpDir,
+      name: 'resumed-nope',
+      resumeSessionId: fakeId,
+    });
+
+    // Should not throw — just no carry-over
+    expect(session.id).toBeDefined();
+    expect(session.model).toBeUndefined();
+  });
+});

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -260,6 +260,14 @@ export interface CreateSessionRequest {
   autoApprove?: boolean;
   parentId?: string;
   memoryKeys?: string[];
+  /** Issue #2535 / #3948: Model name at creation (e.g. "claude-sonnet-4-6"). Carried over on resume. */
+  model?: string;
+  /** Issue #3948: Effort level at creation. Carried over on resume. */
+  effort?: string;
+  /** Issue #2913: Per-session custom system prompt. */
+  systemPrompt?: string;
+  /** Issue #3613: Per-session isolation policy override. */
+  isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
 }
 
 export interface PaneResponse {

--- a/src/session.ts
+++ b/src/session.ts
@@ -807,6 +807,20 @@ export class SessionManager {
     windowId = '';
     finalName = displayName;
 
+    // Issue #3948: When resuming, carry over model/effort from the original session
+    // if no explicit override is provided. This preserves /model changes made mid-session.
+    let effectiveModel = opts.model || detectedModel;
+    let effectiveEffort = opts.effort;
+    if (opts.resumeSessionId && !opts.model) {
+      const oldSession = this.state.sessions[opts.resumeSessionId];
+      if (oldSession?.model) {
+        effectiveModel = oldSession.model;
+      }
+      if (!opts.effort && oldSession?.effort) {
+        effectiveEffort = oldSession.effort;
+      }
+    }
+
     const session: SessionInfo = {
       id,
       windowId,
@@ -831,8 +845,9 @@ export class SessionManager {
       tenantId: opts.tenantId,
       // Issue #2535: Store model at creation so analytics can group by model
       // Issue #3740: Fall back to model from CC settings if not provided at creation.
-      model: opts.model || detectedModel,
-      effort: opts.effort,
+      // Issue #3948: effectiveModel includes resume carry-over from original session.
+      model: effectiveModel,
+      effort: effectiveEffort,
       runnerName: opts.runnerName,
       isolationMode: isolationMode,
       isolationPolicy: policy,


### PR DESCRIPTION
## Summary

Fixes #3948

Per Daedalus diagnosis — two gaps in the resume/model stack:

### Gap 1: `src/session.ts` — Resume model carry-over
When `resumeSessionId` is set and no explicit `model`/`effort` override is provided, `_createSession()` now looks up the original session and inherits its `model` and `effort` fields. This preserves `/model` changes made mid-session that were captured via hook events.

### Gap 2: `src/api-contracts.ts` — Missing CreateSessionRequest fields
Added `model`, `effort`, `systemPrompt`, and `isolationPolicy` to the `CreateSessionRequest` TypeScript interface. The Zod route schema already accepted them, but the API contract type was incomplete — the dashboard literally could not send model at creation time.

## Changes

| File | Change |
|------|--------|
| `src/session.ts` | Add resume model/effort lookup in `_createSession()` before session object creation |
| `src/api-contracts.ts` | Add `model`, `effort`, `systemPrompt`, `isolationPolicy` to `CreateSessionRequest` |
| `src/__tests__/resume-model-persist-3948.test.ts` | 6 unit tests (new file) |

## Verification

```
tsc --noEmit: ✅ clean (no errors in changed files)
Tests: ✅ 6 passed
```

### Test Coverage
- ✅ Model carried over from original session on resume
- ✅ Effort carried over from original session on resume
- ✅ Explicit model override wins over carry-over
- ✅ Explicit effort override wins over carry-over
- ✅ Fresh session without model uses detected fallback
- ✅ Graceful handling of non-existent resumeSessionId

## Dashboard follow-up
@Daedalus — `CreateSessionRequest` now has `model` and `effort`. You can update the dashboard create-session flow to send the selected model at creation time.