### PR TITLE
docs: add /v1/sse bridge endpoint

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -213,6 +213,7 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | Method | Path | Auth | Summary |
 |--------|------|------|---------|
 | `GET` | `/v1/events` | SSE Token | Global SSE event stream (all sessions) |
+| `GET` | `/v1/sse` | SSE Token / Cookie | SSE bridge stream (dashboard, same events with tenant scoping) |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4181,6 +4181,40 @@ curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN"
 data: {"event":"connected","timestamp":"2026-04-22T10:00:00.000Z","data":{"activeSessions":5}}
 ```
 
+### SSE Bridge (Dashboard)
+
+```
+GET /v1/sse
+```
+
+Server-Sent Events stream bridging the internal `SessionEventBus` to browser/dashboard clients. Similar to `GET /v1/events` but optimized for dashboard consumption.
+
+```bash
+# Step 1: Get an SSE token
+curl -s -X POST http://localhost:9100/v1/auth/sse-token \
+  -H "Authorization: Bearer $API_KEY"
+# Step 2: Connect to the bridge stream
+curl -N "http://localhost:9100/v1/sse?token=$SSE_TOKEN"
+```
+
+**Authentication:** SSE token via query parameter (`?token=<sse-token>`) or Bearer header (`Authorization: Bearer sse_...`). Also accepts dashboard cookie auth. Regular API keys are rejected.
+
+**Event types:** Same as `GET /v1/events` — all global session events filtered by tenant scope.
+
+**Tenant scoping:** Events are filtered via `isGlobalEventVisibleToRequest()`. Admin/master keys see all events; tenant-scoped keys see only their own.
+
+**Connection limits:** Per-IP and global connection limits apply (shared with `GET /v1/events`). Returns `429` when per-IP limit is reached, `503` when global limit is reached.
+
+**Heartbeat:** Server sends `: hb` comments every 30 seconds to keep the connection alive.
+
+**Error responses:**
+
+| Status | Description |
+|--------|-------------|
+| 429 | Per-IP connection limit reached |
+| 500 | Failed to create SSE subscription |
+| 503 | Global connection limit reached |
+
 ---
 
 ## Usage & Metering

--- a/docs/guides/real-time-events.md
+++ b/docs/guides/real-time-events.md
@@ -72,6 +72,14 @@ GET /v1/sessions/:id/events?token=<sse-token>
 
 Streams events for a single session. Also available as `GET /v1/sessions/:id/stream` (alias).
 
+### SSE Bridge (Dashboard)
+
+```
+GET /v1/sse?token=<sse-token>
+```
+
+Bridges the internal `SessionEventBus` to browser/dashboard clients. Same event format as the global stream, with tenant-scoped filtering and connection limiting. Also accepts dashboard cookie authentication.
+
 ## Event Reference
 
 ### Per-Session Event Types


### PR DESCRIPTION
## Summary

Documents the `GET /v1/sse` SSE bridge endpoint introduced in #4373 and hardened in #4395.

### What's added
- **api-reference.md:** Full endpoint spec with auth model, tenant scoping, connection limits, heartbeat, and error responses (429/500/503)
- **api-quick-ref.md:** Quick reference entry with SSE Token/Cookie auth
- **real-time-events.md:** SSE Bridge section alongside global and per-session streams

### Why
The `/v1/sse` endpoint was live but undocumented. Users connecting to the API had no reference for this endpoint's behavior, auth requirements, or how it differs from `GET /v1/events`.