### PR TITLE
docs: session purge endpoint and auto-cleanup env vars (#4140)

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -17,6 +17,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `GET` | `/v1/sessions/stats` | Bearer | Aggregated session statistics |
 | `GET` | `/v1/sessions/health` | Bearer | Bulk health check for all sessions |
 | `DELETE` | `/v1/sessions/batch` | Bearer | Kill and remove sessions by ID or status |
+| `DELETE` | `/v1/sessions/purge` | Bearer | Purge killed sessions older than threshold |
 
 ## Session (by ID)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1602,6 +1602,36 @@ curl -X DELETE http://localhost:9100/v1/sessions/abc123 \
 
 ---
 
+### Purge Killed Sessions
+
+```
+DELETE /v1/sessions/purge
+```
+
+Removes killed sessions older than a threshold from in-memory state. Cleans up associated permission requests, questions, and approval timeouts.
+
+**RBAC:** `admin`, `operator`
+
+```bash
+curl -X DELETE "http://localhost:9100/v1/sessions/purge?olderThanHours=24" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Query Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `olderThanHours` | number | `24` | Minimum age in hours (1–8760) |
+
+**Response:** `{ "ok": true, "purged": 5, "olderThanHours": 24, "olderThanMs": 86400000 }`
+
+| Status | Error |
+|--------|-------|
+| `400` | Invalid `olderThanHours` value |
+| `403` | Insufficient role (requires admin or operator) |
+
+---
+
 
 
 ### Session Approval
@@ -4086,6 +4116,7 @@ All core session endpoints are available without the `/v1` prefix for backward c
 | `GET /v1/sessions/:id/read` | `GET /sessions/:id/read` |
 | `POST /v1/sessions/:id/send` | `POST /sessions/:id/send` |
 | `POST /v1/sessions/:id/interrupt` | `POST /sessions/:id/interrupt` |
+| `DELETE /v1/sessions/purge` | `DELETE /sessions/purge` |
 | `DELETE /v1/sessions/:id` | `DELETE /sessions/:id` |
 | `POST /v1/sessions/:id/spawn` | `POST /sessions/:id/spawn` |
 | `POST /v1/sessions/:id/fork` | `POST /sessions/:id/fork` |

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -274,6 +274,8 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 | `AEGIS_BLOCKED_ACP_ARGS` | _see below_ | Comma-separated list of CLI flags blocked from user-configured args in ACP child process spawn. Prevents overriding protocol-critical flags like `--output-format`, `--resume`, `--session-id`, `--api-key`, `--model`. Defaults to the built-in list when empty |
 | `AEGIS_ACTION_SWEEPER_ENABLED` | `true` | Enable periodic sweeper that recovers orphaned ACP actions (actions stuck in `leased` state after a worker crash) |
 | `AEGIS_ACTION_SWEEPER_INTERVAL_MS` | `60000` | Sweep interval in milliseconds for orphan action recovery |
+| `AEGIS_SESSION_CLEANUP_INTERVAL_MS` | `3600000` | Auto-cleanup interval for killed sessions. Set to `0` to disable |
+| `AEGIS_SESSION_CLEANUP_AGE_MS` | `86400000` | Minimum age (ms) before a killed session is eligible for auto-cleanup |
 | `AEGIS_ISOLATION_POLICY` | `respect-cc` | Session isolation policy: `respect-cc` (follow CC settings, default), `enforce-worktree` (reject sessions without worktree — prevents file conflicts with concurrent sessions), `enforce-direct` (force direct edits, no worktree) |
 | `AEGIS_CONFIG` | _(auto)_ | Path to `aegis.config.json` |
 | `AEGIS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |


### PR DESCRIPTION
Documents the session auto-cleanup feature from #4140:\n\n- **DELETE /v1/sessions/purge** — endpoint docs with RBAC, params, response, errors\n- **AEGIS_SESSION_CLEANUP_INTERVAL_MS** / **AEGIS_SESSION_CLEANUP_AGE_MS** — env vars in enterprise.md\n- api-quick-ref.md — purge route added\n\nRef #4140