### PR TITLE
docs: fix AEGIS_ALLOWED_WORK_DIRS env var name in enterprise.md

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -297,7 +297,7 @@ All configuration is done via environment variables (prefixed `AEGIS_`). Legacy 
 
 | Variable | Default | Description |
 |---|---|---|
-| `AEGIS_ALLOWED_WORKDIRS` | _(home, cwd)_ | JSON array of allowed session working directories. System temp dirs (`/tmp`, `/var/tmp`) are excluded by default for security — add them explicitly if needed |
+| `AEGIS_ALLOWED_WORK_DIRS` | _(home, cwd)_ | JSON array of allowed session working directories. System temp dirs (`/tmp`, `/var/tmp`) are excluded by default for security — add them explicitly if needed |
 | `AEGIS_STRICT_RBAC` | `false` | Enforce RBAC checks even when auth is disabled. When `true`, unauthenticated requests to role/permission-protected endpoints return 401 instead of being allowed through |
 | `AEGIS_ENV_DENYLIST` | _(none)_ | Comma-separated list of environment variable names to strip from session environments (case-insensitive). E.g. `AWS_SECRET_ACCESS_KEY,DATABASE_URL` |
 | `AEGIS_ENV_ADMIN_ALLOWLIST` | _(none)_ | Comma-separated list of environment variable names that admin-level users may pass through despite denylist (case-insensitive) |


### PR DESCRIPTION
## What
Fixes incorrect env var name `AEGIS_ALLOWED_WORKDIRS` → `AEGIS_ALLOWED_WORK_DIRS` in the enterprise.md env var table.

## Why
`src/config.ts:624` reads `process.env.AEGIS_ALLOWED_WORK_DIRS` (with underscore before DIRS), but the docs table had `AEGIS_ALLOWED_WORKDIRS` (no underscore). Users copying from docs would set the wrong variable and it would silently be ignored.

Found during proactive accuracy audit (heartbeat PHASE 3).

## Scope
- `docs/enterprise.md` line 300: one env var name fix