### PR TITLE
docs: agent bootstrap best practice — GitHub as source of truth

### DIFF
--- a/docs/guides/agent-bootstrap-best-practice.md
+++ b/docs/guides/agent-bootstrap-best-practice.md
@@ -1,0 +1,80 @@
+# Agent Bootstrap Best Practice: GitHub as Source of Truth
+
+> **Pattern:** Agents should read GitHub assignments on startup, not rely on channel messages or daily logs for task discovery.
+
+## The Problem
+
+When agents wake up (session start, heartbeat), they need to know what to work on. Three possible sources:
+
+| Source | Reliability | Latency | Persistence |
+|--------|------------|---------|-------------|
+| **GitHub assignments** | High — canonical system of record | Near-zero | Persistent |
+| **Channel messages** | Low — scrolls away, easy to miss | Variable | Ephemeral |
+| **Daily logs / memory** | Medium — depends on what was captured | Stale | Session-bound |
+
+## The Pattern
+
+**On every session bootstrap, an agent should:**
+
+1. `gh issue list --assignee @me --state open` — find your work
+2. `gh pr list --author @me --state open` — check your open PRs
+3. Then read channel messages / memory for context
+
+GitHub is the canonical source. Everything else is supplementary context.
+
+## Case Study: Hephaestus (2026-05-27)
+
+**Before fix:** Hep's bootstrap read channel messages and daily logs for task discovery. When the team was active, messages scrolled fast. Hep appeared idle because he never checked GitHub assignments.
+
+**After fix (one line):** Added `gh issue list --assignee aegis-hephaestus[bot]` to his startup sequence. Result: **31 PRs shipped in one day** — the architecture sequence (#4237 → #4246 ×8 → #4230 → #4229) plus Telegram one-tap (#4370), all landing clean.
+
+**Diagnosis:** The agent wasn't broken. His bootstrap was.
+
+## Bootstrap Sequence (Recommended)
+
+```bash
+# 1. GitHub assignments — PRIMARY source
+gh issue list --repo OneStepAt4time/aegis --assignee aegis-<agent>[bot] --state open
+gh pr list --repo OneStepAt4time/aegis --author aegis-<agent>[bot] --state open
+
+# 2. Agent identity files — WHO you are
+cat SOUL.md IDENTITY.md AGENTS.md
+
+# 3. Recent memory — WHAT happened recently
+cat memory/$(date +%Y-%m-%d).md
+cat memory/$(date -d 'yesterday' +%Y-%m-%d).md
+
+# 4. Channel context — WHY things are happening (supplementary)
+# Read from session history / recent messages
+```
+
+## Priority Hierarchy
+
+```
+GitHub assignments (what to do NOW)
+    ↓
+Agent identity files (who you are, how you work)
+    ↓
+Recent memory (what happened recently)
+    ↓
+Channel messages (why, context, decisions)
+```
+
+## Why This Matters
+
+- **Agents wake up fresh.** No session survives a restart. The bootstrap sequence is the only thing that determines what happens in the first 60 seconds.
+- **Channel messages are lossy.** Mentions get missed, conversations scroll, context degrades.
+- **GitHub is structured.** Assignees, labels, milestones, linked PRs — it's a task system, not a chat log.
+- **One line fixed a "broken" agent.** The gap wasn't intelligence or capability — it was discovery.
+
+## Anti-Patterns to Avoid
+
+- ❌ Relying on channel pings as the primary task source
+- ❌ Reading only memory/logs without checking GitHub
+- ❌ Asking "what should I work on?" without first checking assignments
+- ❌ Treating the heartbeat idle ping as a substitute for GitHub-driven work
+
+## See Also
+
+- [HEARTBEAT.md](../../HEARTBEAT.md) — heartbeat rules and idle behavior
+- [AGENTS.md](../../AGENTS.md) — agent workspace conventions

--- a/docs/guides/real-time-events.md
+++ b/docs/guides/real-time-events.md
@@ -1,0 +1,277 @@
+# Real-Time Events (SSE)
+
+Aegis streams real-time events via Server-Sent Events (SSE). This guide covers how to authenticate, connect, and consume the event streams — whether you're building a dashboard, writing a CLI tool, or integrating with external systems.
+
+## Quick Start
+
+```bash
+# 1. Get an SSE token (requires API key)
+SSE_TOKEN=$(curl -s -X POST http://localhost:9100/v1/auth/sse-token \
+  -H "Authorization: Bearer $API_KEY" | jq -r '.token')
+
+# 2. Connect to the global event stream (all sessions)
+curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN"
+
+# 3. Or connect to a single session
+curl -N "http://localhost:9100/v1/sessions/abc123/events?token=$SSE_TOKEN"
+```
+
+## Authentication
+
+SSE endpoints **do not accept regular API keys**. You must obtain a short-lived SSE token first.
+
+### Create an SSE Token
+
+```
+POST /v1/auth/sse-token
+```
+
+```bash
+curl -X POST http://localhost:9100/v1/auth/sse-token \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+**Response:**
+
+```json
+{
+  "token": "sse_abc123...",
+  "expiresIn": 300
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token` | string | `sse_`-prefixed token for SSE stream auth |
+| `expiresIn` | number | Token lifetime in seconds |
+
+**Limits:** Max 10 outstanding SSE tokens per API key. Returns `429` if exceeded.
+
+### Using the Token
+
+Pass the token in one of two ways:
+
+1. **Query parameter:** `?token=<sse-token>`
+2. **Bearer header:** `Authorization: Bearer sse_...`
+
+## Endpoints
+
+### Global Event Stream
+
+```
+GET /v1/events?token=<sse-token>
+```
+
+Streams events from **all** active sessions. Events are scoped to the caller's API key tenant — admin/master keys see everything, operator/viewer keys see only their own sessions.
+
+### Per-Session Event Stream
+
+```
+GET /v1/sessions/:id/events?token=<sse-token>
+```
+
+Streams events for a single session. Also available as `GET /v1/sessions/:id/stream` (alias).
+
+## Event Reference
+
+### Per-Session Event Types
+
+These events are emitted on the per-session stream (`/v1/sessions/:id/events`):
+
+| Event | Description | Payload Fields |
+|-------|-------------|----------------|
+| `status` | Session status changed | `status`, `detail` |
+| `message` | User or assistant message | `role`, `text`, `contentType`, `tool_name`, `tool_id` |
+| `system` | System-generated message | `role` (always `"system"`), `text`, `contentType`, `isSystem` (always `true`) |
+| `approval` | Approval/permission request | `prompt` |
+| `approval_resolved` | Approval granted or rejected | `action` (`"approved"` or `"rejected"`), `approvalId` |
+| `permission_denied` | Permission denied by policy | varies |
+| `heartbeat` | Keep-alive + cost data | `sessionCosts` map with `estimatedCostUsd` per session |
+| `ended` | Session terminated | `reason` |
+| `stall` | Session stalled | `stallType`, `detail` |
+| `dead` | Session unresponsive | `reason` |
+| `hook` | Claude Code hook fired | `hookEvent`, plus hook-specific fields |
+| `subagent_start` | Sub-agent spawned | varies |
+| `subagent_stop` | Sub-agent stopped | varies |
+| `verification` | Verification result | verification result fields |
+| `circuit_breaker` | Circuit breaker triggered | varies |
+
+### Global Event Types
+
+The global stream (`/v1/events`) maps per-session events to a namespaced format:
+
+| Global Event | Source Event | Description |
+|-------------|-------------|-------------|
+| `session_status_change` | `status`, `heartbeat` | Any session status transition |
+| `session_message` | `message`, `system`, `hook` | Message or hook event |
+| `session_approval` | `approval` | Approval request |
+| `session_ended` | `ended` | Session ended |
+| `session_created` | — | New session created |
+| `session_stall` | `stall` | Session stalled |
+| `session_dead` | `dead` | Session unresponsive |
+| `session_subagent_start` | `subagent_start` | Sub-agent started |
+| `session_subagent_stop` | `subagent_stop` | Sub-agent stopped |
+| `session_verification` | `verification` | Verification result |
+| `shutdown` | — | Server shutting down |
+
+All global events include `sessionId`, `timestamp`, and `data` fields.
+
+### Connection Event
+
+Both streams emit a `connected` event on successful connection:
+
+```
+data: {"event":"connected","timestamp":"2026-05-27T10:00:00.000Z","data":{"activeSessions":5}}
+```
+
+## Event Replay
+
+Both streams support the `Last-Event-ID` header for replaying missed events after a reconnect:
+
+```bash
+# After reconnect, replay from last seen event ID
+curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN" \
+  -H "Last-Event-ID: 42"
+```
+
+Aegis buffers the last 50 events per session and 50 global events for replay. Events beyond the buffer are lost.
+
+## Heartbeat and Cost Tracking
+
+The `heartbeat` event fires periodically and includes a `sessionCosts` map:
+
+```
+data: {
+  "event": "heartbeat",
+  "sessionId": "abc123",
+  "timestamp": "2026-05-27T10:00:30.000Z",
+  "data": {
+    "sessionCosts": {
+      "abc123": { "estimatedCostUsd": 0.042 },
+      "def456": { "estimatedCostUsd": 0.118 }
+    }
+  }
+}
+```
+
+Use this for real-time cost tracking in dashboards.
+
+## Status Values
+
+Sessions emit `status` events with these values:
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Created but not yet running |
+| `working` | Actively processing |
+| `waiting_for_input` | Waiting for user/approval input |
+| `idle` | Finished processing, session alive |
+| `compacting` | Compacting context window |
+| `awaiting_approval` | Waiting for session-level approval |
+
+Terminal states (session ended): `completed`, `killed`, `crashed`.
+
+## Rate Limiting
+
+- **Per-IP connection limit:** Prevents any single IP from opening too many SSE connections
+- **Global connection limit:** Total concurrent SSE connections across all clients
+- **SSE token limit:** Max 10 outstanding tokens per API key
+
+If rate limited, the connection returns `429 Too Many Requests`.
+
+## Reconnection Strategy
+
+SSE connections can drop. Best practices for consumers:
+
+1. **Use native EventSource** — it auto-reconnects
+2. **Track `Last-Event-ID`** — pass it on reconnect to replay missed events
+3. **Exponential backoff** — if reconnect fails, wait 1s → 2s → 4s → 8s (max 30s)
+4. **Refresh SSE tokens** — tokens expire (default 5 min); obtain a new one before reconnecting
+
+### Example: JavaScript EventSource
+
+```javascript
+// 1. Get SSE token
+const { token } = await fetch('/v1/auth/sse-token', {
+  method: 'POST',
+  headers: { 'Authorization': `Bearer ${apiKey}` }
+}).then(r => r.json());
+
+// 2. Connect with auto-reconnect
+const source = new EventSource(`/v1/events?token=${token}`);
+
+source.addEventListener('session_status_change', (e) => {
+  const data = JSON.parse(e.data);
+  console.log(`Session ${data.sessionId} → ${data.data.status}`);
+});
+
+source.addEventListener('session_approval', (e) => {
+  const data = JSON.parse(e.data);
+  console.log(`Approval needed: ${data.data.prompt}`);
+});
+
+source.onerror = () => {
+  // EventSource auto-reconnects, but check if token expired
+  console.log('Connection lost, reconnecting...');
+};
+```
+
+## Architecture
+
+```
+┌──────────────┐     emit()      ┌──────────────────┐
+│ Session      │ ───────────────▶│ SessionEventBus  │
+│ Monitor      │                 │ (src/events.ts)  │
+│ Hooks        │                 │                  │
+│ Metering     │                 │  per-session     │
+└──────────────┘                 │  emitters +      │
+                                 │  global emitter  │
+                                 └────────┬─────────┘
+                                          │
+                          ┌───────────────┼───────────────┐
+                          ▼               ▼               ▼
+                   /v1/events    /v1/sessions/:id/events  Dashboard
+                   (global SSE)  (per-session SSE)        (React hook)
+```
+
+The `SessionEventBus` is the central hub. All event producers (hooks, monitor, metering) call `emit()`, and SSE route handlers subscribe to receive events in real time.
+
+## Dashboard Integration (for developers)
+
+When building the SSE consumer in the Aegis dashboard (see issue #4347):
+
+### Recommended Hook: `useSSEEvents`
+
+```typescript
+// src/hooks/useSSEEvents.ts
+function useSSEEvents() {
+  const [events, setEvents] = useState([]);
+  const [status, setStatus] = useState<'connected' | 'reconnecting' | 'disconnected'>('disconnected');
+
+  // 1. Fetch SSE token
+  // 2. Create EventSource to /v1/events
+  // 3. Listen for relevant event types
+  // 4. Auto-reconnect with exponential backoff
+  // 5. Debounce rapid events (tool calls) to avoid render storms
+
+  return { events, status };
+}
+```
+
+### Event Type Filters
+
+The dashboard should prioritize these events for the MVP:
+
+- `session_status_change` — update session list in real time
+- `session_approval` — show approval notifications with one-tap action
+- `session_ended` — move session to completed/killed/crashed
+- `heartbeat` — update cost ticker
+
+Tool call streaming (`session_message` with tool metadata) is a nice-to-have for follow-up.
+
+## See Also
+
+- [API Reference: SSE Endpoints](../api-reference.md#13-events-sse-stream) — full endpoint specs
+- [API Reference: SSE Token](../api-reference.md#create-sse-token) — token creation details
+- [Architecture Overview](../architecture.md) — system design
+- [Phone Approvals Guide](./phone-approvals.md) — Telegram one-tap approval flow


### PR DESCRIPTION
## Summary

New guide: `docs/guides/agent-bootstrap-best-practice.md`

Documents the pattern discovered during the Hephaestus bootstrap fix (2026-05-27): agents should read GitHub assignments on startup as the primary task source, not rely on channel messages or daily logs.

## Case Study

Hephaestus shipped **31 PRs in one day** after adding one line to his startup: `gh issue list --assignee aegis-hephaestus[bot]`. The agent was not broken — his bootstrap was.

## Contents

- Priority hierarchy: GitHub > identity files > memory > channel messages
- Recommended bootstrap sequence with concrete commands
- Anti-patterns to avoid
- Why channel messages are lossy for task discovery

## Credit

Pattern identified by Athena. Suggested by Athena for documentation.