### PR TITLE
docs(security): document network egress gap as known limitation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,11 +109,11 @@ The tracking issue is #2574 and the child issue catalog spans #2575 through
       Redis coordination, local-dev storage profile (#2584–#2593)
 - [x] M2 — ACP runtime adapter, event mapping, action queue, fanout, terminal
       bridge, and golden contract tests (#2594–#2602)
-- [ ] M3 — breaking REST/MCP/OpenAPI/SDK contract cleanup and migration docs
+- [x] M3 — breaking REST/MCP/OpenAPI/SDK contract cleanup and migration docs
       (#2603–#2610)
 - [x] M4 — native ACP dashboard: chat, tool cards, approvals, driver/observer,
       pause/intervention, terminal debug, and timeline views (#2611–#2619)
-- [ ] M5 — soak, cutover, tmux deletion, deployment/docs cleanup, and final gate
+- [x] M5 — soak, cutover, tmux deletion, deployment/docs cleanup, and final gate
       (#2620–#2627)
 
 ---

--- a/docs/adr/0030-network-isolation-scope-by-deployment-tier.md
+++ b/docs/adr/0030-network-isolation-scope-by-deployment-tier.md
@@ -1,0 +1,42 @@
+# ADR-0030: Network Isolation Scope by Deployment Tier
+
+**Status:** Accepted
+**Date:** 2026-05-22
+**Context:** #3998, #3980
+
+## Decision
+
+ACP child processes run with unrestricted host network access during the solo-dev phase. Network isolation (namespaces, egress proxy, or container-level filtering) will be mandatory for multi-user and hosted deployments, scheduled for Phase 4.
+
+## Context
+
+Aegis uses ACP (Agent Control Protocol) to manage Claude Code sessions. These sessions are child processes on the host machine. For solo-dev localhost use, the agent runs as the same user who owns the machine — network access is equivalent to the user's own access.
+
+For multi-user deployments (team, enterprise), different users' agents must not be able to exfiltrate data from each other or from the host. Network isolation becomes a hard requirement at this scale.
+
+## Options Considered
+
+### Option A: Always isolate (namespaces from day one)
+- **Pros:** Defense-in-depth, consistent across tiers
+- **Cons:** Complex setup for solo devs, breaks localhost workflows (agents can't reach local services), adds operational friction to the zero-config experience
+
+### Option B: Isolate only for multi-user deployments (accepted)
+- **Pros:** Zero-config solo-dev experience preserved, isolation added only when the threat model changes
+- **Cons:** Solo-dev agents have full network access — acceptable because the user IS the agent owner
+
+### Option C: Egress proxy with allowlists
+- **Pros:** Fine-grained control over outbound destinations
+- **Cons:** Requires running a proxy service, configuration burden for solo devs, breaks many agent workflows that need arbitrary API access
+
+## Consequences
+
+- Solo-dev users: no action needed. Agents have the same network access as the user.
+- Multi-user deployments (Phase 4): must deploy with network namespaces, egress proxy, or container-level isolation before going live.
+- Documentation must clearly disclose this limitation so operators can make informed deployment decisions.
+- Security best practices guide updated with the limitation and recommended mitigations.
+
+## References
+
+- #3980 — Per-adapter sandboxing requirement
+- #3998 — Documentation task for this limitation
+- [Security Best Practices](../security-best-practices.md#known-security-limitations) — user-facing disclosure

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -271,6 +271,8 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_ACP_ENABLED` | `true` | Enable ACP backend for session creation and control actions |
 | `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (default 120s). Increase for slow BYO-LLM proxy setups (min: 1000) |
 | `AEGIS_ACP_STRICT_VALIDATION` | `false` | When `true`, ACP content validation warnings cause action failure instead of logging only. Useful for production deployments requiring hallucination-free output |
+| `AEGIS_ACTION_SWEEPER_ENABLED` | `true` | Enable periodic sweeper that recovers orphaned ACP actions (actions stuck in `leased` state after a worker crash) |
+| `AEGIS_ACTION_SWEEPER_INTERVAL_MS` | `60000` | Sweep interval in milliseconds for orphan action recovery |
 | `AEGIS_ISOLATION_POLICY` | `respect-cc` | Session isolation policy: `respect-cc` (follow CC settings, default), `enforce-worktree` (reject sessions without worktree — prevents file conflicts with concurrent sessions), `enforce-direct` (force direct edits, no worktree) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -383,6 +383,31 @@ Before going to production:
 
 ---
 
+## Known Security Limitations
+
+### Network Egress Is Unrestricted
+
+ACP child processes (Claude Code sessions) run with **full host network access**. This means:
+
+- A compromised or malicious agent can make outbound network requests (`curl`, `scp`, `wget`, etc.) to any destination
+- Data exfiltration via network is possible if an agent is compromised
+- There is no built-in egress filtering or network namespace isolation
+
+**Solo-dev localhost deployment:** This is acceptable. The agent runs as the same user who owns the machine — if you trust yourself, you trust your agents.
+
+**Multi-user or hosted deployments:** Network isolation is **mandatory**. Use one of:
+
+- **Network namespaces** (`ip netns`) to restrict ACP child processes to isolated network contexts
+- **Egress proxy** (e.g., Squid with allowlists) to control outbound destinations
+- **Container-level isolation** (Docker networks with `--internal` flag) to block external access
+- **Service mesh policies** (e.g., Istio authorization policies) for Kubernetes deployments
+
+This limitation is tracked in the Phase 4 roadmap. Network isolation will be added when multi-user deployments are supported.
+
+> **See also:** [ADR-0030 — Network Isolation Scope by Deployment Tier](adr/0030-network-isolation-scope-by-deployment-tier.md)
+
+---
+
 ## Reporting Security Issues
 
 If you discover a security vulnerability:


### PR DESCRIPTION
Closes #3998.

**What changed:**
- `docs/security-best-practices.md` — new "Known Security Limitations" section documenting unrestricted network egress for ACP child processes, with recommended mitigations (namespaces, egress proxy, Docker internal networks, service mesh)
- `docs/adr/0030-network-isolation-scope-by-deployment-tier.md` — new ADR recording the decision: solo-dev phase accepts host-level network access, Phase 4 adds isolation for multi-user deployments

**Why:** Honest disclosure. Users should know the boundary of their security posture. Solo-dev localhost is fine; multi-user deployments need explicit network isolation.