### PR TITLE
fix(dashboard): batch replace raw Tailwind colors with CSS variable design tokens

### DIFF
--- a/dashboard/src/__tests__/AnalyticsPage.test.tsx
+++ b/dashboard/src/__tests__/AnalyticsPage.test.tsx
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { I18nProvider } from '../i18n/context';
+import AnalyticsPage from '../pages/AnalyticsPage';
+import type { AnalyticsSummary, RateLimitAnalyticsResponse } from '../types';
+
+const mockGetAnalyticsSummary = vi.fn();
+const mockGetRateLimitAnalytics = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getAnalyticsSummary: (...args: unknown[]) => mockGetAnalyticsSummary(...args),
+  getRateLimitAnalytics: (...args: unknown[]) => mockGetRateLimitAnalytics(...args),
+}));
+
+vi.mock('../store/useStore', () => ({
+  useStore: vi.fn((sel: (s: Record<string, unknown>) => unknown) => sel({ sseConnected: false, sseError: null })),
+}));
+
+const mockAnalyticsSummary: AnalyticsSummary = {
+  sessionVolume: [
+    { date: '2026-05-16', created: 5 },
+    { date: '2026-05-17', created: 8 },
+    { date: '2026-05-18', created: 3 },
+  ],
+  tokenUsageByModel: [
+    { model: 'claude-sonnet-4.6', inputTokens: 50000, outputTokens: 25000, cacheCreationTokens: 10000, cacheReadTokens: 5000, estimatedCostUsd: 12.50 },
+    { model: 'claude-opus-4.7', inputTokens: 20000, outputTokens: 15000, cacheCreationTokens: 0, cacheReadTokens: 2000, estimatedCostUsd: 8.75 },
+  ],
+  costTrends: [
+    { date: '2026-05-16', cost: 5.20, sessions: 5 },
+    { date: '2026-05-17', cost: 8.30, sessions: 8 },
+    { date: '2026-05-18', cost: 7.75, sessions: 3 },
+  ],
+  topApiKeys: [
+    { keyId: 'key-1', keyName: 'ops-primary', sessions: 10, messages: 150, estimatedCostUsd: 15.00 },
+  ],
+  durationTrends: [
+    { date: '2026-05-16', avgDurationSec: 120, count: 5 },
+    { date: '2026-05-17', avgDurationSec: 180, count: 8 },
+    { date: '2026-05-18', avgDurationSec: 90, count: 3 },
+  ],
+  errorRates: {
+    totalSessions: 16,
+    failedSessions: 1,
+    failureRate: 0.0625,
+    infraFailures: 0,
+    adjustedFailureRate: 0.0625,
+    permissionPrompts: 12,
+    approvals: 10,
+    autoApprovals: 8,
+  },
+  generatedAt: '2026-05-18T12:00:00.000Z',
+};
+
+const mockRateLimitResponse: RateLimitAnalyticsResponse = {
+  global: { max: 100, timeWindowMs: 60000 },
+  perKey: [
+    { keyId: 'key-1', keyName: 'ops-primary', activeSessions: 3, maxSessions: 10, tokensInWindow: 5000, maxTokens: 100000, spendInWindowUsd: 2.50, maxSpendUsd: 50, windowMs: 60000 },
+  ],
+  forecast: { estimatedSessionsRemaining: 7, bottleneck: null },
+  generatedAt: '2026-05-18T12:00:00.000Z',
+};
+
+function renderPage(): void {
+  render(
+    <MemoryRouter>
+      <I18nProvider>
+        <AnalyticsPage />
+      </I18nProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('AnalyticsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state initially', () => {
+    mockGetAnalyticsSummary.mockReturnValue(new Promise(() => {}));
+    mockGetRateLimitAnalytics.mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    expect(screen.getByRole('status')).toBeDefined();
+    expect(screen.getByText('Loading analytics...')).toBeDefined();
+  });
+
+  it('fetches and displays analytics data with KPI banner and chart sections', async () => {
+    mockGetAnalyticsSummary.mockResolvedValue(mockAnalyticsSummary);
+    mockGetRateLimitAnalytics.mockResolvedValue(mockRateLimitResponse);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Analytics' })).toBeDefined();
+    });
+
+    // KPI banner items rendered
+    expect(screen.getAllByText('Total Cost').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Total Tokens').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Sessions').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Avg Duration').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Error Rate').length).toBeGreaterThan(0);
+
+    // Summary cards rendered
+    expect(screen.getAllByText('16').length).toBeGreaterThan(0);
+
+    // Chart section headings
+    expect(screen.getAllByText('Session Volume Over Time').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Token Usage by Model').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Cost Trends (USD per Day)').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Top API Keys by Usage').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Avg Session Duration Over Time').length).toBeGreaterThan(0);
+
+    // Top API key rendered
+    expect(screen.getByText('ops-primary')).toBeDefined();
+  });
+
+  it('shows empty chart state when no data', async () => {
+    const emptySummary: AnalyticsSummary = {
+      ...mockAnalyticsSummary,
+      sessionVolume: [],
+      tokenUsageByModel: [],
+      costTrends: [],
+      topApiKeys: [],
+      durationTrends: [],
+    };
+    mockGetAnalyticsSummary.mockResolvedValue(emptySummary);
+    mockGetRateLimitAnalytics.mockResolvedValue(mockRateLimitResponse);
+
+    renderPage();
+
+    await waitFor(() => {
+      const emptyMessages = screen.getAllByText('No data available yet');
+      expect(emptyMessages.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it('shows error state when API fails', async () => {
+    mockGetAnalyticsSummary.mockRejectedValue(new Error('Server error'));
+    mockGetRateLimitAnalytics.mockRejectedValue(new Error('Server error'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeDefined();
+    });
+  });
+
+  it('displays rate limit analytics section when available', async () => {
+    mockGetAnalyticsSummary.mockResolvedValue(mockAnalyticsSummary);
+    mockGetRateLimitAnalytics.mockResolvedValue(mockRateLimitResponse);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Analytics' })).toBeDefined();
+    });
+
+    // Rate limit data is passed to RateLimitChart + RateLimitForecastCard
+    expect(mockGetRateLimitAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows data consistency warning when sessions exist but charts have no data', async () => {
+    const inconsistentSummary: AnalyticsSummary = {
+      ...mockAnalyticsSummary,
+      sessionVolume: [],
+      tokenUsageByModel: [],
+      durationTrends: [],
+      // errorRates.totalSessions = 16 > 0, but chart arrays empty
+    };
+    mockGetAnalyticsSummary.mockResolvedValue(inconsistentSummary);
+    mockGetRateLimitAnalytics.mockResolvedValue(mockRateLimitResponse);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Data aggregation in progress/)).toBeDefined();
+    });
+  });
+
+  it('renders model distribution bar when tokenUsageByModel has data', async () => {
+    mockGetAnalyticsSummary.mockResolvedValue(mockAnalyticsSummary);
+    mockGetRateLimitAnalytics.mockResolvedValue(null);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Model Distribution')).toBeDefined();
+      expect(screen.getByText('claude-sonnet-4.6')).toBeDefined();
+      expect(screen.getByText('claude-opus-4.7')).toBeDefined();
+    });
+  });
+
+  it('calculates error rate correctly and color-codes high error rates', async () => {
+    const highErrorSummary: AnalyticsSummary = {
+      ...mockAnalyticsSummary,
+      errorRates: {
+        totalSessions: 20,
+        failedSessions: 3,
+        failureRate: 0.15,
+        infraFailures: 0,
+        adjustedFailureRate: 0.15,
+        permissionPrompts: 5,
+        approvals: 4,
+        autoApprovals: 2,
+      },
+    };
+    mockGetAnalyticsSummary.mockResolvedValue(highErrorSummary);
+    mockGetRateLimitAnalytics.mockResolvedValue(null);
+
+    renderPage();
+
+    await waitFor(() => {
+      // 3/20 = 15% > 5% threshold → should show "15.0%" in KPI banner
+      expect(screen.getAllByText('15.0%').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/dashboard/src/__tests__/ConfirmDialog.test.tsx
+++ b/dashboard/src/__tests__/ConfirmDialog.test.tsx
@@ -169,6 +169,6 @@ describe('ConfirmDialog', () => {
       />,
     );
     const confirmBtn = screen.getByText('Confirm');
-    expect(confirmBtn.className).toContain('text-[var(--color-accent)]');
+    expect(confirmBtn.className).toContain('text-[var(--color-cta-bg)]');
   });
 });

--- a/dashboard/src/__tests__/CostPage.test.tsx
+++ b/dashboard/src/__tests__/CostPage.test.tsx
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { I18nProvider } from '../i18n/context';
+import CostPage from '../pages/CostPage';
+import type { AnalyticsCostsResponse, CostSummaryResponse, CostByModelResponse } from '../types';
+
+const mockGetAnalyticsCosts = vi.fn();
+const mockGetCostSummary = vi.fn();
+const mockGetCostByModel = vi.fn();
+const mockGetSessions = vi.fn();
+const mockGetBudgetSettings = vi.fn();
+
+vi.mock('../api/client', () => ({
+  getAnalyticsCosts: (...args: unknown[]) => mockGetAnalyticsCosts(...args),
+  getCostSummary: (...args: unknown[]) => mockGetCostSummary(...args),
+  getCostByModel: (...args: unknown[]) => mockGetCostByModel(...args),
+  getSessions: (...args: unknown[]) => mockGetSessions(...args),
+}));
+
+vi.mock('../store/useStore', () => ({
+  useStore: vi.fn((sel: (s: Record<string, unknown>) => unknown) => sel({ sseConnected: false, sseError: null })),
+}));
+
+vi.mock('../utils/budgetSettings', () => ({
+  getBudgetSettings: () => mockGetBudgetSettings(),
+}));
+
+const mockCostsResponse: AnalyticsCostsResponse = {
+  totalCostUsd: 45.67,
+  totalSessions: 42,
+  byModel: [
+    { model: 'claude-sonnet-4.6', estimatedCostUsd: 30.00, inputTokens: 100000, outputTokens: 50000, cacheCreationTokens: 20000, cacheReadTokens: 10000 },
+    { model: 'claude-opus-4.7', estimatedCostUsd: 15.67, inputTokens: 40000, outputTokens: 30000, cacheCreationTokens: 0, cacheReadTokens: 5000 },
+  ],
+  byKey: [
+    { keyId: 'key-1', keyName: 'ops-primary', estimatedCostUsd: 45.67, sessions: 42, messages: 500 },
+  ],
+  dailyTrends: [
+    { date: '2026-05-17', estimatedCostUsd: 5.20, sessions: 5 },
+    { date: '2026-05-18', estimatedCostUsd: 8.30, sessions: 8 },
+    { date: '2026-05-19', estimatedCostUsd: 7.75, sessions: 6 },
+    { date: '2026-05-20', estimatedCostUsd: 12.42, sessions: 10 },
+    { date: '2026-05-21', estimatedCostUsd: 6.00, sessions: 7 },
+    { date: '2026-05-22', estimatedCostUsd: 4.00, sessions: 4 },
+    { date: '2026-05-23', estimatedCostUsd: 2.00, sessions: 2 },
+  ],
+  generatedAt: '2026-05-23T06:00:00.000Z',
+};
+
+const mockCostSummary: CostSummaryResponse = {
+  from: null,
+  to: null,
+  totalInputTokens: 140000,
+  totalOutputTokens: 80000,
+  totalCacheCreationTokens: 20000,
+  totalCacheReadTokens: 15000,
+  cacheHitRate: 0.35,
+  estimatedCostUsd: 45.67,
+  burnRateUsdPerHour: 1.50,
+  sessions: 42,
+};
+
+const mockCostByModel: CostByModelResponse = {
+  from: null,
+  to: null,
+  models: [
+    { model: 'claude-sonnet-4.6', inputTokens: 100000, outputTokens: 50000, cacheCreationTokens: 20000, cacheReadTokens: 10000, estimatedCostUsd: 30.00, cacheHitRate: 0.40 },
+    { model: 'claude-opus-4.7', inputTokens: 40000, outputTokens: 30000, cacheCreationTokens: 0, cacheReadTokens: 5000, estimatedCostUsd: 15.67, cacheHitRate: 0.25 },
+  ],
+  totalModels: 2,
+  totalCostUsd: 45.67,
+};
+
+const emptySessionsResponse = {
+  sessions: [],
+  pagination: { page: 1, limit: 50, total: 0, totalPages: 0 },
+};
+
+function setupMocks(overrides?: { costs?: AnalyticsCostsResponse | null; summary?: CostSummaryResponse | null; byModel?: CostByModelResponse | null }) {
+  mockGetAnalyticsCosts.mockResolvedValue(overrides?.costs ?? mockCostsResponse);
+  mockGetCostSummary.mockResolvedValue(overrides?.summary ?? mockCostSummary);
+  mockGetCostByModel.mockResolvedValue(overrides?.byModel ?? mockCostByModel);
+  mockGetSessions.mockResolvedValue(emptySessionsResponse);
+  mockGetBudgetSettings.mockReturnValue({ budgetDailyCapUsd: 100, budgetMonthlyCapUsd: 1000, budgetAlertEnabled: true });
+}
+
+function renderPage(): void {
+  render(
+    <MemoryRouter>
+      <I18nProvider>
+        <CostPage />
+      </I18nProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('CostPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading skeleton state with header', () => {
+    mockGetAnalyticsCosts.mockReturnValue(new Promise(() => {}));
+    mockGetCostSummary.mockReturnValue(new Promise(() => {}));
+    mockGetCostByModel.mockReturnValue(new Promise(() => {}));
+    mockGetSessions.mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    expect(screen.getByText('Cost & Billing')).toBeDefined();
+  });
+
+  it('shows empty state when no cost data', async () => {
+    const emptyCosts: AnalyticsCostsResponse = {
+      totalCostUsd: 0,
+      totalSessions: 0,
+      byModel: [],
+      byKey: [],
+      dailyTrends: [],
+      generatedAt: '2026-05-23T06:00:00.000Z',
+    };
+    setupMocks({ costs: emptyCosts });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No cost data yet')).toBeDefined();
+    });
+  });
+
+  it('shows error state when data fetch fails', async () => {
+    // Promise.allSettled absorbs rejections; getAnalyticsCosts rejection
+    // means costData stays null → component falls through to empty/error.
+    // Synchronous throw bypasses allSettled and hits outer catch → dataError set.
+    mockGetAnalyticsCosts.mockImplementation(() => { throw new Error('Server error'); });
+    mockGetCostSummary.mockResolvedValue(mockCostSummary);
+    mockGetCostByModel.mockResolvedValue(mockCostByModel);
+    mockGetSessions.mockResolvedValue(emptySessionsResponse);
+    mockGetBudgetSettings.mockReturnValue({ budgetDailyCapUsd: 100, budgetMonthlyCapUsd: 1000, budgetAlertEnabled: true });
+
+    renderPage();
+
+    await waitFor(() => {
+      // ErrorState renders the error message
+      expect(screen.getAllByText('Server error').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('fetches and displays cost data with model names', async () => {
+    setupMocks();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Cost & Billing')).toBeDefined();
+    });
+
+    // Model names should be visible in the model breakdown
+    expect(screen.getAllByText('claude-sonnet-4.6').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('claude-opus-4.7').length).toBeGreaterThan(0);
+  });
+
+  it('displays time range picker with 7d, 30d, and 90d options', async () => {
+    setupMocks();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '7 Days' })).toBeDefined();
+    });
+    expect(screen.getByRole('button', { name: '30 Days' })).toBeDefined();
+    expect(screen.getByRole('button', { name: '90 Days' })).toBeDefined();
+  });
+
+  it('switches active time range on click', async () => {
+    setupMocks();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '7 Days' })).toBeDefined();
+    });
+
+    const sevenDayBtn = screen.getByRole('button', { name: '7 Days' });
+    fireEvent.click(sevenDayBtn);
+
+    expect(sevenDayBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('renders budget overview section with disabled alerts', async () => {
+    // NOTE: BudgetOverview has a rule-of-hooks violation — useT() is called
+    // inside a conditional return. When budgetAlertEnabled=false, the
+    // warning path may not render correctly. This test verifies the page
+    // still renders without crashing when alerts are disabled.
+    setupMocks();
+    mockGetBudgetSettings.mockReturnValue({ budgetDailyCapUsd: 100, budgetMonthlyCapUsd: 1000, budgetAlertEnabled: false });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Cost & Billing')).toBeDefined();
+    });
+
+    // Page renders without crashing even with budget alerts disabled
+    expect(screen.getByText(/Daily Spend/)).toBeDefined();
+  });
+
+  it('renders budget overview section when budgetAlertEnabled is true', async () => {
+    setupMocks();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Cost & Billing')).toBeDefined();
+    });
+
+    // Budget overview section should be present (BudgetProgressBar renders within it)
+    // The component renders daily + monthly progress bars and a forecast chart
+    expect(screen.getByText(/Daily Spend/)).toBeDefined();
+  });
+
+  it('handles zero-cost edge case showing empty state', async () => {
+    const zeroCostResponse: AnalyticsCostsResponse = {
+      ...mockCostsResponse,
+      totalCostUsd: 0,
+      byModel: [],
+      dailyTrends: mockCostsResponse.dailyTrends.map(d => ({ ...d, estimatedCostUsd: 0 })),
+    };
+    setupMocks({ costs: zeroCostResponse });
+
+    renderPage();
+
+    await waitFor(() => {
+      // All daily costs are zero → hasData check fails → empty state
+      expect(screen.getByText('No cost data yet')).toBeDefined();
+    });
+  });
+});

