### PR TITLE
fix(auth): drop __Host- cookie prefix over HTTP (#4146)

### DIFF
--- a/src/dashboard-session-auth.ts
+++ b/src/dashboard-session-auth.ts
@@ -1,7 +1,8 @@
 import type { FastifyRequest } from 'fastify';
 import type { ApiKeyPermission, ApiKeyRole } from './services/auth/index.js';
 import {
-  DASHBOARD_SESSION_COOKIE,
+  DASHBOARD_SESSION_COOKIE_SECURE,
+  DASHBOARD_SESSION_COOKIE_INSECURE,
   getDashboardSessionAuthContext,
   type DashboardOIDCManager,
   type DashboardRequestAuthContext,
@@ -31,7 +32,8 @@ export function resolveDashboardSessionAuthContext(
   manager: Pick<DashboardOIDCManager, 'getSession'> | null | undefined,
 ): DashboardRequestAuthContext | null {
   if (!manager) return null;
-  const sessionId = parseCookies(cookieHeader).get(DASHBOARD_SESSION_COOKIE);
+  const cookies = parseCookies(cookieHeader);
+  const sessionId = cookies.get(DASHBOARD_SESSION_COOKIE_SECURE) || cookies.get(DASHBOARD_SESSION_COOKIE_INSECURE);
   const session = manager.getSession(sessionId);
   return session ? getDashboardSessionAuthContext(session) : null;
 }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -16,7 +16,7 @@ function isSecureRequest(req: FastifyRequest): boolean {
   if (proto) return proto === 'https';
   return req.protocol === 'https';
 }
-import { DASHBOARD_SESSION_COOKIE, DASHBOARD_SESSION_TTL_MS } from '../services/auth/OIDCManager.js';
+import { dashboardSessionCookie, DASHBOARD_SESSION_TTL_MS } from '../services/auth/OIDCManager.js';
 
 const setQuotasSchema = z.object({
   maxConcurrentSessions: z.number().int().positive().nullable().optional(),
@@ -56,7 +56,7 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
         claims: { authMethod: 'token', keyId: null },
       });
       if (session) {
-        appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000, 'Strict', isSecureRequest(req)));
+        appendSetCookie(reply, buildCookie(dashboardSessionCookie(isSecureRequest(req)), session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000, 'Strict', isSecureRequest(req)));
       }
       return { valid: true, role };
     }
@@ -78,7 +78,7 @@ export function registerAuthRoutes(app: FastifyInstance, ctx: RouteContext): voi
       claims: { authMethod: 'token', keyId: result.keyId },
     });
     if (session) {
-      appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000, 'Strict', isSecureRequest(req)));
+      appendSetCookie(reply, buildCookie(dashboardSessionCookie(isSecureRequest(req)), session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000, 'Strict', isSecureRequest(req)));
     }
     return { valid: true, role };
   }));

