### PR TITLE
fix(dashboard): move budgetAlertSection i18n keys into cost object

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -137,6 +137,12 @@ export const en = {
     dailyCost: 'Daily Cost',
     loadingDailySpend: 'Loading daily spend chart',
     loadingCostByModel: 'Loading cost by model chart',
+    budgetAlertSection: {
+      title: 'Budget Alerts',
+      description: 'Configure daily and monthly spending caps in',
+      settingsLink: 'Settings',
+    },
+    dismissBudgetAlert: 'Dismiss budget alert',
   },
   
   audit: {
@@ -647,12 +653,6 @@ export const en = {
     claudeRuntimeStatus: 'Claude runtime status',
     sessionSummary: 'Session summary',
     permissionPrompt: 'Permission prompt',
-    budgetAlertSection: {
-      title: 'Budget Alerts',
-      description: 'Configure daily and monthly spending caps in',
-      settingsLink: 'Settings',
-    },
-    dismissBudgetAlert: 'Dismiss budget alert',
     close: 'Close',
     removeRow: 'Remove row',
     newSession: 'New Session',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -139,6 +139,12 @@ export const it = {
     dailyCost: 'Costo Giornaliero',
     loadingDailySpend: 'Caricamento grafico spesa giornaliera',
     loadingCostByModel: 'Caricamento grafico costi per modello',
+    budgetAlertSection: {
+      title: 'Avvisi Budget',
+      description: 'Configura i limiti di spesa giornalieri e mensili in',
+      settingsLink: 'Impostazioni',
+    },
+    dismissBudgetAlert: 'Ignora avviso budget',
   },
 
   audit: {
@@ -646,12 +652,6 @@ export const it = {
     claudeRuntimeStatus: 'Stato runtime Claude',
     sessionSummary: 'Riepilogo sessione',
     permissionPrompt: 'Richiesta di permesso',
-    budgetAlertSection: {
-      title: 'Avvisi Budget',
-      description: 'Configura i limiti di spesa giornalieri e mensili in',
-      settingsLink: 'Impostazioni',
-    },
-    dismissBudgetAlert: 'Ignora avviso budget',
     close: 'Chiudi',
     removeRow: 'Rimuovi riga',
     newSession: 'Nuova Sessione',


### PR DESCRIPTION
## Summary
Moves `budgetAlertSection` and `dismissBudgetAlert` i18n keys from root level into the `cost` object in both `en.ts` and `it.ts`.

## Problem
`CostPage.tsx` references `t('cost.budgetAlertSection.title')` and `t('cost.budgetAlertSection.description')`, but the keys were at the root level of the i18n catalog, causing missing translation warnings.

## Changes
- `dashboard/src/i18n/en.ts` — moved keys into `cost` object
- `dashboard/src/i18n/it.ts` — moved keys into `cost` object

## Testing
- Vite build passes
- No type errors in dashboard code
- i18n key structure verified programmatically

Closes #4389