### PR TITLE
feat(telegram): one-tap approve with inline feedback and audit log (#4349)

### DIFF
--- a/src/channels/telegram/telegram-polling.ts
+++ b/src/channels/telegram/telegram-polling.ts
@@ -6,7 +6,7 @@ import { esc } from '../telegram-style.js';
 import { StructuredLogger } from '../../logger.js';
 
 import type { TelegramChannelInternals } from './types.js';
-import { sleep, sendImmediate, removeReplyMarkup } from './telegram-sender.js';
+import { sleep, sendImmediate, removeReplyMarkup, editMessage } from './telegram-sender.js';
 
 const log = new StructuredLogger();
 
@@ -164,13 +164,19 @@ async function handleCallbackQuery(ctx: TelegramChannelInternals, cbQuery: unkno
           await removeReplyMarkup(ctx, sessionId, cb.message.message_id);
         }
       } else if (data.startsWith('session_approve:')) {
+        const approver = cb.from?.first_name ?? 'Telegram user';
+        log.info({ component: 'telegram', operation: 'inlineApprove', attributes: { sessionId, actorType: 'telegram', userId: String(cb.from?.id ?? 0), approver } });
         await ctx.onInbound?.({ sessionId, action: 'session_approve', actor: { type: 'telegram' as const, userId: cb.from?.id ?? 0, firstName: cb.from?.first_name ?? 'Unknown' } });
         if (cb.message.message_id) {
+          try { await editMessage(ctx, sessionId, cb.message.message_id, `✅ Approved by ${esc(approver)}`); } catch { /* non-critical */ }
           await removeReplyMarkup(ctx, sessionId, cb.message.message_id);
         }
       } else if (data.startsWith('session_reject:')) {
+        const rejector = cb.from?.first_name ?? 'Telegram user';
+        log.info({ component: 'telegram', operation: 'inlineReject', attributes: { sessionId, actorType: 'telegram', userId: String(cb.from?.id ?? 0), rejector } });
         await ctx.onInbound?.({ sessionId, action: 'session_reject', actor: { type: 'telegram' as const, userId: cb.from?.id ?? 0, firstName: cb.from?.first_name ?? 'Unknown' } });
         if (cb.message.message_id) {
+          try { await editMessage(ctx, sessionId, cb.message.message_id, `❌ Rejected by ${esc(rejector)}`); } catch { /* non-critical */ }
           await removeReplyMarkup(ctx, sessionId, cb.message.message_id);
         }
       } else if (data.startsWith('cb_option:')) {
@@ -183,6 +189,7 @@ async function handleCallbackQuery(ctx: TelegramChannelInternals, cbQuery: unkno
         }
         await ctx.onInbound?.({ sessionId, action: 'message', text: optValue });
         if (cb.message.message_id) {
+          try { await editMessage(ctx, sessionId, cb.message.message_id, `✅ Selected: ${esc(optValue)}`); } catch { /* non-critical */ }
           await removeReplyMarkup(ctx, sessionId, cb.message.message_id);
         }
       } else if (data.startsWith('cb_yes:')) {


### PR DESCRIPTION
## Summary

Add immediate visual feedback and audit logging for inline Telegram callback approvals/rejections.

## What changed
- **Only `src/channels/telegram/telegram-polling.ts`** — 8 lines added
- `session_approve`: logs actor info, edits message to show approver name, then removes buttons
- `session_reject`: logs actor info, edits message to show rejector name, then removes buttons  
- `cb_option`: edits message to show confirmed selection
- All edits wrapped in try/catch (non-critical failures tolerated)

## Audit logging (per #4370 review)
Each approve/reject action now logs to StructuredLogger:
```
{ component: "telegram", operation: "inlineApprove", attributes: { sessionId, actorType: "telegram", userId, approver } }
```

## What this fixes (vs previous attempt #4370)
- Previous PR was not rebased (273 files, 649K additions)
- Previous PR had no audit trail for approval actions
- This PR: clean rebase from develop, only telegram-polling.ts, audit logging added

## Verification
- tsc: ✅ (no new errors)