### PR TITLE
test(dashboard): fix PauseControlBar interventionStatus type literals (#4298 batch 6)

### DIFF
--- a/dashboard/src/__tests__/PauseControlBar.test.tsx
+++ b/dashboard/src/__tests__/PauseControlBar.test.tsx
@@ -44,24 +44,24 @@ describe('PauseControlBar', () => {
   });
 
   it('shows intervene and resume buttons when paused', () => {
-    render(<PauseControlBar sessionStatus="running" interventionStatus="paused" />);
+    render(<PauseControlBar sessionStatus="running" interventionStatus={'paused' as const} />);
     expect(screen.getByLabelText('Start intervention')).toBeDefined();
     expect(screen.getByLabelText('Resume session')).toBeDefined();
   });
 
   it('shows paused status badge when interventionStatus is paused', () => {
-    render(<PauseControlBar sessionStatus="paused" interventionStatus="paused" />);
+    render(<PauseControlBar sessionStatus="paused" interventionStatus={'paused' as const} />);
     expect(screen.getByText('Paused')).toBeDefined();
   });
 
   it('shows intervening status and complete button', () => {
-    render(<PauseControlBar sessionStatus="paused" interventionStatus="intervening" />);
+    render(<PauseControlBar sessionStatus="paused" interventionStatus={'intervening' as const} />);
     expect(screen.getByText('Intervening')).toBeDefined();
     expect(screen.getByLabelText('Complete intervention with guidance')).toBeDefined();
   });
 
   it('shows guidance form when complete button is clicked', async () => {
-    render(<PauseControlBar sessionStatus="paused" interventionStatus="intervening" />);
+    render(<PauseControlBar sessionStatus="paused" interventionStatus={'intervening' as const} />);
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Complete intervention with guidance'));
     });
@@ -73,7 +73,7 @@ describe('PauseControlBar', () => {
     render(
       <PauseControlBar
         sessionStatus="paused"
-        interventionStatus="intervening"
+        interventionStatus={'intervening' as const}
         onCompleteIntervention={onCompleteIntervention}
       />
     );
@@ -96,7 +96,7 @@ describe('PauseControlBar', () => {
     render(
       <PauseControlBar
         sessionStatus="paused"
-        interventionStatus="paused"
+        interventionStatus={'paused' as const}
         onIntervene={onIntervene}
       />
     );
@@ -112,7 +112,7 @@ describe('PauseControlBar', () => {
     render(
       <PauseControlBar
         sessionStatus="paused"
-        interventionStatus="paused"
+        interventionStatus={'paused' as const}
         onResume={onResume}
       />
     );


### PR DESCRIPTION
Replacement for #4375 (which had 274 stale files behind develop).

## Changes
- PauseControlBar.test.tsx: `as const` on `interventionStatus` prop values to satisfy TS literal type narrowing

## Verification
- tsc ✅ (clean on develop)
- 5804 tests ✅

Replaces: #4375