### PR TITLE
refactor(logger): migrate session.ts, hooks.ts, permission-guard.ts to StructuredLogger

### DIFF
--- a/src/__tests__/fix-3713-state-persistence-errors.test.ts
+++ b/src/__tests__/fix-3713-state-persistence-errors.test.ts
@@ -11,6 +11,7 @@
  * 7. doSave() with store backend failure
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setStructuredLogSink } from '../logger.js';
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -33,19 +34,20 @@ function createSM(stateDir: string, store?: any): SessionManager {
 
 describe('Issue #3713 — session.ts state persistence error branches', () => {
   let tmpDir: string;
-  let _consoleWarnSpy: any;
-  let consoleErrorSpy: any;
-  let consoleLogSpy: any;
+  let capturedLogs: Array<{ level: string; operation: string; [k: string]: any }>;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'aegis-state-test-'));
-    _consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    capturedLogs = [];
+    setStructuredLogSink({
+      info: (r) => { capturedLogs.push({ ...r, level: 'info' }); },
+      warn: (r) => { capturedLogs.push({ ...r, level: 'warn' }); },
+      error: (r) => { capturedLogs.push({ ...r, level: 'error' }); },
+    });
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    setStructuredLogSink({ info: () => {}, warn: () => {}, error: () => {} });
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -118,7 +120,7 @@ describe('Issue #3713 — session.ts state persistence error branches', () => {
       const sessions = (sm as any).state.sessions;
       expect(Object.keys(sessions)).toHaveLength(1);
       expect(sessions['sess-1'].displayName).toBe('backup-session');
-      expect(consoleLogSpy).toHaveBeenCalledWith('Restored state from backup');
+      expect(capturedLogs.some(r => r.level === 'info' && r.operation === 'stateRestoredFromBackup')).toBe(true);
     });
 
     it('starts empty when both primary and backup are corrupted', async () => {
@@ -237,7 +239,7 @@ describe('Issue #3713 — session.ts state persistence error branches', () => {
       await sm.load();
       await sm.save();
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith('State save error:', expect.any(Error));
+      expect(capturedLogs.some(r => r.level === 'error' && r.operation === 'stateSaveFailed')).toBe(true);
     });
   });
 
@@ -258,7 +260,7 @@ describe('Issue #3713 — session.ts state persistence error branches', () => {
       await vi.advanceTimersByTimeAsync(10_000);
 
       // save() catches internally and logs 'State save error:' — the debounced catch never fires
-      expect(consoleErrorSpy).toHaveBeenCalledWith('State save error:', expect.anything());
+      expect(capturedLogs.some(r => r.level === 'error' && r.operation === 'stateSaveFailed')).toBe(true);
 
       vi.useRealTimers();
     });

--- a/src/__tests__/hooks-coverage-1305.test.ts
+++ b/src/__tests__/hooks-coverage-1305.test.ts
@@ -15,12 +15,26 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setStructuredLogSink, type StructuredLogRecord } from '../logger.js';
 import Fastify from 'fastify';
 import { registerHookRoutes } from '../hooks.js';
 import { SessionEventBus } from '../events.js';
 import type { SessionManager, SessionInfo, PermissionDecision } from '../session.js';
 import type { UIState } from '../api-contracts.js';
 import type { MetricsCollector } from '../metrics.js';
+
+
+
+/** Capture structured log records for assertion. */
+function captureLogs(): { records: StructuredLogRecord[]; stop: () => void } {
+  const records: StructuredLogRecord[] = [];
+  setStructuredLogSink({
+    info: (r) => { records.push(r); },
+    warn: (r) => { records.push(r); },
+    error: (r) => { records.push(r); },
+  });
+  return { records, stop: () => setStructuredLogSink({ info: () => {}, warn: () => {}, error: () => {} }) };
+}
 
 function flushAsync(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve));
@@ -251,7 +265,7 @@ describe('Issue #1305: hooks.ts additional coverage', () => {
     });
 
     it('should log PermissionDenied as informational event', async () => {
-      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const { records, stop } = captureLogs();
 
       await app.inject({
         method: 'POST',
@@ -259,8 +273,9 @@ describe('Issue #1305: hooks.ts additional coverage', () => {
         payload: { tool_name: 'Bash' },
       });
 
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('PermissionDenied'));
-      logSpy.mockRestore();
+      const infoRecords = records.filter(r => r.level === 'info' && r.operation === 'informationalEvent');
+      expect(infoRecords.some(r => r.attributes?.eventName === 'PermissionDenied')).toBe(true);
+      stop();
     });
   });
 
