### PR TITLE
test(dashboard): hook tests batch 2 — useHaptics, useConfetti

### DIFF
--- a/dashboard/src/hooks/__tests__/useConfetti.test.ts
+++ b/dashboard/src/hooks/__tests__/useConfetti.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockConfetti = vi.fn();
+vi.mock('canvas-confetti', () => ({
+  default: (...args: unknown[]) => mockConfetti(...args),
+}));
+
+import { renderHook, act } from '@testing-library/react';
+import { useConfetti } from '../useConfetti';
+
+describe('useConfetti', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockConfetti.mockClear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('triggers confetti on first call', () => {
+    const { result } = renderHook(() => useConfetti());
+    act(() => {
+      result.current.triggerFirstSessionConfetti();
+    });
+    expect(mockConfetti).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('aegis:first-session')).toBe('done');
+  });
+
+  it('does not trigger on subsequent calls within same hook', () => {
+    const { result } = renderHook(() => useConfetti());
+    act(() => {
+      result.current.triggerFirstSessionConfetti();
+    });
+    expect(mockConfetti).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.triggerFirstSessionConfetti();
+    });
+    // Still 1 — second call should be no-op
+    expect(mockConfetti).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger if already done in localStorage', () => {
+    localStorage.setItem('aegis:first-session', 'done');
+    const { result } = renderHook(() => useConfetti());
+    act(() => {
+      result.current.triggerFirstSessionConfetti();
+    });
+    expect(mockConfetti).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/hooks/__tests__/useHaptics.test.ts
+++ b/dashboard/src/hooks/__tests__/useHaptics.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useHaptics } from '../useHaptics';
+
+describe('useHaptics', () => {
+  beforeEach(() => {
+    vi.stubGlobal('navigator', { vibrate: vi.fn().mockReturnValue(true) });
+  });
+
+  it('vibrate calls navigator.vibrate with pattern', () => {
+    const { result } = renderHook(() => useHaptics());
+    result.current.vibrate(200);
+    expect(navigator.vibrate).toHaveBeenCalledWith(200);
+  });
+
+  it('approve triggers short vibration', () => {
+    const { result } = renderHook(() => useHaptics());
+    result.current.approve();
+    expect(navigator.vibrate).toHaveBeenCalledWith([30]);
+  });
+
+  it('reject triggers double vibration', () => {
+    const { result } = renderHook(() => useHaptics());
+    result.current.reject();
+    expect(navigator.vibrate).toHaveBeenCalledWith([60, 30, 60]);
+  });
+
+  it('returns false when vibrate API unavailable', () => {
+    vi.stubGlobal('navigator', { vibrate: undefined });
+    const { result } = renderHook(() => useHaptics());
+    expect(result.current.vibrate(100)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for 2 more untested dashboard hooks (from #4298):

### useHaptics (4 tests)
- Calls navigator.vibrate with pattern
- Approve triggers short vibration [30]
- Reject triggers double vibration [60, 30, 60]
- Returns false when vibrate API unavailable

### useConfetti (3 tests)
- Triggers confetti on first call + sets localStorage
- Idempotent on subsequent calls
- Does not trigger if localStorage already set

**7/7 tests green. TSC clean.**

Related: #4298

— Daedalus 🏛️