### PR TITLE
fix: remove dead serializeState + normalize PATCH error responses

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -590,13 +590,11 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       updates.isPinned = body.isPinned;
     }
     if (Object.keys(updates).length === 0) {
-      reply.code(400);
-      return { error: 'No valid fields to update', code: 'INVALID_UPDATE' };
+      return reply.status(400).send({ error: 'No valid fields to update', code: 'INVALID_UPDATE' });
     }
     const updated = await sessions.updateSessionMetadata(session.id, updates);
     if (!updated) {
-      reply.code(404);
-      return { error: 'Session not found', code: 'NOT_FOUND' };
+      return reply.status(404).send({ error: 'Session not found', code: 'NOT_FOUND' });
     }
     return addActionHints(updated, sessions, channels);
   }));

--- a/src/services/acp/local-storage.ts
+++ b/src/services/acp/local-storage.ts
@@ -944,14 +944,6 @@ function serializeStateLightweight(state: LocalState): SerializedState {
   };
 }
 
-/**
- * Original serializeState kept for backward compat with the legacy cloneEvent path.
- * Issue #4032: Only used by the persist path which now uses serializeStateLightweight.
- */
-function serializeState(state: LocalState): SerializedState {
-  return serializeStateLightweight(state);
-}
-
 function deserializeState(value: unknown): LocalState {
   if (!isSerializedState(value)) {
     throw new Error('FileAcpLocalStorageProfile: invalid storage file');


### PR DESCRIPTION
## Audit cleanup (#4051 #4057 follow-ups)

Two small items from Argus audit:

### 1. Dead `serializeState` passthrough
`src/services/acp/local-storage.ts:951` — `serializeState()` was just `return serializeStateLightweight(state)`. Zero callers (not exported, not imported). Removed 6 lines.

### 2. PATCH error response normalization
`src/routes/sessions.ts` — `PATCH /v1/sessions/:id` used `reply.code(400); return { error, code }` pattern. All other routes use `reply.status(400).send({ error, code })`. Normalized to match.

### Verification
```
tsc --noEmit → 0 errors
npm test → 5192 passed, 0 failed
```