### PR TITLE
fix(dashboard): awaiting_approval status + riskLevel crash batch

### DIFF
--- a/dashboard/src/api/acp-approval-client.ts
+++ b/dashboard/src/api/acp-approval-client.ts
@@ -67,5 +67,7 @@ export async function getPendingApproval(
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`Failed to get pending approval: ${res.status}`);
-  return res.json();
+  const data = await res.json();
+  // Backend returns { pending: AcpApprovalRequest | null }
+  return data?.pending ?? null;
 }

--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -42,7 +42,7 @@ const BOARD_COLUMNS: BoardColumn[] = [
   {
     id: 'waiting',
     title: 'colWaiting',
-    statuses: ['permission_prompt', 'ask_question', 'bash_approval', 'context_warning', 'waiting_for_input'],
+    statuses: ['permission_prompt', 'ask_question', 'bash_approval', 'context_warning', 'waiting_for_input', 'awaiting_approval', 'pending'],
     color: 'text-[var(--color-warning)]',
   },
   {

--- a/dashboard/src/components/session/SessionStateBadge.tsx
+++ b/dashboard/src/components/session/SessionStateBadge.tsx
@@ -68,6 +68,8 @@ export function uiStateToSessionBadgeStatus(
     case 'working': return 'working';
     case 'permission_prompt':
     case 'bash_approval': return 'permission';
+    case 'awaiting_approval':
+    case 'pending':
     case 'ask_question':
     case 'waiting_for_input': return 'waiting';
     case 'error': return 'error';

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -655,6 +655,7 @@ export default function SessionDetailPage() {
             )}
 
             {pendingApproval && (
+              <ErrorBoundary>
               <motion.div
                 initial={{ opacity: 0, y: -20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -671,6 +672,7 @@ export default function SessionDetailPage() {
                   onReject={rejectAcp}
                 />
               </motion.div>
+              </ErrorBoundary>
             )}
 
             <AnimatePresence mode="wait">


### PR DESCRIPTION
## Summary

Batch fix for 3 dashboard bugs from the audit (#4148).

### Closes #4156 — SessionBoard missing awaiting_approval/pending statuses
- `BOARD_COLUMNS` in `SessionBoard.tsx` didn't include `awaiting_approval` or `pending`
- Sessions with these statuses fell into generic "Other" column
- **Fix:** Added to `waiting` column statuses

### Closes #4155 — SessionStateBadge shows Unknown for awaiting_approval
- `uiStateToSessionBadgeStatus()` had no case for `awaiting_approval` → showed "Unknown"
- **Fix:** Added `awaiting_approval` and `pending` cases → maps to `waiting` badge

### Closes #4150 — SessionDetailPage crash (riskLevel undefined)
- `getPendingApproval()` returned `{ pending: null }` (truthy) instead of extracting `.pending`
- Approval modal rendered with undefined `tool` → crash on `riskLevel`
- **Fix:** Extract `data?.pending` from API response + ErrorBoundary around modal

### Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] E2E verify: sessions with `awaiting_approval` status show in correct board column

— Daedalus 🏛️
