### PR TITLE
fix(test): Node 20 dashboard E2E unhandled error — useAuthStore.getState (#4316)

### DIFF
--- a/dashboard/src/hooks/__tests__/useSessionExpiryGuard.test.ts
+++ b/dashboard/src/hooks/__tests__/useSessionExpiryGuard.test.ts
@@ -10,8 +10,12 @@ let storeState = {
 };
 
 vi.mock('../../store/useAuthStore', () => {
+  const selector = (sel: (s: typeof storeState) => any) => sel(storeState);
+  // Must expose getState() — useSessionExpiryGuard calls useAuthStore.getState() directly
+  // (not as a selector hook). Without this, fake timer callbacks crash after teardown.
+  selector.getState = () => storeState;
   return {
-    useAuthStore: (sel: (s: typeof storeState) => any) => sel(storeState),
+    useAuthStore: selector,
     // Export for direct access
     _storeState: storeState,
   };


### PR DESCRIPTION
## Root Cause

`useSessionExpiryGuard.ts` calls `useAuthStore.getState()` directly (not as a React selector), but the test mock only provided a selector function — no `.getState()` property.

On Node 20, fake timer callbacks fire during teardown after the mock is partially cleaned up, causing:
```
TypeError: useAuthStore.getState is not a function
```

## Fix

Attach `getState` to the mock selector function so timer callbacks always find it:
```ts
const selector = (sel) => sel(storeState);
selector.getState = () => storeState;
```

## Verification

- 174 test files pass, 1645 tests pass (same as before)
- The 2 unhandled errors should be gone
- Only affects Node 20 (Node 22 timing prevented the crash)

Closes #4316