### PR TITLE
fix(dashboard): lazy-import tour, onboarding, and command palette

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -10,8 +10,8 @@ import ProtectedRoute from './components/ProtectedRoute';
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useDrawerStore } from './store/useDrawerStore';
-import { FirstRunTour, isTourCompleted } from './components/tour/FirstRunTour';
-import { OnboardingWizard } from './components/brand/OnboardingWizard';
+import { isTourCompleted } from './utils/tourState';
+
 import { useAuthStore } from './store/useAuthStore';
 
 const AuditPage = lazy(() => import('./pages/AuditPage'));
@@ -19,6 +19,8 @@ const MetricsPage = lazy(() => import('./pages/MetricsPage'));
 const AuthKeysPage = lazy(() => import('./pages/AuthKeysPage'));
 const CostPage = lazy(() => import('./pages/CostPage'));
 const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'));
+const FirstRunTour = lazy(() => import('./components/tour/FirstRunTour').then(m => ({ default: m.FirstRunTour })));
+const OnboardingWizard = lazy(() => import('./components/brand/OnboardingWizard').then(m => ({ default: m.OnboardingWizard })));
 const LoginPage = lazy(() => import('./pages/LoginPage'));
 const OverviewPage = lazy(() => import('./pages/OverviewPage'));
 const ActivityPage = lazy(() => import('./pages/ActivityPage'));
@@ -107,10 +109,10 @@ export default function App() {
   });
 
   if (isAuthenticated && showOnboarding) {
-    return <OnboardingWizard onComplete={() => {
+    return <Suspense fallback={<LoadingFallback />}><OnboardingWizard onComplete={() => {
       setShowOnboarding(false);
       if (!isTourCompleted()) setShowTour(true);
-    }} />;
+    }} /></Suspense>;
   }
 
   return (
@@ -259,7 +261,7 @@ export default function App() {
 
       <KeyboardShortcutsHelp open={showHelp} onClose={() => setShowHelp(false)} />
       
-      {showTour && <FirstRunTour onComplete={() => { tourDismissed.current = true; setShowTour(false); }} />}
+      {showTour && <Suspense fallback={null}><FirstRunTour onComplete={() => { tourDismissed.current = true; setShowTour(false); }} /></Suspense>}
     </ErrorBoundary>
   );
 }

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -4,11 +4,11 @@ import { logger } from '../utils/logger';
  */
 
 import { NavLink, Outlet } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import Breadcrumb from './shared/Breadcrumb';
 import { ErrorBoundary } from './shared/ErrorBoundary';
 import { useTheme } from '../hooks/useTheme';
-import CommandPalette from './shared/CommandPalette';
+const CommandPalette = lazy(() => import('./shared/CommandPalette'));
 import LiveAuditStream from './shared/LiveAuditStream';
 import { ApprovalNotification, ApprovalBadge } from './approvals/ApprovalNotification';
 import { NewSessionDrawer } from './NewSessionDrawer';
@@ -718,7 +718,7 @@ export default function Layout() {
       <ServerHealthBanner />
       <SessionExpiredModal />
       {/* Command Palette */}
-      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+      <Suspense fallback={null}><CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} /></Suspense>
       <ApprovalNotification />
       {/* New Session Drawer */}
       <NewSessionDrawer />

--- a/dashboard/src/components/tour/FirstRunTour.tsx
+++ b/dashboard/src/components/tour/FirstRunTour.tsx
@@ -10,7 +10,8 @@ import { createSessionWithFallback, approve, killSession, getSession } from '../
 import { useToastStore } from '../../store/useToastStore';
 import { useT } from '../../i18n/context';
 
-const TOUR_COMPLETED_KEY = 'aegis:tour:completed';
+import { markTourCompleted } from '../../utils/tourState';
+const TOUR_COMPLETED_KEY = 'aegis:tour:completed'; // kept for reference
 const SANDBOX_DIR = '/tmp/aegis-tour';
 
 type TourStep = 'welcome' | 'creating' | 'waiting-permission' | 'approved' | 'killing' | 'complete';
@@ -130,8 +131,7 @@ export function FirstRunTour({ onComplete }: FirstRunTourProps) {
       
       // Mark tour as completed
       try {
-        localStorage.setItem(TOUR_COMPLETED_KEY, '1');
-        sessionStorage.setItem(TOUR_COMPLETED_KEY, '1');
+        markTourCompleted();
       } catch {
         // Ignore storage errors
       }
@@ -156,8 +156,7 @@ export function FirstRunTour({ onComplete }: FirstRunTourProps) {
       killSession(sessionId).catch(() => {});
     }
     try {
-      localStorage.setItem(TOUR_COMPLETED_KEY, '1');
-      sessionStorage.setItem(TOUR_COMPLETED_KEY, '1');
+      markTourCompleted();
     } catch {
       // Ignore storage errors
     }

--- a/dashboard/src/utils/tourState.ts
+++ b/dashboard/src/utils/tourState.ts
@@ -1,0 +1,22 @@
+/**
+ * utils/tourState.ts — Tour completion state (sync, no component imports).
+ */
+
+const TOUR_COMPLETED_KEY = 'aegis:tour:completed';
+
+export function isTourCompleted(): boolean {
+  try {
+    return localStorage.getItem(TOUR_COMPLETED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function markTourCompleted(): void {
+  try {
+    localStorage.setItem(TOUR_COMPLETED_KEY, '1');
+    sessionStorage.setItem(TOUR_COMPLETED_KEY, '1');
+  } catch {
+    // Ignore storage errors
+  }
+}


### PR DESCRIPTION
## Summary

Lazy-import infrequently-used components to reduce initial bundle size, addressing the bundle threshold concern from #4157.

### Changes
- **Extract `isTourCompleted()`** to `utils/tourState.ts` for synchronous access without importing the full tour component
- **Lazy-load `FirstRunTour`** — only needed on first visit (~6KB chunk)
- **Lazy-load `OnboardingWizard`** — only for new users (~7KB chunk)
- **Lazy-load `CommandPalette`** — only on Ctrl+K (~8KB chunk)

### Bundle Impact
- **index.js: 166KB → 146KB (-20KB / -12%)** initial load reduction
- Three new lazy chunks: FirstRunTour (6KB), OnboardingWizard (7KB), CommandPalette (8KB)
- All wrapped in `<Suspense>` with appropriate fallbacks

### Testing
- `tsc --noEmit` clean
- `npm run build` clean
- Functional: tour still triggers on first visit, onboarding shows for new users, Ctrl+K opens palette

Addresses #4157 (bundle size over threshold).