### PR TITLE
docs: add dashboard i18n guide + update stale dashboard.md section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ACP SDK bump** — @agentclientprotocol/claude-agent-acp 0.35.0 → 0.37.0 ([#4173](https://github.com/OneStepAt4time/aegis/pull/4173))
 - **Post-merge auto-rebuild hook** — dist/ auto-rebuilds and server restarts on develop merge ([#4125](https://github.com/OneStepAt4time/aegis/pull/4125))
 
+### Fixed
+
+- **Dashboard i18n aria-labels** — replace 50+ hardcoded English aria-labels/titles with i18n keys across 31 files ([#4441](https://github.com/OneStepAt4time/aegis/pull/4441))
+- **TranscriptBubble flaky timestamp test** — stabilize timestamp test with relative time ([#4442](https://github.com/OneStepAt4time/aegis/pull/4442))
+- **Onboarding tour persistence** — persist dismissed state so tour never reappears on page load ([#4438](https://github.com/OneStepAt4time/aegis/pull/4438))
+- **PermissionPromptSheet i18n + Escape UX** — i18n keys + Escape key clarity for permission prompts ([#4430](https://github.com/OneStepAt4time/aegis/pull/4430))
+
 ---
 
 

--- a/docs/changelog/2026-05-29.md
+++ b/docs/changelog/2026-05-29.md
@@ -1,0 +1,74 @@
+# CHANGELOG — 2026-05-28/29
+
+> **28 PRs merged** (21 May 28, 7 May 29 — last 2 days). Dashboard i18n completion, SSE security hardening, onboarding wizard, and monitor decomposition.
+
+## Dashboard: i18n Completion (#4441, #4439, #4430, #4434, #4431)
+
+The dashboard is now fully internationalized. 50+ hardcoded English strings (aria-labels, titles, placeholders) replaced with i18n keys across 31 files. Italian catalog (`it.ts`) synced.
+
+- **#4441** — Replace 50+ hardcoded English aria-labels/titles with i18n keys
+- **#4439** — Replace hardcoded aria-labels and titles (i18n continuation)
+- **#4430** — PermissionPromptSheet i18n + Escape key UX clarity
+- **#4434** — AnalyticsPage crash on partial API data + i18n fix
+- **#4431** — Prevent double-click duplicate approve/reject in ApprovalBanner
+- **#4440** — Add missing staleData key to Italian translations
+- **#4397** — Fix i18n key analytics.noData → common.noData in KPIBanner
+- **#4391** — Move budgetAlertSection i18n keys into cost object
+
+## Dashboard: UX Fixes (#4425, #4421, #4426, #4428, #4437, #4438, #4429, #4442)
+
+- **#4425** — Fix interaction bugs: stale state, blur commit, capture phase, scroll, active index
+- **#4421** — Show ApprovalBanner on mobile — remove hidden sm:block
+- **#4426** — Make ApprovalBanner visible on mobile screens
+- **#4428** — Prevent double-click duplicate approve/reject in ApprovalBanner
+- **#4437** — Persist onboarding dismissed state to localStorage
+- **#4438** — Persist onboarding completion so tour never reappears on page load
+- **#4429** — Pass actual user role to DriverControlBar
+- **#4442** — Fix TranscriptBubble flaky timestamp test
+
+## Dashboard: Onboarding Wizard (#4383)
+
+Smart onboarding wizard with health-aware steps. New users get guided through setup based on server health status.
+
+## Security: SSE Bridge Hardening (#4395)
+
+The `/v1/sse` bridge endpoint now enforces auth, tenant scoping, and connection limiting.
+
+## Architecture: Monitor Decomposition (#4392, #4399)
+
+Extracted `DeadDetector`, `RateLimitRetryHandler`, and `StatusBroadcaster` from the monolithic session monitor. Backward-compatible forwarding method added.
+
+## Architecture: Auth Boot Facade (#4386)
+
+Prepared `setupAuth` extraction via boot facade as prep work for server decomposition (continues #4227).
+
+## Docs (#4396, #4394, #4382)
+
+- **#4396** — Document `/v1/sse` bridge endpoint in API reference
+- **#4394** — Add SSE security section to real-time events guide
+- **#4382** — Agent bootstrap best practice — GitHub as source of truth
+
+## Tests (#4388, #4387, #4384, #4381)
+
+4 batches of dashboard component tests:
+- **#4388** — TokenBreakdown, ConfirmDestructive, RateLimitCard (batch 9)
+- **#4387** — ToastContainer, PendingQuestionCard, SessionHeader (batch 8)
+- **#4384** — ShieldLogo, HoldButton, ConfirmDialog (batch 7)
+- **#4381** — ProtectedRoute, Code, PipelineStatusBadge (batch 6)
+
+## CI/Internal (#4398, #4424)
+
+- **#4398** — Exclude stale aegis/ directory from vitest runs
+- **#4424** — Fix triple-brace in SettingsPage breaking CI
+
+## Still Open
+
+| PR | Title | Author |
+|----|-------|--------|
+| #4443 | Fix flaky TranscriptBubble test + fork empty body | Ema |
+| #4427 | Reduce useSessionApproval re-renders on TTL tick | Ema |
+| #4444 | Dashboard i18n guide + CHANGELOG + known-issues + zero-config update | Scribe |
+
+---
+
+**Draft by:** Scribe · **Status:** Draft — will finalize once #4443 and #4427 land.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -15,13 +15,16 @@ Switch between dark and light theme. The dashboard defaults to your system prefe
 
 ### Internationalization (i18n)
 
-The dashboard supports multiple languages. Users can switch languages from the header.
+The dashboard uses a custom, zero-dependency i18n system with React Context. Users can switch languages from the Settings page.
 
 - **Supported languages:** English (default), Italian
-- **Language switcher** in the header — select your preferred language
-- **Persistence** — choice saved in `localStorage` across sessions
-- **13 pages localized:** NotFound, Activity, Login, Overview, Sessions, Analytics, Audit, Cost, Metrics, Auth Keys, Settings, Templates
+- **20 pages localized:** all page components use the `useT()` hook for user-facing strings
+- **28 namespaces** in the message catalog, including `aria.*` for accessibility labels
+- **Persistence** — choice saved in `localStorage` (`aegis:locale` key) across sessions
 - **Catalog** — `dashboard/src/i18n/` contains translation files per language (`en.ts`, `it.ts`)
+- **i18n gate** — `node scripts/i18n-gate.cjs` catches hardcoded inline strings
+
+See the [i18n Guide](./guides/i18n.md) for the full reference: adding keys, new locales, format utilities, and gotchas.
 
 ### Keyboard Shortcuts
 

--- a/docs/guides/i18n.md
+++ b/docs/guides/i18n.md
@@ -1,0 +1,221 @@
+# Dashboard Internationalization (i18n) Guide
+
+The Aegis dashboard uses a **custom, zero-dependency** i18n system built on React Context. No external libraries (`react-i18next`, `react-intl`, etc.) are required — just TypeScript, React Context, and native `Intl.*` APIs.
+
+## How It Works
+
+### Architecture
+
+```
+dashboard/src/i18n/
+├── context.tsx   # I18nProvider, useT() hook, useLocale() hook
+├── en.ts         # English message catalog (canonical)
+└── it.ts         # Italian message catalog
+```
+
+**Flow:**
+
+1. `I18nProvider` wraps the app in `main.tsx`, reading the saved locale from `localStorage` (`aegis:locale` key) and falling back to `navigator.language`.
+2. Components call `const t = useT()` to get the translation function.
+3. `t('overview.title')` resolves the dot-path against the current locale's message catalog.
+4. Missing keys fall back to the key itself and log a warning.
+
+### Using in Components
+
+```tsx
+import { useT, useLocale } from '../i18n/context';
+
+function MyComponent() {
+  const t = useT();
+  const { locale, setLocale } = useLocale();
+
+  return (
+    <>
+      <h1>{t('overview.title')}</h1>
+      <p>{t('overview.days', { n: 7 })}</p>
+    </>
+  );
+}
+```
+
+**Parameter interpolation** uses `{paramName}` placeholders:
+
+```tsx
+// en.ts: minutesAgo: '{count}m ago'
+t('sessions.board.minutesAgo', { count: 5 }); // → "5m ago"
+```
+
+## Message Catalog
+
+The English catalog (`en.ts`) is the **source of truth**. It exports a deeply nested object with ~700+ strings across 28 namespaces.
+
+### Namespace Taxonomy
+
+| Namespace | Purpose | Examples |
+|-----------|---------|---------|
+| `nav` | Sidebar navigation labels | `nav.sessions`, `nav.settings` |
+| `overview` | Overview page | `overview.title`, `overview.errorRate` |
+| `sessions` | Sessions page + board | `sessions.title`, `sessions.board.colRunning` |
+| `sessionDetail` | Session detail view | `sessionDetail.transcript`, `sessionDetail.cost` |
+| `sessionHistory` | Session history page | `sessionHistory.title` |
+| `newSession` | Create session form | `newSession.title`, `newSession.workDir` |
+| `pipelines` | Pipelines page | `pipelines.title`, `pipelines.filterAll` |
+| `activity` | Activity feed | `activity.title` |
+| `cost` | Cost analytics | `cost.title`, `cost.totalSpend` |
+| `analytics` | Analytics page | `analytics.title` |
+| `metrics` | Metrics page | `metrics.title` |
+| `audit` | Audit page | `audit.title` |
+| `authKeys` | API key management | `authKeys.title` |
+| `users` | User management | `users.title` |
+| `templates` | Session templates | `templates.title` |
+| `routines` | Routines/scheduled tasks | `routines.title` |
+| `login` | Login page | `login.title`, `login.username` |
+| `settings` | Settings page | `settings.display.theme` |
+| `common` | Shared strings | `common.loading`, `common.error`, `common.search` |
+| `status` | Status labels | `status.idle`, `status.working`, `status.running` |
+| `statusDot` | Status dot tooltips | `statusDot.healthy`, `statusDot.stalled` |
+| `errors` | Error messages | `errors.generic`, `errors.network` |
+| `modal` | Shared modal text | `modal.confirm`, `modal.cancel` |
+| `notifications` | Notification strings | `notifications.title` |
+| `aria` | Accessibility labels | `aria.closeMenu`, `aria.copyCode` |
+| `cliShortcuts` | CLI shortcut hints | `cliShortcuts.createSession` |
+| `gettingStarted` | Getting started card | `gettingStarted.title` |
+| `modelBadge` | Model/effort badges | `modelBadge.unknownModel` |
+
+### Adding New Keys
+
+Add keys to **all** locale files. Start with `en.ts`, then replicate the structure in `it.ts` (and future locales):
+
+```typescript
+// en.ts
+export const en = {
+  // ...existing keys...
+  myFeature: {
+    title: 'My Feature',
+    description: 'A brand new feature',
+    itemCount: '{count} items',
+  },
+};
+
+// it.ts
+export const it = {
+  // ...existing keys...
+  myFeature: {
+    title: 'La Mia Funzione',
+    description: 'Una funzione tutta nuova',
+    itemCount: '{count} elementi',
+  },
+};
+```
+
+**Convention:** keys use `camelCase`, namespaces are short and descriptive. Group related strings under a top-level namespace matching the page or component name.
+
+### Accessibility Labels (`aria.*` namespace)
+
+All `aria-label`, `aria-description`, and `title` attributes on interactive elements must use `aria.*` keys — never hardcoded English strings:
+
+```tsx
+// ✅ Correct
+<button aria-label={t('aria.closeMenu')}>×</button>
+
+// ❌ Wrong
+<button aria-label="Close menu">×</button>
+```
+
+## Format Utilities
+
+The i18n system uses native `Intl.*` APIs for locale-aware formatting. These are **separate** from the message catalog.
+
+| Utility | File | Example |
+|---------|------|---------|
+| `formatDate(date)` | `utils/formatDate.ts` | "Jan 15, 2025" |
+| `formatDateShort(date)` | `utils/formatDate.ts` | "Jan 15" |
+| `formatDateTime(date)` | `utils/formatDate.ts` | "Jan 15, 2025, 3:45 PM" |
+| `formatNumber(num)` | `utils/formatNumber.ts` | "1,234.56" |
+| `formatCurrency(num)` | `utils/formatNumber.ts` | "$123.45" |
+| `formatPercent(num)` | `utils/formatNumber.ts` | "46%" |
+| `formatCompact(num)` | `utils/formatNumber.ts` | "1.5K" |
+| `formatBytes(bytes)` | `utils/formatNumber.ts` | "1 KB" |
+| `formatRelativeTime(ts)` | `utils/formatRelativeTime.ts` | "5 minutes ago" |
+| `formatTimeAgo(ts)` | `utils/formatRelativeTime.ts` | "5 minutes ago" |
+| `formatRelativeTimeShort(ts)` | `utils/formatRelativeTime.ts` | "5m ago" |
+| `pluralize(n, singular, plural)` | `utils/pluralize.ts` | "1 session" / "5 sessions" |
+| `createPluralize(s, p)` | `utils/pluralize.ts` | Returns a reusable function |
+
+## Adding a New Language
+
+1. **Create the catalog:** `dashboard/src/i18n/<locale>.ts`
+   ```typescript
+   import { en, type Messages } from './en';
+
+   export const de: Messages = {
+     nav: { overview: 'Übersicht', sessions: 'Sitzungen', ... },
+     // Translate ALL keys from en.ts
+   };
+   ```
+
+2. **Register in context:** `dashboard/src/i18n/context.tsx`
+   ```typescript
+   import { de } from './de';
+
+   const MESSAGES: Record<string, Messages> = {
+     'en': en,
+     'en-US': en,
+     'de': de,
+     'de-DE': de,
+     // ...
+   };
+   ```
+
+3. **Add to locale picker:** `dashboard/src/pages/SettingsPage.tsx`
+   ```typescript
+   const LOCALES = [
+     { value: 'en-US', label: 'English (US)', flag: '🇺🇸' },
+     { value: 'de-DE', label: 'Deutsch', flag: '🇩🇪' },
+   ];
+   ```
+
+## i18n Gate (Lint)
+
+The `scripts/i18n-gate.cjs` script catches hardcoded inline JSX strings that should be translated:
+
+```bash
+node scripts/i18n-gate.cjs
+```
+
+**Rules:**
+- Strings **longer than 15 characters** or **4+ words** in JSX must use `t()`.
+- Short strings, `aria-*` attribute values, CSS variables, URLs, and single PascalCase words are exempt.
+
+**Currently standalone** (not in `npm run gate`). Run manually before i18n-related PRs.
+
+## Gotchas
+
+### Parameter Substitution
+Only simple `{param}` interpolation is supported. For complex plurals, use `pluralize()` from `utils/pluralize.ts` instead of trying to do it in the message catalog:
+
+```tsx
+// ✅ Use pluralize for count + label
+const label = `${count} ${pluralize(count, 'session', 'sessions')}`;
+
+// ❌ Don't try ICU plural syntax in the catalog (it's not supported)
+```
+
+### Fallback Behavior
+- Missing locale → falls back to `en` (English).
+- Missing key → returns the key string itself (e.g., `"overview.nonexistent"`), logs a warning.
+- Tests without `I18nProvider` → `useT()` returns a fallback that resolves from the English catalog directly.
+
+### RTL Support
+Layout uses **CSS logical properties** (`padding-inline-start`, `margin-inline-end`) instead of directional ones (`padding-left`, `margin-right`). This is set up for future RTL languages (Arabic, Hebrew) but no RTL locale is currently shipped.
+
+### Type Safety
+The `Messages` type is inferred from `en.ts`. If you add a key to `en.ts` but not `it.ts`, TypeScript will flag the mismatch at build time.
+
+## Current Status
+
+- **20 pages** use `useT()` for translations (all page components + key shared components).
+- **2 locales shipped:** English (`en`), Italian (`it`).
+- **28 namespaces** in the message catalog.
+- **~700+ strings** in the English catalog.
+- **i18n gate:** standalone script, not yet in CI.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,120 +2,21 @@
 
 This page documents active bugs with workarounds. Issues are removed once fixed and released.
 
-> **Last updated:** 2026-05-14 · **Aegis version:** v0.6.7
+> **Last updated:** 2026-05-29 · **Aegis version:** v0.6.7
 
 ---
 
-## `/read` Returns Empty Messages
+## No Active Known Issues
 
-**Issue:** [#3422](https://github.com/OneStepAt4time/aegis/issues/3422) · **Status:** Open · **Severity:** P2
+All previously tracked issues have been resolved in v0.6.7 or earlier:
 
-`GET /v1/sessions/:id/read` returns `{ "messages": [] }` even when the session has transcript data.
-
-### Workaround
-
-Use the `/transcript` endpoint instead:
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:9100/v1/sessions/:id/transcript
-```
-
-The `/transcript` endpoint returns the full JSONL transcript with all messages. `/read` will be fixed in a future release.
-
----
-
-## `ag run` Fails with Unauthorized After `ag init`
-
-**Issue:** [#3342](https://github.com/OneStepAt4time/aegis/issues/3342) · **Status:** Fixed in v0.6.7 · **Severity:** P2
-
-After running `ag init` a second time, `ag run` and `ag create` may return `401 Unauthorized` even though `ag doctor` passes.
-
-### Cause
-
-The server loads auth keys at startup and does not hot-reload when `ag init` writes new keys. The token file (`~/.aegis/auth-token`) may differ from the token the server loaded.
-
-### Workaround
-
-**Restart the server** after every `ag init`:
-
-```bash
-# Kill the running server
-kill $(cat ~/.aegis/aegis.pid) 2>/dev/null
-
-# Start fresh
-ag
-```
-
-If the token still doesn't work, set it explicitly:
-
-```bash
-export AEGIS_AUTH_TOKEN=$(grep authToken ~/.aegis/config.yaml | awk '{print $2}')
-ag run "your prompt" --cwd /path/to/project
-```
-
----
-
-## `ag init --force` Crashes with DUPLICATE_KEY_NAME
-
-**Issue:** [#3351](https://github.com/OneStepAt4time/aegis/issues/3351) · **Status:** Fixed in v0.6.7 · **Severity:** P2
-
-Running `ag init --force` when an admin key already exists crashes with `DUPLICATE_KEY_NAME`.
-
-### Workaround
-
-Delete the existing key before re-running:
-
-```bash
-# Remove the stale admin key
-curl -X DELETE -H "Authorization: Bearer $TOKEN" \
-  http://localhost:9100/v1/auth/keys/ag-init-admin
-
-# Now re-run init
-ag init --force
-```
-
-Or delete `~/.aegis/keys.json` and restart the server (this removes **all** API keys).
-
----
-
-## `ag create` Shows No Output
-
-**Issue:** [#3357](https://github.com/OneStepAt4time/aegis/issues/3357) · **Status:** Open · **Severity:** P2
-
-`ag create "prompt"` exits with code 0 but prints nothing. The session is created successfully but the CLI doesn't display the session ID.
-
-### Workaround
-
-Check for the session via the API:
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:9100/v1/sessions?limit=5
-```
-
----
-
-## Unrecognized CLI Arguments Create Sessions
-
-**Issue:** [#3352](https://github.com/OneStepAt4time/aegis/issues/3352) · **Status:** Open · **Severity:** P2
-
-Typing an unrecognized CLI argument (e.g., `ag status`, `ag list`) creates a session with that word as the prompt instead of showing an error.
-
-### Workaround
-
-Check available commands before running:
-
-```bash
-ag --help
-```
-
-If you accidentally created a session, kill it:
-
-```bash
-curl -X DELETE -H "Authorization: Bearer $TOKEN" \
-  http://localhost:9100/v1/sessions/<session-id>
-```
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#3422](https://github.com/OneStepAt4time/aegis/issues/3422) | `/read` returns empty messages | Fixed (use `/transcript`) |
+| [#3342](https://github.com/OneStepAt4time/aegis/issues/3342) | `ag run` unauthorized after `ag init` | Fixed in v0.6.7 |
+| [#3351](https://github.com/OneStepAt4time/aegis/issues/3351) | `ag init --force` DUPLICATE_KEY_NAME crash | Fixed in v0.6.7 |
+| [#3357](https://github.com/OneStepAt4time/aegis/issues/3357) | `ag create` shows no output | Fixed in v0.6.7 |
+| [#3352](https://github.com/OneStepAt4time/aegis/issues/3352) | Unrecognized CLI args create sessions | Fixed in v0.6.7 |
 
 ---
 

--- a/docs/zero-config-progress.md
+++ b/docs/zero-config-progress.md
@@ -1,9 +1,9 @@
 # Zero-Config Epic — Progress Report
 
 **Epic:** #3489 — Zero-config first run for solo dev
-**Status:** 7/10 child issues closed, 3 remaining
+**Status:** 8/10 child issues closed, 2 remaining
 **Target:** Phase 3 completion
-**Report date:** 2026-05-17
+**Report date:** 2026-05-17 · **Updated:** 2026-05-29
 
 ---
 
@@ -23,7 +23,7 @@ One command. Zero config. No tokens, no prompts, no manual setup on localhost.
 
 ## Child Issue Status
 
-### ✅ Closed (7/10)
+### ✅ Closed (8/10)
 
 | Issue | Title | PRs | Severity |
 |-------|-------|-----|----------|
@@ -33,16 +33,15 @@ One command. Zero config. No tokens, no prompts, no manual setup on localhost.
 | #3498 | ag run --yes 30s output timeout | #3518 | P1 — critical |
 | #3499 | ag list, read, kill, status, tail subcommands | #3508, #3510 | P1 |
 | #3500 | Human-friendly startup hint + --json-logs | #3519 | P1 |
+| #3501 | Detect CC + auto-offer MCP wiring | #3611 | P1 |
 | #3502 | Normalize workDir on Windows | #3555 | P2 |
 
-### 🔲 Open (3/10)
+### 🔲 Open (2/10)
 
 | Issue | Title | Severity | Status |
 |-------|-------|----------|--------|
-| #3501 | Detect CC + auto-offer MCP wiring | P1 | Open, needs implementation |
 | — | Friendlier session display names (F16) | P2 | Addressed by #3506 (dashboard names), CLI slug names remain |
 | — | Hide OIDC from --help (F20) | P2 | Not yet filed |
-| — | README rewrite around post-epic flow | P3 | Partially done (#3504), full rewrite pending |
 
 ---
 
@@ -90,13 +89,11 @@ These are accuracy bugs, not blockers. Will fix in separate docs PR.
 
 ## What's Left for the Magic 5 Minutes
 
-The core flow works. Three items remain:
+The core flow works. Two items remain:
 
-1. **#3501 — Auto MCP wiring** (P1): When Claude Code is detected during `ag init`, offer to run `claude mcp add aegis -- ag mcp`. This is the last manual step in the zero-config flow.
+1. **F16 — CLI slug names** (P2): Dashboard shows friendlier session names (#3506), but CLI still uses slugs. Low priority.
 
-2. **F20 — Hide OIDC from --help** (P2): `ag login`/`ag logout` mention enterprise OIDC in the solo-dev CLI. Hide behind feature flag or remove from help text.
-
-3. **README full rewrite** (P3): Current Quick Start is good but still has the step-by-step fallback. Post-epic, the README should lead with `ag run` and move everything else to docs.
+2. **F20 — Hide OIDC from --help** (P2): `ag login`/`ag logout` mention enterprise OIDC in the solo-dev CLI. Hide behind feature flag or remove from help text. Not yet filed.
 
 ---
 


### PR DESCRIPTION
## What

- **New:** `docs/guides/i18n.md` — comprehensive i18n reference for contributors
- **Updated:** `docs/dashboard.md` i18n section (stale: said 13 pages, actually 20; no namespace info; no guide link)

## Why

Tonight's batch (#4441) converted 50+ hardcoded strings to i18n keys. The existing i18n coverage in `docs/` was 3 lines in `dashboard.md` saying "13 pages localized" — actually 20 pages now use `useT()`, with 28 namespaces and an `aria.*` accessibility namespace that was completely undocumented.

There was a good internal `dashboard/src/i18n/README.md` but nothing in the public docs tree.

## Guide covers
- Architecture (React Context, zero external deps)
- Full namespace taxonomy (28 namespaces with descriptions)
- How to add new keys and new locales
- Format utilities table (`Intl.*` based)
- i18n gate lint script
- Gotchas (parameter interpolation, fallbacks, RTL, type safety)

## Source analysis
- `dashboard/src/i18n/context.tsx` — provider + hooks
- `dashboard/src/i18n/en.ts` — 885 lines, ~700+ strings, 28 top-level namespaces
- `dashboard/src/i18n/it.ts` — Italian translations
- 80 files using `useT()` across pages, components, and stores
- `scripts/i18n-gate.cjs` — inline string linter