@@ -612,7 +627,7 @@ describe('Issue #1305: hooks.ts additional coverage', () => {
       const app2 = Fastify({ logger: false });
       registerHookRoutes(app2, { sessions: mgr, eventBus });
 
-      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const { records, stop } = captureLogs();
 
       const res = await app2.inject({
         method: 'POST',
@@ -621,9 +636,10 @@ describe('Issue #1305: hooks.ts additional coverage', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('WorktreeRemove'));
+      const infoRecords = records.filter(r => r.level === 'info' && r.operation === 'worktreeEvent');
+      expect(infoRecords.some(r => r.attributes?.eventName === 'WorktreeRemove')).toBe(true);
 
-      logSpy.mockRestore();
+      stop();
       await app2.close();
     });
 
@@ -995,7 +1011,7 @@ describe('Issue #1305: hooks.ts additional coverage', () => {
       const app2 = Fastify({ logger: false });
       registerHookRoutes(app2, { sessions: mgr, eventBus });
 
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { records, stop } = captureLogs();
 
       const res = await app2.inject({
         method: 'POST',
@@ -1004,11 +1020,10 @@ describe('Issue #1305: hooks.ts additional coverage', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('invalid permission_mode "totally_invalid"'),
-      );
+      const warnRecords = records.filter(r => r.level === 'warn' && r.operation === 'invalidPermissionMode');
+      expect(warnRecords.some(r => r.attributes?.rawMode === 'totally_invalid')).toBe(true);
 
-      warnSpy.mockRestore();
+      stop();
       await app2.close();
     });
   });

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -6,12 +6,29 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setStructuredLogSink, type StructuredLogRecord } from '../logger.js';
 import Fastify from 'fastify';
 import { registerHookRoutes } from '../hooks.js';
 import { SessionEventBus } from '../events.js';
 import type { SessionManager } from '../session.js';
 import type { SessionInfo } from '../session.js';
 import type { UIState } from '../session.js';
+
+
+
+/** Capture structured log records for assertion. */
+function captureLogs(): { records: StructuredLogRecord[]; stop: () => void } {
+  const records: StructuredLogRecord[] = [];
+  const start = (): void => {
+    setStructuredLogSink({
+      info: (r) => { records.push(r); },
+      warn: (r) => { records.push(r); },
+      error: (r) => { records.push(r); },
+    });
+  };
+  start();
+  return { records, stop: () => setStructuredLogSink({ info: () => {}, warn: () => {}, error: () => {} }) };
+}
 
 /** Flush all pending setImmediate callbacks. */
 function flushAsync(): Promise<void> {
@@ -638,7 +655,7 @@ describe('Hook-driven status detection (Issue #169 Phase 3)', () => {
 
   it('Notification hook should be logged', async () => {
     setupWithSession('working');
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { records, stop } = captureLogs();
 
     await app.inject({
       method: 'POST',
@@ -646,14 +663,16 @@ describe('Hook-driven status detection (Issue #169 Phase 3)', () => {
       payload: { message: 'Build complete' },
     });
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Notification'));
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(session.id));
-    logSpy.mockRestore();
+    const infoRecords = records.filter(r => r.level === 'info');
+    expect(infoRecords.length).toBeGreaterThanOrEqual(1);
+    expect(infoRecords.some(r => r.operation === 'informationalEvent' && r.attributes?.eventName === 'Notification')).toBe(true);
+    expect(infoRecords.some(r => r.sessionId === session.id)).toBe(true);
+    stop();
   });
 
   it('FileChanged hook should be logged', async () => {
     setupWithSession('working');
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { records, stop } = captureLogs();
 
     await app.inject({
       method: 'POST',
@@ -661,13 +680,14 @@ describe('Hook-driven status detection (Issue #169 Phase 3)', () => {
       payload: { path: '/tmp/test/file.ts' },
     });
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('FileChanged'));
-    logSpy.mockRestore();
+    const infoRecords = records.filter(r => r.level === 'info');
+    expect(infoRecords.some(r => r.operation === 'informationalEvent' && r.attributes?.eventName === 'FileChanged')).toBe(true);
+    stop();
   });
 
   it('CwdChanged hook should be logged', async () => {
     setupWithSession('working');
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { records, stop } = captureLogs();
 
     await app.inject({
       method: 'POST',
@@ -675,8 +695,9 @@ describe('Hook-driven status detection (Issue #169 Phase 3)', () => {
       payload: { cwd: '/tmp/test/subdir' },
     });
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('CwdChanged'));
-    logSpy.mockRestore();
+    const infoRecords = records.filter(r => r.level === 'info');
+    expect(infoRecords.some(r => r.operation === 'informationalEvent' && r.attributes?.eventName === 'CwdChanged')).toBe(true);
+    stop();
   });
 });
 
@@ -708,7 +729,7 @@ describe('Hook validation (Issue #89)', () => {
     });
 
     it('should fallback to "default" for invalid permission_mode', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { records, stop } = captureLogs();
       const res = await app.inject({
         method: 'POST',
         url: `/v1/hooks/PermissionRequest?sessionId=${session.id}`,
@@ -716,10 +737,10 @@ describe('Hook validation (Issue #89)', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('invalid permission_mode "invalid_mode"'),
-      );
-      warnSpy.mockRestore();
+      const warnRecords = records.filter(r => r.level === 'warn' && r.operation === 'invalidPermissionMode');
+      expect(warnRecords.length).toBeGreaterThanOrEqual(1);
+      expect(warnRecords[0].attributes?.rawMode).toBe('invalid_mode');
+      stop();
     });
 
     it('should not warn when permission_mode is absent', async () => {
@@ -809,7 +830,7 @@ describe('Hook validation (Issue #89)', () => {
     });
 
     it('should log worktree hook events', async () => {
-      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const { records, stop } = captureLogs();
 
       await app.inject({
         method: 'POST',
@@ -817,9 +838,11 @@ describe('Hook validation (Issue #89)', () => {
         payload: { worktree_path: '/tmp/test-wt' },
       });
 
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('WorktreeCreate'));
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(session.id));
-      logSpy.mockRestore();
+      const infoRecords = records.filter(r => r.level === 'info' && r.operation === 'worktreeEvent');
+      expect(infoRecords.length).toBeGreaterThanOrEqual(1);
+      expect(infoRecords[0].attributes?.eventName).toBe('WorktreeCreate');
+      expect(infoRecords[0].sessionId).toBe(session.id);
+      stop();
     });
   });
 

--- a/src/__tests__/security-629-630-634.test.ts
+++ b/src/__tests__/security-629-630-634.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setStructuredLogSink } from '../logger.js';
 import Fastify from 'fastify';
 import { registerHookRoutes } from '../hooks.js';
 import { SessionEventBus } from '../events.js';
@@ -77,14 +78,16 @@ describe('Issue #629: Hook endpoint secret validation', () => {
   });
 
   it('should accept hook with valid session ID and correct secret in query param (backward compat)', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const capturedWarns: any[] = [];
+    setStructuredLogSink({ info: () => {}, warn: (r) => { capturedWarns.push(r); }, error: () => {} });
     const res = await app.inject({
       method: 'POST',
       url: `/v1/hooks/Stop?sessionId=${VALID_SESSION_ID}&secret=${VALID_SECRET}`,
       payload: {},
     });
     expect(res.statusCode).toBe(200);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('query-string hook secret is deprecated'));
+    expect(capturedWarns.some(r => r.operation === 'deprecatedQuerySecret')).toBe(true);
+    setStructuredLogSink({ info: () => {}, warn: () => {}, error: () => {} });
   });
 
   it('should reject query-param hook secret in header-only mode', async () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -29,6 +29,8 @@ import { evaluatePermissionProfile } from './services/permission/index.js';
 import { timingSafeStringEqual } from './crypto-utils.js';
 import { startToolSpan, setToolResult, spanOk as tracingSpanOk, spanError as tracingSpanError } from './tracing.js';
 import type { Span } from '@opentelemetry/api';
+import { StructuredLogger } from './logger.js';
+const log = new StructuredLogger();
 
 /** CC hook events that require a decision response. */
 
@@ -230,7 +232,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
       return reply.status(401).send({ error: 'Unauthorized — hook secret must be sent via X-Hook-Secret header' });
     }
     if (!deps.hookSecretHeaderOnly && hasQueryHookSecret) {
-      console.warn(`Hooks: query-string hook secret is deprecated (session ${sessionId}, event ${eventName}); use X-Hook-Secret header`);
+      log.warn({ component: 'hooks', operation: 'deprecatedQuerySecret', sessionId, attributes: { eventName } });
     }
     const hookSecret = headerHookSecret || queryHookSecret;
     if (session.hookSecret && !timingSafeStringEqual(hookSecret, session.hookSecret)) {
@@ -280,12 +282,12 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
 
     // Issue #89 L26: WorktreeCreate/Remove hooks — informational tracking only
     if (eventName === 'WorktreeCreate' || eventName === 'WorktreeRemove') {
-      console.log(`Hooks: ${eventName} for session ${sessionId}`);
+      log.info({ component: 'hooks', operation: 'worktreeEvent', sessionId, attributes: { eventName } });
     }
 
     // Informational events — log and forward to SSE (already forwarded below via emitHook)
     if (INFORMATIONAL_EVENTS.has(eventName)) {
-      console.log(`Hooks: ${eventName} for session ${sessionId}`);
+      log.info({ component: 'hooks', operation: 'informationalEvent', sessionId, attributes: { eventName } });
     }
 
     // PreCompact/PostCompact — update activity timestamp
@@ -297,7 +299,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
     const HOOK_PAYLOAD_WARN_BYTES = 1536;
     const payloadSize = JSON.stringify(req.body ?? {}).length;
     if (payloadSize > HOOK_PAYLOAD_WARN_BYTES) {
-      console.warn(`Hooks: ${eventName} payload for session ${sessionId.slice(0, 8)} is ${payloadSize} bytes (${(payloadSize / 1024).toFixed(1)} KB) — exceeds ${HOOK_PAYLOAD_WARN_BYTES} byte warning threshold. CC may truncate SessionStart content >2KB (upstream #55750).`);
+      log.warn({ component: 'hooks', operation: 'payloadSizeExceeded', sessionId, attributes: { eventName, payloadSize, thresholdBytes: HOOK_PAYLOAD_WARN_BYTES } });
       deps.eventBus.emit(sessionId, {
         event: 'system',
         sessionId,
@@ -315,7 +317,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
     if (eventName === 'StopFailure') {
       deps.sessions.recordHookFailure(sessionId);
       if (deps.sessions.checkHookCircuitBreaker(sessionId, HOOK_CIRCUIT_BREAKER_MAX, HOOK_CIRCUIT_BREAKER_WINDOW_MS)) {
-        console.warn(`Hooks: circuit breaker tripped for session ${sessionId} — ${HOOK_CIRCUIT_BREAKER_MAX} StopFailure events in ${HOOK_CIRCUIT_BREAKER_WINDOW_MS}ms, returning ok:true to break CC retry loop`);
+        log.warn({ component: 'hooks', operation: 'circuitBreakerTripped', sessionId, attributes: { maxFailures: HOOK_CIRCUIT_BREAKER_MAX, windowMs: HOOK_CIRCUIT_BREAKER_WINDOW_MS } });
         deps.eventBus.emit(sessionId, {
           event: 'circuit_breaker',
           sessionId,
@@ -341,7 +343,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
     if (eventName === 'PermissionRequest') {
       const rawMode = hookBody.permission_mode;
       if (rawMode !== undefined && !VALID_PERMISSION_MODES.has(rawMode)) {
-        console.warn(`Hooks: invalid permission_mode "${rawMode}" from PermissionRequest, using "default"`);
+        log.warn({ component: 'hooks', operation: 'invalidPermissionMode', sessionId, attributes: { rawMode } });
         hookBody.permission_mode = 'default';
       }
     }
@@ -474,12 +476,12 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
             data: { status: 'ask_question', questionId: toolUseId, question: questionText },
           });
 
-          console.log(`Hooks: AskUserQuestion for session ${sessionId} — waiting for answer (timeout: ${ANSWER_TIMEOUT_MS}ms)`);
+          log.info({ component: 'hooks', operation: 'askUserQuestionWaiting', sessionId, attributes: { timeoutMs: ANSWER_TIMEOUT_MS } });
 
           const answer = await deps.sessions.waitForAnswer(sessionId, toolUseId, questionText, ANSWER_TIMEOUT_MS);
 
           if (answer !== null) {
-            console.log(`Hooks: AskUserQuestion answered for session ${sessionId}`);
+            log.info({ component: 'hooks', operation: 'askUserQuestionAnswered', sessionId });
             return reply.status(200).send({
               hookSpecificOutput: {
                 hookEventName: 'PreToolUse',
@@ -490,7 +492,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
           }
 
           // Timeout: allow without answer (CC shows question to user in terminal)
-          console.log(`Hooks: AskUserQuestion timeout for session ${sessionId} — allowing without answer`);
+          log.info({ component: 'hooks', operation: 'askUserQuestionTimeout', sessionId });
         }
 
         if (session.permissionProfile) {
@@ -538,7 +540,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
         if (toolName === 'Edit' && hookBody.tool_input?.new_string) {
           const deduplicated = deduplicateConsecutiveLines(hookBody.tool_input.new_string as string);
           if (deduplicated !== null) {
-            console.log(`Hooks: deduplicated Edit new_string for session ${sessionId} (CC bug #32891 workaround)`);
+            log.info({ component: 'hooks', operation: 'deduplicatedEditNewString', sessionId });
             return reply.status(200).send({
               hookSpecificOutput: {
                 hookEventName: 'PreToolUse',
@@ -566,7 +568,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
         // Auto-approve modes respond immediately; others wait for client.
         const permMode = session.permissionMode || 'default';
         if (AUTO_APPROVE_MODES.has(permMode)) {
-          console.log(`Hooks: auto-approving PermissionRequest for session ${sessionId} (mode: ${permMode})`);
+          log.info({ component: 'hooks', operation: 'autoApprovePermission', sessionId, attributes: { permissionMode: permMode } });
           return reply.status(200).send({
             hookSpecificOutput: {
               hookEventName: 'PermissionRequest',
@@ -577,7 +579,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
 
         // Non-auto-approve: wait for client to approve/reject via API.
         // Store pending permission and block until resolved or timeout.
-        console.log(`Hooks: waiting for client permission decision for session ${sessionId}`);
+        log.info({ component: 'hooks', operation: 'waitingForPermissionDecision', sessionId });
         const decision: PermissionDecision = await deps.sessions.waitForPermissionDecision(
           sessionId,
           PERMISSION_TIMEOUT_MS,
@@ -586,7 +588,7 @@ export function registerHookRoutes(app: FastifyInstance, deps: HookRouteDeps): v
         );
 
         const decisionLabel = decision === 'allow' ? 'approved' : 'rejected';
-        console.log(`Hooks: PermissionRequest for session ${sessionId} — ${decisionLabel} by client`);
+        log.info({ component: 'hooks', operation: 'permissionDecisionResolved', sessionId, attributes: { decision: decisionLabel } });
 
         return reply.status(200).send({
           hookSpecificOutput: {

--- a/src/permission-guard.ts
+++ b/src/permission-guard.ts
@@ -25,6 +25,8 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { ccSettingsSchema } from './validation.js';
+import { StructuredLogger } from './logger.js';
+const log = new StructuredLogger();
 
 const SETTINGS_DIR = '.claude';
 const LOCAL_SETTINGS_FILE = 'settings.local.json';
@@ -113,10 +115,10 @@ async function neutralizeOneFile(filePath: string, bpPath: string, targetMode: s
     await writeFile(tmpFile, JSON.stringify(settings, null, 2) + '\n');
     await rename(tmpFile, filePath);
 
-    console.log(`Permission guard: neutralized bypassPermissions in ${filePath} (backup: ${bpPath})`);
+    log.info({ component: 'permission-guard', operation: 'neutralizedBypass', attributes: { filePath, backupPath: bpPath } });
     return true;
   } catch (e) {
-    console.error(`Permission guard: failed to neutralize ${filePath}: ${(e as Error).message}`);
+    log.error({ component: 'permission-guard', operation: 'neutralizeFailed', attributes: { filePath, error: (e as Error).message } });
     return false;
   }
 }
@@ -149,10 +151,10 @@ async function restoreOneFile(filePath: string, bpPath: string): Promise<boolean
     const raw = await readFile(bpPath, 'utf-8');
     await writeFile(filePath, raw);
     await unlink(bpPath);
-    console.log(`Permission guard: restored ${filePath} from backup`);
+    log.info({ component: 'permission-guard', operation: 'restoredFromBackup', attributes: { filePath } });
     return true;
   } catch (e) {
-    console.error(`Permission guard: failed to restore from ${bpPath}: ${(e as Error).message}`);
+    log.error({ component: 'permission-guard', operation: 'restoreFailed', attributes: { backupPath: bpPath, error: (e as Error).message } });
     return false;
   }
 }
@@ -175,9 +177,9 @@ export async function restoreSettings(workDir: string, homeDir?: string): Promis
   if (existsSync(legacy)) {
     try {
       await rename(legacy, settingsPath(workDir));
-      console.log(`Permission guard: restored ${settingsPath(workDir)} from legacy backup`);
+      log.info({ component: 'permission-guard', operation: 'restoredLegacyBackup', attributes: { filePath: settingsPath(workDir) } });
     } catch (e) {
-      console.error(`Permission guard: failed to restore from legacy ${legacy}: ${(e as Error).message}`);
+      log.error({ component: 'permission-guard', operation: 'restoreLegacyFailed', attributes: { backupPath: legacy, error: (e as Error).message } });
     }
   }
 }
@@ -223,10 +225,10 @@ export async function activateBypassPermissions(workDir: string, homeDir?: strin
     await writeFile(tmpFile, JSON.stringify(settings, null, 2) + '\n');
     await rename(tmpFile, localSettings);
 
-    console.log(`Permission guard: activated bypassPermissions in ${localSettings}`);
+    log.info({ component: 'permission-guard', operation: 'activatedBypass', attributes: { filePath: localSettings } });
     return true;
   } catch (e) {
-    console.error(`Permission guard: failed to activate bypassPermissions in ${localSettings}: ${(e as Error).message}`);
+    log.error({ component: 'permission-guard', operation: 'activateFailed', attributes: { filePath: localSettings, error: (e as Error).message } });
     return false;
   }
 }
@@ -246,9 +248,9 @@ export async function cleanOrphanedBackup(workDir: string, homeDir?: string): Pr
       const raw = await readFile(loc.backupPath, 'utf-8');
       await writeFile(loc.filePath, raw);
       await unlink(loc.backupPath);
-      console.log(`Permission guard: cleaned orphaned backup for ${loc.filePath}`);
+      log.info({ component: 'permission-guard', operation: 'cleanedOrphanedBackup', attributes: { filePath: loc.filePath } });
     } catch (e) {
-      console.error(`Permission guard: failed to clean orphaned backup: ${(e as Error).message}`);
+      log.error({ component: 'permission-guard', operation: 'cleanOrphanedFailed', attributes: { error: (e as Error).message } });
     }
   }
 
@@ -257,9 +259,9 @@ export async function cleanOrphanedBackup(workDir: string, homeDir?: string): Pr
   if (existsSync(legacy)) {
     try {
       await rename(legacy, settingsPath(workDir));
-      console.log(`Permission guard: cleaned legacy orphaned backup in ${workDir}`);
+      log.info({ component: 'permission-guard', operation: 'cleanedLegacyOrphaned', attributes: { workDir } });
     } catch (e) {
-      console.error(`Permission guard: failed to clean legacy orphaned backup: ${(e as Error).message}`);
+      log.error({ component: 'permission-guard', operation: 'cleanLegacyOrphanedFailed', attributes: { error: (e as Error).message } });
     }
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -29,6 +29,8 @@ import { maybeInjectFault } from './fault-injection.js';
 import type { Span } from '@opentelemetry/api';
 import type { PendingPermissionInfo, PendingQuestionInfo } from './api-contracts.js';
 import { startSessionSpan, spanError, spanOk } from './tracing.js';
+import { StructuredLogger } from './logger.js';
+const log = new StructuredLogger();
 
 /** UI states for Claude Code sessions. */
 export type UIState =
@@ -400,7 +402,7 @@ export class SessionManager {
         if (entry.endsWith('.tmp')) {
           const fullPath = join(dir, entry);
           try { unlinkSync(fullPath); } catch { /* best effort */ }
-          console.log(`Cleaned stale tmp file: ${entry}`);
+          log.info({ component: 'session', operation: 'cleanStaleTmp', attributes: { entry } });
         }
       }
     } catch { /* dir may not exist yet */ }
@@ -436,7 +438,7 @@ export class SessionManager {
             this.state = { sessions: hydrateSessions(parsed.data) };
             await this.restoreSessionHookSecrets();
           } else {
-            console.warn('State file failed validation, attempting backup restore');
+            log.warn({ component: 'session', operation: 'stateValidationFailed' });
             const backupFile = `${this.stateFile}.bak`;
             if (existsSync(backupFile)) {
               try {
@@ -445,7 +447,7 @@ export class SessionManager {
                 if (backupParsed.success && this.isValidState({ sessions: backupParsed.data })) {
                   this.state = { sessions: hydrateSessions(backupParsed.data) };
                   await this.restoreSessionHookSecrets();
-                  console.log('Restored state from backup');
+                  log.info({ component: 'session', operation: 'stateRestoredFromBackup' });
                 } else {
                   this.state = { sessions: Object.create(null) as Record<string, SessionInfo> };
                 }
@@ -477,7 +479,7 @@ export class SessionManager {
       (s) => s.status === 'awaiting_approval'
     );
     if (stuckSessions.length > 0) {
-      console.warn(`[session] Recovering ${stuckSessions.length} session(s) stuck in awaiting_approval after restart`);
+      log.warn({ component: 'session', operation: 'recoveringStuckApprovals', attributes: { count: stuckSessions.length } });
       for (const session of stuckSessions) {
         this.emitSessionAwaitingApproval(session);
       }
@@ -487,7 +489,7 @@ export class SessionManager {
   /** Save state to disk atomically (write to temp, then rename).
    *  #218: Uses a write queue to serialize concurrent saves and prevent corruption. */
   async save(): Promise<void> {
-    this.saveQueue = this.saveQueue.then(() => this.doSave()).catch(e => console.error('State save error:', e));
+    this.saveQueue = this.saveQueue.then(() => this.doSave()).catch(e => log.error({ component: 'session', operation: 'stateSaveFailed', attributes: { error: String(e) } }));
     await this.saveQueue;
   }
 
@@ -497,7 +499,7 @@ export class SessionManager {
     if (this.saveDebounceTimer !== null) clearTimeout(this.saveDebounceTimer);
     this.saveDebounceTimer = setTimeout(() => {
       this.saveDebounceTimer = null;
-      void this.save().catch(e => console.error('Session: debounced save failed:', e));
+      void this.save().catch(e => log.error({ component: 'session', operation: 'debouncedSaveFailed', attributes: { error: String(e) } }));
     }, SessionManager.SAVE_DEBOUNCE_MS);
   }
 
@@ -778,7 +780,7 @@ export class SessionManager {
     // Issue #3613: Enforce isolation policy
     const policy = opts.isolationPolicy ?? this.config.isolationPolicy;
     if (policy === 'enforce-worktree' && isolationMode === 'none') {
-      console.warn(`Session ${id}: enforce-worktree policy rejecting session with detected bgIsolation="none"`);
+      log.warn({ component: 'session', operation: 'worktreePolicyRejected', sessionId: id, attributes: { policy, detectedIsolation: 'none' } });
       throw new SessionCreationError(
         `Session rejected: isolation policy is 'enforce-worktree' but CC settings have bgIsolation="none". ` +
         `Set worktree.bgIsolation to "worktree" in .claude/settings.json or change the server isolation policy.`
@@ -786,7 +788,7 @@ export class SessionManager {
     }
     if (policy === 'enforce-direct') {
       if (isolationMode !== 'none') {
-        console.warn(`Session ${id}: enforce-direct policy overriding detected worktree isolation to none`);
+        log.warn({ component: 'session', operation: 'directPolicyOverride', sessionId: id });
       }
       isolationMode = 'none';
     }
@@ -812,7 +814,7 @@ export class SessionManager {
               lastCleanupWorkDir = opts.workDir;
             }
           } catch (e) {
-            console.warn(`Hook cleanup: failed to clean stale hooks: ${(e as Error).message}`);
+            log.warn({ component: 'session', operation: 'hookCleanupFailed', attributes: { error: (e as Error).message } });
           }
         }
 
@@ -821,7 +823,7 @@ export class SessionManager {
       const baseUrl = getConfiguredBaseUrl(this.config);
       hookSettingsFile = await writeHookSettingsFile(baseUrl, id, hookSecret, opts.workDir);
     } catch (e) {
-      console.error(`Hook settings: failed to generate settings file: ${(e as Error).message}`);
+      log.error({ component: 'session', operation: 'hookSettingsGenerateFailed', attributes: { error: (e as Error).message } });
       // Non-fatal: hooks won't work for this session, but CC still launches
     }
 
@@ -998,9 +1000,12 @@ export class SessionManager {
       const duration = now - session.createdAt;
       if (toolCount > 0 && toolCount <= PREMATURE_MIN_TOOLS && duration >= PREMATURE_MIN_DURATION_MS) {
         session.prematureTermination = true;
-        console.warn(
-          `Session ${id.slice(0, 8)}: possible premature termination — ${toolCount} tool uses in ${Math.round(duration / 1000)}s (threshold: <=${PREMATURE_MIN_TOOLS} tools, >=${PREMATURE_MIN_DURATION_MS}ms duration)`
-        );
+        log.warn({
+          component: 'session',
+          operation: 'possiblePrematureTermination',
+          sessionId: id,
+          attributes: { toolCount, durationMs: duration, thresholdTools: PREMATURE_MIN_TOOLS, thresholdMs: PREMATURE_MIN_DURATION_MS },
+        });
       }
     }
 
@@ -1013,8 +1018,7 @@ export class SessionManager {
       // Issue #828: Clamp future timestamps to prevent clock skew corruption.
       // If the client's clock is ahead of ours, store our timestamp instead.
       if (hookTimestamp > now) {
-        console.warn(`updateStatusFromHook: clamping future hookTimestamp ` +
-          `(${hookTimestamp} > ${now}) for session ${id.slice(0, 8)}`);
+        log.warn({ component: 'session', operation: 'clampedFutureTimestamp', sessionId: id, attributes: { hookTimestamp, now } });
         session.lastHookEventAt = now;
       } else {
         session.lastHookEventAt = hookTimestamp;
@@ -1125,7 +1129,7 @@ export class SessionManager {
       this.approvalTimeouts.delete(sessionId);
       const session = this.state.sessions[sessionId];
       if (session && session.status === 'awaiting_approval') {
-        console.warn(`[session] Auto-rejecting session ${sessionId} after ${timeoutMs}ms approval timeout`);
+        log.warn({ component: 'session', operation: 'autoRejectApproval', sessionId, attributes: { timeoutMs } });
         try {
           await this.rejectSession(sessionId);
           // Notify channels about auto-rejection
@@ -1133,7 +1137,7 @@ export class SessionManager {
             this.onSessionApprovalRecovery({ ...session, status: 'killed' });
           }
         } catch (e) {
-          console.error(`[session] Failed to auto-reject session ${sessionId}:`, e);
+          log.error({ component: 'session', operation: 'autoRejectFailed', sessionId, attributes: { error: String(e) } });
         }
       }
     }, timeoutMs);
@@ -1222,7 +1226,7 @@ export class SessionManager {
     try {
       this.discovery.startDiscoveryPolling(id, session.workDir);
     } catch (e) {
-      console.error(`[session] approveSession: discovery polling failed for ${id}:`, e);
+      log.error({ component: 'session', operation: 'approveDiscoveryFailed', sessionId: id, attributes: { error: String(e) } });
     }
     return session;
   }


### PR DESCRIPTION
## Summary

Batch 2 of the console.log → StructuredLogger migration from #4157 audit.

**34 instances migrated across 3 files:**
- `src/session.ts`: 15 console.* → StructuredLogger (state persistence, session lifecycle, approval timeouts)
- `src/hooks.ts`: 13 console.* → StructuredLogger (hook events, permission flow, circuit breaker, AskUserQuestion)
- `src/permission-guard.ts`: 12 console.* → StructuredLogger (bypass neutralization, backup restore, cleanup)

### Test updates
Updated 2 test files that were spying on `console.log`/`console.warn` to use a `captureLogs()` helper with `setStructuredLogSink()` instead. This is the pattern all future batches will follow.

```
hooks.test.ts: 55/55 pass
hooks-coverage-1305.test.ts: 51/51 pass
All 33 related test files: 557/557 pass
```

No behavior changes — pure logging migration.

Refs #4157