### PR TITLE
fix(dashboard): i18n hardcoded strings in 4 pages

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -580,6 +580,10 @@ export const en = {
     goHome: 'Back to Dashboard',
   },
 
+  notifications: {
+    disconnect: 'Disconnect',
+  },
+
   aria: {
     // Layout & Navigation
     primarySidebar: 'Primary sidebar',

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -79,6 +79,12 @@ export const en = {
     metricFailed: 'Failed',
     loading: 'Loading pipelines…',
     loadErrorTitle: 'Unable to load pipelines',
+    noPipelinesYet: 'No pipelines yet',
+    createPipeline: 'Create a pipeline to automate session workflows.',
+    total: 'Total',
+    running: 'Running',
+    completed: 'Completed',
+    failed: 'Failed',
     loadErrorDefault: 'Try adjusting your filters',
     emptyTitle: 'No pipelines yet',
     emptyDescription: 'Create a pipeline to automate session workflows.',
@@ -108,6 +114,9 @@ export const en = {
   },
   
   cost: {
+    daily: 'Daily',
+    monthly: 'Monthly',
+    noCostData: 'No cost data yet',
     title: 'Cost & Billing',
     subtitle: 'Track API usage and spending',
     todaySpent: 'Today',
@@ -159,6 +168,8 @@ export const en = {
   },
 
   metrics: {
+    chartSessions: 'Sessions',
+    chartTokenCost: 'Token Cost',
     title: 'Metrics',
     subtitle: 'Aggregate session metrics and export',
     loading: 'Loading metrics...',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -81,6 +81,12 @@ export const it = {
     metricFailed: 'Fallite',
     loading: 'Caricamento pipeline…',
     loadErrorTitle: 'Impossibile caricare le pipeline',
+    noPipelinesYet: 'Nessuna pipeline',
+    createPipeline: 'Crea una pipeline per automatizzare i flussi di lavoro.',
+    total: 'Totale',
+    running: 'In esecuzione',
+    completed: 'Completate',
+    failed: 'Fallite',
     loadErrorDefault: 'Prova a modificare i filtri',
     emptyTitle: 'Nessuna pipeline ancora',
     emptyDescription: 'Crea una pipeline per automatizzare i flussi di sessione.',
@@ -110,6 +116,9 @@ export const it = {
   },
 
   cost: {
+    daily: 'Giornaliero',
+    monthly: 'Mensile',
+    noCostData: 'Nessun dato sui costi',
     title: 'Costi e Fatturazione',
     subtitle: "Traccia l'utilizzo API e la spesa",
     todaySpent: 'Oggi',
@@ -162,6 +171,8 @@ export const it = {
   },
 
   metrics: {
+    chartSessions: 'Sessioni',
+    chartTokenCost: 'Costo Token',
     title: 'Metriche',
     subtitle: 'Metriche aggregate delle sessioni ed esportazione',
     loading: 'Caricamento metriche...',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -582,6 +582,10 @@ export const it = {
     goHome: 'Torna alla Dashboard',
   },
 
+  notifications: {
+    disconnect: 'Disconnetti',
+  },
+
   aria: {
     primarySidebar: 'Barra laterale principale',
     closeMenu: 'Chiudi menu',

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -150,13 +150,13 @@ function BudgetOverview({ dailyData, budgetSettings, navigateToSettings }: Budge
         <BudgetProgressBar
           currentSpend={todaySpend}
           cap={budgetSettings.budgetDailyCapUsd}
-          label="Daily"
+          label={t("cost.daily")}
           period="today"
         />
         <BudgetProgressBar
           currentSpend={monthSpend}
           cap={budgetSettings.budgetMonthlyCapUsd}
-          label="Monthly"
+          label={t("cost.monthly")}
           period={`${today.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}`}
         />
       </div>
@@ -282,7 +282,7 @@ export default function CostPage() {
         </div>
         <EmptyState
           icon={<DollarSign className="h-8 w-8" />}
-          title="No cost data yet"
+          title={t("cost.noCostData")}
           description={hasSessions
             ? 'Sessions are running but cost data is not yet available. Cost metrics populate once the metrics pipeline processes session data.'
             : 'Cost metrics will appear once Aegis starts tracking usage. Start a session to begin collecting data.'

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -309,7 +309,7 @@ export default function MetricsPage() {
                 <Bar
                   yAxisId="sessions"
                   dataKey="sessions"
-                  name="Sessions"
+                  name={t("metrics.chartSessions")}
                   fill={CHART_COLORS.cyan}
                   radius={[4, 4, 0, 0]}
                 />
@@ -344,7 +344,7 @@ export default function MetricsPage() {
                 <Line
                   type="monotone"
                   dataKey="tokenCostUsd"
-                  name="Token Cost"
+                  name={t("metrics.chartTokenCost")}
                   stroke={CHART_COLORS.purple}
                   strokeWidth={2}
                   dot={false}

--- a/dashboard/src/pages/NotificationSettingsPage.tsx
+++ b/dashboard/src/pages/NotificationSettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import { useToastStore } from '../store/useToastStore';
+import { useT } from '../i18n/context';
 import { ConfirmDestructive } from '../components/shared/ConfirmDestructive';
 import type {
   TelegramConnectionState,
@@ -46,6 +47,7 @@ const STATUS_CONFIG: Record<ConnectionStatus, { color: string; icon: typeof Chec
 
 export default function NotificationSettingsPage() {
   const addToast = useToastStore((s) => s.addToast);
+  const t = useT();
 
   // ── State ────────────────────────────────────────────
   const [connection, setConnection] = useState<TelegramConnectionState>({ status: 'disconnected' });
@@ -369,7 +371,7 @@ export default function NotificationSettingsPage() {
 
                     <ConfirmDestructive
                       mode="hold"
-                      label="Disconnect"
+                      label={t("notifications.disconnect")}
                       onConfirm={handleDisconnect}
                     />
                   </>

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -194,10 +194,10 @@ export default function PipelinesPage() {
 
       {/* Metrics */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <MetricCard label="Total" value={counts.total} />
-        <MetricCard label="Running" value={counts.running} />
-        <MetricCard label="Completed" value={counts.completed} />
-        <MetricCard label="Failed" value={counts.failed} />
+        <MetricCard label={t("pipelines.total")} value={counts.total} />
+        <MetricCard label={t("pipelines.running")} value={counts.running} />
+        <MetricCard label={t("pipelines.completed")} value={counts.completed} />
+        <MetricCard label={t("pipelines.failed")} value={counts.failed} />
       </div>
 
       {/* Pipeline List */}
@@ -205,15 +205,15 @@ export default function PipelinesPage() {
         <EmptyState
           variant="empty-error"
           icon={<GitBranch className="h-8 w-8" />}
-          title="Unable to load pipelines"
+          title={t("pipelines.loadErrorTitle")}
           description={loadError || 'Try adjusting your filters'}
         />
       ) : isEmpty ? (
         <div className="space-y-4">
           <EmptyState
             icon={<GitBranch className="h-8 w-8" />}
-            title="No pipelines yet"
-            description="Create a pipeline to automate session workflows."
+            title={t("pipelines.noPipelinesYet")}
+            description={t("pipelines.createPipeline")}
             action={
               <button
                 type="button"


### PR DESCRIPTION
## i18n Completion — Audit #4226

Replace hardcoded English strings with i18n key references in 4 pages.

### Pages fixed
- PipelinesPage: metric labels, error/empty state titles
- CostPage: Daily/Monthly labels, no-cost-data title  
- MetricsPage: chart names
- NotificationSettingsPage: Disconnect label, added useT import

### i18n catalog
- en.ts + it.ts: 11 new keys each

tsc clean. No functional changes.