### PR TITLE
fix(dashboard): split SessionBoard Other column into Errors and Completed

### DIFF
--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -54,13 +54,13 @@ const BOARD_COLUMNS: BoardColumn[] = [
   {
     id: 'errors',
     title: 'colErrors',
-    statuses: ['error', 'rate_limit', 'killed'],
+    statuses: ['error', 'rate_limit', 'crashed'],
     color: 'text-[var(--color-danger)]',
   },
   {
     id: 'completed',
     title: 'colCompleted',
-    statuses: ['completed'],
+    statuses: ['completed', 'killed'],
     color: 'text-[var(--color-text-muted)]/70',
   },
 ];
@@ -290,7 +290,7 @@ export function SessionBoard() {
       colSessions.sort((a, b) => {
         const activityDiff = b.lastActivity - a.lastActivity;
         if (activityDiff !== 0) return activityDiff;
-        return b.createdAt - a.createdAt;
+        return a.id.localeCompare(b.id);
       });
     }
 


### PR DESCRIPTION
## Summary

Implements #4016 — split the SessionBoard column status assignments:

- **Errors column**: `['error', 'rate_limit', 'killed']` → `['error', 'rate_limit', 'crashed']` (add crashed, remove killed)
- **Completed column**: `['completed']` → `['completed', 'killed']` (add killed)
- **Deterministic sort**: Secondary sort key changed from `b.createdAt - a.createdAt` to `a.id.localeCompare(b.id)` for stable ordering when lastActivity is equal

## Verification
- `npx tsc --noEmit` — ✅ passes
- `npx vitest run src/components/overview/__tests__/SessionBoard.test.tsx` — ✅ 31/31 tests pass