### PR TITLE
refactor(session): extract _createSession to SessionFactory (#4246 step 7)

### DIFF
--- a/src/__tests__/session-factory.test.ts
+++ b/src/__tests__/session-factory.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for session-factory.ts — buildSessionInfo
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildSessionInfo, SessionCreationError, resetCleanupCache, type CreateSessionOpts } from '../services/session/session-factory.js';
+import type { Config } from '../config.js';
+import type { ExistingSessionRef } from '../services/session/session-factory.js';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+// Mock permission-guard to avoid actual file writes
+vi.mock('../permission-guard.js', () => ({
+  neutralizeBypassPermissions: vi.fn().mockResolvedValue(false),
+  activateBypassPermissions: vi.fn().mockResolvedValue(true),
+  restoreSettings: vi.fn(),
+  cleanOrphanedBackup: vi.fn(),
+}));
+
+// Mock hook-settings to avoid actual file writes
+vi.mock('../hook-settings.js', () => ({
+  writeHookSettingsFile: vi.fn().mockResolvedValue('/tmp/hooks.json'),
+  cleanupStaleSessionHooks: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock session-helpers
+vi.mock('../session-helpers.js', () => ({
+  detectIsolationMode: vi.fn().mockResolvedValue('worktree'),
+  detectModelFromSettings: vi.fn().mockResolvedValue('claude-sonnet-4-6'),
+  hydrateSessions: vi.fn(),
+  isObjectRecord: vi.fn(),
+  getUiApprovalInput: vi.fn(),
+}));
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    defaultPermissionMode: 'default',
+    defaultSessionEnv: {},
+    isolationPolicy: 'respect-cc',
+    ...overrides,
+  } as Config;
+}
+
+function makeOpts(overrides: Partial<CreateSessionOpts> = {}): CreateSessionOpts {
+  return {
+    workDir: '/tmp/test-workdir',
+    tenantId: 'default',
+    ...overrides,
+  };
+}
+
+describe('buildSessionInfo', () => {
+  beforeEach(() => {
+    resetCleanupCache();
+    vi.clearAllMocks();
+  });
+
+  it('creates a session with default values', async () => {
+    const config = makeConfig();
+    const opts = makeOpts();
+    const { session } = await buildSessionInfo('test-id-1234', opts, config, [], new Set());
+
+    expect(session.id).toBe('test-id-1234');
+    expect(session.workDir).toBe('/tmp/test-workdir');
+    expect(session.tenantId).toBe('default');
+    expect(session.status).toBe('pending');
+    expect(session.windowId).toBe('');
+    expect(session.permissionMode).toBe('default');
+    expect(session.isolationMode).toBe('worktree');
+    expect(session.settingsPatched).toBe(false);
+    expect(session.hookSecret).toBeTruthy();
+    expect(session.hookSecret).toHaveLength(64); // 32 bytes hex
+  });
+
+  it('uses explicit name when provided', async () => {
+    const config = makeConfig();
+    const opts = makeOpts({ name: 'My Session' });
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+
+    expect(session.displayName).toBe('My Session');
+  });
+
+  it('falls back to basename of workDir for display name', async () => {
+    const config = makeConfig();
+    const opts = makeOpts({ name: undefined, workDir: '/home/user/projects/my-app' });
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+
+    expect(session.displayName).toBe('my-app');
+  });
+
+  it('deduplicates display names within same tenant', async () => {
+    const config = makeConfig();
+    const opts = makeOpts({ name: 'Test' });
+    const existing: ExistingSessionRef[] = [
+      { id: 'old-1', tenantId: 'default', displayName: 'Test' },
+    ];
+
+    const { session } = await buildSessionInfo('new-id', opts, config, existing, new Set());
+    expect(session.displayName).toBe('Test-1');
+  });
+
+  it('does not deduplicate across different tenants', async () => {
+    const config = makeConfig();
+    const opts = makeOpts({ name: 'Test', tenantId: 'tenant-B' });
+    const existing: ExistingSessionRef[] = [
+      { id: 'old-1', tenantId: 'tenant-A', displayName: 'Test' },
+    ];
+
+    const { session } = await buildSessionInfo('new-id', opts, config, existing, new Set());
+    expect(session.displayName).toBe('Test');
+  });
+
+  it('uses bypassPermissions when permissionMode is set', async () => {
+    const { activateBypassPermissions } = await import('../permission-guard.js');
+    const config = makeConfig();
+    const opts = makeOpts({ permissionMode: 'bypassPermissions' });
+
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+    expect(session.permissionMode).toBe('bypassPermissions');
+    expect(session.settingsPatched).toBe(true);
+    expect(activateBypassPermissions).toHaveBeenCalled();
+  });
+
+  it('uses autoApprove=true as bypassPermissions', async () => {
+    const { activateBypassPermissions } = await import('../permission-guard.js');
+    const config = makeConfig();
+    const opts = makeOpts({ autoApprove: true });
+
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+    expect(session.permissionMode).toBe('bypassPermissions');
+    expect(activateBypassPermissions).toHaveBeenCalled();
+  });
+
+  it('throws SessionCreationError for enforce-worktree policy with none isolation', async () => {
+    const { detectIsolationMode } = await import('../session-helpers.js');
+    (detectIsolationMode as ReturnType<typeof vi.fn>).mockResolvedValueOnce('none');
+
+    const config = makeConfig({ isolationPolicy: 'enforce-worktree' });
+    const opts = makeOpts();
+
+    await expect(buildSessionInfo('id', opts, config, [], new Set())).rejects.toThrow(SessionCreationError);
+  });
+
+  it('forces isolationMode to none when policy is enforce-direct', async () => {
+    const { detectIsolationMode } = await import('../session-helpers.js');
+    (detectIsolationMode as ReturnType<typeof vi.fn>).mockResolvedValueOnce('worktree');
+
+    const config = makeConfig({ isolationPolicy: 'enforce-direct' });
+    const opts = makeOpts();
+
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+    expect(session.isolationMode).toBe('none');
+    expect(session.isolationPolicy).toBe('enforce-direct');
+  });
+
+  it('carries over model from resumed session', async () => {
+    const config = makeConfig();
+    const opts = makeOpts({ resumeSessionId: 'old-session', model: undefined });
+    const existing: ExistingSessionRef[] = [
+      { id: 'old-session', tenantId: 'default', displayName: 'Old', model: 'claude-opus-4' },
+    ];
+
+    const { session } = await buildSessionInfo('new-id', opts, config, existing, new Set());
+    expect(session.model).toBe('claude-opus-4');
+  });
+
+  it('does not override explicit model with resume carryover', async () => {
+    const config = makeConfig();
+    const opts = makeOpts({ resumeSessionId: 'old-session', model: 'claude-haiku' });
+    const existing: ExistingSessionRef[] = [
+      { id: 'old-session', tenantId: 'default', displayName: 'Old', model: 'claude-opus-4' },
+    ];
+
+    const { session } = await buildSessionInfo('new-id', opts, config, existing, new Set());
+    expect(session.model).toBe('claude-haiku');
+  });
+
+  it('uses custom stall thresholds when provided', async () => {
+    const config = makeConfig();
+    const opts = makeOpts({ stallThresholdMs: 60000, permissionStallMs: 120000 });
+
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+    expect(session.stallThresholdMs).toBe(60000);
+    expect(session.permissionStallMs).toBe(120000);
+  });
+
+  it('detects model from settings when not provided', async () => {
+    const { detectModelFromSettings } = await import('../session-helpers.js');
+    (detectModelFromSettings as ReturnType<typeof vi.fn>).mockResolvedValueOnce('detected-model');
+
+    const config = makeConfig();
+    const opts = makeOpts({ model: undefined });
+
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+    expect(session.model).toBe('detected-model');
+  });
+
+  it('truncates display name to 200 chars', async () => {
+    const config = makeConfig();
+    const longName = 'A'.repeat(300);
+    const opts = makeOpts({ name: longName });
+
+    const { session } = await buildSessionInfo('id', opts, config, [], new Set());
+    expect(session.displayName.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/src/services/session/session-factory.ts
+++ b/src/services/session/session-factory.ts
@@ -1,0 +1,239 @@
+/**
+ * session-factory.ts — Pure session construction logic extracted from SessionManager.
+ *
+ * Handles the computational steps of creating a SessionInfo object without
+ * touching SessionManager state (sessions map, persistence, discovery, etc.).
+ */
+
+import { randomBytes } from 'node:crypto';
+import { basename } from 'node:path';
+import type { Config } from '../../config.js';
+import { computeStallThreshold } from '../../config.js';
+import { getConfiguredBaseUrl } from '../../base-url.js';
+import { validateWorkdirPath } from '../../tenant-workdir.js';
+import {
+  neutralizeBypassPermissions,
+  activateBypassPermissions,
+} from '../../permission-guard.js';
+import { sanitizeWindowName } from '../../validation.js';
+import { writeHookSettingsFile, cleanupStaleSessionHooks } from '../../hook-settings.js';
+import { sanitizeSessionEnv } from '../../session-env.js';
+import {
+  detectIsolationMode,
+  detectModelFromSettings,
+} from '../../session-helpers.js';
+import type { SessionInfo, UIState } from '../../session-types.js';
+import { StructuredLogger } from '../../logger.js';
+
+const log = new StructuredLogger();
+
+const DEFAULT_STALL_THRESHOLD_MS = computeStallThreshold();
+const DEFAULT_PERMISSION_STALL_MS = 5 * 60 * 1000;
+
+/** Cache for hook cleanup to avoid running on every createSession (Issue #1134). */
+let lastCleanupTime = 0;
+let lastCleanupWorkDir = '';
+const CLEANUP_TTL_MS = 30_000;
+
+/** Minimal reference to an existing session for name dedup and resume lookup. */
+export interface ExistingSessionRef {
+  id: string;
+  tenantId: string;
+  displayName: string;
+  model?: string;
+  effort?: string;
+}
+
+/** Options for creating a session (mirrors the SessionManager.createSession param type). */
+export interface CreateSessionOpts {
+  id?: string;
+  workDir: string;
+  name?: string | null;
+  prd?: string;
+  resumeSessionId?: string;
+  claudeCommand?: string;
+  env?: Record<string, string>;
+  stallThresholdMs?: number;
+  permissionStallMs?: number;
+  permissionMode?: string;
+  /** @deprecated Use permissionMode instead. */
+  autoApprove?: boolean;
+  parentId?: string;
+  ownerKeyId?: string | null;
+  tenantId?: string;
+  initialStatus?: UIState;
+  model?: string;
+  effort?: string;
+  runnerName?: string;
+  isolationPolicy?: 'respect-cc' | 'enforce-worktree' | 'enforce-direct';
+}
+
+/** Result of building a session: the SessionInfo plus metadata. */
+export interface BuildSessionResult {
+  session: SessionInfo;
+}
+
+/**
+ * Pure-ish factory that computes a SessionInfo object.
+ *
+ * Performs: validation, name dedup, env merge, permission resolution,
+ * hook secret generation, isolation detection, and hook settings file creation.
+ *
+ * Does NOT touch SessionManager.state or persistence — the caller handles that.
+ */
+export async function buildSessionInfo(
+  id: string,
+  opts: CreateSessionOpts,
+  config: Config,
+  existingSessions: ExistingSessionRef[],
+  activeSessionIds: Set<string>,
+): Promise<BuildSessionResult> {
+  // Step 1: Validate workdir path against tenant namespace
+  const workdirValidation = validateWorkdirPath(opts.tenantId, opts.workDir, config);
+  if (!workdirValidation.allowed) {
+    throw new Error(workdirValidation.reason ?? 'workDir is outside tenant root');
+  }
+
+  // Step 2: Compute display name with deduplication (per-tenant scope)
+  const candidateName = opts.name
+    ? String(opts.name)
+    : basename(opts.workDir || '') || `cc-${id.slice(0, 8)}`;
+  let displayName = sanitizeWindowName(candidateName);
+  if (displayName.length > 200) displayName = displayName.slice(0, 200);
+
+  const existing = existingSessions
+    .filter(s => s.tenantId === opts.tenantId)
+    .map(s => s.displayName);
+  if (existing.includes(displayName)) {
+    let suffix = 1;
+    const originalBase = displayName;
+    while (existing.includes(displayName)) {
+      const suffixStr = `-${suffix}`;
+      const maxBaseLen = 200 - suffixStr.length;
+      displayName = `${originalBase.slice(0, maxBaseLen)}${suffixStr}`;
+      suffix++;
+    }
+  }
+
+  // Step 3: Merge defaultSessionEnv with per-session env
+  const mergedEnv = sanitizeSessionEnv(config.defaultSessionEnv, opts.env);
+  void mergedEnv;
+
+  // Step 4: Resolve effective permission mode + settings patching
+  const effectivePermissionMode = opts.permissionMode
+    ?? (opts.autoApprove === true ? 'bypassPermissions' : opts.autoApprove === false ? 'default' : undefined)
+    ?? config.defaultPermissionMode
+    ?? 'default';
+  let settingsPatched = false;
+  if (effectivePermissionMode === 'bypassPermissions') {
+    settingsPatched = await activateBypassPermissions(opts.workDir);
+  } else {
+    settingsPatched = await neutralizeBypassPermissions(opts.workDir, effectivePermissionMode);
+  }
+
+  // Step 5: Generate per-session HMAC secret for hook URL authentication
+  const hookSecret = randomBytes(32).toString('hex');
+
+  // Step 6: Detect isolation mode and enforce policy
+  const detectedIsolation = await detectIsolationMode(opts.workDir).catch(() => undefined);
+  const detectedModel = await detectModelFromSettings(opts.workDir).catch(() => undefined);
+  let isolationMode: 'worktree' | 'none' = detectedIsolation ?? 'worktree';
+
+  const policy = opts.isolationPolicy ?? config.isolationPolicy;
+  if (policy === 'enforce-worktree' && isolationMode === 'none') {
+    log.warn({ component: 'session', operation: 'worktreePolicyRejected', sessionId: id, attributes: { policy, detectedIsolation: 'none' } });
+    throw new SessionCreationError(
+      `Session rejected: isolation policy is 'enforce-worktree' but CC settings have bgIsolation="none". ` +
+      `Set worktree.bgIsolation to "worktree" in .claude/settings.json or change the server isolation policy.`
+    );
+  }
+  if (policy === 'enforce-direct') {
+    if (isolationMode !== 'none') {
+      log.warn({ component: 'session', operation: 'directPolicyOverride', sessionId: id });
+    }
+    isolationMode = 'none';
+  }
+
+  // Step 7: Cleanup stale session hooks + write hook settings file
+  const now = Date.now();
+  if (now - lastCleanupTime < CLEANUP_TTL_MS && lastCleanupWorkDir === opts.workDir) {
+    // Skipped: cleanup ran recently for this workDir
+  } else {
+    try {
+      activeSessionIds.add(id);
+      if (activeSessionIds.size > 0) {
+        await cleanupStaleSessionHooks(opts.workDir, activeSessionIds);
+        lastCleanupTime = now;
+        lastCleanupWorkDir = opts.workDir;
+      }
+    } catch (e) {
+      log.warn({ component: 'session', operation: 'hookCleanupFailed', attributes: { error: (e as Error).message } });
+    }
+  }
+
+  let hookSettingsFile: string | undefined;
+  try {
+    const baseUrl = getConfiguredBaseUrl(config);
+    hookSettingsFile = await writeHookSettingsFile(baseUrl, id, hookSecret, opts.workDir);
+  } catch (e) {
+    log.error({ component: 'session', operation: 'hookSettingsGenerateFailed', attributes: { error: (e as Error).message } });
+  }
+
+  // Step 8: Resolve effective model/effort (including resume carryover)
+  let effectiveModel = opts.model || detectedModel;
+  let effectiveEffort = opts.effort;
+  if (opts.resumeSessionId && !opts.model) {
+    const oldSession = existingSessions.find(s => s.id === opts.resumeSessionId);
+    if (oldSession?.model) {
+      effectiveModel = oldSession.model;
+    }
+    if (!opts.effort && oldSession?.effort) {
+      effectiveEffort = oldSession.effort;
+    }
+  }
+
+  // Step 9: Build the SessionInfo object
+  const session: SessionInfo = {
+    id,
+    windowId: '',
+    displayName,
+    workDir: opts.workDir,
+    claudeSessionId: undefined,
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: opts.initialStatus ?? 'pending' as UIState,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    latestActivityText: 'Starting session',
+    stallThresholdMs: opts.stallThresholdMs || DEFAULT_STALL_THRESHOLD_MS,
+    permissionStallMs: opts.permissionStallMs || DEFAULT_PERMISSION_STALL_MS,
+    permissionMode: effectivePermissionMode,
+    settingsPatched,
+    hookSettingsFile,
+    hookSecret,
+    prd: opts.prd,
+    ownerKeyId: opts.ownerKeyId ?? undefined,
+    tenantId: opts.tenantId,
+    model: effectiveModel,
+    effort: effectiveEffort,
+    runnerName: opts.runnerName,
+    isolationMode,
+    isolationPolicy: policy,
+  };
+
+  return { session };
+}
+
+/** Issue #3613: Error thrown when session creation is rejected by isolation policy. */
+export class SessionCreationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionCreationError';
+  }
+}
+
+/** Reset cleanup cache (for testing). */
+export function resetCleanupCache(): void {
+  lastCleanupTime = 0;
+  lastCleanupWorkDir = '';
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,23 +5,18 @@
  * Tracks: session ID, window ID, byte offset for JSONL reading, status.
  */
 
-import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { join, dirname, basename } from 'node:path';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import type { StateStore, SerializedSessionState } from './services/state/state-store.js';
 import { readNewEntries, type ParsedEntry } from './transcript.js';
 import { SessionTranscripts } from './session-transcripts.js';
 import { SessionDiscovery } from './session-discovery.js';
 import type { Config } from './config.js';
+import { restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
+import { cleanupHookSettingsFile } from './hook-settings.js';
 import { computeStallThreshold } from './config.js';
-import { getConfiguredBaseUrl } from './base-url.js';
-import { validateWorkdirPath } from './tenant-workdir.js';
-import { neutralizeBypassPermissions, activateBypassPermissions, restoreSettings, cleanOrphanedBackup } from './permission-guard.js';
-import { persistedStateSchema, type PermissionPolicy, type PermissionProfile, sanitizeWindowName } from './validation.js';
-import type { z } from 'zod';
-import { writeHookSettingsFile, cleanupHookSettingsFile, cleanupStaleSessionHooks } from './hook-settings.js';
 // PermissionDecision and request management now via SessionPermissionService
 import { QuestionManager } from './question-manager.js';
 import { Mutex } from 'async-mutex';
@@ -35,7 +30,7 @@ import { SessionPermissionService, resolveApprovalInput, normalizeApprovalLabel 
 import { SessionApprovalService } from './services/session/approval-flow.js';
 import { readHookSecretFromSettingsFile } from './services/session/hook-secret-reader.js';
 import { computeLatencyMetrics, type LatencyMetrics } from './services/session/latency-metrics.js';
-import { hydrateSessions, isObjectRecord, detectModelFromSettings, detectIsolationMode, getUiApprovalInput, type PermissionDecision } from './session-helpers.js';
+import { hydrateSessions, isObjectRecord, getUiApprovalInput, type PermissionDecision } from './session-helpers.js';
 export { resolveApprovalInput };
 export type { PermissionDecision };
 
@@ -48,15 +43,12 @@ export type { UIState, SessionInfo, SessionState, PersistedStateData };
 import { detectUIState, hasBlankPromptNearBottom, detectApprovalMethod } from './session-ui-parser.js';
 import { recordHookFailure as _recordHookFailure, recordHookSuccess as _recordHookSuccess, checkHookCircuitBreaker as _checkHookCircuitBreaker } from './session-hook-circuit-breaker.js';
 import { applyHookEvent } from './session-status-updater.js';
-import { sanitizeSessionEnv } from './session-env.js';
+import { buildSessionInfo, SessionCreationError } from './services/session/session-factory.js';
+export { SessionCreationError };
 export { detectUIState, hasBlankPromptNearBottom, detectApprovalMethod };
 
 /** Convert parsed JSON arrays to Sets for activeSubagents (#668). */
-// Cache for hook cleanup to avoid running on every createSession (Issue #1134).
-// TTL of 30 seconds prevents redundant disk I/O during batch session creation.
-let lastCleanupTime = 0;
-let lastCleanupWorkDir = '';
-const CLEANUP_TTL_MS = 30_000;
+// Hook cleanup cache moved to session-factory.ts
 
 /** Issue #1798: Maximum time (ms) sendMessage waits for CC to become idle. */
 const SEND_MESSAGE_IDLE_TIMEOUT_MS = 30_000;
@@ -96,13 +88,7 @@ const SEND_MESSAGE_IDLE_POLL_MS = 500;
  * Coordinates session lifecycle, persistence, transcript discovery, and
  * interactive approval/question flows for all managed Claude Code sessions.
  */
-/** Issue #3613: Error thrown when session creation is rejected by isolation policy. */
-export class SessionCreationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'SessionCreationError';
-  }
-}
+// SessionCreationError moved to session-factory.ts (re-exported above)
 
 export class SessionManager {
   private state: SessionState = { sessions: Object.create(null) as Record<string, SessionInfo> };
@@ -306,175 +292,24 @@ export class SessionManager {
     opts: Parameters<SessionManager['createSession']>[0],
     parentSpan: Span,
   ): Promise<SessionInfo> {
-    // Issue #1945: Validate workdir path against tenant workdir namespace
-    const workdirValidation = validateWorkdirPath(opts.tenantId, opts.workDir, this.config);
-    if (!workdirValidation.allowed) {
-      throw new Error(workdirValidation.reason ?? 'workDir is outside tenant root');
-    }
+    // Delegate pure construction to SessionFactory
+    const existingSessions = this.listSessions().map(s => ({
+      id: s.id,
+      tenantId: s.tenantId as string,
+      displayName: s.displayName,
+      model: s.model,
+      effort: s.effort,
+    }));
+    const activeIds = new Set(this.listSessions().map(s => s.id));
 
-    // Compute a sensible display name with fallbacks:
-    // 1) explicit name
-    // 3) basename(workDir)
-    // 4) fallback id prefix
-    const candidateName = opts.name ? String(opts.name) : basename(opts.workDir || '') || `cc-${id.slice(0,8)}`;
-    let displayName = sanitizeWindowName(candidateName);
-    // Trim to 200 chars
-    if (displayName.length > 200) displayName = displayName.slice(0, 200);
-    // De-duplicate display names: append numeric suffix when needed (per-tenant scope)
-    const existing = this.listSessions().filter(s => s.tenantId === opts.tenantId).map(s=>s.displayName);
-    if (existing.includes(displayName)) {
-      let suffix = 1;
-      const originalBase = displayName;
-      while (existing.includes(displayName)) {
-        const suffixStr = `-${suffix}`;
-        const maxBaseLen = 200 - suffixStr.length;
-        displayName = `${originalBase.slice(0, maxBaseLen)}${suffixStr}`;
-        suffix++;
-      }
-    }
+    const { session } = await buildSessionInfo(id, opts, this.config, existingSessions, activeIds);
 
-
-    // Merge defaultSessionEnv (from config) with per-session env (per-session wins)
-    const mergedEnv = sanitizeSessionEnv(this.config.defaultSessionEnv, opts.env);
-    const hasEnv = Object.keys(mergedEnv).length > 0;
-
-    // Permission guard: if permissionMode is "default", neutralize any project-level
-    // settings.local.json that has bypassPermissions. The CLI flag --permission-mode
-    // should be authoritative, but CC lets project settings override it.
-    // We back up the file, patch it, and restore on session cleanup.
-    const effectivePermissionMode = opts.permissionMode
-      ?? (opts.autoApprove === true ? 'bypassPermissions' : opts.autoApprove === false ? 'default' : undefined)
-      ?? this.config.defaultPermissionMode
-      ?? 'default';
-    let settingsPatched = false;
-    if (effectivePermissionMode === 'bypassPermissions') {
-      // Issue #3436: When bypassPermissions is requested, we must write it to the
-      // project-level settings.local.json so the ACP agent picks it up. The ACP
-      // reads permissionMode from SettingsManager (settings files), NOT from
-      // session/new params. Without this, Claude always spawns with --permission-mode default.
-      settingsPatched = await activateBypassPermissions(opts.workDir);
-    } else {
-      settingsPatched = await neutralizeBypassPermissions(opts.workDir, effectivePermissionMode);
-    }
-
-    // Issue #629: Generate per-session HMAC secret for hook URL authentication.
-    const hookSecret = randomBytes(32).toString('hex');
-
-    // Issue #169 Phase 2: Generate HTTP hook settings for this session.
-    // Detect isolation mode from project/global Claude settings (Issue #3590)
-    const detectedIsolation = await detectIsolationMode(opts.workDir).catch(() => undefined);
-    const detectedModel = await detectModelFromSettings(opts.workDir).catch(() => undefined);
-    let isolationMode: 'worktree' | 'none' = detectedIsolation ?? 'worktree';
-
-    // Issue #3613: Enforce isolation policy
-    const policy = opts.isolationPolicy ?? this.config.isolationPolicy;
-    if (policy === 'enforce-worktree' && isolationMode === 'none') {
-      log.warn({ component: 'session', operation: 'worktreePolicyRejected', sessionId: id, attributes: { policy, detectedIsolation: 'none' } });
-      throw new SessionCreationError(
-        `Session rejected: isolation policy is 'enforce-worktree' but CC settings have bgIsolation="none". ` +
-        `Set worktree.bgIsolation to "worktree" in .claude/settings.json or change the server isolation policy.`
-      );
-    }
-    if (policy === 'enforce-direct') {
-      if (isolationMode !== 'none') {
-        log.warn({ component: 'session', operation: 'directPolicyOverride', sessionId: id });
-      }
-      isolationMode = 'none';
-    }
-    // policy === 'respect-cc' → use detected isolationMode as-is
-
-    // Writes a temp file with hooks pointing to Aegis's hook receiver.
-      // Issue #936: Clean stale session hooks from settings.local.json before writing new hooks.
-      // This prevents CC from loading dead hook URLs on restart.
-      // Issue #1134: Skip cleanup if ran recently for this workDir
-        // Note: cleanup runs BEFORE the new session is added to this.state.sessions.
-        // We must include the new session's ID in activeIds to prevent cleanup from
-        // removing hooks for a session that was just created.
-        const now = Date.now();
-        if (now - lastCleanupTime < CLEANUP_TTL_MS && lastCleanupWorkDir === opts.workDir) {
-          // Skipped: cleanup ran recently for this workDir
-        } else {
-          try {
-            const activeIds = new Set(this.listSessions().map(s => s.id));
-            activeIds.add(id); // Include the new session so cleanup preserves its hooks
-            if (activeIds.size > 0) {
-              await cleanupStaleSessionHooks(opts.workDir, activeIds);
-              lastCleanupTime = now;
-              lastCleanupWorkDir = opts.workDir;
-            }
-          } catch (e) {
-            log.warn({ component: 'session', operation: 'hookCleanupFailed', attributes: { error: (e as Error).message } });
-          }
-        }
-
-    let hookSettingsFile: string | undefined;
-    try {
-      const baseUrl = getConfiguredBaseUrl(this.config);
-      hookSettingsFile = await writeHookSettingsFile(baseUrl, id, hookSecret, opts.workDir);
-    } catch (e) {
-      log.error({ component: 'session', operation: 'hookSettingsGenerateFailed', attributes: { error: (e as Error).message } });
-      // Non-fatal: hooks won't work for this session, but CC still launches
-    }
-
-    let windowId: string;
-    let finalName: string;
-    let freshSessionId: string | undefined;
-    // ACP mode: create session without window manager
-    windowId = '';
-    finalName = displayName;
-
-    // Issue #3948: When resuming, carry over model/effort from the original session
-    // if no explicit override is provided. This preserves /model changes made mid-session.
-    let effectiveModel = opts.model || detectedModel;
-    let effectiveEffort = opts.effort;
-    if (opts.resumeSessionId && !opts.model) {
-      const oldSession = this.state.sessions[opts.resumeSessionId];
-      if (oldSession?.model) {
-        effectiveModel = oldSession.model;
-      }
-      if (!opts.effort && oldSession?.effort) {
-        effectiveEffort = oldSession.effort;
-      }
-    }
-
-    const session: SessionInfo = {
-      id,
-      windowId,
-      displayName: finalName,
-      workDir: opts.workDir,
-      // If we know the CC session ID upfront (from --session-id), set it immediately.
-      // This eliminates the discovery delay and prevents stale ID assignment entirely.
-      claudeSessionId: freshSessionId || undefined,
-      byteOffset: 0,
-      monitorOffset: 0,
-      status: opts.initialStatus ?? 'pending',
-      createdAt: Date.now(),
-      lastActivity: Date.now(),
-      latestActivityText: 'Starting session',
-      stallThresholdMs: opts.stallThresholdMs || SessionManager.DEFAULT_STALL_THRESHOLD_MS,
-      permissionStallMs: opts.permissionStallMs || SessionManager.DEFAULT_PERMISSION_STALL_MS,
-      permissionMode: effectivePermissionMode,
-      settingsPatched,
-      hookSettingsFile,
-      hookSecret,
-      prd: opts.prd,
-      ownerKeyId: opts.ownerKeyId ?? undefined,
-      tenantId: opts.tenantId,
-      // Issue #2535: Store model at creation so analytics can group by model
-      // Issue #3740: Fall back to model from CC settings if not provided at creation.
-      // Issue #3948: effectiveModel includes resume carry-over from original session.
-      model: effectiveModel,
-      effort: effectiveEffort,
-      runnerName: opts.runnerName,
-      isolationMode: isolationMode,
-      isolationPolicy: policy,
-    };
-
+    // State mutations remain in SessionManager
     this.state.sessions[id] = session;
     this.invalidateSessionsListCache();
     await this.save();
 
-        // Issue #702: Register child with parent
+    // Register child with parent (Issue #702)
     if (opts.parentId) {
       const parent = this.state.sessions[opts.parentId];
       if (parent) {
@@ -483,31 +318,20 @@ export class SessionManager {
         await this.save();
       }
     }
-    // Issue #353: Fetch CC process PID for swarm parent matching.
-    // Fire-and-forget — PID is not needed synchronously.
-    // Issue #574: Add .catch() to prevent unhandled rejection if runtime fails mid-lookup.
 
-    // Issue #4088: Session approval gate — skip CC launch when approval is required.
+    // Session approval gate (Issue #4088)
     if (this.config.requireSessionApproval) {
       session.status = 'awaiting_approval';
       session.awaitingApproval = true;
       this.invalidateSessionsListCache();
       await this.save();
-      // Issue #4114: Auto-reject after timeout.
       this.scheduleApprovalTimeout(session.id);
       return session;
     }
-    // Start coordinated discovery polling:
-    // - Hook/session_map sync: fast path
-    // - Filesystem scan fallback: works when hooks fail or are skipped (Issue #16)
-    // Field bug (Zeus 2026-03-22): hooks may not fire even without --bare
-    this.discovery.startDiscoveryPolling(id, opts.workDir);
 
-    // P0 fix: Clean stale entries from session_map.json for BOTH window name AND id.
-    // After archiving old .jsonl files, stale session_map entries would point
-    // to moved files, causing discovery to pick up ghost session IDs.
-    // Also cleans stale windowId entries that could collide after restart.
-    await this.discovery.cleanSessionMapForWindow(finalName, windowId);
+    // Start discovery polling
+    this.discovery.startDiscoveryPolling(id, opts.workDir);
+    await this.discovery.cleanSessionMapForWindow(session.displayName, session.windowId);
 
     return session;
   }


### PR DESCRIPTION
## Summary

Extract the pure construction logic from `_createSession` (~335 lines) into a dedicated `buildSessionInfo()` factory function.

### What changed
- **New:** `src/services/session/session-factory.ts` — `buildSessionInfo()` handles:
  - Workdir path validation
  - Display name computation with per-tenant deduplication
  - Environment variable merge & sanitization
  - Permission mode resolution + settings file patching
  - Hook secret generation + hook settings file creation
  - Isolation mode detection + policy enforcement
  - Model/effort resolution including resume carryover
  - SessionInfo object construction
- **Modified:** `src/session.ts` — `_createSession` reduced to a thin wrapper that:
  - Calls `buildSessionInfo()` for construction
  - Persists into state, registers parent-child, enforces approval gate, starts discovery

### Metrics
- session.ts: **1102 → 926 lines** (-15.9%)
- Cumulative session.ts reduction: **1648 → 926 (-43.8%)**
- 14 new unit tests for SessionFactory

## Verification
- tsc --noEmit ✅ (0 errors in changed files)
- npm run build ✅
- npm test ✅ (400 files, 5742 tests passed)
- 14 new factory tests ✅

Refs #4246 step 7