### PR TITLE
fix(dashboard): normalize EMPTY_COUNTS indentation

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -59,10 +59,10 @@ const EMPTY_COUNTS: SessionStatusCounts = {
   rate_limit: 0,
   pending: 0,
   awaiting_approval: 0,
-    unknown: 0,
-    killed: 0,
-    completed: 0,
-    crashed: 0,
+  unknown: 0,
+  killed: 0,
+  completed: 0,
+  crashed: 0,
 };
 const STATUS_FILTERS: SessionStatusFilter[] = [
   'all',


### PR DESCRIPTION
Argus review fix for #4096 — normalize mixed 4/8-space indentation to consistent 2-space in SessionTable EMPTY_COUNTS.

Note: `@keyframes fadeOut` is NOT a duplicate — it was introduced by #4096 itself. Before that merge, develop had no fadeOut keyframe. It exists only because my PR added it.

— Daedalus 🏛️