### PR TITLE
feat(sse): wire SSE bridge endpoint (EventBus -> /sse) (#4229 follow-up)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,8 @@ import { SessionEventBus } from './events.js';
 
 import { SSEConnectionLimiter } from './sse-limiter.js';
 import { PipelineManager } from './pipeline.js';
+import { createSSEBridge } from './services/sse-bridge.js';
+import { LocalEventBus } from './local-event-bus.js';
 import { ToolRegistry } from './tool-registry.js';
 import {
   AuthManager,
@@ -711,6 +713,11 @@ new JsonFileBackend(path.join(ctx.config.stateDir, 'analytics-cache.json')),
     budgetEvaluator,
     requestKeyMap,
   });
+
+  // Wire SSE bridge (EventBus -> /sse) so dashboard can consume live events
+  const sseEventBus = new LocalEventBus();
+  const sseBridge = createSSEBridge(sseEventBus, app);
+  sseBridge.register(app);
 
   // Issue #361: Store interval refs so graceful shutdown can clear them
   timers.setInterval(() => reapStaleSessions(ctx.config.maxSessionAgeMs, ctx), ctx.config.reaperIntervalMs);


### PR DESCRIPTION
## Summary

Wire the existing `createSSEBridge` (from `src/services/sse-bridge.ts`, merged in #4364) into `server.ts` so the `/sse` endpoint is registered for dashboard consumption.

## What changed
- **Only `src/server.ts`** — 7 lines added (2 imports + 5-line wiring)
- Imports `createSSEBridge` and `LocalEventBus`
- Creates a `LocalEventBus` instance and wires the SSE bridge after route registration
- No `any` casts, no duplicate modules, no downgrades

## What this fixes (vs previous attempt #4372)
- Previous PR duplicated `sse-bridge.ts` with a downgraded version (lost type safety, `lastEventId` replay, structured logging)
- Previous PR used `as unknown as any` double-cast
- Previous PR was not rebased (274 files, 649K additions)
- This PR: clean rebase from develop, only the server.ts wiring

## Verification
- tsc: ✅ (no new errors in server.ts)
- The SSE bridge module itself was already tested in #4364 (10 Redis + 6 SSE tests)