### PR TITLE
fix(cli): standardize ag logout exit codes

### DIFF
--- a/src/__tests__/device-flow-cli.test.ts
+++ b/src/__tests__/device-flow-cli.test.ts
@@ -216,7 +216,7 @@ describe('ag logout', () => {
 
     const io = createMockIO();
     const code = await handleLogout([], io);
-    expect(code).toBe(1);
+    expect(code).toBe(0);
     expect(io.getStdout()).toContain('Not logged in');
   });
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -86,11 +86,11 @@ export async function handleLogout(args: string[], io: CliIO, fetchFn: typeof fe
     const entries = Object.entries(store);
     if (entries.length === 0) {
       if (jsonOutput) {
-        writeLine(io.stdout, JSON.stringify({ error: 'Not logged in', code: 'NOT_LOGGED_IN' }));
+        writeLine(io.stdout, JSON.stringify({ message: 'Not logged in', code: 'NOT_LOGGED_IN' }));
       } else {
         writeLine(io.stdout, '  Not logged in.');
       }
-      return 1;
+      return 0;
     }
     if (entries.length === 1) {
       serverOrigin = entries[0]![0];
@@ -114,11 +114,11 @@ export async function handleLogout(args: string[], io: CliIO, fetchFn: typeof fe
   const auth = store[serverOrigin];
   if (!auth) {
     if (jsonOutput) {
-      writeLine(io.stdout, JSON.stringify({ error: 'Not logged in to this server', server: serverOrigin }));
+      writeLine(io.stdout, JSON.stringify({ message: 'Not logged in to this server', server: serverOrigin }));
     } else {
       writeLine(io.stdout, `  Not logged in to ${serverOrigin}.`);
     }
-    return 1;
+    return 0;
   }
 
   // Attempt revocation at IdP


### PR DESCRIPTION
## Summary

Standardizes exit codes for `ag logout` and `ag logout --all` when no credentials exist.

### Before
```bash
ag logout       # "Not logged in." exit 1
ag logout --all # "No stored credentials found." exit 0
```

### After
```bash
ag logout       # "Not logged in." exit 0
ag logout --all # "No stored credentials found." exit 0
```

Exit 1 is now reserved for actual errors (network failure, ambiguous input like multiple servers without `--server`).

### Changes
- `src/commands/logout.ts`: exit code 1 → 0 for empty store and server-not-found cases; JSON field `error` → `message` for informational states
- `src/__tests__/device-flow-cli.test.ts`: updated expected exit code from 1 to 0

### Testing
All 16 tests in device-flow-cli.test.ts pass.

Closes #4462