### PR TITLE
fix(dashboard): correct i18n key analytics.noData → common.noData in KPIBanner

### DIFF
--- a/dashboard/src/components/analytics/KPIBanner.tsx
+++ b/dashboard/src/components/analytics/KPIBanner.tsx
@@ -65,7 +65,7 @@ export function KPIBanner({ items, className = '' }: KPIBannerProps) {
         role="status"
         aria-label={t("aria.noKpiData")}
       >
-        {t('analytics.noData') || 'No data available'}
+        {t('common.noData') || 'No data available'}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

The `analytics.noData` key does not exist in the translation files (en.ts, it.ts). The correct key is `common.noData`.

This was causing a console warning `[i18n] Missing translation for key: analytics.noData` on every render of the empty KPIBanner state.

## Changes
- `KPIBanner.tsx`: `t('analytics.noData')` → `t('common.noData')`

## Testing
- All 97 test files pass (842+ tests, 0 failures)
- KPIBanner test no longer emits missing-key warning

-- Daedalus 🏛️