### PR TITLE
feat(session): per-session metadata KV store (#4484)

### DIFF
--- a/src/__tests__/session-metadata-4484.test.ts
+++ b/src/__tests__/session-metadata-4484.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for per-session metadata KV store (Issue #4484)
+ *
+ * Covers:
+ * - POST /v1/sessions/:id/meta — set metadata
+ * - GET /v1/sessions/:id/meta — get metadata
+ * - DELETE /v1/sessions/:id/meta/:key — delete key
+ * - Validation: max keys, max value length, empty key, key too long
+ */
+
+import Fastify from 'fastify';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { registerSessionRoutes } from '../routes/sessions.js';
+import type { RouteContext } from '../routes/context.js';
+import type { SessionInfo } from '../session.js';
+
+const SESSION_ID = 'a0000000-meta-4000-8000-000000000000';
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: SESSION_ID,
+    displayName: 'meta-test',
+    workDir: '/tmp/meta-test',
+    byteOffset: 0,
+    monitorOffset: 0,
+    status: 'idle',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    stallThresholdMs: 300_000,
+    permissionStallMs: 300_000,
+    permissionMode: 'default',
+    ...overrides,
+  } as SessionInfo;
+}
+
+function buildApp(session: SessionInfo | null) {
+  const sessions = {
+    get: vi.fn(() => []),
+    getSession: vi.fn((id: string) => (id === SESSION_ID && session ? session : undefined)),
+    create: vi.fn(async () => makeSession()),
+    update: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    kill: vi.fn(async () => {}),
+    save: vi.fn(async () => {}),
+    getHealth: vi.fn(async () => null),
+    readMessagesFromSession: vi.fn(async () => ({ messages: [], status: 'idle', statusText: null, interactiveContent: null })),
+    submitAnswer: vi.fn(() => true),
+    getAll: vi.fn(() => session ? [session] : []),
+  };
+
+  const ctx: RouteContext = {
+    auth: {
+      authenticate: vi.fn(async (req) => ({ ok: true, keyId: 'master', tenantId: 'default' })),
+      requireRole: vi.fn(() => true),
+    },
+    sessions,
+    config: { requireApproval: false },
+    getAuditLogger: vi.fn(() => null),
+    eventBus: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+    terminalBridge: undefined,
+    acpBackend: undefined,
+    promptManager: undefined,
+    alertManager: undefined,
+  } as unknown as RouteContext;
+
+  const app = Fastify();
+  registerSessionRoutes(app, ctx);
+  return { app, sessions, ctx };
+}
+
+describe('Session metadata KV store', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+  let session: SessionInfo;
+
+  beforeEach(async () => {
+    session = makeSession();
+    app = buildApp(session);
+  });
+
+  describe('POST /v1/sessions/:id/meta', () => {
+    it('sets metadata on a session', async () => {
+      const res = await app.app.inject({
+        method: 'POST',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+        payload: { pr_number: '1234', author: 'boss' },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().metadata).toEqual({ pr_number: '1234', author: 'boss' });
+      expect(session.metadata).toEqual({ pr_number: '1234', author: 'boss' });
+    });
+
+    it('merges with existing metadata', async () => {
+      session.metadata = { pr_number: '1234' };
+
+      const res = await app.app.inject({
+        method: 'POST',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+        payload: { status: 'in-review' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().metadata).toEqual({ pr_number: '1234', status: 'in-review' });
+    });
+
+    it('overwrites existing keys', async () => {
+      session.metadata = { pr_number: '1234' };
+
+      const res = await app.app.inject({
+        method: 'POST',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+        payload: { pr_number: '5678' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().metadata).toEqual({ pr_number: '5678' });
+    });
+
+    it('rejects empty metadata', async () => {
+      const res = await app.app.inject({
+        method: 'POST',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('at least one key');
+    });
+
+    it('rejects value exceeding 256 characters', async () => {
+      const res = await app.app.inject({
+        method: 'POST',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+        payload: { key: 'x'.repeat(257) },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/256|Invalid/);
+    });
+
+    it('rejects when exceeding 20 keys total', async () => {
+      const metadata: Record<string, string> = {};
+      for (let i = 0; i < 20; i++) metadata[`key${i}`] = `val${i}`;
+      session.metadata = metadata;
+
+      const res = await app.app.inject({
+        method: 'POST',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+        payload: { overflow: 'nope' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('20');
+    });
+
+    it('returns 404 for unknown session', async () => {
+      const res = await app.app.inject({
+        method: 'POST',
+        url: '/v1/sessions/00000000-0000-0000-0000-000000000000/meta',
+        payload: { key: 'val' },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('GET /v1/sessions/:id/meta', () => {
+    it('returns empty object for session with no metadata', async () => {
+      const res = await app.app.inject({
+        method: 'GET',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().metadata).toEqual({});
+    });
+
+    it('returns all metadata', async () => {
+      session.metadata = { pr_number: '1234', status: 'review' };
+
+      const res = await app.app.inject({
+        method: 'GET',
+        url: `/v1/sessions/${SESSION_ID}/meta`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().metadata).toEqual({ pr_number: '1234', status: 'review' });
+    });
+  });
+
+  describe('DELETE /v1/sessions/:id/meta/:key', () => {
+    it('deletes a single key', async () => {
+      session.metadata = { pr_number: '1234', status: 'review' };
+
+      const res = await app.app.inject({
+        method: 'DELETE',
+        url: `/v1/sessions/${SESSION_ID}/meta/status`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().metadata).toEqual({ pr_number: '1234' });
+    });
+
+    it('returns 404 for non-existent key', async () => {
+      const res = await app.app.inject({
+        method: 'DELETE',
+        url: `/v1/sessions/${SESSION_ID}/meta/nonexistent`,
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json().error).toContain('not found');
+    });
+
+    it('cleans up metadata object when last key deleted', async () => {
+      session.metadata = { lone: 'wolf' };
+
+      await app.app.inject({
+        method: 'DELETE',
+        url: `/v1/sessions/${SESSION_ID}/meta/lone`,
+      });
+
+      // Metadata should be undefined after cleanup
+      expect(session.metadata).toBeUndefined();
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import { handleLogout } from './commands/logout.js';
 import { handleWhoami } from './commands/whoami.js';
 import { handleRun } from './commands/run.js';
 import { handleList } from './commands/list.js';
+import { handleMeta } from './commands/meta.js';
 import { handleUpdate } from './commands/update.js';
 import { handleRead } from './commands/read.js';
 import { handleKill } from './commands/kill.js';
@@ -349,6 +350,7 @@ function printHelp(io: CliIO): void {
     ag update --check       Only check, no update (exit 1 if available)
     ag update --yes         Skip confirmation prompt
     ag update --dry-run      Show what would happen without updating
+    ag meta <id> [--set key=val] [--delete key]  Per-session metadata KV store
 ${authBlock}  Flags:
     --json-logs           Emit structured JSON logs (default: quiet mode)
 
@@ -384,7 +386,7 @@ ${authBlock}  Flags:
 export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO = defaultCliIO): Promise<number> {
   // Issue #3796: Only show generic help if no subcommand is provided.
   // Subcommands like 'run' handle their own --help with command-specific flags.
-  const knownCommands = ['mcp', 'init', 'doctor', 'create', 'login', 'logout', 'whoami', 'run', 'list', 'read', 'status', 'kill', 'sessions', 'stop', 'send', 'update', 'version', 'setup'];
+  const knownCommands = ['mcp', 'init', 'doctor', 'create', 'login', 'logout', 'whoami', 'run', 'list', 'read', 'status', 'kill', 'sessions', 'stop', 'send', 'meta', 'update', 'version', 'setup'];
   const hasKnownCommand = argv.length > 0 && knownCommands.includes(argv[0]);
   if ((argv.includes('--help') || argv.includes('-h')) && !hasKnownCommand) {
     printHelp(io);
@@ -465,6 +467,9 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
     return handleTail(argv.slice(1), io);
   }
 
+  if (argv[0] === 'meta') {
+    return handleMeta(argv.slice(1), io);
+  }
   if (argv[0] === 'update') {
     return handleUpdate(argv.slice(1), io);
   }

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -1,0 +1,128 @@
+/**
+ * commands/meta.ts — `ag meta <session-id> [--set key=value ...] [--delete key ...]`
+ *
+ * Per-session metadata KV store.
+ *
+ * Usage:
+ *   ag meta <session-id>                     — show all metadata
+ *   ag meta <session-id> --set key=value      — set one or more keys
+ *   ag meta <session-id> --delete key         — remove a key
+ */
+
+import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+import { resolveSessionId } from './read.js';
+
+export async function handleMeta(args: string[], io: CliIO): Promise<number> {
+  // Parse arguments
+  const setIndex = args.indexOf('--set');
+  const deleteIndex = args.indexOf('--delete');
+
+  const positionalArgs = args.filter(a => !a.startsWith('--'));
+  const setArgs = setIndex >= 0 ? args.slice(setIndex + 1, deleteIndex >= 0 ? deleteIndex : args.length) : [];
+  const deleteArgs = deleteIndex >= 0 ? args.slice(deleteIndex + 1) : [];
+
+  const sessionArg = positionalArgs[0];
+  const baseUrl = await resolveBaseUrl(args);
+  const authToken = await resolveAuthToken();
+  if (!(await requireServer(baseUrl, authToken, io))) return 1;
+
+  const headers = buildHeaders(authToken);
+
+  // Resolve session ID (accept short prefixes)
+  let sessionId: string | null;
+  try {
+    sessionId = await resolveSessionId(sessionArg, baseUrl, headers, io);
+  } catch {
+    writeLine(io.stderr, `  ❌ Could not resolve session: ${sessionArg}`);
+    return 1;
+  }
+
+  if (!sessionId) {
+    writeLine(io.stderr, '  ❌ Could not resolve session ID');
+    return 1;
+  }
+
+  if (setArgs.length > 0) {
+    return handleSet(sessionId, setArgs, baseUrl, headers, io);
+  } else if (deleteArgs.length > 0) {
+    return handleDelete(sessionId, deleteArgs, baseUrl, headers, io);
+  } else {
+    return handleGet(sessionId, baseUrl, headers, io);
+  }
+}
+
+async function handleGet(sessionId: string, baseUrl: string, headers: Record<string, string>, io: CliIO): Promise<number> {
+  const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/meta`, {
+    headers,
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    writeLine(io.stderr, `  ❌ Failed to fetch metadata: ${res.statusText}`);
+    return 1;
+  }
+
+  const data = await res.json() as { metadata: Record<string, string> };
+  const meta = data.metadata ?? {};
+
+  if (Object.keys(meta).length === 0) {
+    writeLine(io.stdout, `  No metadata for session ${sessionId}`);
+    return 0;
+  }
+
+  writeLine(io.stdout, `  Metadata for ${sessionId}`);
+  writeLine(io.stdout, '  ─────────────────────');
+  for (const [key, value] of Object.entries(meta)) {
+    writeLine(io.stdout, `  ${key}: ${value}`);
+  }
+  return 0;
+}
+
+async function handleSet(sessionId: string, setArgs: string[], baseUrl: string, headers: Record<string, string>, io: CliIO): Promise<number> {
+  const metadata: Record<string, string> = {};
+  for (const arg of setArgs) {
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex < 1 || eqIndex >= arg.length - 1) {
+      writeLine(io.stderr, `  ❌ Invalid format: "${arg}" (expected key=value)`);
+      return 1;
+    }
+    const key = arg.slice(0, eqIndex);
+    const value = arg.slice(eqIndex + 1);
+    metadata[key] = value;
+  }
+
+  const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/meta`, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(metadata),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    const err = await res.json() as { error?: string } | null;
+    writeLine(io.stderr, `  ❌ ${err?.error ?? res.statusText}`);
+    return 1;
+  }
+
+  writeLine(io.stdout, `  ✅ Set ${Object.keys(metadata).length} key(s) on ${sessionId}`);
+  return 0;
+}
+
+async function handleDelete(sessionId: string, deleteArgs: string[], baseUrl: string, headers: Record<string, string>, io: CliIO): Promise<number> {
+  for (const key of deleteArgs) {
+    const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}/meta/${encodeURIComponent(key)}`, {
+      method: 'DELETE',
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      const err = await res.json() as { error?: string } | null;
+      writeLine(io.stderr, `  ❌ Delete "${key}": ${err?.error ?? res.statusText}`);
+      return 1;
+    }
+
+    writeLine(io.stdout, `  ✅ Deleted "${key}"`);
+  }
+  return 0;
+}

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -62,6 +62,8 @@ function buildCreateSessionSchema(ctx: RouteContext) {
   }).strict();
 }
 
+const metaSetSchema = z.record(z.string().min(1).max(64), z.string().max(256));
+
 const batchDeleteSchema = z.object({
   ids: z.array(z.string().uuid()).max(100).optional(),
   status: z.enum([
@@ -698,6 +700,65 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
       return reply.status(404).send({ error: safeErrorMessage(e, 404) });
     }
   }));
+
+  // ── Issue #4484: Per-session metadata KV store ─────────────────────
+  const META_MAX_KEYS = 20;
+  const META_MAX_VALUE_LENGTH = 256;
+
+  /** Validate metadata input: max 20 keys, max 256 chars per value. */
+  function validateMetadata(metadata: Record<string, string>): string | null {
+    const keys = Object.keys(metadata);
+    if (keys.length === 0) return 'Metadata must contain at least one key';
+    if (keys.length > META_MAX_KEYS) return `Maximum ${META_MAX_KEYS} keys allowed`;
+    for (const [key, value] of Object.entries(metadata)) {
+      if (!key.trim()) return 'Metadata keys must be non-empty';
+      if (key.length > 64) return 'Metadata keys must be 64 characters or less';
+      if (value.length > META_MAX_VALUE_LENGTH) return `Metadata value for "${key}" exceeds ${META_MAX_VALUE_LENGTH} characters`;
+    }
+    return null;
+  }
+
+  // POST /v1/sessions/:id/meta — set metadata key/value pairs (merge)
+  registerWithLegacy(app, 'post', '/v1/sessions/:id/meta', withOwnership(sessions, async (req: FastifyRequest, reply: FastifyReply, session) => {
+    const parsed = metaSetSchema.safeParse(req.body);
+    if (!parsed.success) return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
+
+    const validationError = validateMetadata(parsed.data);
+    if (validationError) return reply.status(400).send({ error: validationError });
+
+    if (!session.metadata) session.metadata = {};
+    const currentCount = Object.keys(session.metadata ?? {}).length;
+    const newKeys = Object.keys(parsed.data).filter(k => !(k in (session.metadata ?? {})));
+    if (currentCount + newKeys.length > META_MAX_KEYS) {
+      return reply.status(400).send({ error: `Would exceed maximum ${META_MAX_KEYS} keys (currently ${currentCount})` });
+    }
+
+    Object.assign(session.metadata!, parsed.data);
+    return { metadata: session.metadata };
+  }));
+
+  // GET /v1/sessions/:id/meta — retrieve all metadata
+  registerWithLegacy(app, 'get', '/v1/sessions/:id/meta', withOwnership(sessions, async (_req: FastifyRequest, _reply: FastifyReply, session) => {
+    return { metadata: session.metadata ?? {} };
+  }));
+
+  // DELETE /v1/sessions/:id/meta/:key — remove a single metadata key
+  registerWithLegacy(app, 'delete', '/v1/sessions/:id/meta/:key', withOwnership(sessions, async (req: FastifyRequest, reply: FastifyReply, session) => {
+    const key = (req.params as { key: string }).key;
+    if (!key) return reply.status(400).send({ error: 'Metadata key is required' });
+
+    if (!session.metadata || !(key in session.metadata)) {
+      return reply.status(404).send({ error: `Metadata key "${key}" not found` });
+    }
+
+    delete session.metadata[key];
+    // Clean up empty metadata object
+    if (Object.keys(session.metadata).length === 0) {
+      session.metadata = undefined;
+    }
+    return { metadata: session.metadata ?? {} };
+  }));
+
   // ACP-063: POST /v1/sessions/:id/events/replay — Replay events from durable event store
   // NOTE: GET /v1/sessions/:id/events is handled by session-data.ts (SSE streaming)
   registerWithLegacy(app, 'post', '/v1/sessions/:id/events/replay', withSessionOwnership(ctx, async (req: FastifyRequest, reply: FastifyReply, session) => {

--- a/src/session-types.ts
+++ b/src/session-types.ts
@@ -74,6 +74,8 @@ export interface SessionInfo {
   promptDelivery?: { delivered: boolean; attempts: number; status?: "pending" | "delivered" | "failed" | "timeout" };  // Issue #3243: async prompt delivery status
   runnerName?: string;            // Issue #3681: Agent runner name (e.g. "claude-code", "codex", "gemini-cli")
   actionHints?: Record<string, { method: string; url: string; description: string }>;  // API contract compat: actionable hints
+  /** Issue #4484: Per-session user-defined metadata KV store. Max 20 keys, max 256 chars/value. */
+  metadata?: Record<string, string>;
   // Issue #2518: Hook failure circuit breaker
   hookFailureTimestamps?: number[];   // Sliding window of StopFailure timestamps (ms)
   circuitBreakerTripped?: boolean;    // True once the circuit breaker has fired


### PR DESCRIPTION
## Summary

Per-session user-defined metadata KV store. Tag sessions with `pr_number`, `pipeline_status`, custom keys — anything. 3 API endpoints + CLI command.

## API

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/v1/sessions/:id/meta` | Set/merge key-value pairs |
| GET | `/v1/sessions/:id/meta` | Retrieve all metadata |
| DELETE | `/v1/sessions/:id/meta/:key` | Remove a single key |

## CLI

```bash
ag meta <id>                          # show all metadata
ag meta <id> --set pr_number=1234      # set key
ag meta <id> --set k1=v1 k2=v2        # set multiple
ag meta <id> --delete pr_number        # remove key
```

## Constraints

- Max 20 keys per session
- Max 256 chars per value, 64 chars per key
- POST merges (doesn't replace) existing metadata
- Empty metadata object cleaned up automatically

## Implementation

- `metadata?: Record<string, string>` added to `SessionInfo` (session-types.ts)
- Routes in sessions.ts with Zod validation (`z.record(z.string().max(64), z.string().max(256))`)
- CLI in new `commands/meta.ts` (128 lines)
- Metadata persists with existing session state (no new DB needed)

## Verification

- TypeScript: 0 errors
- 412 test files, 5894 tests, 0 failures
- 12 new tests: CRUD, merge, overwrite, validation (max keys, value length, 404s, cleanup)

Closes #4484