### PR TITLE
fix(cli): ag list --json outputs JSON; --status active maps to non-terminal states

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,9 +2,13 @@
  * commands/list.ts — `ag list` — List active sessions.
  *
  * Wraps GET /v1/sessions with optional status filter.
+ * Supports --json for machine-readable output.
  */
 
 import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+
+/** Non-terminal states that represent "active" sessions for --status active. */
+const ACTIVE_STATES = ['idle', 'running', 'awaiting_approval', 'paused', 'intervention'];
 
 export async function handleList(args: string[], io: CliIO): Promise<number> {
   const baseUrl = await resolveBaseUrl(args);
@@ -13,9 +17,20 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
 
   const headers = buildHeaders(authToken);
   const params = new URLSearchParams();
+  let jsonOutput = false;
+  let filterActive = false;
+
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--status' && args[i + 1]) {
-      params.set('status', args[++i]!);
+    if (args[i] === '--json') {
+      jsonOutput = true;
+    } else if (args[i] === '--status' && args[i + 1]) {
+      const statusValue = args[++i]!;
+      if (statusValue === 'active') {
+        // "active" maps to non-terminal states — filter client-side after fetching all
+        filterActive = true;
+      } else {
+        params.set('status', statusValue);
+      }
     }
   }
 
@@ -24,12 +39,26 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
+    if (jsonOutput) {
+      writeLine(io.stdout, JSON.stringify({ error: ((err as { error?: string }).error) || res.statusText }));
+    } else {
+      writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
+    }
     return 1;
   }
 
-  const body = await res.json() as { sessions?: any[]; data?: any[] };
-  const sessions = body.sessions ?? body.data ?? [];
+  const body = await res.json() as { sessions?: any[]; data?: any[]; pagination?: any };
+  let sessions = body.sessions ?? body.data ?? [];
+
+  if (filterActive) {
+    sessions = sessions.filter(s => ACTIVE_STATES.includes(s.status));
+    body.sessions = sessions;
+  }
+
+  if (jsonOutput) {
+    writeLine(io.stdout, JSON.stringify(body));
+    return 0;
+  }
 
   if (sessions.length === 0) {
     writeLine(io.stdout, '  No sessions found.');


### PR DESCRIPTION
## Changes

Fixes two `ag list` bugs in a single file (`src/commands/list.ts`):

### #4457 — `ag list --json` outputs human text instead of JSON
- Added `--json` flag handling to `handleList()`
- When `--json` is passed, outputs raw API JSON response (same as `GET /v1/sessions`)
- Error responses also output JSON when `--json` is set

### #4459 — `ag list --status active` excludes idle sessions
- `--status active` now maps to non-terminal states: `idle`, `running`, `awaiting_approval`, `paused`, `intervention`
- Filtering is done client-side after fetching all sessions (API only supports exact match)
- Literal status values (e.g., `--status idle`) still pass through to API as before

## Test plan
- [ ] `ag list --json` returns valid JSON with sessions array and pagination
- [ ] `ag list --status active` shows all non-terminated sessions
- [ ] `ag list --status idle` still filters to exact match
- [ ] `ag list` without flags still shows human-readable table
- [ ] `ag list --json` on error returns `{"error":"..."}` instead of human text

Fixes #4457
Fixes #4459