### PR TITLE
fix: session filter 'All (0)' — add total field to stats (#4153)

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -367,7 +367,7 @@ export async function getSessionStatusCounts(): Promise<SessionStatusCounts> {
   });
 
   const counts: SessionStatusCounts = {
-    all: stats.active,
+    all: stats.total ?? stats.active,
     idle: 0,
     working: 0,
     compacting: 0,

--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -231,6 +231,7 @@ export const SessionStatsSchema: z.ZodType<SessionStats> = z.object({
   totalCreated: z.number(),
   totalCompleted: z.number(),
   totalFailed: z.number(),
+  total: z.number().optional(),
 });
 
 // ── SessionHealth ──────────────────────────────────────────────

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -352,6 +352,8 @@ export interface SessionStats {
   totalCreated: number;
   totalCompleted: number;
   totalFailed: number;
+  /** Total sessions currently in memory (including killed). */
+  total?: number;
 }
 
 /** Issue #754: Bulk-delete request body. */

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -278,6 +278,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       totalCompleted: global.sessions.completed,
       totalFailed: global.sessions.failed,
       totalKilled: global.sessions.killed ?? 0,
+      total: all.length,
     };
   });
 


### PR DESCRIPTION
## Issue
Fixes #4153 — session status filter shows "All (0)" when sessions exist.

## Root Cause
The frontend uses `stats.active` for the "All" filter count. `active` only counts live sessions (not killed/completed/crashed). When all sessions are killed, "All" shows 0.

## Changes
**Backend:** Added `total` field to `/v1/sessions/stats` response — counts all sessions in memory regardless of status.

**Frontend:** Changed `all: stats.active` → `all: stats.total ?? stats.active` for backward compatibility.

**Shared type:** Added `total?: number` to `SessionStats` interface in `api-contracts.ts`.

## Verification
- `tsc --noEmit` — clean
- `npm run build` — success
- Backward compatible: `total` is optional, frontend falls back to `active`