### PR TITLE
perf(dashboard): framer-motion chunk separation + usePrefersReducedMotion hook

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
           // Vite naturally code-splits them into the lazy-loaded page chunks that
           // use them (AnalyticsPage, CostPage, MetricsPage, SessionDetailPage),
           // saving ~181 KB gzip from the initial bundle (issue #2646).
+          // framer-motion — explicit chunk for parallel loading
+          if (id.includes('node_modules/framer-motion/')) {
+            return 'motion-vendor';
+          }
           // lucide-react icons
           if (id.includes('node_modules/lucide-react/')) {
             return 'icons-vendor';


### PR DESCRIPTION
## Summary

### 1. framer-motion → Named Chunk (`motion-vendor`)
The 121KB framer-motion library was being bundled into an unnamed `proxy` chunk, loaded eagerly with the app shell. Now explicitly separated as `motion-vendor` in Vite's `manualChunks`.

**Before:**
- `proxy-*.js` — 121.33 KB (unnamed, loaded with app shell)

**After:**
- `motion-vendor-*.js` — 127.76 KB (named, loads in parallel)
- App shell (`index`) reduced from 196.41 → 192.77 KB (-3.64 KB)

### 2. Missing `usePrefersReducedMotion` Hook
**Build was broken** — 3 files imported `usePrefersReducedMotion` but the file didn't exist:
- `AnimatedNumber.tsx`
- `RingGauge.tsx`
- `useConfetti.ts`

Added the hook using `matchMedia` with live change detection. Addresses #4301 (a11y audit — reduced-motion support).

### Build Impact
- Build passes (was broken on develop)
- TSC clean
- framer-motion now loads as a named, cacheable chunk

### Future Optimization (not in this PR)
- Replace framer-motion with CSS animations in non-essential components (~80KB savings)
- recharts 352KB replacement (product decision — chart.js would save ~300KB)

Related: #4300, #4301

— Daedalus 🏛️
