### PR TITLE
fix(security): sanitize error responses — redact internal details from 5xx responses

### DIFF
--- a/src/__tests__/safe-error-message.test.ts
+++ b/src/__tests__/safe-error-message.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { safeErrorMessage } from '../routes/context.js';
+
+describe('safeErrorMessage', () => {
+  it('returns generic message for 5xx errors', () => {
+    const err = new Error('Internal path: /Users/admin/.aegis/keys.json');
+    expect(safeErrorMessage(err, 500)).toBe('Internal server error');
+  });
+
+  it('returns generic message for 5xx non-Error throws', () => {
+    expect(safeErrorMessage('raw string', 500)).toBe('Internal server error');
+    expect(safeErrorMessage(42, 500)).toBe('Internal server error');
+    expect(safeErrorMessage(undefined, 500)).toBe('Internal server error');
+  });
+
+  it('returns original message for 4xx errors (client-facing)', () => {
+    const err = new Error('Session not found');
+    expect(safeErrorMessage(err, 404)).toBe('Session not found');
+  });
+
+  it('returns stringified non-Error for 4xx', () => {
+    expect(safeErrorMessage('raw string', 400)).toBe('raw string');
+    expect(safeErrorMessage(42, 400)).toBe('42');
+  });
+
+  it('treats 4xx as client-facing boundary', () => {
+    const err = new Error('Too many requests');
+    expect(safeErrorMessage(err, 429)).toBe('Too many requests');
+  });
+
+  it('redacts internal paths from 5xx via Error objects', () => {
+    const err = new Error('ENOENT: no such file, open \'/home/user/.aegis/state/keys.json\'');
+    expect(safeErrorMessage(err, 500)).toBe('Internal server error');
+  });
+
+  it('redacts internal variable names from 5xx', () => {
+    const err = new Error('Cannot read property acpAgentSessionId of undefined');
+    expect(safeErrorMessage(err, 500)).toBe('Internal server error');
+  });
+});

--- a/src/routes/context.ts
+++ b/src/routes/context.ts
@@ -526,6 +526,21 @@ export function withValidation<T>(
   };
 }
 
