### PR TITLE
fix(dashboard): persist onboarding dismissed state to localStorage

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -111,6 +111,7 @@ export default function App() {
   if (isAuthenticated && showOnboarding) {
     return <Suspense fallback={<LoadingFallback />}><OnboardingWizard onComplete={() => {
       setShowOnboarding(false);
+      localStorage.setItem('aegis:onboarded', 'true');
       if (!isTourCompleted()) setShowTour(true);
     }} /></Suspense>;
   }


### PR DESCRIPTION
Fixes #4436

The onboarding wizard reappeared on every page load because onComplete never persisted the dismissed state to localStorage. The useEffect that checks hasOnboarded on every auth/location change found it null and re-showed the wizard.

Fix: add localStorage.setItem for aegis:onboarded in the onComplete callback. 1 file changed, 1 insertion.