### PR TITLE
fix(dashboard): a11y — scope=col on table headers, usePrefersReducedMotion tests (#4301)

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -817,7 +817,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
             <table className="w-full text-left text-sm" aria-label={t("aria.sessionsTable")}>
               <thead>
                 <tr className="border-b border-[var(--color-void-lighter)] text-[var(--color-text-muted)]">
-                  <th className="px-4 py-3 font-medium">
+                  <th scope="col" className="px-4 py-3 font-medium">
                     <input
                       type="checkbox"
                       aria-label={t("aria.selectAll")}
@@ -826,15 +826,15 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                       className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
                     />
                   </th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="hidden md:table-cell px-4 py-3 font-medium">Created by</th>
-                  <th className="px-4 py-3 font-medium">Name</th>
-                  <th className="px-4 py-3 font-medium">WorkDir</th>
-                  <th className="px-4 py-3 font-medium">Age</th>
-                  <th className="px-4 py-3 font-medium">Last Activity</th>
-                  <th className="px-4 py-3 font-medium">Permission</th>
-                  <th className="px-4 py-3 font-medium">Cost</th>
-                  <th className="px-4 py-3 font-medium">Actions</th>
+                  <th scope="col" className="px-4 py-3 font-medium">Status</th>
+                  <th scope="col" className="hidden md:table-cell px-4 py-3 font-medium">Created by</th>
+                  <th scope="col" className="px-4 py-3 font-medium">Name</th>
+                  <th scope="col" className="px-4 py-3 font-medium">WorkDir</th>
+                  <th scope="col" className="px-4 py-3 font-medium">Age</th>
+                  <th scope="col" className="px-4 py-3 font-medium">Last Activity</th>
+                  <th scope="col" className="px-4 py-3 font-medium">Permission</th>
+                  <th scope="col" className="px-4 py-3 font-medium">Cost</th>
+                  <th scope="col" className="px-4 py-3 font-medium">Actions</th>
                 </tr>
               </thead>
               <tbody className="sr-only">

--- a/dashboard/src/components/session/SessionMetricsPanel.tsx
+++ b/dashboard/src/components/session/SessionMetricsPanel.tsx
@@ -213,11 +213,11 @@ export function SessionMetricsPanel({ sessionId }: SessionMetricsPanelProps) {
           <table className="w-full text-xs">
             <thead>
               <tr>
-                <th className="text-left pb-2 font-normal text-[var(--color-text-muted)] uppercase tracking-wider">
+                <th scope="col" className="text-left pb-2 font-normal text-[var(--color-text-muted)] uppercase tracking-wider">
                   Type
                 </th>
-                <th className="pb-2 w-1/2" />
-                <th className="text-right pb-2 font-normal font-mono text-[var(--color-text-muted)] uppercase tracking-wider">
+                <th scope="col" className="pb-2 w-1/2" />
+                <th scope="col" className="text-right pb-2 font-normal font-mono text-[var(--color-text-muted)] uppercase tracking-wider">
                   Count
                 </th>
               </tr>

--- a/dashboard/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
+++ b/dashboard/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
@@ -2,7 +2,7 @@
  * usePrefersReducedMotion.test.tsx — Tests for reduced-motion media query hook.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { usePrefersReducedMotion } from '../usePrefersReducedMotion';
 

--- a/dashboard/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
+++ b/dashboard/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * usePrefersReducedMotion.test.tsx — Tests for reduced-motion media query hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePrefersReducedMotion } from '../usePrefersReducedMotion';
+
+let listeners: Record<string, (e: MediaQueryListEvent) => void> = {};
+let matches = false;
+
+const mockMql = {
+  matches: false,
+  media: '(prefers-reduced-motion: reduce)',
+  addEventListener: vi.fn((event: string, handler: (e: MediaQueryListEvent) => void) => {
+    listeners[event] = handler;
+  }),
+  removeEventListener: vi.fn(),
+};
+
+const mockMatchMedia = vi.fn().mockImplementation(() => {
+  mockMql.matches = matches;
+  return mockMql;
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: mockMatchMedia,
+});
+
+function fireMediaChange(newMatches: boolean) {
+  matches = newMatches;
+  const handler = listeners['change'];
+  if (handler) {
+    act(() => {
+      handler({ matches: newMatches } as MediaQueryListEvent);
+    });
+  }
+}
+
+describe('usePrefersReducedMotion', () => {
+  beforeEach(() => {
+    matches = false;
+    listeners = {};
+    vi.clearAllMocks();
+  });
+
+  it('returns false when user does not prefer reduced motion', () => {
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when user prefers reduced motion', () => {
+    matches = true;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when media query changes', () => {
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    fireMediaChange(true);
+    expect(result.current).toBe(true);
+
+    fireMediaChange(false);
+    expect(result.current).toBe(false);
+  });
+
+  it('queries the correct media query string', () => {
+    renderHook(() => usePrefersReducedMotion());
+    expect(mockMatchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+  });
+
+  it('cleans up listener on unmount', () => {
+    const { unmount } = renderHook(() => usePrefersReducedMotion());
+    expect(mockMql.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    unmount();
+    expect(mockMql.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});

--- a/dashboard/src/pages/AuditPage.tsx
+++ b/dashboard/src/pages/AuditPage.tsx
@@ -841,7 +841,7 @@ export default function AuditPage() {
             <thead>
               <tr className="border-b border-[var(--color-void-lighter)]">
                 {TABLE_HEADER_KEYS.map((key) => (
-                  <th key={key} className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">{t(`audit.${key}`)}</th>
+                  <th key={key} scope="col" className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">{t(`audit.${key}`)}</th>
                 ))}
               </tr>
             </thead>
@@ -868,7 +868,7 @@ export default function AuditPage() {
               <thead>
                 <tr className="border-b border-[var(--color-void-lighter)]">
                   {TABLE_HEADER_KEYS.map((key) => (
-                    <th key={key} className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">{t(`audit.${key}`)}</th>
+                    <th key={key} scope="col" className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">{t(`audit.${key}`)}</th>
                   ))}
                 </tr>
               </thead>

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -365,11 +365,11 @@ export default function MetricsPage() {
             <table className="w-full text-sm" aria-label={t("aria.metricsByKey")}>
               <thead>
                 <tr className="border-b border-[var(--color-border-strong)]">
-                  <th className="pb-2 text-left text-xs font-medium text-[var(--color-text-muted)]">Key Name</th>
-                  <th className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Sessions</th>
-                  <th className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Messages</th>
-                  <th className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Tool Calls</th>
-                  <th className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Token Cost</th>
+                  <th scope="col" className="pb-2 text-left text-xs font-medium text-[var(--color-text-muted)]">Key Name</th>
+                  <th scope="col" className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Sessions</th>
+                  <th scope="col" className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Messages</th>
+                  <th scope="col" className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Tool Calls</th>
+                  <th scope="col" className="pb-2 text-right text-xs font-medium text-[var(--color-text-muted)]">Token Cost</th>
                 </tr>
               </thead>
               <tbody>

--- a/dashboard/src/pages/PipelineDetailPage.tsx
+++ b/dashboard/src/pages/PipelineDetailPage.tsx
@@ -157,10 +157,10 @@ export default function PipelineDetailPage() {
           <table className="w-full text-left text-sm" aria-label={t('pipelines.stepsLabel')}>
             <thead>
               <tr className="border-b border-[var(--color-void-lighter)] text-[var(--color-text-muted)]">
-                <th className="px-4 py-3 font-medium w-16">#</th>
-                <th className="px-4 py-3 font-medium">{t('pipelines.statusLabel')}</th>
-                <th className="px-4 py-3 font-medium">{t('common.name')}</th>
-                <th className="px-4 py-3 font-medium">{t('pipelines.sessionLabel')}</th>
+                <th scope="col" className="px-4 py-3 font-medium w-16">#</th>
+                <th scope="col" className="px-4 py-3 font-medium">{t('pipelines.statusLabel')}</th>
+                <th scope="col" className="px-4 py-3 font-medium">{t('common.name')}</th>
+                <th scope="col" className="px-4 py-3 font-medium">{t('pipelines.sessionLabel')}</th>
               </tr>
             </thead>
             <tbody>

--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -652,7 +652,7 @@ export default function SessionHistoryPage() {
                       className="h-4 w-4 rounded border-[var(--color-void-lighter)] bg-[var(--color-void-light)] text-[var(--color-accent-cyan)] focus:ring-[var(--color-accent-cyan)]/30"
                     />
                   </th>
-                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">{t('sessionHistory.nameColumn')}</th>
+                  <th scope="col" className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">{t('sessionHistory.nameColumn')}</th>
                   {sortableHeader(t('sessionHistory.sessionIdColumn'), "id")}
                   {sortableHeader(t('sessionHistory.ownerColumn'), "owner")}
                   {sortableHeader(t('sessionHistory.statusColumn'), "status")}


### PR DESCRIPTION
## Closes #4301

### Changes
- **Table headers a11y**: Added `scope="col"` to all `<th>` elements across 6 table components (SessionTable, AuditPage, MetricsPage, PipelineDetailPage, SessionHistoryPage, SessionMetricsPanel) — screen readers need scope to properly associate headers with data cells
- **usePrefersReducedMotion tests**: 5 new tests for the previously-untested hook (default state, active state, media query change, correct query string, listener cleanup)

### Verified (no changes needed — already correct)
- `prefers-reduced-motion` respected in AnimatedNumber, RingGauge, useConfetti
- `aria-live` regions in ToastContainer, MetricCards, ConnectionBanner
- Progress bars have `role="progressbar"` with `aria-valuenow/min/max`

### Test Results
- 51 a11y hook tests pass (useFocusTrap, useKeyboardShortcuts, usePrefersReducedMotion)
- 31 a11y page tests pass
- TypeScript: no new errors from these changes

— Daedalus 🏛️