### PR TITLE
feat(dashboard): server connection health indicator

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -42,6 +42,7 @@ import { useDrawerStore } from '../store/useDrawerStore';
 import { checkForUpdates, getHealth, subscribeGlobalSSE, type UpdateCheckResult } from '../api/client';
 import ToastContainer from './ToastContainer';
 import ConnectionBanner from './ConnectionBanner';
+import { ServerHealthDot, ServerHealthBanner } from './shared/ServerHealthIndicator';
 import { ShieldWordmark } from './brand/ShieldLogo';
 import { useT } from '../i18n/context';
 
@@ -507,6 +508,9 @@ export default function Layout() {
             {!isCollapsed && <span className="truncate">Settings</span>}
           </NavLink>
 
+          {/* Server health indicator */}
+          {!isCollapsed && <ServerHealthDot />}
+
           {/* Collapse toggle — desktop only */}
           <button
             type="button"
@@ -710,6 +714,7 @@ export default function Layout() {
       <ToastContainer />
       {/* Connection banner (SSE/WS disconnect) */}
       <ConnectionBanner />
+      <ServerHealthBanner />
       {/* Command Palette */}
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <ApprovalNotification />

--- a/dashboard/src/components/shared/ServerHealthIndicator.tsx
+++ b/dashboard/src/components/shared/ServerHealthIndicator.tsx
@@ -24,7 +24,7 @@ export function ServerHealthDot() {
   const config = STATUS_CONFIG[health.status];
 
   return (
-    <div className="flex items-center gap-2 px-3 py-2" role="status" aria-label={`Server status: ${config.label}`}>
+    <div className="flex items-center gap-2 px-3 py-2" role="status" aria-label={`Server health: ${config.label}`}>
       <config.Icon
         className={`h-3.5 w-3.5 ${config.color} ${health.status === 'reconnecting' || health.status === 'checking' ? 'animate-spin' : ''}`}
         aria-hidden="true"

--- a/dashboard/src/components/shared/ServerHealthIndicator.tsx
+++ b/dashboard/src/components/shared/ServerHealthIndicator.tsx
@@ -1,0 +1,54 @@
+/**
+ * components/shared/ServerHealthIndicator.tsx — Server connection health dot + banner.
+ *
+ * Shows in the sidebar footer:
+ * - Green dot + "Connected" when Aegis server is healthy
+ * - Amber dot + "Reconnecting…" when temporarily disconnected
+ * - Red dot + "Server unreachable" when down for >60s
+ *
+ * Also shows a top banner when disconnected for extended time.
+ */
+
+import { useServerHealth, type ServerHealthStatus } from '../../hooks/useServerHealth';
+import { Wifi, WifiOff, Loader2, AlertTriangle } from 'lucide-react';
+
+const STATUS_CONFIG: Record<ServerHealthStatus, { color: string; label: string; Icon: typeof Wifi }> = {
+  connected: { color: 'text-[var(--color-success)]', label: 'Connected', Icon: Wifi },
+  reconnecting: { color: 'text-[var(--color-warning)]', label: 'Reconnecting…', Icon: Loader2 },
+  disconnected: { color: 'text-[var(--color-danger)]', label: 'Server unreachable', Icon: WifiOff },
+  checking: { color: 'text-[var(--color-text-muted)]', label: 'Checking…', Icon: Loader2 },
+};
+
+export function ServerHealthDot() {
+  const health = useServerHealth();
+  const config = STATUS_CONFIG[health.status];
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2" role="status" aria-label={`Server status: ${config.label}`}>
+      <config.Icon
+        className={`h-3.5 w-3.5 ${config.color} ${health.status === 'reconnecting' || health.status === 'checking' ? 'animate-spin' : ''}`}
+        aria-hidden="true"
+      />
+      <span className={`text-xs font-medium ${config.color}`}>
+        {config.label}
+      </span>
+    </div>
+  );
+}
+
+export function ServerHealthBanner() {
+  const health = useServerHealth();
+
+  if (health.status !== 'disconnected' || !health.errorMessage) return null;
+
+  return (
+    <div
+      role="alert"
+      className="fixed top-0 left-0 right-0 z-50 flex h-9 items-center justify-center gap-2 bg-[var(--color-danger)]/15 border-b border-[var(--color-danger)]/30 text-xs font-medium backdrop-blur-sm"
+      data-testid="server-health-banner"
+    >
+      <AlertTriangle className="h-3.5 w-3.5 text-[var(--color-danger)]" aria-hidden="true" />
+      <span className="text-[var(--color-danger)]">{health.errorMessage}</span>
+    </div>
+  );
+}

--- a/dashboard/src/components/shared/__tests__/ServerHealthIndicator.test.tsx
+++ b/dashboard/src/components/shared/__tests__/ServerHealthIndicator.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * ServerHealthIndicator.test.tsx — Tests for the health indicator components.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ServerHealthDot, ServerHealthBanner } from '../ServerHealthIndicator';
+
+// Mock the hook
+vi.mock('../../../hooks/useServerHealth', () => ({
+  useServerHealth: vi.fn(),
+}));
+
+import { useServerHealth } from '../../../hooks/useServerHealth';
+
+const mockUseServerHealth = vi.mocked(useServerHealth);
+
+describe('ServerHealthDot', () => {
+  it('shows green Connected when status is connected', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'connected',
+      lastCheck: new Date(),
+      downSince: null,
+      errorMessage: null,
+    } as ReturnType<typeof useServerHealth>);
+
+    render(<ServerHealthDot />);
+    expect(screen.getByText('Connected')).toBeDefined();
+  });
+
+  it('shows amber Reconnecting when status is reconnecting', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'reconnecting',
+      lastCheck: new Date(),
+      downSince: new Date(),
+      errorMessage: 'Connection to Aegis server lost. Reconnecting…',
+    } as ReturnType<typeof useServerHealth>);
+
+    render(<ServerHealthDot />);
+    expect(screen.getByText('Reconnecting…')).toBeDefined();
+  });
+
+  it('shows red Server unreachable when status is disconnected', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'disconnected',
+      lastCheck: new Date(),
+      downSince: new Date(),
+      errorMessage: 'Aegis server is unreachable. Check if the server is running.',
+    } as ReturnType<typeof useServerHealth>);
+
+    render(<ServerHealthDot />);
+    expect(screen.getByText('Server unreachable')).toBeDefined();
+  });
+
+  it('shows Checking when status is checking', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'checking',
+      lastCheck: null,
+      downSince: null,
+      errorMessage: null,
+    } as ReturnType<typeof useServerHealth>);
+
+    render(<ServerHealthDot />);
+    expect(screen.getByText('Checking…')).toBeDefined();
+  });
+
+  it('has role=status for accessibility', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'connected',
+      lastCheck: new Date(),
+      downSince: null,
+      errorMessage: null,
+    } as ReturnType<typeof useServerHealth>);
+
+    const { container } = render(<ServerHealthDot />);
+    const statusEl = container.querySelector('[role="status"]');
+    expect(statusEl).toBeDefined();
+  });
+});
+
+describe('ServerHealthBanner', () => {
+  it('renders banner when disconnected', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'disconnected',
+      lastCheck: new Date(),
+      downSince: new Date(),
+      errorMessage: 'Aegis server is unreachable. Check if the server is running.',
+    } as ReturnType<typeof useServerHealth>);
+
+    render(<ServerHealthBanner />);
+    expect(screen.getByText('Aegis server is unreachable. Check if the server is running.')).toBeDefined();
+  });
+
+  it('does not render when connected', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'connected',
+      lastCheck: new Date(),
+      downSince: null,
+      errorMessage: null,
+    } as ReturnType<typeof useServerHealth>);
+
+    const { container } = render(<ServerHealthBanner />);
+    expect(container.querySelector('[data-testid="server-health-banner"]')).toBeNull();
+  });
+
+  it('does not render when reconnecting', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'reconnecting',
+      lastCheck: new Date(),
+      downSince: new Date(),
+      errorMessage: 'Connection to Aegis server lost. Reconnecting…',
+    } as ReturnType<typeof useServerHealth>);
+
+    const { container } = render(<ServerHealthBanner />);
+    expect(container.querySelector('[data-testid="server-health-banner"]')).toBeNull();
+  });
+
+  it('has role=alert for accessibility', () => {
+    mockUseServerHealth.mockReturnValue({
+      status: 'disconnected',
+      lastCheck: new Date(),
+      downSince: new Date(),
+      errorMessage: 'Aegis server is unreachable.',
+    } as ReturnType<typeof useServerHealth>);
+
+    const { container } = render(<ServerHealthBanner />);
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).toBeDefined();
+  });
+});

