### PR TITLE
feat(dashboard): display Claude Code session ID in SessionHeader

### DIFF
--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -143,6 +143,7 @@ export function SessionHeader({
   onSaveTemplate,
   onFork,
 }: SessionHeaderProps) {
+  const t = useT();
 
   const needsApproval = health.status === 'permission_prompt' || health.status === 'bash_approval';
   const badgeStatus = uiStateToSessionBadgeStatus(health.status, health.alive);
@@ -193,6 +194,12 @@ export function SessionHeader({
             Owner: {session.ownerKeyId.slice(0, 8)}
             {session.ownerKeyId.length > 8 ? '…' : ''}
             <CopyButton value={session.ownerKeyId} label="owner key ID" size={16} />
+          </span>
+        )}
+        {session.claudeSessionId && (
+          <span className="group hidden font-mono sm:inline-flex items-center gap-1">
+            {t('aria.ccSessionId')}: {truncateMiddle(session.claudeSessionId, 16)}
+            <CopyButton value={session.claudeSessionId} label={t('aria.copyCcSessionId')} size={16} />
           </span>
         )}
         {session.permissionMode && session.permissionMode !== 'default' && (

--- a/dashboard/src/components/session/__tests__/SessionHeader.test.tsx
+++ b/dashboard/src/components/session/__tests__/SessionHeader.test.tsx
@@ -275,4 +275,15 @@ describe('SessionHeader', () => {
     render(<SessionHeader session={baseSession} health={baseHealth} />);
     expect(screen.queryByText('default')).toBeNull();
   });
+
+  it('shows CC session ID when claudeSessionId is present', () => {
+    const session = { ...baseSession, claudeSessionId: 'cc-xyz789abc012' };
+    render(<SessionHeader session={session} health={baseHealth} />);
+    expect(screen.getByText(/Claude Code session/)).not.toBeNull();
+  });
+
+  it('does not show CC session ID when absent', () => {
+    render(<SessionHeader session={baseSession} health={baseHealth} />);
+    expect(screen.queryByText(/Claude Code session/)).toBeNull();
+  });
 });

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -848,6 +848,8 @@ export const en = {
     filterByPipelineStatus: 'Filter by status',
     sortBy: 'Sort by',
     copySessionId: 'Copy session ID',
+    ccSessionId: 'Claude Code session',
+    copyCcSessionId: 'Copy CC session ID',
     activeSessions: 'Active sessions',
     allSessions: 'All sessions',
     checkingAuth: 'Checking authentication',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -841,6 +841,8 @@ export const it = {
     filterByPipelineStatus: 'Filtra per stato',
     sortBy: 'Ordina per',
     copySessionId: 'Copia ID sessione',
+    ccSessionId: 'Sessione Claude Code',
+    copyCcSessionId: 'Copia ID sessione CC',
     activeSessions: 'Sessioni attive',
     allSessions: 'Tutte le sessioni',
     checkingAuth: 'Verifica autenticazione',


### PR DESCRIPTION
## Summary

Dashboard piece of #4455 — displays the Claude Code session ID on the session detail page when present.

### Context
CC v2.1.154 passes `CLAUDE_CODE_SESSION_ID` to MCP subprocesses. Aegis already stores this as `claudeSessionId` in the API response and dashboard schema — it just wasn't rendered anywhere.

### Changes
- **SessionHeader.tsx**: conditional row showing CC session ID with copy button (only when `session.claudeSessionId` is set)
- **i18n**: `aria.ccSessionId` + `aria.copyCcSessionId` (en + it)
- **Tests**: 2 new tests (presence/absence)

### Screenshots (conceptual)
When `claudeSessionId` exists: `Claude Code session: cc-xyz789...`
When absent: nothing rendered (existing sessions without CC bridge)

### Verification
- SessionHeader tests: 23/23 pass
- TypeScript strict: 0 errors
- Build: clean

— Daedalus 🏛️