### PR TITLE
fix(auth): remove __Host- cookie prefix for HTTP compatibility (#4146)

### DIFF
--- a/src/__tests__/oidc-auth-routes.test.ts
+++ b/src/__tests__/oidc-auth-routes.test.ts
@@ -234,7 +234,7 @@ describe('OIDC auth routes', () => {
     expect(sessionCookie).toContain('HttpOnly');
     expect(sessionCookie).toContain('Secure');
     expect(sessionCookie).toContain('SameSite=Strict');
-    expect(sessionCookie).toContain('Max-Age=3600');
+    expect(sessionCookie).toContain('Max-Age=86400'); // Issue #4152: 24h TTL
 
     const sessionValue = callback.cookies.find((cookie) => cookie.name === DASHBOARD_SESSION_COOKIE)?.value;
     const session = await app.inject({ method: 'GET', url: '/auth/session', headers: { cookie: `${DASHBOARD_SESSION_COOKIE}=${sessionValue}` } });

--- a/src/services/auth/OIDCManager.ts
+++ b/src/services/auth/OIDCManager.ts
@@ -7,9 +7,9 @@ import { parseDashboardOidcConfig, type DashboardOidcConfig } from './oidc-confi
 import { permissionsForRole, type ApiKeyPermission } from './permissions.js';
 import type { ApiKeyRole } from './types.js';
 
-export const DASHBOARD_SESSION_COOKIE = '__Host-aegis_dashboard_session';
-export const OIDC_STATE_COOKIE = '__Host-aegis_oidc_state';
-export const DASHBOARD_SESSION_TTL_MS = 60 * 60 * 1000;
+export const DASHBOARD_SESSION_COOKIE = 'aegis_dashboard_session';
+export const OIDC_STATE_COOKIE = 'aegis_oidc_state';
+export const DASHBOARD_SESSION_TTL_MS = 24 * 60 * 60 * 1000; // Issue #4152: 24h for local dev usability
 export const OIDC_AUTH_REQUEST_TTL_MS = 10 * 60 * 1000;
 export const OIDC_DISCOVERY_TTL_MS = 60 * 60 * 1000;
 export const MAX_DASHBOARD_SESSIONS_PER_USER = 5;


### PR DESCRIPTION
## Summary

Fixes #4146 — dashboard session cookie silently rejected over HTTP due to `__Host-` prefix.

Also fixes #4152 (partially) — increases session cookie TTL from 1 hour to 24 hours.

## Changes

- **Remove `__Host-` prefix** from `DASHBOARD_SESSION_COOKIE` and `OIDC_STATE_COOKIE`
  - `__Host-` requires `Secure` + HTTPS + no Domain; browsers silently drop over HTTP
  - `Secure` flag + `Path=/` + `HttpOnly` already set by `buildCookie()` — equivalent security on HTTPS
- **Increase TTL** from 1h (`3600000ms`) to 24h (`86400000ms`)
  - Solo dev working locally should not be kicked out hourly

## Impact

**CRITICAL** — dashboard was completely unusable over HTTP (localhost, dev setups).

## Verification

```
tsc --noEmit ✓
npm run build ✓
oidc-auth-routes.test.ts: 9/9 ✓
oidc-dashboard-manager.test.ts: 11/11 ✓
```

Commit: 3486ba99