--- a/dashboard/src/hooks/useServerHealth.ts
+++ b/dashboard/src/hooks/useServerHealth.ts
@@ -1,0 +1,86 @@
+/**
+ * hooks/useServerHealth.ts — Server health polling hook.
+ *
+ * Polls /v1/health every 30s to detect if the Aegis server is reachable.
+ * Returns connection status for the health indicator.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export type ServerHealthStatus = 'connected' | 'disconnected' | 'reconnecting' | 'checking';
+
+interface ServerHealth {
+  status: ServerHealthStatus;
+  lastCheck: Date | null;
+  downSince: Date | null;
+  errorMessage: string | null;
+}
+
+const POLL_INTERVAL_MS = 30_000;
+const DOWN_THRESHOLD_MS = 60_000;
+
+async function fetchHealth(): Promise<{ ok: boolean; status?: string }> {
+  try {
+    const res = await fetch('/v1/health', {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return { ok: false };
+    const data = await res.json();
+    return { ok: true, status: data.status };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function useServerHealth(): ServerHealth {
+  const [health, setHealth] = useState<ServerHealth>({
+    status: 'checking',
+    lastCheck: null,
+    downSince: null,
+    errorMessage: null,
+  });
+
+  const downSinceRef = useRef<Date | null>(null);
+
+  const check = useCallback(async () => {
+    const result = await fetchHealth();
+
+    if (result.ok) {
+      downSinceRef.current = null;
+      setHealth({
+        status: 'connected',
+        lastCheck: new Date(),
+        downSince: null,
+        errorMessage: null,
+      });
+    } else {
+      const now = new Date();
+      if (!downSinceRef.current) {
+        downSinceRef.current = now;
+      }
+      const downMs = now.getTime() - downSinceRef.current.getTime();
+      const isExtended = downMs >= DOWN_THRESHOLD_MS;
+
+      setHealth({
+        status: isExtended ? 'disconnected' : 'reconnecting',
+        lastCheck: now,
+        downSince: downSinceRef.current,
+        errorMessage: isExtended
+          ? 'Aegis server is unreachable. Check if the server is running.'
+          : 'Connection to Aegis server lost. Reconnecting…',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial check
+    check();
+    // Poll every 30s
+    const interval = setInterval(check, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [check]);
+
+  return health;
+}


### PR DESCRIPTION
## Summary

Server health indicator for the zero-config init experience — shows the user if Aegis is alive within seconds of the dashboard opening.

### What's new
- **`useServerHealth` hook** — polls `/v1/health` every 30s, tracks connection state
- **`ServerHealthDot`** — sidebar footer indicator:
  - 🟢 Connected
  - 🟡 Reconnecting… (animated spinner)
  - 🔴 Server unreachable (after 60s)
  - ⚪ Checking… (initial state)
- **`ServerHealthBanner`** — fixed top banner when server unreachable >60s:
  - "Aegis server is unreachable. Check if the server is running."
- Wired into `Layout.tsx` — dot in sidebar, banner at top

### Why it matters
The zero-config init sprint is about the first 60 seconds. If something goes wrong and the dashboard silently shows nothing, the user bounces. This catches issues early.

### Test plan
- [x] 9 Vitest tests (4 dot states, 3 banner visibility, 2 a11y checks)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] No backend dependency — `/v1/health` already exists

— Daedalus 🏛️
