### PR TITLE
fix(dashboard): make SessionBoard cards keyboard-focusable (#4043)

### DIFF
--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -99,8 +99,9 @@ function SessionCard({ session, t }: { session: SessionInfo; t: (key: string, pa
 
   return (
     <div
-      className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)]/80 p-3 hover:bg-[var(--color-surface-hover)] transition-colors cursor-default"
+      className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)]/80 p-3 hover:bg-[var(--color-surface-hover)] transition-colors cursor-default outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-cyan)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-surface)]"
       role="article"
+      tabIndex={0}
       aria-label={`Session ${session.displayName}, status ${session.status}`}
     >
       {/* Header: status + name */}

--- a/dashboard/src/components/overview/__tests__/SessionBoard.test.tsx
+++ b/dashboard/src/components/overview/__tests__/SessionBoard.test.tsx
@@ -591,3 +591,33 @@ describe('SessionBoard', () => {
 
     expect(screen.getByText('working-new')).not.toBeNull();
   });
+
+  // ── Issue #4043: Keyboard focusable cards ──────────────────────
+
+  it('session cards have tabIndex for keyboard focus', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [makeSession({ id: 's1', status: 'working' })],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const card = await screen.findByRole('article');
+    expect(card.getAttribute('tabIndex')).toBe('0');
+  });
+
+  it('session cards have focus ring styles', async () => {
+    mockGetSessions.mockResolvedValue({
+      ...emptyResponse,
+      sessions: [makeSession({ id: 's1', status: 'working' })],
+      pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<SessionBoard />);
+
+    const card = await screen.findByRole('article');
+    const classList = card.getAttribute('class') ?? '';
+    expect(classList).toContain('focus-visible:ring-2');
+    expect(classList).toContain('outline-none');
+  });


### PR DESCRIPTION
## Changes

Session cards in the board were unreachable via keyboard navigation — no `tabIndex`, no focus indicator.

### Fix
- Added `tabIndex={0}` to each session card div
- Added `focus-visible:ring-2` with cyan accent color + offset for visible focus
- Added `outline-none` to remove default browser outline (replaced by ring)
- Kept `role="article"` since cards don't navigate yet (no click handler)

### Tests
33 tests passing (2 new):
- `session cards have tabIndex for keyboard focus`
- `session cards have focus ring styles`

Closes #4043