### PR TITLE
docs: zero-config init — ag init starts server + opens browser (#4100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ After your first session, you might want to:
 Aegis works out of the box. If you want to customize:
 
 ```bash
-ag init              # Interactive setup (token, model, Telegram, etc.)
+ag init              # Zero-config: scaffold + start server + open browser
+ag init --no-open    # Scaffold + start server, skip browser
 ag init --defaults    # Non-interactive — use all defaults
 ag init --force       # Overwrite existing config
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,23 +70,28 @@ npm install -g @onestepat4time/aegis
 ag init
 ```
 
+`ag init` now runs in **zero-config mode**: it scaffolds the config, auto-detects a free port (9100 default), starts the Aegis server, and opens the dashboard in your browser. On a fresh machine, you're up and running in under 60 seconds.
+
+If Aegis is already running, `ag init` prints the dashboard URL and exits (code 2).
+
+```bash
+ag init --no-open     # Start server but skip browser
+ag init --no-start    # Scaffold config only
+ag init --yes          # Non-interactive — use all defaults
+ag init --force        # Overwrite existing config
+```
+
 > **Zero-config on localhost:** On `localhost`, `127.0.0.1`, or `::1`, `ag init` skips admin token creation by default. No auth setup needed.
 >
 > **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml` and regenerates auth keys. **You must restart the server** for the new keys to take effect — the running server does not hot-reload keys from disk. Without a restart, CLI commands will return `401 Unauthorized` with the new token.
 >
-> `ag init` now supports conversational onboarding with `--model` and `--name` flags for non-interactive setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session. Use `--force` to create a token even on localhost.
+> `ag init` supports conversational onboarding with `--model` and `--name` flags for non-interactive setup. Use `--model <provider/model>` to set the default model and `--name <name>` to set a display name for the session.
 >
 > **Project-local state:** For new configs, `ag init` stores state (keys, auth-token) in the project `.aegis/` directory alongside `config.yaml`, not in the global `~/.aegis/`. This keeps each project isolated. Override with `AEGIS_STATE_DIR`.
 >
 > **Claude Code auto-wiring:** If `claude` is on your PATH, `ag init` automatically offers to register Aegis as an MCP server in Claude Code. In `--yes` mode this happens automatically. You can verify with `claude mcp list`.
 
-```bash
-ag
-```
-
-> The primary CLI command is `ag`. The legacy name `aegis` is kept as an alias for backward compatibility — both resolve to the same binary.
-
-Aegis starts on **http://localhost:9100** by default. Verify it's running:
+Aegis starts on **http://localhost:9100** by default (or the next free port). Verify it's running:
 
 ```bash
 curl http://localhost:9100/v1/health

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -16,17 +16,38 @@ npx --package=@onestepat4time/aegis ag
 
 ### `ag init` — Bootstrap a Project
 
-Create `.aegis/config.yaml` with an API token, preferred base URL, optional BYO-LLM defaults, and dashboard settings.
+Create `.aegis/config.yaml` with an API token, preferred base URL, optional BYO-LLM defaults, and dashboard settings. **Zero-config mode**: `ag init` scaffolds the config, starts the server, and opens the dashboard in your browser — all in one command.
 
 ```bash
-ag init
-ag init --yes            # Non-interactive defaults for CI
-ag init --yes --force     # Overwrite existing config in non-interactive mode
+ag init                              # Scaffold + start server + open browser
+ag init --no-open                    # Scaffold + start server, skip browser
+ag init --no-start                   # Scaffold only, don't start server
+ag init --yes                        # Non-interactive defaults for CI
+ag init --yes --force                # Overwrite existing config in non-interactive mode
 ag init --list-templates
 ag init --from-template code-reviewer
 ```
 
+**Zero-config behavior (default):**
+
+1. Scaffolds `.aegis/config.yaml` with safe defaults (localhost only)
+2. Auto-detects a free port (9100 default, increments until free)
+3. Starts the Aegis server as a detached child process
+4. Waits for health check (up to 30s)
+5. Opens the dashboard in your default browser
+6. Prints success message with URL, config path, and PID
+
+If Aegis is **already running** on the target port, `ag init` prints the dashboard URL and exits with code 2. No duplicate instance is created.
+
 The interactive flow is idempotent: if `.aegis/config.yaml` already exists, `ag init` keeps it unless you confirm an overwrite. In `--yes` mode, existing config is preserved by default — use `--force` (or `-f`) to allow overwriting.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|----------|
+| `0` | Success — config scaffolded, server started, browser opened |
+| `1` | Error (port exhaustion, health check timeout, etc.) |
+| `2` | Aegis already running (prints existing URL) |
 
 **Project-local state:** When `ag init` creates a **new** config (no existing file), state (keys, auth-token) is stored in the project-local `.aegis/` directory alongside `config.yaml`, not in the global `~/.aegis/`. Existing configs are unaffected. You can override this with `AEGIS_STATE_DIR`.
 
@@ -47,6 +68,19 @@ Scaffold one into the current directory, then validate it:
 ag init --from-template docs-writer
 ag doctor
 ```
+
+**Flags:**
+
+| Flag | Description |
+|------|------------|
+| `--yes` | Non-interactive mode — use all defaults |
+| `--force` / `-f` | Overwrite existing config |
+| `--no-start` | Scaffold config only, don't start the server |
+| `--no-open` | Start server but skip opening the browser |
+| `--model <provider/model>` | Set default model during setup |
+| `--name <name>` | Set display name for the session |
+| `--list-templates` | List available starter templates |
+| `--from-template <name>` | Scaffold from a starter template |
 
 ### `ag run "prompt"` — Zero-to-Session
 


### PR DESCRIPTION
Documents PR #4108 (zero-config init).

## Changes
- **cli.md**: Added --no-start, --no-open flags, exit codes table, zero-config behavior section, flags table
- **getting-started.md**: Replaced standalone `ag` server start step with zero-config description, added --no-open/--no-start/--yes examples
- **README.md**: Updated Quick Start config section with zero-config init description

## New behavior to document
`ag init` now:
1. Scaffolds `.aegis/config.yaml` with safe defaults
2. Auto-detects free port (9100 default, increments)
3. Starts server as detached process
4. Opens dashboard in browser
5. Prints URL + config path + PID

If already running → prints URL, exits code 2.

## PRs documented
- #4108 — feat: zero-config init