### PR TITLE
docs: document as-is architecture + quality rules for CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,34 @@ npm run hooks:install
 
 This sets `core.hooksPath` to `.githooks/` and runs the gate automatically on every push.
 
+### File Size Limits
+
+Aegis enforces strict file size limits to maintain codebase health:
+
+| Limit | Rule | Enforcement |
+|---|---|---|
+| **500 lines** | No source file should exceed 500 lines without explicit approval | Argus enforces on review |
+| **800 lines** | Hard maximum — PRs adding files >800 lines are rejected | CI gate |
+| **Refactor first** | If a file is growing past 400 lines, refactor before adding features | Self-enforced |
+
+Files currently exceeding these limits (as of v0.7.0): `telegram.ts` (1997), `server.ts` (1611), `session.ts` (1594), `acp-lifecycle-probe.ts` (1521), `openapi.ts` (1275), `services/acp/backend.ts` (1243). These are tracked tech debt and should be split before adding new functionality.
+
+### Config Centralization
+
+All configuration MUST go through `src/config.ts`:
+
+- **Env vars** — only read via `process.env` inside `config.ts` with proper typing and defaults
+- **No raw `process.env`** — never read environment variables directly in route handlers, services, or components
+- **Zod validation** — all config values must have Zod schemas with type-safe defaults
+- **Single source of truth** — if a setting exists in `config.ts`, don't add it as a standalone `process.env` read elsewhere
+
+### Type Safety Rules
+
+- **No `as any`** — use proper types or Zod parsing. If `as any` is unavoidable, add a `// TODO: type this` comment with the issue number
+- **No non-null assertions (`!.`)** — use proper null guards, optional chaining, or fallback values. 48 `!.` assertions in dashboard code are tracked for removal
+- **API contracts** — all request/response types must be defined in `src/api-contracts.ts` using Zod schemas
+- **No `console.log`** — use `src/logger.ts` (StructuredLogger) for all logging. No raw `console.*` in production code
+
 ### PR Size
 
 - Target **<500 lines** per PR — split larger changes into multiple PRs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,11 +33,23 @@ src/
 ├── acp-event-stream.ts       # Real-time ACP event streaming
 ├── channels/                  # Notification channels (event fan-out)
 │   ├── manager.ts            # Event fan-out to all active channels
-│   ├── telegram.ts           # Telegram bot — bidirectional (approve/reject from chat)
+│   ├── telegram.ts           # Telegram bot — bidirectional (approve/reject from chat) ⚠️ 1997 lines — needs splitting
 │   ├── slack.ts              # Slack incoming webhooks — session alerts
 │   ├── email.ts             # SMTP email alerts — stall/dead/error to ops
 │   ├── webhook.ts           # Generic HTTP webhooks — configurable per-endpoint
 │   └── types.ts             # Channel interface, SessionEvent types
+├── commands/                  # CLI subcommands
+│   ├── init.ts              # `ag init` — bootstrap config, detect CC, start server
+│   ├── run.ts               # `ag run` — one-shot session creation with streaming
+│   └── doctor.ts            # `ag doctor` — health checks and diagnostics
+├── runners/                   # Pluggable agent runner abstraction
+│   └── (runner implementations for Claude Code, Codex, etc.)
+├── budgets/                   # Cost alerts and budget enforcement
+│   ├── routes.ts            # REST API: CRUD + evaluate budgets
+│   ├── store.ts             # Budget persistence
+│   ├── evaluator.ts         # Threshold evaluation against session costs
+│   ├── notifications.ts      # Alert delivery to channels
+│   └── types.ts             # Budget, Threshold, Window schemas
 ├── transcript.ts             # JSONL transcript parsing — entries, token usage
 ├── jsonl-watcher.ts          # File watcher for Claude Code JSONL output
 │
@@ -62,6 +74,25 @@ src/
 ├── events.ts                 # SSE event types (session + global)
 ├── sse-writer.ts             # SSE response streaming
 ├── sse-limiter.ts            # SSE rate limiting per client
+├── metering.ts               # Per-session token/cost metering (separate from metrics)
+├── metrics.ts                # Aggregate metrics — token usage, cost estimation, stats
+├── prometheus.ts             # Prometheus metric exposition (prom-client)
+├── rate-limit.ts             # Per-IP and per-key sliding-window rate limiter
+├── rate-limit-coordinator.ts  # Cross-session rate-limit retry coordination
+├── alerting.ts               # Alert rules engine — threshold-based notifications
+├── audit.ts                  # Structured audit logging
+├── activity-text.ts          # Derives human-readable activity text from CC hooks
+├── session-discovery.ts      # Discovers sessions from Claude Code state files
+├── session-transcripts.ts    # Transcript API — read/export session conversations
+├── dashboard-session-auth.ts # Dashboard session cookie management
+├── platform/                 # Platform-specific code (Docker detection, etc.)
+├── plugins/                  # Fastify plugins (structured logging, etc.)
+├── webhook/                  # Outbound webhook delivery
+│   ├── sender.ts            # HTTP webhook sender with retry and signing
+│   └── webhook-signature.ts  # HMAC-SHA256 webhook signature verification
+├── crypto-utils.ts           # Cryptographic helpers (token generation, hashing)
+├── base-url.ts               # Server base URL resolution
+├── openapi.ts                # OpenAPI spec generation for auto-documentation
 ├── ws-terminal.ts            # WebSocket terminal relay (PTY streaming + catchup)
 │
 ├── permission-guard.ts       # Permission request interception and routing
