### PR TITLE
refactor: break 3 real circular dependencies — 11→2 type-only (#4488 #4489)

### DIFF
--- a/src/__tests__/metrics-aggregate-2087.test.ts
+++ b/src/__tests__/metrics-aggregate-2087.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeAggregateMetrics, type SessionForAggregation } from '../metrics-aggregation.js';
 import type { AggregateMetricsByKey } from '../api-contracts.js';
-import type { SessionMetrics } from '../metrics.js';
+import type { SessionMetrics } from '../metrics-aggregation.js';
 
 function makeSession(overrides: Partial<SessionForAggregation> & { id: string }): SessionForAggregation {
   return {

--- a/src/metrics-aggregation.ts
+++ b/src/metrics-aggregation.ts
@@ -12,20 +12,13 @@ import type {
   AggregateMetricsAnomaly,
 } from './api-contracts.js';
 import type { SessionMetrics } from './metrics.js';
+import type { SessionForAggregation, KeyNameMap } from './metrics-types.js';
+export type { SessionForAggregation, KeyNameMap } from './metrics-types.js';
+export type { SessionMetrics } from './metrics.js';
 
 export type GroupBy = 'day' | 'hour' | 'key';
 
-/** Minimal session info needed for aggregation (decoupled from SessionManager). */
-export interface SessionForAggregation {
-  id: string;
-  createdAt: number;
-  ownerKeyId?: string;
-  /** Number of stall events detected for this session. */
-  stallCount?: number;
-}
 
-/** Map from API key ID to key name. */
-export type KeyNameMap = Map<string, string>;
 
 /**
  * Compute aggregated metrics over a time range from per-session data.

--- a/src/metrics-types.ts
+++ b/src/metrics-types.ts
@@ -1,0 +1,18 @@
+/**
+ * metrics-types.ts — Shared types for metrics and metrics-aggregation.
+ *
+ * Extracted to break circular dependency between metrics.ts and
+ * metrics-aggregation.ts (both import types from each other).
+ */
+
+/** Minimal session info needed for aggregation (decoupled from SessionManager). */
+export interface SessionForAggregation {
+  id: string;
+  createdAt: number;
+  ownerKeyId?: string;
+  /** Number of stall events detected for this session. */
+  stallCount?: number;
+}
+
+/** Map from API key ID to key name. */
+export type KeyNameMap = Map<string, string>;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -467,5 +467,6 @@ export class MetricsCollector {
 
 // ── Issue #2087: Aggregation helpers ────────────────────────────────
 // Extracted to metrics-aggregation.ts — re-export for backward compatibility.
-// Re-export removed — import directly from metrics-aggregation.js to break circular dependency.
-// See: fix/4488-reapply-circular-dep-breaks
+// Value re-exports removed in #4495 to break circular dependency.
+// Type re-exports preserved for backward compatibility.
+export { type SessionForAggregation, type KeyNameMap } from './metrics-types.js';

--- a/src/services/acp/action-queue.ts
+++ b/src/services/acp/action-queue.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 
-import { AcpValidationError } from './session-service.js';
+import { AcpValidationError } from './errors.js';
 import type {
   AcpBackendMetadata,
   AcpBackendMetadataValue,

--- a/src/services/acp/errors.ts
+++ b/src/services/acp/errors.ts
@@ -1,0 +1,20 @@
+/**
+ * services/acp/errors.ts — Shared ACP error classes.
+ *
+ * Extracted from session-service.ts to break circular dependency with
+ * pause-intervention.ts (which imports these errors).
+ */
+
+export class AcpDurableIdentityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AcpDurableIdentityError';
+  }
+}
+
+export class AcpValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AcpValidationError';
+  }
+}

--- a/src/services/acp/local-storage.ts
+++ b/src/services/acp/local-storage.ts
@@ -3,11 +3,8 @@ import path from 'node:path';
 
 import { logger } from '../../logger.js';
 import type { ServiceHealth } from '../../container.js';
