### PR TITLE
chore(dashboard): replace unguarded console.warn with logger utility

### DIFF
--- a/dashboard/src/components/Icon.tsx
+++ b/dashboard/src/components/Icon.tsx
@@ -32,6 +32,7 @@ import {
   Zap,
 } from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
+import { logger } from '../utils/logger';
 
 export type IconSize = 12 | 16 | 20 | 24;
 
@@ -98,7 +99,7 @@ export function Icon({
   const LucideIcon = ICON_MAP[name];
   if (!LucideIcon) {
     if (typeof console !== 'undefined') {
-      console.warn(`[Icon] Unknown icon: "${name}". Add it to Icon.tsx allowlist.`);
+      logger.warn('Icon', `Unknown icon: "${name}". Add it to Icon.tsx allowlist.`);
     }
     return null;
   }


### PR DESCRIPTION
## Summary

Replaces the single unguarded `console.warn` in dashboard production code with the existing `logger` utility.

### Change
- `Icon.tsx`: `console.warn(...)` → `logger.warn(Icon, ...)`
- Adds `logger` import

### Audit Findings (#4157)
The audit flagged 168 `console.*` calls across the repo. Dashboard analysis:
- **1 unguarded** — `Icon.tsx` (this PR fixes it)
- **5 DEV-guarded** — `main.tsx` (SW registration), `SettingsPage.tsx` (localStorage) — appropriate, no change needed
- **2 in `logger.ts`** — expected (implementation)

Dashboard is now **zero unguarded console.* calls** in production code.

Closes #4180.