### PR TITLE
chore: add AEGIS_DEBUG_TRANSCRIPT logging for JSONL watcher (#4166)

### DIFF
--- a/src/jsonl-watcher.ts
+++ b/src/jsonl-watcher.ts
@@ -249,6 +249,7 @@ export class JsonlWatcher {
 
     try {
       const previousOffset = entry.offset;
+      if (process.env.AEGIS_DEBUG_TRANSCRIPT) console.error(`[WATCHER-DEBUG] readAndEmit: sessionId=${entry.sessionId} path=${entry.jsonlPath} offset=${previousOffset}`);
       const result = await readNewEntries(entry.jsonlPath, previousOffset);
       entry.offset = result.newOffset;
 
@@ -265,12 +266,13 @@ export class JsonlWatcher {
           tokenUsageDelta: extractTokenDelta(result.raw),
         };
 
+        if (process.env.AEGIS_DEBUG_TRANSCRIPT) console.error(`[WATCHER-DEBUG] emitting ${result.entries.length} entries for session ${entry.sessionId}. newOffset=${result.newOffset} truncated=${truncated}`);
         for (const listener of this.listeners) {
           listener(event);
         }
       }
-    } catch {
-      // File may be temporarily unavailable — ignore
+    } catch (err) {
+      console.error(`[WATCHER-ERROR] readAndEmit FAILED for session ${entry.sessionId}:`, err);
     }
   }
 }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -255,6 +255,7 @@ export async function readNewEntries(
     }
 
     if (fromOffset >= fileStat.size) {
+      if (process.env.AEGIS_DEBUG_TRANSCRIPT) console.error(`[TRANSCRIPT-DEBUG] readNewEntries: no new data. path=${filePath} offset=${fromOffset} size=${fileStat.size}`);
       return { entries: [], newOffset: fromOffset, raw: [] };
     }
 
@@ -308,6 +309,7 @@ export async function readNewEntries(
     }
 
     const parsed = parseEntries(rawEntries, preserveFullText);
+    if (process.env.AEGIS_DEBUG_TRANSCRIPT) console.error(`[TRANSCRIPT-DEBUG] readNewEntries: read ${rawEntries.length} raw entries, ${parsed.length} parsed. path=${filePath} fromOffset=${fromOffset} effectiveOffset=${effectiveOffset} readEnd=${readEnd} fileSize=${fileStat.size}`);
     return { entries: parsed, newOffset: readEnd, raw: rawEntries };
   } finally {
     await fd.close();


### PR DESCRIPTION
## Summary

Add conditional debug logging to help diagnose intermittent CC session stalling (#4166).

### What changed
- `src/transcript.ts` — `readNewEntries()`: log offset advancement, raw vs parsed counts, file sizes
- `src/jsonl-watcher.ts` — `readAndEmit()`: log watcher events, entries emitted, truncation detection
- `src/jsonl-watcher.ts` — catch block: always log errors (was previously silent `catch {}`)

### How to use
Set `AEGIS_DEBUG_TRANSCRIPT=1` environment variable when starting Aegis to enable. Zero overhead when disabled.

### Testing
- `tsc --noEmit` ✅
- `npm run build` ✅
- 8 test sessions with debug logging enabled — all completed, logs show correct offset advancement

Refs: #4166