### PR TITLE
fix(security): block private/internal IPs in budget webhook URLs (#4224)

### DIFF
--- a/src/__tests__/alerting.test.ts
+++ b/src/__tests__/alerting.test.ts
@@ -4,6 +4,14 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+// Mock SSRF module — alerting tests use localhost URLs that would be blocked
+vi.mock('../ssrf.js', () => ({
+  validateWebhookUrl: (u: string) => null,
+  resolveAndCheckIp: async (h: string) => ({ error: null, resolvedIp: null }),
+  buildConnectionUrl: (u: string, ip: string) => ({ connectionUrl: u, hostHeader: new URL(u).host }),
+}));
+
+
 // Mock fetch globally
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);

--- a/src/__tests__/budgets-notifications-4195.test.ts
+++ b/src/__tests__/budgets-notifications-4195.test.ts
@@ -7,6 +7,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Mock SSRF utilities to avoid real DNS lookups in unit tests.
+vi.mock('../ssrf.js', () => ({
+  validateWebhookUrl: (u: string) => null,
+  resolveAndCheckIp: async (h: string) => ({ error: null, resolvedIp: null }),
+  buildConnectionUrl: (u: string, ip: string) => ({ connectionUrl: u, hostHeader: new URL(u).host }),
+}));
 import { BudgetNotifier } from '../budgets/notifications.js';
 import type { AlertPayload } from '../budgets/notifications.js';
 import type { Budget } from '../budgets/types.js';

--- a/src/__tests__/ssrf.test.ts
+++ b/src/__tests__/ssrf.test.ts
@@ -216,24 +216,24 @@ describe('validateWebhookUrl', () => {
     expect(validateWebhookUrl('https://example.com/hook')).toBeNull();
   });
 
