### PR TITLE
fix(ci): use du --apparent-size in bundle size gate

### DIFF
--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -9,7 +9,7 @@ if [ ! -d "dist" ]; then
   exit 1
 fi
 
-SERVER_SIZE=$(find dist/ -name "*.js" ! -path "*/__tests__/*" ! -path "*/dashboard/*" -exec du -ck {} + | tail -1 | awk '{print $1}')
+SERVER_SIZE=$(find dist/ -name "*.js" ! -path "*/__tests__/*" ! -path "*/dashboard/*" -exec du --apparent-size -ck {} + | tail -1 | awk '{print $1}')
 SERVER_SIZE_KB=$((SERVER_SIZE))
 
 echo "Bundle size: ${SERVER_SIZE_KB}KB (threshold: ${THRESHOLD_KB}KB)"


### PR DESCRIPTION
## Summary
Closes #4451

The bundle size gate was using plain `du -ck` which reports 4KB block allocation instead of actual file content bytes. With 266 compiled JS files, block rounding added ~577KB (29.7%) of phantom overhead.

### Before
```
du -ck: 2516 KB → ❌ fails (threshold 2508 KB)
```

### After
```
du --apparent-size -ck: 1940 KB → ✅ passes (568 KB under threshold)
```

### Changes
- Single change: add `--apparent-size` flag to `du` in `scripts/check-bundle-size.sh`

### Testing
- [x] `npm run build` succeeds
- [x] `bash scripts/check-bundle-size.sh` passes (1940 KB)
- [x] No code changes — CI gate script only