### PR TITLE
fix(api): OPTIONS preflight returns 200 instead of 404 on API routes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -639,8 +639,15 @@ setupAuth(app, ctx);
   if (corsOrigin === '*') {
     throw new Error('CORS_ORIGIN=* wildcard is not allowed. Specify explicit origins (comma-separated) or leave unset to disable CORS.');
   }
+  // Issue #4356: Use a callback instead of `false` so the CORS plugin still
+  // registers its OPTIONS handler. With `origin: false` the plugin is a no-op
+  // and OPTIONS requests fall through to route matching → 404.
   await app.register(fastifyCors, {
-    origin: corsOrigin ? corsOrigin.split(',').map(s => s.trim()) : false,
+    origin: corsOrigin
+      ? corsOrigin.split(',').map(s => s.trim())
+      : ((origin: string | undefined, callback: (err: Error | null, allow: boolean) => void) => {
+          callback(null, false);
+        }),
   });
 await container.start(['sessionManager', 'sessionMonitor', 'authManager', 'channelManager', 'acpLocalProfile', 'acpBackend']);
 


### PR DESCRIPTION
## Summary

Fixes #4356

CORS preflight (OPTIONS) requests to API routes returned 404 instead of 200 with CORS headers. This broke browser-based API clients making cross-origin requests.

### Root Cause

When `CORS_ORIGIN` is not set, `fastify-cors` was configured with `origin: false`, which makes it a **complete no-op** — it doesn't register any hooks at all. OPTIONS requests fell through to route matching, which returned 404.

### Fix

Replace the static `false` with a callback function that always returns `false`. This makes the CORS plugin register its hooks (including the OPTIONS handler) while still denying CORS for all origins.

**Behavior:**
- `CORS_ORIGIN` unset → OPTIONS returns 200 with no CORS headers (no origin is allowed)
- `CORS_ORIGIN` set → OPTIONS returns 200 with proper `Access-Control-Allow-*` headers for allowed origins

### Testing

- TypeScript compilation passes
- No test suite in repo for integration testing