### PR TITLE
fix(dashboard): prevent double-click duplicate approve/reject in ApprovalBanner

### DIFF
--- a/dashboard/src/components/session/ApprovalBanner.tsx
+++ b/dashboard/src/components/session/ApprovalBanner.tsx
@@ -25,6 +25,7 @@ export function ApprovalBanner({
   onReject,
 }: ApprovalBannerProps) {
   const [expanded, setExpanded] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   if (permissionMode && permissionMode !== 'default' && AUTO_APPROVE_MODES.has(permissionMode)) {
     return (
@@ -91,8 +92,9 @@ export function ApprovalBanner({
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
           type="button"
-          onClick={onApprove}
-          className="min-h-[44px] rounded-lg border border-[var(--color-success)]/40 bg-[var(--color-success)]/20 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-success)] transition-colors hover:bg-[var(--color-success)]/30 hover:border-[var(--color-success)]/60 shadow-[0_0_15px_rgba(34,197,94,0.15)] hover:shadow-[0_0_20px_rgba(34,197,94,0.3)]"
+          disabled={isLoading}
+          onClick={async () => { if (isLoading) return; setIsLoading(true); await onApprove?.(); }}
+          className={`min-h-[44px] rounded-lg border border-[var(--color-success)]/40 bg-[var(--color-success)]/20 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-success)] transition-colors hover:bg-[var(--color-success)]/30 hover:border-[var(--color-success)]/60 shadow-[0_0_15px_rgba(34,197,94,0.15)] hover:shadow-[0_0_20px_rgba(34,197,94,0.3)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[var(--color-success)]/20`}
         >
           APPROVE
         </motion.button>
@@ -100,8 +102,9 @@ export function ApprovalBanner({
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
           type="button"
-          onClick={onReject}
-          className="min-h-[44px] rounded-lg border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/10 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger)]/20 hover:border-[var(--color-danger)]/50"
+          disabled={isLoading}
+          onClick={async () => { if (isLoading) return; setIsLoading(true); await onReject?.(); }}
+          className={`min-h-[44px] rounded-lg border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/10 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger)]/20 hover:border-[var(--color-danger)]/50 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[var(--color-danger)]/10`}
         >
           REJECT
         </motion.button>


### PR DESCRIPTION
## Summary
Fixes #4410 — APPROVE/REJECT buttons had no loading state, allowing duplicate API requests on rapid clicks.

### Changes
- Added `isLoading` state to `ApprovalBanner`
- Both buttons disabled during in-flight request with `disabled:opacity-50 disabled:cursor-not-allowed`
- Wrapped handlers with loading guard to prevent race conditions

### Testing
- [x] Vite build succeeds
- [x] Buttons visually disabled during loading

Matches the pattern used in `AcpApprovalModal.tsx` which already handles this correctly.