### PR TITLE
docs: finalize changelog + add Multica to competitive docs

### DIFF
--- a/docs/changelog/2026-05-29.md
+++ b/docs/changelog/2026-05-29.md
@@ -1,21 +1,27 @@
 # CHANGELOG — 2026-05-28/29
 
-> **28 PRs merged** (21 May 28, 7 May 29 — last 2 days). Dashboard i18n completion, SSE security hardening, onboarding wizard, and monitor decomposition.
+> **30 PRs merged** across 2 days. Dashboard i18n completion, SSE security hardening, onboarding wizard, E2E zero-config tests, and monitor decomposition.
 
-## Dashboard: i18n Completion (#4441, #4439, #4430, #4434, #4431)
+## Dashboard: Full i18n Migration (#4441, #4449, #4448, #4447, #4446, #4445, #4440, #4439, #4430, #4452)
 
-The dashboard is now fully internationalized. 50+ hardcoded English strings (aria-labels, titles, placeholders) replaced with i18n keys across 31 files. Italian catalog (`it.ts`) synced.
+The dashboard is now fully internationalized. Every user-facing string — aria-labels, titles, placeholders, page text — uses the `useT()` hook with i18n keys. Italian catalog (`it.ts`) synced.
 
 - **#4441** — Replace 50+ hardcoded English aria-labels/titles with i18n keys
+- **#4449** — Extract OnboardingWizard + HomeStatusPanel strings to i18n — kill last CI flake
+- **#4448** — Wire i18n resolver into test mocks — kill recurring CI flake
+- **#4447** — Merge misplaced a11y i18n keys into aria block — fixes BurnRateChart CI flake
+- **#4446** — Extract hardcoded strings in ActivityPage + NewSessionPage to i18n
+- **#4445** — Remove unnecessary 'as any' cast for runnerName in SessionTable
+- **#4440** — Add missing staleData key to Italian translations
 - **#4439** — Replace hardcoded aria-labels and titles (i18n continuation)
 - **#4430** — PermissionPromptSheet i18n + Escape key UX clarity
+- **#4452** — Wire remaining hardcoded strings to i18n keys
 - **#4434** — AnalyticsPage crash on partial API data + i18n fix
 - **#4431** — Prevent double-click duplicate approve/reject in ApprovalBanner
-- **#4440** — Add missing staleData key to Italian translations
 - **#4397** — Fix i18n key analytics.noData → common.noData in KPIBanner
 - **#4391** — Move budgetAlertSection i18n keys into cost object
 
-## Dashboard: UX Fixes (#4425, #4421, #4426, #4428, #4437, #4438, #4429, #4442)
+## Dashboard: UX Fixes (#4425, #4421, #4426, #4428, #4437, #4438, #4429, #4442, #4427)
 
 - **#4425** — Fix interaction bugs: stale state, blur commit, capture phase, scroll, active index
 - **#4421** — Show ApprovalBanner on mobile — remove hidden sm:block
