### PR TITLE
test(dashboard): hook tests batch 3 — useIdleTips, useSwipeGesture

### DIFF
--- a/dashboard/src/hooks/__tests__/useIdleTips.test.tsx
+++ b/dashboard/src/hooks/__tests__/useIdleTips.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useIdleTips } from '../useIdleTips';
+
+describe('useIdleTips', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with showTip=false', () => {
+    const { result } = renderHook(() => useIdleTips({ idleTimeMs: 10000 }));
+    expect(result.current.showTip).toBe(false);
+  });
+
+  it('returns a tip string from the provided list', () => {
+    const tips = ['Tip A', 'Tip B'];
+    const { result } = renderHook(() => useIdleTips({ tips, idleTimeMs: 60000 }));
+    expect(tips).toContain(result.current.currentTip);
+  });
+
+  it('shows tip after idle time elapses', () => {
+    const { result } = renderHook(() => useIdleTips({ idleTimeMs: 1000 }));
+    expect(result.current.showTip).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(result.current.showTip).toBe(true);
+  });
+
+  it('hides tip on user interaction', () => {
+    const { result } = renderHook(() => useIdleTips({ idleTimeMs: 500 }));
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.showTip).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new Event('mousedown'));
+    });
+    expect(result.current.showTip).toBe(false);
+  });
+});

--- a/dashboard/src/hooks/__tests__/useSwipeGesture.test.tsx
+++ b/dashboard/src/hooks/__tests__/useSwipeGesture.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSwipeGesture } from '../useSwipeGesture';
+
+// jsdom doesn't implement Touch — polyfill
+class MockTouch {
+  identifier: number;
+  target: EventTarget;
+  clientX: number;
+  clientY: number;
+  pageX: number;
+  pageY: number;
+  screenX: number;
+  screenY: number;
+  radiusX = 0;
+  radiusY = 0;
+  rotationAngle = 0;
+  force = 1;
+  constructor(init: { identifier: number; target: EventTarget; clientX: number; clientY: number }) {
+    this.identifier = init.identifier;
+    this.target = init.target;
+    this.clientX = init.clientX;
+    this.clientY = init.clientY;
+    this.pageX = init.clientX;
+    this.pageY = init.clientY;
+    this.screenX = init.clientX;
+    this.screenY = init.clientY;
+  }
+}
+
+// @ts-expect-error polyfill
+globalThis.Touch = MockTouch;
+
+function createTouchEvent(type: string, x: number, y: number) {
+  return new TouchEvent(type, {
+    touches: type === 'touchstart' ? [new MockTouch({ identifier: 0, target: window, clientX: x, clientY: y })] : [],
+    changedTouches: type === 'touchend' ? [new MockTouch({ identifier: 0, target: window, clientX: x, clientY: y })] : [],
+    bubbles: true,
+  });
+}
+
+describe('useSwipeGesture', () => {
+  it('detects right swipe', () => {
+    const onSwipe = vi.fn();
+    renderHook(() => useSwipeGesture({ onSwipe, threshold: 50 }));
+
+    window.dispatchEvent(createTouchEvent('touchstart', 100, 200));
+    window.dispatchEvent(createTouchEvent('touchend', 200, 200));
+
+    expect(onSwipe).toHaveBeenCalledWith('right', { x: 200, y: 200 });
+  });
+
+  it('detects left swipe', () => {
+    const onSwipe = vi.fn();
+    renderHook(() => useSwipeGesture({ onSwipe, threshold: 50 }));
+
+    window.dispatchEvent(createTouchEvent('touchstart', 200, 200));
+    window.dispatchEvent(createTouchEvent('touchend', 100, 200));
+
+    expect(onSwipe).toHaveBeenCalledWith('left', { x: 100, y: 200 });
+  });
+
+  it('ignores swipes below threshold', () => {
+    const onSwipe = vi.fn();
+    renderHook(() => useSwipeGesture({ onSwipe, threshold: 50 }));
+
+    window.dispatchEvent(createTouchEvent('touchstart', 100, 200));
+    window.dispatchEvent(createTouchEvent('touchend', 120, 200));
+
+    expect(onSwipe).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when disabled', () => {
+    const onSwipe = vi.fn();
+    renderHook(() => useSwipeGesture({ onSwipe, enabled: false, threshold: 50 }));
+
+    window.dispatchEvent(createTouchEvent('touchstart', 100, 200));
+    window.dispatchEvent(createTouchEvent('touchend', 200, 200));
+
+    expect(onSwipe).not.toHaveBeenCalled();
+  });
+
+  it('ignores edge swipes (browser back gesture)', () => {
+    const onSwipe = vi.fn();
+    renderHook(() => useSwipeGesture({ onSwipe, threshold: 50, edgeExclusion: 30 }));
+
+    // Start at x=10 (within 30px edge exclusion)
+    window.dispatchEvent(createTouchEvent('touchstart', 10, 200));
+    window.dispatchEvent(createTouchEvent('touchend', 100, 200));
+
+    expect(onSwipe).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for 2 more untested dashboard hooks (from #4298):

### useIdleTips (4 tests)
- Starts with showTip=false
- Returns tip from provided list
- Shows tip after idle time
- Hides tip on user interaction

### useSwipeGesture (5 tests)
- Detects right swipe
- Detects left swipe
- Ignores swipes below threshold
- Does not fire when disabled
- Ignores edge swipes (browser back gesture protection)

**9/9 tests green. TSC clean.**

Related: #4298

— Daedalus 🏛️