### PR TITLE
fix(dashboard): make ApprovalBanner visible on mobile screens

### DIFF
--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -286,9 +286,6 @@ export default function SessionDetailPage() {
 
   return (
     <div className="min-h-screen bg-transparent">
-      {needsApproval && (
-        <div className="fixed inset-0 z-30 bg-black/40 sm:hidden" aria-hidden="true" />
-      )}
 
       <div
         className="mx-auto max-w-6xl px-3 py-3 sm:px-4 sm:py-4"
@@ -344,7 +341,7 @@ export default function SessionDetailPage() {
               <motion.div
                 initial={{ opacity: 0, y: -20 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="hidden p-3 pb-0 sm:block sm:p-4"
+                className="p-3 pb-0 sm:p-4"
               >
                 <ApprovalBanner
                   prompt={pendingPermission?.prompt ?? h.details}


### PR DESCRIPTION
## Summary

Fixes #4400 — ApprovalBanner was completely invisible on mobile screens (<640px).

### Changes
- Removed `hidden sm:block` from the ApprovalBanner wrapper in SessionDetailPage — banner now visible on all screen sizes
- Removed the blocking dark overlay (`fixed inset-0 bg-black/40 sm:hidden`) that prevented mobile interaction without providing any UI

### Why
The ApprovalBanner component already has responsive layout (`flex-col` on mobile → `flex-row` on `sm:`) and proper touch targets (`min-h-[44px]`). The only problem was the parent wrapper hiding it on mobile.

Mobile approval is a core use case for solo devs using Aegis — this was a P1 blocker.

### Testing
- [x] Vite build succeeds
- [x] No new TypeScript errors introduced
- [x] Diff is minimal: 1 file, -4 lines, +1 line