### PR TITLE
fix(metrics): preserve cost/token data across session lifecycle (#4149)

### DIFF
--- a/src/__tests__/metrics-cache-2250.test.ts
+++ b/src/__tests__/metrics-cache-2250.test.ts
@@ -264,7 +264,8 @@ describe('MetricsCache (Issue #2250)', () => {
           totalSessionsCreated: 5,
           totalSessionsFailed: 1,
           totalSessionsInfraFailed: 0,
-          totalSessionsKilled: 0,
+totalSessionsKilled: 0,
+accumulatedSessionIds: [],
           savedAt: Date.now(),
         }),
         save: async () => {},
@@ -522,12 +523,93 @@ describe('MetricsCache (Issue #2250)', () => {
         totalSessionsCreated: 1,
         totalSessionsFailed: 0,
         totalSessionsInfraFailed: 0,
-          totalSessionsKilled: 0,
+totalSessionsKilled: 0,
+accumulatedSessionIds: [],
         savedAt: Date.now(),
       };
       await b.save(data);
       const loaded = await b.load();
       expect(loaded).toEqual(data);
     });
+
+  });
+
+  // ── Issue #4149: Metrics persistence across session lifecycle ──────
+
+  it('preserves cost/token data after sessions end (Issue #4149)', async () => {
+    deps.metricsMap.set('s-cost-1', {
+      messages: 10,
+      durationSec: 120,
+      toolCalls: 0,
+      statusChanges: [],
+      approvals: 0,
+      autoApprovals: 0,
+      tokenUsage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheCreationTokens: 100,
+        cacheReadTokens: 50,
+        estimatedCostUsd: 0.015,
+      },
+    });
+
+    deps.sessionsMap.set('s-cost-1', { id: 's-cost-1', createdAt: '2026-05-24T10:00:00Z', model: 'claude-3.5-sonnet', ownerKeyId: 'key1' } as any);
+
+    const cache1 = new MetricsCache(deps.sessions, deps.metrics, deps.auth, backend, deps.eventBus);
+    await cache1.start();
+
+    const liveMetrics = cache1.getMetrics();
+    expect(liveMetrics.costTrends).toHaveLength(1);
+    expect(liveMetrics.costTrends[0].cost).toBe(0.015);
+    expect(liveMetrics.tokenUsageByModel[0].inputTokens).toBe(1000);
+
+    // Flush (persist)
+    await cache1.flush();
+
+    // Now the session ends and disappears from live list
+    deps.sessionsMap.delete('s-cost-1');
+
+    // Recreate cache from persisted data (simulates server restart)
+    const cache2 = new MetricsCache(deps.sessions, deps.metrics, deps.auth, backend, deps.eventBus);
+    await cache2.start();
+
+    const persistedMetrics = cache2.getMetrics();
+    // Cost and token data should survive
+    expect(persistedMetrics.costTrends).toHaveLength(1);
+    expect(persistedMetrics.costTrends[0].cost).toBeCloseTo(0.015, 4);
+    expect(persistedMetrics.tokenUsageByModel[0].inputTokens).toBe(1000);
+    expect(persistedMetrics.tokenUsageByModel[0].outputTokens).toBe(500);
+  });
+
+  it('does not double-count sessions across recompute cycles (Issue #4149)', async () => {
+    deps.metricsMap.set('s-dup-1', {
+      messages: 5,
+      durationSec: 60,
+      toolCalls: 0,
+      statusChanges: [],
+      approvals: 0,
+      autoApprovals: 0,
+      tokenUsage: {
+        inputTokens: 500,
+        outputTokens: 250,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        estimatedCostUsd: 0.008,
+      },
+    });
+
+    deps.sessionsMap.set('s-dup-1', { id: 's-dup-1', createdAt: '2026-05-24T10:00:00Z', model: 'claude-3.5-sonnet', ownerKeyId: 'key1' } as any);
+
+    const cache = new MetricsCache(deps.sessions, deps.metrics, deps.auth, backend, deps.eventBus);
+    await cache.start();
+
+    // Trigger multiple recomputes — session should only be counted once
+    cache.invalidate();
+    cache.invalidate();
+    cache.invalidate();
+
+    const metrics = cache.getMetrics();
+    expect(metrics.costTrends[0].cost).toBeCloseTo(0.008, 4);
+    expect(metrics.tokenUsageByModel[0].inputTokens).toBe(500);
   });
 });

