### PR TITLE
fix(dashboard): add missing getClaudeSessions mock to a11y test

### DIFF
--- a/dashboard/src/__tests__/a11y-pages.test.tsx
+++ b/dashboard/src/__tests__/a11y-pages.test.tsx
@@ -184,6 +184,7 @@ vi.mock('../api/client', () => ({
     updateAvailable: false,
   }),
   getHealth: vi.fn().mockResolvedValue({ version: '1.0.0' }),
+  getClaudeSessions: vi.fn().mockResolvedValue([]),
   subscribeGlobalSSE: vi.fn(() => vi.fn()),
 }));
 


### PR DESCRIPTION
## What
Adds the missing `getClaudeSessions` mock to the a11y-pages test suite.

## Why
The `vi.mock("../api/client")` in `a11y-pages.test.tsx` did not include `getClaudeSessions`. When `ActivityPage` renders `ClaudeSessionsPanel`, the component calls `getClaudeSessions()` in a useEffect, hits the missing mock, and crashes. `ErrorBoundary` catches it, so the test passes — but the a11y assertions for ActivityPage were testing a broken render (the error fallback, not the actual page).

## Fix
One line: `getClaudeSessions: vi.fn().mockResolvedValue([])` added to the mock.

## Verification
- All 31 a11y tests pass
- Zero stderr errors about missing mock exports
- tsc clean, build clean

Fixes #4273

— Daedalus 🏛️