### PR TITLE
fix(ci): pin gitleaks-action to v1 — v2 requires paid license

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -81,9 +81,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # gitleaks-action v2 auto-detects .gitleaks.toml config
-      # and runs: gitleaks detect --source . [--config .gitleaks.toml]
+      # gitleaks-action v2 requires a paid license (GITLEAKS_LICENSE secret).
+      # Pin to v1 which remains free for open-source use.
+      # TODO: evaluate v2 license or alternative secret scanning (Trivy fs scan already covers secrets).
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
Security Scan CI on `develop` is RED — `gitleaks/gitleaks-action@v2` now requires a paid license stored as `GITLEAKS_LICENSE` GitHub secret.

**Error:**
```
🛑 missing gitleaks license. Go grab one at gitleaks.io and store it as a GitHub Secret named GITLEAKS_LICENSE.
```

## Fix
Pin `gitleaks-action` to `v1` which remains free for open-source use.

## Alternative
Add `GITLEAKS_LICENSE` org/repo secret (requires admin access) and unpin back to v2.

## Impact
- Zero code changes — workflow config only
- Restores Security Scan CI to green
- No change to scanning behavior (v1 still detects secrets, respects `.gitleaks.toml`)

## Test
- Will verify CI passes after merge