### PR TITLE
docs: rewrite onboarding.md for zero-config ag run flow

### DIFF
--- a/docs/competitive-intel/cc-v2.1.153-156.md
+++ b/docs/competitive-intel/cc-v2.1.153-156.md
@@ -1,0 +1,54 @@
+# CC v2.1.153–156 Intel — 2026-05-29
+
+> Claude Code released 3 versions in 48 hours (May 28-29). Key changes affecting Aegis positioning.
+
+## ⚠️ Competitive Threats
+
+### Dynamic Workflows (v2.1.154)
+Claude Code now has **native multi-agent orchestration**: "ask Claude to create a workflow and it orchestrates work across tens to hundreds of agents in the background."
+
+- `/workflows` command to view runs
+- This competes directly with Aegis pipelines
+- **Impact:** High. Aegis must differentiate on control plane features (RBAC, audit, approval gates, cost tracking) that native CC workflows won't have.
+
+### `claude agents` + Background Sessions
+- `! <command>` runs shell commands as background sessions with attach/detach
+- `claude --bg --exec '<command>'` for programmatic background runs
+- `claude agents` view with PR tracking, session management
+- **Impact:** Medium. More native session management, but still single-user, no approval gates, no REST API, no multi-agent coordination.
+
+### Lean System Prompt Default
+- Lean prompt now default for all models except Haiku, Sonnet, and Opus ≤4.7
+- **Impact:** Low for Aegis. Our value is orchestration, not prompt efficiency.
+
+## 🟢 Opportunities for Aegis
+
+### MCP Session Context
+- Stdio MCP servers now receive `CLAUDE_CODE_SESSION_ID` and `CLAUDECODE=1` env vars
+- **Opportunity:** Aegis MCP bridge can use this for session-aware orchestration
+
+### Opus 4.8 Support
+- New model, high effort default, fast mode at 2x rate for 2.5x speed
+- **Action:** Update Aegis model picker and docs to reference Opus 4.8
+
+### Strict MCP Config
+- `--strict-mcp-config` security tightening for subagent MCP access
+- **Opportunity:** Aegis already enforces MCP security via RBAC — reinforce in positioning
+
+### `/simplify` Command
+- Runs cleanup-only review (reuse, simplification, efficiency)
+- **Opportunity:** Template idea for Aegis — pre-built quality gate templates
+
+## Non-Impactful
+
+- Opus 4.8 thinking block fix (v2.1.156) — bug fix, no positioning impact
+- Plugin `defaultEnabled: false` — plugin marketplace feature
+- Chrome browser selection — UX improvement
+- Many bug fixes for background sessions stability
+
+## Recommended Actions
+
+1. **Update competitive-threat-matrix.md** — add Dynamic Workflows as a CC native feature
+2. **Reinforce Aegis differentiators** — RBAC, cost tracking, audit trail, approval gates, REST API, multi-user
+3. **Update model docs** — Opus 4.8 references
+4. **Consider pipeline positioning** — CC workflows are in-product; Aegis pipelines need a clear advantage story (cross-tool orchestration, CI/CD integration, policy enforcement)

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,6 +1,6 @@
 # Aegis Onboarding Guide
 
-Welcome to Aegis. This guide gets you from zero to running your first session in 5 minutes.
+Welcome to Aegis. This guide gets you from zero to running your first Claude Code session in under 5 minutes.
 
 ## What is Aegis?
 
@@ -14,25 +14,88 @@ Aegis is a **Claude Code control plane** — a self-hosted server that manages C
 
 ## Prerequisites
 
-- **Node.js 20+**
-- **Claude Code CLI** installed and configured (`claude --version`)
+| Requirement | Minimum Version | Check Command |
+|---|---|---|
+| Node.js | ≥ 20 | `node --version` |
+| Claude Code CLI | ≥ 2.1.145 | `claude --version` |
+| Claude Code auth | Logged in | `claude auth status` |
 
 Aegis bundles `claude-agent-acp` — no tmux or psmux required on any platform.
 
