### PR TITLE
refactor(server): extract route registration scaffold into services/api/routes

### DIFF
--- a/src/__tests__/routes-register.test.ts
+++ b/src/__tests__/routes-register.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { registerRoutes } from '../services/api/routes/index.js';
+
+describe('routes.register scaffold', () => {
+  it('exports registerRoutes function', () => {
+    expect(typeof registerRoutes).toBe('function');
+  });
+});

--- a/src/services/api/routes/index.ts
+++ b/src/services/api/routes/index.ts
@@ -1,0 +1,13 @@
+import type { FastifyInstance } from 'fastify';
+
+/**
+ * Register application routes.
+ *
+ * This file is the initial scaffold for extracting route registration out of server.ts.
+ * It should be populated incrementally with route registration calls migrated from server.ts.
+ */
+export function registerRoutes(app: FastifyInstance) {
+  // No-op scaffold. Individual route modules will be imported and registered here.
+}
+
+export default registerRoutes;


### PR DESCRIPTION
Initial scaffold for extracting route registration from server.ts.\n\nThis PR adds services/api/routes/index.ts with a registerRoutes(app) function and a minimal unit test.\n\nNext: migrate small sets of route registrations from server.ts into services/api/routes/* in follow-up PRs.\n\nRelated: #4227 (refactor server extraction)