### PR TITLE
test(dashboard): component test coverage Batch 3 — 31 tests

### DIFF
--- a/dashboard/src/components/agents/__tests__/AgentBadge.test.tsx
+++ b/dashboard/src/components/agents/__tests__/AgentBadge.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AgentBadge } from "../AgentBadge";
+
+vi.mock("../agent-registry", () => ({
+  getAgentMeta: (runnerName: string | undefined) => {
+    const meta: Record<string, { label: string; color: string }> = {
+      "claude-code": { label: "Claude Code", color: "purple" },
+      codex: { label: "Codex", color: "green" },
+      "gemini-cli": { label: "Gemini CLI", color: "blue" },
+      qwen: { label: "Qwen", color: "amber" },
+      copilot: { label: "Copilot", color: "cyan" },
+    };
+    return meta[runnerName ?? ""] ?? { label: runnerName ?? "Unknown", color: "gray" };
+  },
+}));
+
+describe("AgentBadge", () => {
+  it("renders with runnerName", () => {
+    render(<AgentBadge runnerName="claude-code" />);
+    expect(screen.getByText("Claude Code")).toBeDefined();
+  });
+
+  it("renders with aria-label", () => {
+    render(<AgentBadge runnerName="claude-code" />);
+    expect(screen.getByText("Claude Code").getAttribute("aria-label")).toBe("Agent: Claude Code");
+  });
+
+  it("renders compact mode without label", () => {
+    const { container } = render(<AgentBadge runnerName="claude-code" compact />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("infers runner from model when runnerName absent", () => {
+    render(<AgentBadge model="claude-opus-4.7" />);
+    expect(screen.getByText("Claude Code")).toBeDefined();
+  });
+
+  it("renders unknown for unrecognized model", () => {
+    render(<AgentBadge model="llama-3.1-70b" />);
+    expect(screen.getByText("Unknown")).toBeDefined();
+  });
+
+  it("renders unknown when no props provided", () => {
+    render(<AgentBadge />);
+    expect(screen.getByText("Unknown")).toBeDefined();
+  });
+
+  it("renders Codex for GPT models", () => {
+    render(<AgentBadge model="gpt-4o" />);
+    expect(screen.getByText("Codex")).toBeDefined();
+  });
+
+  it("renders Gemini CLI for gemini models", () => {
+    render(<AgentBadge model="gemini-2.5-pro" />);
+    expect(screen.getByText("Gemini CLI")).toBeDefined();
+  });
+
+  it("applies custom className", () => {
+    render(<AgentBadge runnerName="claude-code" className="custom-class" />);
+    const badge = screen.getByText("Claude Code");
+    expect(badge.classList.contains("custom-class")).toBe(true);
+  });
+});

--- a/dashboard/src/components/overview/__tests__/SessionMobileCard.test.tsx
+++ b/dashboard/src/components/overview/__tests__/SessionMobileCard.test.tsx
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SessionMobileCard } from "../SessionMobileCard";
+import { MemoryRouter } from "react-router-dom";
+import type { SessionInfo } from "../../../types";
+
+vi.mock("../StatusDot", () => ({
+  default: ({ status }: { status: string }) => (
+    <span data-testid="status-dot" data-status={status} />
+  ),
+}));
+
+const baseSession: SessionInfo = {
+  id: "sess-tes2345678",
+  status: "working",
+  workDir: "~/project",
+  createdAt: new Date("2026-05-27T08:00:00Z"),
+  lastActivity: new Date("2026-05-27T08:30:00Z"),
+  displayName: null,
+  latestActivityText: "Implementing feature X",
+  permissionMode: "default",
+  model: "claude-opus-4.7",
+} as unknown as SessionInfo;
+
+const baseRowProps = {
+  session: baseSession,
+  isAlive: true,
+  health: null,
+  selected: false,
+  currentAction: null,
+  estimatedCostUsd: 0.05,
+  isFocused: false,
+  onToggleSelect: vi.fn(),
+  onApprove: vi.fn(),
+  onReject: vi.fn(),
+  onInterrupt: vi.fn(),
+  onKill: vi.fn(),
+};
+
+function renderCard(overrides = {}) {
+  return render(
+    <MemoryRouter>
+      <SessionMobileCard {...baseRowProps} {...overrides} />
+    </MemoryRouter>,
+  );
+}
+
+describe("SessionMobileCard", () => {
+  it("renders session card", () => {
+    renderCard();
+    expect(screen.getByText("sess-tes")).toBeDefined();
+  });
+
+  it("renders work directory", () => {
+    renderCard();
+    expect(screen.getByText("~/project")).toBeDefined();
+  });
+
+  it("renders status dot", () => {
+    renderCard();
+    expect(screen.getByTestId("status-dot")).toBeDefined();
+  });
+
+  it("renders latest activity text", () => {
+    renderCard();
+    expect(screen.getByText("Implementing feature X")).toBeDefined();
+  });
+
+  it("renders cost estimate", () => {
+    renderCard({ estimatedCostUsd: 1.23 });
+    expect(screen.getByText("$1.23")).toBeDefined();
+  });
+
+  it("renders permission mode badge", () => {
+    renderCard();
+    expect(screen.getByText("default")).toBeDefined();
+  });
+
+  it("renders custom permission mode", () => {
+    renderCard({ session: { ...baseSession, permissionMode: "strict" } as SessionInfo });
+    expect(screen.getByText("strict")).toBeDefined();
+  });
+
+  it("renders session link", () => {
+    renderCard();
+    const link = screen.getByText("sess-tes").closest("a");
+    expect(link?.getAttribute("href")).toContain("/sessions/sess-tes2345678");
+  });
+
+  it("renders interrupt button", () => {
+    renderCard();
+    expect(screen.getByRole("button", { name: /Interrupt/i })).toBeDefined();
+  });
+
+  it("renders kill button", () => {
+    renderCard();
+    expect(screen.getByRole("button", { name: /Kill/i })).toBeDefined();
+  });
+
+  it("calls onInterrupt when button clicked", () => {
+    const onInterrupt = vi.fn();
+    renderCard({ onInterrupt });
+    fireEvent.click(screen.getByRole("button", { name: /Interrupt/i }));
+    expect(onInterrupt).toHaveBeenCalled();
+  });
+
+  it("calls onKill when button clicked", () => {
+    const onKill = vi.fn();
+    renderCard({ onKill });
+    fireEvent.click(screen.getByRole("button", { name: /Kill/i }));
+    expect(onKill).toHaveBeenCalled();
+  });
+
+  it("renders approve and reject buttons for permission_prompt status", () => {
+    renderCard({
+      session: { ...baseSession, status: "permission_prompt" } as SessionInfo,
+    });
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /Reject/i })).toBeDefined();
+  });
+
+  it("calls onToggleSelect when checkbox changed", () => {
+    const onToggleSelect = vi.fn();
+    renderCard({ onToggleSelect });
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+    expect(onToggleSelect).toHaveBeenCalledWith("sess-tes2345678", true);
+  });
+
+  it("shows dead indicator when not alive", () => {
+    renderCard({ isAlive: false });
+    const deadIcon = document.querySelector("svg.lucide-circle-x");
+    expect(deadIcon).not.toBeNull();
+  });
+});

