### PR TITLE
docs: fix PATCH /v1/sessions/:id RBAC role claim

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -883,9 +883,7 @@ PATCH /v1/sessions/:id
 
 Updates mutable session metadata fields. Currently supports pinning sessions to protect them from automatic reaping.
 
-| Role | Required |
-|------|----------|
-| admin, operator | Yes |
+> **Ownership:** Requires a valid API key that owns the session (enforced by `withOwnership`).
 
 ```bash
 # Pin a session (reapers will never kill it)


### PR DESCRIPTION
## Accuracy Fix

PR #4058 documented the PATCH `/v1/sessions/:id` endpoint with an `admin, operator` RBAC role requirement table. However, the actual route code uses `withOwnership` (session key ownership scoping), not `requireRole`:

```ts
registerWithLegacy(app, 'patch', '/v1/sessions/:id', withOwnership(sessions, async (req, reply, session) => {
```

No `requireRole(auth, req, reply, 'admin', 'operator')` call exists.

### Change
Replaced the incorrect RBAC role table with an accurate ownership note.

> **Note:** If role-based access was intended for this endpoint, a code change is needed to add `requireRole`. This PR only fixes docs to match current code behavior.