### PR TITLE
docs: OTEL PII data classification for agent_id/parent_agent_id (#4036)

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -196,6 +196,35 @@ Aegis emits distributed traces via OTLP HTTP when tracing is enabled.
 | `AEGIS_OTEL_INCLUDE_HOSTNAME` | `true` | Include `os.hostname()` in resource attributes (set `false` to redact PII) |
 | `AEGIS_OTEL_INCLUDE_PID` | `true` | Include process PID in resource attributes (set `false` to redact) |
 
+### OTEL Data Classification (PII Compliance)
+
+When exporting traces to external backends (Datadog, Honeycomb, Grafana Cloud, etc.),
+it's important to understand what Aegis emits:
+
+**Not PII — machine-generated correlation IDs:**
+
+| Field | Source | Format |
+|-------|--------|--------|
+| `aegis.agent.id` | Claude Code session identifier | CC-generated (e.g. `sess_abc123`) |
+| `aegis.agent.parent_id` | Parent agent correlation ID | CC-generated (same format) |
+| `aegis.session.id` | Aegis session UUID | Server-generated UUID |
+| `aegis.node` | Hostname (configurable) | `os.hostname()` |
+| `aegis.pid` | Process ID (configurable) | `process.pid` |
+
+These fields are **not personal data under GDPR or CCPA**. They are internal
+correlation identifiers used to trace request flows across services and agents.
+No user names, emails, or account identifiers are included in OTEL spans.
+
+**Suppress hostname/PID for strict environments:**
+
+```bash
+# Disable hostname and PID in resource attributes
+AEGIS_OTEL_INCLUDE_HOSTNAME=false
+AEGIS_OTEL_INCLUDE_PID=false
+```
+
+For enterprise compliance documentation, see [Security Best Practices → OTEL Data Classification](security-best-practices.md#otel-data-classification).
+
 ### Span Taxonomy
 
 | Span | Kind | Key Attributes |

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -387,6 +387,7 @@ Before going to production:
 - [ ] Stale sessions monitored and cleaned up regularly
 - [ ] No credentials in `.env` files in working directories
 - [ ] Docker runs as non-root with resource limits
+- [ ] OTEL data classification reviewed if exporting traces to external backends
 - [ ] SSO/SAML configured for team access (enterprise tier)
 
 ---
@@ -413,6 +414,31 @@ ACP child processes (Claude Code sessions) run with **full host network access**
 This limitation is tracked in the Phase 4 roadmap. Network isolation will be added when multi-user deployments are supported.
 
 > **See also:** [ADR-0030 — Network Isolation Scope by Deployment Tier](adr/0030-network-isolation-scope-by-deployment-tier.md)
+
+---
+
+## OTEL Data Classification
+
+When exporting OpenTelemetry traces to third-party backends (Datadog, Honeycomb, Grafana Cloud, New Relic), verify the data classification of emitted attributes:
+
+**Non-sensitive attributes (safe to export):**
+
+- `aegis.agent.id`, `aegis.agent.parent_id` — CC-generated correlation IDs (e.g. `sess_abc123`). These are **not PII** under GDPR/CCPA. They identify agent sessions, not people.
+- `aegis.session.id` — Aegis UUID, server-generated.
+- `aegis.tool.name`, `aegis.tool.result` — tool metadata, no user content.
+- `service.name`, `service.version` — deployment identifiers.
+
+**Potentially sensitive attributes:**
+
+- `aegis.node` — exposes `os.hostname()`. May reveal internal infrastructure naming conventions (e.g. `prod-worker-03`). Suppress with `AEGIS_OTEL_INCLUDE_HOSTNAME=false`.
+- `aegis.pid` — process identifier, low risk. Suppress with `AEGIS_OTEL_INCLUDE_PID=false`.
+
+**Never exported by Aegis:**
+
+- User prompts, tool inputs/outputs, file contents, API keys, or any conversation data.
+- OTEL spans capture metadata about operations, not the data flowing through them.
+
+**Enterprise recommendation:** Configure your OTEL collector to redact or transform `aegis.node` before forwarding to external backends if infrastructure naming is considered sensitive. See [OBSERVABILITY.md](OBSERVABILITY.md#otel-data-classification-pii-compliance) for the full attribute reference.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the PII compliance audit findings from #4036 (OTEL agent_id/parent_agent_id).

Code fixes already merged: #4037 (span attribute bug), #4046 (hostname/PID config). This PR covers the documentation follow-up.

## Changes

### docs/OBSERVABILITY.md
- New **"OTEL Data Classification (PII Compliance)"** section after the config table
- Explicitly classifies `aegis.agent.id` and `aegis.agent.parent_id` as CC-generated correlation IDs, **not PII under GDPR/CCPA**
- Documents `AEGIS_OTEL_INCLUDE_HOSTNAME` and `AEGIS_OTEL_INCLUDE_PID` suppression vars
- Cross-links to security-best-practices.md

### docs/security-best-practices.md
- New **"OTEL Data Classification"** section with full attribute classification table
- Categorizes all OTEL fields as non-sensitive, potentially sensitive, or never-exported
- Enterprise recommendation: configure OTEL collector to redact `aegis.node` if infrastructure naming is sensitive
- Added OTEL classification item to production security checklist

## What this closes
- Closes #4036 (documentation portion — code fixes already merged)

## Verification
- `git diff --cached` — 55 lines added, 0 removed, no broken changes
- All attribute names match code (`src/tracing.ts` span attributes table)
- Cross-links between OBSERVABILITY.md and security-best-practices.md are correct