### PR TITLE
fix(dashboard): prevent polling refresh from resetting SessionBoard pagination (#4009)

### DIFF
--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -179,9 +179,20 @@ export function SessionBoard() {
     try {
       setError(null);
       const result = await getSessions({ limit: PAGE_SIZE, page: 1 });
-      setSessions(result.sessions);
       setTotalCount(result.pagination.total);
-      setCurrentPage(1);
+      setSessions((prev) => {
+        // Issue #4009: Merge-by-ID refresh instead of wipe.
+        // On poll, fetch page 1 and merge into the existing list:
+        // - Update existing sessions in-place (status changes, etc.)
+        // - Prepend new sessions not yet in the list
+        // - Keep sessions from pages 2+ intact even if not in page 1
+        const freshMap = new Map(result.sessions.map((s) => [s.id, s]));
+        const existingMap = new Map(prev.map((s) => [s.id, s]));
+        const updated = prev.map((s) => freshMap.get(s.id) ?? s);
+        const newFromPage1 = result.sessions.filter((s) => !existingMap.has(s.id));
+        return [...newFromPage1, ...updated];
+      });
+      // Do NOT reset currentPage — preserve loaded pages on refresh
       setLoading(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load sessions');


### PR DESCRIPTION
## Summary

Fixes #4009

**Diagnosis:** This is a **frontend-only** bug. The backend `GET /v1/sessions` API correctly supports `page` + `limit` pagination params. The issue is in `SessionBoard.tsx` where `fetchSessions` hardcodes `page: 1` and wipes the entire session list on every poll cycle.

**Fix:** Merge-by-ID refresh strategy instead of wipe-and-replace:
- On poll, still fetch only page 1 (efficient, single API call)
- Use `setSessions` with functional update to merge intelligently:
  - Update existing sessions in-place (status changes, model updates, etc.)
  - Prepend new sessions not yet in the list
  - Keep sessions from loaded pages 2+ completely intact
- Remove `setCurrentPage(1)` — preserve loaded page state

## Changes

| File | Change |
|------|--------|
| `dashboard/src/components/overview/SessionBoard.tsx` | `fetchSessions` now uses merge-by-ID instead of wipe |

## Verification

```
Dashboard tests: ✅ all pass (no regressions)
```

The fix is 11 lines of merge logic replacing 2 lines of wipe logic. No API changes, no new dependencies.