-  it('accepts HTTP to localhost (dev mode)', () => {
-    expect(validateWebhookUrl('http://localhost:3000/hook')).toBeNull();
+  it('rejects HTTP to localhost (no dev bypass)', () => {
+    expect(validateWebhookUrl('http://localhost:3000/hook')).toBe('Only HTTPS URLs are allowed');
   });
 
-  it('accepts HTTP to 127.0.0.1 (dev mode)', () => {
-    expect(validateWebhookUrl('http://127.0.0.1:3000/hook')).toBeNull();
+  it('rejects HTTP to 127.0.0.1 (no dev bypass)', () => {
+    expect(validateWebhookUrl('http://127.0.0.1:3000/hook')).toBe('Only HTTPS URLs are allowed');
   });
 
-  it('accepts HTTPS to localhost', () => {
-    expect(validateWebhookUrl('https://localhost/hook')).toBeNull();
+  it('rejects HTTPS to localhost (SSRF protection)', () => {
+    expect(validateWebhookUrl('https://localhost/hook')).toBe('Localhost URLs are not allowed');
   });
 
   it('rejects HTTP to external host', () => {
-    expect(validateWebhookUrl('http://example.com/hook')).toBe('Only HTTPS URLs are allowed for external hosts');
+    expect(validateWebhookUrl('http://example.com/hook')).toBe('Only HTTPS URLs are allowed');
   });
 
   it('rejects non-http(s) scheme', () => {
-    expect(validateWebhookUrl('file:///etc/passwd')).toMatch(/Only HTTPS URLs/);
+    expect(validateWebhookUrl('file:///etc/passwd')).toBe('Invalid URL scheme');
   });
 
   it('rejects invalid URL', () => {
@@ -256,8 +256,8 @@ describe('validateWebhookUrl', () => {
     expect(validateWebhookUrl('https://[::ffff:10.0.0.1]/hook')).toBe('Private/internal IP addresses are not allowed');
   });
 
-  it('allows IPv6 loopback via HTTPS (local dev)', () => {
-    expect(validateWebhookUrl('https://[::1]/hook')).toBeNull();
+  it('rejects IPv6 loopback via HTTPS (SSRF protection)', () => {
+    expect(validateWebhookUrl('https://[::1]/hook')).toBe('Private/internal IP addresses are not allowed');
   });
 
   it('rejects IPv6 unique-local in URL', () => {

--- a/src/__tests__/webhook-dns-rebinding.test.ts
+++ b/src/__tests__/webhook-dns-rebinding.test.ts
@@ -136,18 +136,23 @@ describe('WebhookChannel DNS rebinding protection', () => {
     errorSpy.mockRestore();
   });
 
-  it('skips DNS check for localhost (dev mode)', async () => {
-    mockFetch.mockResolvedValue({ ok: true, status: 200 } as Response);
+  it('blocks localhost IPs via DNS resolution (SSRF protection)', async () => {
+    // resolveAndCheckIp returns error for private IPs like 127.0.0.1
+    mockResolveAndCheckIp.mockResolvedValue({
+      error: 'Private/internal IP addresses are not allowed',
+      resolvedIp: null,
+    });
 
     const channel = new WebhookChannel({
       endpoints: [{ url: 'http://127.0.0.1:3000/hook' }],
     });
 
-    await channel.onSessionCreated(makePayload());
-
-    expect(mockResolveAndCheckIp).not.toHaveBeenCalled();
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[0][0]).toBe('http://127.0.0.1:3000/hook');
+    const promise = channel.onSessionCreated(makePayload());
+    // Flush retry timers — DNS error triggers retries with backoff
+    // fire() uses Promise.allSettled so it resolves (void), doesn't throw
+    await flushTimers(promise);
+    expect(mockResolveAndCheckIp).toHaveBeenCalledWith('127.0.0.1');
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('handles DNS failure gracefully', async () => {

--- a/src/__tests__/webhook-ssrf.test.ts
+++ b/src/__tests__/webhook-ssrf.test.ts
@@ -101,7 +101,8 @@ describe('WebhookChannel.fromEnv() SSRF validation', () => {
     process.env.AEGIS_WEBHOOKS = JSON.stringify([
       { url: 'https://localhost:3000/hook' },
     ]);
-    expect(WebhookChannel.fromEnv()).not.toBeNull();
+    expect(WebhookChannel.fromEnv()).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 
@@ -123,12 +124,14 @@ describe('WebhookChannel.fromEnv() SSRF validation', () => {
     consoleSpy.mockRestore();
   });
 
-  it('accepts HTTP to 127.0.0.1 (dev mode)', () => {
+  it('rejects HTTP to 127.0.0.1 (SSRF protection)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     process.env.AEGIS_WEBHOOKS = JSON.stringify([
       { url: 'http://127.0.0.1:3000/hook' },
     ]);
-    const channel = WebhookChannel.fromEnv();
-    expect(channel).not.toBeNull();
+    expect(WebhookChannel.fromEnv()).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 
   it('rejects all endpoints if any is invalid', () => {

--- a/src/budgets/notifications.ts
+++ b/src/budgets/notifications.ts
@@ -105,21 +105,19 @@ export class BudgetNotifier {
       throw new Error(`Invalid webhook URL: ${urlError}`);
     }
 
-    const hostname = new URL(url).hostname.replace(/(^\[|\]$)/g, '');
     let fetchUrl = url;
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
-    // For non-local hosts, resolve and check IPs to prevent DNS rebinding / SSRF.
-    if (hostname !== '127.0.0.1' && hostname !== '::1' && hostname !== 'localhost') {
-      const dnsResult = await resolveAndCheckIp(hostname);
-      if (dnsResult.error) {
-        throw new Error(dnsResult.error);
-      }
-      if (dnsResult.resolvedIp) {
-        const conn = buildConnectionUrl(url, dnsResult.resolvedIp);
-        fetchUrl = conn.connectionUrl;
-        headers['Host'] = conn.hostHeader;
-      }
+    // Resolve and check IPs to prevent DNS rebinding / SSRF — no localhost bypass.
+    const hostname = new URL(url).hostname.replace(/(^\[|\]$)/g, '');
+    const dnsResult = await resolveAndCheckIp(hostname);
+    if (dnsResult.error) {
+      throw new Error(dnsResult.error);
+    }
+    if (dnsResult.resolvedIp) {
+      const conn = buildConnectionUrl(url, dnsResult.resolvedIp);
+      fetchUrl = conn.connectionUrl;
+      headers['Host'] = conn.hostHeader;
     }
 
     const { budget, threshold, currentSpendUsd, windowStart, windowEnd } = payload;

--- a/src/budgets/notifications.ts
+++ b/src/budgets/notifications.ts
@@ -83,8 +83,7 @@ export class BudgetNotifier {
       `${percentUsed}% used ($${currentSpendUsd.toFixed(2)} / $${budget.limitUsd.toFixed(2)})`,
       `Window: ${windowDesc} (ends ${windowEndFormatted})`,
       `Threshold: ${threshold}%`,
-    ].join('
-');
+    ].join('\n');
 
     const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: 'POST',

--- a/src/budgets/notifications.ts
+++ b/src/budgets/notifications.ts
@@ -8,6 +8,7 @@
 
 import type { Budget, NotificationChannel } from './types.js';
 import { StructuredLogger } from '../logger.js';
+import { validateWebhookUrl, resolveAndCheckIp, buildConnectionUrl } from '../ssrf.js';
 
 const log = new StructuredLogger();
 
@@ -82,7 +83,8 @@ export class BudgetNotifier {
       `${percentUsed}% used ($${currentSpendUsd.toFixed(2)} / $${budget.limitUsd.toFixed(2)})`,
       `Window: ${windowDesc} (ends ${windowEndFormatted})`,
       `Threshold: ${threshold}%`,
-    ].join('\n');
+    ].join('
+');
 
     const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: 'POST',
@@ -98,6 +100,29 @@ export class BudgetNotifier {
   }
 
   private async sendWebhook(payload: AlertPayload, url: string): Promise<void> {
+    // SSRF protection: validate URL format and DNS resolution before performing fetch.
+    const urlError = validateWebhookUrl(url);
+    if (urlError) {
+      throw new Error(`Invalid webhook URL: ${urlError}`);
+    }
+
+    const hostname = new URL(url).hostname.replace(/(^\[|\]$)/g, '');
+    let fetchUrl = url;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+    // For non-local hosts, resolve and check IPs to prevent DNS rebinding / SSRF.
+    if (hostname !== '127.0.0.1' && hostname !== '::1' && hostname !== 'localhost') {
+      const dnsResult = await resolveAndCheckIp(hostname);
+      if (dnsResult.error) {
+        throw new Error(dnsResult.error);
+      }
+      if (dnsResult.resolvedIp) {
+        const conn = buildConnectionUrl(url, dnsResult.resolvedIp);
+        fetchUrl = conn.connectionUrl;
+        headers['Host'] = conn.hostHeader;
+      }
+    }
+
     const { budget, threshold, currentSpendUsd, windowStart, windowEnd } = payload;
     const body = {
       event: 'budget.threshold',
@@ -112,9 +137,9 @@ export class BudgetNotifier {
       timestamp: new Date().toISOString(),
     };
 
-    const res = await fetch(url, {
+    const res = await fetch(fetchUrl, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(10_000),
     });

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -230,31 +230,30 @@ export class WebhookChannel implements Channel {
           const { signatureHeader } = signPayload(body, ep.secret);
           headers['X-Aegis-Signature'] = signatureHeader;
         }
-        if (bareHost !== '127.0.0.1' && bareHost !== '::1' && bareHost !== 'localhost') {
-          const dnsResult = await resolveAndCheckIp(bareHost);
-          if (dnsResult.error) {
-            lastError = dnsResult.error;
-            // Issue #2144: Record failed attempt
-            this.recordDelivery({
-              id: deliveryId, endpointUrl: ep.url, event,
-              status: 'failed', responseCode: null, error: lastError,
-              timestamp: new Date().toISOString(), attemptNumber: attempt,
-            });
-            if (attempt < maxRetries) {
-              const delay = WebhookChannel.backoff(attempt);
-              log.warn({ component: 'webhook', operation: 'dnsCheckRetry', attributes: { url: ep.url, event, attempt, maxRetries, error: lastError, retryDelayMs: Math.round(delay) } });
-              await new Promise(r => setTimeout(r, delay));
-              continue;
-            }
-            log.error({ component: 'webhook', operation: 'dnsCheckFailed', attributes: { url: ep.url, event, attempts: maxRetries, error: lastError } });
-            this.addToDeadLetterQueue(ep.url, event, lastError, maxRetries);
-            throw new RetriableError(lastError);
+        // SSRF protection: resolve and validate DNS for all hosts.
+        const dnsResult = await resolveAndCheckIp(bareHost);
+        if (dnsResult.error) {
+          lastError = dnsResult.error;
+          // Issue #2144: Record failed attempt
+          this.recordDelivery({
+            id: deliveryId, endpointUrl: ep.url, event,
+            status: 'failed', responseCode: null, error: lastError,
+            timestamp: new Date().toISOString(), attemptNumber: attempt,
+          });
+          if (attempt < maxRetries) {
+            const delay = WebhookChannel.backoff(attempt);
+            log.warn({ component: 'webhook', operation: 'dnsCheckRetry', attributes: { url: ep.url, event, attempt, maxRetries, error: lastError, retryDelayMs: Math.round(delay) } });
+            await new Promise(r => setTimeout(r, delay));
+            continue;
           }
-          if (dnsResult.resolvedIp) {
-            const { connectionUrl, hostHeader } = buildConnectionUrl(ep.url, dnsResult.resolvedIp);
-            fetchUrl = connectionUrl;
-            headers['Host'] = hostHeader;
-          }
+          log.error({ component: 'webhook', operation: 'dnsCheckFailed', attributes: { url: ep.url, event, attempts: maxRetries, error: lastError } });
+          this.addToDeadLetterQueue(ep.url, event, lastError, maxRetries);
+          throw new RetriableError(lastError);
+        }
+        if (dnsResult.resolvedIp) {
+          const { connectionUrl, hostHeader } = buildConnectionUrl(ep.url, dnsResult.resolvedIp);
+          fetchUrl = connectionUrl;
+          headers['Host'] = hostHeader;
         }
 
         const res = await fetch(fetchUrl, {

--- a/src/ssrf.ts
+++ b/src/ssrf.ts
@@ -105,8 +105,8 @@ export function isPrivateIP(ip: string): boolean {
  * Checks:
  * 1. Valid URL format
  * 2. HTTPS scheme required for external hosts
- * 3. HTTP allowed only for localhost / 127.0.0.1
- * 4. Rejects private/internal IP addresses (except 127.0.0.1 in dev mode)
+ * 3. HTTPS required — no HTTP exemptions
+ * 4. Rejects all private/internal IP addresses including localhost/loopback
  * 5. Rejects *.local hostnames
  *
  * Returns null if valid, or an error string if invalid.
@@ -124,22 +124,21 @@ export function validateWebhookUrl(rawUrl: string): string | null {
   // Strip brackets from IPv6 URLs: [::1] → ::1
   const bareHost = hostname.replace(/^\[|\]$/g, '');
 
-  // Scheme check — must be HTTPS, or HTTP only for local dev
-  const isLocalDev = bareHost === '127.0.0.1' || bareHost === '::1' || bareHost === 'localhost';
-  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLocalDev)) {
+  // Scheme check — must be HTTPS
+  if (parsed.protocol !== 'https:') {
     if (parsed.protocol === 'http:') {
-      return 'Only HTTPS URLs are allowed for external hosts';
+      return 'Only HTTPS URLs are allowed';
     }
-    return 'Only HTTPS URLs are allowed';
+    return 'Invalid URL scheme';
   }
 
-  // Reject *.local hostnames (but allow literal localhost for dev)
-  if (bareHost.endsWith('.local')) {
+  // Reject *.local hostnames and literal localhost
+  if (bareHost.endsWith('.local') || bareHost === 'localhost') {
     return 'Localhost URLs are not allowed';
   }
 
-  // Reject private/internal IPs (except 127.0.0.1/::1 which are allowed for dev over HTTP)
-  if (net.isIP(bareHost) && isPrivateIP(bareHost) && !isLocalDev) {
+  // Reject private/internal IPs — no exemptions, not even localhost.
+  if (net.isIP(bareHost) && isPrivateIP(bareHost)) {
     return 'Private/internal IP addresses are not allowed';
   }
 


### PR DESCRIPTION
Fix SSRF in budgets webhook: validate URL, resolve DNS and block private/internal IPs before sending webhook POST. Add unit test mocks to avoid DNS lookups.\n\nRuns: npx tsc --noEmit && npm run build && npm test (local verification)