### PR TITLE
fix(ci): point gitleaks-action to root .gitleaks.toml config

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -86,5 +86,7 @@ jobs:
       # TODO: evaluate v2 license or alternative secret scanning (Trivy fs scan already covers secrets).
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v1
+        with:
+          config-path: .gitleaks.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Fix: Security Scan failing — gitleaks ignores our allowlist

**Root cause:** `gitleaks-action@v1` defaults to `.github/.gitleaks.toml` as config path. Our allowlist config lives at `.gitleaks.toml` (repo root). The action never found it, fell back to default rules with zero path exclusions, and flagged 12 false positives in test files (`check-no-hardcoded-tokens.test.ts`, `acp-event-redaction-3617.test.ts`).

**Fix:** Add `config-path: .gitleaks.toml` to the workflow step so gitleaks picks up our allowlist with `src/__tests__/.*` path exclusion.

### Why the existing `.gitleaks.toml` was being ignored
CI log shows:
```
config-path: .github/.gitleaks.toml
```
That file does not exist. gitleaks silently falls back to default rules.

### Verification
- No code changes, only CI workflow config
- The root `.gitleaks.toml` already has `src/__tests__/.*` in both `[allowlist].paths` and `[[ruleset]].exclude`