### PR TITLE
fix(cli): ag list --json envelope + --status active alias (#4457 #4459)

### DIFF
--- a/src/__tests__/commands/list.test.ts
+++ b/src/__tests__/commands/list.test.ts
@@ -121,6 +121,108 @@ describe('handleList', () => {
     const allTip = calls.filter((l: string) => l && l.includes('--all'));
     expect(allTip.length).toBe(0);
   });
+
+  // #4457: --json should output full API envelope (sessions + pagination)
+  it('--json outputs full API envelope with sessions and pagination', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        sessions: [
+          { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'idle', displayName: 'test-session' },
+        ],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      }),
+    }) as any;
+
+    const { handleList } = await importList();
+    const exitCode = await handleList(['--json'], mockIO as any);
+
+    expect(exitCode).toBe(0);
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const jsonOutput = calls.find((l: string) => l && l.startsWith('{'));
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse(jsonOutput!);
+    expect(parsed).toHaveProperty('sessions');
+    expect(parsed).toHaveProperty('pagination');
+    expect(parsed.sessions).toHaveLength(1);
+    expect(parsed.pagination).toEqual({ page: 1, limit: 20, total: 1, totalPages: 1 });
+  });
+
+  it('--json with empty sessions outputs envelope with empty array', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        sessions: [],
+        pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+      }),
+    }) as any;
+
+    const { handleList } = await importList();
+    const exitCode = await handleList(['--json'], mockIO as any);
+
+    expect(exitCode).toBe(0);
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    const jsonOutput = calls.find((l: string) => l && l.startsWith('{'));
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse(jsonOutput!);
+    expect(parsed.sessions).toEqual([]);
+    expect(parsed.pagination).toEqual({ page: 1, limit: 20, total: 0, totalPages: 0 });
+    // Should NOT output human-readable "No sessions found" text
+    const humanText = calls.find((l: string) => l && l.includes('No sessions'));
+    expect(humanText).toBeUndefined();
+  });
+
+  // #4459: --status active should map to non-terminal states
+  it('--status active shows idle and running sessions but not killed', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([
+      { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'idle', displayName: 'idle-session' },
+      { id: 'bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'running', displayName: 'running-session' },
+      { id: '11111111-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'killed', displayName: 'dead-session' },
+      { id: '22222222-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'completed', displayName: 'done-session' },
+    ])) as any;
+
+    const { handleList } = await importList();
+    const exitCode = await handleList(['--status', 'active'], mockIO as any);
+
+    expect(exitCode).toBe(0);
+    const calls = mockWriteLine.mock.calls.map((c: any[]) => c[1]);
+    // Should include idle and running sessions
+    const idleLines = calls.filter((l: string) => l && l.includes('idle-session'));
+    const runningLines = calls.filter((l: string) => l && l.includes('running-session'));
+    expect(idleLines.length).toBe(1);
+    expect(runningLines.length).toBe(1);
+    // Should NOT include killed/completed
+    const deadLines = calls.filter((l: string) => l && (l.includes('dead-session') || l.includes('done-session')));
+    expect(deadLines.length).toBe(0);
+    // Should NOT send status=active to server
+    const fetchUrl = (globalThis.fetch as any).mock.calls[0][0] as string;
+    expect(fetchUrl).not.toContain('status=active');
+  });
+
+  it('--status active fetches all sessions (no server-side filter)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([])) as any;
+
+    const { handleList } = await importList();
+    await handleList(['--status', 'active'], mockIO as any);
+
+    const fetchUrl = (globalThis.fetch as any).mock.calls[0][0] as string;
+    // Should not have any status param in URL
+    expect(fetchUrl).not.toContain('status=');
+  });
+
+  it('--status idle still passes exact status to server', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse([])) as any;
+
+    const { handleList } = await importList();
+    await handleList(['--status', 'idle'], mockIO as any);
+
+    const fetchUrl = (globalThis.fetch as any).mock.calls[0][0] as string;
+    expect(fetchUrl).toContain('status=idle');
+  });
 });
 
 // Restore fetch after all tests

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -24,9 +24,25 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
   let jsonOutput = false;
   let showAll = false;
 
