### PR TITLE
fix(dashboard): replace non-null assertions with proper null guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ wt/
 coverage/
 wt-last-updated
 wt-i18n-sessionboard
+node_modules

--- a/dashboard/src/components/overview/SessionBoard.tsx
+++ b/dashboard/src/components/overview/SessionBoard.tsx
@@ -287,7 +287,7 @@ export function SessionBoard() {
     for (const session of sessions) {
       const groupId = getStatusGroup(session.status);
       if (!grouped.has(groupId)) grouped.set(groupId, []);
-      grouped.get(groupId)!.push(session);
+      { const g = grouped.get(groupId); if (g) g.push(session); };
     }
 
     // Sort within each column: primary by most recent activity, secondary by createdAt

--- a/dashboard/src/components/session/DriverControlBar.tsx
+++ b/dashboard/src/components/session/DriverControlBar.tsx
@@ -95,7 +95,7 @@ export function DriverControlBar({
           <Gamepad2 className="h-4 w-4 text-[var(--color-cta-bg)]" />
           {hasDriver ? (
             <span className="text-sm text-[var(--color-text-primary)]">
-              Driver: <span className="font-medium">{participants!.driver!.subscriberId}</span>
+              Driver: <span className="font-medium">{participants?.driver?.subscriberId ?? "unknown"}</span>
               {isDriver && (
                 <span className={`ml-2 rounded px-1.5 py-0.5 text-xs ${ROLE_COLORS.driver.bg} ${ROLE_COLORS.driver.text}`}>
                   You

--- a/dashboard/src/i18n/context.tsx
+++ b/dashboard/src/i18n/context.tsx
@@ -89,7 +89,7 @@ export function I18nProvider({ children }: { children: ReactNode }) {
     // Simple parameter substitution: {count} -> params.count
     if (params) {
       Object.entries(params).forEach(([paramKey, value]) => {
-        message = message!.replace(new RegExp(`\\{${paramKey}\\}`, 'g'), String(value));
+        message = message?.replace(new RegExp(`\\{${paramKey}\\}`, 'g'), String(value));
       });
     }
     


### PR DESCRIPTION
## Summary
Replace 3 non-null assertions (!.) with optional chaining and proper null guards to prevent potential runtime crashes.

### Changes
- `src/i18n/context.tsx:92` — `message!.replace()` → `message?.replace()`
- `src/components/session/DriverControlBar.tsx:98` — `participants!.driver!.subscriberId` → `participants?.driver?.subscriberId ?? "unknown"`
- `src/components/overview/SessionBoard.tsx:290` — `grouped.get(groupId)!.push()` → null-safe guard with early exit

### Note
The issue referenced `TimeFilterBar.tsx` but this file does not exist in the current codebase (likely removed in a prior refactor).

### Verification
- ✅ Build passes
- ✅ DriverControlBar tests: 19/19 pass
- ✅ No new tsc errors introduced

Closes #4262