### PR TITLE
feat(cost): add estimatedCostUsd to session health API and SSE heartbeat (#4204)

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -273,12 +273,12 @@ export class SessionEventBus {
   }
 
   /** Emit a status change event. */
-  emitStatus(sessionId: string, status: string, detail: string): void {
+  emitStatus(sessionId: string, status: string, detail: string, extra?: Record<string, unknown>): void {
     this.emit(sessionId, {
       event: 'status',
       sessionId,
       timestamp: new Date().toISOString(),
-      data: { status, detail },
+      data: { status, detail, ...extra },
     });
   }
 

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -43,7 +43,7 @@ function visibleActiveSessionCount(
 }
 
 export function registerEventRoutes(app: FastifyInstance, ctx: RouteContext): void {
-  const { sessions, eventBus, sseLimiter, config } = ctx;
+  const { sessions, eventBus, sseLimiter, config, metrics } = ctx;
 
   // Global SSE event stream — aggregates events from ALL active sessions
   registerWithLegacy(app, 'get', '/v1/events', async (req: FastifyRequest, reply: FastifyReply) => {
@@ -123,9 +123,18 @@ export function registerEventRoutes(app: FastifyInstance, ctx: RouteContext): vo
 
     sseLimiter.registerWriter(writer);
 
-    writer.startHeartbeat(30_000, config.sseIdleMs, config.sseClientTimeoutMs, () =>
-      `data: ${JSON.stringify({ event: 'heartbeat', timestamp: new Date().toISOString() })}\n\n`
-    );
+    // Issue #4204: Heartbeat includes per-session cost snapshot for dashboard alerts.
+    writer.startHeartbeat(30_000, config.sseIdleMs, config.sseClientTimeoutMs, () => {
+      const sessionCosts: Record<string, { estimatedCostUsd: number }> = {};
+      for (const s of sessions.listSessions()) {
+        if (!eventIsVisible({ sessionId: s.id } as GlobalSSEEvent)) continue;
+        const m = metrics.getSessionMetrics(s.id);
+        if (m?.tokenUsage) {
+          sessionCosts[s.id] = { estimatedCostUsd: m.tokenUsage.estimatedCostUsd };
+        }
+      }
+      return `data: ${JSON.stringify({ event: 'heartbeat', timestamp: new Date().toISOString(), data: { sessionCosts } })}\n\n`;
+    });
 
     await reply;
   });

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -653,6 +653,8 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       lastActivityAgo: number;
       sessionAge: number;
       details: string;
+      /** Issue #4204: Estimated session cost in USD. */
+      estimatedCostUsd?: number;
     }> = {};
     await Promise.all(allSessions.map(async (s) => {
       try {
@@ -667,13 +669,26 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         };
       }
     }));
+    // Issue #4204: Enrich health with per-session estimated cost.
+    for (const [id, health] of Object.entries(results)) {
+      const m = metrics.getSessionMetrics(id);
+      if (m?.tokenUsage) {
+        (health as Record<string, unknown>).estimatedCostUsd = m.tokenUsage.estimatedCostUsd;
+      }
+    }
     return results;
   });
 
   // Session health check (Issue #2)
   registerWithLegacy(app, 'get', '/v1/sessions/:id/health', withOwnership(sessions, async (_req, reply, session) => {
     try {
-      return await sessions.getHealth(session.id);
+      const health = await sessions.getHealth(session.id);
+      // Issue #4204: Include estimated cost in session health.
+      const m = metrics.getSessionMetrics(session.id);
+      if (m?.tokenUsage) {
+        (health as Record<string, unknown>).estimatedCostUsd = m.tokenUsage.estimatedCostUsd;
+      }
+      return health;
     } catch (e: unknown) {
       return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
     }


### PR DESCRIPTION
## Summary

Backend dependency for #4204 (Cost Alert Threshold Config + Toast Notifications).

### Changes

1. **Health API enrichment** — Both `GET /v1/sessions/health` (bulk) and `GET /v1/sessions/:id/health` (single) now include `estimatedCostUsd` from per-session metrics when token usage data is available.

2. **SSE heartbeat cost snapshot** — Global SSE heartbeat (`/v1/events`) now includes a `sessionCosts` map in its data payload, allowing the dashboard to track real-time cost changes every 30s without polling.

3. **`emitStatus()` extensible** — Added optional `extra` parameter to `SessionEventBus.emitStatus()` for future event data enrichment without breaking changes.

### Files changed
- `src/routes/sessions.ts` — enrich health endpoints with cost from metrics
- `src/routes/events.ts` — enrich SSE heartbeat with per-session cost snapshot
- `src/events.ts` — `emitStatus()` accepts optional extra data

### Verification
```
Aegis API: v0.6.7
Commit: 8d0be713
Worktree: /home/bubuntu/projects/wt-4204

tsc --noEmit ✓ (0 new errors)
npm run build ✓
npx vitest run ✓ (374 files, 5269 tests passed, 1 skipped [pre-existing])
```

### Dashboard usage
The SSE heartbeat now sends:
```json
{
  "event": "heartbeat",
  "timestamp": "2026-05-25T10:07:00.000Z",
  "data": {
    "sessionCosts": {
      "abc-123": { "estimatedCostUsd": 0.042 },
      "def-456": { "estimatedCostUsd": 0.118 }
    }
  }
}
```

The health endpoint returns:
```json
{
  "abc-123": {
    "alive": true,
    "status": "working",
    "estimatedCostUsd": 0.042,
    ...
  }
}
```

Closes #4204 (backend dependency)