### PR TITLE
fix(dashboard): surface heatmap fetch errors in ActivityPage

### DIFF
--- a/dashboard/src/pages/ActivityPage.tsx
+++ b/dashboard/src/pages/ActivityPage.tsx
@@ -16,8 +16,10 @@ export default function ActivityPage() {
   const t = useT();
   const [heatmapData, setHeatmapData] = useState<HeatmapDataPoint[]>([]);
   const [heatmapLoading, setHeatmapLoading] = useState(true);
+  const [heatmapError, setHeatmapError] = useState<string | null>(null);
 
   const fetchHeatmapData = useCallback(async () => {
+    setHeatmapError(null);
     try {
       // Fetch last 365 days of session history to build the heatmap
       const oneYearAgo = Math.floor((Date.now() - 365 * 24 * 60 * 60 * 1000) / 1000);
@@ -43,8 +45,9 @@ export default function ActivityPage() {
         points.push({ date, value: count });
       }
       setHeatmapData(points);
-    } catch {
-      // Silently fail — heatmap is non-critical
+    } catch (err) {
+      // Heatmap is non-critical but surface the error for transparency
+      setHeatmapError(err instanceof Error ? err.message : 'Failed to load heatmap data');
     } finally {
       setHeatmapLoading(false);
     }
@@ -92,6 +95,18 @@ export default function ActivityPage() {
           {heatmapLoading ? (
             <div className="flex h-20 items-center justify-center">
               <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent" />
+            </div>
+          ) : heatmapError ? (
+            <div className="flex h-20 flex-col items-center justify-center gap-2">
+              <p className="text-sm text-[var(--color-text-muted)]">{heatmapError}</p>
+              <button
+                type="button"
+                onClick={() => { setHeatmapLoading(true); void fetchHeatmapData(); }}
+                className="rounded-md border border-[var(--color-void-lighter)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] hover:border-[var(--color-text-muted)]"
+                aria-label="Retry loading heatmap"
+              >
+                Retry
+              </button>
             </div>
           ) : heatmapData.length > 0 ? (
             <HeatmapGrid

--- a/dashboard/src/pages/__tests__/ActivityPage.test.tsx
+++ b/dashboard/src/pages/__tests__/ActivityPage.test.tsx
@@ -52,7 +52,10 @@ describe('ActivityPage', () => {
   });
 
   it('shows empty state when no heatmap data', async () => {
-    mockFetchSessionHistory.mockResolvedValue({ records: [], total: 0 });
+    mockFetchSessionHistory.mockResolvedValue({
+      records: [],
+      pagination: { page: 1, limit: 25, total: 0, totalPages: 0 },
+    });
     render(<ActivityPage />);
     await waitFor(() => {
       expect(screen.getByText('No session activity recorded yet')).not.toBeNull();
@@ -77,7 +80,10 @@ describe('ActivityPage', () => {
     });
 
     // Now make the next call succeed
-    mockFetchSessionHistory.mockResolvedValue({ records: [], total: 0 });
+    mockFetchSessionHistory.mockResolvedValue({
+      records: [],
+      pagination: { page: 1, limit: 25, total: 0, totalPages: 0 },
+    });
     fireEvent.click(screen.getByText('Retry'));
 
     await waitFor(() => {
@@ -87,8 +93,14 @@ describe('ActivityPage', () => {
 
   it('shows heatmap grid when data loads successfully', async () => {
     mockFetchSessionHistory.mockResolvedValue({
-      records: [{ createdAt: Math.floor(Date.now() / 1000), lastSeenAt: 0 }],
-      total: 1,
+      records: [{
+        id: 'test-record-1',
+        createdAt: Math.floor(Date.now() / 1000),
+        lastSeenAt: 0,
+        finalStatus: 'active',
+        source: 'live',
+      }],
+      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
     });
     render(<ActivityPage />);
     await waitFor(() => {

--- a/dashboard/src/pages/__tests__/ActivityPage.test.tsx
+++ b/dashboard/src/pages/__tests__/ActivityPage.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ActivityPage from '../ActivityPage';
+
+// Mock the API client
+vi.mock('../../api/client', () => ({
+  fetchSessionHistory: vi.fn(),
+}));
+
+// Mock i18n
+vi.mock('../../i18n/context', () => ({
+  useT: () => (key: string) => key,
+}));
+
+// Mock child components that make their own API calls
+vi.mock('../../components/overview/MetricCards', () => ({
+  default: () => <div data-testid="metric-cards">MetricCards</div>,
+}));
+vi.mock('../../components/LiveAuditStream', () => ({
+  default: () => <div data-testid="live-audit">LiveAuditStream</div>,
+}));
+vi.mock('../../components/shared/LiveStatusIndicator', () => ({
+  default: () => <span data-testid="live-status">●</span>,
+}));
+vi.mock('../../components/shared/ClaudeSessionsPanel', () => ({
+  ClaudeSessionsPanel: () => <div data-testid="claude-sessions">ClaudeSessions</div>,
+}));
+vi.mock('../../components/shared/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../components/analytics/HeatmapGrid', () => ({
+  HeatmapGrid: () => <div data-testid="heatmap-grid">HeatmapGrid</div>,
+}));
+
+import { fetchSessionHistory } from '../../api/client';
+const mockFetchSessionHistory = vi.mocked(fetchSessionHistory);
+
+describe('ActivityPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading spinner while heatmap data loads', () => {
+    mockFetchSessionHistory.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<ActivityPage />);
+    expect(screen.getByRole('heading', { name: 'Live Activity' })).not.toBeNull();
+    const spinner = document.querySelector('.animate-spin');
+    expect(spinner).not.toBeNull();
+  });
+
+  it('shows empty state when no heatmap data', async () => {
+    mockFetchSessionHistory.mockResolvedValue({ records: [], total: 0 });
+    render(<ActivityPage />);
+    await waitFor(() => {
+      expect(screen.getByText('No session activity recorded yet')).not.toBeNull();
+    });
+  });
+
+  it('shows error state with retry when heatmap fetch fails', async () => {
+    mockFetchSessionHistory.mockRejectedValue(new Error('Network error'));
+    render(<ActivityPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).not.toBeNull();
+    });
+    expect(screen.getByText('Retry')).not.toBeNull();
+  });
+
+  it('retries heatmap fetch when retry button clicked', async () => {
+    mockFetchSessionHistory.mockRejectedValueOnce(new Error('Network error'));
+    render(<ActivityPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).not.toBeNull();
+    });
+
+    // Now make the next call succeed
+    mockFetchSessionHistory.mockResolvedValue({ records: [], total: 0 });
+    fireEvent.click(screen.getByText('Retry'));
+
+    await waitFor(() => {
+      expect(screen.getByText('No session activity recorded yet')).not.toBeNull();
+    });
+  });
+
+  it('shows heatmap grid when data loads successfully', async () => {
+    mockFetchSessionHistory.mockResolvedValue({
+      records: [{ createdAt: Math.floor(Date.now() / 1000), lastSeenAt: 0 }],
+      total: 1,
+    });
+    render(<ActivityPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('heatmap-grid')).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The ActivityPage heatmap catch block silently swallowed errors, leaving users with an empty heatmap and no explanation.

### Changes
- Added `heatmapError` state to ActivityPage
- Error message shown inline in heatmap section with retry button
- Non-blocking: rest of page still renders normally
- 5 new Vitest tests covering loading, empty, error, retry, and success states

### Closes
- #4199

### Test Evidence
```
✓ src/pages/__tests__/ActivityPage.test.tsx (5 tests) 301ms
  ✓ shows loading spinner while heatmap data loads
  ✓ shows empty state when no heatmap data
  ✓ shows error state with retry when heatmap fetch fails
  ✓ retries heatmap fetch when retry button clicked
  ✓ shows heatmap grid when data loads successfully
```

— Daedalus 🏛️