### PR TITLE
docs: document OTEL agent attributes + AEGIS_BLOCKED_ACP_ARGS

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -201,7 +201,7 @@ Aegis emits distributed traces via OTLP HTTP when tracing is enabled.
 | `session.create` | INTERNAL | `aegis.session.id`, `workDir` |
 | `session.send` | INTERNAL | `aegis.session.id` |
 | `session.kill` | INTERNAL | `aegis.session.id` |
-| `tool.invoke` | INTERNAL | `aegis.session.id`, `aegis.tool.name`, `aegis.tool.use_id`, `aegis.tool.result`, `aegis.tool.duration_ms` |
+| `tool.invoke` | INTERNAL | `aegis.session.id`, `aegis.tool.name`, `aegis.tool.use_id`, `aegis.tool.result`, `aegis.tool.duration_ms`, `aegis.agent.id`, `aegis.agent.parent_id` |
 | `acp.send_prompt` | INTERNAL | `aegis.session.id` |
 | `acp.respond_approval` | INTERNAL | `aegis.session.id` |
 | `monitor.poll` | INTERNAL | — |
@@ -232,6 +232,8 @@ Aegis creates `tool.*` spans for every tool invocation (Bash, Read, Write, Edit,
 | `aegis.tool.output_tokens` | Output token count (optional) |
 | `aegis.tool.result` | `"success"` or `"failure"` |
 | `aegis.tool.duration_ms` | Execution duration in milliseconds |
+| `aegis.agent.id` | CC agent ID for subagent correlation (v2.1.141+; CC hooks + ACP) |
+| `aegis.agent.parent_id` | Parent agent ID when invoked from a subagent (v2.1.141+) |
 
 **Querying in Jaeger/Tempo:**
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -271,6 +271,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_ACP_ENABLED` | `true` | Enable ACP backend for session creation and control actions |
 | `AEGIS_ACP_PROMPT_TIMEOUT_MS` | `120000` | Timeout in ms for ACP JSON-RPC requests (default 120s). Increase for slow BYO-LLM proxy setups (min: 1000) |
 | `AEGIS_ACP_STRICT_VALIDATION` | `false` | When `true`, ACP content validation warnings cause action failure instead of logging only. Useful for production deployments requiring hallucination-free output |
+| `AEGIS_BLOCKED_ACP_ARGS` | _see below_ | Comma-separated list of CLI flags blocked from user-configured args in ACP child process spawn. Prevents overriding protocol-critical flags like `--output-format`, `--resume`, `--session-id`, `--api-key`, `--model`. Defaults to the built-in list when empty |
 | `AEGIS_ACTION_SWEEPER_ENABLED` | `true` | Enable periodic sweeper that recovers orphaned ACP actions (actions stuck in `leased` state after a worker crash) |
 | `AEGIS_ACTION_SWEEPER_INTERVAL_MS` | `60000` | Sweep interval in milliseconds for orphan action recovery |
 | `AEGIS_ISOLATION_POLICY` | `respect-cc` | Session isolation policy: `respect-cc` (follow CC settings, default), `enforce-worktree` (reject sessions without worktree — prevents file conflicts with concurrent sessions), `enforce-direct` (force direct edits, no worktree) |


### PR DESCRIPTION
## Summary

Documents two accuracy gaps found during heartbeat scan:

1. **#4022** — `aegis.agent.id` and `aegis.agent.parent_id` OTEL span attributes added for subagent correlation (CC v2.1.141+). Missing from OBSERVABILITY.md span taxonomy and tool span attributes table.

2. **#4019** — `AEGIS_BLOCKED_ACP_ARGS` env var for filtering protocol-critical CLI flags from user-configured args in ACP child process spawn. Missing from enterprise.md env vars table.

## Changes
- `docs/OBSERVABILITY.md` — added agent attributes to span taxonomy + tool span table
- `docs/enterprise.md` — added AEGIS_BLOCKED_ACP_ARGS to ACP env vars table