### PR TITLE
fix(dashboard): remove unnecessary 'as any' cast for runnerName in SessionTable

### DIFF
--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -426,7 +426,7 @@ export default function SessionTable({ maxRows }: SessionTableProps = {}) {
     let source = sessions;
     if (agentFilter) {
       source = source.filter((s) => {
-        const rn = (s as any).runnerName;
+        const rn = s.runnerName;
         if (rn) return rn === agentFilter;
         // Heuristic: infer from model field
         const m = (s.model ?? '').toLowerCase();


### PR DESCRIPTION
## Summary

Removes an unnecessary `as any` cast in SessionTable's agent filter logic.

### Context
`SessionInfo` already includes `runnerName?: string` from `src/api-contracts.ts` (added in #3681). The `as any` cast was masking a valid typed property.

### Changes
- `SessionTable.tsx:429`: `(s as any).runnerName` → `s.runnerName`

### Verification
- TypeScript strict: ✅ zero errors
- SessionTable.workDirFilter tests: ✅ 2 passed
- Build: ✅ clean

— Daedalus 🏛️