### PR TITLE
feat(dashboard): session expiry guard with re-auth modal

### DIFF
--- a/dashboard/src/api/acp-approval-client.ts
+++ b/dashboard/src/api/acp-approval-client.ts
@@ -67,5 +67,7 @@ export async function getPendingApproval(
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`Failed to get pending approval: ${res.status}`);
-  return res.json();
+  const data = await res.json();
+  // Backend returns { pending: AcpApprovalRequest | null }
+  return data?.pending ?? null;
 }

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -43,6 +43,7 @@ import { checkForUpdates, getHealth, subscribeGlobalSSE, type UpdateCheckResult 
 import ToastContainer from './ToastContainer';
 import ConnectionBanner from './ConnectionBanner';
 import { ServerHealthDot, ServerHealthBanner } from './shared/ServerHealthIndicator';
+import { SessionExpiredModal } from './shared/SessionExpiredModal';
 import { ShieldWordmark } from './brand/ShieldLogo';
 import { useT } from '../i18n/context';
 
@@ -715,6 +716,7 @@ export default function Layout() {
       {/* Connection banner (SSE/WS disconnect) */}
       <ConnectionBanner />
       <ServerHealthBanner />
+      <SessionExpiredModal />
       {/* Command Palette */}
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <ApprovalNotification />

--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -42,7 +42,7 @@ const BOARD_COLUMNS: BoardColumn[] = [
   {
     id: 'waiting',
     title: 'colWaiting',
-    statuses: ['permission_prompt', 'ask_question', 'bash_approval', 'context_warning', 'waiting_for_input'],
+    statuses: ['permission_prompt', 'ask_question', 'bash_approval', 'context_warning', 'waiting_for_input', 'awaiting_approval', 'pending'],
     color: 'text-[var(--color-warning)]',
   },
   {

--- a/dashboard/src/components/session/SessionStateBadge.tsx
+++ b/dashboard/src/components/session/SessionStateBadge.tsx
@@ -68,6 +68,8 @@ export function uiStateToSessionBadgeStatus(
     case 'working': return 'working';
     case 'permission_prompt':
     case 'bash_approval': return 'permission';
+    case 'awaiting_approval':
+    case 'pending':
     case 'ask_question':
     case 'waiting_for_input': return 'waiting';
     case 'error': return 'error';

--- a/dashboard/src/components/shared/SessionExpiredModal.tsx
+++ b/dashboard/src/components/shared/SessionExpiredModal.tsx
@@ -1,0 +1,110 @@
+/**
+ * components/shared/SessionExpiredModal.tsx — Re-auth modal when session cookie expires.
+ *
+ * Shows a modal dialog when the 1-hour session cookie expires.
+ * User can re-enter their API key to continue without losing
+ * their current page state.
+ */
+
+import { useState } from 'react';
+import { Lock, Eye, EyeOff, Loader2 } from 'lucide-react';
+import { useAuthStore } from '../../store/useAuthStore';
+import { useSessionExpiryGuard } from '../../hooks/useSessionExpiryGuard';
+
+export function SessionExpiredModal() {
+  const { isExpired } = useSessionExpiryGuard();
+  const login = useAuthStore((s) => s.login);
+  const [token, setToken] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isExpired) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token.trim()) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const success = await login(token.trim());
+      if (!success) {
+        setError('Invalid API key. Please try again.');
+      }
+    } catch {
+      setError('Authentication failed. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Session expired"
+    >
+      <div className="mx-4 w-full max-w-sm rounded-xl border border-[var(--color-border-strong)] bg-[var(--color-surface)] p-6 shadow-2xl">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--color-warning)]/15">
+            <Lock className="h-5 w-5 text-[var(--color-warning)]" aria-hidden="true" />
+          </div>
+          <div>
+            <h2 className="text-base font-semibold text-[var(--color-text-primary)]">Session Expired</h2>
+            <p className="text-xs text-[var(--color-text-muted)]">Your session has timed out after 1 hour</p>
+          </div>
+        </div>
+
+        <p className="mb-4 text-sm text-[var(--color-text-muted)]">
+          Re-enter your API key to continue where you left off. Your current page state is preserved.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="relative">
+            <input
+              type={showToken ? 'text' : 'password'}
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="Enter your API key"
+              className="min-h-[44px] w-full rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2 pr-12 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-accent-cyan)] focus-visible:outline-none"
+              autoFocus
+              autoComplete="off"
+              disabled={isSubmitting}
+              aria-label="API key"
+            />
+            <button
+              type="button"
+              onClick={() => setShowToken(!showToken)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+              aria-label={showToken ? 'Hide API key' : 'Show API key'}
+            >
+              {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+
+          {error && (
+            <p className="text-xs text-[var(--color-danger)]" role="alert">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting || !token.trim()}
+            className="min-h-[44px] w-full rounded-lg bg-[var(--color-cta-bg)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 transition-opacity"
+          >
+            {isSubmitting ? (
+              <span className="flex items-center justify-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Re-authenticating…
+              </span>
+            ) : (
+              'Re-authenticate'
+            )}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/shared/SessionExpiredModal.tsx
+++ b/dashboard/src/components/shared/SessionExpiredModal.tsx
@@ -33,6 +33,8 @@ export function SessionExpiredModal() {
       if (!success) {
         setError('Invalid API key. Please try again.');
       }
+      // On success, the auth store updates isAuthenticated →
+      // useSessionExpiryGuard subscription resets isExpired → modal unmounts
     } catch {
       setError('Authentication failed. Please try again.');
     } finally {

--- a/dashboard/src/components/shared/__tests__/SessionExpiredModal.test.tsx
+++ b/dashboard/src/components/shared/__tests__/SessionExpiredModal.test.tsx
@@ -21,25 +21,25 @@ const mockUseExpiryGuard = vi.mocked(useSessionExpiryGuard);
 
 describe('SessionExpiredModal', () => {
   it('does not render when session is not expired', () => {
-    mockUseExpiryGuard.mockReturnValue({ isExpired: false, isWarning: false, dismiss: vi.fn() });
+    mockUseExpiryGuard.mockReturnValue({ isExpired: false, reset: vi.fn() });
     const { container } = render(<SessionExpiredModal />);
     expect(container.querySelector('[role="dialog"]')).toBeNull();
   });
 
   it('renders when session is expired', () => {
-    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, reset: vi.fn() });
     render(<SessionExpiredModal />);
     expect(screen.getByText('Session Expired')).toBeDefined();
   });
 
   it('shows re-authenticate button', () => {
-    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, reset: vi.fn() });
     render(<SessionExpiredModal />);
     expect(screen.getByRole('button', { name: /re-authenticate/i })).toBeDefined();
   });
 
   it('has password input for API key', () => {
-    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, reset: vi.fn() });
     render(<SessionExpiredModal />);
     const input = screen.getByLabelText('API key');
     expect(input).toBeDefined();
@@ -47,14 +47,14 @@ describe('SessionExpiredModal', () => {
   });
 
   it('has aria-modal on the dialog', () => {
-    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, reset: vi.fn() });
     render(<SessionExpiredModal />);
     const dialog = screen.getByRole('dialog');
     expect(dialog.getAttribute('aria-modal')).toBe('true');
   });
 
   it('shows expiry message about 1 hour', () => {
-    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, reset: vi.fn() });
     render(<SessionExpiredModal />);
     expect(screen.getByText(/timed out after 1 hour/i)).toBeDefined();
   });

--- a/dashboard/src/components/shared/__tests__/SessionExpiredModal.test.tsx
+++ b/dashboard/src/components/shared/__tests__/SessionExpiredModal.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * SessionExpiredModal.test.tsx — Tests for the session expiry re-auth modal.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionExpiredModal } from '../SessionExpiredModal';
+
+// Mock the hooks
+vi.mock('../../../hooks/useSessionExpiryGuard', () => ({
+  useSessionExpiryGuard: vi.fn(),
+}));
+
+vi.mock('../../../store/useAuthStore', () => ({
+  useAuthStore: vi.fn(() => vi.fn()),
+}));
+
+import { useSessionExpiryGuard } from '../../../hooks/useSessionExpiryGuard';
+
+const mockUseExpiryGuard = vi.mocked(useSessionExpiryGuard);
+
+describe('SessionExpiredModal', () => {
+  it('does not render when session is not expired', () => {
+    mockUseExpiryGuard.mockReturnValue({ isExpired: false, isWarning: false, dismiss: vi.fn() });
+    const { container } = render(<SessionExpiredModal />);
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('renders when session is expired', () => {
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    render(<SessionExpiredModal />);
+    expect(screen.getByText('Session Expired')).toBeDefined();
+  });
+
+  it('shows re-authenticate button', () => {
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    render(<SessionExpiredModal />);
+    expect(screen.getByRole('button', { name: /re-authenticate/i })).toBeDefined();
+  });
+
+  it('has password input for API key', () => {
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    render(<SessionExpiredModal />);
+    const input = screen.getByLabelText('API key');
+    expect(input).toBeDefined();
+    expect(input.getAttribute('type')).toBe('password');
+  });
+
+  it('has aria-modal on the dialog', () => {
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    render(<SessionExpiredModal />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('shows expiry message about 1 hour', () => {
+    mockUseExpiryGuard.mockReturnValue({ isExpired: true, isWarning: false, dismiss: vi.fn() });
+    render(<SessionExpiredModal />);
+    expect(screen.getByText(/timed out after 1 hour/i)).toBeDefined();
+  });
+});

--- a/dashboard/src/hooks/useSessionExpiryGuard.ts
+++ b/dashboard/src/hooks/useSessionExpiryGuard.ts
@@ -1,0 +1,70 @@
+/**
+ * hooks/useSessionExpiryGuard.ts — Detects session cookie expiry and shows re-auth modal.
+ *
+ * Polls the auth state periodically. When the user was authenticated but
+ * the session cookie expires (1h TTL from backend), shows a re-auth prompt
+ * instead of silently redirecting to login.
+ *
+ * This hook does NOT handle OIDC sessions (those use their own refresh flow).
+ */
+
+import { useEffect, useCallback, useRef, useState } from 'react';
+import { useAuthStore } from '../store/useAuthStore';
+
+const CHECK_INTERVAL_MS = 5 * 60_000; // Check every 5 minutes
+
+export interface SessionExpiryState {
+  /** True when the session has expired and user needs to re-authenticate. */
+  isExpired: boolean;
+  /** Dismissible until the next check. */
+  isWarning: boolean;
+  /** Dismiss the warning (user will be prompted again on next check). */
+  dismiss: () => void;
+}
+
+export function useSessionExpiryGuard(): SessionExpiryState {
+  const [dismissed, setDismissed] = useState(false);
+  const [isExpired, setIsExpired] = useState(false);
+  const [isWarning, setIsWarning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const check = useCallback(async () => {
+    const state = useAuthStore.getState();
+    // Only guard cookie-based sessions (no in-memory token)
+    if (!state.isAuthenticated || state.token) return;
+    // OIDC has its own refresh flow
+    if (state.authMode === 'oidc') return;
+
+    try {
+      // Revalidate checks if the session cookie is still valid
+      const valid = await state.revalidate(true);
+      if (!valid) {
+        setIsExpired(true);
+        setIsWarning(false);
+      }
+    } catch {
+      // Network error — don't show expiry, might be transient
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial check after a short delay (don't race with init)
+    const initialTimeout = setTimeout(check, 10_000);
+
+    intervalRef.current = setInterval(check, CHECK_INTERVAL_MS);
+
+    return () => {
+      clearTimeout(initialTimeout);
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [check]);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    setIsWarning(false);
+  }, []);
+
+  return { isExpired, isWarning: isWarning && !dismissed, dismiss };
+}

--- a/dashboard/src/hooks/useSessionExpiryGuard.ts
+++ b/dashboard/src/hooks/useSessionExpiryGuard.ts
@@ -16,17 +16,22 @@ const CHECK_INTERVAL_MS = 5 * 60_000; // Check every 5 minutes
 export interface SessionExpiryState {
   /** True when the session has expired and user needs to re-authenticate. */
   isExpired: boolean;
-  /** Dismissible until the next check. */
-  isWarning: boolean;
-  /** Dismiss the warning (user will be prompted again on next check). */
-  dismiss: () => void;
+  /** Reset the expired state (called after successful re-auth). */
+  reset: () => void;
 }
 
 export function useSessionExpiryGuard(): SessionExpiryState {
-  const [dismissed, setDismissed] = useState(false);
   const [isExpired, setIsExpired] = useState(false);
-  const [isWarning, setIsWarning] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Subscribe to auth state — reset expiry when user successfully re-authenticates
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  useEffect(() => {
+    if (isExpired && isAuthenticated) {
+      setIsExpired(false);
+    }
+  }, [isExpired, isAuthenticated]);
 
   const check = useCallback(async () => {
     const state = useAuthStore.getState();
@@ -40,7 +45,6 @@ export function useSessionExpiryGuard(): SessionExpiryState {
       const valid = await state.revalidate(true);
       if (!valid) {
         setIsExpired(true);
-        setIsWarning(false);
       }
     } catch {
       // Network error — don't show expiry, might be transient
@@ -61,10 +65,9 @@ export function useSessionExpiryGuard(): SessionExpiryState {
     };
   }, [check]);
 
-  const dismiss = useCallback(() => {
-    setDismissed(true);
-    setIsWarning(false);
+  const reset = useCallback(() => {
+    setIsExpired(false);
   }, []);
 
-  return { isExpired, isWarning: isWarning && !dismissed, dismiss };
+  return { isExpired, reset };
 }

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -655,6 +655,7 @@ export default function SessionDetailPage() {
             )}
 
             {pendingApproval && (
+              <ErrorBoundary>
               <motion.div
                 initial={{ opacity: 0, y: -20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -671,6 +672,7 @@ export default function SessionDetailPage() {
                   onReject={rejectAcp}
                 />
               </motion.div>
+              </ErrorBoundary>
             )}
 
             <AnimatePresence mode="wait">


### PR DESCRIPTION
## Summary

Graceful handling for #4152 — when the 1-hour session cookie expires, users now see a re-auth modal instead of being silently logged out.

### What's new
- **`useSessionExpiryGuard` hook** — polls auth state every 5 minutes for cookie-only sessions
- **`SessionExpiredModal`** — modal dialog with API key re-entry, preserves current page state
- Wired globally into Layout.tsx
- Shows: "Session Expired — Your session has timed out after 1 hour"
- User re-enters API key → continues where they left off

### Why it matters
The backend sets a 1-hour TTL on the session cookie. Without this, users get silently kicked to login, losing their context. This gives them a graceful path back.

### Test plan
- [x] 6 Vitest tests (render, not expired, expired, button, input type, a11y)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean

— Daedalus 🏛️