+  // #4459: Map human-friendly status aliases to actual ACP session states
+  const STATUS_ALIASES: Record<string, string[]> = {
+    active: ['idle', 'running', 'awaiting_approval', 'paused', 'intervention'],
+    alive: ['idle', 'running', 'awaiting_approval', 'paused', 'intervention'],
+  };
+
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--status' && args[i + 1]) {
-      params.set('status', args[++i]!);
+      const statusValue = args[++i]!;
+      const alias = STATUS_ALIASES[statusValue.toLowerCase()];
+      if (alias) {
+        // Don't send status filter to server; filter client-side after fetching all
+        // (server only supports exact status match, not multi-status)
+        params.delete('status');
+        // Store alias for later filtering — use a custom param
+        params.set('_statusAlias', statusValue.toLowerCase());
+      } else {
+        params.set('status', statusValue);
+      }
     } else if (args[i] === '--cwd' && args[i + 1]) {
       params.set('project', args[i + 1]!);
       i++;
@@ -39,6 +55,10 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
     }
   }
 
+  // #4459: Extract and strip internal alias param before building URL
+  const statusAlias = params.get('_statusAlias');
+  if (statusAlias) params.delete('_statusAlias');
+
   const url = `${baseUrl}/v1/sessions${params.toString() ? '?' + params : ''}`;
   const res = await fetch(url, { headers, signal: AbortSignal.timeout(10_000) });
 
@@ -48,17 +68,23 @@ export async function handleList(args: string[], io: CliIO): Promise<number> {
     return 1;
   }
 
-  const body = await res.json() as { sessions?: any[]; data?: any[] };
+  const body = await res.json() as { sessions?: any[]; data?: any[]; pagination?: any };
   let sessions = body.sessions ?? body.data ?? [];
 
+  // #4459: Apply status alias filter (active/alive → non-terminal states)
+  if (statusAlias && STATUS_ALIASES[statusAlias]) {
+    const allowed = new Set(STATUS_ALIASES[statusAlias]);
+    sessions = sessions.filter(s => allowed.has(s.status));
+  }
+
   // #3731: Filter terminal statuses unless --all
-  if (!showAll) {
+  if (!showAll && !statusAlias) {
     sessions = sessions.filter(s => !TERMINAL_STATUSES.has(s.status));
   }
 
   if (jsonOutput) {
-    // Machine-readable JSON output — include full IDs
-    writeLine(io.stdout, JSON.stringify(sessions, null, 2));
+    // Machine-readable JSON output — return full API envelope for programmatic use (#4457)
+    writeLine(io.stdout, JSON.stringify({ sessions, pagination: body.pagination ?? null }, null, 2));
     return 0;
   }
 


### PR DESCRIPTION
## Summary

Two CLI bugs in `ag list` fixed in one PR:

### #4457: `ag list --json` outputs human text instead of JSON
**Before:** `ag list --json` outputs a bare `[]` array, not the full API envelope.
**After:** Outputs `{ "sessions": [...], "pagination": {...} }` — consistent with `GET /v1/sessions` response structure.

### #4459: `ag list --status active` shows nothing
**Before:** `--status active` sends literal `status=active` to the server, which no session has.
**After:** `--status active` (and `--status alive`) map client-side to non-terminal states: `idle`, `running`, `awaiting_approval`, `paused`, `intervention`. Exact values like `--status idle` still pass through unchanged.

## Changes
- `src/commands/list.ts` — JSON envelope output, status alias mapping
- `src/__tests__/commands/list.test.ts` — 5 new tests (10 total, all pass)

## Test Plan
- [x] `npx vitest run src/__tests__/commands/list.test.ts` — 10/10 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean