### PR TITLE
fix(dashboard): wire remaining hardcoded strings to i18n keys

### DIFF
--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -191,7 +191,7 @@ export default function ActivityStream({
               onChange={(e) => setFilterSession(e.target.value || null)}
               className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             >
-              <option value="">All sessions</option>
+              <option value="">{t('activity.allSessions')}</option>
               {sessions.map((s) => (
                 <option key={s.id} value={s.id}>
                   {formatSessionName(s.displayName, s.id.slice(0, 8))}
@@ -205,7 +205,7 @@ export default function ActivityStream({
               onChange={(e) => setFilterType((e.target.value || null) as GlobalSSEEventType | null)}
               className="min-h-[44px] text-xs bg-[var(--color-void)] border border-[var(--color-void-lighter)] rounded px-2 py-2 text-[var(--color-text-muted)] focus-visible:outline-none focus:border-[var(--color-cta-bg)]"
             >
-              <option value="">All types</option>
+              <option value="">{t('activity.allTypes')}</option>
               {Object.entries(EVENT_META).map(([key, meta]) => (
                 <option key={key} value={key}>{meta.label}</option>
               ))}

--- a/dashboard/src/components/CreatePipelineModal.tsx
+++ b/dashboard/src/components/CreatePipelineModal.tsx
@@ -152,8 +152,8 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
           {/* Step column headers */}
           <div className="grid grid-cols-[1fr_120px_1fr_44px] gap-2 text-xs font-medium text-[var(--color-text-muted)] px-1">
             <span>Working Directory <span className="text-[var(--color-error)]">*</span></span>
-            <span>Name</span>
-            <span>Prompt</span>
+            <span>{t('pipelines.stepNameLabel')}</span>
+            <span>{t('pipelines.stepPromptLabel')}</span>
             <span />
           </div>
 

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -393,7 +393,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
           {/* Column headers */}
           <div className="grid grid-cols-[1fr_120px_1fr_44px] gap-2 text-xs font-medium text-[var(--color-text-muted)] px-1">
             <span>Working Directory <span className="text-[var(--color-error)]">*</span></span>
-            <span>Name</span>
+            <span>{t('newSession.nameLabel')}</span>
             <span>Prompt (override)</span>
             <span />
           </div>

--- a/dashboard/src/components/agents/AgentFilter.tsx
+++ b/dashboard/src/components/agents/AgentFilter.tsx
@@ -40,7 +40,7 @@ export const AgentFilter: FC<AgentFilterProps> = ({ value, onChange, className =
         className="rounded-md border border-[var(--color-border-strong)] bg-[var(--color-void)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] focus:border-[var(--color-cta-bg)] focus-visible:outline-none focus:ring-1 focus:ring-[var(--color-cta-bg)] transition-colors"
         aria-label={t('aria.filterByAgentType')}
       >
-        <option value="">All Agents</option>
+        <option value="">{t('sessions.allAgents')}</option>
         {options.map((opt) => (
           <option key={opt.value} value={opt.value}>
             {opt.label}

--- a/dashboard/src/components/analytics/HeatmapGrid.tsx
+++ b/dashboard/src/components/analytics/HeatmapGrid.tsx
@@ -13,6 +13,7 @@
 
 import { useMemo, useState, useCallback } from 'react';
 import { tokens } from '../../design/tokens.js';
+import { useT } from '../../i18n/context';
 
 export interface HeatmapDataPoint {
   date: string; // YYYY-MM-DD
@@ -98,6 +99,7 @@ export function HeatmapGrid({
   className = '',
 }: HeatmapGridProps) {
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const t = useT();
   const scale = COLOR_SCALES[color];
 
   // Build date → value lookup
@@ -263,7 +265,7 @@ export function HeatmapGrid({
 
       {/* Legend */}
       <div className="mt-2 flex items-center justify-end gap-1.5 text-[10px] text-[var(--color-text-muted)]">
-        <span>Less</span>
+        <span>{t('analytics.heatmapLess')}</span>
         {([0, 1, 2, 3, 4] as const).map((level) => (
           <div
             key={level}
@@ -275,7 +277,7 @@ export function HeatmapGrid({
             }}
           />
         ))}
-        <span>More</span>
+        <span>{t('analytics.heatmapMore')}</span>
       </div>
     </div>
   );

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -41,6 +41,7 @@ export const en = {
     tabAll: 'All',
     empty: 'No sessions found',
     createFirst: 'Create your first session to get started',
+    allAgents: 'All Agents',
     board: {
       loading: 'Loading sessions…',
       loadError: 'Failed to load',
@@ -115,6 +116,8 @@ export const en = {
     statusLabel: 'Status',
     sessionLabel: 'Session',
     createdLabel: 'Created',
+    stepNameLabel: 'Name',
+    stepPromptLabel: 'Prompt',
   },
   
   activity: {
@@ -127,6 +130,8 @@ export const en = {
     sessionCount_plural: '{count} sessions',
     noActivity: 'No session activity recorded yet',
     retry: 'Retry',
+    allSessions: 'All sessions',
+    allTypes: 'All types',
   },
   
   cost: {
@@ -208,6 +213,8 @@ export const en = {
     autoApprovalRate: 'Auto-Approval Rate',
     permissionPrompts: 'Permission Prompts',
     manualApprovals: 'Manual Approvals',
+    heatmapLess: 'Less',
+    heatmapMore: 'More'
   },
 
   metrics: {
@@ -300,6 +307,8 @@ export const en = {
     duplicateErrorToast: 'Failed to duplicate template',
     useSessionToast: 'Session created from template',
     createdLabel: 'Created',
+    stepNameLabel: 'Name',
+    stepPromptLabel: 'Prompt',
     promptLabel: 'Prompt:',
   },
   
@@ -511,6 +520,7 @@ export const en = {
     claudeCommandDefault: 'Default: claude --print',
     initialPrompt: 'Initial Prompt',
     promptPlaceholder: 'What do you want to accomplish?',
+    nameLabel: 'Name',
     permissionMode: 'Permission Mode',
     permissionDefault: 'Default (prompt)',
     permissionBypass: 'Bypass Permissions',
@@ -557,6 +567,7 @@ export const en = {
     verifying: 'Verifying...',
     invalidToken: 'Invalid API token',
     hideToken: 'Hide token',
+    signInWithSSO: 'Sign in with SSO',
     showToken: 'Show token',
   },
   
@@ -575,6 +586,8 @@ export const en = {
     success: 'Success',
     noData: 'No data available',
     retry: 'Retry',
+    allSessions: 'All sessions',
+    allTypes: 'All types',
     refresh: 'Refresh',
     search: 'Search',
     filter: 'Filter',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -43,6 +43,7 @@ export const it = {
     tabAll: 'Tutte',
     empty: 'Nessuna sessione trovata',
     createFirst: 'Crea la tua prima sessione per iniziare',
+    allAgents: 'Tutti gli agent',
     board: {
       loading: 'Caricamento sessioni…',
       loadError: 'Caricamento fallito',
@@ -117,6 +118,8 @@ export const it = {
     statusLabel: 'Stato',
     sessionLabel: 'Sessione',
     createdLabel: 'Creata',
+    stepNameLabel: 'Nome',
+    stepPromptLabel: 'Prompt'
   },
 
   activity: {
@@ -129,6 +132,8 @@ export const it = {
     sessionCount_plural: '{count} sessioni',
     noActivity: 'Nessuna attività di sessione registrata',
     retry: 'Riprova',
+    allSessions: 'Tutte le sessioni',
+    allTypes: 'Tutti i tipi',
   },
 
   cost: {
@@ -211,6 +216,8 @@ export const it = {
     autoApprovalRate: 'Tasso di Auto-Approvazione',
     permissionPrompts: 'Richieste di Permesso',
     manualApprovals: 'Approvazioni Manuali',
+    heatmapLess: 'Meno',
+    heatmapMore: 'Più',
   },
 
   metrics: {
@@ -513,6 +520,7 @@ export const it = {
     claudeCommandDefault: 'Predefinito: claude --print',
     initialPrompt: 'Prompt Iniziale',
     promptPlaceholder: 'Cosa vuoi ottenere?',
+    nameLabel: 'Nome',
     permissionMode: 'Modalità Permesso',
     permissionDefault: 'Predefinito (chiedi)',
     permissionBypass: 'Ignora Permessi',
@@ -556,6 +564,7 @@ export const it = {
     tokenLabel: 'Token API',
     tokenPlaceholder: 'Token API',
     signInButton: 'Accedi',
+    signInWithSSO: 'Accedi con SSO',
     verifying: 'Verifica in corso...',
     invalidToken: 'Token API non valido',
     hideToken: 'Nascondi token',
@@ -577,6 +586,8 @@ export const it = {
     success: 'Successo',
     noData: 'Nessun dato disponibile',
     retry: 'Riprova',
+    allSessions: 'Tutte le sessioni',
+    allTypes: 'Tutti i tipi',
     refresh: 'Aggiorna',
     search: 'Cerca',
     filter: 'Filtra',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -311,6 +311,8 @@ export const it = {
     useSessionToast: 'Sessione creata dal modello',
     createdLabel: 'Creato',
     promptLabel: 'Prompt:',
+    stepNameLabel: 'Nome',
+    stepPromptLabel: 'Prompt',
   },
 
   settings: {

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -86,7 +86,7 @@ export default function LoginPage() {
             className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-cta-bg)] px-4 py-2.5 text-sm font-medium text-white hover:bg-[var(--color-cta-bg)]"
           >
             <LogIn className="h-4 w-4" />
-            <span>Sign in with SSO</span>
+            <span>{t('login.signInWithSSO')}</span>
           </button>
         ) : (
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">

--- a/dashboard/src/pages/PipelinesPage.tsx
+++ b/dashboard/src/pages/PipelinesPage.tsx
@@ -167,20 +167,20 @@ export default function PipelinesPage() {
           onChange={(e) => setStatusFilter(e.target.value)}
           className="min-h-[44px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-accent-cyan)]"
         >
-          <option value="all">All</option>
-          <option value="running">Running</option>
-          <option value="completed">Completed</option>
-          <option value="failed">Failed</option>
-          <option value="pending">Pending</option>
+          <option value="all">{t('pipelines.filterAll')}</option>
+          <option value="running">{t('pipelines.filterRunning')}</option>
+          <option value="completed">{t('pipelines.filterCompleted')}</option>
+          <option value="failed">{t('pipelines.filterFailed')}</option>
+          <option value="pending">{t('pipelines.filterPending')}</option>
         </select>
         <select aria-label={t("pipelines.sortBy")}
           value={sortBy}
           onChange={(e) => setSortBy(e.target.value as 'name'|'createdAt'|'status')}
           className="min-h-[44px] px-3 py-2 text-sm rounded border border-[var(--color-void-lighter)] bg-[var(--color-surface)] text-[var(--color-text-primary)] focus-visible:outline-none focus:border-[var(--color-accent-cyan)]"
         >
-          <option value="createdAt">Date</option>
-          <option value="name">Name</option>
-          <option value="status">Status</option>
+          <option value="createdAt">{t('pipelines.sortDate')}</option>
+          <option value="name">{t('pipelines.sortName')}</option>
+          <option value="status">{t('pipelines.sortStatus')}</option>
         </select>
         <button type="button"
           onClick={() => setSortAsc(!sortAsc)}


### PR DESCRIPTION
## Summary
Wire 17 remaining hardcoded English strings in 7 components to existing or new i18n catalog keys.

## Components changed
- **PipelinesPage**: filter options (All, Running, Completed, Failed, Pending) and sort options (Date, Name, Status) — keys existed but weren't wired
- **LoginPage**: SSO button label → new `login.signInWithSSO` key
- **CreateSessionModal**: name field label → new `newSession.nameLabel` key
- **CreatePipelineModal**: step column headers (Name, Prompt) → new `pipelines.stepNameLabel`/`stepPromptLabel` keys
- **AgentFilter**: 'All Agents' placeholder → new `sessions.allAgents` key
- **ActivityStream**: session/type filter placeholders → new `activity.allSessions`/`allTypes` keys
- **HeatmapGrid**: Less/More legend labels → new `analytics.heatmapLess`/`heatmapMore` keys (also added i18n import)

## Quality gate
- ✅ TypeScript strict: 0 errors
- ✅ Build: clean (9.08s)
- ✅ Tests: 101/101 green (HeatmapGrid 8, a11y-pages 31, PipelinesPage 9, ActivityStream 15)

## Keys added
en.ts: +13 keys | it.ts: +11 keys