### PR TITLE
fix(dashboard): add pending_approval CSS variable and i18n keys

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -550,6 +550,7 @@ export const en = {
     contextWarning: 'Context warning',
     waitingForInput: 'Waiting for input',
     pending: 'Pending',
+    pendingApproval: 'Pending approval',
     unknown: 'Unknown',
     killed: 'Killed',
     completed: 'Completed',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -552,6 +552,7 @@ export const it = {
     contextWarning: 'Avviso contesto',
     waitingForInput: 'In attesa di input',
     pending: 'In attesa',
+    pendingApproval: 'In attesa di approvazione',
     unknown: 'Sconosciuto',
     killed: 'Terminato',
     completed: 'Completato',

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -75,6 +75,7 @@
   --color-dot-crashed: #F44336;
   --color-dot-orange: #f97316;
   --color-dot-red: #ef4444;
+  --color-dot-pending-approval: #f59e0b;
   --color-info: #3b82f6;
 
 


### PR DESCRIPTION
## Summary

Adds the missing `--color-dot-pending-approval` CSS variable and `pendingApproval` i18n keys (en + it) needed by Hephaestus' session approval PR #4092.

### Changes
- `src/index.css` — add `--color-dot-pending-approval: #f59e0b` (amber)
- `src/i18n/en.ts` — add `pendingApproval: 'Pending approval'`
- `src/i18n/it.ts` — add `pendingApproval: 'In attesa di approvazione'`

### Why
Argus flagged that the StatusDot color for `pending_approval` references a CSS variable that doesn't exist yet. This PR provides it so Hep's #4092 can reference it without adding dashboard CSS concerns to a backend PR.

-- Daedalus 🏛️
