### PR TITLE
docs: session-level approval gate (#4088)

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -44,6 +44,8 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `POST` | `/v1/sessions/{id}/fork` | Bearer | Fork the session |
 | `POST` | `/v1/sessions/{id}/approve` | Bearer | Approve permission request |
 | `POST` | `/v1/sessions/{id}/reject` | Bearer | Reject permission request |
+| `POST` | `/v1/sessions/{id}/session-approve` | Bearer | Approve session awaiting approval |
+| `POST` | `/v1/sessions/{id}/session-reject` | Bearer | Reject session awaiting approval |
 | `POST` | `/v1/sessions/{id}/answer` | Bearer | Answer a pending question |
 | `POST` | `/v1/sessions/{id}/discover-commands` | Bearer | Discover available slash commands |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1089,9 +1089,11 @@ curl http://localhost:9100/v1/sessions/abc123/read \
 }
 ```
 
-> **Session status values:** `idle`, `working`, `compacting`, `context_warning`, `waiting_for_input`, `permission_prompt`, `plan_mode`, `ask_question`, `bash_approval`, `settings`, `error`, `rate_limit`, `pending`, `killed`, `completed`, `crashed`, `unknown`.
+> **Session status values:** `idle`, `working`, `compacting`, `context_warning`, `waiting_for_input`, `permission_prompt`, `plan_mode`, `ask_question`, `bash_approval`, `settings`, `error`, `rate_limit`, `pending`, `awaiting_approval`, `killed`, `completed`, `crashed`, `unknown`.
 >
-> **Terminal states:** `killed` (session was stopped via API), `completed` (session finished normally), `crashed` (session terminated unexpectedly). Terminal sessions return 404 on kill attempts and are retained for audit.
+> **Terminal states:** `killed` (session was stopped via API or rejected during approval), `completed` (session finished normally), `crashed` (session terminated unexpectedly). Terminal sessions return 404 on kill attempts and are retained for audit.
+>
+> **Approval state:** `awaiting_approval` — session is gated by the approval system (see [Session Approval](#session-approval)). The session will not start Claude Code until explicitly approved. If rejected, the session transitions to `killed`.
 
 ---
 
@@ -1601,6 +1603,76 @@ curl -X DELETE http://localhost:9100/v1/sessions/abc123 \
 ---
 
 
+
+### Session Approval
+
+When `requireSessionApproval` is enabled, new sessions enter `awaiting_approval` status instead of starting immediately. Use these endpoints to approve or reject them.
+
+#### Approve Session
+
+```
+POST /v1/sessions/:id/session-approve
+```
+
+Approves a session that is awaiting approval. The session transitions from `awaiting_approval` to its normal running lifecycle. Telegram (and other channels) receive a `session.approved` event.
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions/abc123/session-approve \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "status": "pending",
+  "approvedBy": "key_abc123",
+  "approvedAt": "2026-05-24T08:00:00.000Z"
+}
+```
+
+| Status | Error | Condition |
+|--------|-------|-----------|
+| 409 | `SESSION_NOT_AWAITING_APPROVAL` | Session is not in `awaiting_approval` status |
+
+**RBAC:** Requires session ownership (`send` permission). See [Authentication](#authentication).
+
+---
+
+#### Reject Session
+
+```
+POST /v1/sessions/:id/session-reject
+```
+
+Rejects a session that is awaiting approval. The session is immediately killed (`status: "killed"`). Telegram (and other channels) receive a `session.rejected` event.
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions/abc123/session-reject \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "status": "killed"
+}
+```
+
+| Status | Error | Condition |
+|--------|-------|-----------|
+| 409 | `SESSION_NOT_AWAITING_APPROVAL` | Session is not in `awaiting_approval` status |
+
+**RBAC:** Requires session ownership (`kill` permission). See [Authentication](#authentication).
+
+---
+
+> **Configuration:** Enable session approval by setting `requireSessionApproval: true` in your Aegis config, or set the environment variable `AEGIS_REQUIRE_SESSION_APPROVAL=true`. Sessions will wait in `awaiting_approval` until approved or rejected. If the server restarts while sessions are awaiting approval, they are automatically recovered and re-notified via configured channels.
+
+---
 
 ### Answer Pending Question
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -296,6 +296,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_ALLOWED_WORKDIRS` | _(home, cwd)_ | JSON array of allowed session working directories. System temp dirs (`/tmp`, `/var/tmp`) are excluded by default for security — add them explicitly if needed |
 | `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC checks even when auth is disabled. When `true`, unauthenticated requests to role/permission-protected endpoints return 401 instead of being allowed through |
 | `AEGIS_ENFORCE_SESSION_OWNERSHIP` | `true` | Enforce session ownership — tenants can only access their own sessions |
+| `AEGIS_REQUIRE_SESSION_APPROVAL` | `false` | Require explicit approval before new sessions start Claude Code. Sessions enter `awaiting_approval` status until approved or rejected via `POST /v1/sessions/:id/session-approve` or `/session-reject` |
 | `AEGIS_DEFAULT_TENANT_ID` | `default` | Default tenant ID for single-tenant deployments |
 
 #### Hooks

--- a/docs/guides/phone-approvals.md
+++ b/docs/guides/phone-approvals.md
@@ -237,10 +237,34 @@ End-to-end latency: typically under 2 seconds.
 
 ## What's Next
 
+- [Session Approval](../api-reference.md#session-approval) — gate new sessions with explicit approval before Claude Code starts
 - [Notification Channels](../integrations/notifications.md) — Slack, email, webhooks
 - [Dashboard](../dashboard.md) — visual session management
 - [API Reference](../api-reference.md) — approve/reject via REST API
 - [Security Best Practices](../security-best-practices.md) — production hardening
+
+---
+
+## Session-Level Approval
+
+In addition to **permission prompts** (described above), Aegis supports **session-level approval** — requiring explicit approval before Claude Code even starts.
+
+Enable it with:
+
+```bash
+export AEGIS_REQUIRE_SESSION_APPROVAL=true
+```
+
+When enabled, new sessions enter `awaiting_approval` status. You receive a Telegram notification with **Approve ✅** and **Reject ❌** inline buttons. The session only starts Claude Code after you tap Approve.
+
+### Session vs Permission Approval
+
+| | Permission Approval | Session Approval |
+|---|---|---|
+| **When** | CC asks for permission mid-run | Before CC starts |
+| **Endpoints** | `POST /v1/sessions/:id/approval/approve` | `POST /v1/sessions/:id/session-approve` |
+| **Config** | Always on (when Telegram configured) | `AEGIS_REQUIRE_SESSION_APPROVAL=true` |
+| **Status** | `permission_prompt` | `awaiting_approval` |
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the session-level approval gate introduced in PR #4092.

### Changes
- **api-reference.md**: Adds `POST /v1/sessions/:id/session-approve` and `POST /v1/sessions/:id/session-reject` endpoints with request/response examples, error codes, RBAC notes
- **api-reference.md**: Adds `awaiting_approval` to session status values + description of approval state
- **api-quick-ref.md**: Adds both new endpoints to the quick reference table
- **enterprise.md**: Adds `AEGIS_REQUIRE_SESSION_APPROVAL` env var to config table
- **phone-approvals.md**: Adds Session-Level Approval section with session vs permission approval comparison table

### Feature covered
- PR #4092 — session-level approval gate with Telegram inline buttons
- Config: `requireSessionApproval` / `AEGIS_REQUIRE_SESSION_APPROVAL`
- New status: `awaiting_approval`
- Auto-recovery after server restart