@@ -25,6 +31,7 @@ The dashboard is now fully internationalized. 50+ hardcoded English strings (ari
 - **#4438** — Persist onboarding completion so tour never reappears on page load
 - **#4429** — Pass actual user role to DriverControlBar
 - **#4442** — Fix TranscriptBubble flaky timestamp test
+- **#4427** — Reduce useSessionApproval re-renders on TTL tick
 
 ## Dashboard: Onboarding Wizard (#4383)
 
@@ -34,6 +41,10 @@ Smart onboarding wizard with health-aware steps. New users get guided through se
 
 The `/v1/sse` bridge endpoint now enforces auth, tenant scoping, and connection limiting.
 
+## Security: Fork Empty Body Fix (#4443)
+
+Fix 400 error on `/v1/sessions/:id/fork` when request body is empty. Validates that fork works with no parameters (returns a bare clone).
+
 ## Architecture: Monitor Decomposition (#4392, #4399)
 
 Extracted `DeadDetector`, `RateLimitRetryHandler`, and `StatusBroadcaster` from the monolithic session monitor. Backward-compatible forwarding method added.
@@ -42,8 +53,13 @@ Extracted `DeadDetector`, `RateLimitRetryHandler`, and `StatusBroadcaster` from 
 
 Prepared `setupAuth` extraction via boot facade as prep work for server decomposition (continues #4227).
 
-## Docs (#4396, #4394, #4382)
+## Testing: E2E Zero-Config (#4450)
 
+End-to-end tests for `ag init` → `ag run` zero-config flow. Validates the 5-minute bar from install to running session.
+
+## Docs (#4444, #4396, #4394, #4382)
+
+- **#4444** — Dashboard i18n guide, CHANGELOG entries, known-issues cleanup, zero-config progress update
 - **#4396** — Document `/v1/sse` bridge endpoint in API reference
 - **#4394** — Add SSE security section to real-time events guide
 - **#4382** — Agent bootstrap best practice — GitHub as source of truth
@@ -56,19 +72,12 @@ Prepared `setupAuth` extraction via boot facade as prep work for server decompos
 - **#4384** — ShieldLogo, HoldButton, ConfirmDialog (batch 7)
 - **#4381** — ProtectedRoute, Code, PipelineStatusBadge (batch 6)
 
-## CI/Internal (#4398, #4424)
+## CI (#4398, #4424, #4453)
 
 - **#4398** — Exclude stale aegis/ directory from vitest runs
 - **#4424** — Fix triple-brace in SettingsPage breaking CI
-
-## Still Open
-
-| PR | Title | Author |
-|----|-------|--------|
-| #4443 | Fix flaky TranscriptBubble test + fork empty body | Ema |
-| #4427 | Reduce useSessionApproval re-renders on TTL tick | Ema |
-| #4444 | Dashboard i18n guide + CHANGELOG + known-issues + zero-config update | Scribe |
+- **#4453** — Use `du --apparent-size` in bundle size gate
 
 ---
 
-**Draft by:** Scribe · **Status:** Draft — will finalize once #4443 and #4427 land.
+**Authored by:** Scribe · **Status:** Final

--- a/docs/competitive-differentiators.md
+++ b/docs/competitive-differentiators.md
@@ -1,25 +1,25 @@
 # Aegis Competitive Differentiators
 
 > **Audience:** Technical decision-makers evaluating Claude Code orchestration platforms.
-> **Last updated:** 2026-05-14 | **Sources:** Issue #2764 positioning, #3216 (Verdent AI), #3316 (hooks), competitive-threat-matrix.md, Orpheus gap analyses.
+> **Last updated:** 2026-05-29 | **Sources:** Issue #2764 positioning, #3216 (Verdent AI), #3316 (hooks), competitive-threat-matrix.md, Orpheus gap analyses.
 
 ## Executive Summary
 
 Aegis is the **only open-source, API-first Claude Code orchestration middleware** with enterprise-grade security, observability, and deployment. Competitors win on simplicity or agent count. Aegis wins on **production readiness**: the layer between "someone typed a message" and "code shipped to production."
 
-This document compares Aegis against two key competitors across three pillars: **Security**, **Deployment**, and **Extensibility**.
+This document compares Aegis against three key competitors across three pillars: **Security**, **Deployment**, and **Extensibility**.
 
 ---
 
 ## Competitors Covered
 
-| | Aegis | cc-connect | Verdent AI |
-|---|---|---|---|
-| **License** | MIT (open source) | Proprietary | Proprietary |
-| **Architecture** | Node.js API server + MCP | Go binary + TOML | Mac desktop app |
-| **Agent support** | Claude Code (1 runner) | 10+ agent backends | Parallel agents (proprietary) |
-| **Target market** | Enterprise / DevOps | Developer tools | Consumer / prosumer |
-| **⭐ Stars** | ~200 | 8K | N/A (closed) |
+| | Aegis | cc-connect | Verdent AI | Multica |
+|---|---|---|---|---|
+| **License** | MIT (open source) | Proprietary | Proprietary | MIT (open source) |
+| **Architecture** | Node.js API server + MCP | Go binary + TOML | Mac desktop app | Go + Next.js + PostgreSQL |
+| **Agent support** | Claude Code (1 runner) | 10+ agent backends | Parallel agents (proprietary) | 11+ CLI runtimes (auto-detected) |
+| **Target market** | Enterprise / DevOps | Developer tools | Consumer / prosumer | Teams ("Linear for AI agents") |
+| **⭐ Stars** | ~200 | 8K | N/A (closed) | 30.7K |
 
 ---
 
@@ -66,20 +66,21 @@ This document compares Aegis against two key competitors across three pillars: *
 
 ### Security Scorecard
 
-| Capability | Aegis | cc-connect | Verdent AI |
-|-----------|-------|-----------|-----------|
-| RBAC with roles | ✅ 3 roles | ❌ | ❌ |
-| OIDC/SSO | ✅ | ❌ | ❌ |
-| Audit trail (hash-chained) | ✅ | ❌ | ❌ |
-| API key rotation | ✅ immediate + grace period | ❌ | ❌ |
-| Per-key quotas | ✅ | ❌ | ❌ |
-| Per-key permissions | ✅ | ❌ | ❌ |
-| Hook secret auth | ✅ timing-safe | ⚠️ basic | N/A |
-| Session ID enumeration protection | ✅ | ❌ | N/A |
-| Release signing | ✅ Sigstore | ❌ | ✅ App Store |
-| SOC2/GDPR readiness | ✅ | ❌ | ❌ |
+| Capability | Aegis | cc-connect | Verdent AI | Multica |
+|-----------|-------|-----------|-----------|--------|
+| RBAC with roles | ✅ 3 roles + strictRBAC | ❌ | ❌ | ⚠️ workspace-scoped |
+| OIDC/SSO | ✅ | ❌ | ❌ | ❌ |
+| Audit trail (hash-chained) | ✅ | ❌ | ❌ | ❌ |
+| API key rotation | ✅ immediate + grace period | ❌ | ❌ | ❌ (PAT with expiry only) |
+| Per-key quotas | ✅ | ❌ | ❌ | ❌ |
+| Per-key permissions | ✅ | ❌ | ❌ | ❌ |
+| Hook secret auth | ✅ timing-safe | ⚠️ basic | N/A | N/A |
+| Session ID enumeration protection | ✅ | ❌ | N/A | ❌ |
+| Release signing | ✅ Sigstore | ❌ | ✅ App Store | ❌ |
+| SOC2/GDPR readiness | ✅ | ❌ | ❌ | ❌ |
+| Webhook delivery tracking | ❌ | ❌ | ❌ | ✅ delivery history + retry |
 
-**Verdict:** Aegis is the only option for organizations that need compliance, audit, and access control. Neither competitor has any enterprise security story.
+**Verdict:** Aegis is the only option for organizations that need compliance, audit, and access control. Multica has workspace-scoped roles and webhook delivery tracking but lacks hash-chained audit, OIDC, and per-key quotas. Neither cc-connect nor Verdent AI has any enterprise security story.
 
 ---
 
@@ -132,20 +133,22 @@ This document compares Aegis against two key competitors across three pillars: *
 
 ### Deployment Scorecard
 
-| Capability | Aegis | cc-connect | Verdent AI |
-|-----------|-------|-----------|-----------|
-| REST API (programmatic) | ✅ 108 endpoints | ❌ | ❌ |
-| MCP server | ✅ 34 tools | ❌ | ❌ |
-| Web dashboard | ✅ full React | ⚠️ basic | ❌ (desktop) |
-| Docker/K8s deployment | ✅ Helm chart | ❌ | ❌ |
-| SSE event streaming | ✅ per-session + global | ❌ | ❌ |
-| CI/CD automation | ✅ `ag run` + API | ⚠️ CLI-only | ❌ |
-| Client SDKs | ✅ TS + Python | ❌ | ❌ |
-| Prometheus/OTel | ✅ | ❌ | ❌ |
-| Chat platform breadth | ⚠️ 4 platforms | ✅ 11 platforms | ⚠️ 2 platforms |
-| Cross-platform | ✅ Linux/Mac/Docker | ✅ Mac/Linux/Win | ❌ Mac only |
+| Capability | Aegis | cc-connect | Verdent AI | Multica |
+|-----------|-------|-----------|-----------|--------|
+| REST API (programmatic) | ✅ 108 endpoints | ❌ | ❌ | ✅ full CRUD |
+| MCP server | ✅ 34 tools | ❌ | ❌ | ❌ |
+| Web dashboard | ✅ full React | ⚠️ basic | ❌ (desktop) | ✅ Next.js + Kanban |
+| Docker/K8s deployment | ✅ Helm chart | ❌ | ❌ | ⚠️ Docker Compose only |
+| SSE event streaming | ✅ per-session + global | ❌ | ❌ | ✅ WebSocket + Redis |
+| CI/CD automation | ✅ `ag run` + API | ⚠️ CLI-only | ❌ | ⚠️ CLI + daemon |
+| Client SDKs | ✅ TS + Python | ❌ | ❌ | ❌ |
+| Prometheus/OTel | ✅ | ❌ | ❌ | ❌ |
+| Chat platform breadth | ⚠️ 4 platforms | ✅ 11 platforms | ⚠️ 2 platforms | ❌ email only |
+| Cross-platform | ✅ Linux/Mac/Docker | ✅ Mac/Linux/Win | ❌ Mac only | ✅ Mac/Linux/Win |
+| Desktop app | ❌ | ❌ | ✅ Mac | ✅ Electron |
+| CLI self-update | ❌ | ❌ | N/A | ✅ `multica update` |
 
-**Verdict:** Aegis is the only infrastructure-grade option. cc-connect wins on chat breadth. Verdent AI is consumer-only — cannot be deployed as infrastructure.
+**Verdict:** Aegis is the only infrastructure-grade option with MCP, OTel, and Kubernetes. Multica wins on desktop UX and task management (Kanban, agent profiles). cc-connect wins on chat breadth. Verdent AI is consumer-only — cannot be deployed as infrastructure.
 
 ---
 
@@ -192,20 +195,26 @@ This document compares Aegis against two key competitors across three pillars: *
 
 ### Extensibility Scorecard
 
-| Capability | Aegis | cc-connect | Verdent AI |
-|-----------|-------|-----------|-----------|
-| MCP server (34 tools) | ✅ | ❌ | ❌ |
-| Lifecycle hooks (29 events) | ✅ with policy engine | ⚠️ basic callbacks | ❌ |
-| ACP runner abstraction | ✅ | ❌ | ❌ |
-| Session templates | ✅ | ⚠️ TOML config | ❌ |
-| Pipeline orchestration | ✅ | ❌ | ❌ |
-| Cross-session memory | ✅ Memory Bridge | ❌ | ✅ project memory |
-| Permission profiles | ✅ per-tool/per-path | ⚠️ flat lists | ❌ |
-| Plugin system | ✅ Fastify plugins | ❌ | ❌ |
-| Dead-letter queue | ✅ | ❌ | ❌ |
-| Parallel agents | ❌ | ✅ multi-backend | ✅ core feature |
+| Capability | Aegis | cc-connect | Verdent AI | Multica |
+|-----------|-------|-----------|-----------|--------|
+| MCP server (34 tools) | ✅ | ❌ | ❌ | ❌ |
+| Lifecycle hooks (29 events) | ✅ with policy engine | ⚠️ basic callbacks | ❌ | ❌ |
+| ACP runner abstraction | ✅ | ❌ | ❌ | ❌ |
+| Session templates | ✅ | ⚠️ TOML config | ❌ | ❌ (autopilots instead) |
+| Pipeline orchestration | ✅ | ❌ | ❌ | ❌ |
+| Cross-session memory | ✅ Memory Bridge | ❌ | ✅ project memory | ❌ |
+| Permission profiles | ✅ per-tool/per-path | ⚠️ flat lists | ❌ | ⚠️ per-workspace |
+| Plugin system | ✅ Fastify plugins | ❌ | ❌ | ❌ |
+| Dead-letter queue | ✅ | ❌ | ❌ | ❌ |
+| Parallel agents | ❌ | ✅ multi-backend | ✅ core feature | ✅ squads + auto-delegation |
+| Skills marketplace | ❌ | ❌ | ❌ | ✅ reusable + importable |
+| Webhook delivery tracking | ❌ | ❌ | ❌ | ✅ history + retry |
+| Agent profiles/identity | ❌ | ❌ | ❌ | ✅ named profiles + avatars |
+| Task board (Kanban) | ❌ | ❌ | ❌ | ✅ full issue lifecycle |
+| Multi-runtime (11+ CLIs) | ❌ | ✅ 10+ backends | ❌ | ✅ 11+ auto-detected |
+| Session metadata KV | ❌ | ❌ | ❌ | ✅ per-issue queryable KV |
 
-**Verdict:** Aegis is the most extensible platform for programmatic control. Verdent AI wins on parallel agent execution and project memory — both identified gaps. cc-connect is rigid — TOML config, no API, no plugins.
+**Verdict:** Aegis is the most extensible platform for programmatic control via API/MCP. Multica dominates on task management and multi-agent features (squads, skills, Kanban). cc-connect is rigid — TOML config, no API, no plugins.
 
 ---
 
@@ -253,22 +262,31 @@ Aegis is the **middleware** that connects enterprise systems to AI coding agents
 
 | Gap | Who has it | Priority |
 |-----|-----------|----------|
-| **Parallel agents** | Verdent AI, cc-connect, Ruflo | P0 |
+| **Parallel agents** | Verdent AI, cc-connect, Ruflo, Multica | P0 |
+| **Multi-runtime support** (11+ CLIs) | Multica, cc-connect | P0 |
+| **Task board (Kanban)** | Multica, Cline | P0 |
+| **Agent profiles/identity** | Multica | P1 |
+| **Skills marketplace** | Multica | P1 |
 | **Project memory** | Verdent AI, Ruflo | P1 |
 | **Chat platform breadth** (11 platforms) | cc-connect | P1 |
-| **Desktop app** | Verdent AI | P2 |
+| **Webhook delivery tracking** | Multica | P1 |
+| **Session metadata KV store** | Multica | P1 |
+| **CLI self-update** | Multica | P2 |
+| **Desktop app** | Verdent AI, Multica | P2 |
 | **Task decomposition** | Verdent AI | P2 |
 | **Academic credibility** (ICSE paper) | Verdent AI | P3 |
 
 These are real gaps. But they're **feature gaps**, not architectural gaps. Adding parallel agents to Aegis is a runner backend. Adding project memory is a storage layer. Adding chat platforms is a channel adapter.
 
-What competitors **cannot easily add** is enterprise security, audit, observability, and API-first architecture — those require fundamental redesign.
+What competitors **cannot easily add** is enterprise security, audit, observability, and API-first architecture — those require fundamental redesign. Multica's 30.7K-star velocity is the highest competitive threat — they're building breadth fast, but lack depth in security, audit, MCP, and observability.
 
 ---
 
 ## See Also
 
 - [Competitive Threat Matrix](./competitive-threat-matrix.md) — full competitive landscape with star counts and market pulse
+- [Multica Feature Gap Analysis](./competitive-intel/multica-feature-gap-raw.md) — 52-point feature gap comparison
+- [CC v2.1.153-156 Intel](./competitive-intel/cc-v2.1.153-156.md) — Dynamic Workflows threat assessment
 - [Lifecycle Hooks Guide](./hooks-guide.md) — detailed hook architecture comparison
 - [Architecture Overview](./architecture.md) — Aegis internal architecture
 - [API Reference](./api-reference.md) — full REST API documentation

--- a/docs/competitive-threat-matrix.md
+++ b/docs/competitive-threat-matrix.md
@@ -1,6 +1,6 @@
 # Aegis Competitive Threat Matrix
 
-> **Last updated:** 2026-05-15 | **Source:** Issues #3013, #3014, #3016, #3003, #3004, #3216, #3236 + ECC analysis (Orpheus) + deep competitive research (Scribe)
+> **Last updated:** 2026-05-29 | **Source:** Issues #3013, #3014, #3016, #3003, #3004, #3216, #3236 + ECC analysis (Orpheus) + deep competitive research (Scribe)
 > **Audience:** Leadership (Ema, Boss) for strategic planning
 
 ---
@@ -32,6 +32,7 @@ The Claude Code orchestration space is **crowded and moving fast**. 10+ competit
 | #11 | **Roo Code** | ~~30K~~ 💀 | ⬛ DEAD | — | — | — | — | — | — | Shut down May 15, 2026. IDE-first tool killed by platform shift. |
 | #12 | **Cline** | 61K | 🟡 MEDIUM | VS Code ext + Kanban + CLI | 1+ (Kanban workers) | UI only | ✅ SDK (`@cline/sdk`) | 🟢 Kanban board | SSO, 3-tier RBAC, OTel, prompt storage (Enterprise) |
 | — | **ccusage-dashboard** | 1 | 🟢 ADJACENT | Self-hosted | N/A (analytics) | N/A | ❌ | 9-panel React | ❌ |
+| #13 | **Multica** | 30.7K | 🟠 HIGH | `multica setup` | 11+ CLI runtimes | Email + in-app | ✅ full CRUD | ✅ Next.js + Electron | ⚠️ workspace roles |
 | — | **Aegis** | ~200 | — | `npx + ag run` (2 cmds) | 1 (Claude Code) | 4 | ✅ 34 MCP tools | ✅ Full React | ✅ OIDC/RBAC |
 
 ---
@@ -66,7 +67,9 @@ No single competitor has ALL of these. This is the enterprise wedge:
 | **Chat platform breadth** | Missing entire Asian market (WeChat, QQ, DingTalk) | cc-connect (11 platforms) | P1 |
 | **Natural language scheduling** | Dev productivity killer feature | cc-connect | P2 |
 | **Project memory** | Adoption — users want persistent context across sessions | Verdent AI, Ruflo | P1 |
-| **Parallel agent execution** | Adoption — every prosumer competitor has it | Verdent AI, cc-connect, Ruflo | P0 |
+| **Multi-runtime support** (11+ CLIs) | Existential — Multica auto-detects 11+ CLIs | Multica, cc-connect | P0 |
+| **Parallel agent execution** | Adoption — every prosumer competitor has it | Verdent AI, cc-connect, Ruflo, Multica | P0 |
+| **Task board (Kanban)** | Users expect issue tracking, not just sessions | Multica, Cline | P0 |
 | **Self-learning memory** | Agents improve over time | Ruflo | P2 |
 | **Multi-language docs** | International adoption blocked | OMC (6 languages), cc-connect (5) | P2 |
 
@@ -113,6 +116,18 @@ This is the tagline. Ruflo and OMC are developer tools. Aegis is **enterprise mi
 - **Task decomposition:** Kanban shows parent-child tasks with real-time parallel execution. Aegis has no equivalent — but this is Phase 4 scope (Session Groups / Workflow View).
 - **What we beat them on:** Web-first (any OS), RBAC + audit, multi-tenant, PWA, open source (MIT), persistent named agents.
 - **What we should NOT copy:** Conversation-first UI (our users want data/control), Mac-only, consumer pricing, ephemeral workers, AI-generated dashboards.
+
+## Market Pulse — 2026-05-29
+
+**Multica (30.7K ⭐, MIT, Go+Next.js+PostgreSQL):** Full-stack multi-agent task management platform — "Linear for AI agents." Key features: Kanban board, agent profiles, squads, skills marketplace, autopilots (scheduled automations), webhook delivery tracking, 11+ CLI runtime auto-detection (claude, codex, copilot, gemini, cursor, kimi, kiro, etc.), Docker Compose + Cloud SaaS, Electron desktop app, workspace-scoped RBAC.
+- **What they beat us on:** Task management depth, multi-runtime breadth, desktop UX, skills compounding, community scale (30.7K stars in ~4 months).
+- **What we beat them on:** MCP integration, cost analytics, hash-chained audit, OIDC/SSO, Prometheus/OTel, Kubernetes/Helm, multi-channel notifications (Telegram/Slack/Discord), solo-dev zero-config, ACP depth.
+- **Existential threat:** If Multica normalizes "use any CLI agent," being Claude-only becomes a liability. Their skills marketplace compounds value — every solution becomes reusable across agents.
+- **Action:** Don't try to match feature-for-feature. Lean into depth (MCP, audit, cost tracking, enterprise governance). Close CLI self-update and webhook delivery tracking gaps.
+
+**CC v2.1.154 Dynamic Workflows:** Claude Code now has native multi-agent orchestration ("tens to hundreds of agents in the background") via `/workflows`. Also: background sessions with attach/detach, `! <command>` shell dispatch, Opus 4.8 with high effort default.
+- **Impact on Aegis:** CC is building orchestration natively. Aegis must differentiate on what CC won't have: RBAC, audit trails, approval gates, cost enforcement, multi-user access, REST API for external consumers.
+- **See also:** `docs/competitive-intel/cc-v2.1.153-156.md`
 
 ## Market Pulse — 2026-05-12
 


### PR DESCRIPTION
## What

Three doc updates from Athena sprint:

### 1. Finalize `docs/changelog/2026-05-29.md`
- Update PR count: 28 → 30
- Add 7 PRs that merged after initial draft (#4443-#4453)
- Remove "Still Open" table (#4443 and #4427 both merged)
- Mark as final (was draft)

### 2. Add Multica to `docs/competitive-differentiators.md`
Multica (30.7K ⭐, MIT, Go+Next.js+PostgreSQL) is now a 4th competitor column across all 3 pillars:
- **Security:** workspace-scoped RBAC (not strictRBAC), PAT tokens (no rotation), no audit trail, no OIDC. Has webhook delivery tracking (we don't).
- **Deployment:** Docker Compose + Cloud SaaS, Electron desktop, 11+ CLI runtimes. No MCP, no OTel, no K8s, no SDKs.
- **Extensibility:** Skills marketplace, autopilots, agent profiles, Kanban board, squads. No MCP, no hooks, no ACP, no plugins.
- **Updated honest gaps:** 6 new gaps identified (multi-runtime, task board, agent profiles, skills marketplace, webhook delivery tracking, session metadata KV)

### 3. Add Multica + CC Dynamic Workflows to `docs/competitive-threat-matrix.md`
- Multica row in threat matrix (#13, 30.7K ⭐, HIGH)
- CC v2.1.154 Dynamic Workflows market pulse entry
- 3 new critical gaps: multi-runtime support (P0), task board (P0), agent profiles (P1)

### 3b. Zero-config progress check (#3)
Still 8/10. The 2 remaining (F16 CLI slug names, F20 hide OIDC) are informal tracking items with no formal issues filed. No change needed.