@@ -141,7 +172,49 @@ dashboard/                     # React dashboard (served by Fastify static)
 │   │   └── client.ts         # Typed fetch wrapper for Aegis REST API
 │   └── components/           # Shared UI components
 
-## Dashboard Architecture
+## Known Structural Issues
+
+> This section documents the current state, not aspirations.
+
+### Large Files Needing Refactor
+
+| File | Lines | Problem | Proposed Split |
+|---|---|---|---|
+| `src/channels/telegram.ts` | 1997 | Monolithic — client, formatting, keyboards, media all in one | TelegramClient, TelegramFormatter, TelegramKeyboards, TelegramMediaHandler |
+| `src/server.ts` | 1611 | Route registration + middleware + startup all mixed | Fastify plugins per concern |
+| `src/session.ts` | 1594 | Core session logic acceptable but growing | Extract sub-modules for lifecycle stages |
+| `src/acp-lifecycle-probe.ts` | 1521 | Probe logic tightly coupled | Extract as service |
+| `src/routes/openapi.ts` | 1275 | Auto-generated, acceptable | No action needed |
+| `src/services/acp/backend.ts` | 1243 | Growing fast | Extract action handling |
+
+### Routes Directory (22 files)
+
+The architecture.md module overview previously showed zero route files. Current routes:
+
+| File | Purpose |
+|---|---|
+| `sessions.ts` | Session CRUD, create, send, kill |
+| `session-data.ts` | Session detail, transcript, export |
+| `session-actions.ts` | Session interrupt, escape, capture |
+| `session-approval.ts` | Session-level approval gate (awaiting_approval) |
+| `auth.ts` | API key CRUD, bearer token verification, SSE tokens |
+| `oidc-auth.ts` | OIDC/SSO authentication (Phase 4) |
+| `device-auth.ts` | Device flow authentication |
+| `quick-approve-reject.ts` | Dashboard quick approve/reject with audit trail |
+| `control-actions.ts` | Session control actions (CC-specific) |
+| `driver-controls.ts` | Runner driver controls |
+| `analytics.ts` | Analytics and cost breakdown endpoints |
+| `cost.ts` | Per-key and per-session cost records |
+| `usage.ts` | Usage metering, per-key breakdowns |
+| `audit.ts` | Audit log query endpoints |
+| `templates.ts` | Session template CRUD |
+| `pipelines.ts` | Pipeline creation and management |
+| `health.ts` | Health check endpoints |
+| `events.ts` | SSE event streaming |
+| `terminal.ts` | Terminal relay (WebSocket + PTY) |
+| `context.ts` | Route context — auth, ownership, RBAC helpers |
+| `openapi.ts` | OpenAPI spec generation |
+| `index.ts` | Route registration |
 
 ### Technology Stack
 
@@ -418,6 +491,12 @@ For the full hook event reference (29 lifecycle events), permission policy evalu
 | `signal-cleanup-helper.ts` | Signal handler cleanup on process exit |
 | `verification.ts` | External verification integration |
 | `worktree-lookup.ts` | Git worktree discovery for session workDir |
+
+### Non-Null Assertions in Dashboard
+
+48 `!.` non-null assertions found in dashboard code. These mask potential runtime crashes when the assumed non-null value is undefined. Should be replaced with proper null guards or fallback values.
+
+---
 
 ## Request Flow
 


### PR DESCRIPTION
## Summary

Per Argus directive from audit #4231 — document the current architecture as-is (not aspirational) and add quality enforcement rules to CONTRIBUTING.md.

## Changes

**docs/architecture.md:**
- Added 30+ missing source modules not previously documented (budgets/, alerting.ts, metering.ts, rate-limit.ts, rate-limit-coordinator.ts, session-discovery.ts, commands/, runners/, webhook/, platform/, plugins/, crypto-utils.ts, etc.)
- Documented all 22 route files in routes/ directory (previously zero were listed)
- Added **Known Structural Issues** section with line counts and proposed splits for all files >500 lines
- Flagged `telegram.ts` (1997 lines) and 48 non-null assertions (`!.`) in dashboard code

**CONTRIBUTING.md:**
- **File size limits** — 500 lines soft limit, 800 lines hard maximum, Argus enforces on review
- **Config centralization** — all env vars must go through config.ts, no raw process.env
- **Type safety rules** — no `as any`, no `!.`, API contracts in api-contracts.ts, StructuredLogger only

## References
- #4231 (systemic fixes — architectural gate)
- Argus directive: "Document the current architecture (as-is, not aspirational)"