### PR TITLE
docs: mark M3 + M5 complete in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,11 +109,11 @@ The tracking issue is #2574 and the child issue catalog spans #2575 through
       Redis coordination, local-dev storage profile (#2584–#2593)
 - [x] M2 — ACP runtime adapter, event mapping, action queue, fanout, terminal
       bridge, and golden contract tests (#2594–#2602)
-- [ ] M3 — breaking REST/MCP/OpenAPI/SDK contract cleanup and migration docs
+- [x] M3 — breaking REST/MCP/OpenAPI/SDK contract cleanup and migration docs
       (#2603–#2610)
 - [x] M4 — native ACP dashboard: chat, tool cards, approvals, driver/observer,
       pause/intervention, terminal debug, and timeline views (#2611–#2619)
-- [ ] M5 — soak, cutover, tmux deletion, deployment/docs cleanup, and final gate
+- [x] M5 — soak, cutover, tmux deletion, deployment/docs cleanup, and final gate
       (#2620–#2627)
 
 ---

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -271,6 +271,8 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_ACP_ENABLED` | `true` | Enable ACP backend for session creation and control actions |
 | `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (default 120s). Increase for slow BYO-LLM proxy setups (min: 1000) |
 | `AEGIS_ACP_STRICT_VALIDATION` | `false` | When `true`, ACP content validation warnings cause action failure instead of logging only. Useful for production deployments requiring hallucination-free output |
+| `AEGIS_ACTION_SWEEPER_ENABLED` | `true` | Enable periodic sweeper that recovers orphaned ACP actions (actions stuck in `leased` state after a worker crash) |
+| `AEGIS_ACTION_SWEEPER_INTERVAL_MS` | `60000` | Sweep interval in milliseconds for orphan action recovery |
 | `AEGIS_ISOLATION_POLICY` | `respect-cc` | Session isolation policy: `respect-cc` (follow CC settings, default), `enforce-worktree` (reject sessions without worktree — prevents file conflicts with concurrent sessions), `enforce-direct` (force direct edits, no worktree) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |


### PR DESCRIPTION
Phase 3.5 is fully complete — all milestones checked off.

- M3 (#2603–#2610): REST/MCP/OpenAPI/SDK contract cleanup — all 8 issues CLOSED
- M5 (#2620–#2627): soak, cutover, tmux deletion, deployment/docs cleanup — all 8 issues CLOSED

Spotted by Hep — ROADMAP needed checkbox update.