### PR TITLE
fix(dashboard): consolidate approve/reject to quick-approve/quick-reject

### DIFF
--- a/dashboard/src/__tests__/SessionTable.test.tsx
+++ b/dashboard/src/__tests__/SessionTable.test.tsx
@@ -7,7 +7,7 @@ import type { GlobalSSEEvent, SessionInfo, SessionStatusCounts } from '../types'
 const mockGetSessions = vi.fn();
 const mockGetSessionStatusCounts = vi.fn();
 const mockGetAllSessionsHealth = vi.fn();
-const mockApprove = vi.fn();
+const mockQuickApprove = vi.fn();
 const mockInterrupt = vi.fn();
 const mockKillSession = vi.fn();
 const mockAddToast = vi.fn();
@@ -21,7 +21,7 @@ vi.mock('../api/client', () => ({
   getSessions: (...args: unknown[]) => mockGetSessions(...args),
   getSessionStatusCounts: (...args: unknown[]) => mockGetSessionStatusCounts(...args),
   getAllSessionsHealth: (...args: unknown[]) => mockGetAllSessionsHealth(...args),
-  approve: (...args: unknown[]) => mockApprove(...args),
+  quickApprove: (...args: unknown[]) => mockQuickApprove(...args),
   interrupt: (...args: unknown[]) => mockInterrupt(...args),
   killSession: (...args: unknown[]) => mockKillSession(...args),
 }));
@@ -134,7 +134,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
       s2: { alive: true },
       s3: { alive: false },
     });
-    mockApprove.mockResolvedValue({ ok: true });
+    mockQuickApprove.mockResolvedValue({ ok: true });
     mockInterrupt.mockResolvedValue({ ok: true });
     mockKillSession.mockResolvedValue({ ok: true });
     vi.stubGlobal('confirm', vi.fn(() => true));
@@ -402,7 +402,7 @@ describe('SessionTable filtering, search, and bulk actions', () => {
     fireEvent.click(approveButtons[approveButtons.length - 1]);
 
     await waitFor(() => {
-      expect(mockApprove).toHaveBeenCalledWith('s3');
+      expect(mockQuickApprove).toHaveBeenCalledWith('s3');
     });
   });
 

--- a/dashboard/src/api/sessions.ts
+++ b/dashboard/src/api/sessions.ts
@@ -202,39 +202,11 @@ export function quickApprove(id: string, opts?: { approverId?: string }): Promis
   });
 }
 
-/** Legacy approve — kept for backward compatibility with Telegram one-tap flow. */
-export function approve(id: string): Promise<OkResponse> {
-  return request(`/v1/sessions/${encodeURIComponent(id)}/approve`, {
-    method: 'POST',
-  });
-}
-
 /** Issue #4193: Quick reject via dedicated permission endpoint (richer audit trail with reason). */
 export function quickReject(id: string, opts?: { reason?: string }): Promise<OkResponse> {
   return request(`/v1/sessions/${encodeURIComponent(id)}/permission/reject`, {
     method: 'POST',
     body: JSON.stringify({ reason: opts?.reason }),
-  });
-}
-
-/** Legacy reject — kept for backward compatibility with Telegram one-tap flow. */
-export function reject(id: string): Promise<OkResponse> {
-  return request(`/v1/sessions/${encodeURIComponent(id)}/reject`, {
-    method: 'POST',
-  });
-}
-
-/** Session-level approval (Telegram one-tap flow) */
-export function sessionApprove(id: string): Promise<OkResponse> {
-  return request(`/v1/sessions/${encodeURIComponent(id)}/session-approve`, {
-    method: "POST",
-  });
-}
-
-/** Session-level rejection (Telegram one-tap flow) */
-export function sessionReject(id: string): Promise<OkResponse> {
-  return request(`/v1/sessions/${encodeURIComponent(id)}/session-reject`, {
-    method: "POST",
   });
 }
 

--- a/dashboard/src/components/approvals/ApprovalBanner.tsx
+++ b/dashboard/src/components/approvals/ApprovalBanner.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useCallback } from 'react';
 import { CheckCircle2, XCircle, Loader2, Clock } from 'lucide-react';
