### PR TITLE
ci(console-guard): upgrade no-console to error + baseline guard (#4233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         run: npm run security-check
       - name: Run linter
         run: npm run lint
+      - name: Console.* guard — block new console.log/warn/error in src/
+        run: bash scripts/console-guard.sh
   feat-minor-bump-gate:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -57,25 +57,20 @@ docs/superpowers/
 .omc/
 competitors/
 _competitors/
-
 # Ad-hoc analysis/report artifacts (not published)
 docs/*-analysis-20??-??-??.md
 docs/*-report-20??-??-??.md
 *-analysis-20??-??-??.md
 *-report-20??-??-??.md
-
 # TypeDoc API reference (generated, served via GitHub Pages)
 docs/api/
 keys.env
 tracked.txt
-
 # Dashboard icon audit output (reporter, regenerated on demand)
 scripts/dashboard-icons-audit.current.txt
-
 # Local memory / vibe files and release tarballs
 memory/
 *.tgz
-
 # Test artifacts (leaked in 996feb8)
 /.test-scratch/
 playwright-report/
@@ -85,3 +80,4 @@ coverage/
 wt-last-updated
 wt-i18n-sessionboard
 node_modules
+aegis

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,15 +29,54 @@ export default [
       ],
     },
   },
+  // no-console: error for production src/ — existing violators are excluded so CI stays green.
+  // Goal: shrink this list over time by migrating to StructuredLogger.
   {
     files: ['src/**/*.ts'],
     ignores: [
       'src/__tests__/**',
+      // Core infra — logger, CLI, startup bootstrap
       'src/cli.ts',
       'src/logger.ts',
+      'src/startup.ts',
       'src/suppress.ts',
+      'src/tracing.ts',
+      // Hooks & permissions
+      'src/hooks.ts',
       'src/hook.ts',
+      'src/permission-guard.ts',
+      'src/permission-request-manager.ts',
+      // Sessions
+      'src/session.ts',
+      'src/session-discovery.ts',
+      'src/session-transcripts.ts',
+      // ACP
+      'src/services/acp/backend.ts',
+      'src/services/auth/AuthManager.ts',
+      'src/services/state/JsonFileStore.ts',
+      // Channels
+      'src/channels/email.ts',
+      'src/channels/manager.ts',
+      'src/channels/slack.ts',
+      'src/channels/telegram.ts',
+      'src/channels/webhook.ts',
+      // Server & config
+      'src/server.ts',
+      'src/config.ts',
+      'src/events.ts',
+      // Memory & learnings
+      'src/memory-bridge-learning.ts',
+      'src/memory-bridge.ts',
+      'src/structured-learnings.ts',
+      // Misc
+      'src/file-utils.ts',
+      'src/jsonl-watcher.ts',
       'src/mcp/server.ts',
+      'src/question-manager.ts',
+      'src/signal-cleanup-helper.ts',
+      'src/template-store.ts',
+      'src/transcript.ts',
+      'src/webhook/verify.ts',
     ],
     rules: {
       'no-console': 'error',

--- a/scripts/console-guard.sh
+++ b/scripts/console-guard.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# console-guard.sh — CI guard: fail if production src/ adds new console.* calls
+# Existing exceptions are tracked in eslint.config.js ignores.
+# This script provides a second layer: a baseline count that must not increase.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+# Count console.* calls in non-test src/ (excluding comments)
+VIOLATIONS=$(grep -rn "console\.\(log\|warn\|error\)" src/ --include="*.ts" \
+  | grep -v "node_modules" \
+  | grep -v "__tests__" \
+  | grep -v "^\s*//" \
+  | grep -v "^\s*\*" \
+  | wc -l)
+
+BASELINE=165
+
+echo "Console.* violations in src/: ${VIOLATIONS}"
+echo "Baseline: ${BASELINE}"
+
+if [ "$VIOLATIONS" -gt "$BASELINE" ]; then
+  DIFF=$((VIOLATIONS - BASELINE))
+  echo ""
+  echo "❌ FAIL: ${DIFF} new console.* call(s) detected in production code."
+  echo "   Use StructuredLogger instead, or add the file to eslint.config.js ignores."
+  echo ""
+  echo "New violations:"
+  grep -rn "console\.\(log\|warn\|error\)" src/ --include="*.ts" \
+    | grep -v "node_modules" \
+    | grep -v "__tests__" \
+    | grep -v "^\s*//" \
+    | grep -v "^\s*\*" \
+    | head -20
+  exit 1
+fi
+
+if [ "$VIOLATIONS" -lt "$BASELINE" ]; then
+  DIFF=$((BASELINE - VIOLATIONS))
+  echo "✅ PASS: ${DIFF} violation(s) removed since baseline — consider updating BASELINE in this script."
+fi
+
+echo "✅ PASS: No new console.* violations."
+exit 0


### PR DESCRIPTION
## Summary

Closes #4233

Upgrades the ESLint `no-console` rule from `warn` to `error` for production `src/` code and adds a CI guard script to prevent new `console.*` calls from being introduced.

## Changes

### eslint.config.js
- Upgraded `no-console` from `warn` → `error` for `src/**/*.ts`
- Expanded ignore list to cover all 34 existing violator files (excluding tests)
- Added comment: goal is to shrink the ignore list over time by migrating to StructuredLogger

### scripts/console-guard.sh (new)
- Baseline counter script: counts `console.log/warn/error` in non-test `src/`
- Fails CI if count exceeds baseline (165)
- Warns if count drops below baseline (suggest updating)
- Acts as a second layer of defense beyond ESLint

### .github/workflows/ci.yml
- Added `Console.* guard` step to lint job, runs `bash scripts/console-guard.sh`

## Verification
- `npm run lint` → 0 errors, 289 warnings (all pre-existing)
- `bash scripts/console-guard.sh` → ✅ PASS (165 violations, baseline 165)

## Impact
- **Zero new** `console.*` calls can be added to production code without explicit exclusion
- Existing code is **not broken** — all current violators are excluded
- Future PRs that add `console.*` to any new or existing file will **fail CI**