### PR TITLE
test(dashboard): ShieldLogo, HoldButton, ConfirmDialog tests (batch 7)

### DIFF
--- a/dashboard/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/dashboard/src/components/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { ConfirmDialog } from '../ConfirmDialog';
+
+// Mock useFocusTrap to return a plain ref
+vi.mock('../../hooks/useFocusTrap.js', () => ({
+  useFocusTrap: () => ({ current: document.createElement('div') }),
+}));
+
+describe('ConfirmDialog', () => {
+  const defaults = {
+    open: true,
+    title: 'Delete item?',
+    message: 'This action cannot be undone.',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when open=false', () => {
+    const { container } = render(<ConfirmDialog {...defaults} open={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders title and message when open=true', () => {
+    render(<ConfirmDialog {...defaults} />);
+    expect(screen.getByText('Delete item?')).not.toBeNull();
+    expect(screen.getByText('This action cannot be undone.')).not.toBeNull();
+  });
+
+  it('has role="alertdialog" and aria-modal="true"', () => {
+    render(<ConfirmDialog {...defaults} />);
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('links title via aria-labelledby', () => {
+    render(<ConfirmDialog {...defaults} />);
+    const dialog = screen.getByRole('alertdialog');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBe('confirm-dialog-title');
+    const title = document.getElementById('confirm-dialog-title');
+    expect(title).not.toBeNull();
+    expect(title?.textContent).toBe('Delete item?');
+  });
+
+  it('calls onConfirm when confirm button clicked', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...defaults} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('Confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel button clicked', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...defaults} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when backdrop is clicked', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...defaults} onCancel={onCancel} />);
+    // Backdrop is the first child div inside the fixed overlay
+    const overlay = screen.getByRole('alertdialog').parentElement!;
+    const backdrop = overlay.firstChild as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses custom confirmLabel and cancelLabel', () => {
+    render(<ConfirmDialog {...defaults} confirmLabel="Delete" cancelLabel="Go back" />);
+    expect(screen.getByText('Delete')).not.toBeNull();
+    expect(screen.getByText('Go back')).not.toBeNull();
+  });
+
+  it('auto-focuses confirm button after opening', () => {
+    render(<ConfirmDialog {...defaults} />);
+    act(() => { vi.advanceTimersByTime(100); });
+    const confirmBtn = screen.getByText('Confirm');
+    expect(document.activeElement).toBe(confirmBtn);
+  });
+
+  it('calls onCancel on Escape key', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...defaults} onCancel={onCancel} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies danger variant styles to confirm button', () => {
+    render(<ConfirmDialog {...defaults} variant="danger" />);
+    const confirmBtn = screen.getByText('Confirm');
+    expect(confirmBtn.getAttribute('class')).toContain('color-danger');
+  });
+
+  it('applies warning variant styles to confirm button', () => {
+    render(<ConfirmDialog {...defaults} variant="warning" />);
+    const confirmBtn = screen.getByText('Confirm');
+    expect(confirmBtn.getAttribute('class')).toContain('color-warning');
+  });
+
+  it('renders confirm and cancel buttons as type="button"', () => {
+    render(<ConfirmDialog {...defaults} />);
+    const buttons = screen.getAllByRole('button');
+    for (const btn of buttons) {
+      expect(btn.getAttribute('type')).toBe('button');
+    }
+  });
+});

