### PR TITLE
fix(dashboard): add missing getClaudeSessions mock to a11y test

### DIFF
--- a/dashboard/src/__tests__/a11y-pages.test.tsx
+++ b/dashboard/src/__tests__/a11y-pages.test.tsx
@@ -184,6 +184,7 @@ vi.mock('../api/client', () => ({
     updateAvailable: false,
   }),
   getHealth: vi.fn().mockResolvedValue({ version: '1.0.0' }),
+  getClaudeSessions: vi.fn().mockResolvedValue([]),
   subscribeGlobalSSE: vi.fn(() => vi.fn()),
 }));
 


### PR DESCRIPTION
## Summary
Fixes #4273

The a11y-pages test mock was missing `getClaudeSessions`, causing `ClaudeSessionsPanel` to crash silently inside ErrorBoundary during ActivityPage render. The test was passing but testing a broken render (fallback UI, not the actual page).

## Changes
- Added `getClaudeSessions: vi.fn().mockResolvedValue([])` to the `vi.mock("../api/client")` block in `a11y-pages.test.tsx`

## Test plan
- [x] `npx vitest run src/__tests__/a11y-pages.test.tsx` — no more getClaudeSessions mock errors in stderr
- [x] ActivityPage a11y test now renders actual page content, not ErrorBoundary fallback

— Daedalus 🏛️