### PR TITLE
docs(security): document minimum Claude Code version ≥2.1.145

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Built-in templates: `code-reviewer`, `ci-runner`, `pr-reviewer`, `docs-writer`.
 
 > **Claude Code must be authenticated.** Run `claude auth status` first — if it shows "Not logged in", run `claude login`. Sessions created without auth will silently produce no output.
 >
-> **Prerequisites:** [Node.js ≥ 20](https://nodejs.org/) and [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (authenticated). That's it.
+> **Prerequisites:** [Node.js ≥ 20](https://nodejs.org/) and [Claude Code CLI ≥ 2.1.145](https://docs.anthropic.com/en/docs/claude-code) (authenticated). That's it.
 >
 > **CLI naming:** the primary command is `ag`. The legacy name `aegis` is preserved as an alias.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,6 +6,7 @@ This guide covers deploying Aegis in development, CI/CD, and production environm
 
 - Node.js 20+ (LTS recommended)
 - npm 10+
+- Claude Code ≥ 2.1.145 ([security baseline](https://docs.anthropic.com/en/docs/claude-code/changelog))
 - Linux/macOS (Windows via WSL2)
 - Tailscale, Cloudflare Tunnel, or ngrok (optional, for remote access)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ Get from zero to orchestrating Claude Code sessions in **two commands**.
 | Requirement | Minimum Version | Check Command |
 |---|---|---|
 | Node.js | ≥ 20 | `node --version` |
-| Claude Code CLI | Latest | `claude --version` |
+| Claude Code CLI | ≥ 2.1.145 | `claude --version` |
 | Claude Code auth | Logged in | `claude auth status` |
 
 Aegis bundles `claude-agent-acp` — no tmux installation required.

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -4,6 +4,14 @@ Hardening guide for production Aegis deployments. Covers authentication, network
 
 For the full security policy, see [SECURITY.md](../SECURITY.md).
 
+## Minimum Version Requirements
+
+| Dependency | Minimum Version | Reason |
+|-----------|----------------|--------|
+| Claude Code CLI | ≥ 2.1.145 | Security baseline: fixes bash permission-prompt bypass where bare variable assignments to non-allowlisted env vars were auto-approved |
+
+> Future security fixes in Claude Code may raise this floor. Always run the latest available version.
+
 ---
 
 ## Authentication


### PR DESCRIPTION
Closes #4029.

Security baseline from #4026 audit (Themis). CC v2.1.145 fixes bash permission-prompt bypass where bare variable assignments to non-allowlisted env vars were auto-approved.

**Updated in 4 locations:**
- `README.md` — prerequisites line
- `docs/getting-started.md` — prerequisites table (Latest → ≥ 2.1.145)
- `docs/deployment.md` — prerequisites list
- `docs/security-best-practices.md` — new Minimum Version Requirements section with rationale

Follow-up from Themis #4026 security audit.