-## Quick Start
+> **Before you start:** Claude Code must be authenticated. Run `claude auth status` — if it shows "Not logged in", run `claude login` first. Sessions created without Claude auth will silently produce no output.
+
+## Quick Start (1 command)
 
 ```bash
-# 1. Install Aegis
+npx --package=@onestepat4time/aegis ag run "Summarize this folder" --cwd ./my-project
+```
+
+That's it. Behind the scenes, `ag run`:
+1. Bootstraps config (first run only — no auth prompts on localhost)
+2. Starts the server on `http://127.0.0.1:9100`
+3. Creates a Claude Code session
+4. Streams Claude's response to your terminal
+
+When Claude needs permission (to run a command, write a file), you'll see a prompt right in your terminal.
+
+> **Zero-config on localhost:** When the server host is `localhost`, `127.0.0.1`, or `::1`, no auth tokens are needed. Aegis auto-configures for local use. No setup, no prompts.
+>
+> **System temp dirs are blocked:** `/tmp`, `/var/tmp` are not allowed as workDir for security. Run from your project directory or home folder.
+
+Open **http://127.0.0.1:9100/dashboard/** in your browser to see your session with live status, cost tracking, and transcript.
+
+## Step-by-Step Setup (alternative)
+
+If you prefer to control each step separately:
+
+### 1. Install Aegis
+
+```bash
 npm install -g @onestepat4time/aegis
+```
 
-# 2. Bootstrap configuration (creates ~/.aegis/config.json)
+### 2. Bootstrap configuration
+
+```bash
 ag init
+```
 
-# 3. Start the server
+`ag init` scaffolds `.aegis/config.yaml` with sensible defaults, auto-detects a free port (9100 default), and — if Claude Code is on your PATH — automatically offers to register Aegis as an MCP server in Claude Code.
+
+```bash
+ag init --yes       # Non-interactive — use all defaults, auto-wire MCP
+ag init --force     # Overwrite existing config
+ag init --no-start  # Scaffold config only (don't start the server)
+ag init --no-open   # Start server but skip opening the browser
+```
+
+> **Zero-config on localhost:** On `localhost`, `127.0.0.1`, or `::1`, `ag init` skips admin token creation. No auth setup needed.
+>
+> **Warning:** Running `ag init` a second time overwrites `.aegis/config.yaml` and regenerates auth keys. You must restart the server for the new keys to take effect — the running server does not hot-reload keys from disk.
+
+### 3. Start the server
+
+```bash
 ag
 ```
 
-The server starts on `http://localhost:9100`. Open `http://localhost:9100/dashboard/` for the web UI.
+The server starts on `http://localhost:9100`. Verify:
+
+```bash
+curl http://localhost:9100/v1/health
+```
+
+### 4. Run your first session
+
+```bash
+# Via CLI (streams output to terminal)
+ag run "Review the PR and summarize the changes" --cwd /path/to/project
+
+# Via API
+curl -X POST http://localhost:9100/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"workDir": "/path/to/project", "prompt": "Review the PR and summarize the changes"}'
+```
 
 ## Core Concepts
 
@@ -43,15 +106,6 @@ A **session** is one Claude Code process managed by Aegis via the ACP runtime. E
 - A display name (e.g., `cc-my-task`)
 - A working directory
 - A JSONL transcript file
-
-Create a session:
-```bash
-curl -X POST http://localhost:9100/v1/sessions \
-  -H "Content-Type: application/json" \
-  -d '{"workDir": "/path/to/project", "prompt": "Review the PR and summarize the changes"}'
-```
-
-The response includes a session ID. Save it for subsequent API calls.
 
 ### Session Lifecycle
 
@@ -67,7 +121,7 @@ create → working → permission_prompt? → idle → done
 2. **working** — Claude Code is processing
 3. **permission_prompt** — Waiting for approval (see Permission Modes below)
 4. **idle** — Claude Code finished, ready for next prompt
-5. **rate_limit** — Claude Code hit a rate limit and is showing an interactive menu (choose an option or wait)
+5. **rate_limit** — Claude Code hit a rate limit and is showing an interactive menu
 6. **done** — Session terminated
 
 Poll for status:
@@ -75,9 +129,9 @@ Poll for status:
 curl http://localhost:9100/v1/sessions/{id}
 ```
 
-Read the transcript when idle:
+Read the transcript:
 ```bash
-curl http://localhost:9100/v1/sessions/{id}/read
+curl http://localhost:9100/v1/sessions/{id}/transcript
 ```
 
 Send a follow-up:
@@ -110,10 +164,16 @@ curl -X POST http://localhost:9100/v1/sessions \
 
 ```bash
 ag                          # Start the server
