### PR TITLE
fix(dashboard): TranscriptBubble flaky timestamp test

### DIFF
--- a/dashboard/src/components/session/__tests__/TranscriptBubble.test.tsx
+++ b/dashboard/src/components/session/__tests__/TranscriptBubble.test.tsx
@@ -56,7 +56,7 @@ describe('TranscriptBubble', () => {
     });
 
     it('shows absolute timestamp for user messages', () => {
-      const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'Hi', timestamp: '2026-05-27T14:30:00Z' };
+      const entry: ParsedEntry = { ...baseEntry, role: 'user', text: 'Hi', timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString() };
       render(<TranscriptBubble entry={entry} index={0} />);
       // toLocaleTimeString output varies by env, just check the time is present
       const timeEl = screen.getByTitle(/\d+m ago|\d+h ago|\d+s ago/);


### PR DESCRIPTION
Fixes the flaky TranscriptBubble test that was blocking green CI across all dashboard PRs.

**Root cause:** Test used a fixed date (2026-05-27T14:30:00Z) for the timestamp assertion. After 24h, formatRelativeTime returns 'Xd ago' which doesn't match the regex /\d+m ago|\d+h ago|\d+s ago/.

**Fix:** Use Date.now() - 5min to always produce '5m ago' regardless of when the test runs.

1 file changed, 1 insertion, 1 deletion.