### PR TITLE
test(dashboard): hook tests batch 4 — useServerHealth, useSessionTimeline

### DIFF
--- a/dashboard/src/hooks/__tests__/useServerHealth.test.tsx
+++ b/dashboard/src/hooks/__tests__/useServerHealth.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * useServerHealth.test.tsx — Tests for server health polling hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useServerHealth } from '../useServerHealth';
+
+// Mock the module-level fetchHealth by mocking fetch
+vi.stubGlobal('fetch', vi.fn());
+
+describe('useServerHealth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with checking status', () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useServerHealth());
+    expect(result.current.status).toBe('checking');
+    expect(result.current.lastCheck).toBeNull();
+  });
+
+  it('transitions to connected on successful health check', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ok' }),
+    });
+
+    const { result } = renderHook(() => useServerHealth());
+
+    await waitFor(() => expect(result.current.status).toBe('connected'), { timeout: 3000 });
+    expect(result.current.lastCheck).toBeInstanceOf(Date);
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('transitions to reconnecting on failed health check', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useServerHealth());
+
+    await waitFor(() => expect(result.current.status).toBe('reconnecting'), { timeout: 3000 });
+    expect(result.current.downSince).toBeInstanceOf(Date);
+    expect(result.current.errorMessage).toContain('Reconnecting');
+  });
+
+});

--- a/dashboard/src/hooks/__tests__/useSessionTimeline.test.tsx
+++ b/dashboard/src/hooks/__tests__/useSessionTimeline.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useSessionTimeline } from '../useSessionTimeline';
+
+vi.mock('../../api/acp-timeline-client', () => ({
+  replaySessionEvents: vi.fn(),
+}));
+
+import { replaySessionEvents } from '../../api/acp-timeline-client';
+
+describe('useSessionTimeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with empty events and no error', () => {
+    (replaySessionEvents as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useSessionTimeline('s1'));
+    expect(result.current.events).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('loads events on mount', async () => {
+    const mockEvents = [{ type: 'start', ts: 1000 }];
+    (replaySessionEvents as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvents);
+
+    const { result } = renderHook(() => useSessionTimeline('s1'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.events).toEqual(mockEvents);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error on fetch failure', async () => {
+    (replaySessionEvents as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useSessionTimeline('s1'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe('Network error');
+  });
+
+  it('does not fetch when sessionId is undefined', () => {
+    (replaySessionEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    renderHook(() => useSessionTimeline(undefined));
+    expect(replaySessionEvents).not.toHaveBeenCalled();
+  });
+
+  it('clearError clears the error', async () => {
+    (replaySessionEvents as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useSessionTimeline('s1'));
+
+    await waitFor(() => expect(result.current.error).toBe('fail'));
+    await act(async () => { result.current.clearError(); });
+    expect(result.current.error).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for 2 more untested dashboard hooks (from #4298):

### useServerHealth (3 tests)
- Starts with checking status
- Transitions to connected on success
- Transitions to reconnecting on failure

### useSessionTimeline (5 tests)
- Starts with empty events
- Loads events on mount
- Sets error on fetch failure
- Does not fetch when sessionId is undefined
- clearError clears the error state

**8/8 tests green. TSC clean.**

Related: #4298

— Daedalus 🏛️