### PR TITLE
feat(dashboard): live agent status — latestActivityText in session rows

### DIFF
--- a/dashboard/src/api/schemas.ts
+++ b/dashboard/src/api/schemas.ts
@@ -209,6 +209,7 @@ export const SessionInfoSchema: z.ZodType<SessionInfo> = z.object({
   })).optional(),
   model: z.string().optional(),
   runnerName: z.string().optional(),
+  latestActivityText: z.string().optional(),
 });
 
 // ── SessionsListResponse ────────────────────────────────────────

--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -123,6 +123,11 @@ function SessionCard({ session, t }: { session: SessionInfo; t: (key: string, pa
         )}
         <span title={`Started ${age} ago`}>⏱ {age}</span>
         <span title={`Last active ${lastActive}`}>💬 {lastActive}</span>
+        {session.latestActivityText && (
+          <span className="truncate max-w-[160px] text-[var(--color-accent-cyan)]" title={session.latestActivityText}>
+            ⚡ {session.latestActivityText}
+          </span>
+        )}
       </div>
 
       {/* Status indicator for waiting sessions */}

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -108,6 +108,11 @@ export const SessionMobileCard = memo(function SessionMobileCard({
       <div className="flex flex-wrap items-center gap-3 text-xs text-[var(--color-text-muted)]">
         <span>Age: {formatTimeAgo(session.createdAt)}</span>
         <span>Active: {formatTimeAgo(session.lastActivity)}</span>
+        {session.latestActivityText && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-accent-cyan)]/10 px-2 py-0.5 text-[10px] text-[var(--color-accent-cyan)] truncate max-w-[180px]">
+            {session.latestActivityText}
+          </span>
+        )}
         {estimatedCostUsd != null && estimatedCostUsd > 0 && (
           <span className="font-mono tabular-nums text-[var(--color-accent-cyan)]">
             {`$${estimatedCostUsd < 0.01 ? estimatedCostUsd.toFixed(4) : estimatedCostUsd < 1 ? estimatedCostUsd.toFixed(3) : estimatedCostUsd.toFixed(2)}`}

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -72,7 +72,7 @@ const GROUP_ROW_HEIGHT = 44;
 const DEFAULT_MAX_VISIBLE_ROWS = 12;
 const OVERSCAN_COUNT = 5;
 
-const GRID_COLUMNS = '36px 40px 80px 1fr 150px 80px 90px 80px 60px 80px';
+const GRID_COLUMNS = '36px 40px 80px 1fr 150px 80px 90px 1fr 80px 60px 80px';
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -248,6 +248,11 @@ function VirtualizedRow(props: {
       <div className="flex items-center whitespace-nowrap px-3 text-[var(--color-text-muted)] text-sm">
         {formatTimeAgo(session.lastActivity)}
       </div>
+      <div className="flex items-center px-3 text-xs text-[var(--color-text-muted)] truncate" title={session.latestActivityText ?? ''}>
+        {session.latestActivityText
+          ? <span className="truncate max-w-[120px] inline-block align-bottom">{session.latestActivityText}</span>
+          : <span className="text-[var(--color-text-muted)]/40">—</span>}
+      </div>
       <div className="flex items-center px-3">
         {session.permissionMode && session.permissionMode !== 'default' ? (
           <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-success)]/15 px-2 py-0.5 text-xs text-[var(--color-success)]">
@@ -370,6 +375,7 @@ export function VirtualizedSessionList({
           <div className="flex px-3 py-3 font-medium" role="columnheader">WorkDir</div>
           <div className="px-3 py-3 font-medium" role="columnheader">Age</div>
           <div className="px-3 py-3 font-medium" role="columnheader">Last Activity</div>
+          <div className="px-3 py-3 font-medium" role="columnheader">Activity</div>
           <div className="px-3 py-3 font-medium" role="columnheader">Permission</div>
           <div className="px-3 py-3 font-medium" role="columnheader">Cost</div>
           <div className="px-3 py-3 font-medium" role="columnheader">Actions</div>

--- a/src/api-contracts.ts
+++ b/src/api-contracts.ts
@@ -74,6 +74,7 @@ export interface SessionInfo {
   model?: string;
   effort?: string;
   runnerName?: string;          // Issue #3681: Agent runner name
+  latestActivityText?: string;  // Issue #4203: Human-readable latest activity
 }
 
 export interface SessionHealth {


### PR DESCRIPTION
## v0.7.0 Feature #2: Live Agent Status

Boss-approved scope. Ship second — medium effort, huge observability win.

### What changed
Surfaces the latestActivityText field (added by Hep in #4211) in all session row display surfaces.

**Desktop (VirtualizedSessionList):**
- New Activity column between Last Activity and Permission
- Shows truncated text (max 120px) like "Running: npm test" or "Editing: src/App.tsx"
- Em-dash fallback when no activity text

**Mobile (SessionMobileCard):**
- Inline badge with activity text (max 180px)
- Cyan accent color to stand out from metadata

**Board (SessionBoard):**
- Activity text in card meta row with prefix
- Truncated to 160px

### Before
- Session rows showed status dot + timestamp with no indication of WHAT the agent was doing
- Had to open each session to see current tool call

### After
- At-a-glance view of every agent current action across all sessions
- Updates in real-time via existing SSE/polling

### Files
- src/api-contracts.ts — add field to shared SessionInfo interface
- dashboard/src/api/schemas.ts — add to Zod schema
- VirtualizedSessionList.tsx — new column plus grid update
- SessionMobileCard.tsx — mobile badge
- SessionBoard.tsx — board card text

### Testing
- tsc --noEmit clean
- No new dependencies
- Uses existing SSE infrastructure

Closes #4194. Part of v0.7.0 epic #4192.
