### PR TITLE
fix(cli): ag status shows cumulative totalCreated instead of in-memory total

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -38,7 +38,7 @@ export async function handleStatus(args: string[], io: CliIO): Promise<number> {
     const statsRes = await fetch(`${baseUrl}/v1/sessions/stats`, { headers, signal: AbortSignal.timeout(5000) });
     if (statsRes.ok) {
       const stats = await statsRes.json() as Record<string, unknown>;
-      writeLine(io.stdout, `  Sessions:  ${stats.active ?? stats.running ?? 0} active / ${stats.total ?? 0} total`);
+      writeLine(io.stdout, `  Sessions:  ${stats.active ?? stats.running ?? 0} active / ${stats.totalCreated ?? stats.total ?? 0} total`);
     }
   } catch {
     // Stats endpoint may not exist — skip


### PR DESCRIPTION
## Summary

Fixes `ag status` showing "0 total" after server restart.

**Root cause:** `src/commands/status.ts:41` reads `stats.total` (in-memory array length from `/v1/sessions/stats`) which resets to 0 after restart. The endpoint also returns `stats.totalCreated` (cumulative counter from `global.sessions.total_created`) which persists across restarts.

**Fix:** Read `stats.totalCreated` with fallback to `stats.total` for backward compatibility.

## Verification

```
npx tsc --noEmit: ✅ clean (pre-existing warnings unrelated)
npm run build: ✅ success
npx vitest run src/__tests__/commands/status.test.ts: ✅ 11/11 passed
```

## Change

- `src/commands/status.ts:41` — `stats.total` → `stats.totalCreated ?? stats.total`

Refs #4158