-ag "do something"           # Create session + send brief (shorthand)
+ag run "do something"       # Zero-to-session: create + stream output
 ag init                     # Bootstrap config interactively
+ag init --yes               # Non-interactive, auto-wire MCP
 ag init --list-templates    # List available templates
 ag init --from-template X   # Scaffold from a template
+ag list                     # List sessions
+ag status [session-id]      # Show session or server status
+ag read <session-id>        # Read session output (prefix matching)
+ag tail <session-id>        # Stream session output live
+ag kill <session-id>        # Kill a session
 ag doctor                   # Run diagnostics
 ag mcp                      # Start MCP server (stdio mode)
 ag login                    # Authenticate via OIDC device flow
@@ -137,6 +197,8 @@ ag init --from-template docs-writer     # Documentation agent
 
 Requires `AEGIS_OIDC_ISSUER` and `AEGIS_OIDC_CLIENT_ID` to be set. The CLI authenticates directly with your IdP using the OAuth2 device authorization grant (RFC 8628).
 
+> OIDC/SSO is a Phase 4 feature. Enable with `AEGIS_FEATURE_OIDC=1`.
+
 #### `ag login`
 
 Opens a browser-based auth flow. Prints a verification URL and code — visit the URL, enter the code, and the CLI polls until you authorize.
@@ -148,7 +210,7 @@ ag login --no-open                 # Don't auto-open browser
 ag login --json                    # Machine-readable output
 ```
 
-**Exit codes:** `0` = success, `1` = auth failed/timeout, `2` = config error (OIDC not set up).
+**Exit codes:** `0` = success, `1` = auth failed/timeout, `2` = config error.
 
 #### `ag logout`
 
@@ -178,8 +240,9 @@ Tokens are stored in `~/.aegis/auth/` by default (configurable via `AEGIS_OIDC_A
 Connect Aegis tools directly inside Claude Code. This lets Claude Code create sub-sessions, send prompts, and orchestrate other agents.
 
 ```bash
-# Register Aegis MCP tools in Claude Code
-claude mcp add aegis -- npx @onestepat4time/aegis mcp
+# Auto-wired during ag init --yes (or offered interactively)
+# Manual wiring:
+claude mcp add aegis -- ag mcp
 ```
 
 Aegis exposes **24 MCP tools** covering:
@@ -203,7 +266,7 @@ All endpoints are under `/v1/`. Base URL: `http://localhost:9100`
 | `GET` | `/v1/sessions` | List all sessions |
 | `GET` | `/v1/sessions/:id` | Get session status |
 | `POST` | `/v1/sessions/:id/send` | Send a message |
-| `GET` | `/v1/sessions/:id/read` | Read transcript |
+| `GET` | `/v1/sessions/:id/transcript` | Read transcript |
 | `DELETE` | `/v1/sessions/:id` | Kill session |
 | `GET` | `/v1/sessions/:id/sse` | SSE event stream |
 | `POST` | `/v1/sessions/:id/approve` | Approve permission |
@@ -223,20 +286,21 @@ Features:
 - New session creation
 - Audit log
 - Settings
+- Onboarding wizard (first run)
 
-The dashboard requires authentication. Run `ag init` to set up your auth token.
+On localhost with zero-config, the dashboard loads without authentication. If you've set up auth tokens, you'll be prompted to log in.
 
 ## Configuration
 
-Config file: `~/.aegis/config.json`
+Config file: `.aegis/config.yaml` (project-local) or `~/.aegis/config.yaml` (global)
 
