### PR TITLE
fix(dashboard): a11y test — OverviewPage landmark test passing with WelcomeScreen

### DIFF
--- a/dashboard/src/__tests__/a11y-pages.test.tsx
+++ b/dashboard/src/__tests__/a11y-pages.test.tsx
@@ -139,7 +139,7 @@ vi.mock('../api/client', () => ({
     topApiKeys: [],
     durationTrends: [],
     errorRates: {
-      totalSessions: 0,
+      totalSessions: 1,
       failedSessions: 0,
       failureRate: 0,
       approvals: 0,


### PR DESCRIPTION
## Problem

The a11y landmark test on PR #4108 (and develop) fails:
```
FAIL: 'OverviewPage' renders inside exactly one Layout main landmark without nested main roles
AssertionError: expected false to be true
```

## Root Cause

Recent develop merge added WelcomeScreen to OverviewPage — when `totalSessions === 0`, it renders WelcomeScreen (h1: "Welcome to Aegis") instead of the normal layout (h1: "Overview").

The test's `getAnalyticsSummary` mock returned `errorRates.totalSessions: 0`, so the test hit the WelcomeScreen branch. The a11y test expected heading "Overview" inside the main landmark.

## Fix

Changed mock to `totalSessions: 1` so the normal OverviewPage layout renders in tests.

## Verification

```
✓ 31 tests passed (a11y-pages.test.tsx)
```