### PR TITLE
refactor(logger): migrate config, session-discovery, acp/backend, signal-cleanup, startup to StructuredLogger

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setStructuredLogSink } from '../logger.js';
 import { getConfig } from '../config.js';
 import { testPath } from './helpers/platform.js';
 
@@ -234,10 +235,10 @@ describe('config', () => {
 
     it('falls back and warns when AEGIS_PORT is out of range', () => {
       process.env.AEGIS_PORT = '70000';
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const warnRecords: any[] = []; setStructuredLogSink({ info: () => {}, warn: (r) => { warnRecords.push(r); }, error: () => {} });
 
       const config = getConfig();
-      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+      const warnings = warnRecords.map(r => r.attributes?.message || Object.values(r.attributes || {}).join(' ')).join('\n');
 
       expect(config.port).toBe(9100);
       expect(warnings).toContain("AEGIS_PORT='70000'");
@@ -246,10 +247,10 @@ describe('config', () => {
 
     it('falls back and warns when numeric env value is not a strict integer', () => {
       process.env.AEGIS_MAX_SESSION_AGE_MS = '3600000ms';
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const warnRecords: any[] = []; setStructuredLogSink({ info: () => {}, warn: (r) => { warnRecords.push(r); }, error: () => {} });
 
       const config = getConfig();
-      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+      const warnings = warnRecords.map(r => r.attributes?.message || Object.values(r.attributes || {}).join(' ')).join('\n');
 
       expect(config.maxSessionAgeMs).toBe(2 * 60 * 60 * 1000);
       expect(warnings).toContain("AEGIS_MAX_SESSION_AGE_MS='3600000ms'");
@@ -262,9 +263,9 @@ describe('config', () => {
       expect(zeroConfig.pipelineStageTimeoutMs).toBe(0);
 
       process.env.AEGIS_PIPELINE_STAGE_TIMEOUT_MS = '-1';
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const warnRecords: any[] = []; setStructuredLogSink({ info: () => {}, warn: (r) => { warnRecords.push(r); }, error: () => {} });
       const negativeConfig = getConfig();
-      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+      const warnings = warnRecords.map(r => r.attributes?.message || Object.values(r.attributes || {}).join(' ')).join('\n');
 
       expect(negativeConfig.pipelineStageTimeoutMs).toBe(0);
       expect(warnings).toContain("AEGIS_PIPELINE_STAGE_TIMEOUT_MS='-1'");
@@ -275,22 +276,24 @@ describe('config', () => {
   describe('invalid env warnings', () => {
     it('warns and keeps default when AEGIS_HOOK_SECRET_HEADER_ONLY is invalid', () => {
       process.env.AEGIS_HOOK_SECRET_HEADER_ONLY = 'yes';
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const warnRecords: any[] = []; setStructuredLogSink({ info: () => {}, warn: (r) => { warnRecords.push(r); }, error: () => {} });
 
       const config = getConfig();
-      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+      const warnings = warnRecords.map(r => r.attributes?.message || Object.values(r.attributes || {}).join(' ')).join('\n');
 
       expect(config.hookSecretHeaderOnly).toBe(false);
-      expect(warnings).toContain("AEGIS_HOOK_SECRET_HEADER_ONLY='yes'");
-      expect(warnings).toContain('expected "true" or "false"');
+      const boolWarn = warnRecords.find(r => r.operation === 'invalidBoolEnv');
+      expect(boolWarn).toBeDefined();
+      expect(boolWarn.attributes.envName).toBe('AEGIS_HOOK_SECRET_HEADER_ONLY');
+      expect(boolWarn.attributes.value).toBe('yes');
     });
 
     it('warns for invalid Telegram allowlist entries while keeping valid IDs', () => {
       process.env.AEGIS_TG_ALLOWED_USERS = '111,abc,-5,222';
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const warnRecords: any[] = []; setStructuredLogSink({ info: () => {}, warn: (r) => { warnRecords.push(r); }, error: () => {} });
 
       const config = getConfig();
-      const warnings = warnSpy.mock.calls.map(call => String(call[0])).join('\n');
+      const warnings = warnRecords.map(r => r.attributes?.message || Object.values(r.attributes || {}).join(' ')).join('\n');
 
       expect(config.tgAllowedUsers).toEqual([111, 222]);
       expect(warnings).toContain('AEGIS_TG_ALLOWED_USERS');

--- a/src/__tests__/fix-3716-session-discovery.test.ts
+++ b/src/__tests__/fix-3716-session-discovery.test.ts
@@ -11,6 +11,7 @@
  * 7. purgeStaleSessionMapEntries with missing map file (no-op)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setStructuredLogSink } from '../logger.js';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -44,11 +45,11 @@ function createConfig() {
 
 describe('Issue #3716 — SessionDiscovery error and edge cases', () => {
   let tmpDir: string;
-  let consoleLogSpy: any;
+  let _noop: any;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'aegis-disc-test-'));
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setStructuredLogSink({ info: () => {}, warn: () => {}, error: () => {} });
   });
 
   afterEach(() => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,9 @@ import { parseIntSafe } from './validation.js';
 import { configFileSchema } from './validation.js';
 import { getConfiguredBaseUrl } from './base-url.js';
 import { secureFilePermissions } from './file-utils.js';
+import { StructuredLogger } from './logger.js';
+
+const log = new StructuredLogger();
 
 /** Issue #2267: System tenant ID for admin/master keys and cross-tenant operations. */
 export const SYSTEM_TENANT = '_system';
@@ -293,7 +296,7 @@ function isLegacyManusConfigPath(filePath: string): boolean {
 
 function normalizeConfigFileObject(raw: unknown, filePath: string): Partial<Config> | null {
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-    console.warn(`Config file ${filePath} is not an object, ignoring`);
+    log.warn({ component: 'config', operation: 'invalidConfigFile', attributes: { path: filePath } });
     return null;
   }
 
@@ -303,7 +306,7 @@ function normalizeConfigFileObject(raw: unknown, filePath: string): Partial<Conf
 
   const parsed = configFileSchema.safeParse(candidate);
   if (!parsed.success) {
-    console.warn(`Config file ${filePath} has invalid fields, ignoring:`, parsed.error.format());
+    log.warn({ component: 'config', operation: 'invalidConfigFields', attributes: { path: filePath, errors: String(parsed.error.format()) } });
     return null;
   }
 
@@ -320,7 +323,7 @@ export async function readConfigFile(filePath: string): Promise<Partial<Config> 
     const data = await readFile(filePath, 'utf-8');
     return normalizeConfigFileObject(parseConfigText(filePath, data), filePath);
   } catch (e) {
-    console.warn(`Failed to parse config file ${filePath}:`, e);
+    log.warn({ component: 'config', operation: 'parseFailed', attributes: { path: filePath, error: String(e) } });
     return null;
   }
 }
@@ -361,7 +364,7 @@ async function loadConfigFile(): Promise<Partial<Config>> {
     const parsed = await readConfigFile(path);
     if (!parsed) continue;
     if (isLegacyManusConfigPath(path)) {
-      console.log(`Config: loaded from legacy path ${path} — consider migrating to aegis paths`);
+      log.info({ component: 'config', operation: 'legacyPathUsed', attributes: { path } });
     }
     return parsed;
   }
@@ -425,7 +428,7 @@ function parseNumericEnvOverride(
     strict: true,
     min: bounds.min,
     max: bounds.max,
-    onError: (message) => console.warn(`Config: ${message}`),
+    onError: (message) => log.warn({ component: 'config', operation: 'envParseError', attributes: { message } }),
   });
 }
 
@@ -443,7 +446,7 @@ function parseTgAllowedUsers(envName: string, value: string): number[] {
     parsedUsers.push(parsed);
   }
   if (invalidEntries.length > 0) {
-    console.warn(`Config: invalid ${envName} entries ignored: ${invalidEntries.join(', ')}`);
+    log.warn({ component: 'config', operation: 'invalidTgUsers', attributes: { envName, invalidEntries: invalidEntries.join(', ') } });
   }
   return parsedUsers;
 }
@@ -528,9 +531,7 @@ function applyEnvOverrides(config: Config): Config {
         if (value === 'true' || value === 'false') {
           config[key] = value === 'true';
         } else {
-          console.warn(
-            `Config: Invalid ${envName}='${value}' (expected "true" or "false"); using ${config[key]}`,
-          );
+          log.warn({ component: 'config', operation: 'invalidBoolEnv', attributes: { envName, value: String(value), current: String(config[key]) } });
         }
         break;
       case 'enforceSessionOwnership':
@@ -562,7 +563,7 @@ function applyEnvOverrides(config: Config): Config {
         if (value === 'respect-cc' || value === 'enforce-worktree' || value === 'enforce-direct') {
           config.isolationPolicy = value as Config['isolationPolicy'];
         } else {
-          console.warn(`Invalid AEGIS_ISOLATION_POLICY: "${value}". Must be respect-cc, enforce-worktree, or enforce-direct.`);
+          log.warn({ component: 'config', operation: 'invalidIsolationPolicy', attributes: { value } });
         }
         break;
       default:
@@ -666,7 +667,7 @@ function resolveStateDir(config: Config): Config {
 
   // If stateDir is the default aegis path but doesn't exist, check for legacy manus path
   if (config.stateDir === aegisDir && !existsSync(aegisDir) && existsSync(manusDir)) {
-    console.log(`Config: using legacy state dir ${manusDir} — consider migrating to ${aegisDir}`);
+    log.info({ component: 'config', operation: 'legacyStateDir', attributes: { manusDir, aegisDir } });
     config.stateDir = manusDir;
   }
 
@@ -777,7 +778,7 @@ export function watchConfigFile(
       debounceTimer = null;
       void reloadAllowedWorkDirs(configPath).then((dirs) => {
         if (dirs === null) return; // Config file gone/invalid — skip callback
-        console.log(`Config: hot-reloaded allowedWorkDirs (${dirs.length} entries)`);
+        log.info({ component: 'config', operation: 'hotReload', attributes: { count: dirs.length } });
         onChange(dirs);
       });
     }, 500);

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -34,6 +34,10 @@ import type {
   PromptValidationWarning,
 } from './types.js';
 
+import { StructuredLogger } from '../../logger.js';
+
+const log = new StructuredLogger();
+
 const DEFAULT_PROTOCOL_VERSION = 1;
 const ACP_PROMPT_REQUEST_TIMEOUT_MS = 60_000;
 const ACP_PROMPT_ACK_TIMEOUT_MS = 5_000;
@@ -454,7 +458,7 @@ export class AcpBackend {
         if (err instanceof Error && err.name === 'AcpJsonRpcTimeoutError') {
           // Timeout is acceptable — CC likely received the prompt but hasn't
           // responded yet. Log and continue as delivered.
-          console.warn(`[ACP prompt ack timeout] session=${sessionId} — treating as delivered`);
+          log.warn({ component: 'acp-backend', operation: 'promptAckTimeout', attributes: { sessionId } });
         } else {
           // Actual error (e.g. -32601 Method not found) — surface it
           throw err;
@@ -466,7 +470,7 @@ export class AcpBackend {
         // Handled above — should not reach here, but defensive
         return { delivered: true, attempts: 1 };
       }
-      console.warn(`[ACP prompt error] session=${sessionId} method=session/prompt error=${(err as Error).message}`);
+      log.warn({ component: 'acp-backend', operation: 'promptError', attributes: { sessionId, error: (err as Error).message } });
       return { delivered: false, attempts: 1, error: (err as Error).message };
     } finally {
       this.inFlightPrompts.delete(sessionId);
@@ -853,7 +857,7 @@ export class AcpBackend {
       // Issue #3900: Structured warnings + strict validation enforcement
       const warnings = validatePromptOutput(response.result, text);
       if (warnings.length > 0) {
-        console.warn(`[ACP content validation] session=${sessionId} action=${action.actionId} warnings=${JSON.stringify(warnings)}`);
+        log.warn({ component: 'acp-backend', operation: 'contentValidationWarning', attributes: { sessionId, actionId: action.actionId, warnings: JSON.stringify(warnings) } });
 
         // Issue #3897: Emit validation_warning event for monitoring/alerting (opt-in)
         if (this.emitValidationWarnings) {
@@ -863,7 +867,7 @@ export class AcpBackend {
               warnings,
             });
           } catch (err) {
-            console.warn(`[ACP validation_warning] failed to emit: ${err}`);
+            log.warn({ component: 'acp-backend', operation: 'validationWarningEmitFailed', attributes: { error: String(err) } });
           }
         }
 
@@ -882,16 +886,14 @@ export class AcpBackend {
       return { resultMetadata: metadata };
     } catch (error) {
       if (error instanceof Error && error.name === 'AcpJsonRpcTimeoutError') {
-        console.warn(`[ACP prompt timeout] session=${sessionId} action=${action.actionId} method=session/prompt timeout=${ACP_PROMPT_REQUEST_TIMEOUT_MS}ms`);
+        log.warn({ component: 'acp-backend', operation: 'promptTimeout', attributes: { sessionId, actionId: action.actionId, timeout: ACP_PROMPT_REQUEST_TIMEOUT_MS } });
       }
       try {
         await this.sessionService.transition(sessionId, runtime.scope, {
           type: 'runtime_failed',
         });
       } catch (transitionError) {
-        console.error(
-          `[ACP] failed to transition session=${sessionId} to runtime_failed: ${transitionError}`
-        );
+        log.error({ component: 'acp-backend', operation: 'transitionToFailedError', attributes: { sessionId, error: String(transitionError) } });
       }
       throw error;
     } finally {
@@ -984,9 +986,7 @@ export class AcpBackend {
       try {
         await this.sessionService.transition(sessionId, scope, { type: 'runtime_failed' });
       } catch (transitionError) {
-        console.error(
-          `[ACP] failed to transition session=${sessionId} to runtime_failed during startup: ${transitionError}`
-        );
+        log.error({ component: 'acp-backend', operation: 'startupTransitionFailed', attributes: { sessionId, error: String(transitionError) } });
       }
     } finally {
       if (started) {
@@ -1046,9 +1046,7 @@ export class AcpBackend {
           type: 'runtime_failed',
         });
       } catch (transitionError) {
-        console.error(
-          `[ACP] failed to transition session=${runtime.sessionId} to runtime_failed on exit: ${transitionError}`
-        );
+        log.error({ component: 'acp-backend', operation: 'exitTransitionFailed', attributes: { sessionId: runtime.sessionId, error: String(transitionError) } });
       }
     } finally {
       this.disposeRuntime(runtime);
@@ -1113,7 +1111,7 @@ export function createDefaultAcpBackendClient(
   child.on('stderr', (event) => {
     const text = typeof event.chunk === 'string' ? event.chunk.trim() : '';
     if (text) {
-      console.error(`[ACP stderr:${context.durableSessionId.slice(0, 8)}] ${text}`);
+      log.error({ component: 'acp-backend', operation: 'childStderr', attributes: { sessionId: context.durableSessionId.slice(0, 8), text } });
     }
   });
   return new AcpJsonRpcClient({

--- a/src/session-discovery.ts
+++ b/src/session-discovery.ts
@@ -14,6 +14,9 @@ import { loadContinuationPointers, type ContinuationPointerEntry } from './conti
 import { computeProjectHash } from './path-utils.js';
 import type { Config } from './config.js';
 import type { SessionInfo } from './session.js';
+import { StructuredLogger } from './logger.js';
+
+const log = new StructuredLogger();
 
 /**
  * Callback interface for discovery to interact with SessionManager state
@@ -122,7 +125,7 @@ export class SessionDiscovery {
       const session = this.deps.getSession(id);
       this.stopDiscoveryPolling(id);
       if (session && !session.claudeSessionId) {
-        console.log(`Discovery: session ${session.displayName} — timed out after 5min, no session_id found`);
+        log.info({ component: 'session-discovery', operation: 'discoveryTimeout', attributes: { session: session.displayName } });
       }
     }, 5 * 60 * 1000);
     this.discoveryTimeouts.set(id, discoveryTimeout);
@@ -189,7 +192,7 @@ export class SessionDiscovery {
         const windowNameActive = activeNamesLower.has(windowName);
 
         if (!windowIdActive && !windowNameActive) {
-          console.log(`Reconcile: purging stale session_map entry: ${key}`);
+          log.info({ component: 'session-discovery', operation: 'purgeStaleEntry', attributes: { key } });
           delete mapData[key];
           changed = true;
         }
@@ -226,8 +229,7 @@ export class SessionDiscovery {
             // GUARD 1: Timestamp — reject session_map entries written before this session was created.
             const writtenAt = info.written_at || 0;
             if (writtenAt > 0 && writtenAt < session.createdAt) {
-              console.log(`Discovery: session ${session.displayName} — rejecting stale entry ` +
-                `(written_at ${new Date(writtenAt).toISOString()} < createdAt ${new Date(session.createdAt).toISOString()})`);
+              log.info({ component: 'session-discovery', operation: 'rejectStaleEntry', attributes: { session: session.displayName, writtenAt: new Date(writtenAt).toISOString(), createdAt: new Date(session.createdAt).toISOString() } });
               continue;
             }
 
@@ -241,7 +243,7 @@ export class SessionDiscovery {
 
             // GUARD 2: Reject paths in _archived/ directory — these are stale sessions
             if (jsonlPath && (jsonlPath.includes('/_archived/') || jsonlPath.includes('\\_archived\\'))) {
-              console.log(`Discovery: session ${session.displayName} — rejecting archived path: ${jsonlPath}`);
+              log.info({ component: 'session-discovery', operation: 'rejectArchivedPath', attributes: { session: session.displayName, path: jsonlPath } });
               continue;
             }
 
@@ -253,8 +255,7 @@ export class SessionDiscovery {
             try {
               const fileStat = await stat(jsonlPath);
               if (fileStat.mtimeMs < session.createdAt) {
-                console.log(`Discovery: session ${session.displayName} — rejecting stale JSONL ` +
-                  `(mtime ${new Date(fileStat.mtimeMs).toISOString()} < createdAt ${new Date(session.createdAt).toISOString()})`);
+                log.info({ component: 'session-discovery', operation: 'rejectStaleJsonl', attributes: { session: session.displayName, mtime: new Date(fileStat.mtimeMs).toISOString(), createdAt: new Date(session.createdAt).toISOString() } });
                 continue;
               }
             } catch {
@@ -265,16 +266,14 @@ export class SessionDiscovery {
             const existingSession = (this.deps.getAllSessions() as SessionInfo[])
               .find(s => s.claudeSessionId === info.session_id && s.id !== session.id);
             if (existingSession) {
-              console.log(`Discovery: session ${session.displayName} — rejecting claudeSessionId ${info.session_id.slice(0, 8)}... ` +
-                `already mapped to session ${existingSession.displayName} (${existingSession.id.slice(0, 8)})`);
+              log.info({ component: 'session-discovery', operation: 'rejectDuplicateClaudeSessionId', attributes: { session: session.displayName, claudeSessionId: info.session_id.slice(0, 8), existingSession: existingSession.displayName, existingId: existingSession.id.slice(0, 8) } });
               continue;
             }
 
             session.claudeSessionId = info.session_id;
             session.jsonlPath = jsonlPath;
             session.byteOffset = 0;
-            console.log(`Discovery: session ${session.displayName} mapped to ` +
-              `${info.session_id.slice(0, 8)}... (verified: timestamp + mtime)`);
+            log.info({ component: 'session-discovery', operation: 'sessionMapped', attributes: { session: session.displayName, claudeSessionId: info.session_id.slice(0, 8) } });
             break;
           }
         }
@@ -309,15 +308,14 @@ export class SessionDiscovery {
       const existingSession = (this.deps.getAllSessions() as SessionInfo[])
         .find(s => s.claudeSessionId === sessionId && s.id !== session.id);
       if (existingSession) {
-        console.log(`Discovery (filesystem): session ${session.displayName} — rejecting sessionId ${sessionId.slice(0, 8)}... ` +
-          `already mapped to session ${existingSession.displayName} (${existingSession.id.slice(0, 8)})`);
+        log.info({ component: 'session-discovery', operation: 'rejectDuplicateFsSessionId', attributes: { session: session.displayName, sessionId: sessionId.slice(0, 8), existingSession: existingSession.displayName, existingId: existingSession.id.slice(0, 8) } });
         continue;
       }
 
       session.claudeSessionId = sessionId;
       session.jsonlPath = filePath;
       session.byteOffset = 0;
-      console.log(`Discovery (filesystem): session ${session.displayName} mapped to ${sessionId.slice(0, 8)}...`);
+      log.info({ component: 'session-discovery', operation: 'sessionMappedFromFs', attributes: { session: session.displayName, sessionId: sessionId.slice(0, 8) } });
       await this.deps.save();
       return true;
     }

--- a/src/signal-cleanup-helper.ts
+++ b/src/signal-cleanup-helper.ts
@@ -7,6 +7,9 @@
 
 import type { SessionManager } from './session.js';
 import { cleanupTerminatedSessionState, type SessionCleanupDeps } from './session-cleanup.js';
+import { StructuredLogger } from './logger.js';
+
+const log = new StructuredLogger();
 
 /** Result of killAllSessions operation. */
 export interface KillAllResult {
@@ -45,13 +48,11 @@ export async function killAllSessions(
       killed++;
     } catch (e) {
       errors++;
-      console.error(
-        `Signal cleanup: failed to kill session ${session.displayName} (${session.id.slice(0, 8)}): ${(e as Error).message}`,
-      );
+      log.error({ component: 'signal-cleanup', operation: 'killSessionFailed', attributes: { session: session.displayName, sessionId: session.id.slice(0, 8), error: (e as Error).message } });
     }
   }
 
-  console.log(`Signal cleanup: killed ${killed} sessions (${errors} errors)`);
+  log.info({ component: 'signal-cleanup', operation: 'killAllComplete', attributes: { killed, errors } });
   return { killed, errors };
 }
 
@@ -85,17 +86,15 @@ export async function killAllSessionsWithTimeout(
     } catch (e) {
       if (e instanceof TimeoutError) {
         timedOut = true;
-        console.error(`Signal cleanup: TIMED OUT killing session ${session.displayName}`);
+        log.error({ component: 'signal-cleanup', operation: 'killSessionTimeout', attributes: { session: session.displayName } });
       } else {
-        console.error(
-          `Signal cleanup: failed to kill session ${session.displayName}: ${(e as Error).message}`,
-        );
+        log.error({ component: 'signal-cleanup', operation: 'killSessionFailed', attributes: { session: session.displayName, error: (e as Error).message } });
       }
       errors++;
     }
   }
 
-  console.log(`Signal cleanup: killed ${killed}/${allSessions.length} sessions (${errors} errors, ${timedOut ? 'some timed out' : 'no timeouts'})`);
+  log.info({ component: 'signal-cleanup', operation: 'killAllWithTimeoutComplete', attributes: { killed, total: allSessions.length, errors, timedOut } });
   return { killed, errors, timedOut };
 }
 
@@ -134,15 +133,15 @@ export function createSignalHandler(
     if (shuttingDown) return;
     shuttingDown = true;
 
-    console.log(`${signal} received — cleaning up ${sessions.listSessions().length} active sessions...`);
+    log.info({ component: 'signal-cleanup', operation: 'signalReceived', attributes: { signal, sessionCount: sessions.listSessions().length } });
 
     void killAllSessions(sessions)
       .then((result) => {
-        console.log(`${signal} cleanup complete: ${result.killed} sessions killed`);
+        log.info({ component: 'signal-cleanup', operation: 'signalCleanupComplete', attributes: { signal, killed: result.killed } });
         process.exit(0);
       })
       .catch((e) => {
-        console.error(`${signal} cleanup error:`, e);
+        log.error({ component: 'signal-cleanup', operation: 'signalCleanupError', attributes: { signal, error: (e as Error).message } });
         process.exit(1);
       });
   };

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -3,6 +3,9 @@ import fs from 'node:fs/promises';
 import { writeFileSync, unlinkSync } from 'node:fs';
 import path from 'node:path';
 import { secureFilePermissions } from './file-utils.js';
+import { StructuredLogger } from './logger.js';
+
+const log = new StructuredLogger();
 import { findPidOnPort, readParentPid } from './process-utils.js';
 
 export async function writePidFile(stateDir: string): Promise<string> {
@@ -106,19 +109,19 @@ async function killStalePortHolder(port: number, stateDir: string): Promise<bool
       if (pid === process.pid) continue;
 
       if (await isAncestorPid(pid)) {
-        console.warn(`EADDRINUSE recovery: skipping ancestor PID ${pid} on port ${port}`);
+        log.warn({ component: 'startup', operation: 'skipAncestorPid', attributes: { pid, port } });
         continue;
       }
 
       const pidFilePid = await readPidFile(stateDir);
       if (pidFilePid !== null && pid === pidFilePid && pid !== process.pid) {
-        console.warn(`EADDRINUSE recovery: skipping peer Aegis PID ${pid} (PID file match) on port ${port}`);
+        log.warn({ component: 'startup', operation: 'skipPeerPid', attributes: { pid, port } });
         continue;
       }
 
       if (!pidExists(pid)) continue;
 
-      console.warn(`EADDRINUSE recovery: killing stale process PID ${pid} on port ${port}`);
+      log.warn({ component: 'startup', operation: 'killingStalePid', attributes: { pid, port } });
 
       try {
         process.kill(pid, 'SIGTERM');
@@ -165,13 +168,13 @@ export async function listenWithRetry(
       if (!(err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EADDRINUSE') || attempt >= maxRetries) {
         throw err;
       }
-      console.error(`EADDRINUSE on port ${port} - attempting recovery (attempt ${attempt + 1}/${maxRetries})`);
+      log.error({ component: 'startup', operation: 'addrInUseRecovery', attributes: { port, attempt: attempt + 1, maxRetries } });
       const killed = await killStalePortHolder(port, stateDir);
       if (!killed) {
         // #3346: Better error message when a peer Aegis is already running
-        console.error(`EADDRINUSE: another Aegis server is already running on port ${port}`);
-        console.error(`  If you want to use the running server, no action needed — just connect to it.`);
-        console.error(`  If you want to restart it, stop the existing server first: ag stop`);
+        log.error({ component: 'startup', operation: 'addrInUsePeerRunning', attributes: { port } });
+        log.error({ component: 'startup', operation: 'addrInUseHintConnect', attributes: { port } });
+        log.error({ component: 'startup', operation: 'addrInUseHintStop', attributes: { port } });
         process.exit(1);
       }
     }


### PR DESCRIPTION
## Summary

Batch 3 of the console.log → StructuredLogger migration from #4157 audit.

**43 instances migrated across 5 files:**
- `src/config.ts`: 10 — env var parse errors, config file validation, legacy path warnings, hot-reload
- `src/session-discovery.ts`: 9 — session mapping, stale entry rejection, discovery timeout
- `src/services/acp/backend.ts`: 9 — ACP prompt ack, content validation, state transitions, stderr
- `src/signal-cleanup-helper.ts`: 8 — signal handling, session kill, cleanup
- `src/startup.ts`: 7 — PID conflict detection, EADDRINUSE recovery

### Test updates
- `config.test.ts`: 5 warn spies → `setStructuredLogSink` capture with attribute-based assertions
- `fix-3716-session-discovery.test.ts`: log spy → no-op structured sink

```
All 36 related test files: 592 passed, 2 skipped, 0 failed
```

### Progress
- Batch 1 (telegram.ts): 19 instances ✅ merged (#4172)
- Batch 2 (session, hooks, permission-guard): 34 instances ✅ merged (#4174)
- Batch 3 (this PR): 43 instances
- **Remaining: ~64 instances** (webhook, jsonl-watcher, channels/manager, mcp/server, and smaller files)

Refs #4157