--- a/src/routes/oidc-auth.ts
+++ b/src/routes/oidc-auth.ts
@@ -1,9 +1,9 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import {
-  DASHBOARD_SESSION_COOKIE,
+  dashboardSessionCookie,
   DASHBOARD_SESSION_TTL_MS,
   OIDC_AUTH_REQUEST_TTL_MS,
-  OIDC_STATE_COOKIE,
+  oidcStateCookie,
   OidcAuthError,
   type DashboardSessionStore,
   type DashboardOIDCManager,
@@ -120,7 +120,7 @@ async function sendOidcRedirect(ctx: OidcRouteContext, req: LoginRequest, reply:
   }
   try {
     const login = await manager.beginLogin({ loginHint: sanitizeLoginHint(req.query.login_hint) });
-    appendSetCookie(reply, buildCookie(OIDC_STATE_COOKIE, login.state, OIDC_AUTH_REQUEST_TTL_MS / 1000, 'Lax', isSecureRequest(req)));
+    appendSetCookie(reply, buildCookie(oidcStateCookie(isSecureRequest(req)), login.state, OIDC_AUTH_REQUEST_TTL_MS / 1000, 'Lax', isSecureRequest(req)));
     await reply.status(302).header('Location', login.redirectUrl.href).send();
   } catch {
     await reply.status(503).type('text/html').send(genericOidcErrorPage());
@@ -143,10 +143,10 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
         if (!manager) return reply.status(404).send({ error: 'Not found' });
-        appendSetCookie(reply, buildClearedCookie(OIDC_STATE_COOKIE, 'Lax', isSecureRequest(req)));
+        appendSetCookie(reply, buildClearedCookie(oidcStateCookie(isSecureRequest(req)), 'Lax', isSecureRequest(req)));
         try {
-          const session = await manager.completeCallback(buildCallbackUrl(req, manager), getCookie(req, OIDC_STATE_COOKIE));
-          appendSetCookie(reply, buildCookie(DASHBOARD_SESSION_COOKIE, session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000, 'Strict', isSecureRequest(req)));
+          const session = await manager.completeCallback(buildCallbackUrl(req, manager), getCookie(req, oidcStateCookie(isSecureRequest(req))));
+          appendSetCookie(reply, buildCookie(dashboardSessionCookie(isSecureRequest(req)), session.sessionId, DASHBOARD_SESSION_TTL_MS / 1000, 'Strict', isSecureRequest(req)));
           return reply.status(302).header('Location', '/dashboard/').send();
         } catch (error: unknown) {
           const statusCode = error instanceof OidcAuthError ? error.statusCode : 502;
@@ -160,7 +160,7 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
       { config: { rateLimit: SESSION_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
-        const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+        const sessionId = getCookie(req, dashboardSessionCookie(isSecureRequest(req)));
         const tokenSessionStore = ctx.dashboardTokenSessions ?? null;
         const tokenSession = tokenSessionStore?.get(sessionId) ?? null;
         if (tokenSession && tokenSessionStore) {
@@ -169,7 +169,7 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
         if (!manager) return { oidcAvailable: false, authenticated: false };
         const session = manager.getSession(sessionId);
         if (!session) {
-          appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE, 'Strict', isSecureRequest(req)));
+          appendSetCookie(reply, buildClearedCookie(dashboardSessionCookie(isSecureRequest(req)), 'Strict', isSecureRequest(req)));
           return reply.status(401).send({ oidcAvailable: true, authenticated: false });
         }
         return { oidcAvailable: true, authMethod: 'oidc', ...manager.sessions.toView(session) };
@@ -181,15 +181,15 @@ export function registerOidcAuthRoutes(app: FastifyInstance, ctx: OidcRouteConte
       { config: { rateLimit: LOGOUT_RATE_LIMIT } },
       async (req, reply) => {
         const manager = getDashboardOidc(ctx);
-        const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+        const sessionId = getCookie(req, dashboardSessionCookie(isSecureRequest(req)));
         const tokenSessionDeleted = ctx.dashboardTokenSessions?.delete(sessionId) ?? false;
         if (!manager) {
-          appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE, 'Strict', isSecureRequest(req)));
+          appendSetCookie(reply, buildClearedCookie(dashboardSessionCookie(isSecureRequest(req)), 'Strict', isSecureRequest(req)));
           return reply.status(204).send();
         }
         const session = manager.getSession(sessionId);
         manager.deleteSession(sessionId);
-        appendSetCookie(reply, buildClearedCookie(DASHBOARD_SESSION_COOKIE, 'Strict', isSecureRequest(req)));
+        appendSetCookie(reply, buildClearedCookie(dashboardSessionCookie(isSecureRequest(req)), 'Strict', isSecureRequest(req)));
         if (tokenSessionDeleted) return reply.status(204).send();
         const endSessionUrl = manager.buildEndSessionUrl(session);
         if (endSessionUrl && acceptsHtml(req)) {

--- a/src/services/auth/OIDCManager.ts
+++ b/src/services/auth/OIDCManager.ts
@@ -7,8 +7,21 @@ import { parseDashboardOidcConfig, type DashboardOidcConfig } from './oidc-confi
 import { permissionsForRole, type ApiKeyPermission } from './permissions.js';
 import type { ApiKeyRole } from './types.js';
 
-export const DASHBOARD_SESSION_COOKIE = '__Host-aegis_dashboard_session';
-export const OIDC_STATE_COOKIE = '__Host-aegis_oidc_state';
+export const DASHBOARD_SESSION_COOKIE_SECURE = '__Host-aegis_dashboard_session';
+export const DASHBOARD_SESSION_COOKIE_INSECURE = 'aegis_dashboard_session';
+
+/** Return the cookie name appropriate for the request protocol.
+ *  __Host- prefix requires HTTPS (browsers silently drop it over HTTP).
+ *  Issue #4146: unconditional __Host- broke localhost/HTTP deployments. */
+export function dashboardSessionCookie(isSecure: boolean): string {
+  return isSecure ? DASHBOARD_SESSION_COOKIE_SECURE : DASHBOARD_SESSION_COOKIE_INSECURE;
+}
+export const OIDC_STATE_COOKIE_SECURE = '__Host-aegis_oidc_state';
+export const OIDC_STATE_COOKIE_INSECURE = 'aegis_oidc_state';
+
+export function oidcStateCookie(isSecure: boolean): string {
+  return isSecure ? OIDC_STATE_COOKIE_SECURE : OIDC_STATE_COOKIE_INSECURE;
+}
 export const DASHBOARD_SESSION_TTL_MS = 60 * 60 * 1000;
 export const OIDC_AUTH_REQUEST_TTL_MS = 10 * 60 * 1000;
 export const OIDC_DISCOVERY_TTL_MS = 60 * 60 * 1000;

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -4,8 +4,12 @@ export type { QuotaCheckResult, QuotaUsage } from './QuotaManager.js';
 export { RateLimiter } from './RateLimiter.js';
 export type { RateLimitBucketInfo } from './RateLimiter.js';
 export {
-  DASHBOARD_SESSION_COOKIE,
-  OIDC_STATE_COOKIE,
+  DASHBOARD_SESSION_COOKIE_SECURE,
+  DASHBOARD_SESSION_COOKIE_INSECURE,
+  dashboardSessionCookie,
+  OIDC_STATE_COOKIE_SECURE,
+  OIDC_STATE_COOKIE_INSECURE,
+  oidcStateCookie,
   DashboardOIDCManager,
   DashboardSessionStore,
   OpenidClientProvider,


### PR DESCRIPTION
## Issue
Fixes #4146 — dashboard session cookie rejected over HTTP.

## Root Cause
The cookie `__Host-aegis_dashboard_session` uses the `__Host-` prefix which requires HTTPS. Browsers silently drop it over plain HTTP. Ema's running on HTTP localhost → cookie never set → dashboard thinks user is unauthenticated → sessions don't load, pages crash.

## What Changed
Cookie name is now protocol-conditional:
- **HTTPS** → `__Host-aegis_dashboard_session` (secure, prefixed)
- **HTTP** → `aegis_dashboard_session` (plain, no prefix)

Same treatment for the OIDC state cookie.

### Files
| File | Change |
|------|--------|
| `src/services/auth/OIDCManager.ts` | Export `dashboardSessionCookie(isSecure)` and `oidcStateCookie(isSecure)` functions |
| `src/services/auth/index.ts` | Re-export new symbols |
| `src/routes/auth.ts` | Use `dashboardSessionCookie(isSecureRequest(req))` |
| `src/routes/oidc-auth.ts` | Use both conditional functions |
| `src/dashboard-session-auth.ts` | Try BOTH cookie names for compatibility during migration |

## Verification
- `tsc --noEmit` — clean (only pre-existing `open` type warnings)
- `npm run build` — success
- Backward compatible: existing HTTPS deployments keep `__Host-` prefix

## Impact
This is the **root cause** of "token not cached" and "sessions not loading" that Ema reported. The dashboard login worked (API key verified) but the session cookie was silently dropped, so every subsequent request was unauthenticated.