### PR TITLE
fix(dashboard): EffortIndicator title test assertion

### DIFF
--- a/dashboard/src/components/shared/__tests__/EffortIndicator.test.tsx
+++ b/dashboard/src/components/shared/__tests__/EffortIndicator.test.tsx
@@ -49,9 +49,9 @@ describe("EffortIndicator", () => {
   });
 
   it("sets title attribute", () => {
-    render(<EffortIndicator effort="high" />);
-    const el = screen.getByText("High").parentElement;
-    expect(el!.getAttribute("title")).toBe("Effort: high");
+    const { container } = render(<EffortIndicator effort="high" />);
+    const span = container.querySelector('[title="Effort: high"]');
+    expect(span).not.toBeNull();
   });
 
   it("is case-insensitive", () => {


### PR DESCRIPTION
## Summary

Fixes CI failure on develop — `EffortIndicator.test.tsx:54`.

The test used `screen.getByText("High").parentElement` expecting to reach the outer `<span>` with `title="Effort: high"`, but in jsdom the text node parent resolves to the inner colored-dot `<span>` (which has no title).

**Fix:** Use `container.querySelector([title=Effort: high])` instead of traversing `parentElement`.

All 11 EffortIndicator tests pass.