### PR TITLE
chore: post-merge hook auto-rebuilds and restarts Aegis on develop (#4125)

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+# post-merge hook — auto-rebuild and restart Aegis after develop merges.
+#
+# Triggers when `git pull` (or merge) completes on the develop branch.
+# Rebuilds the server and restarts the systemd service.
+#
+# To install: npm run hooks:install
+# (or: git config core.hooksPath .githooks)
+
+set -eu
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+if [ "$BRANCH" != "develop" ]; then
+  exit 0
+fi
+
+echo "[post-merge] Develop branch updated. Rebuilding Aegis..."
+
+# Rebuild
+if ! npm run build > /dev/null 2>&1; then
+  echo "[post-merge] ❌ Build failed. Not restarting."
+  exit 1
+fi
+
+echo "[post-merge] ✅ Build succeeded."
+
+# Restart if Aegis service is running
+if systemctl --user is-active --quiet aegis 2>/dev/null; then
+  echo "[post-merge] Restarting Aegis service..."
+  systemctl --user restart aegis
+  echo "[post-merge] ✅ Aegis restarted."
+elif systemctl --user is-active --quiet manus 2>/dev/null; then
+  echo "[post-merge] Restarting manus service (legacy name)..."
+  systemctl --user restart manus
+  echo "[post-merge] ✅ manus restarted."
+else
+  echo "[post-merge] ℹ️  No running Aegis service found. Start manually: npm start"
+fi


### PR DESCRIPTION
## Issue
Fixes #4125 — server doesn't reload after merge to develop.

## What it does
Adds a `.githooks/post-merge` script that triggers after `git pull` on the **develop** branch:

1. Runs `npm run build`
2. Restarts the `aegis` systemd service (or `manus` legacy name)
3. Skips restart if no service is running
4. Skips entirely if not on develop branch

## Install
```bash
npm run hooks:install
```

This sets `core.hooksPath` to `.githooks` (already exists with `pre-push`).

## Why
During development sprints, multiple PRs merge to develop but the running instance stays stale. Developers had to manually rebuild + restart. Now it's automatic.

## Verification
- Hook only fires on develop branch
- Build failure prevents restart
- No-op if no systemd service is running
- Works with both `aegis` and `manus` service names