### PR TITLE
feat(cli): add `ag send` mid-turn messaging command (#4487)

### DIFF
--- a/src/__tests__/commands/send-4487.test.ts
+++ b/src/__tests__/commands/send-4487.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for ag send CLI command (Issue #4487)
+ *
+ * Covers: argument parsing, error handling, success response.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleSend } from '../../commands/send.js';
+
+// Mock cli-http helpers
+vi.mock('../../cli-http.js', () => ({
+  resolveBaseUrl: vi.fn(() => 'http://localhost:3000'),
+  resolveAuthToken: vi.fn(() => 'test-token'),
+  buildHeaders: vi.fn(() => ({ Authorization: 'Bearer test-token' })),
+  requireServer: vi.fn(() => Promise.resolve(true)),
+  writeLine: vi.fn(),
+}));
+
+// Mock resolveSessionId
+vi.mock('../../commands/read.js', () => ({
+  resolveSessionId: vi.fn((_id: string, _url: string, _headers: Record<string, string>, _io: unknown) =>
+    Promise.resolve('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+  ),
+}));
+
+// Mock fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { writeLine } from '../../cli-http.js';
+
+function makeIo() {
+  return { stdout: { write: vi.fn() }, stderr: { write: vi.fn() } } as unknown as import('../../cli-http.js').CliIO;
+}
+
+describe('ag send command', () => {
+  const io = makeIo();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should send message to resolved session', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ delivered: true, attempts: 1 }),
+    });
+
+    const result = await handleSend(['aaaaaaaa', 'use', 'the', 'other', 'approach'], io);
+
+    expect(result).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/sessions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/send',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ text: 'use the other approach' }),
+      }),
+    );
+  });
+
+  it('should handle queued message (attempts === 0)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ delivered: false, attempts: 0 }),
+    });
+
+    const result = await handleSend(['aaaaaaaa', 'queued msg'], io);
+    expect(result).toBe(0);
+  });
+
+  it('should return 1 when no session ID provided', async () => {
+    const result = await handleSend([], io);
+    expect(result).toBe(1);
+    expect(writeLine).toHaveBeenCalledWith(expect.objectContaining({ write: expect.any(Function) }), expect.stringContaining('Missing session ID'));
+  });
+
+  it('should return 1 when no message provided', async () => {
+    const result = await handleSend(['aaaaaaaa'], io);
+    expect(result).toBe(1);
+    expect(writeLine).toHaveBeenCalledWith(expect.objectContaining({ write: expect.any(Function) }), expect.stringContaining('Missing message'));
+  });
+
+  it('should return 1 on server error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: 'Session not found' }),
+    });
+
+    const result = await handleSend(['aaaaaaaa', 'hello'], io);
+    expect(result).toBe(1);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import { handleWhoami } from './commands/whoami.js';
 import { handleRun } from './commands/run.js';
 import { handleList } from './commands/list.js';
 import { handleMeta } from './commands/meta.js';
+import { handleSend } from './commands/send.js';
 import { handleUpdate } from './commands/update.js';
 import { handleRead } from './commands/read.js';
 import { handleKill } from './commands/kill.js';
@@ -342,6 +343,7 @@ function printHelp(io: CliIO): void {
     ag list --status active  Filter by status
     ag read <id>            Read session output
     ag tail <id>            Follow session output in real-time
+    ag send <id> "msg"      Send message to a running session
     ag kill <id>            Terminate a session
     ag status               Show server health + session summary
 
@@ -444,6 +446,10 @@ export async function runCli(argv: string[] = process.argv.slice(2), io: CliIO =
 
   if (argv[0] === 'read') {
     return handleRead(argv.slice(1), io);
+  }
+
+  if (argv[0] === 'send') {
+    return handleSend(argv.slice(1), io);
   }
 
   if (argv[0] === 'kill') {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -1,0 +1,66 @@
+/**
+ * commands/send.ts — `ag send <id> "message"` — Inject a message into a running session.
+ *
+ * Wraps POST /v1/sessions/:id/send.
+ * Issue #4487: Mid-turn messaging to busy sessions.
+ *
+ * Usage:
+ *   ag send <session-id> "use the other approach"
+ */
+
+import { resolveBaseUrl, resolveAuthToken, buildHeaders, requireServer, writeLine, type CliIO } from '../cli-http.js';
+import { resolveSessionId } from './read.js';
+
+export async function handleSend(args: string[], io: CliIO): Promise<number> {
+  // Parse: ag send <session-id> [message...]
+  // The session ID is the first positional arg, everything else is the message
+  const positionalArgs = args.filter(a => !a.startsWith('-'));
+  const sessionId = positionalArgs[0];
+  const messageParts = positionalArgs.slice(1);
+
+  if (!sessionId) {
+    writeLine(io.stderr, '  ❌ Missing session ID. Usage: ag send <session-id> "message"');
+    return 1;
+  }
+
+  if (messageParts.length === 0) {
+    writeLine(io.stderr, '  ❌ Missing message. Usage: ag send <session-id> "message"');
+    return 1;
+  }
+
+  const text = messageParts.join(' ');
+  const baseUrl = await resolveBaseUrl(args);
+  const authToken = await resolveAuthToken();
+  if (!(await requireServer(baseUrl, authToken, io))) return 1;
+
+  const headers = buildHeaders(authToken);
+
+  // Resolve prefix to full UUID
+  const resolvedId = await resolveSessionId(sessionId, baseUrl, headers, io);
+  if (!resolvedId) return 1;
+
+  const res = await fetch(`${baseUrl}/v1/sessions/${resolvedId}/send`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ text }),
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    writeLine(io.stderr, `  ❌ ${((err as { error?: string }).error) || res.statusText}`);
+    return 1;
+  }
+
+  const result = await res.json() as { delivered?: boolean; attempts?: number };
+
+  if (result.delivered) {
+    writeLine(io.stdout, `  ✅ Message delivered (attempt ${result.attempts})`);
+  } else if ((result.attempts ?? 0) === 0) {
+    writeLine(io.stdout, `  ✅ Message queued — agent will pick up shortly`);
+  } else {
+    writeLine(io.stdout, `  ⚠️  Message sent but delivery not confirmed after ${result.attempts} attempts`);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

`ag send <session-id> "message"` — inject messages into running sessions without killing and restarting.

## Usage

```bash
ag send aabbccdd "use the other approach instead"
ag send aabbccdd redirect check auth flow before continuing
```

## How it works

- Wraps existing `POST /v1/sessions/:id/send` API endpoint (already has full route + RBAC + quota test coverage)
- Resolves session ID prefix (same pattern as `ag kill`)
- Reports delivery status: ✅ delivered, ✅ queued, or ⚠️ unconfirmed

## New files

- `src/commands/send.ts` (67 lines)
- `src/__tests__/commands/send-4487.test.ts` (5 tests: success, queued, missing args, server error)

## Verification

- TypeScript: 0 errors
- 413 test files, 5904 tests, 0 failures

Closes #4487