### PR TITLE
docs: document session metadata KV store + ag update --dry-run

### DIFF
--- a/docs/api-quick-ref.md
+++ b/docs/api-quick-ref.md
@@ -49,6 +49,9 @@ A compact summary of all Aegis API endpoints. For detailed documentation, exampl
 | `POST` | `/v1/sessions/{id}/session-reject` | Bearer | Reject session awaiting approval |
 | `POST` | `/v1/sessions/{id}/answer` | Bearer | Answer a pending question |
 | `POST` | `/v1/sessions/{id}/discover-commands` | Bearer | Discover available slash commands |
+| `POST` | `/v1/sessions/{id}/meta` | Bearer | Set/merge metadata key-value pairs |
+| `GET` | `/v1/sessions/{id}/meta` | Bearer | Get all session metadata |
+| `DELETE` | `/v1/sessions/{id}/meta/{key}` | Bearer | Delete a metadata key |
 
 ## ACP Control Actions
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1471,6 +1471,99 @@ curl http://localhost:9100/v1/sessions/abc123/children \
 
 ---
 
+### Session Metadata KV Store
+
+Per-session key-value metadata store. Use it to tag sessions with `pr_number`, `pipeline_status`, or any custom data.
+
+**Constraints:**
+- Max **20 keys** per session
+- Max **64 chars** per key, **256 chars** per value
+- `POST` merges (does not replace) existing metadata
+- Empty metadata objects are cleaned up automatically
+
+#### Set / Merge Metadata
+
+```
+POST /v1/sessions/:id/meta
+```
+
+Merges the provided key-value pairs into the session's metadata. Existing keys are overwritten; other keys are preserved.
+
+```bash
+curl -X POST http://localhost:9100/v1/sessions/abc123/meta \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"pr_number": "1234", "pipeline_status": "running"}'
+```
+
+**Response:**
+
+```json
+{
+  "pr_number": "1234",
+  "pipeline_status": "running"
+}
+```
+
+**Errors:**
+- `400` — key exceeds 64 chars, value exceeds 256 chars, or more than 20 keys
+- `404` — session not found
+
+---
+
+#### Get All Metadata
+
+```
+GET /v1/sessions/:id/meta
+```
+
+Returns all metadata for a session.
+
+```bash
+curl http://localhost:9100/v1/sessions/abc123/meta \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "pr_number": "1234",
+  "pipeline_status": "running"
+}
+```
+
+**Errors:**
+- `404` — session not found
+
+---
+
+#### Delete a Metadata Key
+
+```
+DELETE /v1/sessions/:id/meta/:key
+```
+
+Removes a single key from the session's metadata.
+
+```bash
+curl -X DELETE http://localhost:9100/v1/sessions/abc123/meta/pr_number \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "pipeline_status": "running"
+}
+```
+
+**Errors:**
+- `404` — session not found or key does not exist
+
+---
+
 ### Global Tool Definitions
 
 ```

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -333,6 +333,7 @@ Check for and apply Aegis updates. Auto-detects install method (npm global vs di
 ```bash
 ag update                  # Check and install latest version
 ag update --check         # Check only, don't install
+ag update --dry-run       # Check availability, show what would change, exit (no install)
 ag update --yes           # Skip confirmation prompt
 ```
 
@@ -348,6 +349,7 @@ ag update --yes           # Skip confirmation prompt
 | Flag | Description |
 |------|------------|
 | `--check` | Check for updates without installing |
+| `--dry-run` | Check availability and show what would change, without installing. Exit code 1 if update available, 0 if up-to-date |
 | `--yes` / `-y` | Skip confirmation prompt |
 
 **Exit codes:**
@@ -356,6 +358,26 @@ ag update --yes           # Skip confirmation prompt
 |------|----------|
 | `0` | Success (updated or already up-to-date) |
 | `1` | Error (network failure, SHA mismatch, no platform asset) |
+
+### `ag meta` — Session Metadata
+
+View and manage per-session key-value metadata. Tag sessions with PR numbers, pipeline status, or any custom data.
+
+```bash
+ag meta <session-id>                          # show all metadata
+ag meta <session-id> --set pr_number=1234      # set a key
+ag meta <session-id> --set k1=v1 k2=v2        # set multiple keys
+ag meta <session-id> --delete pr_number        # remove a key
+```
+
+**Constraints:** Max 20 keys per session, 64 chars per key, 256 chars per value.
+
+**Flags:**
+
+| Flag | Description |
+|------|------------|
+| `--set key=value` | Set one or more key-value pairs (merges with existing) |
+| `--delete key` | Remove a single key |
 
 ### `ag login` — Authenticate via OIDC
 
@@ -504,6 +526,7 @@ ag status [id]         Server health or session details (prefix match)
 ag tail <id>           Follow session events in real-time (prefix match)
 ag create "brief"      Create + send
 ag update              Self-update to latest version
+ag meta <id>           View/manage session metadata
 ag login               Authenticate via OIDC
 ag logout              Remove stored credentials
 ag whoami              Show current identity


### PR DESCRIPTION
## Summary

Documents 2 new features from today's merges:

### Session Metadata KV Store (#4499)
- 3 new API endpoints: `POST / GET / DELETE /v1/sessions/:id/meta`
- `ag meta` CLI command with `--set` and `--delete` flags
- Added to api-reference.md, api-quick-ref.md, cli.md

### ag update --dry-run (#4497)
- `--dry-run` flag docs added to cli.md flags table + examples

## Files changed
- `docs/api-reference.md` — 3 endpoint sections with curl examples, constraints, errors
- `docs/api-quick-ref.md` — 3 new rows in Session Actions table
- `docs/integrations/cli.md` — `ag meta` command section, `--dry-run` flag, quick ref update

Covers: #4499, #4497