### PR TITLE
docs: add session approval auto-reject timeout (#4118)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1671,6 +1671,8 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/session-reject \
 ---
 
 > **Configuration:** Enable session approval by setting `requireSessionApproval: true` in your Aegis config, or set the environment variable `AEGIS_REQUIRE_SESSION_APPROVAL=true`. Sessions will wait in `awaiting_approval` until approved or rejected. If the server restarts while sessions are awaiting approval, they are automatically recovered and re-notified via configured channels.
+>
+> **Auto-reject timeout:** Sessions stuck in `awaiting_approval` for longer than `AEGIS_SESSION_APPROVAL_TIMEOUT_MS` (default: 5 minutes) are automatically rejected and transition to `killed`. Set to `0` to disable the timeout.
 
 ---
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -297,6 +297,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC checks even when auth is disabled. When `true`, unauthenticated requests to role/permission-protected endpoints return 401 instead of being allowed through |
 | `AEGIS_ENFORCE_SESSION_OWNERSHIP` | `true` | Enforce session ownership — tenants can only access their own sessions |
 | `AEGIS_REQUIRE_SESSION_APPROVAL` | `false` | Require explicit approval before new sessions start Claude Code. Sessions enter `awaiting_approval` status until approved or rejected via `POST /v1/sessions/:id/session-approve` or `/session-reject` |
+| `AEGIS_SESSION_APPROVAL_TIMEOUT_MS` | `300000` (5 min) | Auto-reject `awaiting_approval` sessions after this many milliseconds of inactivity. Set to `0` to disable auto-reject timeout |
 | `AEGIS_DEFAULT_TENANT_ID` | `default` | Default tenant ID for single-tenant deployments |
 
 #### Hooks


### PR DESCRIPTION
## Summary
PR #4118 adds `AEGIS_SESSION_APPROVAL_TIMEOUT_MS` — auto-rejects sessions stuck in `awaiting_approval` after 5 minutes. This was undocumented.

## Changes
- **enterprise.md** — add `AEGIS_SESSION_APPROVAL_TIMEOUT_MS` to env var table (default: 300000, set 0 to disable)
- **api-reference.md** — add auto-reject timeout note to Session Approval section

Closes N/A (accuracy gap from merged PR #4118)