--- a/dashboard/src/components/shared/__tests__/AnimatedNumber.test.tsx
+++ b/dashboard/src/components/shared/__tests__/AnimatedNumber.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AnimatedNumber } from "../AnimatedNumber";
+
+vi.mock("../../../hooks/usePrefersReducedMotion", () => ({
+  usePrefersReducedMotion: () => true,
+}));
+
+describe("AnimatedNumber", () => {
+  it("renders the value", () => {
+    render(<AnimatedNumber value={42} />);
+    expect(screen.getByText("42")).toBeDefined();
+  });
+
+  it("renders with suffix", () => {
+    render(<AnimatedNumber value={42} suffix="ms" />);
+    expect(screen.getByText("42ms")).toBeDefined();
+  });
+
+  it("renders zero", () => {
+    render(<AnimatedNumber value={0} />);
+    expect(screen.getByText("0")).toBeDefined();
+  });
+
+  it("renders negative values", () => {
+    render(<AnimatedNumber value={-5} />);
+    expect(screen.getByText("-5")).toBeDefined();
+  });
+
+  it("renders with decimals", () => {
+    render(<AnimatedNumber value={3.14159} decimals={2} />);
+    expect(screen.getByText("3.14")).toBeDefined();
+  });
+
+  it("renders with percentage suffix", () => {
+    render(<AnimatedNumber value={87} suffix="%" />);
+    expect(screen.getByText("87%")).toBeDefined();
+  });
+
+  it("applies custom className", () => {
+    render(<AnimatedNumber value={100} className="text-xl font-bold" />);
+    const el = document.querySelector(".text-xl");
+    expect(el).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Adds 31 new Vitest tests across 3 untested dashboard components.

## Components tested
- **AnimatedNumber** (7 tests): value rendering, suffix (ms, %), zero, negative values, decimal places, custom className
- **AgentBadge** (9 tests): runnerName display, model inference (claude/gpt/gemini), compact mode, aria-labels, unknown fallback, custom className
- **SessionMobileCard** (15 tests): session name link, truncated work dir, StatusDot, latest activity text, cost estimate, permission mode badges, session link href, action buttons (interrupt/kill/approve/reject), checkbox selection callback, dead indicator

## Testing
- All 31 tests pass locally
- Zero TypeScript errors in new files (strict mode)
- No production code changes

## Files added (3 test files, 244 lines)
- `dashboard/src/components/shared/__tests__/AnimatedNumber.test.tsx`
- `dashboard/src/components/agents/__tests__/AgentBadge.test.tsx`
- `dashboard/src/components/overview/__tests__/SessionMobileCard.test.tsx`