### PR TITLE
test(dashboard): TranscriptBubble tests (26 tests)

### DIFF
--- a/dashboard/src/components/session/__tests__/TranscriptBubble.test.tsx
+++ b/dashboard/src/components/session/__tests__/TranscriptBubble.test.tsx
@@ -1,125 +1,251 @@
-import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+/**
+ * TranscriptBubble — unit tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { TranscriptBubble } from '../TranscriptBubble';
 import type { ParsedEntry } from '../../../types';
 
-vi.mock('../../shared/CodeBlock', () => ({
-  RenderWithCodeBlocks: ({ text }: { text: string }) => <div>{text}</div>,
-}));
+// Mock clipboard
+Object.assign(navigator, {
+  clipboard: { writeText: vi.fn(() => Promise.resolve()) },
+});
 
-vi.mock('../../shared/CopyButton', () => ({
-  CopyButton: ({ text }: { text?: string }) => (
-    <button data-testid="copy-btn" aria-label="Copy">{(text || '').slice(0, 20)}</button>
-  ),
-}));
-
-vi.mock('../../Icon', () => ({
-  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`}>{name}</span>,
-}));
+// Mock window.location for permalink
+const originalLocation = window.location;
+delete (window as unknown as Record<string, unknown>).location;
+(window as unknown as Record<string, unknown>).location = { ...originalLocation, href: 'http://localhost/session/123', hash: '' } as unknown as Location;
 
 const baseEntry: ParsedEntry = {
   role: 'assistant',
   contentType: 'text',
-  text: 'Hello world',
-  timestamp: '2026-05-27T10:00:00Z',
+  text: 'Hello, world!',
+  timestamp: '2026-05-27T12:00:00Z',
 };
 
 describe('TranscriptBubble', () => {
-  it('renders user message', () => {
-    const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'My message' };
-    render(<TranscriptBubble entry={entry} index={0} />);
-    expect(screen.getByText('My message')).toBeDefined();
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('renders assistant message', () => {
-    render(<TranscriptBubble entry={baseEntry} index={0} />);
-    expect(screen.getByText('Hello world')).toBeDefined();
+  // --- System messages ---
+  describe('system messages', () => {
+    it('renders system message in italic muted text', () => {
+      const entry: ParsedEntry = { ...baseEntry, role: 'system', text: 'Session started' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      expect(screen.getByText('Session started')).toBeDefined();
+    });
+
+    it('calls onFocus on click', () => {
+      const onFocus = vi.fn();
+      const entry: ParsedEntry = { ...baseEntry, role: 'system', text: 'init' };
+      render(<TranscriptBubble entry={entry} index={5} onFocus={onFocus} />);
+      fireEvent.click(screen.getByText('init'));
+      expect(onFocus).toHaveBeenCalledWith(5);
+    });
   });
 
-  it('renders system message', () => {
-    const entry: ParsedEntry = { ...baseEntry, role: 'system', text: 'System notification' };
-    render(<TranscriptBubble entry={entry} index={0} />);
-    expect(screen.getByText('System notification')).toBeDefined();
+  // --- User messages ---
+  describe('user messages', () => {
+    it('renders user message on the right side', () => {
+      const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'My message' };
+      const { container } = render(<TranscriptBubble entry={entry} index={0} />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain('justify-end');
+    });
+
+    it('shows absolute timestamp for user messages', () => {
+      const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'Hi', timestamp: '2026-05-27T14:30:00Z' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      // toLocaleTimeString output varies by env, just check the time is present
+      const timeEl = screen.getByTitle(/\d+m ago|\d+h ago|\d+s ago/);
+      expect(timeEl).toBeDefined();
+    });
+
+    it('copies message on copy button click', () => {
+      const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'copy me' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      const btn = screen.getByLabelText('Copy message');
+      fireEvent.click(btn);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('copy me');
+    });
+
+    it('copies permalink on permalink button click', () => {
+      const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'link me' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      const btn = screen.getByLabelText('Copy permalink');
+      fireEvent.click(btn);
+      expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    });
+
+    it('dispatches copy-transcript-up-to event', () => {
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+      const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'up to here' };
+      render(<TranscriptBubble entry={entry} index={7} />);
+      const btn = screen.getByLabelText('Copy transcript up to here');
+      fireEvent.click(btn);
+      expect(dispatchSpy).toHaveBeenCalled();
+      const event = dispatchSpy.mock.calls[0][0] as CustomEvent;
+      expect(event.type).toBe('copy-transcript-up-to');
+      expect(event.detail.index).toBe(7);
+    });
   });
 
-  it('renders thinking message with collapse toggle', () => {
-    const entry: ParsedEntry = { ...baseEntry, contentType: 'thinking', text: 'Let me think...' };
-    render(<TranscriptBubble entry={entry} index={0} />);
-    expect(screen.getByText('Thinking…')).toBeDefined();
-    // Thinking is collapsed by default, text not shown
-    expect(screen.queryByText('Let me think...')).toBeNull();
+  // --- Assistant messages ---
+  describe('assistant messages', () => {
+    it('renders assistant message on the left side', () => {
+      const entry: ParsedEntry = { ...baseEntry, role: 'assistant', text: 'Response' };
+      const { container } = render(<TranscriptBubble entry={entry} index={0} />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain('justify-start');
+    });
+
+    it('renders text content', () => {
+      render(<TranscriptBubble entry={baseEntry} index={0} />);
+      expect(screen.getByText('Hello, world!')).toBeDefined();
+    });
   });
 
-  it('expands thinking on click', () => {
-    const entry: ParsedEntry = { ...baseEntry, contentType: 'thinking', text: 'Deep thought' };
-    render(<TranscriptBubble entry={entry} index={0} />);
-    const toggleBtn = screen.getByLabelText('Collapse transcript entry');
-    fireEvent.click(toggleBtn);
-    expect(screen.getByText('Deep thought')).toBeDefined();
+  // --- Thinking messages ---
+  describe('thinking messages', () => {
+    it('renders thinking as collapsed by default', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'thinking', text: 'Let me think...' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      expect(screen.getByText('Thinking…')).toBeDefined();
+      // Content should be hidden (collapsed)
+      expect(screen.queryByText('Let me think...')).toBeNull();
+    });
+
+    it('expands thinking on button click', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'thinking', text: 'Deep thought' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      fireEvent.click(screen.getByLabelText('Collapse transcript entry'));
+      expect(screen.getByText('Deep thought')).toBeDefined();
+    });
+
+    it('collapses thinking again on second click', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'thinking', text: 'Reveal then hide' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      const btn = screen.getByLabelText('Collapse transcript entry');
+      fireEvent.click(btn);
+      expect(screen.getByText('Reveal then hide')).toBeDefined();
+      fireEvent.click(btn);
+      expect(screen.queryByText('Reveal then hide')).toBeNull();
+    });
   });
 
-  it('renders tool_use with tool name', () => {
-    const entry: ParsedEntry = {
-      ...baseEntry,
-      contentType: 'tool_use',
-      toolName: 'bash',
-      text: 'Running npm test',
-    };
-    render(<TranscriptBubble entry={entry} index={0} />);
-    expect(screen.getByText('> bash')).toBeDefined();
+  // --- Tool messages ---
+  describe('tool_use messages', () => {
+    it('renders tool_use collapsed by default with tool name', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'tool_use', text: 'some long tool output', toolName: 'readFile' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      expect(screen.getByText(/> readFile/)).toBeDefined();
+    });
+
+    it('shows truncated text when collapsed', () => {
+      const longText = 'a'.repeat(100);
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'tool_use', text: longText, toolName: 'test' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      // Should show truncated (80 chars + …)
+      expect(screen.getByText(`${'a'.repeat(80)}…`)).toBeDefined();
+    });
+
+    it('expands tool output on click', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'tool_use', text: 'full output here', toolName: 'bash' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      const btn = screen.getByLabelText('Collapse transcript entry');
+      fireEvent.click(btn);
+      expect(screen.getByText('full output here')).toBeDefined();
+    });
   });
 
-  it('renders tool_result collapsed by default', () => {
-    const entry: ParsedEntry = {
-      ...baseEntry,
-      contentType: 'tool_result',
-      text: 'A'.repeat(100),
-    };
-    render(<TranscriptBubble entry={entry} index={0} />);
-    // Should show truncated text when collapsed
-    // tool_result renders ✓ result label
-    expect(screen.getByText(/✓ result/)).toBeDefined();
+  describe('tool_result messages', () => {
+    it('renders tool_result with checkmark', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'tool_result', text: 'ok', toolName: 'writeFile' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      expect(screen.getByText(/✓ writeFile/)).toBeDefined();
+    });
   });
 
-  it('renders tool_error with danger styling', () => {
-    const entry: ParsedEntry = {
-      ...baseEntry,
-      contentType: 'tool_error',
-      text: 'Command failed',
-    };
-    render(<TranscriptBubble entry={entry} index={0} />);
-    // tool_error renders ✗ error label
-    expect(screen.getByText(/✗ error/)).toBeDefined();
+  describe('tool_error messages', () => {
+    it('renders tool_error with X mark', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'tool_error', text: 'failed', toolName: 'exec' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      expect(screen.getByText(/✗ exec/)).toBeDefined();
+    });
+
+    it('applies danger border for tool_error', () => {
+      const entry: ParsedEntry = { ...baseEntry, contentType: 'tool_error', text: 'err', toolName: 'test' };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      const btn = screen.getByLabelText('Collapse transcript entry');
+      expect(btn.className).toContain('border-');
+    });
   });
 
-  it('sets id based on toolUseId', () => {
-    const entry: ParsedEntry = { ...baseEntry, toolUseId: 'tool-123' };
-    const { container } = render(<TranscriptBubble entry={entry} index={0} />);
-    const el = container.querySelector('#msg-tool-123');
-    expect(el).toBeDefined();
+  // --- Focus ---
+  describe('focus behavior', () => {
+    it('does not set tabIndex when not focused', () => {
+      const { container } = render(<TranscriptBubble entry={baseEntry} index={0} focused={false} />);
+      const el = container.firstChild as HTMLElement;
+      expect(el.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('sets tabIndex=0 when focused', () => {
+      const { container } = render(<TranscriptBubble entry={baseEntry} index={0} focused={true} />);
+      const el = container.firstChild as HTMLElement;
+      expect(el.getAttribute('tabindex')).toBe('0');
+    });
   });
 
-  it('calls onFocus on click', () => {
-    const onFocus = vi.fn();
-    render(<TranscriptBubble entry={baseEntry} index={5} onFocus={onFocus} />);
-    const bubble = screen.getByText('Hello world').closest('[tabindex]');
-    if (bubble) fireEvent.click(bubble);
-    expect(onFocus).toHaveBeenCalledWith(5);
+  // --- Keyboard shortcut ---
+  describe('keyboard shortcut', () => {
+    it('copies text on "c" key press without modifier', () => {
+      const { container } = render(<TranscriptBubble entry={baseEntry} index={0} />);
+      fireEvent.keyDown(container.firstChild as HTMLElement, { key: 'c', ctrlKey: false, metaKey: false });
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Hello, world!');
+    });
+
+    it('does not copy on Ctrl+C', () => {
+      const { container } = render(<TranscriptBubble entry={baseEntry} index={0} />);
+      fireEvent.keyDown(container.firstChild as HTMLElement, { key: 'c', ctrlKey: true });
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
   });
 
-  it('focuses element when focused prop is true', () => {
-    const { container } = render(
-      <TranscriptBubble entry={baseEntry} index={0} focused={true} />
-    );
-    const el = container.querySelector('[tabindex="0"]');
-    expect(el).toBeDefined();
+  // --- Timestamps ---
+  describe('timestamps', () => {
+    it('hides time column when no timestamp', () => {
+      const entry: ParsedEntry = { ...baseEntry, timestamp: undefined };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      // No time element should be present
+      const timeEl = screen.queryByText(/\d{1,2}:\d{2}/);
+      // In assistant mode, time is shown next to bubble; without timestamp, it's not
+      expect(timeEl).toBeNull();
+    });
+
+    it('shows relative time on hover', () => {
+      const entry: ParsedEntry = { ...baseEntry, role: 'assistant', text: 'msg', timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString() };
+      render(<TranscriptBubble entry={entry} index={0} />);
+      const timeEl = screen.getByTitle(/\d+[mhs] ago/);
+      // Hover to show relative time
+      fireEvent.mouseEnter(timeEl);
+      expect(timeEl.textContent).toMatch(/\d+[mhs] ago/);
+    });
   });
 
-  it('does not set tabIndex=0 when not focused', () => {
-    const { container } = render(
-      <TranscriptBubble entry={baseEntry} index={0} focused={false} />
-    );
-    const el = container.querySelector('[tabindex="-1"]');
-    expect(el).toBeDefined();
+  // --- ID generation ---
+  describe('element ID', () => {
+    it('generates ID from toolUseId when present', () => {
+      const entry: ParsedEntry = { ...baseEntry, toolUseId: 'tool-123' };
+      const { container } = render(<TranscriptBubble entry={entry} index={0} />);
+      expect((container.firstChild as HTMLElement).id).toBe('msg-tool-123');
+    });
+
+    it('generates ID from role-timestamp-index when no toolUseId', () => {
+      const entry: ParsedEntry = { ...baseEntry, timestamp: '2026-05-27T12:00:00Z' };
+      const { container } = render(<TranscriptBubble entry={entry} index={3} />);
+      expect((container.firstChild as HTMLElement).id).toMatch(/^msg-assistant-/);
+    });
   });
 });


### PR DESCRIPTION
## Summary
26 unit tests for the TranscriptBubble component covering all message types and interactions.

### Coverage
- **System messages** (2): rendering, onFocus callback
- **User messages** (4): right alignment, timestamp, clipboard copy, permalink
- **Assistant messages** (2): left alignment, text rendering
- **Thinking messages** (3): collapsed default, expand/collapse toggle
- **Tool messages** (6): tool_use with name, truncated text, expand, tool_result checkmark, tool_error X mark, danger border
- **Focus** (2): tabIndex state
- **Keyboard** (2): copy on 'c' key, no copy on Ctrl+C
- **Timestamps** (2): hidden when no timestamp, relative time on hover
- **Element ID** (2): toolUseId-based, fallback to role-timestamp-index

Refs #4298

## Test Plan
- [x] 26/26 tests pass locally
- [x] tsc clean