### PR TITLE
feat(dashboard): status transition flash animation on StatusDot

### DIFF
--- a/dashboard/src/components/overview/StatusDot.test.tsx
+++ b/dashboard/src/components/overview/StatusDot.test.tsx
@@ -5,8 +5,8 @@
  * aria-labels, and i18n labels.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import StatusDot from './StatusDot';
 import type { UIState } from '../../types';
 
@@ -117,3 +117,28 @@ describe('StatusDot', () => {
     });
   });
 });
+  describe('status transition flash', () => {
+    it('has enlarged glow when status changes to working', () => {
+      const { rerender } = render(<StatusDot status='idle' />);
+      rerender(<StatusDot status='working' />);
+      const dot = screen.getByRole('img');
+      expect(dot.style.boxShadow).toContain('12px');
+    });
+
+    it('returns to normal glow after flash duration', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { rerender } = render(<StatusDot status='idle' />);
+      rerender(<StatusDot status='permission_prompt' />);
+      const dot = screen.getByRole('img');
+      expect(dot.style.boxShadow).toContain('12px');
+      await act(async () => { vi.advanceTimersByTime(801); });
+      expect(dot.style.boxShadow).not.toContain('12px');
+      vi.useRealTimers();
+    });
+
+    it('does not flash on initial render', () => {
+      const { container } = render(<StatusDot status='working' />);
+      const dot = container.firstChild as HTMLElement;
+      expect(dot.style.boxShadow).not.toContain('12px');
+    });
+  });

--- a/dashboard/src/components/overview/StatusDot.tsx
+++ b/dashboard/src/components/overview/StatusDot.tsx
@@ -1,7 +1,11 @@
 /**
  * components/overview/StatusDot.tsx — Colored status indicator dot.
+ *
+ * Includes a one-shot flash animation when the status changes,
+ * making SSE-driven status transitions visually obvious.
  */
 
+import { useEffect, useRef, useState } from 'react';
 import type { UIState } from '../../types';
 import { useT } from '../../i18n/context';
 import type { SessionHealthState } from '../../types';
@@ -70,8 +74,13 @@ const HEALTH_KEYS: Record<SessionHealthState, string> = {
   dead: 'statusDot.dead',
 };
 
+const FLASH_DURATION_MS = 800;
+
 export default function StatusDot({ status, health }: StatusDotProps) {
   const t = useT();
+  const prevStatusRef = useRef(status);
+  const [flashing, setFlashing] = useState(false);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Health state (stall/dead) overrides the status color for emphasis
   const isStall = health === 'stall';
   const isDead = health === 'dead';
@@ -92,6 +101,19 @@ export default function StatusDot({ status, health }: StatusDotProps) {
     ? t(HEALTH_KEYS.stall)
     : t(STATUS_KEYS[status] ?? STATUS_KEYS.unknown);
 
+  // Trigger flash animation when status changes
+  useEffect(() => {
+    if (prevStatusRef.current !== status) {
+      prevStatusRef.current = status;
+      setFlashing(true);
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+      flashTimerRef.current = setTimeout(() => setFlashing(false), FLASH_DURATION_MS);
+    }
+    return () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, [status]);
+
   return (
     <span
       role="img"
@@ -103,8 +125,11 @@ export default function StatusDot({ status, health }: StatusDotProps) {
         height: 8,
         borderRadius: '50%',
         backgroundColor: baseColor,
-        boxShadow: `0 0 6px ${baseColor}66`,
+        boxShadow: flashing
+          ? `0 0 12px ${baseColor}, 0 0 24px ${baseColor}88`
+          : `0 0 6px ${baseColor}66`,
         animation: shouldPulse ? `pulse ${pulseDuration} ease-in-out infinite` : undefined,
+        transition: 'box-shadow 0.4s ease-out',
       }}
     />
   );


### PR DESCRIPTION
## Summary
When a session status changes via SSE,  briefly shows an enlarged glow that fades back to normal over 800ms. This makes real-time SSE-driven status transitions visually obvious — a working→idle transition flashes green, permission_prompt flashes amber — without requiring the user to actively watch any specific row.

## Changes
- **StatusDot.tsx**: Track previous status via , trigger flash state on change
- Flash uses expanded  (12px + 24px double glow) vs normal (6px)
- CSS  for smooth fade
- **StatusDot.test.tsx**: 3 new tests (flash on change, fade after 800ms, no flash on initial render)

## Acceptance Criteria (from #4346)
- [x] Status transitions have visible animation
- [x] Animation is one-shot (doesn't loop)
- [x] All consumers get it for free (StatusDot is used everywhere)
- [x] No new dependencies
- [x] Tests pass (54/54), build clean, TS strict clean

## Related
- Partially addresses #4346 (dashboard streaming UX)
- No backend changes — works with existing SSE event stream