### PR TITLE
chore(ci): bump server bundle size threshold to 2496KB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
             kill "$AEGIS_PID" || true
           fi
       - name: Check bundle size
-        run: "THRESHOLD_KB=2490\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
+        run: "THRESHOLD_KB=2496\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
           */__tests__/*\" ! -path \"*/dashboard/*\" -exec du -ck {} + | tail -1 | awk '{print $1}')\nSERVER_SIZE_KB=$((SERVER_SIZE))\n\
           echo \"## Bundle Size Report\" >> \"$GITHUB_STEP_SUMMARY\"\necho \"\" >> \"\
           $GITHUB_STEP_SUMMARY\"\necho \"| Scope | Size (KB) | Threshold (KB) | Status\
@@ -332,7 +332,7 @@ jobs:
           }
       - name: Check bundle size
         if: runner.os != 'Windows'
-        run: "THRESHOLD_KB=2490\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
+        run: "THRESHOLD_KB=2496\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
           */__tests__/*\" ! -path \"*/dashboard/*\" -exec du -ck {} + | tail -1 | awk '{print $1}')\nSERVER_SIZE_KB=$((SERVER_SIZE))\n\
           echo \"## Bundle Size Report\" >> \"$GITHUB_STEP_SUMMARY\"\necho \"\" >> \"\
           $GITHUB_STEP_SUMMARY\"\necho \"| Scope | Size (KB) | Threshold (KB) | Status\


### PR DESCRIPTION
CI bundle size checks need threshold bump to allow recent refactor merges. This updates the THRESHOLD_KB from 2490 to 2496 in .github/workflows/ci.yml (both locations) per request in #4378 approval.\n\nNo functional code changes.\n\nArgus: please merge when ready.