### PR TITLE
chore(lint): upgrade no-console to error with known exceptions (#4217)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,9 +31,16 @@ export default [
   },
   {
     files: ['src/**/*.ts'],
-    ignores: ['src/__tests__/**', 'src/cli.ts', 'src/logger.ts'],
+    ignores: [
+      'src/__tests__/**',
+      'src/cli.ts',
+      'src/logger.ts',
+      'src/suppress.ts',
+      'src/hook.ts',
+      'src/mcp/server.ts',
+    ],
     rules: {
-      'no-console': 'warn',
+      'no-console': 'error',
     },
   },
   {


### PR DESCRIPTION
## Summary

Closes #4217

Upgrades ESLint `no-console` rule from `warn` to `error` and adds known-exception files to the ignore list, ensuring CI blocks future `console.*` regressions in production code.

### Changes
- `eslint.config.js`: Upgraded `no-console` from `warn` → `error`
- Added known-exception files to ignores: `src/suppress.ts`, `src/hook.ts`, `src/mcp/server.ts`
- These files use `console.*` intentionally (CLI standalone mode, defense-in-depth redirection, debug suppression)

### Verification
```
tsc --noEmit ✓
npm run build ✓ (381 files)
npm test ✓ (5395 tests passed, 8 skipped)
eslint src/ — 0 no-console errors (exceptions properly ignored)
```

### Why these files are exempt
- `src/suppress.ts`: Debug suppression utility, uses `console.debug` intentionally
- `src/hook.ts`: CLI standalone hook runner, console output is the intended UX
- `src/mcp/server.ts`: Defense-in-depth console redirection to structured logger

Commit: 1d05ab06