### PR TITLE
refactor(session): extract SessionEncryptionService (#4228 step 2)

### DIFF
--- a/src/services/session/encryption.ts
+++ b/src/services/session/encryption.ts
@@ -1,0 +1,60 @@
+/**
+ * encryption.ts — Session encryption service.
+ *
+ * Extracted from SessionManager (Issue #4228 Step 2).
+ * Handles AES-256-GCM encryption/decryption of hook secrets at rest.
+ *
+ * Zero behavior changes — pure refactoring.
+ */
+
+import { randomBytes, scryptSync, createCipheriv, createDecipheriv } from 'node:crypto';
+
+/**
+ * SessionEncryptionService — AES-256-GCM encryption for hook secrets.
+ *
+ * Key is derived once from the master token via scrypt.
+ * Ciphertext format: '<iv>:<tag>:<ciphertext>' (all hex-encoded).
+ */
+export class SessionEncryptionService {
+  private encKey: Buffer | null = null;
+
+  /** Derive and store the encryption key from the master token. */
+  setEncryptionKey(masterToken: string): void {
+    if (!masterToken) return;
+    this.encKey = scryptSync(masterToken, 'aegis-hook-key-v1', 32);
+  }
+
+  /** Whether an encryption key is available. */
+  hasKey(): boolean {
+    return this.encKey !== null;
+  }
+
+  /** Get the raw encryption key (for callers that need Buffer access). */
+  getKey(): Buffer | null {
+    return this.encKey;
+  }
+
+  /** Encrypt a hook secret with AES-256-GCM. Returns '<iv>:<tag>:<ciphertext>' hex. */
+  encrypt(secret: string): string {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', this.encKey!, iv);
+    const enc = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return `${iv.toString('hex')}:${tag.toString('hex')}:${enc.toString('hex')}`;
+  }
+
+  /** Decrypt a hook secret from AES-256-GCM '<iv>:<tag>:<ciphertext>' hex. */
+  decrypt(encrypted: string): string | undefined {
+    if (!this.encKey) return undefined;
+    try {
+      const parts = encrypted.split(':');
+      if (parts.length !== 3) return undefined;
+      const [ivHex, tagHex, encHex] = parts as [string, string, string];
+      const decipher = createDecipheriv('aes-256-gcm', this.encKey, Buffer.from(ivHex, 'hex'));
+      decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
+      return Buffer.concat([decipher.update(Buffer.from(encHex, 'hex')), decipher.final()]).toString('utf8');
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/services/session/persistence.ts
+++ b/src/services/session/persistence.ts
@@ -8,7 +8,7 @@
  * Zero behavior changes — pure refactoring.
  */
 
-import { randomBytes, scryptSync, createCipheriv, createDecipheriv } from 'node:crypto';
+// Encryption delegated to SessionEncryptionService (Issue #4228 step 2)
 import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
 import { existsSync, unlinkSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -17,6 +17,7 @@ import { StructuredLogger } from '../../logger.js';
 import type { z } from 'zod';
 import { persistedStateSchema } from '../../validation.js';
 import type { SessionInfo, SessionState } from '../../session.js';
+import { SessionEncryptionService } from './encryption.js';
 
 const log = new StructuredLogger();
 
@@ -80,47 +81,35 @@ export class SessionPersistenceService implements SessionPersistencePort {
   private saveQueue: Promise<void> = Promise.resolve();
   private saveDebounceTimer: NodeJS.Timeout | null = null;
   private static readonly SAVE_DEBOUNCE_MS = 5_000;
-  /** #1644: AES-256-GCM key derived from master token for encrypting hook secrets at rest. */
-  private encKey: Buffer | null = null;
+  /** #4228: Encryption delegated to SessionEncryptionService. */
+  readonly encryption: SessionEncryptionService;
 
   constructor(
     private readonly stateFile: string,
     private readonly store: StateStore | null = null,
-  ) {}
+    encryption?: SessionEncryptionService,
+  ) {
+    this.encryption = encryption ?? new SessionEncryptionService();
+  }
 
   /** Set the encryption key derived from the master token. */
   setEncryptionKey(masterToken: string): void {
-    if (!masterToken) return;
-    this.encKey = scryptSync(masterToken, 'aegis-hook-key-v1', 32);
+    this.encryption.setEncryptionKey(masterToken);
   }
 
-  /** Get the encryption key (for external decrypt operations). */
-  getEncKey(): Buffer | null {
-    return this.encKey;
+  /** Whether encryption key is available. */
+  hasEncryptionKey(): boolean {
+    return this.encryption.hasKey();
   }
 
-  /** Encrypt a hook secret with AES-256-GCM. Returns '<iv>:<tag>:<ciphertext>' hex. */
+  /** Encrypt a hook secret. Delegates to SessionEncryptionService. */
   encryptSecret(secret: string): string {
-    const iv = randomBytes(12);
-    const cipher = createCipheriv('aes-256-gcm', this.encKey!, iv);
-    const enc = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    return `${iv.toString('hex')}:${tag.toString('hex')}:${enc.toString('hex')}`;
+    return this.encryption.encrypt(secret);
   }
 
-  /** Decrypt a hook secret from AES-256-GCM '<iv>:<tag>:<ciphertext>' hex. */
+  /** Decrypt a hook secret. Delegates to SessionEncryptionService. */
   decryptSecret(encrypted: string): string | undefined {
-    if (!this.encKey) return undefined;
-    try {
-      const parts = encrypted.split(':');
-      if (parts.length !== 3) return undefined;
-      const [ivHex, tagHex, encHex] = parts as [string, string, string];
-      const decipher = createDecipheriv('aes-256-gcm', this.encKey, Buffer.from(ivHex, 'hex'));
-      decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
-      return Buffer.concat([decipher.update(Buffer.from(encHex, 'hex')), decipher.final()]).toString('utf8');
-    } catch {
-      return undefined;
-    }
+    return this.encryption.decrypt(encrypted);
   }
 
   /** Validate that parsed data looks like a valid SessionState. */
@@ -237,7 +226,7 @@ export class SessionPersistenceService implements SessionPersistencePort {
   serializeState(state: SessionState): string {
     return JSON.stringify(state, (key, value) => {
       if (key === 'hookSecret') {
-        if (typeof value !== 'string' || !this.encKey) return undefined;
+        if (typeof value !== 'string' || !this.encryption.hasKey()) return undefined;
         return this.encryptSecret(value);
       }
       if (value instanceof Set) return [...value];
@@ -253,7 +242,7 @@ export class SessionPersistenceService implements SessionPersistencePort {
       sessions[id] = {
         ...rest,
         activeSubagents: activeSubagents ? [...activeSubagents] : undefined,
-        hookSecret: (typeof hookSecret === 'string' && this.encKey)
+        hookSecret: (typeof hookSecret === 'string' && this.encryption.hasKey())
           ? this.encryptSecret(hookSecret)
           : undefined,
       } as unknown as SerializedSessionInfo;

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,7 +5,7 @@
  * Tracks: session ID, window ID, byte offset for JSONL reading, status.
  */
 
-import { randomBytes, scryptSync, createCipheriv, createDecipheriv } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
@@ -344,8 +344,7 @@ export class SessionManager {
   private sessionMapFile: string;
   /** Issue #4251: Delegated persistence service. */
   private readonly persistence: SessionPersistenceService;
-  /** #1644: AES-256-GCM key derived from master token for encrypting hook secrets at rest. */
-  private encKey: Buffer | null = null;
+  /** #4228: Encryption delegated to persistence.encryption. */
   private permissionRequests = new PermissionRequestManager();
   private questions = new QuestionManager();
   // Issue #657: Cached session list to avoid allocating a new array per call
@@ -439,41 +438,25 @@ export class SessionManager {
 
   setEncryptionKey(masterToken: string): void {
     if (!masterToken) return;
-    // scryptSync is synchronous — called once at startup, acceptable cost.
-    this.encKey = scryptSync(masterToken, 'aegis-hook-key-v1', 32);
-    // Issue #4251: Delegate encryption key to persistence service
+    // Issue #4228: Delegate to persistence service's encryption
     this.persistence.setEncryptionKey(masterToken);
   }
 
-  /** Encrypt a hook secret with AES-256-GCM. Returns '<iv>:<tag>:<ciphertext>' hex. */
+  /** Encrypt a hook secret. Delegates to persistence encryption service. */
   private encryptSecret(secret: string): string {
-    const iv = randomBytes(12);
-    const cipher = createCipheriv('aes-256-gcm', this.encKey!, iv);
-    const enc = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    return `${iv.toString('hex')}:${tag.toString('hex')}:${enc.toString('hex')}`;
+    return this.persistence.encryptSecret(secret);
   }
 
-  /** Decrypt a hook secret from AES-256-GCM '<iv>:<tag>:<ciphertext>' hex. */
+  /** Decrypt a hook secret. Delegates to persistence encryption service. */
   private decryptSecret(encrypted: string): string | undefined {
-    if (!this.encKey) return undefined;
-    try {
-      const parts = encrypted.split(':');
-      if (parts.length !== 3) return undefined;
-      const [ivHex, tagHex, encHex] = parts as [string, string, string];
-      const decipher = createDecipheriv('aes-256-gcm', this.encKey, Buffer.from(ivHex, 'hex'));
-      decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
-      return Buffer.concat([decipher.update(Buffer.from(encHex, 'hex')), decipher.final()]).toString('utf8');
-    } catch {
-      return undefined;
-    }
+    return this.persistence.decryptSecret(encrypted);
   }
 
   private async restoreSessionHookSecrets(): Promise<void> {
     for (const session of Object.values(this.state.sessions)) {
       // #1644: Decrypt if the stored value is an AES-GCM ciphertext (iv:tag:enc format).
       // Plaintext hookSecrets are 64-char hex strings with no colons.
-      if (session.hookSecret?.includes(':') && this.encKey) {
+      if (session.hookSecret?.includes(':') && this.persistence.hasEncryptionKey()) {
         const decrypted = this.persistence.decryptSecret(session.hookSecret);
         if (decrypted) { session.hookSecret = decrypted; continue; }
         session.hookSecret = undefined; // Decryption failed — force re-read below


### PR DESCRIPTION
## Summary

Extract encryption logic into a dedicated `SessionEncryptionService` (Issue #4228 step 2).

### Changes
- **New** `src/services/session/encryption.ts`: AES-256-GCM encryption service with `encrypt`, `decrypt`, `setEncryptionKey`, `hasKey`
- **Refactored** `src/services/session/persistence.ts`: delegates encryption to `SessionEncryptionService` instead of implementing it directly
- **Refactored** `src/session.ts`: removed duplicated `encKey`, `encryptSecret`, `decryptSecret` methods — delegates to persistence service

### What was removed
- `encKey` field from both SessionManager and PersistenceService
- Duplicate `encryptSecret`/`decryptSecret` implementations (now in one place)
- Direct `scryptSync`/`createCipheriv`/`createDecipheriv` imports from both files

### Zero behavior changes
Pure delegation refactoring. All encryption/decryption behavior is identical.

## Verification
- tsc --noEmit ✅
- npm run build ✅
- 5630 tests passing ✅
- Commit: 2f8ab8d5

Part of #4228 (session extraction epic). Follows #4284 (step 1 persistence).