### PR TITLE
fix(ci): add gitleaksignore entries for false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,4 +1,7 @@
-# False positives in docs — curl examples with REDACTED placeholders and generic API key patterns
+# False positives — explicit ignores for patterns flagged by gitleaks despite .gitleaks.toml path allowlists.
+# NOTE: gitleaks-action v1 does not fully honor [allowlist] paths in .gitleaks.toml.
+# If a finding is in tests/ or docs/ and .gitleaks.toml should catch it but doesn't, add it here.
+# See: .gitleaks.toml [allowlist] paths (src/__tests__/.*, docs/.*) — these work in v2 but not reliably in v1.
 76de56542b23aeba05a081b434698a7aa8eba2ae:docs/enterprise/06-disaster-recovery.md:curl-auth-header:132
 76de56542b23aeba05a081b434698a7aa8eba2ae:docs/enterprise/06-disaster-recovery.md:curl-auth-header:145
 76de56542b23aeba05a081b434698a7aa8eba2ae:docs/enterprise/06-disaster-recovery.md:curl-auth-header:155

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,5 @@
 94bf96e01df2193355abe838b61a112dd765c4ff:docs/api-examples.md:generic-api-key:121
 94bf96e01df2193355abe838b61a112dd765c4ff:docs/api-examples.md:generic-api-key:138
 3b8c29be1265552e541eeeee6a0a026fb59c1e65:docs/user-guide.md:curl-auth-header:88
+7f9f1f07b9b2202f430799547703c1b2108dff46:src/__tests__/hygiene-check-1905.test.ts:AWS Access Key ID:95
+94832628d316a99de4144200355b27906f597afb:docs/adr/0016-release-please-github-app-token.md:RSA Private Key:37


### PR DESCRIPTION
## Problem
Gitleaks secret scan flagging two deliberate non-secret patterns as findings:
- `hygiene-check-1905.test.ts:95` — mock AWS access key (`AKIA...`) in test fixture
- `0016-release-please-github-app-token.md:37` — example RSA private key in ADR docs

## Fix
Added `.gitleaksignore` entries for both false positives with correct commit SHAs.

## Verification
CI Security Scan should pass after merge.

## Note
The `.gitleaks.toml` allowlist already covers `src/__tests__/.*` and `docs/.*` paths, but gitleaks v1 may not respect path-based allowlists the same way v2 does. These explicit ignores are the reliable fix.