### PR TITLE
fix(dashboard): wire quick-approve/quick-reject endpoints

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -503,12 +503,30 @@ export function sendMessage(id: string, text: string): Promise<SendResponse> {
   });
 }
 
+/** Issue #4193: Quick approve via dedicated permission endpoint (richer audit trail). */
+export function quickApprove(id: string, opts?: { approverId?: string }): Promise<OkResponse> {
+  return request(`/v1/sessions/${encodeURIComponent(id)}/permission/approve`, {
+    method: 'POST',
+    body: JSON.stringify({ approverId: opts?.approverId }),
+  });
+}
+
+/** Legacy approve — kept for backward compatibility with Telegram one-tap flow. */
 export function approve(id: string): Promise<OkResponse> {
   return request(`/v1/sessions/${encodeURIComponent(id)}/approve`, {
     method: 'POST',
   });
 }
 
+/** Issue #4193: Quick reject via dedicated permission endpoint (richer audit trail with reason). */
+export function quickReject(id: string, opts?: { reason?: string }): Promise<OkResponse> {
+  return request(`/v1/sessions/${encodeURIComponent(id)}/permission/reject`, {
+    method: 'POST',
+    body: JSON.stringify({ reason: opts?.reason }),
+  });
+}
+
+/** Legacy reject — kept for backward compatibility with Telegram one-tap flow. */
 export function reject(id: string): Promise<OkResponse> {
   return request(`/v1/sessions/${encodeURIComponent(id)}/reject`, {
     method: 'POST',

--- a/dashboard/src/components/tour/FirstRunTour.tsx
+++ b/dashboard/src/components/tour/FirstRunTour.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { X, PlayCircle, CheckCircle2, Shield, Trash2, Lightbulb } from 'lucide-react';
-import { createSessionWithFallback, approve, killSession, getSession } from '../../api/client';
+import { createSessionWithFallback, quickApprove, killSession, getSession } from '../../api/client';
 import { useToastStore } from '../../store/useToastStore';
 import { useT } from '../../i18n/context';
 
@@ -106,7 +106,7 @@ export function FirstRunTour({ onComplete }: FirstRunTourProps) {
     if (!sessionId) return;
     
     try {
-      await approve(sessionId);
+      await quickApprove(sessionId);
       addToast('success', 'Permission approved', 'The session can now execute commands');
       
       // Wait a bit then move to kill step

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -14,8 +14,8 @@ import {
   fetchAuditLogs,
   sendMessage,
   sendCommand,
-  approve,
-  reject,
+  quickApprove,
+  quickReject,
   interrupt,
   escape,
   killSession,
@@ -314,12 +314,12 @@ export default function SessionDetailPage() {
   );
 
   function handleApprove() {
-    approve(s.id).catch((e: unknown) =>
+    quickApprove(s.id).catch((e: unknown) =>
       addToast('error', t('sessionDetail.approveFailed'), e instanceof Error ? e.message : undefined),
     );
   }
   function handleReject() {
-    reject(s.id).catch((e: unknown) =>
+    quickReject(s.id).catch((e: unknown) =>
       addToast('error', t('sessionDetail.rejectFailed'), e instanceof Error ? e.message : undefined),
     );
   }


### PR DESCRIPTION
## Bug Fix — v0.7.0 Quick Approve Uses Wrong Endpoints

The Quick Approve/Reject feature (v0.7.0) was calling the legacy  and  endpoints instead of the dedicated  and  endpoints that Hephaestus shipped in #4212.

### What changed
- **client.ts**: Added  and  calling the new permission endpoints with richer request bodies for audit trail
- **SessionDetailPage**: Approval/reject buttons now use / instead of legacy /
- **FirstRunTour**: Tour approve action uses 

### Why it matters
The new permission endpoints provide:
- Richer audit trail entries (approverId, reason)
- Source tracking (source=dashboard)
- Explicit permission response latency recording

Legacy functions kept for Telegram one-tap backward compatibility.

### Testing
- tsc --noEmit: clean
- vitest: 181 files, 1753 tests pass

Found during architecture audit #4226. Related: #4193, #4212.