### PR TITLE
fix(monitor): preserve StallDetector state in setAcpBackend (#4319 follow-up)

### DIFF
--- a/src/__tests__/stall-detector-setrestart.test.ts
+++ b/src/__tests__/stall-detector-setrestart.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for StallDetector.setRestartSession — state preservation when
+ * updating the restartSession callback (the setAcpBackend state loss fix).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { StallDetector, type StallDetectorConfig, type StallDetectorDeps } from '../stall-detector.js';
+
+function makeConfig(): StallDetectorConfig {
+  return {
+    stallThresholdMs: 60_000,
+    permissionStallMs: 300_000,
+    unknownStallMs: 120_000,
+    permissionTimeoutMs: 600_000,
+    stallRecoveryEnabled: true,
+    stallRecoveryMaxRetries: 3,
+  };
+}
+
+function makeDeps(): StallDetectorDeps {
+  return {
+    rejectSession: vi.fn(),
+    emitStall: vi.fn(),
+    statusChange: vi.fn(),
+    makePayload: vi.fn().mockReturnValue({}),
+  };
+}
+
+describe('StallDetector.setRestartSession', () => {
+  it('preserves stall state when restartSession is updated', () => {
+    const detector = new StallDetector(makeConfig(), makeDeps());
+
+    // Accumulate some state
+    detector.stallAdd('sess-1', 'jsonl');
+    expect(detector.stallHas('sess-1', 'jsonl')).toBe(true);
+
+    // Update restartSession callback (simulates setAcpBackend)
+    const newRestart = vi.fn().mockResolvedValue({ backoffDelayMs: 1000 });
+    detector.setRestartSession(newRestart);
+
+    // State should NOT be lost
+    expect(detector.stallHas('sess-1', 'jsonl')).toBe(true);
+  });
+
+  it('allows updating restartSession from undefined to a function', () => {
+    const deps = makeDeps();
+    // Initially no restartSession
+    expect(deps.restartSession).toBeUndefined();
+
+    const detector = new StallDetector(makeConfig(), deps);
+    const restartFn = vi.fn().mockResolvedValue({ backoffDelayMs: 500 });
+    detector.setRestartSession(restartFn);
+
+    // Now the callback should be set
+    expect(deps.restartSession).toBe(restartFn);
+  });
+
+  it('preserves multiple stall types across update', () => {
+    const detector = new StallDetector(makeConfig(), makeDeps());
+
+    detector.stallAdd('sess-1', 'jsonl');
+    detector.stallAdd('sess-1', 'permission');
+    detector.stallAdd('sess-2', 'unknown');
+
+    detector.setRestartSession(vi.fn().mockResolvedValue({ backoffDelayMs: 0 }));
+
+    expect(detector.stallHas('sess-1', 'jsonl')).toBe(true);
+    expect(detector.stallHas('sess-1', 'permission')).toBe(true);
+    expect(detector.stallHas('sess-2', 'unknown')).toBe(true);
+  });
+
+  it('can be called multiple times without state loss', () => {
+    const detector = new StallDetector(makeConfig(), makeDeps());
+
+    detector.stallAdd('sess-1', 'jsonl');
+
+    // First update
+    detector.setRestartSession(vi.fn());
+    expect(detector.stallHas('sess-1', 'jsonl')).toBe(true);
+
+    // Add more state
+    detector.stallAdd('sess-2', 'permission');
+
+    // Second update
+    detector.setRestartSession(vi.fn());
+    expect(detector.stallHas('sess-1', 'jsonl')).toBe(true);
+    expect(detector.stallHas('sess-2', 'permission')).toBe(true);
+  });
+});

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -189,27 +189,8 @@ export class SessionMonitor {
   /** Issue #3754: Set the ACP backend for rate-limit retry support. */
   setAcpBackend(acpBackend: AcpBackend): void {
     this.acpBackend = acpBackend;
-    // Wire up restartSession callback now that we have the backend
-    this.stallDetector = new StallDetector(
-      {
-        stallThresholdMs: this.config.stallThresholdMs,
-        permissionStallMs: this.config.permissionStallMs,
-        unknownStallMs: this.config.unknownStallMs,
-        permissionTimeoutMs: this.config.permissionTimeoutMs,
-        stallRecoveryEnabled: this.config.stallRecoveryEnabled,
-        stallRecoveryMaxRetries: this.config.stallRecoveryMaxRetries,
-      },
-      {
-        rejectSession: (sid) => this.sessions.reject(sid),
-        emitStall: (sid, type, detail) => this.eventBus?.emitStall(sid, type, detail),
-        statusChange: (payload) => { void this.channels.statusChange(payload); },
-        makePayload: (event, session, detail) => this.makePayload(event, session, detail),
-        alertFailure: (type, detail) => this.alertManager?.recordFailure(type as import('./alerting.js').AlertType, detail),
-        metricsFailed: (sid) => this.metrics?.sessionFailed(sid),
-        restartSession: (params) => acpBackend.restartSession(params),
-        onSessionIdle: (sid) => this.contextWarningCompacted.delete(sid),
-      },
-    );
+    // Wire up restartSession callback without discarding accumulated stall state.
+    this.stallDetector.setRestartSession((params) => acpBackend.restartSession(params));
   }
 
   /** Issue #84: Set the JSONL watcher for fs.watch-based message detection. */

--- a/src/stall-detector.ts
+++ b/src/stall-detector.ts
@@ -76,6 +76,11 @@ export class StallDetector {
     private deps: StallDetectorDeps,
   ) {}
 
+  /** Update the restartSession callback without resetting accumulated state. */
+  setRestartSession(restartSession: StallDetectorDeps['restartSession']): void {
+    this.deps.restartSession = restartSession;
+  }
+
   /** Issue #663: O(1) stall notification check. */
   stallHas(sessionId: string, stallType: string): boolean {
     return this.stallNotified.get(sessionId)?.has(stallType) ?? false;


### PR DESCRIPTION
## Summary

Follow-up to #4319 (StallDetector extraction). Addresses the state loss concern from Argus review.

### Bug

`setAcpBackend` was recreating the entire `StallDetector`, discarding all accumulated stall state:
- `stallNotified`, `lastBytesSeen`, `stateSince`, `prevStatusForStall`
- `rateLimitedSessions`, `stallRecovering`

If `setAcpBackend` was called after the monitor started running, any in-flight stall tracking was silently lost.

### Fix

Add `StallDetector.setRestartSession(cb)` — updates only the `restartSession` callback without resetting any state. `Monitor.setAcpBackend` now calls this method instead of constructing a new `StallDetector`.

### Changes

- **`stall-detector.ts`**: add `setRestartSession(cb)` method
- **`monitor.ts`**: `setAcpBackend` simplified from 15 lines to 3 lines
- **New tests**: `stall-detector-setrestart.test.ts` — 4 tests verifying state preservation across callback updates

### Verification

```
90 stall detection tests pass
4 new setRestartSession tests pass
tsc --noEmit: clean
```