### PR TITLE
docs: add quick approve/reject endpoints + latestActivityText field (#4212, #4211)

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -62,6 +62,8 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `POST` | `/v1/sessions/{id}/cancel` | Bearer | Cancel running session |
 | `POST` | `/v1/sessions/{id}/approval/approve` | Bearer | Approve pending permission |
 | `POST` | `/v1/sessions/{id}/approval/reject` | Bearer | Reject pending permission |
+| `POST` | `/v1/sessions/{id}/permission/approve` | Bearer | Quick approve (dashboard) |
+| `POST` | `/v1/sessions/{id}/permission/reject` | Bearer | Quick reject (dashboard) |
 | `GET` | `/v1/sessions/{id}/approval/pending` | Bearer | Get pending approvals |
 
 ## ACP Driver Controls

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -744,7 +744,7 @@ curl "http://localhost:9100/v1/sessions?page=1&limit=20&status=working" \
 ```json
 {
   "sessions": [
-    { "id": "abc123", "name": "feature-auth", "status": "working", "workDir": "/project", "createdAt": 1712650800000 }
+    { "id": "abc123", "name": "feature-auth", "status": "working", "workDir": "/project", "createdAt": 1712650800000, "latestActivityText": "Running: npm test" }
   ],
   "pagination": { "page": 1, "limit": 20, "total": 42, "totalPages": 3 }
 }
@@ -865,7 +865,11 @@ curl http://localhost:9100/v1/sessions/abc123 \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-**Response:** Session object with `actionHints` for current interactive state. When a Telegram topic is linked, the response includes `telegramTopicId`.
+**Response:** Session object with `actionHints` for current interactive state, `latestActivityText` for live agent activity, and `telegramTopicId` when a Telegram topic is linked.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `latestActivityText` | string | Human-readable description of current agent activity (e.g. `"Running: npm test"`, `"Editing: server.ts"`, `"Idle"`, `"Waiting for input"`, `"Compacting context"`). Updated in real-time from CC hook events. |
 
 **Errors:**
 
@@ -2184,6 +2188,74 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/approval/reject \
 |--------|------------|
 | 500 | No pending permission request for the given approval ID |
 | 501 | ACP backend not configured |
+
+#### Quick Approve Permission
+
+```
+POST /v1/sessions/:id/permission/approve
+```
+
+Dashboard-optimized endpoint for quickly approving a pending permission prompt. Creates a rich audit entry tagged with `source=dashboard`.
+
+| Role | Required |
+|------|----------|
+| admin, operator | Yes |
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions/abc123/permission/approve \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"approverId": "user@example.com"}'
+```
+
+**Request body:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `approverId` | string | no | Identifier of the approver for audit context |
+
+**Response:** `{ "ok": true }`
+
+**Errors:**
+
+| Status | Condition |
+|--------|------------|
+| 403 | Insufficient permissions |
+| 404 | Session not found |
+
+#### Quick Reject Permission
+
+```
+POST /v1/sessions/:id/permission/reject
+```
+
+Dashboard-optimized endpoint for quickly rejecting a pending permission prompt. Creates a rich audit entry with optional reason.
+
+| Role | Required |
+|------|----------|
+| admin, operator | Yes |
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions/abc123/permission/reject \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason": "Unsafe command"}'
+```
+
+**Request body:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `reason` | string | no | Reason for rejection (audit trail) |
+
+**Response:** `{ "ok": true }`
+
+**Errors:**
+
+| Status | Condition |
+|--------|------------|
+| 403 | Insufficient permissions |
+| 404 | Session not found |
 
 #### Get Pending Approvals
 


### PR DESCRIPTION
## Summary

Documents two new features merged today:

### Quick Approve/Reject Endpoints (PR #4212, Issue #4193)
- `POST /v1/sessions/:id/permission/approve` — dashboard quick-approve with `approverId` audit
- `POST /v1/sessions/:id/permission/reject` — dashboard quick-reject with `reason` audit
- RBAC: admin, operator required
- Audit entries tagged `source=dashboard`

### Live Agent Status (PR #4211, Issue #4203)
- `latestActivityText` field added to session list + detail responses
- Real-time activity strings from CC hook events (e.g. `"Running: npm test"`, `"Editing: server.ts"`, `"Idle"`)

### Changes
- `docs/api-reference.md`: Added Quick Approve/Reject sections with RBAC tables, curl examples, request/response schemas. Added `latestActivityText` to session response schema.
- `docs/api-quick-ref.md`: Added 2 new endpoint entries.