### PR TITLE
feat(dashboard): Telegram notification settings page

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -30,6 +30,7 @@ const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const TemplatesPage = lazy(() => import('./pages/TemplatesPage'));
 const RoutinesPage = lazy(() => import('./pages/RoutinesPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
+const NotificationSettingsPage = lazy(() => import('./pages/NotificationSettingsPage'));
 
 function LoadingFallback() {
   return (
@@ -242,6 +243,7 @@ export default function App() {
               }
             />
             <Route path="/settings" element={<Suspense fallback={<LoadingFallback />}><SettingsPage /></Suspense>} />
+            <Route path="/settings/notifications" element={<Suspense fallback={<LoadingFallback />}><NotificationSettingsPage /></Suspense>} />
 
             <Route
               path="*"

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -490,10 +490,10 @@ describe('Layout sidebar', () => {
     expect(screen.queryByText('New Session')).toBeNull();
     expect(screen.queryByText('Audit Trail')).toBeNull();
 
-    // Count nav links (11 main in nav: 4 workspace + 6 operations + 1 admin)
+    // Count nav links (12 main in nav: 4 workspace + 6 operations + 2 admin)
     const nav = document.querySelector('nav[aria-label="Main navigation"]');
     const links = nav?.querySelectorAll('a');
-    expect(links?.length).toBe(11);
+    expect(links?.length).toBe(12);
   });
 
   it('Settings nav link is rendered in sidebar footer', () => {

--- a/dashboard/src/__tests__/Layout.test.tsx
+++ b/dashboard/src/__tests__/Layout.test.tsx
@@ -461,7 +461,7 @@ describe('Layout sidebar', () => {
     expect(overviewLink).toBeDefined();
   });
 
-  it('nav has exactly 7 items in 3 labelled groups', () => {
+  it('nav has correct items in 3 labelled groups', () => {
     mockSubscribeGlobalSSE.mockReturnValue(() => {});
     useSidebarStore.setState({ isCollapsed: false });
 

--- a/dashboard/src/api/telegram-client.ts
+++ b/dashboard/src/api/telegram-client.ts
@@ -1,0 +1,99 @@
+/**
+ * api/telegram-client.ts — Telegram notification integration API client.
+ *
+ * Stubs for the one-tap Telegram approval feature (Phase 2).
+ * Endpoints will be wired to Aegis backend once Hep implements them.
+ */
+
+import type {
+  TelegramConnectionConfig,
+  TelegramConnectionState,
+  TelegramTestNotificationResponse,
+} from '../types';
+
+const API_BASE = '/v1';
+
+// ── Helpers ────────────────────────────────────────────────
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Telegram API ${res.status}: ${body}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ── Public API ─────────────────────────────────────────────
+
+/** Fetch current Telegram connection state */
+export async function getTelegramConnection(): Promise<TelegramConnectionState> {
+  return apiFetch<TelegramConnectionState>('/integrations/telegram');
+}
+
+/** Save Telegram bot token + chat ID */
+export async function saveTelegramConnection(config: TelegramConnectionConfig): Promise<TelegramConnectionState> {
+  return apiFetch<TelegramConnectionState>('/integrations/telegram', {
+    method: 'PUT',
+    body: JSON.stringify(config),
+  });
+}
+
+/** Send a test notification via the connected bot */
+export async function sendTelegramTestNotification(): Promise<TelegramTestNotificationResponse> {
+  return apiFetch<TelegramTestNotificationResponse>('/integrations/telegram/test', {
+    method: 'POST',
+  });
+}
+
+/** Disconnect (delete) the Telegram integration */
+export async function disconnectTelegram(): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>('/integrations/telegram', {
+    method: 'DELETE',
+  });
+}
+
+// ── Mock implementations (dev only, until backend is ready) ──
+
+const MOCK_DELAY_MS = 800;
+
+/** Mock: simulate getTelegramConnection for local dev */
+export async function mockGetTelegramConnection(): Promise<TelegramConnectionState> {
+  await new Promise((r) => setTimeout(r, MOCK_DELAY_MS));
+  // Simulate disconnected state (fresh setup)
+  return { status: 'disconnected' };
+}
+
+/** Mock: simulate saveTelegramConnection */
+export async function mockSaveTelegramConnection(
+  config: TelegramConnectionConfig,
+): Promise<TelegramConnectionState> {
+  await new Promise((r) => setTimeout(r, MOCK_DELAY_MS));
+  if (!config.botToken || !config.chatId) {
+    return { status: 'error', error: 'Bot token and Chat ID are required.' };
+  }
+  return {
+    status: 'connected',
+    botUsername: 'AegisApproveBot',
+    chatTitle: 'Aegis Approvals',
+    connectedAt: new Date().toISOString(),
+  };
+}
+
+/** Mock: simulate sendTelegramTestNotification */
+export async function mockSendTelegramTestNotification(): Promise<TelegramTestNotificationResponse> {
+  await new Promise((r) => setTimeout(r, MOCK_DELAY_MS + 400));
+  return { ok: true, message: '✅ Test notification sent successfully!' };
+}
+
+/** Mock: simulate disconnectTelegram */
+export async function mockDisconnectTelegram(): Promise<{ ok: boolean }> {
+  await new Promise((r) => setTimeout(r, MOCK_DELAY_MS));
+  return { ok: true };
+}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -33,6 +33,7 @@ import {
   Cog,
   Terminal,
   Radio,
+  MessageCircle,
 } from 'lucide-react';
 import { useStore } from '../store/useStore';
 import { useAuthStore } from '../store/useAuthStore.js';
@@ -80,6 +81,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: 'ADMIN',
     items: [
       { to: '/auth/keys', label: 'Auth Keys', icon: KeyRound },
+      { to: '/settings/notifications', label: 'Notifications', icon: MessageCircle },
     ],
   },
 ];

--- a/dashboard/src/pages/NotificationSettingsPage.tsx
+++ b/dashboard/src/pages/NotificationSettingsPage.tsx
@@ -1,0 +1,423 @@
+/**
+ * pages/NotificationSettingsPage.tsx — Telegram notification integration settings.
+ *
+ * Allows users to connect a Telegram bot for one-tap session approval.
+ * Part of the one-tap Telegram approval feature (backend stubs until wired).
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  Send,
+  Unplug,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  AlertTriangle,
+  MessageCircle,
+  Eye,
+  EyeOff,
+  ExternalLink,
+} from 'lucide-react';
+import { useToastStore } from '../store/useToastStore';
+import { ConfirmDestructive } from '../components/shared/ConfirmDestructive';
+import type {
+  TelegramConnectionState,
+  TelegramConnectionConfig,
+} from '../types';
+
+// Use mock implementations until backend is ready
+// Swap to real imports when Hep ships the endpoints:
+// import { getTelegramConnection, saveTelegramConnection, ... } from '../api/telegram-client';
+import {
+  mockGetTelegramConnection as getTelegramConnection,
+  mockSaveTelegramConnection as saveTelegramConnection,
+  mockSendTelegramTestNotification as sendTestNotification,
+  mockDisconnectTelegram as disconnectTelegram,
+} from '../api/telegram-client';
+
+type ConnectionStatus = TelegramConnectionState['status'];
+
+const STATUS_CONFIG: Record<ConnectionStatus, { color: string; icon: typeof CheckCircle2; label: string }> = {
+  connected: { color: 'text-[var(--color-success)]', icon: CheckCircle2, label: 'Connected' },
+  disconnected: { color: 'text-[var(--color-text-muted)]', icon: Unplug, label: 'Disconnected' },
+  error: { color: 'text-[var(--color-danger)]', icon: XCircle, label: 'Error' },
+  testing: { color: 'text-[var(--color-warning)]', icon: Loader2, label: 'Testing…' },
+};
+
+export default function NotificationSettingsPage() {
+  const addToast = useToastStore((s) => s.addToast);
+
+  // ── State ────────────────────────────────────────────
+  const [connection, setConnection] = useState<TelegramConnectionState>({ status: 'disconnected' });
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [botToken, setBotToken] = useState('');
+  const [chatId, setChatId] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  // ── Load connection state ────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const state = await getTelegramConnection();
+        if (!cancelled) {
+          setConnection(state);
+          if (state.status === 'connected') {
+            // Pre-fill with placeholder when connected (token is not returned)
+            setBotToken('••••••••••••••••••');
+            setChatId(state.chatTitle ?? '');
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setConnection({ status: 'error', error: err instanceof Error ? err.message : 'Failed to load' });
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Cleanup ref
+  useEffect(() => () => { mountedRef.current = false; }, []);
+
+  // ── Handlers ─────────────────────────────────────────
+  const handleSave = useCallback(async () => {
+    setSaveError(null);
+    setIsSaving(true);
+    try {
+      const config: TelegramConnectionConfig = { botToken, chatId };
+      const state = await saveTelegramConnection(config);
+      if (mountedRef.current) {
+        setConnection(state);
+        if (state.status === 'connected') {
+          setBotToken('••••••••••••••••••');
+          addToast('success', 'Telegram connected', state.botUsername ?? 'Bot connected successfully');
+        } else {
+          setSaveError(state.error ?? 'Connection failed');
+          addToast('error', 'Connection failed', state.error ?? 'Unknown error');
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to save';
+      if (mountedRef.current) {
+        setSaveError(msg);
+        addToast('error', 'Connection failed', msg);
+      }
+    } finally {
+      if (mountedRef.current) setIsSaving(false);
+    }
+  }, [botToken, chatId, addToast]);
+
+  const handleTest = useCallback(async () => {
+    setIsTesting(true);
+    setConnection((prev) => ({ ...prev, status: 'testing' }));
+    try {
+      const result = await sendTestNotification();
+      if (mountedRef.current) {
+        if (result.ok) {
+          addToast('success', 'Test sent', result.message);
+          setConnection((prev) => ({ ...prev, status: 'connected' }));
+        } else {
+          addToast('error', 'Test failed', result.message);
+          setConnection((prev) => ({ ...prev, status: 'error', error: result.message }));
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Test failed';
+      if (mountedRef.current) {
+        addToast('error', 'Test failed', msg);
+        setConnection((prev) => ({ ...prev, status: 'error', error: msg }));
+      }
+    } finally {
+      if (mountedRef.current) setIsTesting(false);
+    }
+  }, [addToast]);
+
+  const handleDisconnect = useCallback(async () => {
+    try {
+      await disconnectTelegram();
+      if (mountedRef.current) {
+        setConnection({ status: 'disconnected' });
+        setBotToken('');
+        setChatId('');
+        setSaveError(null);
+        addToast('info', 'Telegram disconnected', 'Integration removed');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Disconnect failed';
+      if (mountedRef.current) {
+        addToast('error', 'Disconnect failed', msg);
+      }
+    }
+  }, [addToast]);
+
+  // ── Helpers ──────────────────────────────────────────
+  const isConnected = connection.status === 'connected';
+  const isFormReady = botToken.length > 0 && chatId.length > 0 && botToken !== '••••••••••••••••••';
+  const statusCfg = STATUS_CONFIG[connection.status];
+  const StatusIcon = statusCfg.icon;
+
+  // ── Render ───────────────────────────────────────────
+  return (
+    <div className="flex flex-col gap-6 max-w-2xl">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <MessageCircle className="h-6 w-6 text-[var(--color-accent-cyan)]" />
+        <div className="flex-1">
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">
+            Notifications
+          </h1>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            Connect Telegram to approve sessions from your phone.
+          </p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        /* Loading skeleton */
+        <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5 space-y-4">
+          <div className="h-5 w-32 animate-shimmer rounded bg-[var(--color-surface-hover)]" />
+          <div className="h-10 w-full animate-shimmer rounded bg-[var(--color-surface-hover)]" />
+          <div className="h-10 w-full animate-shimmer rounded bg-[var(--color-surface-hover)]" />
+          <div className="h-10 w-32 animate-shimmer rounded bg-[var(--color-surface-hover)]" />
+        </div>
+      ) : (
+        <>
+          {/* Connection Status Card */}
+          <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-medium text-[var(--color-text-primary)]">
+                Connection Status
+              </h3>
+              <div className="flex items-center gap-2">
+                <StatusIcon
+                  className={`h-4 w-4 ${statusCfg.color} ${
+                    connection.status === 'testing' ? 'animate-spin' : ''
+                  }`}
+                />
+                <span className={`text-sm font-medium ${statusCfg.color}`}>
+                  {statusCfg.label}
+                </span>
+              </div>
+            </div>
+
+            {isConnected && connection.botUsername && (
+              <div className="mb-4 flex flex-col gap-1 rounded-md bg-[var(--color-surface)] p-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-[var(--color-text-muted)]">Bot</span>
+                  <span className="font-mono text-[var(--color-text-primary)]">@{connection.botUsername}</span>
+                </div>
+                {connection.chatTitle && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-[var(--color-text-muted)]">Chat</span>
+                    <span className="text-[var(--color-text-primary)]">{connection.chatTitle}</span>
+                  </div>
+                )}
+                {connection.connectedAt && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-[var(--color-text-muted)]">Connected</span>
+                    <span className="text-[var(--color-text-primary)]">
+                      {new Date(connection.connectedAt).toLocaleDateString(undefined, {
+                        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+                      })}
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {connection.status === 'error' && connection.error && (
+              <div role="alert" className="flex items-start gap-2 rounded-md border border-[var(--color-danger)]/20 bg-[var(--color-error-bg)]/10 p-3 text-sm">
+                <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-[var(--color-danger)]" />
+                <p className="text-[var(--color-danger)]">{connection.error}</p>
+              </div>
+            )}
+          </section>
+
+          {/* Configuration Form */}
+          <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
+            <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-4">
+              {isConnected ? 'Configuration' : 'Setup'}
+            </h3>
+
+            <div className="space-y-4">
+              {/* Bot Token */}
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="telegram-bot-token" className="text-sm font-medium text-[var(--color-text-primary)]">
+                  Bot Token
+                </label>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  From{' '}
+                  <a
+                    href="https://t.me/BotFather"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[var(--color-accent-cyan)] hover:underline inline-flex items-center gap-0.5"
+                  >
+                    @BotFather <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  </a>
+                </p>
+                <div className="relative">
+                  <input
+                    id="telegram-bot-token"
+                    type={showToken ? 'text' : 'password'}
+                    value={botToken}
+                    onChange={(e) => setBotToken(e.target.value)}
+                    placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+                    disabled={isConnected}
+                    autoComplete="off"
+                    aria-label="Telegram bot token"
+                    className="min-h-[44px] w-full rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 pr-10 font-mono text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] transition-colors focus:border-[var(--color-accent-cyan)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-cyan)] disabled:cursor-not-allowed disabled:opacity-60"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowToken((v) => !v)}
+                    disabled={isConnected}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                    aria-label={showToken ? 'Hide token' : 'Show token'}
+                  >
+                    {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+
+              {/* Chat ID */}
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="telegram-chat-id" className="text-sm font-medium text-[var(--color-text-primary)]">
+                  Chat ID
+                </label>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  Your Telegram chat ID for notifications. Use{' '}
+                  <a
+                    href="https://t.me/userinfobot"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[var(--color-accent-cyan)] hover:underline inline-flex items-center gap-0.5"
+                  >
+                    @userinfobot <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  </a>
+                  {' '}to find it.
+                </p>
+                <input
+                  id="telegram-chat-id"
+                  type="text"
+                  value={chatId}
+                  onChange={(e) => setChatId(e.target.value)}
+                  placeholder="-1001234567890"
+                  disabled={isConnected}
+                  autoComplete="off"
+                  aria-label="Telegram chat ID"
+                  className="min-h-[44px] w-full rounded border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-2 font-mono text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] transition-colors focus:border-[var(--color-accent-cyan)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-cyan)] disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+
+              {/* Save error */}
+              {saveError && (
+                <div role="alert" className="flex items-start gap-2 rounded-md border border-[var(--color-danger)]/20 bg-[var(--color-error-bg)]/10 p-3 text-sm">
+                  <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-[var(--color-danger)]" />
+                  <p className="text-[var(--color-danger)]">{saveError}</p>
+                </div>
+              )}
+
+              {/* Action Buttons */}
+              <div className="flex flex-wrap gap-3 pt-2">
+                {!isConnected ? (
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={!isFormReady || isSaving}
+                    className="min-h-[44px] inline-flex items-center gap-2 rounded-lg bg-[var(--color-cta-bg)] px-4 py-2 text-sm font-medium text-[var(--color-cta-text)] transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-cta-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isSaving ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        Connecting…
+                      </>
+                    ) : (
+                      <>
+                        <Send className="h-4 w-4" aria-hidden="true" />
+                        Connect
+                      </>
+                    )}
+                  </button>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleTest}
+                      disabled={isTesting}
+                      className="min-h-[44px] inline-flex items-center gap-2 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-cyan)] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {isTesting ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                          Sending…
+                        </>
+                      ) : (
+                        <>
+                          <Send className="h-4 w-4" aria-hidden="true" />
+                          Send Test
+                        </>
+                      )}
+                    </button>
+
+                    <ConfirmDestructive
+                      mode="hold"
+                      label="Disconnect"
+                      onConfirm={handleDisconnect}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
+          </section>
+
+          {/* How it works — info card */}
+          <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
+            <h3 className="text-sm font-semibold text-[var(--color-text-primary)] mb-3">
+              How it works
+            </h3>
+            <ol className="list-decimal list-inside space-y-2 text-sm text-[var(--color-text-muted)]">
+              <li>
+                Create a bot via{' '}
+                <a
+                  href="https://t.me/BotFather"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--color-accent-cyan)] hover:underline"
+                >
+                  @BotFather
+                </a>{' '}
+                and copy the token.
+              </li>
+              <li>
+                Find your Chat ID using{' '}
+                <a
+                  href="https://t.me/userinfobot"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--color-accent-cyan)] hover:underline"
+                >
+                  @userinfobot
+                </a>
+                .
+              </li>
+              <li>Enter both above and hit <strong className="text-[var(--color-text-primary)]">Connect</strong>.</li>
+              <li>
+                When a session needs approval, you'll get a Telegram message with{' '}
+                <strong className="text-[var(--color-success)]">Approve</strong> /{' '}
+                <strong className="text-[var(--color-danger)]">Reject</strong> buttons.
+              </li>
+            </ol>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/pages/__tests__/NotificationSettingsPage.test.tsx
+++ b/dashboard/src/pages/__tests__/NotificationSettingsPage.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * NotificationSettingsPage.test.tsx — Vitest tests for Telegram settings page.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../api/telegram-client', () => ({
+  mockGetTelegramConnection: vi.fn(),
+  mockSaveTelegramConnection: vi.fn(),
+  mockSendTelegramTestNotification: vi.fn(),
+  mockDisconnectTelegram: vi.fn(),
+}));
+
+vi.mock('../../store/useToastStore', () => ({
+  useToastStore: (selector: (store: { addToast: () => void }) => unknown) =>
+    selector({ addToast: vi.fn() }),
+}));
+
+import * as telegramClient from '../../api/telegram-client';
+
+const mockGetConnection = telegramClient.mockGetTelegramConnection as Mock;
+const mockSaveConnection = telegramClient.mockSaveTelegramConnection as Mock;
+const mockSendTest = telegramClient.mockSendTelegramTestNotification as Mock;
+const mockDisconnect = telegramClient.mockDisconnectTelegram as Mock;
+
+import NotificationSettingsPage from '../NotificationSettingsPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <NotificationSettingsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('NotificationSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConnection.mockResolvedValue({ status: 'disconnected' });
+    mockSaveConnection.mockResolvedValue({
+      status: 'connected',
+      botUsername: 'TestBot',
+      chatTitle: 'Test Chat',
+      connectedAt: '2026-05-24T00:00:00Z',
+    });
+    mockSendTest.mockResolvedValue({ ok: true, message: 'Test sent!' });
+    mockDisconnect.mockResolvedValue({ ok: true });
+  });
+
+  it('renders the page title', async () => {
+    renderPage();
+    expect(await screen.findByText('Notifications')).toBeDefined();
+  });
+
+  it('shows connection form when disconnected', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Telegram bot token')).toBeDefined();
+      expect(screen.getByLabelText('Telegram chat ID')).toBeDefined();
+    });
+    expect(screen.getByRole('button', { name: /connect/i })).toBeDefined();
+  });
+
+  it('disables Connect button when form is empty', async () => {
+    renderPage();
+    const connectBtn = await screen.findByRole('button', { name: /connect/i });
+    expect(connectBtn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('enables Connect button when both fields are filled', async () => {
+    renderPage();
+    await screen.findByText('Disconnected');
+
+    fireEvent.change(screen.getByLabelText('Telegram bot token'), { target: { value: '123456:ABCDEF' } });
+    fireEvent.change(screen.getByLabelText('Telegram chat ID'), { target: { value: '-1001234567890' } });
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /connect/i });
+      expect(btn.hasAttribute('disabled')).toBe(false);
+    });
+  });
+
+  it('saves connection on Connect click', async () => {
+    renderPage();
+    await screen.findByText('Disconnected');
+
+    fireEvent.change(screen.getByLabelText('Telegram bot token'), { target: { value: '123456:ABCDEF' } });
+    fireEvent.change(screen.getByLabelText('Telegram chat ID'), { target: { value: '-1001234567890' } });
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(mockSaveConnection).toHaveBeenCalledWith({
+        botToken: '123456:ABCDEF',
+        chatId: '-1001234567890',
+      });
+    });
+  });
+
+  it('shows connected state with Send Test and Disconnect', async () => {
+    mockGetConnection.mockResolvedValue({
+      status: 'connected',
+      botUsername: 'AegisBot',
+      chatTitle: 'Approvals',
+      connectedAt: '2026-05-24T00:00:00Z',
+    });
+
+    renderPage();
+    await waitFor(() => {
+      const connectedElements = screen.getAllByText('Connected');
+      expect(connectedElements.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('Send Test')).toBeDefined();
+      expect(screen.getByText('Disconnect')).toBeDefined();
+    });
+  });
+
+  it('shows error state with message', async () => {
+    mockGetConnection.mockResolvedValue({
+      status: 'error',
+      error: 'Invalid bot token',
+    });
+
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Error')).toBeDefined();
+      expect(screen.getByText('Invalid bot token')).toBeDefined();
+    });
+  });
+
+  it('toggles token visibility via show/hide button', async () => {
+    renderPage();
+    await screen.findByText('Disconnected');
+
+    const tokenInput = screen.getByLabelText('Telegram bot token') as HTMLInputElement;
+    expect(tokenInput.type).toBe('password');
+
+    fireEvent.click(screen.getByLabelText('Show token'));
+    expect(tokenInput.type).toBe('text');
+
+    fireEvent.click(screen.getByLabelText('Hide token'));
+    expect(tokenInput.type).toBe('password');
+  });
+
+  it('shows How it works section', async () => {
+    renderPage();
+    expect(await screen.findByText('How it works')).toBeDefined();
+  });
+
+  it('has accessible form labels', async () => {
+    renderPage();
+    await screen.findByText('Disconnected');
+    expect(screen.getByLabelText('Telegram bot token')).toBeDefined();
+    expect(screen.getByLabelText('Telegram chat ID')).toBeDefined();
+  });
+
+  it('has external links to BotFather and userinfobot', async () => {
+    renderPage();
+    await screen.findByText('Disconnected');
+    const links = screen.getAllByRole('link');
+    const botfatherLinks = links.filter((l) => l.getAttribute('href')?.includes('BotFather'));
+    const userinfoLinks = links.filter((l) => l.getAttribute('href')?.includes('userinfobot'));
+    expect(botfatherLinks.length).toBeGreaterThan(0);
+    expect(userinfoLinks.length).toBeGreaterThan(0);
+  });
+
+  it('disables inputs when connected', async () => {
+    mockGetConnection.mockResolvedValue({
+      status: 'connected',
+      botUsername: 'AegisBot',
+      connectedAt: '2026-05-24T00:00:00Z',
+    });
+
+    renderPage();
+    await waitFor(() => {
+      const allConnected = screen.getAllByText('Connected');
+      expect(allConnected.length).toBeGreaterThanOrEqual(1);
+      const tokenInput = screen.getByLabelText('Telegram bot token') as HTMLInputElement;
+      const chatInput = screen.getByLabelText('Telegram chat ID') as HTMLInputElement;
+      expect(tokenInput.hasAttribute('disabled')).toBe(true);
+      expect(chatInput.hasAttribute('disabled')).toBe(true);
+    });
+  });
+});

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -253,3 +253,24 @@ export interface SessionCostEntry {
   durationMinutes: number | null;
   recordCount: number;
 }
