### PR TITLE
fix(dashboard): extract hardcoded strings in ActivityPage + NewSessionPage to i18n

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -121,6 +121,12 @@ export const en = {
     title: 'Live Activity',
     subtitle: 'Real-time audit stream and operational metrics.',
     empty: 'No activity yet',
+    sessionActivity: 'Session Activity',
+    sessionsAcross: '{sessions} sessions across {days} active days',
+    sessionCount: '{count} session',
+    sessionCount_plural: '{count} sessions',
+    noActivity: 'No session activity recorded yet',
+    retry: 'Retry',
   },
   
   cost: {
@@ -504,6 +510,7 @@ export const en = {
     claudeCommand: 'Claude Command',
     claudeCommandDefault: 'Default: claude --print',
     initialPrompt: 'Initial Prompt',
+    promptPlaceholder: 'What do you want to accomplish?',
     permissionMode: 'Permission Mode',
     permissionDefault: 'Default (prompt)',
     permissionBypass: 'Bypass Permissions',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -123,6 +123,12 @@ export const it = {
     title: 'Attività Live',
     subtitle: 'Flusso di audit in tempo reale e metriche operative.',
     empty: 'Nessuna attività',
+    sessionActivity: 'Attività Sessioni',
+    sessionsAcross: '{sessions} sessioni in {days} giorni attivi',
+    sessionCount: '{count} sessione',
+    sessionCount_plural: '{count} sessioni',
+    noActivity: 'Nessuna attività di sessione registrata',
+    retry: 'Riprova',
   },
 
   cost: {
@@ -506,6 +512,7 @@ export const it = {
     claudeCommand: 'Comando Claude',
     claudeCommandDefault: 'Predefinito: claude --print',
     initialPrompt: 'Prompt Iniziale',
+    promptPlaceholder: 'Cosa vuoi ottenere?',
     permissionMode: 'Modalità Permesso',
     permissionDefault: 'Predefinito (chiedi)',
     permissionBypass: 'Ignora Permessi',

--- a/dashboard/src/pages/ActivityPage.tsx
+++ b/dashboard/src/pages/ActivityPage.tsx
@@ -71,7 +71,7 @@ export default function ActivityPage() {
       {/* Page header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Live Activity</h1>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">{t('activity.title')}</h1>
           <p className="mt-1 text-sm text-[var(--color-text-muted)] flex items-center gap-2">
             {t('activity.subtitle')}
             <LiveStatusIndicator />
@@ -83,11 +83,11 @@ export default function ActivityPage() {
       <section aria-label={t('aria.activityHeatmap')}>
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-sm font-medium text-[var(--color-text-muted)]">
-            Session Activity
+            {t('activity.sessionActivity')}
           </h2>
           {!heatmapLoading && heatmapData.length > 0 && (
             <span className="text-xs text-[var(--color-text-muted)]">
-              {totalSessions} sessions across {totalActiveDays} active days
+              {t('activity.sessionsAcross', { sessions: totalSessions, days: totalActiveDays })}
             </span>
           )}
         </div>
@@ -105,19 +105,19 @@ export default function ActivityPage() {
                 className="rounded-md border border-[var(--color-void-lighter)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)] hover:border-[var(--color-text-muted)]"
                 aria-label={t('aria.retryLoadingHeatmap')}
               >
-                Retry
+                {t('activity.retry')}
               </button>
             </div>
           ) : heatmapData.length > 0 ? (
             <HeatmapGrid
               data={heatmapData}
               color="cyan"
-              metricLabel="Sessions"
-              formatValue={(v) => `${v} session${v !== 1 ? 's' : ''}`}
+              metricLabel={t('activity.sessionActivity')}
+              formatValue={(v) => t(v !== 1 ? 'activity.sessionCount_plural' : 'activity.sessionCount', { count: v })}
             />
           ) : (
             <div className="flex h-20 items-center justify-center text-sm text-[var(--color-text-muted)]">
-              No session activity recorded yet
+              {t('activity.noActivity')}
             </div>
           )}
         </div>

--- a/dashboard/src/pages/NewSessionPage.tsx
+++ b/dashboard/src/pages/NewSessionPage.tsx
@@ -257,7 +257,7 @@ export default function NewSessionPage() {
             id="prompt"
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
-            placeholder="What do you want to accomplish?"
+            placeholder={t('newSession.promptPlaceholder')}
             rows={3}
             className="w-full rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-3 py-2.5 text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-accent-cyan)] resize-y"
           />


### PR DESCRIPTION
## Summary

Follow-up to i18n scaffolding (#2235). Extracts remaining hardcoded English strings from ActivityPage and NewSessionPage into proper i18n keys with English + Italian translations.

### Changes
- **ActivityPage.tsx**: 7 hardcoded strings →  calls
  - Page title, section heading, session summary, heatmap metric label, empty state, retry button
- **NewSessionPage.tsx**: 1 hardcoded string →  call
  - Prompt textarea placeholder

### New i18n keys
- , , , , , 
- 

### Verification
- TypeScript strict: ✅ zero errors
- Build: ✅ clean (bundle unchanged)

— Daedalus 🏛️