### PR TITLE
test(dashboard): ToastContainer, PendingQuestionCard, SessionHeader tests (batch 8)

### DIFF
--- a/dashboard/src/components/__tests__/ToastContainer.test.tsx
+++ b/dashboard/src/components/__tests__/ToastContainer.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * ToastContainer tests — global toast notification renderer.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ToastContainer from '../ToastContainer';
+
+// ── Mocks ──────────────────────────────────────────────────
+
+const mockRemoveToast = vi.fn();
+let mockToasts: Array<{
+  id: string;
+  type: 'error' | 'success' | 'info' | 'warning' | 'undo';
+  title: string;
+  description?: string;
+  undoAction?: () => void;
+}> = [];
+
+vi.mock('../../store/useToastStore', () => ({
+  useToastStore: (selector: Function) =>
+    selector({
+      toasts: mockToasts,
+      removeToast: mockRemoveToast,
+    }),
+}));
+
+vi.mock('../../i18n/context', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('lucide-react', () => ({
+  X: (props: any) => <svg data-testid="icon-x" {...props} />,
+  CheckCircle: (props: any) => <svg data-testid="icon-check" {...props} />,
+  AlertTriangle: (props: any) => <svg data-testid="icon-alert" {...props} />,
+  Info: (props: any) => <svg data-testid="icon-info" {...props} />,
+  AlertCircle: (props: any) => <svg data-testid="icon-alertcircle" {...props} />,
+  Trash2: (props: any) => <svg data-testid="icon-trash" {...props} />,
+  Undo: (props: any) => <svg data-testid="icon-undo" {...props} />,
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  mockToasts = [];
+  mockRemoveToast.mockReset();
+});
+
+describe('ToastContainer', () => {
+  it('returns null when no toasts', () => {
+    const { container } = render(<ToastContainer />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders a single toast with title', () => {
+    mockToasts = [{ id: 't1', type: 'success', title: 'Saved!' }];
+    render(<ToastContainer />);
+    expect(screen.getByText('Saved!')).not.toBeNull();
+  });
+
+  it('renders toast with description when provided', () => {
+    mockToasts = [{ id: 't1', type: 'info', title: 'Info', description: 'Details here' }];
+    render(<ToastContainer />);
+    expect(screen.getByText('Details here')).not.toBeNull();
+  });
+
+  it('does not render description when omitted', () => {
+    mockToasts = [{ id: 't1', type: 'info', title: 'Info' }];
+    const { container } = render(<ToastContainer />);
+    // Only the title <p> should exist, no second <p> for description
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs.length).toBe(1);
+  });
+
+  it('renders aria-live="polite" region', () => {
+    mockToasts = [{ id: 't1', type: 'success', title: 'Saved!' }];
+    const { container } = render(<ToastContainer />);
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region).not.toBeNull();
+  });
+
+  it('renders multiple toasts', () => {
+    mockToasts = [
+      { id: 't1', type: 'success', title: 'First' },
+      { id: 't2', type: 'error', title: 'Second' },
+    ];
+    render(<ToastContainer />);
+    expect(screen.getByText('First')).not.toBeNull();
+    expect(screen.getByText('Second')).not.toBeNull();
+  });
+
+  it('shows "Clear all" button when multiple toasts', () => {
+    mockToasts = [
+      { id: 't1', type: 'success', title: 'First' },
+      { id: 't2', type: 'error', title: 'Second' },
+    ];
+    render(<ToastContainer />);
+    expect(screen.getByText('Clear all')).not.toBeNull();
+  });
+
+  it('does not show "Clear all" button for single toast', () => {
+    mockToasts = [{ id: 't1', type: 'success', title: 'Only' }];
+    expect(screen.queryByText('Clear all')).toBeNull();
+  });
+
+  it('dismiss button calls removeToast with toast id', () => {
+    mockToasts = [{ id: 't1', type: 'success', title: 'Dismiss me' }];
+    render(<ToastContainer />);
+    const dismissBtn = screen.getByLabelText('aria.dismiss');
+    fireEvent.click(dismissBtn);
+    expect(mockRemoveToast).toHaveBeenCalledWith('t1');
+  });
+
+  it('Clear all removes all toasts', () => {
+    mockToasts = [
+      { id: 't1', type: 'success', title: 'First' },
+      { id: 't2', type: 'error', title: 'Second' },
+    ];
+    render(<ToastContainer />);
+    fireEvent.click(screen.getByLabelText('aria.dismissAll'));
+    expect(mockRemoveToast).toHaveBeenCalledTimes(2);
+    expect(mockRemoveToast).toHaveBeenCalledWith('t1');
+    expect(mockRemoveToast).toHaveBeenCalledWith('t2');
+  });
+
+  it('toast has role="alert"', () => {
+    mockToasts = [{ id: 't1', type: 'success', title: 'Alert!' }];
+    const { container } = render(<ToastContainer />);
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).not.toBeNull();
+    expect(alertEl?.textContent).toContain('Alert!');
+  });
+
+  it('renders undo button when undoAction is provided', () => {
+    const undoFn = vi.fn();
+    mockToasts = [{ id: 't1', type: 'undo', title: 'Deleted', undoAction: undoFn }];
+    render(<ToastContainer />);
+    const undoBtn = screen.getByLabelText('aria.undo');
+    expect(undoBtn).not.toBeNull();
+  });
+
+  it('undo button calls undoAction then removeToast', () => {
+    const undoFn = vi.fn();
+    mockToasts = [{ id: 't1', type: 'undo', title: 'Deleted', undoAction: undoFn }];
+    render(<ToastContainer />);
+    fireEvent.click(screen.getByLabelText('aria.undo'));
+    expect(undoFn).toHaveBeenCalledOnce();
+    expect(mockRemoveToast).toHaveBeenCalledWith('t1');
+  });
+
+  it('no undo button when undoAction is absent', () => {
+    mockToasts = [{ id: 't1', type: 'info', title: 'No undo' }];
+    expect(screen.queryByLabelText('aria.undo')).toBeNull();
+  });
+
+  it('progress bar starts at 100% width', () => {
+    mockToasts = [{ id: 't1', type: 'success', title: 'Hi' }];
+    const { container } = render(<ToastContainer />);
+    // The progress bar is the div with aria-hidden inside the toast
+    const progressBar = container.querySelector('[aria-hidden="true"]');
+    expect(progressBar).not.toBeNull();
+  });
+
+  it('auto-dismisses after timeout', () => {
+    mockToasts = [{ id: 't1', type: 'success', title: 'Bye' }];
+    render(<ToastContainer />);
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    expect(mockRemoveToast).toHaveBeenCalledWith('t1');
+  });
+});