+
+// ── Telegram Notification Integration ─────────────────────
+export type TelegramConnectionStatus = 'connected' | 'disconnected' | 'error' | 'testing';
+
+export interface TelegramConnectionConfig {
+  botToken: string;
+  chatId: string;
+}
+
+export interface TelegramConnectionState {
+  status: TelegramConnectionStatus;
+  botUsername?: string;
+  chatTitle?: string;
+  connectedAt?: string;
+  error?: string;
+}
+
+export interface TelegramTestNotificationResponse {
+  ok: boolean;
+  message: string;
+}


### PR DESCRIPTION
## Summary

Prep work for the one-tap Telegram approval feature. Frontend-ready so we can wire it up fast once Hep ships the backend endpoints.

### New files
- `dashboard/src/pages/NotificationSettingsPage.tsx` — full settings page
- `dashboard/src/api/telegram-client.ts` — API client with mock implementations
- `dashboard/src/pages/__tests__/NotificationSettingsPage.test.tsx` — 12 Vitest tests

### Changes
- **Route:** `/settings/notifications` added to App.tsx
- **Nav:** "Notifications" entry added under ADMIN in sidebar
- **Types:** `TelegramConnectionStatus`, `TelegramConnectionConfig`, `TelegramConnectionState`, `TelegramTestNotificationResponse`

### Features
- Connection status indicator (connected / disconnected / error / testing)
- Bot token input with show/hide toggle
- Chat ID input with @BotFather and @userinfobot helper links
- Test notification button (mock API, ready for real endpoint)
- Hold-to-confirm disconnect button (reuses `ConfirmDestructive`)
- "How it works" step-by-step guide
- Responsive — mobile-first, 44px touch targets

### Mock API to Real API
The page uses mock implementations until the backend ships. When Hep implements the endpoints, swap the mock imports for the real API functions in `telegram-client.ts`.

### Test plan
- [x] 12 Vitest tests pass (all states, form interactions, accessibility)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] All form labels accessible via `getByLabelText`
- [x] External links open in new tab with `rel=noopener noreferrer`

-- Daedalus 🏛️
