### PR TITLE
feat(dashboard): webhook delivery history view (#4486)

### DIFF
--- a/dashboard/src/api/webhook-deliveries.ts
+++ b/dashboard/src/api/webhook-deliveries.ts
@@ -1,0 +1,84 @@
+/**
+ * Webhook delivery API client.
+ * Mock implementation — will be wired to real API when backend lands.
+ */
+
+import type { WebhookDeliveryResponse, WebhookInfo } from '../types/webhook-delivery';
+
+// ── Mock data ──────────────────────────────────────────────
+
+const MOCK_HOOKS: WebhookInfo[] = [
+  {
+    id: 'hook-1',
+    name: 'Slack Notifications',
+    url: 'https://hooks.slack.com/services/T00/B00/xxx',
+    events: ['session.create', 'session.kill', 'permission.prompt'],
+    enabled: true,
+    createdAt: '2026-05-20T10:00:00Z',
+    lastDeliveryAt: '2026-05-29T19:45:00Z',
+  },
+  {
+    id: 'hook-2',
+    name: 'CI Pipeline Trigger',
+    url: 'https://ci.example.com/webhook/aegis',
+    events: ['session.complete', 'session.fail'],
+    enabled: true,
+    createdAt: '2026-05-15T08:00:00Z',
+  },
+  {
+    id: 'hook-3',
+    name: 'Monitoring Alert',
+    url: 'https://monitor.example.com/api/alert',
+    events: ['session.fail', 'permission.deny'],
+    enabled: false,
+    createdAt: '2026-05-10T12:00:00Z',
+  },
+];
+
+const MOCK_DELIVERIES: Record<string, WebhookDeliveryResponse> = {
+  'hook-1': {
+    deliveries: [
+      { id: 'del-1', hookId: 'hook-1', timestamp: '2026-05-29T19:45:00Z', status: 'success', statusCode: 200, durationMs: 145, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
+      { id: 'del-2', hookId: 'hook-1', timestamp: '2026-05-29T19:30:00Z', status: 'success', statusCode: 200, durationMs: 98, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
+      { id: 'del-3', hookId: 'hook-1', timestamp: '2026-05-29T19:15:00Z', status: 'failed', statusCode: 503, durationMs: 5000, attemptCount: 3, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx', errorMessage: 'Service Unavailable' },
+      { id: 'del-4', hookId: 'hook-1', timestamp: '2026-05-29T18:00:00Z', status: 'success', statusCode: 200, durationMs: 210, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
+      { id: 'del-5', hookId: 'hook-1', timestamp: '2026-05-29T17:30:00Z', status: 'retrying', statusCode: 500, durationMs: 3000, attemptCount: 2, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx', errorMessage: 'Internal Server Error' },
+      { id: 'del-6', hookId: 'hook-1', timestamp: '2026-05-29T16:00:00Z', status: 'success', statusCode: 201, durationMs: 67, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
+      { id: 'del-7', hookId: 'hook-1', timestamp: '2026-05-29T14:00:00Z', status: 'failed', statusCode: 0, durationMs: 10000, attemptCount: 3, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx', errorMessage: 'Connection timeout' },
+    ],
+  },
+  'hook-2': {
+    deliveries: [
+      { id: 'del-10', hookId: 'hook-2', timestamp: '2026-05-29T18:00:00Z', status: 'success', statusCode: 200, durationMs: 320, attemptCount: 1, targetUrl: 'https://ci.example.com/webhook/aegis' },
+      { id: 'del-11', hookId: 'hook-2', timestamp: '2026-05-29T15:00:00Z', status: 'failed', statusCode: 404, durationMs: 45, attemptCount: 1, targetUrl: 'https://ci.example.com/webhook/aegis', errorMessage: 'Not Found' },
+    ],
+  },
+  'hook-3': {
+    deliveries: [],
+  },
+};
+
+const USE_MOCK = true;
+
+// ── API functions ──────────────────────────────────────────
+
+export async function fetchWebhookDeliveries(hookId: string): Promise<WebhookDeliveryResponse> {
+  if (USE_MOCK) {
+    // Simulate network latency
+    await new Promise((r) => setTimeout(r, 300));
+    return MOCK_DELIVERIES[hookId] ?? { deliveries: [] };
+  }
+  const res = await fetch(`/v1/hooks/${hookId}/deliveries`);
+  if (!res.ok) throw new Error(`Failed to fetch deliveries for hook ${hookId}`);
+  return res.json();
+}
+
+export async function fetchWebhooks(): Promise<WebhookInfo[]> {
+  if (USE_MOCK) {
+    await new Promise((r) => setTimeout(r, 200));
+    return MOCK_HOOKS;
+  }
+  const res = await fetch('/v1/hooks');
+  if (!res.ok) throw new Error('Failed to fetch webhooks');
+  return res.json();
+}

--- a/dashboard/src/api/webhook-deliveries.ts
+++ b/dashboard/src/api/webhook-deliveries.ts
@@ -1,84 +1,21 @@
 /**
  * Webhook delivery API client.
- * Mock implementation — will be wired to real API when backend lands.
+ * Wired to real Aegis API (Hep's PR #4502).
  */
 
 import type { WebhookDeliveryResponse, WebhookInfo } from '../types/webhook-delivery';
 
-// ── Mock data ──────────────────────────────────────────────
-
-const MOCK_HOOKS: WebhookInfo[] = [
-  {
-    id: 'hook-1',
-    name: 'Slack Notifications',
-    url: 'https://hooks.slack.com/services/T00/B00/xxx',
-    events: ['session.create', 'session.kill', 'permission.prompt'],
-    enabled: true,
-    createdAt: '2026-05-20T10:00:00Z',
-    lastDeliveryAt: '2026-05-29T19:45:00Z',
-  },
-  {
-    id: 'hook-2',
-    name: 'CI Pipeline Trigger',
-    url: 'https://ci.example.com/webhook/aegis',
-    events: ['session.complete', 'session.fail'],
-    enabled: true,
-    createdAt: '2026-05-15T08:00:00Z',
-  },
-  {
-    id: 'hook-3',
-    name: 'Monitoring Alert',
-    url: 'https://monitor.example.com/api/alert',
-    events: ['session.fail', 'permission.deny'],
-    enabled: false,
-    createdAt: '2026-05-10T12:00:00Z',
-  },
-];
-
-const MOCK_DELIVERIES: Record<string, WebhookDeliveryResponse> = {
-  'hook-1': {
-    deliveries: [
-      { id: 'del-1', hookId: 'hook-1', timestamp: '2026-05-29T19:45:00Z', status: 'success', statusCode: 200, durationMs: 145, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
-      { id: 'del-2', hookId: 'hook-1', timestamp: '2026-05-29T19:30:00Z', status: 'success', statusCode: 200, durationMs: 98, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
-      { id: 'del-3', hookId: 'hook-1', timestamp: '2026-05-29T19:15:00Z', status: 'failed', statusCode: 503, durationMs: 5000, attemptCount: 3, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx', errorMessage: 'Service Unavailable' },
-      { id: 'del-4', hookId: 'hook-1', timestamp: '2026-05-29T18:00:00Z', status: 'success', statusCode: 200, durationMs: 210, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
-      { id: 'del-5', hookId: 'hook-1', timestamp: '2026-05-29T17:30:00Z', status: 'retrying', statusCode: 500, durationMs: 3000, attemptCount: 2, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx', errorMessage: 'Internal Server Error' },
-      { id: 'del-6', hookId: 'hook-1', timestamp: '2026-05-29T16:00:00Z', status: 'success', statusCode: 201, durationMs: 67, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
-      { id: 'del-7', hookId: 'hook-1', timestamp: '2026-05-29T14:00:00Z', status: 'failed', statusCode: 0, durationMs: 10000, attemptCount: 3, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx', errorMessage: 'Connection timeout' },
-    ],
-  },
-  'hook-2': {
-    deliveries: [
-      { id: 'del-10', hookId: 'hook-2', timestamp: '2026-05-29T18:00:00Z', status: 'success', statusCode: 200, durationMs: 320, attemptCount: 1, targetUrl: 'https://ci.example.com/webhook/aegis' },
-      { id: 'del-11', hookId: 'hook-2', timestamp: '2026-05-29T15:00:00Z', status: 'failed', statusCode: 404, durationMs: 45, attemptCount: 1, targetUrl: 'https://ci.example.com/webhook/aegis', errorMessage: 'Not Found' },
-    ],
-  },
-  'hook-3': {
-    deliveries: [],
-  },
-};
-
-const USE_MOCK = true;
-
 // ── API functions ──────────────────────────────────────────
 
 export async function fetchWebhookDeliveries(hookId: string): Promise<WebhookDeliveryResponse> {
-  if (USE_MOCK) {
-    // Simulate network latency
-    await new Promise((r) => setTimeout(r, 300));
-    return MOCK_DELIVERIES[hookId] ?? { deliveries: [] };
-  }
   const res = await fetch(`/v1/hooks/${hookId}/deliveries`);
   if (!res.ok) throw new Error(`Failed to fetch deliveries for hook ${hookId}`);
   return res.json();
 }
 
 export async function fetchWebhooks(): Promise<WebhookInfo[]> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 200));
-    return MOCK_HOOKS;
-  }
   const res = await fetch('/v1/hooks');
   if (!res.ok) throw new Error('Failed to fetch webhooks');
-  return res.json();
+  const data = await res.json();
+  return Array.isArray(data) ? data : (data.hooks ?? []);
 }

--- a/dashboard/src/components/webhooks/WebhookDeliveryHistory.tsx
+++ b/dashboard/src/components/webhooks/WebhookDeliveryHistory.tsx
@@ -1,0 +1,204 @@
+/**
+ * WebhookDeliveryHistory — shows delivery log per hook with pass/fail indicators.
+ * Part of #4486 — webhook delivery tracking.
+ */
+
+import { useState, useEffect } from 'react';
+import { useT } from '../../i18n/context';
+import { fetchWebhookDeliveries, fetchWebhooks } from '../../api/webhook-deliveries';
+import type { WebhookDelivery, WebhookInfo, DeliveryStatus } from '../../types/webhook-delivery';
+
+// ── Helpers ────────────────────────────────────────────────
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function statusDot(status: DeliveryStatus): { color: string; label: string } {
+  switch (status) {
+    case 'success': return { color: 'bg-[var(--color-success)]', label: 'Pass' };
+    case 'failed': return { color: 'bg-[var(--color-danger)]', label: 'Fail' };
+    case 'retrying': return { color: 'bg-[var(--color-warning)]', label: 'Retry' };
+  }
+}
+
+// ── Sub-components ─────────────────────────────────────────
+
+function StatusBadge({ status }: { status: DeliveryStatus }) {
+  const { color, label } = statusDot(status);
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`inline-block h-2 w-2 rounded-full ${color}`} />
+      <span className="text-xs font-medium">{label}</span>
+    </span>
+  );
+}
+
+function DeliveryRow({ delivery }: { delivery: WebhookDelivery }) {
+  const t = useT();
+  return (
+    <tr className="border-t border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors">
+      <td className="px-3 py-2 text-xs text-[var(--color-text-muted)] whitespace-nowrap">
+        {formatTimestamp(delivery.timestamp)}
+      </td>
+      <td className="px-3 py-2">
+        <StatusBadge status={delivery.status} />
+      </td>
+      <td className="px-3 py-2 text-xs font-mono text-[var(--color-text-muted)]">
+        {delivery.statusCode || '—'}
+      </td>
+      <td className="px-3 py-2 text-xs text-[var(--color-text-muted)]">
+        {formatDuration(delivery.durationMs)}
+      </td>
+      <td className="px-3 py-2 text-xs text-[var(--color-text-muted)]">
+        {delivery.attemptCount > 1 ? `${delivery.attemptCount} ${t('webhooks.attempts')}` : '—'}
+      </td>
+      <td className="px-3 py-2 text-xs text-[var(--color-danger)] truncate max-w-[200px]" title={delivery.errorMessage}>
+        {delivery.errorMessage || '—'}
+      </td>
+    </tr>
+  );
+}
+
+function HookDeliveryPanel({ hook }: { hook: WebhookInfo }) {
+  const t = useT();
+  const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!expanded) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchWebhookDeliveries(hook.id)
+      .then((res) => { if (!cancelled) setDeliveries(res.deliveries); })
+      .catch((err) => { if (!cancelled) setError(err.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [hook.id, expanded]);
+
+  const successCount = deliveries.filter((d) => d.status === 'success').length;
+  const failCount = deliveries.filter((d) => d.status === 'failed').length;
+  const total = deliveries.length;
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-[var(--color-surface-hover)] transition-colors"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center gap-3">
+          <span className={`inline-block h-2.5 w-2.5 rounded-full ${hook.enabled ? 'bg-[var(--color-success)]' : 'bg-[var(--color-text-muted)]'}`} />
+          <div>
+            <h4 className="text-sm font-medium text-[var(--color-text-primary)]">{hook.name}</h4>
+            <p className="text-xs text-[var(--color-text-muted)] font-mono truncate max-w-[300px]">{hook.url}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-[var(--color-text-muted)]">
+          {total > 0 && (
+            <>
+              <span className="text-[var(--color-success)]">{successCount} ✓</span>
+              {failCount > 0 && <span className="text-[var(--color-danger)]">{failCount} ✗</span>}
+            </>
+          )}
+          <span className="text-xs">{expanded ? '▲' : '▼'}</span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-[var(--color-border)]">
+          {loading ? (
+            <div className="px-5 py-6 text-sm text-[var(--color-text-muted)] animate-pulse">
+              {t('webhooks.loadingDeliveries')}
+            </div>
+          ) : error ? (
+            <div className="px-5 py-4 text-sm text-[var(--color-danger)]">{error}</div>
+          ) : deliveries.length === 0 ? (
+            <div className="px-5 py-6 text-sm text-[var(--color-text-muted)]">{t('webhooks.noDeliveries')}</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-left" aria-label={t('webhooks.deliveryTable')}>
+                <thead>
+                  <tr className="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
+                    <th className="px-3 py-2 font-medium">{t('webhooks.timestamp')}</th>
+                    <th className="px-3 py-2 font-medium">{t('webhooks.status')}</th>
+                    <th className="px-3 py-2 font-medium">{t('webhooks.statusCode')}</th>
+                    <th className="px-3 py-2 font-medium">{t('webhooks.duration')}</th>
+                    <th className="px-3 py-2 font-medium">{t('webhooks.attempts')}</th>
+                    <th className="px-3 py-2 font-medium">{t('webhooks.error')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {deliveries.map((d) => <DeliveryRow key={d.id} delivery={d} />)}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────
+
+export function WebhookDeliveryHistory() {
+  const t = useT();
+  const [hooks, setHooks] = useState<WebhookInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWebhooks()
+      .then((res) => { if (!cancelled) setHooks(res); })
+      .catch((err) => { if (!cancelled) setError(err.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <section aria-labelledby="webhook-delivery-heading">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h3 id="webhook-delivery-heading" className="text-lg font-medium text-[var(--color-text-primary)]">
+            {t('webhooks.deliveryHistory')}
+          </h3>
+          <p className="text-sm text-[var(--color-text-muted)]">
+            {t('webhooks.deliveryHistoryDescription')}
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2].map((i) => (
+            <div key={i} className="h-16 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] animate-pulse" />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/10 px-4 py-3 text-sm text-[var(--color-danger)]">
+          {error}
+        </div>
+      ) : hooks.length === 0 ? (
+        <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] px-5 py-8 text-center text-sm text-[var(--color-text-muted)]">
+          {t('webhooks.noHooks')}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {hooks.map((hook) => <HookDeliveryPanel key={hook.id} hook={hook} />)}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/components/webhooks/__tests__/WebhookDeliveryHistory.test.tsx
+++ b/dashboard/src/components/webhooks/__tests__/WebhookDeliveryHistory.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * WebhookDeliveryHistory tests — delivery log with pass/fail indicators.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WebhookDeliveryHistory } from '../WebhookDeliveryHistory';
+
+// Mock i18n
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
+
+// Mock API
+vi.mock('../../../api/webhook-deliveries', () => ({
+  fetchWebhooks: vi.fn().mockResolvedValue([
+    {
+      id: 'hook-1',
+      name: 'Slack Notifications',
+      url: 'https://hooks.slack.com/services/T00/B00/xxx',
+      events: ['session.create'],
+      enabled: true,
+      createdAt: '2026-05-20T10:00:00Z',
+    },
+    {
+      id: 'hook-2',
+      name: 'CI Pipeline',
+      url: 'https://ci.example.com/webhook',
+      events: ['session.complete'],
+      enabled: false,
+      createdAt: '2026-05-15T08:00:00Z',
+    },
+  ]),
+  fetchWebhookDeliveries: vi.fn().mockImplementation((hookId: string) => {
+    if (hookId === 'hook-1') {
+      return Promise.resolve({
+        deliveries: [
+          { id: 'del-1', hookId: 'hook-1', timestamp: '2026-05-29T19:45:00Z', status: 'success', statusCode: 200, durationMs: 145, attemptCount: 1, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx' },
+          { id: 'del-2', hookId: 'hook-1', timestamp: '2026-05-29T19:15:00Z', status: 'failed', statusCode: 503, durationMs: 5000, attemptCount: 3, targetUrl: 'https://hooks.slack.com/services/T00/B00/xxx', errorMessage: 'Service Unavailable' },
+        ],
+      });
+    }
+    return Promise.resolve({ deliveries: [] });
+  }),
+}));
+
+describe('WebhookDeliveryHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the section heading', async () => {
+    render(<WebhookDeliveryHistory />);
+    expect(await screen.findByText(/Webhook Delivery History/i)).toBeDefined();
+  });
+
+  it('shows configured webhooks', async () => {
+    render(<WebhookDeliveryHistory />);
+    expect(await screen.findByText('Slack Notifications')).toBeDefined();
+    expect(screen.getByText('CI Pipeline')).toBeDefined();
+  });
+
+  it('shows pass/fail counts when expanded', async () => {
+    render(<WebhookDeliveryHistory />);
+    const slackHook = await screen.findByText('Slack Notifications');
+    const expandBtn = slackHook.closest('button')!;
+    fireEvent.click(expandBtn);
+
+    // Should show delivery rows after expansion
+    expect(await screen.findByText('200')).toBeDefined();
+    expect(screen.getByText('503')).toBeDefined();
+  });
+
+  it('shows no deliveries message for empty hooks', async () => {
+    render(<WebhookDeliveryHistory />);
+    const ciHook = await screen.findByText('CI Pipeline');
+    const expandBtn = ciHook.closest('button')!;
+    fireEvent.click(expandBtn);
+
+    expect(await screen.findByText(/No deliveries recorded yet/i)).toBeDefined();
+  });
+});

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -1331,6 +1331,20 @@ export const en = {
     dontAsk: "Don't Ask",
     autoAccept: 'Auto-accept',
   },
+  webhooks: {
+    deliveryHistory: 'Webhook Delivery History',
+    deliveryHistoryDescription: 'Recent delivery attempts for configured webhooks.',
+    loadingDeliveries: 'Loading deliveries…',
+    noDeliveries: 'No deliveries recorded yet.',
+    noHooks: 'No webhooks configured. Webhooks appear here once created.',
+    deliveryTable: 'Webhook delivery log',
+    timestamp: 'Time',
+    status: 'Status',
+    statusCode: 'Code',
+    duration: 'Latency',
+    attempts: 'Attempts',
+    error: 'Error',
+  },
 } as const;
 
 export type Messages = typeof en;

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -1325,4 +1325,20 @@ export const it = {
     dontAsk: "Non Chiedere",
     autoAccept: 'Auto-accetta',
   },
+
+  webhooks: {
+    deliveryHistory: 'Cronologia Consegne Webhook',
+    deliveryHistoryDescription: 'Tentativi di consegna recenti per i webhook configurati.',
+    loadingDeliveries: 'Caricamento consegne…',
+    noDeliveries: 'Nessuna consegna registrata.',
+    noHooks: 'Nessun webhook configurato. I webhook appariranno qui una volta creati.',
+    deliveryTable: 'Log consegne webhook',
+    timestamp: 'Ora',
+    status: 'Stato',
+    statusCode: 'Codice',
+    duration: 'Latenza',
+    attempts: 'Tentativi',
+    error: 'Errore',
+  },
+
 };

--- a/dashboard/src/pages/NotificationSettingsPage.tsx
+++ b/dashboard/src/pages/NotificationSettingsPage.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import { useToastStore } from '../store/useToastStore';
 import { useT } from '../i18n/context';
+import { WebhookDeliveryHistory } from '../components/webhooks/WebhookDeliveryHistory';
 import { ConfirmDestructive } from '../components/shared/ConfirmDestructive';
 import type {
   TelegramConnectionState,
@@ -418,6 +419,11 @@ export default function NotificationSettingsPage() {
               </li>
             </ol>
           </section>
+
+          {/* Webhook Delivery History — #4486 */}
+          <div className="mt-8">
+            <WebhookDeliveryHistory />
+          </div>
         </>
       )}
     </div>

--- a/dashboard/src/types/webhook-delivery.ts
+++ b/dashboard/src/types/webhook-delivery.ts
@@ -1,0 +1,32 @@
+/**
+ * Webhook delivery tracking types.
+ * API contract: GET /v1/hooks/:hookId/deliveries
+ */
+
+export type DeliveryStatus = 'success' | 'failed' | 'retrying';
+
+export interface WebhookDelivery {
+  id: string;
+  hookId: string;
+  timestamp: string;
+  status: DeliveryStatus;
+  statusCode: number;
+  durationMs: number;
+  attemptCount: number;
+  targetUrl: string;
+  errorMessage?: string;
+}
+
+export interface WebhookDeliveryResponse {
+  deliveries: WebhookDelivery[];
+}
+
+export interface WebhookInfo {
+  id: string;
+  name: string;
+  url: string;
+  events: string[];
+  enabled: boolean;
+  createdAt: string;
+  lastDeliveryAt?: string;
+}


### PR DESCRIPTION
## Summary

Dashboard piece of #4486 — webhook delivery tracking with pass/fail indicators.

### What's New
- **WebhookDeliveryHistory** component — expandable per-hook panels with delivery table
- Pass/fail status badges (green ✓ / red ✗ / yellow retry)
- Shows: timestamp, HTTP status code, latency, attempt count, error message
- Mock API client with 3 hooks (7 deliveries) for development

### Files
| File | Purpose |
|------|---------|
| `types/webhook-delivery.ts` | TypeScript types for deliveries |
| `api/webhook-deliveries.ts` | Mock API client (swap to real fetch later) |
| `components/webhooks/WebhookDeliveryHistory.tsx` | Main component |
| `components/webhooks/__tests__/WebhookDeliveryHistory.test.tsx` | 4 tests |

### Integration
- Added to `NotificationSettingsPage` as a new section
- 12 i18n keys (`webhooks.*`) in en + it, parity verified

### Wire-up TODO
When Hep ships `GET /v1/hooks/:hookId/deliveries`, change `USE_MOCK = false` in `api/webhook-deliveries.ts`.

### Verification
- 4 tests green
- i18n parity: 6/6 green
- tsc clean, build clean

Part of #4486

— Daedalus 🏛️