-```json
-{
-  "host": "127.0.0.1",
-  "port": 9100,
-  "authToken": "your-secret-token",
-  "allowedWorkDirs": ["~/projects", "~/workspace"]
-}
+```yaml
+host: "127.0.0.1"
+port: 9100
+# authToken: "your-secret-token"  # Only needed for non-localhost
+allowedWorkDirs:
+  - "~/projects"
+  - "~/workspace"
 ```
 
 > **Security note:** System temp dirs (`/tmp`, `/var/tmp`) are **not** in the default safe directories list. If you need to use a temp directory as a workDir, add it explicitly to `allowedWorkDirs`.
@@ -246,33 +310,39 @@ Environment variables override config values. Prefix with `AEGIS_`:
 
 See [Configuration Reference](getting-started.md#configuration) for all options.
 
+## Approve from Your Phone (optional)
+
+Set up Telegram approvals to handle Claude Code permission prompts from anywhere:
+
+```bash
+ag setup telegram
+```
+
+Follow the guided setup. After that, permission prompts arrive on Telegram — approve or deny from your phone.
+
+> 📖 Full walkthrough: [Phone Approvals guide](./guides/phone-approvals.md).
+
 ## Troubleshooting
 
-**Server won't start:**
-```bash
-ag doctor   # Run diagnostics
-# Check: ACP backend healthy? port 9100 free? Claude Code available?
-```
-
-**Session stuck on `permission_prompt`:**
-```bash
-curl -X POST http://localhost:9100/v1/sessions/{id}/approve
-# or reject:
-curl -X POST http://localhost:9100/v1/sessions/{id}/reject
-```
-
-**Claude Code not found:**
-```bash
-claude --version   # Verify installation
-export PATH="$PATH:$(which claude)"   # Add to PATH
-```
+| Problem | Fix |
+|---------|-----|
+| `claude: command not found` | `npm install -g @anthropic-ai/claude-code` then `claude login` |
+| Session hangs without output | Run `claude auth status` — you must be logged in |
+| `workDir is not in the allowed directories list` | Run from your home directory, or add the path to `allowedWorkDirs` |
+| `401 Unauthorized` | On localhost with a fresh install, this shouldn't happen. If it does, delete `~/.aegis/` and retry |
+| `EADDRINUSE` | Port 9100 in use: `AEGIS_PORT=9200 ag run "..." --cwd ./project` |
+| Server won't start | `ag doctor` — checks ACP, port, Claude Code availability |
+| Session stuck on `permission_prompt` | `curl -X POST http://localhost:9100/v1/sessions/{id}/approve` |
+| Dashboard won't load | Check Aegis is running: `curl http://localhost:9100/v1/health` |
 
 See the [Troubleshooting](troubleshooting.md) guide for more.
 
 ## Next Steps
 
-- [Getting Started](getting-started.md) — Full walkthrough
-- [API Reference](api-reference.md) — All REST endpoints
-- [MCP Tools](mcp-tools.md) — All MCP tool definitions
-- [Advanced Features](advanced.md) — Pipelines, templates, memory bridge
-- [Deployment Guide](deployment.md) — Production deployment
+- [5-Minute Setup](five-minute-setup.md) — fastest path from zero
+- [Getting Started](getting-started.md) — full configuration reference
+- [API Reference](api-reference.md) — every REST endpoint
+- [MCP Tools](mcp-tools.md) — all MCP tool definitions
+- [Advanced Features](advanced.md) — pipelines, templates, memory bridge
+- [Deployment Guide](deployment.md) — production deployment
+- [i18n Guide](guides/i18n.md) — dashboard localization


### PR DESCRIPTION
## What

Rewrote `docs/onboarding.md` to reflect the zero-config `ag run` experience that shipped in v0.6.7.

## Before
- Lead with 3-step manual flow: `npm install -g` → `ag init` → `ag`
- No mention of `ag run` (the headline zero-config command)
- `ag init` described as just "creates config"
- Dashboard section said "requires authentication" (false on localhost)
- CLI reference missing `ag run`, `ag list`, `ag read`, `ag tail`, `ag kill`
- Transcript example used `/read` endpoint (known buggy, should be `/transcript`)
- Config example used JSON (actual output is YAML)

## After
- Lead with `ag run` — 1 command, zero config, streams output
- Step-by-step as explicit alternative for users who want control
- Prerequisites table with min versions (Node 20+, CC ≥ 2.1.145)
- `ag init` fully documented with `--yes`, `--force`, `--no-start`, `--no-open`
- Zero-config localhost callout (no auth on localhost)
- Claude Code auto-wiring callout (ag init offers MCP registration)
- Fixed: /read → /transcript, JSON → YAML config, auth clarification
- Added: phone approvals section, troubleshooting table
- Added: onboarding wizard mention in dashboard features

## Why
Post-#4348 (zero-config init), the onboarding guide was the most stale doc. New users following it would do 3x the work needed. The 5-minute-setup.md and getting-started.md were already updated but onboarding.md still led with the old manual flow.