--- a/dashboard/src/components/session/__tests__/PendingQuestionCard.test.tsx
+++ b/dashboard/src/components/session/__tests__/PendingQuestionCard.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * PendingQuestionCard tests — Claude question UI with optional options.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PendingQuestionCard } from '../PendingQuestionCard';
+import type { PendingQuestionInfo } from '../../../types';
+
+const baseQuestion: PendingQuestionInfo = {
+  toolUseId: 'tool-1',
+  content: 'What label should we use on mobile?',
+  options: ['Ship it', 'Revise copy'],
+  since: Date.now(),
+};
+
+describe('PendingQuestionCard', () => {
+  it('renders question content', () => {
+    render(<PendingQuestionCard pendingQuestion={baseQuestion} />);
+    expect(screen.getByText('What label should we use on mobile?')).not.toBeNull();
+  });
+
+  it('renders "Claude needs an answer" heading', () => {
+    render(<PendingQuestionCard pendingQuestion={baseQuestion} />);
+    expect(screen.getByText('Claude needs an answer')).not.toBeNull();
+  });
+
+  it('renders all option buttons', () => {
+    render(<PendingQuestionCard pendingQuestion={baseQuestion} />);
+    expect(screen.getByRole('button', { name: 'Ship it' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Revise copy' })).not.toBeNull();
+  });
+
+  it('calls onSelectOption when option clicked', () => {
+    const onSelectOption = vi.fn();
+    render(
+      <PendingQuestionCard
+        pendingQuestion={baseQuestion}
+        onSelectOption={onSelectOption}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Ship it' }));
+    expect(onSelectOption).toHaveBeenCalledWith('Ship it');
+  });
+
+  it('calls onSelectOption with correct option for each button', () => {
+    const onSelectOption = vi.fn();
+    render(
+      <PendingQuestionCard
+        pendingQuestion={baseQuestion}
+        onSelectOption={onSelectOption}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Revise copy' }));
+    expect(onSelectOption).toHaveBeenCalledWith('Revise copy');
+  });
+
+  it('renders reply hint text', () => {
+    render(<PendingQuestionCard pendingQuestion={baseQuestion} />);
+    expect(screen.getByText('Reply below to keep the session moving.')).not.toBeNull();
+  });
+
+  it('renders without option buttons when options is null', () => {
+    const noOptionsQ: PendingQuestionInfo = {
+      ...baseQuestion,
+      options: null,
+    };
+    render(<PendingQuestionCard pendingQuestion={noOptionsQ} />);
+    expect(screen.queryByRole('button')).toBeNull();
+    // Content still rendered
+    expect(screen.getByText('What label should we use on mobile?')).not.toBeNull();
+  });
+
+  it('renders without option buttons when options is empty array', () => {
+    const emptyOptionsQ: PendingQuestionInfo = {
+      ...baseQuestion,
+      options: [],
+    };
+    render(<PendingQuestionCard pendingQuestion={emptyOptionsQ} />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('works without onSelectOption callback', () => {
+    render(<PendingQuestionCard pendingQuestion={baseQuestion} />);
+    // Should not throw when clicking an option without callback
+    expect(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Ship it' }));
+    }).not.toThrow();
+  });
+
+  it('renders with single option', () => {
+    const singleOptionQ: PendingQuestionInfo = {
+      ...baseQuestion,
+      options: ['OK'],
+    };
+    render(<PendingQuestionCard pendingQuestion={singleOptionQ} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].textContent).toBe('OK');
+  });
+
+  it('option buttons have min-h-[40px] for touch targets', () => {
+    render(<PendingQuestionCard pendingQuestion={baseQuestion} />);
+    const btn = screen.getByRole('button', { name: 'Ship it' });
+    expect(btn.getAttribute('class')).toContain('min-h-[40px]');
+  });
+});

--- a/dashboard/src/components/session/__tests__/SessionHeader.test.tsx
+++ b/dashboard/src/components/session/__tests__/SessionHeader.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * SessionHeader tests — session detail header with status, actions, and metadata.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionHeader } from '../SessionHeader';
+import type { SessionInfo, SessionHealth } from '../../../types';
+
+// ── Mocks ──────────────────────────────────────────────────
+
+vi.mock('../../../i18n/context', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('lucide-react', () => ({
+  GitFork: (props: any) => <svg data-testid="icon-gitfork" {...props} />,
+  MoreHorizontal: (props: any) => <svg data-testid="icon-more" {...props} />,
+}));
+
+vi.mock('../SessionStateBadge', () => ({
+  SessionStateBadge: ({ status }: { status: string }) => (
+    <span data-testid="session-state-badge">{status}</span>
+  ),
+  uiStateToSessionBadgeStatus: (uiState: string, alive: boolean) =>
+    alive ? uiState : 'offline',
+}));
+
+vi.mock('../TimelineScrubber', () => ({
+  TimelineScrubber: ({ events }: { events: any[] }) => (
+    <div data-testid="timeline-scrubber">events:{events.length}</div>
+  ),
+}));
+
+vi.mock('../../shared/HoldButton', () => ({
+  HoldButton: ({ onConfirm, children, ...props }: any) => (
+    <button data-testid="hold-button" onClick={onConfirm} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('../../shared/CopyButton', () => ({
+  CopyButton: ({ value }: { value: string }) => (
+    <span data-testid="copy-button">{value}</span>
+  ),
+}));
+
+vi.mock('../../shared/ModelBadge', () => ({
+  ModelBadge: ({ model }: { model?: string }) => (
+    <span data-testid="model-badge">{model ?? 'none'}</span>
+  ),
+}));
+
+vi.mock('../../agents/AgentBadge', () => ({
+  AgentBadge: ({ runnerName }: any) => (
+    <span data-testid="agent-badge">{runnerName ?? 'none'}</span>
+  ),
+}));
+
+vi.mock('../../shared/EffortIndicator', () => ({
+  EffortIndicator: ({ effort }: any) => (
+    <span data-testid="effort-indicator">{effort ?? 'none'}</span>
+  ),
+}));
+
+vi.mock('../../shared/IsolationModeBadge', () => ({
+  IsolationModeBadge: ({ isolationMode }: any) => (
+    <span data-testid="isolation-badge">{isolationMode ?? 'none'}</span>
+  ),
+}));
+
+vi.mock('../../../utils/formatSessionName', () => ({
+  formatSessionName: (name: string) => name,
+}));
+
+// ── Fixtures ───────────────────────────────────────────────
+
+const baseSession = {
+  id: 'sess-abc123def456',
+  displayName: 'My Test Session',
+  workDir: '/home/user/projects/aegis',
+  model: 'claude-sonnet-4-20250514',
+  runnerName: 'claude-code',
+  createdAt: Date.now() - 3600000,
+  lastActivity: Date.now(),
+  status: 'idle' as const,
+
+  byteOffset: 0,
+  monitorOffset: 0,
+  stallThresholdMs: 30000,
+  permissionMode: 'default',
+} satisfies SessionInfo;
+
+const baseHealth: SessionHealth = {
+
+  alive: true,
+  claudeRunning: true,
+  status: 'idle' as const,
+  hasTranscript: true,
+  lastActivity: Date.now(),
+  lastActivityAgo: 0,
+  sessionAge: 3600000,
+  details: '',
+};
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe('SessionHeader', () => {
+  it('renders session display name', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.getByText('My Test Session')).not.toBeNull();
+  });
+
+  it('renders working directory', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    const dirEl = screen.getByText(/home\/user/);
+    expect(dirEl).not.toBeNull();
+  });
+
+  it('renders SessionStateBadge', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.getByTestId('session-state-badge')).not.toBeNull();
+  });
+
+  it('renders Interrupt button', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.getByText('Interrupt')).not.toBeNull();
+  });
+
+  it('fires onInterrupt when Interrupt clicked', () => {
+    const onInterrupt = vi.fn();
+    render(
+      <SessionHeader
+        session={baseSession}
+        health={baseHealth}
+        onInterrupt={onInterrupt}
+      />,
+    );
+    fireEvent.click(screen.getByText('Interrupt'));
+    expect(onInterrupt).toHaveBeenCalledOnce();
+  });
+
+  it('shows Approve/Reject buttons when status is permission_prompt', () => {
+    const health = { ...baseHealth, status: 'permission_prompt' as const };
+    render(<SessionHeader session={baseSession} health={health} />);
+    expect(screen.getByText('Approve')).not.toBeNull();
+    expect(screen.getByText('Reject')).not.toBeNull();
+  });
+
+  it('shows Approve/Reject buttons when status is bash_approval', () => {
+    const health = { ...baseHealth, status: 'bash_approval' as const };
+    render(<SessionHeader session={baseSession} health={health} />);
+    expect(screen.getByText('Approve')).not.toBeNull();
+    expect(screen.getByText('Reject')).not.toBeNull();
+  });
+
+  it('hides Approve/Reject when status is idle', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.queryByText('Approve')).toBeNull();
+    expect(screen.queryByText('Reject')).toBeNull();
+  });
+
+  it('fires onApprove when Approve clicked', () => {
+    const onApprove = vi.fn();
+    const health = { ...baseHealth, status: 'permission_prompt' as const };
+    render(
+      <SessionHeader
+        session={baseSession}
+        health={health}
+        onApprove={onApprove}
+      />,
+    );
+    fireEvent.click(screen.getByText('Approve'));
+    expect(onApprove).toHaveBeenCalledOnce();
+  });
+
+  it('fires onReject when Reject clicked', () => {
+    const onReject = vi.fn();
+    const health = { ...baseHealth, status: 'permission_prompt' as const };
+    render(
+      <SessionHeader
+        session={baseSession}
+        health={health}
+        onReject={onReject}
+      />,
+    );
+    fireEvent.click(screen.getByText('Reject'));
+    expect(onReject).toHaveBeenCalledOnce();
+  });
+
+  it('renders overflow menu button', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.getByLabelText('aria.moreActions')).not.toBeNull();
+  });
+
+  it('overflow menu opens and shows Save as Template when handler provided', () => {
+    const onSaveTemplate = vi.fn();
+    render(
+      <SessionHeader
+        session={baseSession}
+        health={baseHealth}
+        onSaveTemplate={onSaveTemplate}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('aria.moreActions'));
+    expect(screen.getByText('Save as Template')).not.toBeNull();
+  });
+
+  it('overflow menu shows Fork option when handler provided', () => {
+    const onFork = vi.fn();
+    render(
+      <SessionHeader
+        session={baseSession}
+        health={baseHealth}
+        onFork={onFork}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('aria.moreActions'));
+    expect(screen.getByText('Fork')).not.toBeNull();
+  });
+
+  it('overflow menu shows Kill Session via HoldButton when handler provided', () => {
+    const onKill = vi.fn();
+    render(
+      <SessionHeader
+        session={baseSession}
+        health={baseHealth}
+        onKill={onKill}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('aria.moreActions'));
+    expect(screen.getByText('Kill Session')).not.toBeNull();
+  });
+
+  it('renders TimelineScrubber when timelineEvents provided', () => {
+    render(
+      <SessionHeader
+        session={baseSession}
+        health={baseHealth}
+        timelineEvents={[{ type: 'message', timestamp: Date.now() } as any]}
+      />,
+    );
+    expect(screen.getByTestId('timeline-scrubber')).not.toBeNull();
+  });
+
+  it('does not render TimelineScrubber when no events', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.queryByTestId('timeline-scrubber')).toBeNull();
+  });
+
+  it('renders ModelBadge', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.getByTestId('model-badge')).not.toBeNull();
+  });
+
+  it('renders AgentBadge', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.getByTestId('agent-badge')).not.toBeNull();
+  });
+
+  it('renders session ID with copy button', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.getByText(/ID:/)).not.toBeNull();
+    expect(screen.getByTestId('copy-button')).not.toBeNull();
+  });
+
+  it('renders permission mode chip when set and not default', () => {
+    const session = { ...baseSession, permissionMode: 'plan' };
+    render(<SessionHeader session={session} health={baseHealth} />);
+    expect(screen.getByText('plan')).not.toBeNull();
+  });
+
+  it('does not render permission mode chip when default', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.queryByText('default')).toBeNull();
+  });
+});


### PR DESCRIPTION
48 new tests for dashboard components:
- **ToastContainer** (16 tests): null render, single/multi toast, description, aria-live, Clear all, dismiss, undo, progress bar, auto-dismiss
- **PendingQuestionCard** (11 tests): question content, heading, options, click callbacks, no options, empty options, no callback, single option, touch targets
- **SessionHeader** (21 tests): display name, workdir, state badge, interrupt/approve/reject buttons, overflow menu, timeline scrubber, model/agent badges, session ID, permission mode chip

All tests pass, zero TS errors, no production code changes.