--- a/dashboard/src/__tests__/PipelineStatusBadge.test.tsx
+++ b/dashboard/src/__tests__/PipelineStatusBadge.test.tsx
@@ -7,7 +7,7 @@ describe('PipelineStatusBadge', () => {
     render(<PipelineStatusBadge status="running" />);
     const badge = screen.getByText('running');
     expect(badge).toBeDefined();
-    expect(badge.className).toContain('text-cyan');
+    expect(badge.className).toContain('text-[var(--color-accent-cyan)]');
   });
 
   it('renders completed status with green color', () => {

--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -29,17 +29,17 @@ interface ActivityStreamProps {
 }
 
 const EVENT_META: Record<GlobalSSEEventType, { icon: typeof Activity; label: string; color: string }> = {
-  session_status_change: { icon: RefreshCw, label: 'Status', color: 'var(--color-accent)' },
+  session_status_change: { icon: RefreshCw, label: 'Status', color: 'var(--color-cta-bg)' },
   session_message: { icon: MessageSquare, label: 'Message', color: 'var(--color-success)' },
   session_approval: { icon: ShieldAlert, label: 'Approval', color: 'var(--color-warning)' },
   session_ended: { icon: Power, label: 'Ended', color: 'var(--color-error)' },
   session_created: { icon: PlusCircle, label: 'Created', color: 'var(--color-accent-indigo)' },
   session_stall: { icon: AlertTriangle, label: 'Stall', color: 'var(--color-warning-dark)' },
   session_dead: { icon: Skull, label: 'Dead', color: 'var(--color-error-dark)' },
-  session_subagent_start: { icon: Users, label: 'Subagent', color: 'var(--color-accent)' },
+  session_subagent_start: { icon: Users, label: 'Subagent', color: 'var(--color-cta-bg)' },
   session_subagent_stop: { icon: UserCheck, label: 'Subagent Done', color: 'var(--color-success)' },
   session_verification: { icon: ShieldAlert, label: 'Verification', color: 'var(--color-info)' },
-  shutdown: { icon: Power, label: 'Shutdown', color: 'var(--color-accent)' },
+  shutdown: { icon: Power, label: 'Shutdown', color: 'var(--color-cta-bg)' },
 };
 
 export function safeStr(val: unknown, fallback: string = 'unknown'): string {
@@ -187,7 +187,7 @@ export default function ActivityStream({
             <select
               value={filterSession ?? ''}
               onChange={(e) => setFilterSession(e.target.value || null)}
-              className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+              className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             >
               <option value="">All sessions</option>
               {sessions.map((s) => (
@@ -201,7 +201,7 @@ export default function ActivityStream({
             <select
               value={filterType ?? ''}
               onChange={(e) => setFilterType((e.target.value || null) as GlobalSSEEventType | null)}
-              className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+              className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             >
               <option value="">All types</option>
               {Object.entries(EVENT_META).map(([key, meta]) => (

--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -27,7 +27,7 @@ const VARIANT_STYLES = {
   },
   default: {
     confirm:
-      'bg-[var(--color-accent)]/10 hover:bg-[var(--color-accent)]/20 text-[var(--color-accent)] border border-[var(--color-accent)]/30',
+      'bg-[var(--color-cta-bg)]/10 hover:bg-[var(--color-cta-bg)]/20 text-[var(--color-cta-bg)] border border-[var(--color-cta-bg)]/30',
   },
 } as const;
 

--- a/dashboard/src/components/CreatePipelineModal.tsx
+++ b/dashboard/src/components/CreatePipelineModal.tsx
@@ -145,7 +145,7 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
               onChange={(e) => setPipelineName(e.target.value)}
               placeholder="my-pipeline"
               aria-label={t("aria.pipelineName")}
-              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             />
           </div>
 
@@ -166,21 +166,21 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
                   value={step.workDir}
                   onChange={(e) => updateStep(i, 'workDir', e.target.value)}
                   placeholder="/home/user/project"
-                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent)] font-mono"
+                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)] font-mono"
                 />
                 <input
                   type="text"
                   value={step.name}
                   onChange={(e) => updateStep(i, 'name', e.target.value)}
                   placeholder="name"
-                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
                 />
                 <input
                   type="text"
                   value={step.prompt}
                   onChange={(e) => updateStep(i, 'prompt', e.target.value)}
                   placeholder="Initial prompt..."
-                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
                 />
                 <button
                   type="button"
@@ -226,7 +226,7 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
             <button
               type="submit"
               disabled={loading || !canSubmit}
-              className="min-h-[44px] flex items-center gap-1.5 px-4 py-2.5 text-xs font-medium rounded bg-[var(--color-accent)]/10 hover:bg-[var(--color-accent)]/20 text-[var(--color-accent)] border border-[var(--color-accent)]/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="min-h-[44px] flex items-center gap-1.5 px-4 py-2.5 text-xs font-medium rounded bg-[var(--color-cta-bg)]/10 hover:bg-[var(--color-cta-bg)]/20 text-[var(--color-cta-bg)] border border-[var(--color-cta-bg)]/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {loading && <Loader2 className="h-3 w-3 animate-spin" />}
               Create Pipeline

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -219,7 +219,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
                 onClick={() => setMode('single')}
                 className={`px-3 py-1 text-xs rounded transition-colors ${
                   mode === 'single'
-                    ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
+                    ? 'bg-[var(--color-cta-bg)]/10 text-[var(--color-cta-bg)]'
                     : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
                 }`}
               >
@@ -230,7 +230,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
                 onClick={() => setMode('batch')}
                 className={`px-3 py-1 text-xs rounded transition-colors ${
                   mode === 'batch'
-                    ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
+                    ? 'bg-[var(--color-cta-bg)]/10 text-[var(--color-cta-bg)]'
                     : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
                 }`}
               >
@@ -274,7 +274,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               value={workDir}
               onChange={(e) => { setWorkDir(e.target.value); setWorkDirError(null); }}
               placeholder="/home/user/project"
-              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)] font-mono"
+              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)] font-mono"
             />
           </div>
 
@@ -289,7 +289,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="my-session"
-              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             />
             {workDirError && (
               <p className="mt-1 text-xs text-[var(--color-error)]">{workDirError}</p>
@@ -307,7 +307,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               value={claudeCommand}
               onChange={(e) => setClaudeCommand(e.target.value)}
               placeholder="claude --print"
-              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             />
           </div>
 
@@ -322,7 +322,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="Fix the login bug..."
               rows={3}
-              className="w-full min-h-[88px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)] resize-none"
+              className="w-full min-h-[88px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)] resize-none"
             />
           </div>
 
@@ -335,7 +335,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               id="modal-permissionMode"
               value={permissionMode}
               onChange={(e) => setPermissionMode(e.target.value)}
-              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             >
               {PERMISSION_MODES.map((m) => (
                 <option key={m.value} value={m.value}>{m.label}</option>
@@ -385,7 +385,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               onChange={(e) => setSharedPrompt(e.target.value)}
               placeholder="Apply to all sessions without a per-row prompt..."
               rows={2}
-              className="w-full min-h-[88px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)] resize-none"
+              className="w-full min-h-[88px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)] resize-none"
             />
           </div>
 
@@ -407,7 +407,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
                   onChange={(e) => updateBatchRow(i, 'workDir', e.target.value)}
                   placeholder="/home/user/project"
                   aria-label={`Batch row ${i + 1} working directory`}
-                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)] font-mono"
+                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)] font-mono"
                 />
                 <input
                   type="text"
@@ -415,7 +415,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
                   onChange={(e) => updateBatchRow(i, 'name', e.target.value)}
                   placeholder="name"
                   aria-label={`Batch row ${i + 1} session name`}
-                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
                 />
                 <input
                   type="text"
@@ -423,7 +423,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
                   onChange={(e) => updateBatchRow(i, 'prompt', e.target.value)}
                   placeholder="Override prompt..."
                   aria-label={`Batch row ${i + 1} prompt`}
-                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+                  className="min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
                 />
                 <button
                   type="button"
@@ -463,7 +463,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
               id="modal-permissionMode"
               value={permissionMode}
               onChange={(e) => setPermissionMode(e.target.value)}
-              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+              className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             >
               {PERMISSION_MODES.map((m) => (
                 <option key={m.value} value={m.value}>{m.label}</option>
@@ -649,7 +649,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
                     <button
                       type="button"
                       onClick={() => { handleClose(); navigate(`/sessions/${s.id}`); }}
-                      className="text-xs text-[var(--color-accent)] hover:underline font-mono"
+                      className="text-xs text-[var(--color-cta-bg)] hover:underline font-mono"
                     >
                       {s.id.slice(0, 8)}...{s.name ? ` - ${s.name}` : ''}
                     </button>

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -391,7 +391,7 @@ export default function Layout() {
 
 
   return (
-    <div className="flex h-screen overflow-hidden bg-void">
+    <div className="flex h-screen overflow-hidden bg-[var(--color-void-dark)]">
       {/* Skip-to-content link */}
       <a
         href="#main-content"
@@ -435,7 +435,7 @@ export default function Layout() {
               onClick={closeMobile}
               tabIndex={hiddenMobileSidebarControlTabIndex}
               disabled={isMobileSidebarHidden}
-              className="md:hidden inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)]"
+              className="md:hidden inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)]"
               aria-label={t("aria.closeMenu")}
               aria-hidden={isMobileSidebarHidden ? 'true' : undefined}
             >
@@ -462,8 +462,8 @@ export default function Layout() {
                   className={({ isActive }) =>
                     `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
                       isActive
-                        ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-cyan dark:bg-cyan/10 dark:text-cyan glow-nav-active'
-                        : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] border-l-2 border-transparent dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)]'
+                        ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-[var(--color-accent-cyan)] dark:bg-[var(--color-cta-bg)]/10 dark:text-[var(--color-accent-cyan)] glow-nav-active'
+                        : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] border-l-2 border-transparent dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)]'
                     } ${isCollapsed ? 'justify-center' : ''}`
                   }
                   title={isCollapsed ? label : undefined}
@@ -495,8 +495,8 @@ export default function Layout() {
             className={({ isActive }) =>
               `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
                 isActive
-                  ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-cyan dark:bg-cyan/10 dark:text-cyan glow-nav-active'
-                  : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] border-l-2 border-transparent dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)]'
+                  ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-[var(--color-accent-cyan)] dark:bg-[var(--color-cta-bg)]/10 dark:text-[var(--color-accent-cyan)] glow-nav-active'
+                  : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] border-l-2 border-transparent dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)]'
               } ${isCollapsed ? 'justify-center' : ''}`
             }
             title={isCollapsed ? 'Settings' : undefined}
@@ -509,7 +509,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={toggleSidebar}
-            className="hidden min-h-[44px] md:flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)] transition-colors w-full"
+            className="hidden min-h-[44px] md:flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)] transition-colors w-full"
             aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
@@ -526,7 +526,7 @@ export default function Layout() {
             type="button"
             onClick={handleLogout}
             tabIndex={hiddenMobileSidebarControlTabIndex}
-            className={`flex items-center gap-2.5 rounded-lg px-3 py-3 min-h-[44px] text-sm font-medium text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)] transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
+            className={`flex items-center gap-2.5 rounded-lg px-3 py-3 min-h-[44px] text-sm font-medium text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)] transition-colors w-full ${isCollapsed ? 'justify-center' : ''}`}
             aria-label={t("aria.signOut")}
           >
             <LogOut className="h-4 w-4 shrink-0" />
@@ -547,7 +547,7 @@ export default function Layout() {
                 onClick={toggleMobile}
                 tabIndex={isMobileDrawerOpen ? -1 : undefined}
                 aria-hidden={isMobileDrawerOpen ? 'true' : undefined}
-                className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)] transition-colors"
+                className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)] transition-colors"
                 aria-label={t("aria.openMenu")}
               >
                 <Menu className="h-5 w-5" />
@@ -559,7 +559,7 @@ export default function Layout() {
 
             <div className={`flex items-center justify-end gap-1.5 sm:gap-3 transition-opacity ${isMobileDrawerOpen ? "pointer-events-none opacity-30" : ""}`}>
               {/* PREVIEW badge — hidden on very small screens */}
-              <span className="hidden sm:inline-flex rounded-md border border-transparent bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-blue-800 ring-1 ring-blue-200 dark:border-[var(--color-accent)]/50 dark:bg-[var(--color-accent)]/10 dark:text-[var(--color-accent)] dark:ring-0">
+              <span className="hidden sm:inline-flex rounded-md border border-transparent bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-blue-800 ring-1 ring-blue-200 dark:border-[var(--color-cta-bg)]/50 dark:bg-[var(--color-cta-bg)]/10 dark:text-[var(--color-cta-bg)] dark:ring-0">
                 PREVIEW
               </span>
 
@@ -572,7 +572,7 @@ export default function Layout() {
                 onClick={openNewSession}
                 aria-label={t("aria.newSessionCmd")}
                 title="New Session (⌘N)"
-                className="inline-flex h-11 w-11 items-center justify-center rounded-lg p-2.5 min-h-[44px] min-w-[44px] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)] transition-colors"
+                className="inline-flex h-11 w-11 items-center justify-center rounded-lg p-2.5 min-h-[44px] min-w-[44px] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)] transition-colors"
               >
                 <Plus className="h-4 w-4" />
               </button>
@@ -590,11 +590,11 @@ export default function Layout() {
               </button>
 
               {/* Version + theme toggle */}
-              <div className="inline-flex items-center gap-1 sm:gap-2 rounded-md border border-[var(--color-border-strong)] bg-white px-1.5 py-1 sm:px-2 text-xs text-[var(--color-text-primary)] dark:border-void-lighter dark:bg-void dark:text-[var(--color-text-primary)]">
+              <div className="inline-flex items-center gap-1 sm:gap-2 rounded-md border border-[var(--color-border-strong)] bg-white px-1.5 py-1 sm:px-2 text-xs text-[var(--color-text-primary)] dark:border-[var(--color-void-lighter)] dark:bg-[var(--color-void-dark)] dark:text-[var(--color-text-primary)]">
                 <button
                   type="button"
                   onClick={toggleTheme}
-                  className="inline-flex h-11 w-11 items-center justify-center rounded p-2 sm:p-2.5 min-h-[44px] min-w-[44px] text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-void-lighter dark:hover:text-[var(--color-text-primary)]"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded p-2 sm:p-2.5 min-h-[44px] min-w-[44px] text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)]"
                   aria-label={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                   title={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                 >
@@ -608,7 +608,7 @@ export default function Layout() {
                 type="button"
                 onClick={handleCheckUpdates}
                 disabled={updateCheckLoading || aegisVersion === '...'}
-                className="hidden min-h-[44px] sm:inline-flex items-center gap-1 rounded-md border border-[var(--color-border-strong)] px-2 py-1 text-xs text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] dark:border-void-lighter dark:hover:bg-void-lighter disabled:cursor-not-allowed disabled:border-slate-300 disabled:bg-slate-50 disabled:text-[var(--color-text-primary)] dark:disabled:border-void-lighter dark:disabled:bg-transparent dark:disabled:text-[var(--color-text-muted)]"
+                className="hidden min-h-[44px] sm:inline-flex items-center gap-1 rounded-md border border-[var(--color-border-strong)] px-2 py-1 text-xs text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] dark:border-[var(--color-void-lighter)] dark:hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:border-slate-300 disabled:bg-slate-50 disabled:text-[var(--color-text-primary)] dark:disabled:border-[var(--color-void-lighter)] dark:disabled:bg-transparent dark:disabled:text-[var(--color-text-muted)]"
               >
                 <RefreshCw className={`h-3 w-3 ${updateCheckLoading ? 'animate-spin' : ''}`} />
                 {updateCheckLoading ? 'Checking…' : 'Check updates'}
@@ -621,7 +621,7 @@ export default function Layout() {
                       href={updateResult.releaseUrl}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-cyan hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent-cyan)]"
+                      className="text-[var(--color-accent-cyan)] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent-cyan)]"
                     >
                       Update available: v{updateResult.latestVersion}
                     </a>

--- a/dashboard/src/components/LiveAuditStream.tsx
+++ b/dashboard/src/components/LiveAuditStream.tsx
@@ -96,7 +96,7 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
               onClick={() => setFilterMode(mode)}
               className={`min-h-[44px] px-3 py-1.5 rounded-md text-[11px] font-bold uppercase tracking-widest transition-all ${
                 filterMode === mode
-                  ? 'bg-[var(--color-accent)] text-white shadow-sm'
+                  ? 'bg-[var(--color-cta-bg)] text-white shadow-sm'
                   : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)]'
               }`}
             >

--- a/dashboard/src/components/NewSessionDrawer.tsx
+++ b/dashboard/src/components/NewSessionDrawer.tsx
@@ -243,7 +243,7 @@ export function NewSessionDrawer() {
                       if (tpl.claudeCommand) setClaudeCommand(tpl.claudeCommand);
                       useToastStore.getState().addToast('info', `Applied template: ${tpl.name || 'Untitled'}`, undefined, { duration: 2000 });
                     }}
-                    className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-accent)]"
+                    className="w-full min-h-[44px] px-3 py-2.5 text-sm bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
                   >
                     <option value="" disabled>
                       {templates.length} template{templates.length !== 1 ? 's' : ''} available…

--- a/dashboard/src/components/ProtectedRoute.tsx
+++ b/dashboard/src/components/ProtectedRoute.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from '../store/useAuthStore.js';
 function LoadingFallback() {
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-accent)]" />
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-cta-bg)]" />
     </div>
   );
 }

--- a/dashboard/src/components/agents/AgentBadge.tsx
+++ b/dashboard/src/components/agents/AgentBadge.tsx
@@ -16,7 +16,7 @@ const COLOR_CLASSES: Record<string, string> = {
   green: "bg-emerald-500/15 text-emerald-400 border-emerald-500/25",
   blue: "bg-blue-500/15 text-blue-400 border-blue-500/25",
   amber: "bg-[var(--color-warning)]/15 text-amber-400 border-[var(--color-warning)]/25",
-  cyan: "bg-[var(--color-cta-bg)]-500/15 text-[var(--color-accent-cyan)]-400 border-[var(--color-accent-cyan)]-500/25",
+  cyan: "bg-[var(--color-accent-cyan)]/15 text-[var(--color-accent-cyan-glow)] border-[var(--color-accent-cyan)]/25",
   rose: "bg-rose-500/15 text-rose-400 border-rose-500/25",
   gray: "bg-gray-500/15 text-gray-400 border-gray-500/25",
 };

--- a/dashboard/src/components/agents/AgentBadge.tsx
+++ b/dashboard/src/components/agents/AgentBadge.tsx
@@ -16,7 +16,7 @@ const COLOR_CLASSES: Record<string, string> = {
   green: "bg-emerald-500/15 text-emerald-400 border-emerald-500/25",
   blue: "bg-blue-500/15 text-blue-400 border-blue-500/25",
   amber: "bg-[var(--color-warning)]/15 text-amber-400 border-[var(--color-warning)]/25",
-  cyan: "bg-cyan-500/15 text-cyan-400 border-cyan-500/25",
+  cyan: "bg-[var(--color-cta-bg)]-500/15 text-[var(--color-accent-cyan)]-400 border-[var(--color-accent-cyan)]-500/25",
   rose: "bg-rose-500/15 text-rose-400 border-rose-500/25",
   gray: "bg-gray-500/15 text-gray-400 border-gray-500/25",
 };

--- a/dashboard/src/components/agents/AgentFilter.tsx
+++ b/dashboard/src/components/agents/AgentFilter.tsx
@@ -35,7 +35,7 @@ export const AgentFilter: FC<AgentFilterProps> = ({ value, onChange, className =
         id="agent-filter"
         value={value ?? ""}
         onChange={handleChange}
-        className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] focus:border-[var(--color-accent)] focus-visible:outline-none focus:ring-1 focus:ring-[var(--color-accent)] transition-colors"
+        className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] focus:border-[var(--color-cta-bg)] focus-visible:outline-none focus:ring-1 focus:ring-[var(--color-cta-bg)] transition-colors"
         aria-label="Filter sessions by agent type"
       >
         <option value="">All Agents</option>

--- a/dashboard/src/components/analytics/KPIBanner.tsx
+++ b/dashboard/src/components/analytics/KPIBanner.tsx
@@ -39,7 +39,7 @@ const COLOR_MAP: Record<KPIItem['color'], string> = {
   output: 'text-[var(--color-accent-purple)]',
   cost: 'text-[var(--color-warning)]',
   efficiency: 'text-[var(--color-success)]',
-  time: 'text-[var(--color-accent)]',
+  time: 'text-[var(--color-cta-bg)]',
   neutral: 'text-[var(--color-text-primary)]',
 };
 

--- a/dashboard/src/components/analytics/ModelDistributionBar.tsx
+++ b/dashboard/src/components/analytics/ModelDistributionBar.tsx
@@ -35,7 +35,7 @@ export interface ModelDistributionBarProps {
 /** Map known model patterns to CSS var colors */
 const MODEL_STYLES: Record<string, { color: string; label: string }> = {
   opus: { color: 'var(--color-accent-purple)', label: 'Opus' },
-  sonnet: { color: 'var(--color-accent)', label: 'Sonnet' },
+  sonnet: { color: 'var(--color-cta-bg)', label: 'Sonnet' },
   haiku: { color: 'var(--color-success)', label: 'Haiku' },
 };
 

--- a/dashboard/src/components/overview/HomeStatusPanel.tsx
+++ b/dashboard/src/components/overview/HomeStatusPanel.tsx
@@ -39,7 +39,7 @@ function StatusCard({ label, value, detail, tone, icon, actionButton }: StatusCa
     blue: {
       border: 'border-[var(--color-accent-cyan)]/20',
       icon: 'text-[var(--color-accent-cyan)]',
-      value: 'text-cyan-300',
+      value: 'text-[var(--color-accent-cyan-glow)]',
     },
     green: {
       border: 'border-emerald-500/20',
@@ -217,7 +217,7 @@ export default function HomeStatusPanel({ onCreateFirstSession }: HomeStatusPane
         <div
           role="status"
           aria-live="polite"
-          className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-void-lighter bg-[var(--color-surface)] px-4 py-3"
+          className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-3"
         >
           <div className="text-xs text-[var(--color-text-muted)]">
             {loadError ?? 'Using the latest available home status data.'}

--- a/dashboard/src/components/overview/MetricCard.tsx
+++ b/dashboard/src/components/overview/MetricCard.tsx
@@ -31,7 +31,7 @@ interface MetricCardProps {
 }
 
 const colorMap: Record<string, string> = {
-  blue: 'text-[var(--color-accent)]',
+  blue: 'text-[var(--color-cta-bg)]',
   green: 'text-[var(--color-success)]',
   amber: 'text-[var(--color-warning)]',
   red: 'text-[var(--color-error)]',
@@ -39,7 +39,7 @@ const colorMap: Record<string, string> = {
 };
 
 const barColorMap: Record<string, string> = {
-  blue: 'bg-[var(--color-accent)]',
+  blue: 'bg-[var(--color-cta-bg)]',
   green: 'bg-[var(--color-success)]',
   amber: 'bg-[var(--color-warning)]',
   red: 'bg-[var(--color-error)]',
@@ -52,9 +52,9 @@ function sparkColor(color: string): string {
     green: 'var(--color-success)',
     amber: 'var(--color-warning)',
     red: 'var(--color-error)',
-    purple: 'var(--color-accent)',
+    purple: 'var(--color-cta-bg)',
   };
-  return map[color] ?? 'var(--color-accent)';
+  return map[color] ?? 'var(--color-cta-bg)';
 }
 
 export default function MetricCard({

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -78,7 +78,7 @@ export default function MetricCards() {
 
   if (isLoading && !metrics && !health) {
     return (
-      <div className="rounded-lg border border-void-lighter bg-[var(--color-surface)] p-6 text-sm text-[var(--color-text-muted)]">
+      <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] p-6 text-sm text-[var(--color-text-muted)]">
         Loading overview metrics...
       </div>
     );
@@ -129,7 +129,7 @@ export default function MetricCards() {
         <div
           role="status"
           aria-live="polite"
-          className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-void-lighter bg-[var(--color-surface)] px-4 py-3"
+          className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-3"
         >
           <div className="text-xs text-[var(--color-text-muted)]">{loadError ?? 'Overview widgets are using the latest available data.'}</div>
           {!sseConnected && sseError && <RealtimeBadge mode="polling" message={sseError} />}

--- a/dashboard/src/components/overview/MetricsPanel.tsx
+++ b/dashboard/src/components/overview/MetricsPanel.tsx
@@ -52,9 +52,9 @@ interface StatTileProps {
   color?: string;
 }
 
-function StatTile({ icon, label, value, color = 'text-[var(--color-accent)]' }: StatTileProps) {
+function StatTile({ icon, label, value, color = 'text-[var(--color-cta-bg)]' }: StatTileProps) {
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-void-lighter bg-[var(--color-surface)] px-4 py-3">
+    <div className="flex items-center gap-3 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-3">
       <div className="flex h-9 w-9 items-center justify-center rounded-md bg-[var(--color-void-dark)] text-[var(--color-text-muted)]">
         {icon}
       </div>
@@ -117,7 +117,7 @@ export default function MetricsPanel() {
         {Array.from({ length: 4 }).map((_, i) => (
           <div
             key={i}
-            className="animate-pulse rounded-lg border border-void-lighter bg-[var(--color-surface)] px-4 py-3"
+            className="animate-pulse rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-3"
           >
             <div className="mb-2 h-3 w-16 rounded bg-[var(--color-void-dark)]" />
             <div className="h-5 w-20 rounded bg-[var(--color-void-dark)]" />
@@ -147,7 +147,7 @@ export default function MetricsPanel() {
           icon={<Layers className="h-4 w-4" />}
           label="Total Sessions"
           value={d.totalSessions}
-          color="text-[var(--color-accent)]"
+          color="text-[var(--color-cta-bg)]"
         />
         <StatTile
           icon={<Timer className="h-4 w-4" />}

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -40,14 +40,14 @@ export const SessionMobileCard = memo(function SessionMobileCard({
             aria-label={`Select session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
             checked={selected}
             onChange={(e) => onToggleSelect(session.id, e.target.checked)}
-            className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+            className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
           />
           <div className="min-w-0">
             <div className="flex min-w-0 items-center gap-2">
               <StatusDot status={session.status} health={health} />
               <Link
                 to={`/sessions/${encodeURIComponent(session.id)}`}
-                className="inline-flex min-h-[44px] items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-cyan"
+                className="inline-flex min-h-[44px] items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-cyan)]"
               >
                 {formatSessionName(session.displayName, session.id.slice(0, 8))}
               </Link>
@@ -105,7 +105,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
             <CheckCircle2 className="h-3 w-3" /> {session.permissionMode}
           </span>
         ) : (
-          <span className="inline-flex items-center gap-1 rounded-full bg-void-lighter px-2 py-0.5 text-[var(--color-text-muted)]">
+          <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-void-lighter)] px-2 py-0.5 text-[var(--color-text-muted)]">
             default
           </span>
         )}

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -527,7 +527,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                     setPage(1);
                   }}
                   aria-label={t("aria.filterByStatus")}
-                  className="min-h-[44px] rounded-md border border-void-lighter bg-void px-3 py-2 text-sm text-[var(--color-text-primary)] outline-none focus:border-cyan"
+                  className="min-h-[44px] rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] px-3 py-2 text-sm text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent-cyan)]"
                 >
                   {STATUS_FILTERS.map((status) => (
                     <option key={status} value={status}>
@@ -543,8 +543,8 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                 aria-label={groupByDir ? 'Show ungrouped session list' : 'Group sessions by directory'}
                 aria-pressed={groupByDir}
                 className={`flex min-h-[36px] items-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium transition-colors ${groupByDir
-                  ? 'border-cyan bg-cyan/10 text-cyan'
-                  : 'border-void-lighter bg-void text-[var(--color-text-muted)] hover:border-cyan/40 hover:text-[var(--color-text-primary)]'}`}
+                  ? 'border-[var(--color-accent-cyan)] bg-[var(--color-cta-bg)]/10 text-[var(--color-accent-cyan)]'
+                  : 'border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-text-muted)] hover:border-[var(--color-accent-cyan)]/40 hover:text-[var(--color-text-primary)]'}`}
               >
                 <FolderOpen className="h-3.5 w-3.5" />
                 {groupByDir ? 'Ungroup' : 'By Directory'}
@@ -560,7 +560,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                       setPage(1);
                     }}
                     aria-label={t("aria.filterByDirectory")}
-                    className="min-h-[36px] rounded-md border border-void-lighter bg-void px-2 py-1 text-xs text-[var(--color-text-primary)] outline-none focus:border-cyan max-w-[180px]"
+                    className="min-h-[36px] rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] px-2 py-1 text-xs text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent-cyan)] max-w-[180px]"
                   >
                     <option value="all">{t("aria.allDirectories")} ({sessions.length})</option>
                     {uniqueWorkDirs.map(([key, full]) => (
@@ -592,8 +592,8 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                       setPage(1);
                     }}
                     className={`min-h-[44px] rounded-full border px-3 py-1.5 text-xs transition-colors ${isActive
-                      ? 'border-cyan bg-cyan/10 text-cyan'
-                      : 'border-void-lighter bg-void text-[var(--color-text-muted)] hover:border-cyan/40 hover:text-[var(--color-text-primary)]'}`}
+                      ? 'border-[var(--color-accent-cyan)] bg-[var(--color-cta-bg)]/10 text-[var(--color-accent-cyan)]'
+                      : 'border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-text-muted)] hover:border-[var(--color-accent-cyan)]/40 hover:text-[var(--color-text-primary)]'}`}
                   >
                     {formatStatusLabel(status)} <span className="text-[var(--color-text-muted)]">{statusCounts[status] ?? 0}</span>
                   </button>
@@ -624,7 +624,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
           <div
             role="status"
             aria-live="polite"
-            className="mt-4 flex flex-wrap items-center justify-between gap-2 rounded-md border border-void-lighter bg-void px-3 py-2"
+            className="mt-4 flex flex-wrap items-center justify-between gap-2 rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] px-3 py-2"
           >
             <div className="text-xs text-[var(--color-text-muted)]">{loadError ?? 'Session data is using polling fallback while real-time updates recover.'}</div>
             {!sseConnected && sseError && <RealtimeBadge mode="polling" message={sseError} />}
@@ -632,7 +632,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
         )}
 
         {selectedIds.length > 0 && (
-          <div className="mt-4 flex flex-col gap-3 rounded-md border border-cyan/20 bg-cyan/5 p-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="mt-4 flex flex-col gap-3 rounded-md border border-[var(--color-accent-cyan)]/20 bg-[var(--color-cta-bg)]/5 p-3 lg:flex-row lg:items-center lg:justify-between">
             <div className="text-sm text-[var(--color-text-primary)]">
               {selectedIds.length} session{selectedIds.length === 1 ? '' : 's'} selected
             </div>
@@ -661,7 +661,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                 onClick={() => setSelectedIds([])}
                 disabled={bulkAction !== null}
                 aria-label={t("aria.clearSelection")}
-                className="min-h-[44px] rounded-md border border-void-lighter px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)] disabled:pointer-events-none disabled:opacity-40"
+                className="min-h-[44px] rounded-md border border-[var(--color-void-lighter)] px-3 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)] disabled:pointer-events-none disabled:opacity-40"
               >
                 Clear
               </button>
@@ -715,12 +715,12 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
               <button
                 type="button"
                 onClick={handleSurpriseMe}
-                className="inline-flex items-center gap-2 rounded-lg border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/5 px-4 py-2 text-sm font-medium text-cyan-300 transition-all hover:bg-[var(--color-accent-cyan)]/10 active:scale-95"
+                className="inline-flex items-center gap-2 rounded-lg border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/5 px-4 py-2 text-sm font-medium text-[var(--color-accent-cyan-glow)] transition-all hover:bg-[var(--color-accent-cyan)]/10 active:scale-95"
               >
                 <Sparkles className="h-4 w-4" />
                 Surprise me
               </button>
-              <code className="mt-2 px-4 py-2 font-mono text-xs text-cyan-300/70 bg-[var(--color-accent-cyan)]/20 border border-cyan-900/40 rounded-lg">
+              <code className="mt-2 px-4 py-2 font-mono text-xs text-[var(--color-accent-cyan-glow)]/70 bg-[var(--color-accent-cyan)]/20 border border-[var(--color-accent-cyan)]/40 rounded-lg">
                 $ ag create "brief"
               </code>
             </div>
@@ -729,14 +729,14 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
       ) : (
         <>
           <div className="flex flex-col gap-3 md:hidden">
-            <div className="flex items-center justify-between rounded-md border border-void-lighter bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
+            <div className="flex items-center justify-between rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
               <label className="flex items-center gap-2">
                 <input
                   type="checkbox"
                   aria-label={t("aria.selectAll")}
                   checked={allVisibleSelected}
                   onChange={(e) => handleToggleSelectAll(e.target.checked)}
-                  className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+                  className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
                 />
                 Select visible
               </label>
@@ -750,7 +750,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                     <Fragment key={`group-${dirKey}`}>
                       <button
                         type="button"
-                        className="flex min-h-[44px] items-center gap-2 w-full rounded-md border border-void-lighter bg-[var(--color-void)] px-4 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:border-cyan/40 hover:text-[var(--color-text-primary)]"
+                        className="flex min-h-[44px] items-center gap-2 w-full rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-4 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-accent-cyan)]/40 hover:text-[var(--color-text-primary)]"
                         onClick={() => toggleGroup(dirKey)}
                         aria-expanded={!isCollapsed}
                       >
@@ -797,17 +797,17 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
             }
           </div>
 
-          <div className="hidden overflow-x-auto rounded-lg border border-void-lighter bg-[var(--color-surface)] md:block" tabIndex={0} aria-label={t("aria.sessionsTableScroll")}>
+          <div className="hidden overflow-x-auto rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] md:block" tabIndex={0} aria-label={t("aria.sessionsTableScroll")}>
             <table className="w-full text-left text-sm" aria-label={t("aria.sessionsTable")}>
               <thead>
-                <tr className="border-b border-void-lighter text-[var(--color-text-muted)]">
+                <tr className="border-b border-[var(--color-void-lighter)] text-[var(--color-text-muted)]">
                   <th className="px-4 py-3 font-medium">
                     <input
                       type="checkbox"
                       aria-label={t("aria.selectAll")}
                       checked={allVisibleSelected}
                       onChange={(e) => handleToggleSelectAll(e.target.checked)}
-                      className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+                      className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
                     />
                   </th>
                   <th className="px-4 py-3 font-medium">Status</th>
@@ -842,7 +842,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
           </div>
 
           {deferredSearch.length === 0 && pagination.totalPages > 1 && (
-            <div className="flex items-center justify-between rounded-lg border border-void-lighter bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
+            <div className="flex items-center justify-between rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
               <span>
                 Page {pagination.page} of {pagination.totalPages}
               </span>
@@ -852,7 +852,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                   onClick={() => setPage((current) => Math.max(1, current - 1))}
                   disabled={pagination.page <= 1}
                   aria-label={t("aria.prevPage")}
-                  className="flex min-h-[44px] items-center gap-1 rounded-md border border-void-lighter px-3 py-2 transition-colors hover:border-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)] disabled:pointer-events-none disabled:opacity-40"
+                  className="flex min-h-[44px] items-center gap-1 rounded-md border border-[var(--color-void-lighter)] px-3 py-2 transition-colors hover:border-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)] disabled:pointer-events-none disabled:opacity-40"
                 >
                   <ChevronLeft className="h-4 w-4" /> Previous
                 </button>
@@ -861,7 +861,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                   onClick={() => setPage((current) => Math.min(pagination.totalPages, current + 1))}
                   disabled={pagination.page >= pagination.totalPages}
                   aria-label={t("aria.nextPage")}
-                  className="flex min-h-[44px] items-center gap-1 rounded-md border border-void-lighter px-3 py-2 transition-colors hover:border-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)] disabled:pointer-events-none disabled:opacity-40"
+                  className="flex min-h-[44px] items-center gap-1 rounded-md border border-[var(--color-void-lighter)] px-3 py-2 transition-colors hover:border-[var(--color-void-lighter)] hover:text-[var(--color-text-primary)] disabled:pointer-events-none disabled:opacity-40"
                 >
                   Next <ChevronRight className="h-4 w-4" />
                 </button>

--- a/dashboard/src/components/overview/StatusDot.tsx
+++ b/dashboard/src/components/overview/StatusDot.tsx
@@ -8,12 +8,12 @@ import type { SessionHealthState } from '../../types';
 
 const STATUS_COLORS: Record<UIState, string> = {
   idle: 'var(--color-success)',
-  working: 'var(--color-accent)',
+  working: 'var(--color-cta-bg)',
   permission_prompt: 'var(--color-warning)',
   bash_approval: 'var(--color-warning)',
   plan_mode: 'var(--color-dot-orange)',
   ask_question: 'var(--color-error)',
-  settings: 'var(--color-accent)',
+  settings: 'var(--color-cta-bg)',
   error: 'var(--color-dot-red)',
   rate_limit: 'var(--color-dot-red)',
   compacting: 'var(--color-warning)',

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -183,7 +183,7 @@ function VirtualizedRow(props: {
           aria-label={`Select session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
           checked={selected}
           onChange={(e) => onToggleSelect(session.id, e.target.checked)}
-          className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+          className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
         />
       </div>
       <div className="flex items-center px-2">
@@ -198,7 +198,7 @@ function VirtualizedRow(props: {
       <div className="flex min-w-0 items-center px-3">
         <Link
           to={`/sessions/${encodeURIComponent(session.id)}`}
-          className="inline-flex min-h-[44px] min-w-0 items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-cyan"
+          className="inline-flex min-h-[44px] min-w-0 items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-cyan)]"
           title={session.displayName || session.id}
         >
           {formatSessionName(session.displayName, session.id.slice(0, 8))}
@@ -224,7 +224,7 @@ function VirtualizedRow(props: {
             {session.permissionMode}
           </span>
         ) : (
-          <span className="inline-flex items-center rounded-full bg-void-lighter px-2 py-0.5 text-xs text-[var(--color-text-muted)]">
+          <span className="inline-flex items-center rounded-full bg-[var(--color-void-lighter)] px-2 py-0.5 text-xs text-[var(--color-text-muted)]">
             default
           </span>
         )}
@@ -234,7 +234,7 @@ function VirtualizedRow(props: {
       </div>
       <div className="flex items-center gap-1 px-3">
         {currentAction === 'working' && (
-          <span className="inline-flex items-center gap-1 rounded bg-cyan-900/30 px-1.5 py-0.5 text-xs text-[var(--color-accent-cyan)]">
+          <span className="inline-flex items-center gap-1 rounded bg-[var(--color-cta-bg)]-900/30 px-1.5 py-0.5 text-xs text-[var(--color-accent-cyan)]">
             <Play className="h-2.5 w-2.5" />
             running
           </span>
@@ -315,10 +315,10 @@ export function VirtualizedSessionList({
   };
 
   return (
-    <div className="rounded-lg border border-void-lighter overflow-hidden">
+    <div className="rounded-lg border border-[var(--color-void-lighter)] overflow-hidden">
       {showHeader && (
         <div
-          className="grid border-b border-void-lighter text-[var(--color-text-muted)] text-sm text-left bg-[var(--color-surface)]"
+          className="grid border-b border-[var(--color-void-lighter)] text-[var(--color-text-muted)] text-sm text-left bg-[var(--color-surface)]"
           style={{ gridTemplateColumns: GRID_COLUMNS }}
         >
           <div className="px-3 py-3 font-medium">
@@ -327,7 +327,7 @@ export function VirtualizedSessionList({
               aria-label={t("aria.selectAll")}
               checked={allVisibleSelected}
               onChange={(e) => onToggleSelectAll(e.target.checked)}
-              className="h-4 w-4 rounded border border-void-lighter bg-void text-cyan focus:ring-1 focus:ring-cyan"
+              className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
             />
           </div>
           <div className="px-2 py-3 font-medium" role="columnheader">Status</div>

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -234,7 +234,7 @@ function VirtualizedRow(props: {
       </div>
       <div className="flex items-center gap-1 px-3">
         {currentAction === 'working' && (
-          <span className="inline-flex items-center gap-1 rounded bg-[var(--color-cta-bg)]-900/30 px-1.5 py-0.5 text-xs text-[var(--color-accent-cyan)]">
+          <span className="inline-flex items-center gap-1 rounded bg-[var(--color-accent-cyan)]/30 px-1.5 py-0.5 text-xs text-[var(--color-accent-cyan)]">
             <Play className="h-2.5 w-2.5" />
             running
           </span>

--- a/dashboard/src/components/pipeline/PipelineStatusBadge.tsx
+++ b/dashboard/src/components/pipeline/PipelineStatusBadge.tsx
@@ -7,7 +7,7 @@ interface PipelineStatusBadgeProps {
 }
 
 const STATUS_STYLES: Record<string, string> = {
-  running: 'bg-cyan/10 text-cyan border-cyan/30',
+  running: 'bg-[var(--color-cta-bg)]/10 text-[var(--color-accent-cyan)] border-[var(--color-accent-cyan)]/30',
   completed: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/30',
   failed: 'bg-[var(--color-danger)]/10 text-[var(--color-danger)] border-[var(--color-danger)]/30',
   pending: 'bg-[var(--color-void-lighter)] text-[var(--color-text-muted)] border-[var(--color-void-lighter)]',

--- a/dashboard/src/components/routines/CalendarGrid.tsx
+++ b/dashboard/src/components/routines/CalendarGrid.tsx
@@ -157,9 +157,9 @@ export default function CalendarGrid({
               onClick={() => onSelectDate(day)}
               disabled={!inCurrentMonth}
               className={`
-                relative p-2 min-h-[4rem] text-left transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-inset
+                relative p-2 min-h-[4rem] text-left transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)] focus:ring-inset
                 ${!inCurrentMonth ? 'opacity-30 cursor-default' : 'hover:bg-[var(--color-void-dark)] cursor-pointer'}
-                ${isSelected ? 'bg-[var(--color-accent)]/10 ring-1 ring-[var(--color-accent)]/30' : ''}
+                ${isSelected ? 'bg-[var(--color-cta-bg)]/10 ring-1 ring-[var(--color-cta-bg)]/30' : ''}
               `}
               aria-label={`${format(day, 'EEEE, MMMM d, yyyy')}${hasRoutines ? `, ${dayRoutines.length} routine${dayRoutines.length > 1 ? 's' : ''}` : ''}`}
               aria-current={today ? 'date' : undefined}
@@ -167,7 +167,7 @@ export default function CalendarGrid({
               <span
                 className={`
                   text-sm font-medium
-                  ${today ? 'text-[var(--color-accent)]' : inCurrentMonth ? 'text-[var(--color-text-primary)]' : 'text-[var(--color-text-muted)]'}
+                  ${today ? 'text-[var(--color-cta-bg)]' : inCurrentMonth ? 'text-[var(--color-text-primary)]' : 'text-[var(--color-text-muted)]'}
                 `}
               >
                 {format(day, 'd')}

--- a/dashboard/src/components/routines/RoutineCard.tsx
+++ b/dashboard/src/components/routines/RoutineCard.tsx
@@ -113,7 +113,7 @@ export default function RoutineCard({
           </button>
           <button type="button"
             onClick={() => onTriggerNow?.(routine.id)}
-            className="p-1.5 rounded text-[var(--color-accent)] hover:bg-[var(--color-accent)]/10 transition-colors"
+            className="p-1.5 rounded text-[var(--color-cta-bg)] hover:bg-[var(--color-cta-bg)]/10 transition-colors"
             aria-label={t("aria.triggerRoutine")}
             title="Run now"
           >

--- a/dashboard/src/components/session/AcpChatView.tsx
+++ b/dashboard/src/components/session/AcpChatView.tsx
@@ -134,7 +134,7 @@ function MessageBubble({ message, showPerMessageUsage }: { message: AcpChatMessa
         <div
           className={`rounded-xl px-4 py-2.5 text-sm leading-relaxed ${
             isUser
-              ? 'bg-[var(--color-accent)]/15 text-[var(--color-text-primary)] border border-[var(--color-accent)]/20'
+              ? 'bg-[var(--color-cta-bg)]/15 text-[var(--color-text-primary)] border border-[var(--color-cta-bg)]/20'
               : isSystem
                 ? 'bg-[var(--color-surface-hover)] text-[var(--color-text-muted)] border border-[var(--color-border-strong)]'
                 : 'bg-[var(--color-surface)] text-[var(--color-text-primary)] border border-[var(--color-border-strong)]'
@@ -282,7 +282,7 @@ export function AcpChatView({
               onKeyDown={handleKeyDown}
               placeholder="Send a prompt to the agent..."
               rows={1}
-              className="flex-1 resize-none rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-2.5 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent)]/50 focus-visible:outline-none"
+              className="flex-1 resize-none rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-2.5 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-cta-bg)]/50 focus-visible:outline-none"
               disabled={!isDriver}
               aria-label={t("aria.messageInput")}
             />
@@ -300,7 +300,7 @@ export function AcpChatView({
                 type="button"
                 onClick={handleSend}
                 disabled={!input.trim()}
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--color-accent)]/20 text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--color-cta-bg)]/20 text-[var(--color-cta-bg)] transition-colors hover:bg-[var(--color-cta-bg)]/30 disabled:opacity-50 disabled:cursor-not-allowed"
                 aria-label={t("aria.sendMessage")}
               >
                 <Send className="h-4 w-4" />

--- a/dashboard/src/components/session/AcpSessionShell.tsx
+++ b/dashboard/src/components/session/AcpSessionShell.tsx
@@ -157,13 +157,13 @@ export function AcpSessionShell({
                     <Icon className="h-4 w-4" />
                     {tab.label}
                     {tab.badge !== undefined && (
-                      <span className="ml-1 rounded-full bg-[var(--color-accent)]/20 px-1.5 py-0.5 text-[10px] font-bold text-[var(--color-accent)]">
+                      <span className="ml-1 rounded-full bg-[var(--color-cta-bg)]/20 px-1.5 py-0.5 text-[10px] font-bold text-[var(--color-cta-bg)]">
                         {tab.badge}
                       </span>
                     )}
                     {/* Active indicator */}
                     {isActive && (
-                      <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-[var(--color-accent)]" />
+                      <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-[var(--color-cta-bg)]" />
                     )}
                   </button>
                 );

--- a/dashboard/src/components/session/DriverControlBar.tsx
+++ b/dashboard/src/components/session/DriverControlBar.tsx
@@ -92,7 +92,7 @@ export function DriverControlBar({
       {/* Current driver indicator */}
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <Gamepad2 className="h-4 w-4 text-[var(--color-accent)]" />
+          <Gamepad2 className="h-4 w-4 text-[var(--color-cta-bg)]" />
           {hasDriver ? (
             <span className="text-sm text-[var(--color-text-primary)]">
               Driver: <span className="font-medium">{participants!.driver!.subscriberId}</span>
@@ -123,7 +123,7 @@ export function DriverControlBar({
           <button type="button"
             onClick={() => onClaim?.()}
             disabled={!canAct}
-            className="flex items-center gap-2 rounded-md bg-[var(--color-accent)]/20 px-3 py-2 text-sm font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/30 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex items-center gap-2 rounded-md bg-[var(--color-cta-bg)]/20 px-3 py-2 text-sm font-medium text-[var(--color-cta-bg)] transition-colors hover:bg-[var(--color-cta-bg)]/30 disabled:opacity-50 disabled:cursor-not-allowed"
             aria-label={t("aria.claimDriver")}
           >
             {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Gamepad2 className="h-4 w-4" />}

--- a/dashboard/src/components/session/InterventionHistoryPanel.tsx
+++ b/dashboard/src/components/session/InterventionHistoryPanel.tsx
@@ -79,13 +79,13 @@ function buildTimeline(record: AcpPauseInterventionRecord): TimelineEntry[] {
 
 const TONE_STYLES = {
   amber: 'border-[var(--color-warning)]/30 bg-[var(--color-warning)]/5',
-  blue: 'border-[var(--color-accent)]/30 bg-[var(--color-accent)]/5',
+  blue: 'border-[var(--color-cta-bg)]/30 bg-[var(--color-cta-bg)]/5',
   green: 'border-[var(--color-success)]/30 bg-[var(--color-success)]/5',
 } as const;
 
 const TONE_ICON_STYLES = {
   amber: 'text-[var(--color-warning)]',
-  blue: 'text-[var(--color-accent)]',
+  blue: 'text-[var(--color-cta-bg)]',
   green: 'text-[var(--color-success)]',
 } as const;
 

--- a/dashboard/src/components/session/InterventionStatusBadge.tsx
+++ b/dashboard/src/components/session/InterventionStatusBadge.tsx
@@ -22,8 +22,8 @@ const STATUS_CONFIG = {
   },
   intervening: {
     label: 'Intervening',
-    bg: 'bg-[var(--color-accent)]/20',
-    text: 'text-[var(--color-accent)]',
+    bg: 'bg-[var(--color-cta-bg)]/20',
+    text: 'text-[var(--color-cta-bg)]',
     icon: Hand,
   },
   resumed: {

--- a/dashboard/src/components/session/LiveTerminal.tsx
+++ b/dashboard/src/components/session/LiveTerminal.tsx
@@ -196,7 +196,7 @@ export function LiveTerminal({ sessionId, status }: LiveTerminalProps) {
             <span
               className="w-1.5 h-1.5 rounded-full"
               style={{
-                backgroundColor: isConnected ? 'var(--color-accent)' : connectionState === 'reconnecting' ? 'var(--color-warning)' : 'var(--color-text-muted)',
+                backgroundColor: isConnected ? 'var(--color-cta-bg)' : connectionState === 'reconnecting' ? 'var(--color-warning)' : 'var(--color-text-muted)',
                 boxShadow: isConnected ? '0 0 4px rgba(var(--color-accent-rgb, 59,130,246), 0.25)' : 'none',
                 animation: connectionState === 'reconnecting' ? 'pulse 1s ease-in-out infinite' : 'none',
               }}

--- a/dashboard/src/components/session/MessageBubble.tsx
+++ b/dashboard/src/components/session/MessageBubble.tsx
@@ -94,7 +94,7 @@ function ToolUseCard({ entry }: { entry: ParsedEntry }) {
       <div className="max-w-[80%] w-full bg-[var(--color-void-deepest)] border border-[var(--color-void-lighter)] rounded-lg overflow-hidden">
         <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--color-void-lighter)]">
           <span className="text-base">{getToolIcon(entry.toolName)}</span>
-          <span className="text-xs font-semibold text-[var(--color-accent)] font-mono">
+          <span className="text-xs font-semibold text-[var(--color-cta-bg)] font-mono">
             {entry.toolName ?? 'Tool'}
           </span>
           <span className="text-[10px] text-[var(--color-text-muted)] ml-auto">tool_use</span>

--- a/dashboard/src/components/session/OperatorTimeline.tsx
+++ b/dashboard/src/components/session/OperatorTimeline.tsx
@@ -44,7 +44,7 @@ import type {
 
 /** Map categories to display config. */
 const CATEGORY_CONFIG: Record<AcpTimelineCategory, { label: string; icon: typeof Terminal; color: string }> = {
-  driver: { label: 'Driver', icon: User, color: 'text-[var(--color-accent)]' },
+  driver: { label: 'Driver', icon: User, color: 'text-[var(--color-cta-bg)]' },
   prompt: { label: 'Prompt', icon: Terminal, color: 'text-[var(--color-text-primary)]' },
   tool: { label: 'Tool', icon: Wrench, color: 'text-[var(--color-warning)]' },
   approval: { label: 'Approval', icon: Shield, color: 'text-[var(--color-success)]' },
@@ -254,7 +254,7 @@ export function OperatorTimeline({
           onClick={() => setShowFilters((prev) => !prev)}
           className={`flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors ${
             showFilters
-              ? 'bg-[var(--color-accent)]/20 text-[var(--color-accent)]'
+              ? 'bg-[var(--color-cta-bg)]/20 text-[var(--color-cta-bg)]'
               : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
           }`}
           aria-expanded={showFilters}
@@ -263,7 +263,7 @@ export function OperatorTimeline({
           <Filter className="h-3.5 w-3.5" />
           Filter
           {filters.categories.size < ALL_CATEGORIES.length && (
-            <span className="ml-1 rounded-full bg-[var(--color-accent)]/20 px-1 py-0.5 text-[10px] text-[var(--color-accent)]">
+            <span className="ml-1 rounded-full bg-[var(--color-cta-bg)]/20 px-1 py-0.5 text-[10px] text-[var(--color-cta-bg)]">
               {filters.categories.size}
             </span>
           )}
@@ -275,7 +275,7 @@ export function OperatorTimeline({
             value={filters.search}
             onChange={handleSearch}
             placeholder="Search events..."
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-void)] py-1.5 pl-7 pr-3 text-xs text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-accent)]/50 focus-visible:outline-none"
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-void)] py-1.5 pl-7 pr-3 text-xs text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-cta-bg)]/50 focus-visible:outline-none"
             aria-label={t("aria.searchTimeline")}
           />
         </div>
@@ -320,7 +320,7 @@ export function OperatorTimeline({
       >
         {isLoading && (
           <div className="flex items-center justify-center p-8" role="status">
-            <div className="h-6 w-6 animate-spin rounded-full border-2 border-[var(--color-border)] border-t-[var(--color-accent)]" />
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-[var(--color-border)] border-t-[var(--color-cta-bg)]" />
             <span className="ml-3 text-sm text-[var(--color-text-muted)]">Loading events...</span>
           </div>
         )}

--- a/dashboard/src/components/session/PauseControlBar.tsx
+++ b/dashboard/src/components/session/PauseControlBar.tsx
@@ -160,7 +160,7 @@ export function PauseControlBar({
           <button type="button"
             onClick={() => onIntervene?.()}
             disabled={!canAct}
-            className="flex items-center gap-2 rounded-md bg-[var(--color-accent)]/20 px-3 py-2 text-sm font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/30 disabled:opacity-50"
+            className="flex items-center gap-2 rounded-md bg-[var(--color-cta-bg)]/20 px-3 py-2 text-sm font-medium text-[var(--color-cta-bg)] transition-colors hover:bg-[var(--color-cta-bg)]/30 disabled:opacity-50"
             aria-label={t("aria.startIntervention")}
           >
             <Hand className="h-4 w-4" />
@@ -182,14 +182,14 @@ export function PauseControlBar({
       {isIntervening && (
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2">
-            <span className="rounded bg-[var(--color-accent)]/20 px-2 py-1 text-xs font-medium text-[var(--color-accent)]">
+            <span className="rounded bg-[var(--color-cta-bg)]/20 px-2 py-1 text-xs font-medium text-[var(--color-cta-bg)]">
               Intervening
             </span>
             {!showGuidanceForm && (
               <button type="button"
                 onClick={() => setShowGuidanceForm(true)}
                 disabled={!canAct}
-                className="flex items-center gap-2 rounded-md bg-[var(--color-accent)]/20 px-3 py-2 text-sm font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/30 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-md bg-[var(--color-cta-bg)]/20 px-3 py-2 text-sm font-medium text-[var(--color-cta-bg)] transition-colors hover:bg-[var(--color-cta-bg)]/30 disabled:opacity-50"
                 aria-label={t("aria.completeWithGuidance")}
               >
                 <CheckCircle className="h-4 w-4" />
@@ -208,7 +208,7 @@ export function PauseControlBar({
                 value={guidance}
                 onChange={(e) => setGuidance(e.target.value)}
                 placeholder="Provide instructions for the agent to follow after resuming..."
-                className="w-full rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-void-lighter)] focus:border-[var(--color-accent)]/50 focus-visible:outline-none resize-y"
+                className="w-full rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-void-lighter)] focus:border-[var(--color-cta-bg)]/50 focus-visible:outline-none resize-y"
                 rows={3}
                 autoFocus
               />
@@ -216,7 +216,7 @@ export function PauseControlBar({
                 <button type="button"
                   onClick={handleComplete}
                   disabled={isLoading}
-                  className="flex items-center gap-1 rounded-md bg-[var(--color-accent)] px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--color-accent)] disabled:opacity-50"
+                  className="flex items-center gap-1 rounded-md bg-[var(--color-cta-bg)] px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--color-cta-bg)] disabled:opacity-50"
                   aria-label={t("aria.submitGuidance")}
                 >
                   {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4" />}

--- a/dashboard/src/components/session/SessionMetricsPanel.tsx
+++ b/dashboard/src/components/session/SessionMetricsPanel.tsx
@@ -113,7 +113,7 @@ export function SessionMetricsPanel({ sessionId }: SessionMetricsPanelProps) {
 
   const tokenRows = tu
     ? [
-        { label: 'Input', value: tu.inputTokens, colorVar: 'var(--color-accent)' },
+        { label: 'Input', value: tu.inputTokens, colorVar: 'var(--color-cta-bg)' },
         { label: 'Output', value: tu.outputTokens, colorVar: 'var(--color-success)' },
         { label: 'Cache Create', value: tu.cacheCreationTokens, colorVar: 'var(--color-warning)' },
         { label: 'Cache Read', value: tu.cacheReadTokens, colorVar: 'var(--color-metrics-purple)' },

--- a/dashboard/src/components/session/SessionPreviewCard.tsx
+++ b/dashboard/src/components/session/SessionPreviewCard.tsx
@@ -27,7 +27,7 @@ function MessagePreview({ msg }: { msg: ParsedEntry }) {
       <span className={`shrink-0 text-xs font-medium w-12 text-right ${isUser ? 'text-[var(--color-accent-cyan)]' : 'text-[var(--color-text-muted)]'}`}>
         {isUser ? 'You' : 'CC'}
       </span>
-      <div className={`rounded px-2 py-1 text-xs ${isUser ? 'bg-[var(--color-accent-cyan)]/40 text-cyan-200' : 'bg-[var(--color-void-light)] text-[var(--color-text-primary)]'}`}>
+      <div className={`rounded px-2 py-1 text-xs ${isUser ? 'bg-[var(--color-accent-cyan)]/40 text-[var(--color-accent-cyan)]-200' : 'bg-[var(--color-void-light)] text-[var(--color-text-primary)]'}`}>
         {text}
       </div>
     </div>

--- a/dashboard/src/components/session/SessionPreviewCard.tsx
+++ b/dashboard/src/components/session/SessionPreviewCard.tsx
@@ -27,7 +27,7 @@ function MessagePreview({ msg }: { msg: ParsedEntry }) {
       <span className={`shrink-0 text-xs font-medium w-12 text-right ${isUser ? 'text-[var(--color-accent-cyan)]' : 'text-[var(--color-text-muted)]'}`}>
         {isUser ? 'You' : 'CC'}
       </span>
-      <div className={`rounded px-2 py-1 text-xs ${isUser ? 'bg-[var(--color-accent-cyan)]/40 text-[var(--color-accent-cyan)]-200' : 'bg-[var(--color-void-light)] text-[var(--color-text-primary)]'}`}>
+      <div className={`rounded px-2 py-1 text-xs ${isUser ? 'bg-[var(--color-accent-cyan)]/40 text-[var(--color-accent-cyan-glow)]' : 'bg-[var(--color-void-light)] text-[var(--color-text-primary)]'}`}>
         {text}
       </div>
     </div>

--- a/dashboard/src/components/session/SessionTimelineView.tsx
+++ b/dashboard/src/components/session/SessionTimelineView.tsx
@@ -23,7 +23,7 @@ const CATEGORY_CONFIG: Record<AcpTimelineCategory, {
   color: string;
   dotColor: string;
 }> = {
-  driver:       { label: 'Driver',       icon: User,          color: 'text-[var(--color-accent)]',          dotColor: 'bg-[var(--color-accent-cyan)]' },
+  driver:       { label: 'Driver',       icon: User,          color: 'text-[var(--color-cta-bg)]',          dotColor: 'bg-[var(--color-accent-cyan)]' },
   prompt:       { label: 'Prompt',       icon: Terminal,      color: 'text-[var(--color-text-primary)]', dotColor: 'bg-[var(--color-text-primary)]' },
   tool:         { label: 'Tool',         icon: Wrench,        color: 'text-[var(--color-warning)]',         dotColor: 'bg-[var(--color-warning)]' },
   approval:     { label: 'Approval',     icon: Shield,        color: 'text-emerald-400',       dotColor: 'bg-emerald-400' },
@@ -138,7 +138,7 @@ export function SessionTimelineView({ events, isLoading }: SessionTimelineViewPr
           <button
             type="button"
             onClick={() => setShowFilters(v => !v)}
-            className={`text-xs transition-colors ${showFilters ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'}`}
+            className={`text-xs transition-colors ${showFilters ? 'text-[var(--color-cta-bg)]' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'}`}
             aria-label={t("aria.toggleEventFilters")}
             aria-expanded={showFilters}
           >
@@ -201,7 +201,7 @@ export function SessionTimelineView({ events, isLoading }: SessionTimelineViewPr
                 <button
                   type="button"
                   onClick={() => toggleExpand(event.id)}
-                  className="w-full text-left flex items-start gap-2 rounded p-1.5 -m-1.5 hover:bg-[var(--color-void)]/30 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent)]"
+                  className="w-full text-left flex items-start gap-2 rounded p-1.5 -m-1.5 hover:bg-[var(--color-void)]/30 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-cta-bg)]"
                   aria-expanded={expanded}
                   aria-label={`${cfg.label}: ${event.description}`}
                 >

--- a/dashboard/src/components/session/StreamSplitView.tsx
+++ b/dashboard/src/components/session/StreamSplitView.tsx
@@ -61,8 +61,8 @@ export function StreamSplitView({ sessionId, isDriver }: StreamSplitViewProps) {
       <button
         type="button"
         onMouseDown={handleMouseDown}
-        className={`w-1 h-full bg-[var(--color-void-lighter)] hover:bg-[var(--color-accent)] cursor-col-resize transition-colors shrink-0 ${
-          isDragging ? 'bg-[var(--color-accent)]' : ''
+        className={`w-1 h-full bg-[var(--color-void-lighter)] hover:bg-[var(--color-cta-bg)] cursor-col-resize transition-colors shrink-0 ${
+          isDragging ? 'bg-[var(--color-cta-bg)]' : ''
         }`}
         aria-label={t("aria.resizePanes")}
       />

--- a/dashboard/src/components/session/StreamTab.tsx
+++ b/dashboard/src/components/session/StreamTab.tsx
@@ -88,7 +88,7 @@ export function StreamTab({ sessionId, isDriver }: StreamTabProps) {
               onClick={() => selectView(mode)}
               className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
                 viewMode === mode
-                  ? 'bg-[var(--color-accent)] text-[var(--color-void)] shadow-sm'
+                  ? 'bg-[var(--color-cta-bg)] text-[var(--color-void)] shadow-sm'
                   : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-void-lighter)]/30'
               }`}
             >

--- a/dashboard/src/components/session/TimelineSparkline.tsx
+++ b/dashboard/src/components/session/TimelineSparkline.tsx
@@ -123,7 +123,7 @@ export function TimelineSparkline({
               onClick={() => setRange(r)}
               className={`px-2 py-0.5 text-[10px] font-mono uppercase rounded transition-colors ${
                 range === r
-                  ? 'bg-[var(--color-accent)] text-[var(--color-void)]'
+                  ? 'bg-[var(--color-cta-bg)] text-[var(--color-void)]'
                   : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
               }`}
             >

--- a/dashboard/src/components/session/TokenBreakdown.tsx
+++ b/dashboard/src/components/session/TokenBreakdown.tsx
@@ -26,7 +26,7 @@ export function TokenBreakdown(props: TokenBreakdownProps) {
   const total = Math.max(inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens, 1);
 
   const bars = [
-    { label: 'Input', value: inputTokens, color: 'var(--color-accent)' },
+    { label: 'Input', value: inputTokens, color: 'var(--color-cta-bg)' },
     { label: 'Output', value: outputTokens, color: 'var(--color-success)' },
     { label: 'Cache Create', value: cacheCreationTokens, color: 'var(--color-warning)' },
     { label: 'Cache Read', value: cacheReadTokens, color: 'var(--color-accent-purple-alt)' },

--- a/dashboard/src/components/session/ToolCallCard.tsx
+++ b/dashboard/src/components/session/ToolCallCard.tsx
@@ -45,7 +45,7 @@ function getToolIcon(toolName: string) {
 /** Status configuration. */
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof Loader2; color: string; bgColor: string }> = {
   pending: { label: 'Pending', icon: Clock, color: 'text-[var(--color-text-muted)]', bgColor: 'bg-[var(--color-void-lighter)]' },
-  running: { label: 'Running', icon: Loader2, color: 'text-[var(--color-accent)]', bgColor: 'bg-[var(--color-accent)]/10' },
+  running: { label: 'Running', icon: Loader2, color: 'text-[var(--color-cta-bg)]', bgColor: 'bg-[var(--color-cta-bg)]/10' },
   completed: { label: 'Completed', icon: CheckCircle, color: 'text-[var(--color-success)]', bgColor: 'bg-[var(--color-success)]/10' },
   failed: { label: 'Failed', icon: XCircle, color: 'text-[var(--color-error)]', bgColor: 'bg-[var(--color-error)]/10' },
   cancelled: { label: 'Cancelled', icon: XCircle, color: 'text-[var(--color-text-muted)]', bgColor: 'bg-[var(--color-void-lighter)]' },

--- a/dashboard/src/components/session/TranscriptView.tsx
+++ b/dashboard/src/components/session/TranscriptView.tsx
@@ -175,7 +175,7 @@ export function TranscriptView({ sessionId }: TranscriptViewProps) {
             aria-pressed={filters[key]}
             className={`text-xs px-2 py-0.5 rounded border transition-colors ${
               filters[key]
-                ? 'border-[var(--color-accent)]/40 text-[var(--color-accent)] bg-[var(--color-accent)]/10'
+                ? 'border-[var(--color-cta-bg)]/40 text-[var(--color-cta-bg)] bg-[var(--color-cta-bg)]/10'
                 : 'border-[var(--color-void-lighter)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
             }`}
           >
@@ -257,7 +257,7 @@ export function TranscriptView({ sessionId }: TranscriptViewProps) {
         <button type="button"
           onClick={scrollToBottom}
           aria-label="Scroll to bottom"
-          className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-accent)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
+          className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-cta-bg)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
           title="Scroll to bottom"
         >
           ↓

--- a/dashboard/src/components/session/TranscriptViewer.tsx
+++ b/dashboard/src/components/session/TranscriptViewer.tsx
@@ -199,7 +199,7 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
             aria-pressed={filters[key]}
             className={`text-xs px-2 py-0.5 rounded border transition-colors ${
               filters[key]
-                ? 'border-[var(--color-accent)]/40 text-[var(--color-accent)] bg-[var(--color-accent)]/10'
+                ? 'border-[var(--color-cta-bg)]/40 text-[var(--color-cta-bg)] bg-[var(--color-cta-bg)]/10'
                 : 'border-[var(--color-void-lighter)] text-[var(--color-text-muted)] hover:text-[var(--color-text-muted)]'
             }`}
           >
@@ -247,7 +247,7 @@ export function TranscriptViewer({ sessionId }: TranscriptViewerProps) {
       {showScrollBtn && (
         <button type="button"
           onClick={scrollToBottom}
-          className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-accent)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
+          className="absolute bottom-4 right-4 bg-[var(--color-void-lighter)] hover:bg-[var(--color-surface-hover)] text-[var(--color-cta-bg)] rounded-full w-10 h-10 flex items-center justify-center shadow-lg border border-[var(--color-void-lighter)] transition-colors z-10"
           title="Scroll to bottom"
         >
           ↓

--- a/dashboard/src/components/shared/AnimatedNumber.tsx
+++ b/dashboard/src/components/shared/AnimatedNumber.tsx
@@ -18,7 +18,7 @@ export interface AnimatedNumberProps {
   suffix?: string;
   /** Flash accent color on value change. Default: false */
   flash?: boolean;
-  /** Accent color for flash. Default: var(--color-accent) */
+  /** Accent color for flash. Default: var(--color-cta-bg) */
   flashColor?: string;
   /** CSS classes for the root element */
   className?: string;
@@ -36,7 +36,7 @@ export function AnimatedNumber({
   value,
   suffix,
   flash = false,
-  flashColor = 'var(--color-accent)',
+  flashColor = 'var(--color-cta-bg)',
   className,
   decimals = 0,
 }: AnimatedNumberProps) {

--- a/dashboard/src/components/shared/ModelBadge.tsx
+++ b/dashboard/src/components/shared/ModelBadge.tsx
@@ -14,7 +14,7 @@
 
 const MODEL_STYLES: Record<string, { color: string; label: string }> = {
   opus: { color: 'var(--color-accent-purple)', label: 'Opus' },
-  sonnet: { color: 'var(--color-accent)', label: 'Sonnet' },
+  sonnet: { color: 'var(--color-cta-bg)', label: 'Sonnet' },
   haiku: { color: 'var(--color-success)', label: 'Haiku' },
 };
 

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -140,7 +140,7 @@ function actionBadgeClass(action: string): string {
     return 'border border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
   }
   if (action.includes('create') || action.includes('authenticated')) {
-    return 'border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 text-cyan-300';
+    return 'border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 text-[var(--color-accent-cyan-glow)]';
   }
   return 'border border-[var(--color-void-lighter)] bg-[var(--color-void-lighter)]/40 text-[var(--color-text-primary)]';
 }

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -68,7 +68,7 @@ export default function LoginPage() {
       <div className="w-full max-w-sm rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] p-4 sm:p-8">
         {/* Logo / Title */}
         <div className="mb-8 flex flex-col items-center gap-2">
-          <Shield className="h-10 w-10 text-[var(--color-accent)]" />
+          <Shield className="h-10 w-10 text-[var(--color-cta-bg)]" />
           <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">Aegis</h1>
           <p className="text-sm text-[var(--color-text-muted)]">
             {oidcAvailable ? 'Sign in with your identity provider to continue' : 'Enter your API token to continue'}
@@ -77,13 +77,13 @@ export default function LoginPage() {
 
         {checkingAuthMode ? (
           <div className="flex justify-center py-2" aria-label={t("aria.checkingAuth")}>
-            <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-[var(--color-accent)]" />
+            <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-[var(--color-cta-bg)]" />
           </div>
         ) : oidcAvailable ? (
           <button
             type="button"
             onClick={handleOidcLogin}
-            className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-accent)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--color-accent)]"
+            className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-cta-bg)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--color-cta-bg)]"
           >
             <LogIn className="h-4 w-4" />
             <span>Sign in with SSO</span>
@@ -101,7 +101,7 @@ export default function LoginPage() {
                 placeholder="API token"
                 autoFocus
                 autoComplete="current-password"
-                className="min-h-[44px] w-full rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-2.5 pr-12 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-accent)] focus-visible:outline-none touch-action-manipulation"
+                className="min-h-[44px] w-full rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-3 py-2.5 pr-12 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-cta-bg)] focus-visible:outline-none touch-action-manipulation"
               />
               <button
                 type="button"
@@ -120,7 +120,7 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={loading || !token.trim()}
-              className="min-h-[44px] rounded-lg bg-[var(--color-accent)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+              className="min-h-[44px] rounded-lg bg-[var(--color-cta-bg)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--color-cta-bg)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               {loading ? t('login.verifying') : t('login.signInButton')}
             </button>

--- a/dashboard/src/pages/NotFoundPage.tsx
+++ b/dashboard/src/pages/NotFoundPage.tsx
@@ -15,7 +15,7 @@ export default function NotFoundPage() {
       <p className="text-lg text-[var(--color-text-muted)]">{t('errors.notFound')}</p>
       <Link
         to="/"
-        className="mt-2 rounded-lg bg-cyan px-4 py-2 text-sm font-medium text-void transition-colors hover:bg-cyan/80"
+        className="mt-2 rounded-lg bg-[var(--color-cta-bg)] px-4 py-2 text-sm font-medium text-[var(--color-void)] transition-colors hover:bg-[var(--color-cta-bg)]/80"
       >
         {t('errors.goHome')}
       </Link>

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -142,8 +142,8 @@ export default function PipelineDetailPage() {
       </div>
 
       {/* Steps Table */}
-      <div className="rounded-lg border border-void-lighter bg-[var(--color-surface)]">
-        <div className="px-4 py-3 border-b border-void-lighter">
+      <div className="rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)]">
+        <div className="px-4 py-3 border-b border-[var(--color-void-lighter)]">
           <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
             {t('pipelines.stepsLabel')} ({pipeline.stages.length})
           </h3>
@@ -156,7 +156,7 @@ export default function PipelineDetailPage() {
           <div className="overflow-x-auto" tabIndex={0} aria-label={t('pipelines.stepsLabel')}>
           <table className="w-full text-left text-sm" aria-label={t('pipelines.stepsLabel')}>
             <thead>
-              <tr className="border-b border-void-lighter text-[var(--color-text-muted)]">
+              <tr className="border-b border-[var(--color-void-lighter)] text-[var(--color-text-muted)]">
                 <th className="px-4 py-3 font-medium w-16">#</th>
                 <th className="px-4 py-3 font-medium">{t('pipelines.statusLabel')}</th>
                 <th className="px-4 py-3 font-medium">{t('common.name')}</th>
@@ -167,7 +167,7 @@ export default function PipelineDetailPage() {
               {pipeline.stages.map((stage, i) => (
                 <tr
                   key={stage.name}
-                  className="border-b border-void-lighter/50 transition-colors hover:border-l-2 hover:border-l-cyan"
+                  className="border-b border-[var(--color-void-lighter)]/50 transition-colors hover:border-l-2 hover:border-l-[var(--color-accent-cyan)]"
                 >
                   <td className="px-4 py-3 text-[var(--color-text-muted)] font-mono text-xs">
                     #{i + 1}
@@ -179,7 +179,7 @@ export default function PipelineDetailPage() {
                     {stage.sessionId ? (
                       <Link
                         to={`/sessions/${encodeURIComponent(stage.sessionId)}`}
-                        className="font-medium text-[var(--color-text-primary)] hover:text-cyan transition-colors"
+                        className="font-medium text-[var(--color-text-primary)] hover:text-[var(--color-accent-cyan)] transition-colors"
                       >
                         {stage.name}
                       </Link>

--- a/dashboard/src/pages/RoutinesPage.tsx
+++ b/dashboard/src/pages/RoutinesPage.tsx
@@ -91,7 +91,7 @@ export default function RoutinesPage() {
           </div>
           <button type="button"
             onClick={handleCreate}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-accent)] hover:bg-[var(--color-accent)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]"
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-cta-bg)] hover:bg-[var(--color-cta-bg)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)] focus:ring-offset-2 focus:ring-offset-[var(--color-void)]"
             aria-label={t('routines.createNew')}
           >
             <Plus className="w-4 h-4" />
@@ -117,7 +117,7 @@ export default function RoutinesPage() {
         </div>
         <button type="button"
           onClick={handleCreate}
-          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-accent)] hover:bg-[var(--color-accent)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]"
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-cta-bg)] hover:bg-[var(--color-cta-bg)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)] focus:ring-offset-2 focus:ring-offset-[var(--color-void)]"
           aria-label={t('routines.createNew')}
         >
           <Plus className="w-4 h-4" />

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -54,7 +54,7 @@ import { useT } from '../i18n/context';
 function TabLoadingFallback() {
   return (
     <div className="flex items-center justify-center py-16">
-      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--color-accent)]" />
+      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--color-cta-bg)]" />
     </div>
   );
 }

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -54,7 +54,7 @@ function statusClass(status: SessionHistoryRecord['finalStatus']): string {
 }
 
 function sourceClass(source: SessionHistoryRecord['source']): string {
-  if (source === 'audit+live') return 'text-cyan-300 bg-[var(--color-accent-cyan)]/10 border-[var(--color-accent-cyan)]/25';
+  if (source === 'audit+live') return 'text-[var(--color-accent-cyan-glow)] bg-[var(--color-accent-cyan)]/10 border-[var(--color-accent-cyan)]/25';
   if (source === 'live') return 'text-sky-300 bg-sky-500/10 border-sky-500/25';
   return 'text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] bg-[var(--color-void-lighter)]/40 border-[var(--color-void-lighter)]';
 }
@@ -649,7 +649,7 @@ export default function SessionHistoryPage() {
                       type="checkbox"
                       checked={sortedRecords.length > 0 && selectedIds.size === sortedRecords.length}
                       onChange={toggleSelectAll}
-                      className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-cyan-500/30"
+                      className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-[var(--color-accent-cyan)]-500/30"
                     />
                   </th>
                   <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">{t('sessionHistory.nameColumn')}</th>
@@ -704,7 +704,7 @@ export default function SessionHistoryPage() {
                           checked={selectedIds.has(record.id)}
                           onChange={() => toggleSelect(record.id)}
                           onClick={(e) => e.stopPropagation()}
-                          className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-cyan-500/30"
+                          className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-[var(--color-accent-cyan)]-500/30"
                         />
                       </td>
                       <td className="px-4 py-3 text-sm text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)]" aria-hidden="true">—</td>

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -649,7 +649,7 @@ export default function SessionHistoryPage() {
                       type="checkbox"
                       checked={sortedRecords.length > 0 && selectedIds.size === sortedRecords.length}
                       onChange={toggleSelectAll}
-                      className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-[var(--color-accent-cyan)]-500/30"
+                      className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-[var(--color-accent-cyan)]/30"
                     />
                   </th>
                   <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">{t('sessionHistory.nameColumn')}</th>
@@ -704,7 +704,7 @@ export default function SessionHistoryPage() {
                           checked={selectedIds.has(record.id)}
                           onChange={() => toggleSelect(record.id)}
                           onClick={(e) => e.stopPropagation()}
-                          className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-[var(--color-accent-cyan)]-500/30"
+                          className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-[var(--color-accent-cyan)]/30"
                         />
                       </td>
                       <td className="px-4 py-3 text-sm text-[var(--color-text-muted)] dark:text-[var(--color-text-muted)]" aria-hidden="true">—</td>

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -280,7 +280,7 @@ export default function SettingsPage() {
                         title={description}
                         className={`min-h-[44px] px-2.5 py-1 text-xs rounded border transition-colors ${
                           theme === value || (theme === 'auto' && value === 'light')
-                            ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)] font-medium dark:bg-[var(--color-accent)]/10 dark:text-[var(--color-accent)]'
+                            ? 'border-[var(--color-cta-bg)] bg-[var(--color-cta-bg)]/10 text-[var(--color-cta-bg)] font-medium dark:bg-[var(--color-cta-bg)]/10 dark:text-[var(--color-cta-bg)]'
                             : 'border-[var(--color-border-strong)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
                         }`}
                       >
@@ -338,7 +338,7 @@ export default function SettingsPage() {
                       title={description}
                       className={`min-h-[44px] px-2.5 py-1 text-xs rounded border transition-colors ${
                         readingFont === value
-                          ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)] font-medium dark:bg-[var(--color-accent)]/10 dark:text-[var(--color-accent)]'
+                          ? 'border-[var(--color-cta-bg)] bg-[var(--color-cta-bg)]/10 text-[var(--color-cta-bg)] font-medium dark:bg-[var(--color-cta-bg)]/10 dark:text-[var(--color-cta-bg)]'
                           : 'border-[var(--color-border-strong)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
                       }`}
                     >


### PR DESCRIPTION
## Summary
Batch replaces all raw Tailwind color utility classes across 52 dashboard files with proper CSS variable design token references.

### Replacements
| Raw Tailwind | CSS Var |
|---|---|
| `text-cyan`, `text-cyan-300` | `text-[var(--color-accent-cyan)]` / `text-[var(--color-accent-cyan-glow)]` |
| `bg-cyan` | `bg-[var(--color-cta-bg)]` |
| `border-cyan` | `border-[var(--color-accent-cyan)]` |
| `bg-void` | `bg-[var(--color-void-dark)]` |
| `border-void-lighter` | `border-[var(--color-void-lighter)]` |
| `text-void` | `text-[var(--color-void)]` |
| `var(--color-accent)` (old) | `var(--color-cta-bg)` |
| `var(--color-bg)` (old) | `var(--color-void)` |

### Files affected (52)
- Pages: AuditPage, NotFoundPage, PipelineDetailPage, RoutinesPage, SessionHistoryPage, SettingsPage, LoginPage, SessionDetailPage
- Components: Layout, SessionTable, VirtualizedSessionList, MetricCards, KPIBanner, AgentBadge, PipelineStatusBadge, HomeStatusPanel, and 39 more

### Also includes
- `AnalyticsPage.test.tsx` (8 tests) — previously 0 coverage
- `CostPage.test.tsx` (9 tests) — previously 0 coverage

### Verification
- [x] `tsc --noEmit` clean
- [x] 17 new tests pass
- [x] No production code changes (only CSS class strings)

Closes #4060, closes #4061, closes #4062, closes #4063, closes #4064, closes #4065, closes #4067