### PR TITLE
fix(dashboard): null safety guards on API responses in 3 pages

### DIFF
--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -215,7 +215,7 @@ export default function AnalyticsPage() {
       {/* Data consistency check */}
       {(() => {
         const hasSessions = data.errorRates.totalSessions > 0;
-        const hasChartData = data.sessionVolume.length > 0 || data.tokenUsageByModel.length > 0 || data.durationTrends.length > 0;
+        const hasChartData = (data.sessionVolume ?? []).length > 0 || (data.tokenUsageByModel ?? []).length > 0 || (data.durationTrends ?? []).length > 0;
         if (hasSessions && !hasChartData) {
           return (
             <div
@@ -238,11 +238,11 @@ export default function AnalyticsPage() {
       <KPIBanner items={buildKPIItems(data, totalCost, totalTokens, avgDuration)} />
 
       {/* Model Distribution Bar */}
-      {data.tokenUsageByModel.length > 0 && (
+      {(data.tokenUsageByModel ?? []).length > 0 && (
         <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
           <h3 className="mb-3 text-sm font-medium text-[var(--color-text-primary)]">Model Distribution</h3>
           <ModelDistributionBar
-            segments={data.tokenUsageByModel.map((m) => ({
+            segments={(data.tokenUsageByModel ?? []).map((m) => ({
               model: m.model,
               fraction: m.estimatedCostUsd / (totalCost || 1),
             }))}
@@ -302,13 +302,13 @@ export default function AnalyticsPage() {
 
         {/* Token Usage by Model */}
         <ChartCard title={t("analytics.tokenUsage")}>
-          {data.tokenUsageByModel.length > 0 ? (
+          {(data.tokenUsageByModel ?? []).length > 0 ? (
             <div className="flex flex-col lg:flex-row items-center gap-4">
               <div className="h-[220px] w-full min-w-0 lg:w-1/2">
                 <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
                   <PieChart>
                     <Pie
-                      data={data.tokenUsageByModel.map((m) => ({
+                      data={(data.tokenUsageByModel ?? []).map((m) => ({
                         ...m,
                         totalTokens: m.inputTokens + m.outputTokens + m.cacheCreationTokens + m.cacheReadTokens,
                       }))}

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -72,7 +72,7 @@ function CustomTooltip({ active, payload, label }: {
 
 function generateCSV(data: AggregateMetricsResponse): string {
   const headers = ['Timestamp', 'Sessions', 'Messages', 'Tool Calls', 'Token Cost (USD)'];
-  const rows = data.timeSeries.map((tp) => [
+  const rows = (data.timeSeries ?? []).map((tp) => [
     tp.timestamp,
     String(tp.sessions),
     String(tp.messages),
@@ -320,7 +320,7 @@ export default function MetricsPage() {
       )}
 
       {/* Cost trend line chart */}
-      {data && granularity !== 'key' && data.timeSeries.length > 0 && (
+      {data && granularity !== 'key' && (data.timeSeries ?? []).length > 0 && (
         <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Token Cost Trend
@@ -356,7 +356,7 @@ export default function MetricsPage() {
       )}
 
       {/* By-key breakdown table */}
-      {data && data.byKey.length > 0 && (
+      {data && (data.byKey ?? []).length > 0 && (
         <section className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5">
           <h3 className="mb-4 text-lg font-medium text-[var(--color-text-primary)]">
             Breakdown by API Key
@@ -373,7 +373,7 @@ export default function MetricsPage() {
                 </tr>
               </thead>
               <tbody>
-                {data.byKey.map((row) => (
+                {(data.byKey ?? []).map((row) => (
                   <tr key={row.keyId} className="border-b border-[var(--color-border-strong)]/50">
                     <td className="py-2 font-mono text-[var(--color-text-primary)]">{row.keyName}</td>
                     <td className="py-2 text-right font-mono text-[var(--color-text-primary)]">{row.sessions.toLocaleString()}</td>
@@ -389,7 +389,7 @@ export default function MetricsPage() {
       )}
 
       {/* Empty state */}
-      {data && data.summary.totalSessions === 0 && (
+      {data && data.summary?.totalSessions === 0 && (
         <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-8 text-center">
           <BarChart3 className="mx-auto h-8 w-8 text-[var(--color-text-muted)]" />
           <p className="mt-2 text-sm text-[var(--color-text-muted)]">

--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -149,12 +149,12 @@ export default function OverviewPage() {
         id: 'errors',
         label: 'Error Rate',
         value: totalSessions > 0
-          ? `${((analytics.errorRates.failedSessions / totalSessions) * 100).toFixed(1)}%`
+          ? `${(((analytics.errorRates?.failedSessions ?? 0) / totalSessions) * 100).toFixed(1)}%`
           : '0%',
-        color: totalSessions > 0 && (analytics.errorRates.failedSessions / totalSessions) > 0.05
+        color: totalSessions > 0 && ((analytics.errorRates?.failedSessions ?? 0) / totalSessions) > 0.05
           ? 'cost'
           : 'efficiency',
-        trend: totalSessions > 0 && (analytics.errorRates.failedSessions / totalSessions) > 0.05
+        trend: totalSessions > 0 && ((analytics.errorRates?.failedSessions ?? 0) / totalSessions) > 0.05
           ? 'up'
           : 'flat',
       },
@@ -229,7 +229,7 @@ export default function OverviewPage() {
             <span>·</span>
             <span>
               {formatDuration(
-                analytics.durationTrends.length > 0
+                (analytics.durationTrends ?? []).length > 0
                   ? Math.round(
                       (analytics.durationTrends ?? []).reduce((s, d) => s + d.avgDurationSec * d.count, 0)
                       / (analytics.durationTrends ?? []).reduce((s, d) => s + d.count, 0),
@@ -240,8 +240,8 @@ export default function OverviewPage() {
             </span>
             <span>·</span>
             <span>
-              {analytics.sessionVolume.length > 0
-                ? `${formatDateShort(analytics.sessionVolume[0].date)} → ${formatDateShort(analytics.sessionVolume[analytics.sessionVolume.length - 1].date)}`
+              {(analytics.sessionVolume ?? []).length > 0
+                ? `${formatDateShort(analytics.sessionVolume?.[0]?.date)} → ${formatDateShort(analytics.sessionVolume?.[analytics.sessionVolume.length - 1]?.date)}`
                 : 'No date range'}
             </span>
             <span>·</span>
@@ -257,7 +257,7 @@ export default function OverviewPage() {
         {/* Cost/Day chart — 2/3 width */}
         <section className="lg:col-span-2 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-5" aria-label={t("aria.dailyCostChart")}>
           <h3 className="mb-4 text-sm font-medium text-[var(--color-text-primary)]">Cost / Day</h3>
-          {analytics && analytics.costTrends.length > 0 ? (
+          {analytics && (analytics.costTrends ?? []).length > 0 ? (
             <Suspense fallback={<div className="h-[220px] animate-pulse rounded bg-[var(--color-void-lighter)]/20" />}>
               <OverviewCostChart data={analytics.costTrends} />
             </Suspense>


### PR DESCRIPTION
## Crash Prevention — Audit #4226

Prevents runtime TypeError crashes when API responses have missing or null fields.

### Pages fixed
- AnalyticsPage: tokenUsageByModel, sessionVolume, durationTrends guarded with null coalescing
- MetricsPage: timeSeries, byKey, summary.totalSessions guarded with optional chaining
- OverviewPage: errorRates.failedSessions, durationTrends, sessionVolume, costTrends guarded

### Before
If the API returned null fields the page would crash with TypeError.

### After
Gracefully falls back to empty array, showing no data instead of crashing.

Pattern consistent with PR #4189. tsc clean.
