### PR TITLE
chore(deps): patch qs DoS vulnerability (GHSA-q8mj-m7cp-5q26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6703,9 +6703,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary

Patches the qs 6.15.1 → 6.15.2 moderate severity vulnerability (CVE-2026-8723).

**Advisory:** [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26)  
**Fix:** `npm audit fix` bumps qs transitive dep  
**Scope:** package-lock.json only — no code changes

Closes #4340

## Verification

- tsc: ✅ zero errors
- build: ✅ success
- tests: ✅ 5683 passed, 8 skipped (394 files)
- npm audit: ✅ 0 vulnerabilities