--- a/dashboard/src/components/brand/__tests__/ShieldLogo.test.tsx
+++ b/dashboard/src/components/brand/__tests__/ShieldLogo.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { ShieldLogoMark, ShieldWordmark } from '../ShieldLogo';
+
+describe('ShieldLogoMark', () => {
+  it('renders an svg element', () => {
+    const { container } = render(<ShieldLogoMark />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
+
+  it('defaults to md size (24x24)', () => {
+    const { container } = render(<ShieldLogoMark />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('24');
+    expect(svg.getAttribute('height')).toBe('24');
+  });
+
+  it('renders sm size (16x16)', () => {
+    const { container } = render(<ShieldLogoMark size="sm" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('16');
+    expect(svg.getAttribute('height')).toBe('16');
+  });
+
+  it('renders lg size (32x32)', () => {
+    const { container } = render(<ShieldLogoMark size="lg" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('32');
+    expect(svg.getAttribute('height')).toBe('32');
+  });
+
+  it('renders xl size (48x48)', () => {
+    const { container } = render(<ShieldLogoMark size="xl" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('48');
+    expect(svg.getAttribute('height')).toBe('48');
+  });
+
+  it('sets aria-hidden="true"', () => {
+    const { container } = render(<ShieldLogoMark />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('has viewBox="0 0 24 24"', () => {
+    const { container } = render(<ShieldLogoMark />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('viewBox')).toBe('0 0 24 24');
+  });
+
+  it('forwards className', () => {
+    const { container } = render(<ShieldLogoMark className="my-class" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('class')).toContain('my-class');
+  });
+
+  it('contains a linearGradient definition', () => {
+    const { container } = render(<ShieldLogoMark />);
+    const defs = container.querySelector('defs');
+    expect(defs).not.toBeNull();
+    const gradient = defs!.querySelector('linearGradient');
+    expect(gradient).not.toBeNull();
+  });
+
+  it('renders two path elements (gradient fill + overlay)', () => {
+    const { container } = render(<ShieldLogoMark />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(2);
+  });
+});
+
+describe('ShieldWordmark', () => {
+  it('renders the mark and text by default', () => {
+    const { container, getByText } = render(<ShieldWordmark />);
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(getByText('Aegis')).not.toBeNull();
+  });
+
+  it('hides text when collapsed=true', () => {
+    const { container, queryByText } = render(<ShieldWordmark collapsed />);
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(queryByText('Aegis')).toBeNull();
+  });
+
+  it('defaults to md size', () => {
+    const { container } = render(<ShieldWordmark />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('24');
+  });
+
+  it('respects size prop', () => {
+    const { container } = render(<ShieldWordmark size="lg" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('32');
+  });
+
+  it('forwards className to outer div', () => {
+    const { container } = render(<ShieldWordmark className="extra-class" />);
+    const div = container.firstChild as HTMLElement;
+    expect(div.getAttribute('class')).toContain('extra-class');
+  });
+
+  it('wraps in a flex container', () => {
+    const { container } = render(<ShieldWordmark />);
+    const div = container.firstChild as HTMLElement;
+    expect(div.getAttribute('class')).toContain('flex');
+  });
+});

--- a/dashboard/src/components/shared/__tests__/HoldButton.test.tsx
+++ b/dashboard/src/components/shared/__tests__/HoldButton.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { HoldButton } from '../HoldButton';
+
+describe('HoldButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders children text', () => {
+    render(<HoldButton onConfirm={vi.fn()}>Kill</HoldButton>);
+    expect(screen.getByText('Kill')).not.toBeNull();
+  });
+
+  it('renders as a button element', () => {
+    const { container } = render(<HoldButton onConfirm={vi.fn()}>Hold</HoldButton>);
+    expect(container.querySelector('button')).not.toBeNull();
+  });
+
+  it('does not fire onConfirm immediately on mousedown', () => {
+    const onConfirm = vi.fn();
+    render(<HoldButton onConfirm={vi.fn()}>Hold</HoldButton>);
+    fireEvent.mouseDown(screen.getByRole('button'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('fires onConfirm after holdDuration elapses', () => {
+    const onConfirm = vi.fn();
+    render(<HoldButton onConfirm={onConfirm} holdDuration={800}>Hold</HoldButton>);
+    fireEvent.mouseDown(screen.getByRole('button'));
+    act(() => { vi.advanceTimersByTime(850); });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onConfirm if released early', () => {
+    const onConfirm = vi.fn();
+    render(<HoldButton onConfirm={onConfirm} holdDuration={800}>Hold</HoldButton>);
+    fireEvent.mouseDown(screen.getByRole('button'));
+    act(() => { vi.advanceTimersByTime(400); });
+    fireEvent.mouseUp(screen.getByRole('button'));
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('cancels hold on mouseLeave', () => {
+    const onConfirm = vi.fn();
+    render(<HoldButton onConfirm={onConfirm} holdDuration={800}>Hold</HoldButton>);
+    fireEvent.mouseDown(screen.getByRole('button'));
+    act(() => { vi.advanceTimersByTime(400); });
+    fireEvent.mouseLeave(screen.getByRole('button'));
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('shows progress ring while holding', () => {
+    render(<HoldButton onConfirm={vi.fn()} holdDuration={800}>Hold</HoldButton>);
+    const btn = screen.getByRole('button');
+    // Before holding, no progress SVG
+    expect(btn.querySelector('svg')).toBeNull();
+    fireEvent.mouseDown(btn);
+    act(() => { vi.advanceTimersByTime(100); });
+    // While holding, progress SVG appears
+    expect(btn.querySelector('svg')).not.toBeNull();
+  });
+
+  it('applies disabled attribute', () => {
+    const { container } = render(<HoldButton onConfirm={vi.fn()} disabled>Hold</HoldButton>);
+    const btn = container.querySelector('button')!;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('does not start hold when disabled', () => {
+    const onConfirm = vi.fn();
+    render(<HoldButton onConfirm={onConfirm} disabled holdDuration={800}>Hold</HoldButton>);
+    fireEvent.mouseDown(screen.getByRole('button'));
+    act(() => { vi.advanceTimersByTime(900); });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('uses default variant danger styling', () => {
+    const { container } = render(<HoldButton onConfirm={vi.fn()} variant="danger">Hold</HoldButton>);
+    const btn = container.querySelector('button')!;
+    expect(btn.getAttribute('class')).toContain('color-danger');
+  });
+
+  it('uses default variant styling when variant=default', () => {
+    const { container } = render(<HoldButton onConfirm={vi.fn()} variant="default">Hold</HoldButton>);
+    const btn = container.querySelector('button')!;
+    expect(btn.getAttribute('class')).toContain('color-void-lighter');
+  });
+
+  it('passes extra HTML attributes to button', () => {
+    const { container } = render(
+      <HoldButton onConfirm={vi.fn()} aria-label="Hold to confirm">Hold</HoldButton>
+    );
+    const btn = container.querySelector('button')!;
+    expect(btn.getAttribute('aria-label')).toBe('Hold to confirm');
+  });
+
+  it('resets progress after successful hold', () => {
+    const onConfirm = vi.fn();
+    const { container } = render(<HoldButton onConfirm={onConfirm} holdDuration={800}>Hold</HoldButton>);
+    const btn = container.querySelector('button')!;
+    fireEvent.mouseDown(btn);
+    act(() => { vi.advanceTimersByTime(850); });
+    expect(onConfirm).toHaveBeenCalled();
+    // Progress ring should be gone
+    expect(btn.querySelector('svg')).toBeNull();
+  });
+});


### PR DESCRIPTION
42 new tests for 3 dashboard components:

- **ShieldLogo** (16 tests): ShieldLogoMark sizes, SVG structure, aria-hidden, className forwarding; ShieldWordmark text visibility, collapsed mode, size prop, flex wrapper
- **HoldButton** (13 tests): render, hold-to-confirm timing, early release cancel, mouseLeave cancel, progress ring visibility, disabled state, variant styling, attribute forwarding
- **ConfirmDialog** (13 tests): open/close rendering, alertdialog role, aria-labelledby, confirm/cancel/backdrop click, Escape key, custom labels, auto-focus, danger/warning variants, button types

All tests pass, zero TS errors, no production code changes.