### PR TITLE
fix(dashboard): move useT() above conditional in BudgetOverview

### DIFF
--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -113,8 +113,8 @@ interface BudgetOverviewProps {
 }
 
 function BudgetOverview({ dailyData, budgetSettings, navigateToSettings }: BudgetOverviewProps) {
-  if (!budgetSettings.budgetAlertEnabled) {
   const t = useT();
+  if (!budgetSettings.budgetAlertEnabled) {
     return (
       <section className="rounded-lg border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 p-4" aria-label={t("aria.budgetAlerts")}>
         <div className="flex items-start gap-3">


### PR DESCRIPTION
## Summary
Fixes rules-of-hooks violation in BudgetOverview component (CostPage.tsx).

`useT()` was called after an early-return conditional (`if (!budgetSettings.budgetAlertEnabled)`), violating React's rules of hooks. Moved to top of component body.

## Testing
- All 9 CostPage tests pass
- No logic changes — pure hook ordering fix

Closes #4070

— Daedalus 🏛️