### PR TITLE
feat(dashboard): SSE connection indicator in header (#4346)

### DIFF
--- a/dashboard/src/components/layout/Header.tsx
+++ b/dashboard/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@
  */
 
 import { lazy, Suspense } from 'react';
+import { SSEStatusIndicator } from './SSEStatusIndicator';
 import Breadcrumb from '../shared/Breadcrumb';
 import { ApprovalBadge } from '../approvals/ApprovalNotification';
 import { Sun, Moon, Plus, Search, RefreshCw, Menu } from 'lucide-react';
@@ -64,6 +65,7 @@ export function Header({
               PREVIEW
             </span>
 
+            <SSEStatusIndicator />
             <ApprovalBadge />
 
             <button

--- a/dashboard/src/components/layout/SSEStatusIndicator.tsx
+++ b/dashboard/src/components/layout/SSEStatusIndicator.tsx
@@ -1,0 +1,35 @@
+/**
+ * SSEStatusIndicator — Subtle persistent indicator for SSE connection state.
+ * Shows a colored dot + label: green "Live", yellow "Reconnecting…", red "Offline".
+ */
+
+import { useStore } from '../../store/useStore';
+
+export function SSEStatusIndicator() {
+  const sseConnected = useStore((s) => s.sseConnected);
+  const sseError = useStore((s) => s.sseError);
+
+  // Don't render until we have a connection attempt (avoid flash on initial load)
+  if (!sseConnected && !sseError) return null;
+
+  const label = sseConnected ? 'Live' : sseError ? 'Reconnecting…' : 'Offline';
+  const color = sseConnected
+    ? 'var(--color-success)'
+    : sseError
+      ? 'var(--color-warning)'
+      : 'var(--color-error)';
+
+  return (
+    <div
+      className="flex items-center gap-1.5 text-xs"
+      role="status"
+      aria-label={`SSE connection: ${label}`}
+    >
+      <span
+        className="inline-block h-1.5 w-1.5 rounded-full animate-pulse"
+        style={{ backgroundColor: color }}
+      />
+      <span className="text-[var(--color-text-muted)]">{label}</span>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/__tests__/SSEStatusIndicator.test.tsx
+++ b/dashboard/src/components/layout/__tests__/SSEStatusIndicator.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SSEStatusIndicator } from '../SSEStatusIndicator';
+import { useStore } from '../../../store/useStore';
+
+vi.mock('../../../store/useStore');
+
+describe('SSEStatusIndicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when SSE state is default (not connected, no error)', () => {
+    vi.mocked(useStore).mockImplementation((selector: any) =>
+      selector({ sseConnected: false, sseError: null }),
+    );
+    const { container } = render(<SSEStatusIndicator />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows "Live" with green dot when connected', () => {
+    vi.mocked(useStore).mockImplementation((selector: any) =>
+      selector({ sseConnected: true, sseError: null }),
+    );
+    render(<SSEStatusIndicator />);
+    expect(screen.getByText('Live')).toBeDefined();
+    const status = screen.getByRole('status');
+    const dot = status.querySelector('span');
+    expect(dot?.style.backgroundColor).toContain('var(--color-success)');
+  });
+
+  it('shows "Reconnecting…" with yellow dot when error', () => {
+    vi.mocked(useStore).mockImplementation((selector: any) =>
+      selector({ sseConnected: false, sseError: 'Connection failed' }),
+    );
+    render(<SSEStatusIndicator />);
+    expect(screen.getByText('Reconnecting…')).toBeDefined();
+    const status = screen.getByRole('status');
+    const dot = status.querySelector('span');
+    expect(dot?.style.backgroundColor).toContain('var(--color-warning)');
+  });
+
+  it('has proper aria-label', () => {
+    vi.mocked(useStore).mockImplementation((selector: any) =>
+      selector({ sseConnected: true, sseError: null }),
+    );
+    render(<SSEStatusIndicator />);
+    expect(screen.getByRole('status').getAttribute('aria-label')).toBe('SSE connection: Live');
+  });
+
+  it('uses role="status"', () => {
+    vi.mocked(useStore).mockImplementation((selector: any) =>
+      selector({ sseConnected: true, sseError: null }),
+    );
+    render(<SSEStatusIndicator />);
+    expect(screen.getByRole('status')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a subtle persistent SSE connection status indicator in the dashboard header.

### Changes
- **New component:** `SSEStatusIndicator.tsx` — small colored dot + label
  - 🟢 Green dot + "Live" when connected
  - 🟡 Yellow dot + "Reconnecting…" when retrying (error set)
  - Hides entirely when no connection attempt yet (avoids flash on load)
- **Wired into** `Header.tsx` — rendered next to the ApprovalBadge in the header actions area
- **Accessibility:** `role="status"`, `aria-label` with current state, animate-pulse on dot
- **5 unit tests** covering all states (default/connected/reconnecting + a11y)
- **Zero new dependencies** — reads `sseConnected` and `sseError` from existing Zustand store

### Verification
- `npx tsc --noEmit` — zero TS errors
- `SSEStatusIndicator.test.tsx` — 5/5 passing
- `Header.test.tsx` — 12/12 passing (no regressions)

Part of #4346 (dashboard streaming UX).