-import { sessionApprove, sessionReject } from '../../api/client';
+import { quickApprove, quickReject } from '../../api/client';
 import { useToastStore } from '../../store/useToastStore';
 
 interface ApprovalBannerProps {
@@ -24,7 +24,7 @@ export function ApprovalBanner({ sessionId, sessionName }: ApprovalBannerProps) 
   const handleApprove = useCallback(async () => {
     setIsApproving(true);
     try {
-      await sessionApprove(sessionId);
+      await quickApprove(sessionId);
       setResolved('approved');
       addToast('success', 'Session approved', sessionName ?? sessionId);
     } catch (err) {
@@ -37,7 +37,7 @@ export function ApprovalBanner({ sessionId, sessionName }: ApprovalBannerProps) 
   const handleReject = useCallback(async () => {
     setIsRejecting(true);
     try {
-      await sessionReject(sessionId);
+      await quickReject(sessionId);
       setResolved('rejected');
       addToast('info', 'Session rejected', sessionName ?? sessionId);
     } catch (err) {

--- a/dashboard/src/components/approvals/__tests__/ApprovalBanner.test.tsx
+++ b/dashboard/src/components/approvals/__tests__/ApprovalBanner.test.tsx
@@ -7,8 +7,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 vi.mock('../../../api/client', () => ({
-  sessionApprove: vi.fn(),
-  sessionReject: vi.fn(),
+  quickApprove: vi.fn(),
+  quickReject: vi.fn(),
 }));
 
 vi.mock('../../../store/useToastStore', () => ({
@@ -16,7 +16,7 @@ vi.mock('../../../store/useToastStore', () => ({
     selector({ addToast: vi.fn() }),
 }));
 
-import { sessionApprove, sessionReject } from '../../../api/client';
+import { quickApprove, quickReject } from '../../../api/client';
 import { ApprovalBanner } from '../ApprovalBanner';
 
 describe('ApprovalBanner', () => {
@@ -43,8 +43,8 @@ describe('ApprovalBanner', () => {
     expect(screen.getByRole('button', { name: /reject/i })).toBeDefined();
   });
 
-  it('calls sessionApprove on Approve click', async () => {
-    (sessionApprove as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+  it('calls quickApprove on Approve click', async () => {
+    (quickApprove as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
     render(
       <MemoryRouter>
         <ApprovalBanner sessionId="test-123" />
@@ -52,15 +52,15 @@ describe('ApprovalBanner', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /approve session/i }));
-    expect(sessionApprove).toHaveBeenCalledWith('test-123');
+    expect(quickApprove).toHaveBeenCalledWith('test-123');
 
     await waitFor(() => {
       expect(screen.getByText('Approved')).toBeDefined();
     });
   });
 
-  it('calls sessionReject on Reject click', async () => {
-    (sessionReject as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+  it('calls quickReject on Reject click', async () => {
+    (quickReject as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
     render(
       <MemoryRouter>
         <ApprovalBanner sessionId="test-123" />
@@ -68,7 +68,7 @@ describe('ApprovalBanner', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /reject session/i }));
-    expect(sessionReject).toHaveBeenCalledWith('test-123');
+    expect(quickReject).toHaveBeenCalledWith('test-123');
 
     await waitFor(() => {
       expect(screen.getByText('Rejected')).toBeDefined();

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -20,13 +20,13 @@ import {
   Filter,
 } from 'lucide-react';
 import {
-  approve,
+  quickApprove,
   getAllSessionsHealth,
   getSessionStatusCounts,
   getSessions,
   interrupt,
   killSession,
-  reject,
+  quickReject,
 } from '../../api/client';
 import { useSseAwarePolling } from '../../hooks/useSseAwarePolling';
 import { useToastStore } from '../../store/useToastStore';
@@ -281,7 +281,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
     e.preventDefault();
     await withLoading(id, 'approve', async () => {
       try {
-        await approve(id);
+        await quickApprove(id);
         await fetchSessions();
       } catch (err: unknown) {
         addToast('error', 'Approve failed', err instanceof Error ? err.message : undefined);
@@ -293,7 +293,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
     e.preventDefault();
     await withLoading(id, 'reject', async () => {
       try {
-        await reject(id);
+        await quickReject(id);
         await fetchSessions();
       } catch (err: unknown) {
         addToast('error', 'Reject failed', err instanceof Error ? err.message : undefined);


### PR DESCRIPTION
## Summary
Addresses #4226 item 3 (duplicate approve/reject functions).

Removes 4 duplicate approve/reject functions from `sessions.ts`, consolidating all callers to use the canonical `quickApprove`/`quickReject` endpoints.

### Removed (legacy endpoints)
- `approve()` → `/v1/sessions/:id/approve`
- `reject()` → `/v1/sessions/:id/reject`
- `sessionApprove()` → `/v1/sessions/:id/session-approve`
- `sessionReject()` → `/v1/sessions/:id/session-reject`

### Canonical (kept)
- `quickApprove()` → `/v1/sessions/:id/permission/approve` (RBAC, audit trail, approverId)
- `quickReject()` → `/v1/sessions/:id/permission/reject` (RBAC, audit trail, reason)

### Updated callers
- `ApprovalBanner.tsx` → `quickApprove`/`quickReject`
- `SessionTable.tsx` → `quickApprove`/`quickReject`
- Tests updated accordingly

### Verification
- TSC clean
- 52/52 dashboard tests green (a11y, ApprovalBanner, CostPage, touch-targets, i18n)

— Daedalus 🏛️