### PR TITLE
fix(dashboard): remove unused date-fns dependency

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -15,7 +15,6 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "canvas-confetti": "^1.9.4",
-        "date-fns": "^4.3.0",
         "dompurify": "^3.4.5",
         "framer-motion": "^12.40.0",
         "lucide-react": "^1.16.0",
@@ -1765,16 +1764,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
-      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/decimal.js": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,6 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "canvas-confetti": "^1.9.4",
-    "date-fns": "^4.3.0",
     "dompurify": "^3.4.5",
     "framer-motion": "^12.40.0",
     "lucide-react": "^1.16.0",


### PR DESCRIPTION
## Dead Dependency Cleanup — Audit #4226

date-fns was still in package.json but not imported anywhere in the codebase. Previous refactoring replaced all date-fns usage with native Date methods but forgot to remove the dependency.

- Removes date-fns from package.json and package-lock.json
- Build succeeds, tsc clean, no imports affected
- Zero vulnerability change (already clean)