### PR TITLE
ci(arch-gate): extend npm run gate with file-size, as-any, and circular-deps checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postinstall": "node scripts/postinstall-verify.cjs",
     "hooks:install": "git config core.hooksPath .githooks",
     "docs": "typedoc",
-    "gate": "npm run hygiene-check && npm run security-check && npm run token-check && npm run audit-check && npm run lint && npm run dashboard:tokens:gate && npm run dashboard:clickable:gate && npx tsc --noEmit && npm run build && npm run check-bundle-size && npm run test",
+    "gate": "npm run gate:arch && npm run hygiene-check && npm run security-check && npm run token-check && npm run audit-check && npm run lint && npm run dashboard:tokens:gate && npm run dashboard:clickable:gate && npx tsc --noEmit && npm run build && npm run check-bundle-size && npm run test",
     "start": "node dist/cli.js",
     "dev": "tsc && node dist/cli.js",
     "prepublishOnly": "bash scripts/check-merge-conflicts.sh && npm run build",
@@ -65,7 +65,8 @@
     "test:e2e": "vitest run e2e/e2e-dogfood.test.ts",
     "test:e2e:ci": "vitest run e2e/e2e-dogfood.test.ts --reporter=verbose",
     "audit-check": "bash scripts/audit-check.sh",
-    "check-bundle-size": "bash scripts/check-bundle-size.sh"
+    "check-bundle-size": "bash scripts/check-bundle-size.sh",
+    "gate:arch": "bash scripts/check-file-size.sh && bash scripts/check-as-any.sh && bash scripts/check-circular-deps.sh"
   },
   "keywords": [
     "claude",

--- a/scripts/check-as-any.sh
+++ b/scripts/check-as-any.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Fail if this branch introduces any new 'as any' occurrences compared to develop
+BASE=${1:-origin/develop}
+# Fetch develop for diff
+git fetch origin develop:develop-fetch || true
+DIFF=$(git diff --no-color --unified=0 $BASE...HEAD || true)
+# Look for added lines containing 'as any'
+ADDITIONS=$(echo "$DIFF" | grep '^+' || true)
+if [ -z "$ADDITIONS" ]; then
+  echo "No additions detected vs $BASE. Skipping as-any check."
+  exit 0
+fi
+COUNT=$(echo "$ADDITIONS" | grep -E "as any" -c || true)
+if [ "$COUNT" -gt 0 ]; then
+  echo "New 'as any' occurrences introduced in this branch: $COUNT"
+  echo "$ADDITIONS" | grep -n -E "as any" || true
+  exit 2
+fi
+echo "No new 'as any' additions detected vs $BASE."

--- a/scripts/check-circular-deps.sh
+++ b/scripts/check-circular-deps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Runs madge circular check
+CIRC=$(npx madge --circular src 2>/dev/null || true)
+if [ -n "$CIRC" ]; then
+  echo "Circular dependencies found:";
+  echo "$CIRC";
+  exit 2
+fi
+echo "No circular dependencies found."

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+THRESHOLD=${1:-500}
+# Find TypeScript files in src/ exceeding threshold
+FOUND=0
+# Use git ls-files to respect repo file set
+FILES=$(git ls-files 'src/**/*.ts' || true)
+if [ -z "$FILES" ]; then
+  echo "No files found under src/."
+  exit 0
+fi
+for f in $FILES; do
+  LINES=$(wc -l < "$f" || echo 0)
+  if [ "$LINES" -gt "$THRESHOLD" ]; then
+    echo "FILE_TOO_LARGE: $f ($LINES lines)"
+    FOUND=1
+  fi
+done
+if [ "$FOUND" -eq 1 ]; then
+  echo "One or more files exceed $THRESHOLD lines. Please split or get approval from Argus+Hephaestus."
+  exit 2
+fi
+echo "File-size check passed (<= $THRESHOLD lines)."


### PR DESCRIPTION
Adds architectural gate scripts and extends 'npm run gate' to run them.\n\n- scripts/check-file-size.sh (fail on files > 500 lines under src/)\n- scripts/check-as-any.sh (fail on new 'as any' additions compared to origin/develop)\n- scripts/check-circular-deps.sh (run madge --circular)\n\nThe gate is expanded via a new 'gate:arch' script and existing 'gate' now runs 'gate:arch' first.\n\nThis enforces the Operational Rules: no file >500 lines, no new 'as any', and no circular deps.\n\nPlease review: @Hephaestus (1490089546099069048), @Argus (1490089830472880218).