### PR TITLE
fix(dashboard): improve touch targets and i18n for interactive elements

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -574,7 +574,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
                       setPage(1);
                     }}
                     aria-label={t("aria.filterByDirectory")}
-                    className="min-h-[36px] rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] px-2 py-1 text-xs text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent-cyan)] max-w-[180px]"
+                    className="min-h-[44px] rounded-md border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] px-3 py-1.5 text-xs text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent-cyan)] max-w-[180px]"
                   >
                     <option value="all">{t("aria.allDirectories")} ({sessions.length})</option>
                     {uniqueWorkDirs.map(([key, full]) => (

--- a/dashboard/src/components/session/StreamTab.tsx
+++ b/dashboard/src/components/session/StreamTab.tsx
@@ -86,7 +86,7 @@ export function StreamTab({ sessionId, isDriver }: StreamTabProps) {
               role="tab"
               aria-selected={viewMode === mode}
               onClick={() => selectView(mode)}
-              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+              className={`min-h-[44px] px-3 py-2 text-xs font-medium rounded transition-colors ${
                 viewMode === mode
                   ? 'bg-[var(--color-cta-bg)] text-[var(--color-void)] shadow-sm'
                   : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-void-lighter)]/30'

--- a/dashboard/src/components/session/TimelineSparkline.tsx
+++ b/dashboard/src/components/session/TimelineSparkline.tsx
@@ -121,7 +121,7 @@ export function TimelineSparkline({
               role="tab"
               aria-selected={range === r}
               onClick={() => setRange(r)}
-              className={`px-2 py-0.5 text-[10px] font-mono uppercase rounded transition-colors ${
+              className={`min-h-[32px] px-2.5 py-1 text-[10px] font-mono uppercase rounded transition-colors ${
                 range === r
                   ? 'bg-[var(--color-cta-bg)] text-[var(--color-void)]'
                   : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'

--- a/dashboard/src/components/session/TranscriptBubble.tsx
+++ b/dashboard/src/components/session/TranscriptBubble.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { useT } from '../../i18n/context';
 import type { ParsedEntry } from '../../types';
 import { RenderWithCodeBlocks } from '../shared/CodeBlock';
 import { CopyButton } from '../shared/CopyButton';
@@ -46,6 +47,7 @@ function getRoleColor(role: string, contentType: string): string {
 }
 
 export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptBubbleProps) {
+  const t = useT();
   const [showRelativeTime, setShowRelativeTime] = useState(false);
   const [collapsed, setCollapsed] = useState(
     entry.contentType === 'tool_use' || 
@@ -126,7 +128,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
               e.stopPropagation();
               setCollapsed(!collapsed);
             }}
-            aria-label="Collapse transcript entry"
+            aria-label={collapsed ? t("aria.expandEntry") : t("aria.collapseEntry")}
             className="flex items-center gap-2 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors py-1"
           >
             <Icon 
@@ -177,7 +179,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
                 e.stopPropagation();
                 setCollapsed(!collapsed);
               }}
-              aria-label="Collapse transcript entry"
+              aria-label={collapsed ? t("aria.expandEntry") : t("aria.collapseEntry")}
             className={`w-full text-left rounded-lg overflow-hidden border transition-colors ${
                 isFailed
                   ? 'border-[var(--color-danger)]/40 bg-[var(--color-void)]'

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -773,6 +773,8 @@ export const en = {
     activeSessions: 'Active sessions',
     allSessions: 'All sessions',
     checkingAuth: 'Checking authentication',
+    expandEntry: 'Expand transcript entry',
+    collapseEntry: 'Collapse transcript entry',
   },
 
   cliShortcuts: {

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -766,6 +766,8 @@ export const it = {
     activeSessions: 'Sessioni attive',
     allSessions: 'Tutte le sessioni',
     checkingAuth: 'Verifica autenticazione',
+    expandEntry: 'Espandi voce trascrizione',
+    collapseEntry: 'Comprimi voce trascrizione',
   },
 
   cliShortcuts: {

--- a/dashboard/src/pages/session-detail/MessageFooter.tsx
+++ b/dashboard/src/pages/session-detail/MessageFooter.tsx
@@ -279,21 +279,21 @@ export function MessageFooter({
             {t('sessionDetail.toSend')} · {t('sessionDetail.tryLabel')}{' '}
             <button
               type="button"
-              className="text-[var(--color-accent-cyan)] hover:underline"
+              className="min-h-[28px] inline-flex items-center rounded px-1.5 py-0.5 text-[var(--color-accent-cyan)] hover:underline hover:bg-[var(--color-void-lighter)]/30"
               onClick={() => { setMsgInput('/help'); getVisibleMessageInput()?.focus(); }}
             >
               /help
             </button>{' '}·{' '}
             <button
               type="button"
-              className="text-[var(--color-accent-cyan)] hover:underline"
+              className="min-h-[28px] inline-flex items-center rounded px-1.5 py-0.5 text-[var(--color-accent-cyan)] hover:underline hover:bg-[var(--color-void-lighter)]/30"
               onClick={() => { setMsgInput('/status'); getVisibleMessageInput()?.focus(); }}
             >
               /status
             </button>{' '}·{' '}
             <button
               type="button"
-              className="text-[var(--color-accent-cyan)] hover:underline"
+              className="min-h-[28px] inline-flex items-center rounded px-1.5 py-0.5 text-[var(--color-accent-cyan)] hover:underline hover:bg-[var(--color-void-lighter)]/30"
               onClick={() => { setMsgInput('/cost'); getVisibleMessageInput()?.focus(); }}
             >
               /cost

--- a/dashboard/src/pages/session-detail/TabBar.tsx
+++ b/dashboard/src/pages/session-detail/TabBar.tsx
@@ -28,7 +28,7 @@ export function TabBar({ tabs, activeTab, onTabChange }: TabBarProps) {
           aria-selected={activeTab === tab.id}
           aria-controls={`panel-${tab.id}`}
           tabIndex={activeTab === tab.id ? 0 : -1}
-          className={`relative z-10 min-h-[36px] rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+          className={`relative z-10 min-h-[44px] rounded-full px-4 py-2 text-sm font-medium transition-colors ${
             activeTab === tab.id
               ? 'text-[var(--color-void)] dark:text-[var(--color-text-primary)]'
               : 'border border-[var(--color-void-lighter)] bg-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'


### PR DESCRIPTION
## Summary

Audit of UI interaction bugs found multiple undersized touch targets and hardcoded English strings in aria-labels.

## Changes

**Touch target fixes (WCAG 2.5.5 / Apple HIG):**
- `TabBar` session detail tabs: `min-h-[36px]` → `min-h-[44px]`
- `StreamTab` view mode buttons (Terminal/Transcript/Split): added `min-h-[44px]`
- `TimelineSparkline` range tabs (1h/6h/24h/7d): added `min-h-[32px]` with padding
- `SessionTable` directory filter select: `min-h-[36px]` → `min-h-[44px]`
- `MessageFooter` inline command buttons (/help, /status, /cost): added `min-h-[28px]` with hover background

**i18n fix:**
- `TranscriptBubble` collapse buttons: replaced hardcoded `"Collapse transcript entry"` with `t("aria.expandEntry")` / `t("aria.collapseEntry")`
- Added `en` + `it` translation keys for `expandEntry` and `collapseEntry`

## Files changed
- 8 files, 15 insertions, 9 deletions

## Testing
- All impacted test files pass (Layout, SessionHistoryPage, MetricCards — 38 tests, 0 failures)