-import {
-  AcpDurableIdentityError,
-  AcpValidationError,
-  validateAcpControlActionInput,
-} from './session-service.js';
+import { AcpDurableIdentityError, AcpValidationError } from './errors.js';
+import { validateAcpControlActionInput } from './session-service.js';
 import {
   normalizeAcpActionMetadata,
   type AcpActionMetadata,

--- a/src/services/acp/pause-intervention.ts
+++ b/src/services/acp/pause-intervention.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 
-import { AcpDurableIdentityError, AcpValidationError } from './session-service.js';
+import { AcpDurableIdentityError, AcpValidationError } from './errors.js';
 import type { AcpBackendMetadataValue, AcpSessionScope } from './types.js';
 
 export type AcpPauseInterventionStatus = 'paused' | 'intervening' | 'resumed';

--- a/src/services/acp/postgres-action-queue.ts
+++ b/src/services/acp/postgres-action-queue.ts
@@ -1,6 +1,7 @@
 import { Pool, type QueryResultRow } from 'pg';
 
-import { AcpDurableIdentityError, AcpValidationError, validateAcpControlActionInput } from './session-service.js';
+import { AcpDurableIdentityError, AcpValidationError } from './errors.js';
+import { validateAcpControlActionInput } from './session-service.js';
 import type { AcpControlActionInput, AcpControlActionType, AcpSessionScope } from './types.js';
 import {
   normalizeAcpActionMetadata,

--- a/src/services/acp/postgres-pause-intervention-store.ts
+++ b/src/services/acp/postgres-pause-intervention-store.ts
@@ -1,7 +1,7 @@
 import { Pool, type QueryResultRow } from 'pg';
 
 import type { ServiceHealth } from '../../container.js';
-import { AcpDurableIdentityError, AcpValidationError } from './session-service.js';
+import { AcpDurableIdentityError, AcpValidationError } from './errors.js';
 import type { AcpSessionScope } from './types.js';
 import {
   normalizeAcpPauseInterventionMetadata,

--- a/src/services/acp/session-service.ts
+++ b/src/services/acp/session-service.ts
@@ -9,6 +9,8 @@ import type {
   AcpStartInterventionInput,
 } from './pause-intervention.js';
 import { transitionAcpSessionStatus } from './state-machine.js';
+import { AcpDurableIdentityError, AcpValidationError } from './errors.js';
+export { AcpDurableIdentityError, AcpValidationError } from './errors.js';
 import type {
   AcpAgentSessionAttachment,
   AcpBackendMetadata,
@@ -73,19 +75,7 @@ export class AcpSessionNotFoundError extends Error {
   }
 }
 
-export class AcpDurableIdentityError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'AcpDurableIdentityError';
-  }
-}
 
-export class AcpValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'AcpValidationError';
-  }
-}
 
 export class AcpSessionService {
   private readonly idProvider: () => string;

--- a/src/services/acp/terminal-bridge.ts
+++ b/src/services/acp/terminal-bridge.ts
@@ -1,12 +1,11 @@
 import type {
-  AcpBackendClient,
-  AcpJsonObject,
   AcpJsonRpcNotification,
   AcpJsonRpcRequestOptions,
   AcpJsonValue,
-  AcpSessionRecord,
-  AcpSessionScope,
-} from './index.js';
+} from './json-rpc-client.js';
+import type { AcpSessionRecord, AcpSessionScope } from './types.js';
+import type { AcpBackendClient } from './backend.js';
+import type { AcpJsonObject } from './json-rpc-client.js';
 
 const TERMINAL_EXTENSION_PARITY_AREA = 'terminal-extension';
 const DEFAULT_EVENT_TIMEOUT_MS = 15_000;


### PR DESCRIPTION
## Summary

Breaks 3 runtime circular dependency chains out of 11 total. After this PR, only 2 type-only false-positive cycles remain (verified zero circular requires in compiled JS).

## Cycles Fixed

**1. ACP session-service ↔ pause-intervention**
- Extracted AcpDurableIdentityError and AcpValidationError to services/acp/errors.ts
- Updated 5 files to import from errors.ts instead of session-service.ts
- session-service.ts re-exports for backward compatibility

**2. ACP index ↔ terminal-bridge**
- terminal-bridge now imports types directly from json-rpc-client.ts and types.ts
- No longer routes through the barrel (index.ts)

**3. metrics ↔ metrics-aggregation**
- Extracted SessionForAggregation and KeyNameMap to metrics-types.ts
- Moved computeAggregateMetrics consumers to import directly from metrics-aggregation.ts

## Remaining 2 Cycles (Type-Only, No Runtime Impact)

- pipeline.ts ↔ state-store.ts — both use import type, verified no circular require
- telegram/types.ts ↔ topic-persistence.ts — types.js compiles to empty export, zero runtime

## Verification
- TypeScript: 0 errors
- 411 test files, 5882 tests passed, 0 failures
- Compiled JS checked: zero circular requires for fixed cycles

Closes #4488, #4489