### PR TITLE
fix(metrics): separate killed sessions from failed in stats (#4147)

### DIFF
--- a/dashboard/src/__tests__/AnalyticsPage.test.tsx
+++ b/dashboard/src/__tests__/AnalyticsPage.test.tsx
@@ -49,6 +49,7 @@ const mockAnalyticsSummary: AnalyticsSummary = {
     permissionPrompts: 12,
     approvals: 10,
     autoApprovals: 8,
+    killedSessions: 0,
   },
   generatedAt: '2026-05-18T12:00:00.000Z',
 };
@@ -206,6 +207,7 @@ describe('AnalyticsPage', () => {
         permissionPrompts: 5,
         approvals: 4,
         autoApprovals: 2,
+    killedSessions: 0,
       },
     };
     mockGetAnalyticsSummary.mockResolvedValue(highErrorSummary);

--- a/dashboard/src/__tests__/SessionHealthBanner.test.tsx
+++ b/dashboard/src/__tests__/SessionHealthBanner.test.tsx
@@ -12,6 +12,7 @@ const mockHealthyRates: AnalyticsErrorRates = {
   permissionPrompts: 10,
   approvals: 10,
   autoApprovals: 8,
+    killedSessions: 0,
 };
 
 const mockWarningRates: AnalyticsErrorRates = {
@@ -23,6 +24,7 @@ const mockWarningRates: AnalyticsErrorRates = {
   permissionPrompts: 20,
   approvals: 18,
   autoApprovals: 15,
+    killedSessions: 0,
 };
 
 const mockCriticalRates: AnalyticsErrorRates = {
@@ -34,6 +36,7 @@ const mockCriticalRates: AnalyticsErrorRates = {
   permissionPrompts: 5,
   approvals: 5,
   autoApprovals: 0,
+    killedSessions: 0,
 };
 
 describe('SessionHealthBanner', () => {

--- a/dashboard/src/__tests__/schemas.test.ts
+++ b/dashboard/src/__tests__/schemas.test.ts
@@ -178,6 +178,7 @@ describe('GlobalMetricsSchema', () => {
       avg_duration_sec: 120,
       avg_messages_per_session: 5.5,
       infra_failed: 0,
+      killed: 0,
     },
     auto_approvals: 3,
     webhooks_sent: 20,

--- a/dashboard/src/__tests__/store.test.ts
+++ b/dashboard/src/__tests__/store.test.ts
@@ -26,6 +26,7 @@ const mockMetrics: GlobalMetrics = {
     avg_duration_sec: 42,
     avg_messages_per_session: 3,
     infra_failed: 0,
+      killed: 0,
   },
   auto_approvals: 0,
   webhooks_sent: 0,

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -327,6 +327,7 @@ export const GlobalMetricsSchema: z.ZodType<GlobalMetrics> = z.object({
     avg_duration_sec: z.number(),
     avg_messages_per_session: z.number(),
     infra_failed: z.number(),
+    killed: z.number(),
   }),
   auto_approvals: z.number(),
   webhooks_sent: z.number(),

--- a/src/__tests__/fix-3224-orphaned-process-cleanup.test.ts
+++ b/src/__tests__/fix-3224-orphaned-process-cleanup.test.ts
@@ -59,7 +59,7 @@ function buildApp(options: { acpEnabled?: boolean; shutdownRejects?: boolean } =
     auth: { authEnabled: false },
     quotas: {},
     config: { acpEnabled: options.acpEnabled !== false, enforceSessionOwnership: true },
-    metrics: { sessionFailed: vi.fn(), cleanupSession: vi.fn() },
+    metrics: { sessionFailed: vi.fn(), sessionKilled: vi.fn(), cleanupSession: vi.fn() },
     monitor: { removeSession: vi.fn() },
     eventBus: { emitEnded: vi.fn() },
     channels: { sessionEnded: vi.fn(async () => undefined) },

--- a/src/__tests__/metrics-cache-2250.test.ts
+++ b/src/__tests__/metrics-cache-2250.test.ts
@@ -264,6 +264,7 @@ describe('MetricsCache (Issue #2250)', () => {
           totalSessionsCreated: 5,
           totalSessionsFailed: 1,
           totalSessionsInfraFailed: 0,
+          totalSessionsKilled: 0,
           savedAt: Date.now(),
         }),
         save: async () => {},
@@ -521,6 +522,7 @@ describe('MetricsCache (Issue #2250)', () => {
         totalSessionsCreated: 1,
         totalSessionsFailed: 0,
         totalSessionsInfraFailed: 0,
+          totalSessionsKilled: 0,
         savedAt: Date.now(),
       };
       await b.save(data);

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -28,6 +28,7 @@ describe('Metrics and usage data (Issue #40)', () => {
         total_created: 0, currently_active: 0, completed: 0,
         failed: 0, avg_duration_sec: 0, avg_messages_per_session: 0,
         infra_failed: 0,
+        killed: 0,
       });
     });
 
@@ -47,6 +48,27 @@ describe('Metrics and usage data (Issue #40)', () => {
       const m = metrics.getGlobalMetrics(0);
       expect((m.sessions as any).completed).toBe(1);
       expect((m.sessions as any).failed).toBe(1);
+    });
+
+    it('should track killed sessions separately from failed (Issue #4147)', () => {
+      metrics.sessionCreated('s1');
+      metrics.sessionCreated('s2');
+      metrics.sessionCreated('s3');
+      metrics.sessionFailed('s1');
+      metrics.sessionKilled('s2');
+      metrics.sessionCompleted('s3');
+      const m = metrics.getGlobalMetrics(0);
+      expect((m.sessions as any).failed).toBe(1);
+      expect((m.sessions as any).killed).toBe(1);
+      expect((m.sessions as any).completed).toBe(1);
+    });
+
+    it('should be idempotent for sessionKilled (Issue #3427)', () => {
+      metrics.sessionCreated('s1');
+      metrics.sessionKilled('s1');
+      metrics.sessionKilled('s1'); // second call should be no-op
+      const m = metrics.getGlobalMetrics(0);
+      expect((m.sessions as any).killed).toBe(1);
     });
 
     it('should calculate avg_duration_sec for completed sessions (#1414)', () => {

--- a/src/__tests__/route-aliases-2461.test.ts
+++ b/src/__tests__/route-aliases-2461.test.ts
@@ -126,6 +126,7 @@ function makeContext(granted: Partial<Record<PermissionName, boolean>> = {}) {
       cleanupSession: vi.fn(),
       sessionCreated: vi.fn(),
       sessionFailed: vi.fn(),
+      sessionKilled: vi.fn(),
       promptSent: vi.fn(),
       recordPermissionResponse: vi.fn(),
       getGlobalMetrics: vi.fn(() => ({

--- a/src/__tests__/session-actions-routes.test.ts
+++ b/src/__tests__/session-actions-routes.test.ts
@@ -91,6 +91,7 @@ function buildApp(session: SessionInfo | null) {
     metrics: {
       sessionCreated: vi.fn(),
       sessionFailed: vi.fn(),
+      sessionKilled: vi.fn(),
       cleanupSession: vi.fn(),
       promptSent: vi.fn(),
       recordPermissionResponse: vi.fn(),

--- a/src/__tests__/session-counter-consistency-2533.test.ts
+++ b/src/__tests__/session-counter-consistency-2533.test.ts
@@ -129,6 +129,7 @@ describe('Session counter consistency (Issue #2533)', () => {
         totalSessionsCreated: 5,
         totalSessionsFailed: 0,
         totalSessionsInfraFailed: 0,
+        totalSessionsKilled: 0,
         savedAt: Date.now(),
       };
 

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -176,6 +176,7 @@ export interface GlobalMetrics {
     avg_duration_sec: number;
     avg_messages_per_session: number;
     infra_failed: number;
+    killed: number;
   };
   auto_approvals: number;
   webhooks_sent: number;
@@ -416,6 +417,8 @@ export interface AnalyticsErrorRates {
   infraFailures: number;
   /** Failure rate excluding infrastructure failures (0 messages exchanged). */
   adjustedFailureRate: number;
+  /** Sessions intentionally killed by operator — not failures. Issue #4147. */
+  killedSessions: number;
   permissionPrompts: number;
   approvals: number;
   autoApprovals: number;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -13,6 +13,7 @@ import {
   sessionsCreatedTotal,
   sessionsCompletedTotal,
   sessionsFailedTotal,
+  sessionsKilledTotal,
   messagesTotal,
   toolCallsTotal,
   autoApprovalsTotal,
@@ -41,6 +42,7 @@ export interface GlobalMetrics {
   sessionsCompleted: number;
   sessionsFailed: number;
   sessionsInfraFailed: number;
+  sessionsKilled: number;
   totalMessages: number;
   totalToolCalls: number;
   autoApprovals: number;
@@ -96,6 +98,7 @@ export class MetricsCollector {
     sessionsCompleted: 0,
     sessionsFailed: 0,
     sessionsInfraFailed: 0,
+    sessionsKilled: 0,
     totalMessages: 0,
     totalToolCalls: 0,
     autoApprovals: 0,
@@ -198,6 +201,16 @@ export class MetricsCollector {
   /** Mark session as infrastructure failure (CC never started / no messages). Issue #2947. */
   sessionInfraFailed(sessionId: string): void {
     this.global.sessionsInfraFailed++;
+    this.finalizeSessionDuration(sessionId);
+  }
+
+  /** Track operator-killed session separately from failures. Issue #4147. */
+  sessionKilled(sessionId: string): void {
+    // Issue #3427: Idempotent — only count once per session
+    if (this.settledSessions.has(sessionId)) return;
+    this.settledSessions.add(sessionId);
+    this.global.sessionsKilled++;
+    sessionsKilledTotal.inc();
     this.finalizeSessionDuration(sessionId);
   }
 
@@ -411,6 +424,7 @@ export class MetricsCollector {
         completed: this.global.sessionsCompleted,
         failed: this.global.sessionsFailed,
         infra_failed: this.global.sessionsInfraFailed,
+        killed: this.global.sessionsKilled,
         avg_duration_sec: avgDuration,
         avg_messages_per_session: avgMessages,
       },

--- a/src/prometheus.ts
+++ b/src/prometheus.ts
@@ -46,6 +46,12 @@ export const sessionsFailedTotal = new Counter({
   registers: [promRegistry],
 });
 
+export const sessionsKilledTotal = new Counter({
+  name: 'aegis_sessions_killed_total',
+  help: 'Total number of sessions killed by operator',
+  registers: [promRegistry],
+});
+
 // ── Message / tool counters ─────────────────────────────────────────────────
 export const messagesTotal = new Counter({
   name: 'aegis_messages_total',

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -258,8 +258,8 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
         }).catch(() => {}); // Best-effort: session may not have ACP runtime
       }
       await sessions.killSession(session.id);
-      // Issue #2067: record session as failed before cleanup
-      metrics.sessionFailed(session.id);
+      // Issue #4147: record killed session separately from failures
+      metrics.sessionKilled(session.id);
       eventBus.emitEnded(session.id, 'killed');
       const auditLogger = getAuditLogger();
       if (auditLogger) void auditLogger.log(resolveRequestAuditActor(auth, req, 'system'), 'session.kill', `Session killed: ${session.id} (permission=${req.matchedPermission ?? 'kill'})`, session.id, req.tenantId);

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -277,6 +277,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       totalCreated: global.sessions.total_created,
       totalCompleted: global.sessions.completed,
       totalFailed: global.sessions.failed,
+      totalKilled: global.sessions.killed ?? 0,
     };
   });
 

--- a/src/services/metrics-cache.ts
+++ b/src/services/metrics-cache.ts
@@ -61,6 +61,7 @@ interface CacheFile {
   totalSessionsCreated: number;
   totalSessionsFailed: number;
   totalSessionsInfraFailed: number;
+  totalSessionsKilled: number;
   savedAt: number;
 }
 
@@ -125,6 +126,7 @@ export class MetricsCache {
   private totalSessionsCreated = 0;
   private totalSessionsFailed = 0;
   private totalSessionsInfraFailed = 0;
+  private totalSessionsKilled = 0;
 
   private dirty = false;
   private unsub: (() => void) | null = null;
@@ -218,11 +220,12 @@ export class MetricsCache {
       }))
       .sort((a, b) => a.date.localeCompare(b.date));
 
-    const realFailures = this.totalSessionsFailed - this.totalSessionsInfraFailed;
-    const realTotal = this.totalSessionsCreated - this.totalSessionsInfraFailed;
+    const realFailures = this.totalSessionsFailed - this.totalSessionsKilled;
+    const realTotal = this.totalSessionsCreated - this.totalSessionsKilled;
     const errorRates: AnalyticsErrorRates = {
       totalSessions: this.totalSessionsCreated,
-      failedSessions: this.totalSessionsFailed,
+      failedSessions: this.totalSessionsFailed - this.totalSessionsKilled,
+      killedSessions: this.totalSessionsKilled,
       failureRate: this.totalSessionsCreated > 0
         ? this.totalSessionsFailed / this.totalSessionsCreated : 0,
       infraFailures: this.totalSessionsInfraFailed,
@@ -275,6 +278,7 @@ export class MetricsCache {
     this.totalSessionsCreated = global.sessions.total_created;
     this.totalSessionsFailed = global.sessions.failed;
     this.totalSessionsInfraFailed = global.sessions.infra_failed ?? 0;
+    this.totalSessionsKilled = global.sessions.killed ?? 0;
   }
 
   /** Full recomputation from live MetricsCollector + SessionManager. */
@@ -291,6 +295,7 @@ export class MetricsCache {
     this.totalSessionsCreated = global.sessions.total_created;
     this.totalSessionsFailed = global.sessions.failed;
     this.totalSessionsInfraFailed = global.sessions.infra_failed ?? 0;
+    this.totalSessionsKilled = global.sessions.killed ?? 0;
 
     for (const session of allSessions) {
       this.accumulateSession(session);
@@ -380,6 +385,7 @@ export class MetricsCache {
       totalSessionsCreated: this.totalSessionsCreated,
       totalSessionsFailed: this.totalSessionsFailed,
       totalSessionsInfraFailed: this.totalSessionsInfraFailed,
+      totalSessionsKilled: this.totalSessionsKilled,
       savedAt: Date.now(),
     };
     await this.backend.save(data);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -405,6 +405,7 @@ export const metricsFileSchema = z.object({
     sessionsCreated: z.number().optional(),
     sessionsCompleted: z.number().optional(),
     sessionsFailed: z.number().optional(),
+    sessionsKilled: z.number().optional(),
     totalMessages: z.number().optional(),
     totalToolCalls: z.number().optional(),
     autoApprovals: z.number().optional(),


### PR DESCRIPTION
## Summary

Fixes #4147 — killed sessions (operator-terminated) were counted as `failed` in `/v1/sessions/stats`, inflating the failure rate from ~0% to 58.4%.

## Changes

- **`MetricsCollector.sessionKilled()`** — new method, tracked independently from `sessionFailed()` with idempotency guard
- **`session-actions.ts`** — kill handler now calls `sessionKilled()` instead of `sessionFailed()`
- **`/v1/sessions/stats`** — adds `totalKilled` field to response
- **`metrics-cache.ts`** — adds `killedSessions` to `AnalyticsErrorRates`, adjusts failure rate to exclude killed
- **Prometheus** — new `aegis_sessions_killed_total` counter
- **Zod schema** — updated for `killed` field
- **2 new tests**: killed tracking + idempotency

## Verification

```
tsc --noEmit ✓ (0 new errors)
npm run build ✓
5281 tests ✓ (374 files, 2 new tests)
```

Commit: 1d7879d0
Session: direct implementation (CC dogfooding bug #4125)