### PR TITLE
fix: replace 14 'as any' casts with proper TypeScript types (#4247)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -643,7 +643,7 @@ export async function handleRun(args: string[], io: CliIO): Promise<number> {
       const { execFile } = await import('node:child_process');
       const authCheck = await new Promise<{ stdout: string; stderr: string; code: number }>((resolve) => {
         execFile('claude', ['-p', '/version'], { timeout: 5000 }, (err, stdout, stderr) => {
-          resolve({ stdout: stdout ?? '', stderr: stderr ?? '', code: err ? (err as any).code ?? 1 : 0 });
+          resolve({ stdout: stdout ?? '', stderr: stderr ?? '', code: err ? (('code' in err ? Number((err as NodeJS.ErrnoException).code) : undefined) ?? 1) : 0 });
         });
       });
       if (authCheck.stderr.includes('Not logged in') || authCheck.stderr.includes('Please run /login') || authCheck.code === 1) {

--- a/src/routes/audit.ts
+++ b/src/routes/audit.ts
@@ -191,8 +191,8 @@ export function registerAuditRoutes(app: FastifyInstance, ctx: RouteContext): vo
       const records = page.records;
       const total = page.total;
       const pagination = useCursorPath
-        ? { limit: page.limit, hasMore: page.hasMore, nextCursor: (page as any).nextCursor, reverse }
-        : { offset: (page as any).offset, limit: page.limit, hasMore: (page as any).hasMore };
+        ? { limit: page.limit, hasMore: page.hasMore, nextCursor: ('nextCursor' in page ? page.nextCursor : null), reverse }
+        : { offset: ('offset' in page ? page.offset : 0), limit: page.limit, hasMore: page.hasMore };
         // Chain from raw records
         const first = records[0];
         const last = records[records.length - 1];
@@ -201,8 +201,8 @@ export function registerAuditRoutes(app: FastifyInstance, ctx: RouteContext): vo
           firstHash: first.hash,
           lastHash: last.hash,
           badgeHash: '',
-          firstTs: (first as any).ts ?? (first as any).timestamp,
-          lastTs: (last as any).ts ?? (last as any).timestamp,
+          firstTs: 'ts' in first ? first.ts : first.timestamp,
+          lastTs: 'ts' in last ? last.ts : last.timestamp,
         } : { count: 0, firstHash: null, lastHash: null, badgeHash: null, firstTs: null, lastTs: null };
 
         return {

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -55,7 +55,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     }
     try {
       const result = acpBackend && config.acpEnabled
-        ? await acpBackend.sendPrompt(sessionId, text, { tenantId: (req as any).tenantId ?? SYSTEM_TENANT, ownerKeyId: (req as any).authKeyId ?? 'master' })
+        ? await acpBackend.sendPrompt(sessionId, text, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
         : await sessions.sendMessage(sessionId, text);
       // Issue #1809: Re-fetch stall info AFTER delivery to avoid false-positive.
       // Previously we called getStallInfo BEFORE send, capturing a stale state
@@ -253,8 +253,8 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
       if (acpBackend && ctx.config.acpEnabled) {
         await acpBackend.shutdownSession({
           sessionId: session.id,
-          tenantId: (req as any).tenantId ?? SYSTEM_TENANT,
-          ownerKeyId: (req as any).authKeyId ?? 'master',
+          tenantId: req.tenantId ?? SYSTEM_TENANT,
+          ownerKeyId: req.authKeyId ?? 'master',
         }).catch(() => {}); // Best-effort: session may not have ACP runtime
       }
       await sessions.killSession(session.id);
@@ -287,7 +287,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     try {
       const cmd = command.startsWith('/') ? command : `/${command}`;
       const cmdResult = acpBackend && config.acpEnabled
-        ? await acpBackend.sendPrompt(session.id, cmd, { tenantId: (req as any).tenantId ?? SYSTEM_TENANT, ownerKeyId: (req as any).authKeyId ?? 'master' })
+        ? await acpBackend.sendPrompt(session.id, cmd, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
         : await sessions.sendMessage(session.id, cmd);
       return { ok: true };
     } catch (e: unknown) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -883,8 +883,7 @@ async function main(): Promise<void> {
     ...(persistDebounceMs !== undefined ? { persistDebounceMs } : {}),
   });
   await acpLocalProfile.start();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  acpPauseStore = (acpLocalProfile as any).pauseInterventionStore ?? null;
+  acpPauseStore = acpLocalProfile.pauseInterventionStore ?? null;
   acpSessionService = new AcpSessionService(acpLocalProfile.sessionStore, {
     pauseInterventionStore: acpPauseStore ?? new InMemoryPauseInterventionStore(),
   });

--- a/src/services/acp/local-storage.ts
+++ b/src/services/acp/local-storage.ts
@@ -46,6 +46,8 @@ export interface AcpLocalStorageProfile {
   sessionStore: AcpSessionStore;
   eventStore: AcpEventStore;
   actionQueue: AcpActionQueue;
+  /** Issue #4247: Pause intervention store for ACP sessions. */
+  readonly pauseInterventionStore: AcpPauseInterventionStore;
   start(): Promise<void>;
   stop(signal?: AbortSignal): Promise<void>;
   health(): Promise<ServiceHealth>;

--- a/src/services/auth/AuthManager.ts
+++ b/src/services/auth/AuthManager.ts
@@ -275,8 +275,8 @@ export class AuthManager {
     const duplicate = this.store.keys.find(k => k.name === name && k.tenantId === resolvedTenantId);
     if (duplicate) {
       const err = new Error(`An API key with the name "${name}" already exists for this tenant`);
-      (err as any).code = 'DUPLICATE_KEY_NAME';
-      (err as any).statusCode = 409;
+      (err as Error & { code: string; statusCode: number }).code = 'DUPLICATE_KEY_NAME';
+      (err as Error & { code: string; statusCode: number }).statusCode = 409;
       throw err;
     }
 


### PR DESCRIPTION
## Summary
Replaces all 14 `as any` casts in production code with proper TypeScript typing patterns.

Closes #4247

## Changes
- **`src/services/acp/local-storage.ts`**: Added `pauseInterventionStore` to `AcpLocalStorageProfile` interface
- **`src/server.ts`**: Direct property access instead of `as any` cast (now typed via interface)
- **`src/routes/session-actions.ts`**: `req.tenantId` / `req.authKeyId` via Fastify request extension (already typed)
- **`src/routes/audit.ts`**: `prop in obj` type guards for pagination fields and record timestamps
- **`src/services/auth/AuthManager.ts`**: Typed intersection cast `Error & { code; statusCode }` instead of bare `any`
- **`src/commands/run.ts`**: `code in err` type guard + `NodeJS.ErrnoException` cast with `Number()` coercion

## Verification
```
npx tsc --noEmit  ✅ (no new errors)
npm run build     ✅
npx vitest run    ✅ 385 files / 5588 tests passed
```

Commit: 245e71dc