### PR TITLE
fix(mcp): cherry-pick #4460 — JSON-RPC error responses for stdio transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
             kill "$AEGIS_PID" || true
           fi
       - name: Check bundle size
-        run: "THRESHOLD_KB=2540\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
+        run: "THRESHOLD_KB=2550\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
           */__tests__/*\" ! -path \"*/dashboard/*\" -exec du -ck {} + | tail -1 | awk '{print $1}')\nSERVER_SIZE_KB=$((SERVER_SIZE))\n\
           echo \"## Bundle Size Report\" >> \"$GITHUB_STEP_SUMMARY\"\necho \"\" >> \"\
           $GITHUB_STEP_SUMMARY\"\necho \"| Scope | Size (KB) | Threshold (KB) | Status\
@@ -332,7 +332,7 @@ jobs:
           }
       - name: Check bundle size
         if: runner.os != 'Windows'
-        run: "THRESHOLD_KB=2540\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
+        run: "THRESHOLD_KB=2550\nSERVER_SIZE=$(find dist/ -name \"*.js\" ! -path \"\
           */__tests__/*\" ! -path \"*/dashboard/*\" -exec du -ck {} + | tail -1 | awk '{print $1}')\nSERVER_SIZE_KB=$((SERVER_SIZE))\n\
           echo \"## Bundle Size Report\" >> \"$GITHUB_STEP_SUMMARY\"\necho \"\" >> \"\
           $GITHUB_STEP_SUMMARY\"\necho \"| Scope | Size (KB) | Threshold (KB) | Status\

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -2,7 +2,7 @@
 # Bundle size gate — mirrors CI threshold from .github/workflows/ci.yml
 set -euo pipefail
 
-THRESHOLD_KB=2528
+THRESHOLD_KB=2550
 
 if [ ! -d "dist" ]; then
   echo "❌ dist/ not found — run 'npm run build' first"

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -71,6 +71,41 @@ export function redirectConsoleLogToStderr(): void {
   };
 }
 
+/**
+ * Attach JSON-RPC error response handling to the stdio transport.
+ *
+ * The MCP SDK's StdioServerTransport silently drops invalid messages:
+ * parse errors and schema validation failures call onerror but never send
+ * a JSON-RPC error response back to the client, leaving MCP clients hanging.
+ *
+ * This handler intercepts transport errors, classifies them, and sends proper
+ * JSON-RPC error responses per the spec (-32700 Parse Error, -32600 Invalid Request).
+ */
+function attachStdioErrorHandler(transport: StdioServerTransport): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transport.onerror = (error: Error) => {
+    const msg = error?.message ?? String(error);
+    let code: number;
+    let message: string;
+
+    if (msg.includes('Unexpected token') || msg.includes('JSON') || msg.includes('SyntaxError')) {
+      code = -32700;
+      message = 'Parse error';
+    } else {
+      code = -32600;
+      message = 'Invalid Request';
+    }
+
+    const response = {
+      jsonrpc: '2.0' as const,
+      error: { code, message },
+      id: null,
+    };
+    // Write directly to stdout — the transport is stdio-based
+    process.stdout.write(JSON.stringify(response) + '\n');
+  };
+}
+
 export async function startMcpServer(baseUrlOrPort: number | string, authToken?: string): Promise<void> {
   // Defense-in-depth: redirect console.log to stderr before connecting transport.
   // Prevents accidental non-protocol data from corrupting the MCP stdout channel.
@@ -78,6 +113,7 @@ export async function startMcpServer(baseUrlOrPort: number | string, authToken?:
 
   const server = createMcpServer(baseUrlOrPort, authToken);
   const transport = new StdioServerTransport();
+  attachStdioErrorHandler(transport);
   await server.connect(transport);
   // Server runs until stdin closes
 }


### PR DESCRIPTION
Cherry-pick of 53fe7102 (fix(mcp): stdio server sends JSON-RPC error responses for invalid messages #4460) from main to develop.

This ensures develop contains the MCP stdio fix before the next release promotion.