### PR TITLE
feat(dashboard): row-level amber pulse for approval-pending sessions

### DIFF
--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -33,7 +33,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
   onKill,
 }: SessionRowProps) {
   return (
-    <div className={`card-glass p-5 animate-bento-reveal transition-all ${isFocused ? 'border-[var(--color-accent-cyan)] ring-1 ring-cyan-500/30' : ''}`}>
+    <div className={`card-glass p-5 animate-bento-reveal transition-all ${isFocused ? 'border-[var(--color-accent-cyan)] ring-1 ring-cyan-500/30' : ''}${needsApproval(session) ? ' approval-pending-row' : ''}`}>
       <div className="mb-2 flex items-start justify-between gap-3">
         <label className="flex min-w-0 flex-1 items-center gap-3 text-sm text-[var(--color-text-primary)]">
           <input

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -199,7 +199,7 @@ function VirtualizedRow(props: {
         isFocused
           ? 'bg-[var(--color-accent-cyan)]/10 ring-1 ring-inset ring-[var(--color-accent-cyan)]/40 shadow-[0_0_15px_rgba(6,182,212,0.15)]'
           : 'hover:bg-white/5 hover:scale-[1.002] cursor-pointer'
-      }`}
+      }${needsApproval(session) ? ' approval-pending-row' : ''}`}
       data-session-id={session.id}
       {...ariaAttributes}
     >

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1312,3 +1312,19 @@ main[id="main-content"] {
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+/* ── Approval-pending row pulse ────────────────────────────── */
+@keyframes approval-row-pulse {
+  0%, 100% { box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.15); }
+  50% { box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.4), 0 0 12px rgba(245, 158, 11, 0.08); }
+}
+
+.approval-pending-row {
+  animation: approval-row-pulse 2.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .approval-pending-row {
+    animation: none;
+    box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.35);
+  }
+}


### PR DESCRIPTION
## Summary
Adds a subtle amber pulsing border to session rows awaiting approval (`permission_prompt` / `bash_approval`).

## Changes
- **CSS:** New `approval-row-pulse` keyframe animation (2.5s amber glow cycle)
- **VirtualizedSessionList:** Apply `approval-pending-row` class to desktop rows
- **SessionMobileCard:** Apply same class to mobile cards
- **a11y:** Respects `prefers-reduced-motion` — falls back to static amber inset border

## Visual
- Subtle amber (`#f59e0b`) inset border that pulses between 15% and 40% opacity
- Soft outer glow at peak (12px, 8% opacity)
- Works alongside existing StatusDot pulse — row-level indicator catches the eye during scan

## Testing
- tsc: 0 errors
- build: ✅ clean
- Existing StatusDot + approval button tests unaffected

Closes #4202

— Daedalus 🏛️