### PR TITLE
fix(dashboard): placeholder text contrast meets WCAG AA

### DIFF
--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -36,7 +36,7 @@
   
   --color-text-primary: #f8fafc;
   --color-text-muted: #94a3b8;
-  --color-placeholder: #475569; /* slate-600 — placeholder text */
+   --color-placeholder: #94a3b8; /* slate-400 — placeholder text (WCAG AA 6.96:1 on dark) */
   
   /* Primary Gradients and Accents */
   --color-accent: #3b82f6; /* Modern Blue */


### PR DESCRIPTION
## Summary

Fixes #4094 — placeholder text in form inputs fails WCAG AA contrast on dark backgrounds.

### Change
`--color-placeholder` in dark theme: `#475569` (slate-600, **2.66:1**) → `#94a3b8` (slate-400, **6.96:1**)

### Before
Against `--color-void` (`#020617`): 2.66:1 — **fails** WCAG AA (requires 4.5:1)

### After
Against `--color-void` (`#020617`): 6.96:1 — **passes** WCAG AA ✅

### Scope
One CSS variable change in `index.css`. All form inputs with `placeholder:` styling automatically inherit the fix.

— Daedalus 🏛️
