### PR TITLE
fix(validation): add docs link to workDir validation error messages (#4126)

### DIFF
--- a/src/__tests__/allowed-dirs-hint-3798.test.ts
+++ b/src/__tests__/allowed-dirs-hint-3798.test.ts
@@ -62,3 +62,27 @@ describe('Issue #3798: error message includes allowed directories', () => {
     }
   });
 });
+
+describe('Issue #4126: error message includes docs link for troubleshooting', () => {
+  it('includes docs link in rejection message for non-allowed dir', async () => {
+    const result = await validateWorkDir('/tmp');
+    expect(typeof result).toBe('object');
+    if (typeof result === 'object') {
+      expect(result.code).toBe('INVALID_WORKDIR');
+      expect(result.error).toContain('five-minute-setup.md');
+      expect(result.error).toContain('troubleshooting');
+    }
+  });
+
+  it('includes docs link when path does not exist', async () => {
+    // Use a path under homedir (allowed prefix) but that doesn't exist
+    const nonexistent = path.join(os.homedir(), 'nonexistent-dir-for-test-4126');
+    const result = await validateWorkDir(nonexistent);
+    expect(typeof result).toBe('object');
+    if (typeof result === 'object') {
+      expect(result.code).toBe('INVALID_WORKDIR');
+      expect(result.error).toContain('five-minute-setup.md');
+      expect(result.error).toContain('troubleshooting');
+    }
+  });
+});

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -783,7 +783,7 @@ export async function validateWorkDir(
   if (!preAllowed) {
     const hint = windowsSuggestion
       ? ` Did you mean \`${windowsSuggestion}\`?`
-      : ` Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory. Allowed: ${candidateSafeDirs.join(", ")}`;
+      : ` Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory. See: https://github.com/OneStepAt4time/aegis/blob/develop/docs/five-minute-setup.md#troubleshooting. Allowed: ${candidateSafeDirs.join(", ")}`;
     return { error: `workDir ${resolved} is not in the allowed directories list.${hint}`, code: 'INVALID_WORKDIR' };
   }
 
@@ -792,7 +792,7 @@ export async function validateWorkDir(
   try {
     realPath = await fs.realpath(resolved);
   } catch { /* path does not exist on disk */
-    const hint = windowsSuggestion ? ` Did you mean \`${windowsSuggestion}\`?` : '';
+    const hint = windowsSuggestion ? ` Did you mean \`${windowsSuggestion}\`?` : ' See: https://github.com/OneStepAt4time/aegis/blob/develop/docs/five-minute-setup.md#troubleshooting.';
     return { error: `workDir does not exist: ${resolved}.${hint}`, code: 'INVALID_WORKDIR' };
   }
 
@@ -801,7 +801,7 @@ export async function validateWorkDir(
   if (!allowed) {
     const hint = windowsSuggestion
       ? ` Did you mean \`${windowsSuggestion}\`?`
-      : ` Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory. Allowed: ${candidateSafeDirs.join(", ")}`;
+      : ` Add it to allowedWorkDirs in .aegis/config.yaml, or run from your home directory. See: https://github.com/OneStepAt4time/aegis/blob/develop/docs/five-minute-setup.md#troubleshooting. Allowed: ${candidateSafeDirs.join(", ")}`;
     return { error: `workDir ${resolved} is not in the allowed directories list.${hint}`, code: 'INVALID_WORKDIR' };
   }
 


### PR DESCRIPTION
## Summary

Fixes #4126 — workDir validation error messages now include a link to the troubleshooting docs.

### Changes
- Added `five-minute-setup.md#troubleshooting` link to all `INVALID_WORKDIR` error messages (both "not in allowed directories" and "does not exist" cases)
- 2 new tests verifying docs link presence in error output

### Files changed
| File | Change |
|------|--------|
| `src/validation.ts` | Added docs link to 3 error hint messages |
| `src/__tests__/allowed-dirs-hint-3798.test.ts` | 2 new tests for docs link |

### Verification
```
tsc --noEmit: ✓ (pre-existing test-only type errors, not from this PR)
npm run build: ✓
npm test: ✓ 372 files, 5254 tests passed, 0 failures
```

Commit: d2b9a95a
Session: direct implementation (CC session stalled — dogfooding bug #4125)