### PR TITLE
feat(dashboard): E2E smoke tests for analytics and session detail pages

### DIFF
--- a/dashboard/e2e/analytics-smoke.spec.ts
+++ b/dashboard/e2e/analytics-smoke.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * e2e/analytics-smoke.spec.ts — Smoke tests for the Analytics page.
+ *
+ * Verifies the analytics page renders its main sections:
+ * KPI banner, model distribution, cost trends, and rate-limit charts.
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockDashboardFixtures } from './helpers/dashboard-fixtures';
+
+const DASHBOARD_BASE_URL = 'http://localhost:5200/dashboard/';
+
+test.describe('Analytics Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockDashboardFixtures(page);
+
+    // Mock analytics-specific endpoints
+    await page.route('**/v1/analytics/summary**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          totalSessions: 12,
+          totalTokens: 45000,
+          totalCostUsd: 1.26,
+          avgSessionDurationSec: 1800,
+          modelBreakdown: [
+            { model: 'claude-sonnet-4-20250514', tokens: 30000, costUsd: 0.90, sessions: 8 },
+            { model: 'claude-opus-4-20250514', tokens: 12000, costUsd: 0.30, sessions: 3 },
+            { model: 'claude-haiku-3-20250414', tokens: 3000, costUsd: 0.06, sessions: 1 },
+          ],
+          dailyUsage: [
+            { date: '2026-05-23', sessions: 3, tokens: 12000, costUsd: 0.35 },
+            { date: '2026-05-24', sessions: 5, tokens: 18000, costUsd: 0.52 },
+            { date: '2026-05-25', sessions: 4, tokens: 15000, costUsd: 0.39 },
+          ],
+          topKeys: [
+            { keyId: 'admin-key', sessions: 8, tokens: 35000, costUsd: 1.00 },
+            { keyId: 'user-key', sessions: 4, tokens: 10000, costUsd: 0.26 },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/v1/analytics/rate-limits**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          activeSessions: 4,
+          maxConcurrentSessions: 10,
+          rateLimitStatus: 'healthy',
+          recentLimits: [],
+          forecast: { projectedSessions: 6, projectedTokens: 60000, riskLevel: 'low' },
+        }),
+      });
+    });
+
+    await page.goto(`${DASHBOARD_BASE_URL}analytics`);
+  });
+
+  test('renders analytics page heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /analytics/i })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('renders KPI banner with key metrics', async ({ page }) => {
+    // KPI banner should show total sessions, tokens, cost
+    await expect(page.getByText(/12.*sessions/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('renders model distribution section', async ({ page }) => {
+    await expect(page.getByText(/sonnet|opus|haiku/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('renders rate limit status', async ({ page }) => {
+    // Rate limit chart or forecast card should be visible
+    const rateLimitSection = page.getByText(/rate.?limit|concurrent/i).first();
+    await expect(rateLimitSection).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('page is accessible — has main landmark', async ({ page }) => {
+    const main = page.locator('main');
+    await expect(main).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/dashboard/e2e/session-detail-smoke.spec.ts
+++ b/dashboard/e2e/session-detail-smoke.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * e2e/session-detail-smoke.spec.ts — Smoke tests for the Session Detail page.
+ *
+ * Verifies the session detail page loads correctly with:
+ * Status badge, stream/metrics tabs, action buttons, and transcript.
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockDashboardFixtures, SESSION_COCKPIT_ID } from './helpers/dashboard-fixtures';
+
+const DASHBOARD_BASE_URL = 'http://localhost:5200/dashboard/';
+
+test.describe('Session Detail Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockDashboardFixtures(page);
+  });
+
+  test('renders session detail with status badge', async ({ page }) => {
+    await page.goto(`${DASHBOARD_BASE_URL}sessions/${SESSION_COCKPIT_ID}`);
+    // Session ID or status should be visible
+    await expect(page.getByText(SESSION_COCKPIT_ID)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('renders tab strip with Stream and Metrics', async ({ page }) => {
+    await page.goto(`${DASHBOARD_BASE_URL}sessions/${SESSION_COCKPIT_ID}`);
+    await expect(page.getByRole('tab', { name: /stream/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('tab', { name: /metrics/i })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Stream tab shows content by default', async ({ page }) => {
+    await page.goto(`${DASHBOARD_BASE_URL}sessions/${SESSION_COCKPIT_ID}`);
+    // Should show some stream content or empty state
+    const streamContent = page.locator('[data-testid="stream-tab"], .stream-content, [role="tabpanel"]');
+    await expect(streamContent.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Metrics tab renders KPI data when clicked', async ({ page }) => {
+    await page.goto(`${DASHBOARD_BASE_URL}sessions/${SESSION_COCKPIT_ID}`);
+    const metricsTab = page.getByRole('tab', { name: /metrics/i });
+    await expect(metricsTab).toBeVisible({ timeout: 10_000 });
+    await metricsTab.click();
+    // Metrics panel should appear
+    await expect(page.getByText(/\d+.*message|\d+.*tool/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('session detail page is accessible — has main landmark', async ({ page }) => {
+    await page.goto(`${DASHBOARD_BASE_URL}sessions/${SESSION_COCKPIT_ID}`);
+    const main = page.locator('main');
+    await expect(main).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('kill button is present for active sessions', async ({ page }) => {
+    await page.goto(`${DASHBOARD_BASE_URL}sessions/${SESSION_COCKPIT_ID}`);
+    const killBtn = page.getByRole('button', { name: /kill|terminate/i });
+    await expect(killBtn).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright E2E smoke tests for the two dashboard pages with zero prior coverage.

### New Files
- **`e2e/analytics-smoke.spec.ts`** (5 tests)
  - Renders analytics page heading
  - KPI banner with key metrics visible
  - Model distribution section renders
  - Rate limit status visible
  - Page has accessible main landmark
- **`e2e/session-detail-smoke.spec.ts`** (6 tests)
  - Renders session detail with status badge
  - Tab strip shows Stream + Metrics
  - Stream tab shows content by default
  - Metrics tab renders KPI data when clicked
  - Page has accessible main landmark
  - Kill button present for active sessions

### Testing Approach
- Both specs use existing `mockDashboardFixtures` helper
- Analytics spec mocks additional `/v1/analytics/summary` and `/v1/analytics/rate-limits` endpoints
- No real server dependency — all API responses mocked

### CI Integration
Currently CI runs: `login.spec.ts session-list.spec.ts audit.spec.ts`
Recommend adding: `analytics-smoke.spec.ts session-detail-smoke.spec.ts`

Addresses #3705 (E2E testing foundation).