### PR TITLE
fix(dashboard): welcome screen a11y landmark test

### DIFF
--- a/dashboard/src/components/shared/WelcomeScreen.tsx
+++ b/dashboard/src/components/shared/WelcomeScreen.tsx
@@ -1,0 +1,99 @@
+/**
+ * components/shared/WelcomeScreen.tsx — First-run welcome screen.
+ *
+ * Full-page hero shown when the dashboard has zero sessions.
+ * This is the first thing a user sees after `aegis init` opens the browser.
+ *
+ * Primary CTA: Connect Telegram (links to /settings/notifications)
+ * Secondary: CLI quick-start hint
+ */
+
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { MessageCircle, Terminal, Copy, Check, ArrowRight, Zap } from 'lucide-react';
+import { copyToClipboard } from '../../utils/clipboard';
+
+const CLI_COMMAND = 'ag run "hello world"';
+
+export default function WelcomeScreen() {
+  const navigate = useNavigate();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(CLI_COMMAND);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div className="flex min-h-[70vh] flex-col items-center justify-center px-4 py-12">
+      {/* Hero */}
+      <div className="flex flex-col items-center gap-4 text-center">
+        {/* Logo / Icon */}
+        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-[var(--color-accent-cyan)]/20 to-[var(--color-accent-cyan)]/5">
+          <Zap className="h-8 w-8 text-[var(--color-accent-cyan)]" aria-hidden="true" />
+        </div>
+
+        <div>
+          <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
+            Welcome to Aegis
+          </h1>
+          <p className="mt-2 max-w-md text-base text-[var(--color-text-muted)]">
+            Your coding agents, managed. Approve sessions, track costs, and stay in control — from your browser or your phone.
+          </p>
+        </div>
+      </div>
+
+      {/* Primary CTA: Connect Telegram */}
+      <div className="mt-10 flex flex-col items-center gap-3">
+        <button
+          type="button"
+          onClick={() => navigate('/settings/notifications')}
+          className="min-h-[48px] inline-flex items-center gap-2.5 rounded-xl bg-[var(--color-accent-cyan)] px-8 py-3 text-base font-semibold text-[var(--color-void)] shadow-lg shadow-[var(--color-accent-cyan)]/20 transition-all hover:shadow-xl hover:shadow-[var(--color-accent-cyan)]/30 hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-cyan)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-void)]"
+          aria-label="Connect Telegram to approve sessions from your phone"
+        >
+          <MessageCircle className="h-5 w-5" aria-hidden="true" />
+          Connect Telegram
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <p className="text-xs text-[var(--color-text-muted)]">
+          Approve sessions from your phone — one tap.
+        </p>
+      </div>
+
+      {/* Divider */}
+      <div className="mt-10 flex w-full max-w-sm items-center gap-3">
+        <div className="h-px flex-1 bg-[var(--color-border-strong)]" />
+        <span className="text-xs text-[var(--color-text-muted)]">or get started from the CLI</span>
+        <div className="h-px flex-1 bg-[var(--color-border-strong)]" />
+      </div>
+
+      {/* Secondary: CLI hint */}
+      <div className="mt-6 flex flex-col items-center gap-2">
+        <div className="flex items-center gap-2 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] px-4 py-2.5">
+          <Terminal className="h-4 w-4 text-[var(--color-text-muted)]" aria-hidden="true" />
+          <code className="font-mono text-sm text-[var(--color-text-primary)]">
+            {CLI_COMMAND}
+          </code>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center justify-center rounded p-1 text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
+            aria-label={copied ? 'Copied' : 'Copy command'}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-[var(--color-success)]" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </div>
+        <p className="text-xs text-[var(--color-text-muted)]">
+          Run your first agent session from the terminal
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/shared/__tests__/WelcomeScreen.test.tsx
+++ b/dashboard/src/components/shared/__tests__/WelcomeScreen.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * WelcomeScreen.test.tsx — Tests for the first-run welcome screen.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../../utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}));
+
+import WelcomeScreen from '../WelcomeScreen';
+
+// Need to wrap in router since component uses useNavigate
+function renderWelcome() {
+  return render(
+    <MemoryRouter>
+      <WelcomeScreen />
+    </MemoryRouter>,
+  );
+}
+
+describe('WelcomeScreen', () => {
+  it('renders the welcome heading', () => {
+    renderWelcome();
+    expect(screen.getByText('Welcome to Aegis')).toBeDefined();
+  });
+
+  it('renders the tagline', () => {
+    renderWelcome();
+    expect(screen.getByText(/Your coding agents, managed/)).toBeDefined();
+  });
+
+  it('renders Connect Telegram button', () => {
+    renderWelcome();
+    const cta = screen.getByRole('button', { name: /connect telegram/i });
+    expect(cta).toBeDefined();
+  });
+
+  it('renders CLI command hint', () => {
+    renderWelcome();
+    expect(screen.getByText(/ag run "hello world"/)).toBeDefined();
+  });
+
+  it('renders copy button for CLI command', () => {
+    renderWelcome();
+    expect(screen.getByRole('button', { name: /copy command/i })).toBeDefined();
+  });
+
+  it('renders the "or get started" divider text', () => {
+    renderWelcome();
+    expect(screen.getByText(/or get started from the CLI/)).toBeDefined();
+  });
+
+  it('renders approve from phone subtext', () => {
+    renderWelcome();
+    expect(screen.getByText(/Approve sessions from your phone/)).toBeDefined();
+  });
+});

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -163,10 +163,8 @@ export default function OverviewPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      {/* First-run welcome screen — shows when no sessions exist and analytics loaded */}
-      {!analyticsLoading && totalSessions === 0 ? (
-        <WelcomeScreen />
-      ) : (<>
+      {/* First-run welcome screen when no sessions exist */}
+      {!analyticsLoading && totalSessions === 0 && <WelcomeScreen />}
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-center gap-3">
@@ -316,7 +314,6 @@ export default function OverviewPage() {
         <div aria-labelledby="recent-sessions-heading"><SessionTable maxRows={5} /></div>
       </div>
 
-      </>)}
       <CreateSessionModal open={modalOpen} onClose={() => setModalOpen(false)} />
     </div>
   );

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -162,12 +162,11 @@ export default function OverviewPage() {
   }
 
   return (
-    <>
+    <div className="flex flex-col gap-6">
       {/* First-run welcome screen — shows when no sessions exist and analytics loaded */}
       {!analyticsLoading && totalSessions === 0 ? (
         <WelcomeScreen />
-      ) : (
-      <div className="flex flex-col gap-6">
+      ) : (<>
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-center gap-3">
@@ -317,9 +316,8 @@ export default function OverviewPage() {
         <div aria-labelledby="recent-sessions-heading"><SessionTable maxRows={5} /></div>
       </div>
 
+      </>)}
       <CreateSessionModal open={modalOpen} onClose={() => setModalOpen(false)} />
-      </div>
-      )}
-    </>
+    </div>
   );
 }

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -26,6 +26,7 @@ import { useSessionRealtimeUpdates } from '../hooks/useSessionRealtimeUpdates';
 import { useT } from '../i18n/context';
 import { SessionHealthBanner } from '../components/shared/SessionHealthBanner';
 import GettingStartedCard from '../components/shared/GettingStartedCard';
+import WelcomeScreen from '../components/shared/WelcomeScreen';
 import { useStore } from '../store/useStore';
 import { getAnalyticsSummary } from '../api/client';
 import { formatCurrency, formatNumber } from '../utils/formatNumber';
@@ -161,7 +162,12 @@ export default function OverviewPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <>
+      {/* First-run welcome screen — shows when no sessions exist and analytics loaded */}
+      {!analyticsLoading && totalSessions === 0 ? (
+        <WelcomeScreen />
+      ) : (
+      <div className="flex flex-col gap-6">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-center gap-3">
@@ -312,6 +318,8 @@ export default function OverviewPage() {
       </div>
 
       <CreateSessionModal open={modalOpen} onClose={() => setModalOpen(false)} />
-    </div>
+      </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Fixes the a11y test failure on OverviewPage — the WelcomeScreen was replacing the page content (including the h1), which moved the heading outside the main landmark.

Fix: render WelcomeScreen above the header instead of replacing it. The h1 stays in the main landmark.

31/31 a11y tests green.

— Daedalus 🏛️