### PR TITLE
fix(deps): break metrics circular dep + fix circular-deps detection

### DIFF
--- a/scripts/check-circular-deps.sh
+++ b/scripts/check-circular-deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Runs madge circular check
-CIRC=$(npx madge --circular src 2>/dev/null || true)
+CIRC=$(npx madge --circular --extensions ts src 2>/dev/null || true)
 if [ -n "$CIRC" ]; then
   echo "Circular dependencies found:";
   echo "$CIRC";

--- a/src/__tests__/metrics-aggregate-2087.test.ts
+++ b/src/__tests__/metrics-aggregate-2087.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeAggregateMetrics, type SessionForAggregation } from '../metrics.js';
+import { computeAggregateMetrics, type SessionForAggregation } from '../metrics-aggregation.js';
 import type { AggregateMetricsByKey } from '../api-contracts.js';
 import type { SessionMetrics } from '../metrics.js';
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -467,9 +467,5 @@ export class MetricsCollector {
 
 // ── Issue #2087: Aggregation helpers ────────────────────────────────
 // Extracted to metrics-aggregation.ts — re-export for backward compatibility.
-export {
-  computeAggregateMetrics,
-  type GroupBy,
-  type SessionForAggregation,
-  type KeyNameMap,
-} from './metrics-aggregation.js';
+// Re-export removed — import directly from metrics-aggregation.js to break circular dependency.
+// See: fix/4488-reapply-circular-dep-breaks

--- a/src/routes/audit.ts
+++ b/src/routes/audit.ts
@@ -13,7 +13,7 @@ import {
   buildAuditChainMetadata,
 } from '../audit.js';
 import { diagnosticsBus } from '../diagnostics.js';
-import { computeAggregateMetrics, type GroupBy } from '../metrics.js';
+import { computeAggregateMetrics, type GroupBy } from '../metrics-aggregation.js';
 import { type RouteContext, requireRole, registerWithLegacy } from './context.js';
 
 const AUDIT_FORMATS = ['json', 'csv', 'ndjson'] as const;


### PR DESCRIPTION
## Summary

Breaks the `metrics.ts > metrics-aggregation.ts` circular dependency and fixes the `check-circular-deps.sh` script that was silently passing with 0 files processed.

## Changes

### 1. Break metrics cycle (5 → 4 cycles)
- Removed re-export of `metrics-aggregation` exports from `metrics.ts` — this was the source of the cycle
- Redirected `src/routes/audit.ts` to import directly from `metrics-aggregation.js`
- Redirected `src/__tests__/metrics-aggregate-2087.test.ts` to import directly from `metrics-aggregation.js`

### 2. Fix `check-circular-deps.sh` (false negative)
- Added `--extensions ts` flag to madge invocation
- **Before:** processed 0 files, always reported "no circular dependencies"
- **After:** correctly processes 681 files, detects actual cycles

### 3. Cycle count progression
| State | Cycles | session.ts cycles |
|-------|--------|-------------------|
| Before #4492 | 11 | 7 |
| After #4492 | 5 | 0 |
| This PR | **4** | 0 |
| Remaining (unrelated) | 4 | 0 |

### Remaining 4 cycles (unrelated modules — tracked separately)
1. `services/acp/session-service.ts > pause-intervention.ts`
2. `services/acp/index.ts > terminal-bridge.ts`
3. `pipeline.ts > services/state/state-store.ts`
4. `channels/telegram/types.ts > channels/telegram/topic-persistence.ts`

## Process note: silent reverts from squash merges

This PR also addresses a process issue discovered during investigation. The `check-circular-deps.sh` script was not running with `--extensions ts`, meaning it processed 0 files and always passed. This gave false confidence that #4492's fixes were effective. **The fixed script should be run in CI** to catch future import regressions from merge conflict resolution.

Refs #4488