### PR TITLE
fix(dashboard): make SessionBoard responsive on mobile (#4041)

### DIFF
--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -146,7 +146,7 @@ function BoardColumnView({
 }) {
   const colTitle = t(`sessions.board.${column.title}`);
   return (
-    <div className="w-[280px] shrink-0 flex flex-col gap-2" role="region" aria-label={`${colTitle} sessions`}>
+    <div className="w-full sm:w-[280px] shrink-0 flex flex-col gap-2" role="region" aria-label={`${colTitle} sessions`}>
       {/* Column header */}
       <div className="flex items-center justify-between px-1">
         <div className="flex items-center gap-2">
@@ -336,7 +336,7 @@ export function SessionBoard() {
 
       {/* Board */}
       <div
-        className="flex gap-4 overflow-x-auto pb-4"
+        className="flex flex-col sm:flex-row sm:gap-4 sm:overflow-x-auto pb-4"
         role="region"
         aria-label="Session board"
         tabIndex={0}
@@ -352,7 +352,7 @@ export function SessionBoard() {
 
         {/* Other column (only if there are sessions in it) */}
         {columns.hasOther && (
-          <div className="w-[280px] shrink-0 flex flex-col gap-2" role="region" aria-label="Other sessions">
+          <div className="w-full sm:w-[280px] shrink-0 flex flex-col gap-2" role="region" aria-label="Other sessions">
             <div className="flex items-center gap-2 px-1">
               <div className="h-2 w-2 rounded-full bg-[var(--color-text-muted)]/50" />
               <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">


### PR DESCRIPTION
## Changes

SessionBoard columns were fixed at 280px × 5 = 1400px+ total width, requiring constant horizontal scrolling on mobile devices.

### Fix
- **Mobile (<640px):** Columns stack vertically — each column takes full width
- **Tablet+ (≥640px):** Horizontal scroll layout preserved with fixed 280px columns
- Board container: `flex-col sm:flex-row` — stacks on mobile, scrolls on larger screens
- Column wrapper: `w-full sm:w-[280px]` — full width on mobile, fixed on tablet+

### Approach
Chose the simplest responsive fix — vertical stacking on mobile. This matches how Trello and Jira handle board views on small screens. No collapse/expand complexity, no custom breakpoints.

### Tests
31 existing tests still pass. Layout changes don't affect data/logic.

Closes #4041