--- a/src/__tests__/session-counter-consistency-2533.test.ts
+++ b/src/__tests__/session-counter-consistency-2533.test.ts
@@ -129,7 +129,8 @@ describe('Session counter consistency (Issue #2533)', () => {
         totalSessionsCreated: 5,
         totalSessionsFailed: 0,
         totalSessionsInfraFailed: 0,
-        totalSessionsKilled: 0,
+totalSessionsKilled: 0,
+accumulatedSessionIds: [],
         savedAt: Date.now(),
       };
 

--- a/src/services/metrics-cache.ts
+++ b/src/services/metrics-cache.ts
@@ -62,6 +62,8 @@ interface CacheFile {
   totalSessionsFailed: number;
   totalSessionsInfraFailed: number;
   totalSessionsKilled: number;
+  /** Session IDs already accumulated into daily/model/key buckets (Issue #4149). */
+  accumulatedSessionIds: string[];
   savedAt: number;
 }
 
@@ -127,6 +129,8 @@ export class MetricsCache {
   private totalSessionsFailed = 0;
   private totalSessionsInfraFailed = 0;
   private totalSessionsKilled = 0;
+  /** Session IDs already accumulated into daily/model/key buckets (Issue #4149). */
+  private accumulatedSessionIds = new Set<string>();
 
   private dirty = false;
   private unsub: (() => void) | null = null;
@@ -281,24 +285,22 @@ export class MetricsCache {
     this.totalSessionsKilled = global.sessions.killed ?? 0;
   }
 
-  /** Full recomputation from live MetricsCollector + SessionManager. */
+  /** Incremental recomputation — only accumulates sessions not yet tracked (Issue #4149). */
   private recompute(): void {
     const allSessions = this.sessions.listSessions();
     const global = this.metrics.getGlobalMetrics(allSessions.length);
 
-    this.dailyMap.clear();
-    this.modelMap.clear();
-    this.keyUsageMap.clear();
-    this.totalPermissionPrompts = 0;
-    this.totalApprovals = 0;
-    this.totalAutoApprovals = 0;
+    // Lifetime counters always refresh from MetricsCollector (idempotent).
     this.totalSessionsCreated = global.sessions.total_created;
     this.totalSessionsFailed = global.sessions.failed;
     this.totalSessionsInfraFailed = global.sessions.infra_failed ?? 0;
     this.totalSessionsKilled = global.sessions.killed ?? 0;
 
-    for (const session of allSessions) {
+    // Only accumulate sessions not already counted in the persisted cache.
+    const newSessions = allSessions.filter((s) => !this.accumulatedSessionIds.has(s.id));
+    for (const session of newSessions) {
       this.accumulateSession(session);
+      this.accumulatedSessionIds.add(session.id);
     }
 
     this.dirty = false;
@@ -369,12 +371,14 @@ export class MetricsCache {
     this.totalAutoApprovals = data.totalAutoApprovals;
     this.totalSessionsCreated = data.totalSessionsCreated;
     this.totalSessionsFailed = data.totalSessionsFailed;
+    this.accumulatedSessionIds = new Set(data.accumulatedSessionIds ?? []);
     this.dirty = false;
   }
 
   async flush(): Promise<void> {
-    // Recompute before saving so persisted data is accurate
-    this.recompute();
+    // Persist current in-memory state (Issue #4149: do NOT recompute —
+    // that would clear maps and lose historical data from ended sessions).
+    this.refreshLifetimeCounters();
     const data: CacheFile = {
       daily: Object.fromEntries(this.dailyMap),
       models: Object.fromEntries(this.modelMap),
@@ -386,6 +390,7 @@ export class MetricsCache {
       totalSessionsFailed: this.totalSessionsFailed,
       totalSessionsInfraFailed: this.totalSessionsInfraFailed,
       totalSessionsKilled: this.totalSessionsKilled,
+accumulatedSessionIds: [...this.accumulatedSessionIds],
       savedAt: Date.now(),
     };
     await this.backend.save(data);


### PR DESCRIPTION
## Summary

Fixes #4149 — dashboard shows zero cost/tokens/duration despite 245 sessions. Also fixes #4144.

## Root Cause

`recompute()` cleared `dailyMap`/`modelMap`/`keyUsageMap` and rebuilt from only live sessions. Once a session ended (completed/failed/killed), its cost/token data was permanently lost. Worse, `flush()` called `recompute()` before saving, so the persisted cache was always empty.

## Changes

- **Track `accumulatedSessionIds`** in cache file — set of session IDs already counted
- **`recompute()` is now incremental** — only accumulates sessions not in the set, preserving historical data
- **`flush()` no longer calls `recompute()`** — saves current in-memory state (already accurate)
- **`hydrate()` restores `accumulatedSessionIds`** from persisted cache on startup
- **2 new tests**: data survives session end + no double-counting across recomputes

## Impact

**HIGH** — all analytics dashboards show zero metrics. Every deployment is affected.

## Verification

```
tsc --noEmit ✓
npm run build ✓
metrics-cache-2250.test.ts: 22/22 ✓ (2 new tests)
```

Commit: b3d357f3