+
+/**
+ * Sanitize an error for HTTP response bodies.
+ * Internal error details (stack traces, internal paths, variable names)
+ * must never reach API consumers. Returns a generic message for 5xx errors,
+ * and the original message for 4xx errors (which are client-facing).
+ */
+export function safeErrorMessage(e: unknown, statusCode: number): string {
+  if (statusCode >= 500) {
+    // Never leak internal error details to clients on 5xx
+    return 'Internal server error';
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
 /**
  * Wrap an ownership check around a session route handler. Validates that
  * the caller owns the session identified by `req.params.id`, then passes

--- a/src/routes/control-actions.ts
+++ b/src/routes/control-actions.ts
@@ -23,7 +23,7 @@ import {
   approveToolSchema,
   rejectToolSchema,
 } from '../validation.js';
-import {
+import { safeErrorMessage,
   type RouteContext,
   registerWithLegacy,
   withSessionOwnership,
@@ -159,7 +159,7 @@ export function registerControlActionRoutes(app: Parameters<typeof registerWithL
 
       return buildResult(session.id, session.status, session.lastActivity, record);
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -200,7 +200,7 @@ export function registerControlActionRoutes(app: Parameters<typeof registerWithL
 
       return buildResult(session.id, session.status, session.lastActivity, record);
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -236,7 +236,7 @@ export function registerControlActionRoutes(app: Parameters<typeof registerWithL
 
       return buildResult(session.id, session.status, session.lastActivity, record);
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -257,7 +257,7 @@ export function registerControlActionRoutes(app: Parameters<typeof registerWithL
       if (audit) void audit.log(resolveRequestAuditActor(auth, req, 'api-key'), 'session.cancel', `Session cancelled: ${session.id}`, session.id, scope.tenantId);
       return { ok: true };
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -275,7 +275,7 @@ export function registerControlActionRoutes(app: Parameters<typeof registerWithL
       }
       return serializeRecord(record);
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }));
 
@@ -297,7 +297,7 @@ export function registerControlActionRoutes(app: Parameters<typeof registerWithL
       ctx.eventBus.emit(session.id, { event: 'approval_resolved', sessionId: session.id, timestamp: new Date().toISOString(), data: { action: 'approved', approvalId: parsed.data.approvalId } });
       return result;
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -319,7 +319,7 @@ export function registerControlActionRoutes(app: Parameters<typeof registerWithL
       ctx.eventBus.emit(session.id, { event: 'approval_resolved', sessionId: session.id, timestamp: new Date().toISOString(), data: { action: 'rejected', approvalId: parsed.data.approvalId } });
       return result;
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 

--- a/src/routes/quick-approve-reject.ts
+++ b/src/routes/quick-approve-reject.ts
@@ -8,7 +8,7 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import {
+import { safeErrorMessage,
   type RouteContext,
   registerWithLegacy,
   requirePermission,
@@ -60,7 +60,7 @@ export function registerQuickApproveRejectRoutes(app: FastifyInstance, ctx: Rout
 
       return reply.send({ ok: true });
     } catch (e: unknown) {
-      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(404).send({ error: safeErrorMessage(e, 404) });
     }
   };
 
@@ -99,7 +99,7 @@ export function registerQuickApproveRejectRoutes(app: FastifyInstance, ctx: Rout
 
       return reply.send({ ok: true });
     } catch (e: unknown) {
-      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(404).send({ error: safeErrorMessage(e, 404) });
     }
   };
 

--- a/src/routes/session-approval.ts
+++ b/src/routes/session-approval.ts
@@ -7,7 +7,7 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import {
+import { safeErrorMessage,
   type RouteContext,
   requireSessionOwnership,
 } from './context.js';
@@ -45,7 +45,7 @@ export function registerSessionApprovalRoutes(
 
       return { ok: true, status: updated.status, approvedBy: updated.approvedBy, approvedAt: updated.approvedAt };
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   };
 
@@ -78,7 +78,7 @@ export function registerSessionApprovalRoutes(
 
       return { ok: true, status: 'killed' };
     } catch (e: unknown) {
-      return reply.status(500).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   };
 

--- a/src/routes/session-data.ts
+++ b/src/routes/session-data.ts
@@ -12,7 +12,7 @@ import { runVerification } from '../verification.js';
 import { readNewEntries } from '../transcript.js';
 import { SSEWriter } from '../sse-writer.js';
 import type { SessionSSEEvent } from '../events.js';
-import {
+import { safeErrorMessage,
   type RouteContext,
   registerWithLegacy, requireRole, withOwnership, withValidation,
 } from './context.js';
@@ -57,7 +57,7 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
   // Session summary (Issue #35)
   registerWithLegacy(app, 'get', '/v1/sessions/:id/summary', withOwnership(sessions, async (_req, reply, session) => {
     try { return await sessions.getSummary(session.id); } catch (e: unknown) {
-      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(404).send({ error: safeErrorMessage(e, 404) });
     }
   }));
 
@@ -75,7 +75,7 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
       const sessionId = (req.params as { id: string }).id;
       return await sessions.readTranscript(sessionId, page, limit, roleFilter as 'user' | 'assistant' | 'system' | undefined);
     } catch (e: unknown) {
-      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(404).send({ error: safeErrorMessage(e, 404) });
     }
   }));
 
@@ -102,7 +102,7 @@ export function registerSessionDataRoutes(app: FastifyInstance, ctx: RouteContex
         roleFilter as 'user' | 'assistant' | 'system' | undefined,
       );
     } catch (e: unknown) {
-      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(404).send({ error: safeErrorMessage(e, 404) });
     }
   }));
 

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -19,7 +19,7 @@ import {
   resolveRequestAuditActor,
   getRequestRole,
   addActionHints,
-  redactSession,
+  redactSession, safeErrorMessage,
   makePayload,
   registerWithLegacy, withOwnership, withSessionOwnership, withValidation,
 } from './context.js';
@@ -480,7 +480,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
         const auditLogger = getAuditLogger();
         if (auditLogger) void auditLogger.log(resolveRequestAuditActor(auth, req, 'system'), 'session.acp.failed', `ACP session record creation failed for workDir ${safeWorkDir}: ${(e as Error).message}`, undefined, req.tenantId);
         const acpErr = e instanceof Error ? e.message : String(e);
-        return reply.status(500).send({ error: 'Session creation failed', details: acpErr });
+        return reply.status(500).send({ error: 'Session creation failed' });
       }
       try {
         session = await sessions.createSession({ id: acpResult.session.id, workDir: safeWorkDir, name, prd, resumeSessionId, claudeCommand, env: env as Record<string, string> | undefined, stallThresholdMs, permissionMode, autoApprove, parentId, ownerKeyId: req.authKeyId, tenantId: req.tenantId, model, effort, isolationPolicy, runnerName: 'claude-code' });
@@ -695,7 +695,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       }
       return health;
     } catch (e: unknown) {
-      return reply.status(404).send({ error: e instanceof Error ? e.message : String(e) });
+      return reply.status(404).send({ error: safeErrorMessage(e, 404) });
     }
   }));
   // ACP-063: POST /v1/sessions/:id/events/replay — Replay events from durable event store
@@ -727,7 +727,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      return reply.status(500).send({ error: 'Failed to query event store', details: msg });
+      return reply.status(500).send({ error: 'Failed to query event store' });
     }
   }));
 

--- a/src/routes/templates.ts
+++ b/src/routes/templates.ts
@@ -6,7 +6,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import * as templateStore from '../template-store.js';
 import type { RouteContext } from './context.js';
-import { registerWithLegacy, withValidation, requireRole } from './context.js';
+import { safeErrorMessage, registerWithLegacy, withValidation, requireRole } from './context.js';
 
 // #1393: claudeCommand must not contain shell metacharacters
 const SAFE_COMMAND_RE = /^[a-zA-Z0-9_./@:= -]+$/;
@@ -92,7 +92,7 @@ export function registerTemplateRoutes(
         });
         return reply.status(201).send(template);
       } catch (e: unknown) {
-        return reply.status(500).send({ error: e instanceof Error ? e.message : 'Failed to create template' });
+        return reply.status(500).send({ error: safeErrorMessage(e, 500) });
       }
     }),
   });
@@ -116,7 +116,7 @@ export function registerTemplateRoutes(
         if (!template) return reply.status(404).send({ error: 'Template not found' });
         return template;
       } catch (e: unknown) {
-        return reply.status(500).send({ error: e instanceof Error ? e.message : 'Failed to get template' });
+        return reply.status(500).send({ error: safeErrorMessage(e, 500) });
       }
     },
   });
@@ -132,7 +132,7 @@ export function registerTemplateRoutes(
         if (!template) return reply.status(404).send({ error: 'Template not found' });
         return template;
       } catch (e: unknown) {
-        return reply.status(500).send({ error: e instanceof Error ? e.message : 'Failed to update template' });
+        return reply.status(500).send({ error: safeErrorMessage(e, 500) });
       }
     }),
   });
@@ -147,7 +147,7 @@ export function registerTemplateRoutes(
         if (!deleted) return reply.status(404).send({ error: 'Template not found' });
         return { ok: true };
       } catch (e: unknown) {
-        return reply.status(500).send({ error: e instanceof Error ? e.message : 'Failed to delete template' });
+        return reply.status(500).send({ error: safeErrorMessage(e, 500) });
       }
     },
   });

--- a/src/routes/terminal.ts
+++ b/src/routes/terminal.ts
@@ -11,7 +11,7 @@
  */
 
 import { z } from 'zod';
-import {
+import { safeErrorMessage,
   type RouteContext,
   registerWithLegacy,
   withSessionOwnership,
@@ -110,7 +110,7 @@ export function registerTerminalRoutes(app: Parameters<typeof registerWithLegacy
       if (message.includes('not active')) {
         return reply.status(503).send({ error: 'ACP runtime is not active for this session', code: 'RUNTIME_UNAVAILABLE' });
       }
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -129,7 +129,7 @@ export function registerTerminalRoutes(app: Parameters<typeof registerWithLegacy
       return { ok: true };
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -148,7 +148,7 @@ export function registerTerminalRoutes(app: Parameters<typeof registerWithLegacy
       return { ok: true };
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -167,7 +167,7 @@ export function registerTerminalRoutes(app: Parameters<typeof registerWithLegacy
       return result;
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 
@@ -188,7 +188,7 @@ export function registerTerminalRoutes(app: Parameters<typeof registerWithLegacy
       return { ok: true };
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: safeErrorMessage(e, 500) });
     }
   }, 'send'));
 }


### PR DESCRIPTION
## Summary

Route handlers previously leaked raw `Error.message` in 500 responses, exposing internal paths (`/home/user/.aegis/keys.json`), variable names (`acpAgentSessionId`), and stack details to API consumers.

## Changes

**New helper: `safeErrorMessage(e, statusCode)`** (routes/context.ts)
- 5xx errors → returns generic "Internal server error"
- 4xx errors → returns original message (client-facing, useful for debugging)

**Applied across 7 route files** (25 instances total):
- control-actions.ts (7 replacements)
- terminal.ts (5)
- templates.ts (4)
- session-data.ts (3)
- sessions.ts (2, also removed `details:` fields that leaked internal info)
- session-approval.ts (2)
- quick-approve-reject.ts (2)

**Test coverage:** 7 new tests for `safeErrorMessage` behavior

## Verification

- TypeScript: 0 errors
- 411 test files, 5883 tests passed, 0 failures