### PR TITLE
fix(dashboard): wire i18n resolver into test mocks — kill recurring CI flake

### DIFF
--- a/dashboard/src/__tests__/i18n-test-helper.ts
+++ b/dashboard/src/__tests__/i18n-test-helper.ts
@@ -1,0 +1,37 @@
+/**
+ * i18n test helper — resolves translation keys from the English catalog.
+ *
+ * Use in vi.mock() to make tests assert against real user-facing text
+ * instead of raw i18n keys like 'activity.noActivity'.
+ *
+ * Usage:
+ *   vi.mock('../../i18n/context', () => {
+ *     const { testT } = await import('../../__tests__/i18n-test-helper');
+ *     return { useT: () => testT };
+ *   });
+ */
+import { en } from '../i18n/en';
+
+function resolve(obj: unknown, key: string): string {
+  const parts = key.split('.');
+  let result: unknown = obj;
+  for (const part of parts) {
+    if (result && typeof result === 'object' && part in (result as Record<string, unknown>)) {
+      result = (result as Record<string, unknown>)[part];
+    } else {
+      return key; // key not found, return as-is
+    }
+  }
+  return typeof result === 'string' ? result : key;
+}
+
+/** test-compatible `t()` that resolves from the English catalog. */
+export const testT = (key: string, params?: Record<string, string | number>): string => {
+  let result = resolve(en, key);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      result = result.replace(`{${k}}`, String(v));
+    }
+  }
+  return result;
+};

--- a/dashboard/src/components/__tests__/ToastContainer.test.tsx
+++ b/dashboard/src/components/__tests__/ToastContainer.test.tsx
@@ -24,9 +24,10 @@ vi.mock('../../store/useToastStore', () => ({
     }),
 }));
 
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 vi.mock('lucide-react', () => ({
   X: (props: any) => <svg data-testid="icon-x" {...props} />,
@@ -104,7 +105,7 @@ describe('ToastContainer', () => {
   it('dismiss button calls removeToast with toast id', () => {
     mockToasts = [{ id: 't1', type: 'success', title: 'Dismiss me' }];
     render(<ToastContainer />);
-    const dismissBtn = screen.getByLabelText('aria.dismiss');
+    const dismissBtn = screen.getByLabelText('Dismiss');
     fireEvent.click(dismissBtn);
     expect(mockRemoveToast).toHaveBeenCalledWith('t1');
   });
@@ -115,7 +116,7 @@ describe('ToastContainer', () => {
       { id: 't2', type: 'error', title: 'Second' },
     ];
     render(<ToastContainer />);
-    fireEvent.click(screen.getByLabelText('aria.dismissAll'));
+    fireEvent.click(screen.getByLabelText('Dismiss all notifications'));
     expect(mockRemoveToast).toHaveBeenCalledTimes(2);
     expect(mockRemoveToast).toHaveBeenCalledWith('t1');
     expect(mockRemoveToast).toHaveBeenCalledWith('t2');
@@ -133,7 +134,7 @@ describe('ToastContainer', () => {
     const undoFn = vi.fn();
     mockToasts = [{ id: 't1', type: 'undo', title: 'Deleted', undoAction: undoFn }];
     render(<ToastContainer />);
-    const undoBtn = screen.getByLabelText('aria.undo');
+    const undoBtn = screen.getByLabelText('Undo');
     expect(undoBtn).not.toBeNull();
   });
 
@@ -141,14 +142,14 @@ describe('ToastContainer', () => {
     const undoFn = vi.fn();
     mockToasts = [{ id: 't1', type: 'undo', title: 'Deleted', undoAction: undoFn }];
     render(<ToastContainer />);
-    fireEvent.click(screen.getByLabelText('aria.undo'));
+    fireEvent.click(screen.getByLabelText('Undo'));
     expect(undoFn).toHaveBeenCalledOnce();
     expect(mockRemoveToast).toHaveBeenCalledWith('t1');
   });
 
   it('no undo button when undoAction is absent', () => {
     mockToasts = [{ id: 't1', type: 'info', title: 'No undo' }];
-    expect(screen.queryByLabelText('aria.undo')).toBeNull();
+    expect(screen.queryByLabelText('Undo')).toBeNull();
   });
 
   it('progress bar starts at 100% width', () => {

--- a/dashboard/src/components/analytics/__tests__/RateLimitChart.test.tsx
+++ b/dashboard/src/components/analytics/__tests__/RateLimitChart.test.tsx
@@ -12,9 +12,10 @@ vi.mock('../../../utils/chartTheme', () => ({
   CHART_RGB: { cyan: '6,182,212', warning: '245,158,11', danger: '239,68,68' },
 }));
 
-vi.mock('../../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 const sampleData: RateLimitKeyUsage[] = [
   {

--- a/dashboard/src/components/layout/__tests__/Header.test.tsx
+++ b/dashboard/src/components/layout/__tests__/Header.test.tsx
@@ -11,9 +11,10 @@ vi.mock('../../store/useDrawerStore.js', () => ({
   useDrawerStore: (sel: (s: Record<string, unknown>) => unknown) => sel({ openNewSession: vi.fn() }),
 }));
 
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 vi.mock('../shared/Breadcrumb.tsx', () => ({
   default: () => <nav data-testid="breadcrumb">Breadcrumb</nav>,

--- a/dashboard/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/dashboard/src/components/layout/__tests__/Sidebar.test.tsx
@@ -9,9 +9,10 @@ vi.mock('../../store/useAuthStore.js', () => ({
   }),
 }));
 
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 vi.mock('../shared/ServerHealthIndicator.tsx', () => ({
   ServerHealthDot: () => <div data-testid="health-dot">Health</div>,

--- a/dashboard/src/components/overview/__tests__/HomeStatusPanel.test.tsx
+++ b/dashboard/src/components/overview/__tests__/HomeStatusPanel.test.tsx
@@ -23,9 +23,10 @@ vi.mock('../../api/client.js', () => ({
   }),
 }));
 
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 vi.mock('./RealtimeBadge.js', () => ({
   default: () => <span data-testid="realtime-badge">RT</span>,

--- a/dashboard/src/components/session/__tests__/AuditTrailPanel.test.tsx
+++ b/dashboard/src/components/session/__tests__/AuditTrailPanel.test.tsx
@@ -3,9 +3,10 @@ import { render, screen } from '@testing-library/react';
 import { AuditTrailPanel } from '../AuditTrailPanel';
 import type { AuditRecord } from '../../../types';
 
-vi.mock('../../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 const mockRecords: AuditRecord[] = [
   {
@@ -114,6 +115,6 @@ describe('AuditTrailPanel', () => {
     render(
       <AuditTrailPanel records={mockRecords} loading={false} error={null} />
     );
-    expect(screen.getByRole('list').getAttribute('aria-label')).toBe('aria.auditTrail');
+    expect(screen.getByRole('list').getAttribute('aria-label')).toBe('Audit trail');
   });
 });

--- a/dashboard/src/components/session/__tests__/SessionHeader.test.tsx
+++ b/dashboard/src/components/session/__tests__/SessionHeader.test.tsx
@@ -8,9 +8,10 @@ import type { SessionInfo, SessionHealth } from '../../../types';
 
 // ── Mocks ──────────────────────────────────────────────────
 
-vi.mock('../../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 vi.mock('lucide-react', () => ({
   GitFork: (props: any) => <svg data-testid="icon-gitfork" {...props} />,
@@ -190,7 +191,7 @@ describe('SessionHeader', () => {
 
   it('renders overflow menu button', () => {
     render(<SessionHeader session={baseSession} health={baseHealth} />);
-    expect(screen.getByLabelText('aria.moreActions')).not.toBeNull();
+    expect(screen.getByLabelText('More session actions')).not.toBeNull();
   });
 
   it('overflow menu opens and shows Save as Template when handler provided', () => {
@@ -202,7 +203,7 @@ describe('SessionHeader', () => {
         onSaveTemplate={onSaveTemplate}
       />,
     );
-    fireEvent.click(screen.getByLabelText('aria.moreActions'));
+    fireEvent.click(screen.getByLabelText('More session actions'));
     expect(screen.getByText('Save as Template')).not.toBeNull();
   });
 
@@ -215,7 +216,7 @@ describe('SessionHeader', () => {
         onFork={onFork}
       />,
     );
-    fireEvent.click(screen.getByLabelText('aria.moreActions'));
+    fireEvent.click(screen.getByLabelText('More session actions'));
     expect(screen.getByText('Fork')).not.toBeNull();
   });
 
@@ -228,7 +229,7 @@ describe('SessionHeader', () => {
         onKill={onKill}
       />,
     );
-    fireEvent.click(screen.getByLabelText('aria.moreActions'));
+    fireEvent.click(screen.getByLabelText('More session actions'));
     expect(screen.getByText('Kill Session')).not.toBeNull();
   });
 

--- a/dashboard/src/components/session/__tests__/StreamTab.test.tsx
+++ b/dashboard/src/components/session/__tests__/StreamTab.test.tsx
@@ -21,9 +21,10 @@ vi.mock("../StreamSplitView", () => ({
   ),
 }));
 
-vi.mock("../../../i18n/context", () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 function renderStreamTab(initialView?: string) {
   const search = initialView ? `?view=${initialView}` : "";

--- a/dashboard/src/components/shared/Breadcrumb.test.tsx
+++ b/dashboard/src/components/shared/Breadcrumb.test.tsx
@@ -6,9 +6,10 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Breadcrumb from './Breadcrumb';
 
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 function renderWithPath(path: string) {
   return render(
@@ -41,7 +42,7 @@ describe('Breadcrumb', () => {
   it('has nav with aria-label', () => {
     renderWithPath('/audit');
     const nav = screen.getByRole('navigation');
-    expect(nav.getAttribute('aria-label')).toBe('aria.breadcrumb');
+    expect(nav.getAttribute('aria-label')).toBe('Breadcrumb');
   });
 
   it('last crumb is plain text (no link)', () => {

--- a/dashboard/src/components/shared/CodeBlock.test.tsx
+++ b/dashboard/src/components/shared/CodeBlock.test.tsx
@@ -5,9 +5,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CodeBlock, RenderWithCodeBlocks } from './CodeBlock';
 
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 Object.assign(navigator, {
   clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
@@ -32,7 +33,7 @@ describe('CodeBlock', () => {
 
   it('copy button has aria-label', () => {
     render(<CodeBlock code="test" language="bash" />);
-    expect(screen.getByLabelText('aria.copyCode')).not.toBeNull();
+    expect(screen.getByLabelText('Copy code')).not.toBeNull();
   });
 
   it('highlights keywords using CSS class', () => {

--- a/dashboard/src/components/shared/__tests__/CommandPalette.test.tsx
+++ b/dashboard/src/components/shared/__tests__/CommandPalette.test.tsx
@@ -35,9 +35,10 @@ vi.mock('../../../hooks/useFocusTrap', () => ({
   useFocusTrap: () => ({ current: null }),
 }));
 
-vi.mock('../../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 function renderPalette(open = true) {
   return render(

--- a/dashboard/src/components/shared/__tests__/NLFilterBar.test.tsx
+++ b/dashboard/src/components/shared/__tests__/NLFilterBar.test.tsx
@@ -8,9 +8,10 @@ vi.mock('../../Icon', () => ({
   ),
 }));
 
-vi.mock('../../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 describe('parseNLQuery', () => {
   it('parses status keywords', () => {
@@ -133,12 +134,12 @@ describe('NLFilterBar', () => {
 
   it('renders with placeholder', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    expect(screen.getByLabelText('aria.naturalLanguageFilter')).toBeDefined();
+    expect(screen.getByLabelText('Natural language filter')).toBeDefined();
   });
 
   it('commits filter on Enter', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(onFilter).toHaveBeenCalledWith(
@@ -151,7 +152,7 @@ describe('NLFilterBar', () => {
 
   it('commits filter on comma', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: ',' });
     expect(onFilter).toHaveBeenCalled();
@@ -159,7 +160,7 @@ describe('NLFilterBar', () => {
 
   it('does not commit filter on blur (removed auto-commit)', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'today' } });
     fireEvent.blur(input);
     expect(onFilter).not.toHaveBeenCalled();
@@ -167,14 +168,14 @@ describe('NLFilterBar', () => {
 
   it('does not commit on blur when input is empty', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.blur(input);
     expect(onFilter).not.toHaveBeenCalled();
   });
 
   it('displays chips after commit', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(screen.getByText('status: active')).toBeDefined();
@@ -182,7 +183,7 @@ describe('NLFilterBar', () => {
 
   it('removes chip on chip button click', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     // Find remove button for the chip
@@ -193,7 +194,7 @@ describe('NLFilterBar', () => {
 
   it('removes last chip on Backspace with empty input', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     // Now input is empty, backspace should remove last chip
@@ -203,30 +204,30 @@ describe('NLFilterBar', () => {
 
   it('shows clear all button when chips exist', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(screen.getByLabelText('aria.clearAllFilters')).toBeDefined();
+    expect(screen.getByLabelText('Clear all filters')).toBeDefined();
   });
 
   it('clears all chips on clear button click', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: 'Enter' });
-    fireEvent.click(screen.getByLabelText('aria.clearAllFilters'));
+    fireEvent.click(screen.getByLabelText('Clear all filters'));
     expect(onFilter).toHaveBeenCalledWith([], '');
   });
 
   it('uses custom placeholder', () => {
     render(<NLFilterBar onFilter={onFilter} placeholder="Custom placeholder" />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     expect(input.getAttribute('placeholder')).toBe('Custom placeholder');
   });
 
   it('switches placeholder to "Add filter…" after first chip', () => {
     render(<NLFilterBar onFilter={onFilter} />);
-    const input = screen.getByLabelText('aria.naturalLanguageFilter');
+    const input = screen.getByLabelText('Natural language filter');
     fireEvent.change(input, { target: { value: 'active' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(input.getAttribute('placeholder')).toBe('Add filter…');

--- a/dashboard/src/pages/__tests__/ActivityPage.test.tsx
+++ b/dashboard/src/pages/__tests__/ActivityPage.test.tsx
@@ -11,9 +11,10 @@ vi.mock('../../api/client', () => ({
 }));
 
 // Mock i18n
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 // Mock child components that make their own API calls
 vi.mock('../../components/overview/MetricCards', () => ({

--- a/dashboard/src/pages/__tests__/SessionsPage.test.tsx
+++ b/dashboard/src/pages/__tests__/SessionsPage.test.tsx
@@ -32,9 +32,10 @@ vi.mock('../../components/shared/Skeleton', () => ({
   SkeletonTable: () => <div data-testid="skeleton">Loading skeleton</div>,
 }));
 
-vi.mock('../../i18n/context', () => ({
-  useT: () => (key: string) => key,
-}));
+vi.mock('../../i18n/context', async () => {
+  const { testT } = await import('../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
 
 import SessionsPage from '../SessionsPage';
 


### PR DESCRIPTION
## Summary

Fixes the recurring `test (ubuntu-latest, 20)` failures that hit every dashboard PR after i18n string extraction.

### Root Cause
14 test files mocked `useT()` as `(key) => key`, returning raw i18n key names. This worked when components had hardcoded English text, but broke as strings migrated to `t()` calls — tests searched for translated English text that the mock never rendered.

### Fix
- **New shared helper**: `src/__tests__/i18n-test-helper.ts` — `testT` resolves keys from the English catalog with parameter interpolation
- **14 test files**: switched from `(key) => key` mock to `testT` resolver
- **6 test files**: updated assertions from key names to real English text (e.g. `'aria.moreActions'` → `'More session actions'`)

### Verification
- 14 test files, 166 tests — all green
- TypeScript strict: 0 errors
- Build: clean

This should be the last of the i18n-related CI flakes.

— Daedalus 🏛️