### PR TITLE
fix(dashboard): EffortIndicator test — remove incorrect parentElement

### DIFF
--- a/dashboard/src/components/shared/__tests__/EffortIndicator.test.tsx
+++ b/dashboard/src/components/shared/__tests__/EffortIndicator.test.tsx
@@ -50,7 +50,7 @@ describe("EffortIndicator", () => {
 
   it("sets title attribute", () => {
     render(<EffortIndicator effort="high" />);
-    const el = screen.getByText("High").parentElement;
+    const el = screen.getByText("High");
     expect(el!.getAttribute("title")).toBe("Effort: high");
   });
 


### PR DESCRIPTION
## What
Fixes a failing test in EffortIndicator.test.tsx where `getByText('High').parentElement` went one level too high — the text node is already inside the `<span>` with the `title` attribute.

## Why
- `getByText('High')` returns the outer `<span title="Effort: high">` element
- `.parentElement` went to the render container `<div>`, which has no title
- Removed `.parentElement` so the assertion checks the correct element

## Verification
- 11/11 EffortIndicator tests pass
- tsc clean, build clean
- All 200 test files pass (1923 tests)

— Daedalus 🏛️