### PR TITLE
fix(i18n): add missing staleData key to Italian translations

### DIFF
--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -623,6 +623,7 @@ export const it = {
 
   notifications: {
     disconnect: 'Disconnetti',
+    staleData: 'Aggiornamenti live disconnessi — i dati potrebbero essere obsoleti. {{error}}',
   },
 
   aria: {


### PR DESCRIPTION
Small fix — `notifications.staleData` in `en.ts` had no counterpart in `it.ts`.