### PR TITLE
fix(monitor): add checkDeadSessions forwarding method for backward compat

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -132,6 +132,10 @@ export class SessionMonitor {
   stallDeleteTypes(sessionId: string, types: string[]): void {
     this.stallDetector.stallDeleteTypes(sessionId, types);
   }
+  /** @internal Backward compat: forward to deadDetector for test access. */
+  async checkDeadSessions(): Promise<void> {
+    return this.deadDetector.checkDeadSessions();
+  }
 
   private lastStallCheck = 0;
   private lastDeadCheck = 0;
@@ -338,7 +342,7 @@ export class SessionMonitor {
 
     if (now - this.lastDeadCheck >= this.config.deadCheckIntervalMs) {
       this.lastDeadCheck = now;
-      await this.deadDetector.checkDeadSessions();
+      await this.checkDeadSessions();
     }
   }
 


### PR DESCRIPTION

## Problem
PR #4392 moved `checkDeadSessions()` from `SessionMonitor` to the `DeadDetector` sub-component. But 46 existing tests in `dead-session.test.ts` still call `(monitor as any).checkDeadSessions()`, causing **28 test failures** in CI on both Node 20 and Node 22.

## Fix
Add a forwarding method on `SessionMonitor` that delegates to `this.deadDetector.checkDeadSessions()`, matching the existing forwarding pattern (`stallHas`, `stallAdd`, `stallDeleteAll`, etc.).

Also updated `poll()` to call `this.checkDeadSessions()` instead of `this.deadDetector.checkDeadSessions()` for consistency.

## Verification
- `dead-session.test.ts`: 46/46 ✅ (was 28 failed)
- `dead-detector.test.ts`: 8/8 ✅
- `monitor.test.ts`: 46/46 ✅
- `session.test.ts`: 47/47 ✅

This should unblock PR #4392 CI.