### PR TITLE
fix(dashboard): deflake AnalyticsPage + CostPage model name assertions

### DIFF
--- a/dashboard/src/__tests__/AnalyticsPage.test.tsx
+++ b/dashboard/src/__tests__/AnalyticsPage.test.tsx
@@ -188,11 +188,9 @@ describe('AnalyticsPage', () => {
 
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText('Model Distribution')).toBeDefined();
-      expect(screen.getByText('claude-sonnet-4.6')).toBeDefined();
-      expect(screen.getByText('claude-opus-4.7')).toBeDefined();
-    });
+    await screen.findByText('Model Distribution');
+    expect(await screen.findByText('claude-sonnet-4.6')).toBeDefined();
+    expect(await screen.findByText('claude-opus-4.7')).toBeDefined();
   });
 
   it('calculates error rate correctly and color-codes high error rates', async () => {

--- a/dashboard/src/__tests__/CostPage.test.tsx
+++ b/dashboard/src/__tests__/CostPage.test.tsx
@@ -165,8 +165,10 @@ describe('CostPage', () => {
     });
 
     // Model names should be visible in the model breakdown
-    expect(screen.getAllByText('claude-sonnet-4.6').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('claude-opus-4.7').length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.getAllByText('claude-sonnet-4.6').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('claude-opus-4.7').length).toBeGreaterThan(0);
+    });
   });
 
   it('displays time range picker with 7d, 30d, and 90d options', async () => {


### PR DESCRIPTION
## Summary
Replaces synchronous `getByText` calls with `findByText` / `waitFor` for model name assertions that happen after async data fetching in AnalyticsPage and CostPage tests.

## Root Cause
`TestingLibraryElementError: Unable to find an element with the text: claude-sonnet-4.6` — the synchronous `getByText` in a `waitFor` callback can flake when chart.js canvas rendering is slow in CI (no GPU, jsdom environment).

## Fix
- AnalyticsPage: replaced `waitFor + getByText` with `findByText` (built-in retry)
- CostPage: wrapped model name assertions in `waitFor`

## Test Plan
- [x] All 17 tests pass locally (AnalyticsPage: 8, CostPage: 9)
- [x] tsc clean
- [x] build clean

Closes #4357