### PR TITLE
feat(dashboard): session metadata KV panel (#4484)

### DIFF
--- a/dashboard/src/api/session-metadata.ts
+++ b/dashboard/src/api/session-metadata.ts
@@ -1,0 +1,35 @@
+/**
+ * Session metadata API client.
+ * Contract: GET/POST/DELETE /v1/sessions/:id/meta
+ */
+
+export interface SessionMetadataMap {
+  [key: string]: string;
+}
+
+export async function fetchSessionMeta(sessionId: string): Promise<SessionMetadataMap> {
+  const res = await fetch(`/v1/sessions/${sessionId}/meta`);
+  if (!res.ok) throw new Error('Failed to fetch session metadata');
+  const data = await res.json();
+  return data.metadata ?? {};
+}
+
+export async function setSessionMeta(sessionId: string, pairs: SessionMetadataMap): Promise<SessionMetadataMap> {
+  const res = await fetch(`/v1/sessions/${sessionId}/meta`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(pairs),
+  });
+  if (!res.ok) throw new Error('Failed to set session metadata');
+  const data = await res.json();
+  return data.metadata ?? {};
+}
+
+export async function deleteSessionMetaKey(sessionId: string, key: string): Promise<SessionMetadataMap> {
+  const res = await fetch(`/v1/sessions/${sessionId}/meta/${encodeURIComponent(key)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error('Failed to delete metadata key');
+  const data = await res.json();
+  return data.metadata ?? {};
+}

--- a/dashboard/src/components/session/SessionMetadataPanel.tsx
+++ b/dashboard/src/components/session/SessionMetadataPanel.tsx
@@ -1,0 +1,166 @@
+/**
+ * SessionMetadataPanel — display and edit per-session key/value metadata.
+ * Part of #4484 — session metadata KV store.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useT } from '../../i18n/context';
+import { fetchSessionMeta, setSessionMeta, deleteSessionMetaKey } from '../../api/session-metadata';
+import type { SessionMetadataMap } from '../../api/session-metadata';
+
+const MAX_KEYS = 20;
+
+interface SessionMetadataPanelProps {
+  sessionId: string;
+}
+
+export function SessionMetadataPanel({ sessionId }: SessionMetadataPanelProps) {
+  const t = useT();
+  const [metadata, setMetadata] = useState<SessionMetadataMap>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await fetchSessionMeta(sessionId);
+      setMetadata(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load metadata');
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAdd = async () => {
+    const key = newKey.trim();
+    const value = newValue.trim();
+    if (!key || !value) return;
+
+    const currentCount = Object.keys(metadata).length;
+    if (!(key in metadata) && currentCount >= MAX_KEYS) return;
+
+    try {
+      setSaving(true);
+      const updated = await setSessionMeta(sessionId, { [key]: value });
+      setMetadata(updated);
+      setNewKey('');
+      setNewValue('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (key: string) => {
+    try {
+      const updated = await deleteSessionMetaKey(sessionId, key);
+      setMetadata(updated);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !saving && newKey.trim() && newValue.trim()) {
+      handleAdd();
+    }
+  };
+
+  const entries = Object.entries(metadata).sort(([a], [b]) => a.localeCompare(b));
+  const keyCount = Object.keys(metadata).length;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-32 text-[var(--color-text-muted)] text-sm animate-pulse">
+        {t('metadata.loading')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4" role="region" aria-label={t('metadata.panelLabel')}>
+      {error && (
+        <div className="rounded border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/10 px-3 py-2 text-xs text-[var(--color-danger)]">
+          {error}
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)] py-4">{t('metadata.empty')}</p>
+      ) : (
+        <table className="w-full text-left" aria-label={t('metadata.tableLabel')}>
+          <thead>
+            <tr className="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] border-b border-[var(--color-border)]">
+              <th className="pb-2 font-medium">{t('metadata.key')}</th>
+              <th className="pb-2 font-medium">{t('metadata.value')}</th>
+              <th className="pb-2 w-10"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(([key, value]) => (
+              <tr key={key} className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors">
+                <td className="py-2 pr-3 text-xs font-mono font-medium text-[var(--color-accent-cyan)]">{key}</td>
+                <td className="py-2 pr-3 text-xs text-[var(--color-text-primary)] break-all">{value}</td>
+                <td className="py-2">
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(key)}
+                    className="text-[var(--color-text-muted)] hover:text-[var(--color-danger)] transition-colors text-xs"
+                    aria-label={t('metadata.deleteKey', { key })}
+                  >
+                    ✕
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {keyCount < MAX_KEYS && (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={newKey}
+            onChange={(e) => setNewKey(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={t('metadata.keyPlaceholder')}
+            className="min-h-[36px] flex-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1.5 text-xs text-[var(--color-text-primary)] font-mono placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent-cyan)]/50 focus-visible:outline-none"
+            aria-label={t('metadata.newKeyLabel')}
+          />
+          <input
+            type="text"
+            value={newValue}
+            onChange={(e) => setNewValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={t('metadata.valuePlaceholder')}
+            className="min-h-[36px] flex-1 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-light)] px-2 py-1.5 text-xs text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent-cyan)]/50 focus-visible:outline-none"
+            aria-label={t('metadata.newValueLabel')}
+          />
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={saving || !newKey.trim() || !newValue.trim()}
+            className="min-h-[36px] rounded bg-[var(--color-accent-cyan)]/10 border border-[var(--color-accent-cyan)]/30 px-3 py-1.5 text-xs font-medium text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {t('metadata.add')}
+          </button>
+        </div>
+      )}
+
+      <p className="text-[10px] text-[var(--color-text-muted)]">
+        {t('metadata.countHint', { count: keyCount, max: MAX_KEYS })}
+      </p>
+    </div>
+  );
+}

--- a/dashboard/src/components/session/__tests__/SessionMetadataPanel.test.tsx
+++ b/dashboard/src/components/session/__tests__/SessionMetadataPanel.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * SessionMetadataPanel tests — KV metadata display and editing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SessionMetadataPanel } from '../SessionMetadataPanel';
+
+vi.mock('../../../i18n/context', async () => {
+  const { testT } = await import('../../../__tests__/i18n-test-helper');
+  return { useT: () => testT };
+});
+
+vi.mock('../../../api/session-metadata', () => ({
+  fetchSessionMeta: vi.fn().mockResolvedValue({
+    pr_number: '1234',
+    github_issue: 'https://github.com/org/repo/issues/56',
+    pipeline_status: 'running',
+  }),
+  setSessionMeta: vi.fn().mockImplementation((_id: string, pairs: Record<string, string>) => {
+    return Promise.resolve({
+      pr_number: '1234',
+      github_issue: 'https://github.com/org/repo/issues/56',
+      pipeline_status: 'running',
+      ...pairs,
+    });
+  }),
+  deleteSessionMetaKey: vi.fn().mockImplementation((_id: string, key: string) => {
+    const base: Record<string, string> = {
+      pr_number: '1234',
+      github_issue: 'https://github.com/org/repo/issues/56',
+      pipeline_status: 'running',
+    };
+    delete base[key];
+    return Promise.resolve(base);
+  }),
+}));
+
+describe('SessionMetadataPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders existing metadata entries', async () => {
+    render(<SessionMetadataPanel sessionId="sess-1" />);
+    expect(await screen.findByText('pr_number')).toBeDefined();
+    expect(screen.getByText('1234')).toBeDefined();
+    expect(screen.getByText('pipeline_status')).toBeDefined();
+  });
+
+  it('shows add form with key/value inputs', async () => {
+    render(<SessionMetadataPanel sessionId="sess-1" />);
+    await screen.findByText('pr_number');
+    expect(screen.getByLabelText(/New metadata key/i)).toBeDefined();
+    expect(screen.getByLabelText(/New metadata value/i)).toBeDefined();
+  });
+
+  it('calls setSessionMeta when adding a new key', async () => {
+    render(<SessionMetadataPanel sessionId="sess-1" />);
+    await screen.findByText('pr_number');
+
+    const keyInput = screen.getByLabelText(/New metadata key/i);
+    const valueInput = screen.getByLabelText(/New metadata value/i);
+
+    fireEvent.change(keyInput, { target: { value: 'env' } });
+    fireEvent.change(valueInput, { target: { value: 'production' } });
+    fireEvent.click(screen.getByText('Add'));
+
+    const { setSessionMeta } = await import('../../../api/session-metadata');
+    await waitFor(() => {
+      expect(setSessionMeta).toHaveBeenCalledWith('sess-1', { env: 'production' });
+    });
+  });
+
+  it('shows empty state when no metadata', async () => {
+    const { fetchSessionMeta } = await import('../../../api/session-metadata');
+    (fetchSessionMeta as ReturnType<typeof vi.fn>).mockResolvedValueOnce({});
+
+    render(<SessionMetadataPanel sessionId="sess-empty" />);
+    expect(await screen.findByText(/No metadata set/i)).toBeDefined();
+  });
+});

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -549,6 +549,7 @@ export const en = {
     timeline: 'Timeline',
     pr: 'PR',
     diff: 'Diff',
+    metadata: 'Metadata',
     insertSlash: 'Insert Slash',
     sendingSlash: 'Sending Slash…',
     runSlash: 'Run Slash',
@@ -1345,7 +1346,22 @@ export const en = {
     attempts: 'Attempts',
     error: 'Error',
   },
-} as const;
+
+  metadata: {
+    panelLabel: 'Session metadata',
+    loading: 'Loading metadata…',
+    empty: 'No metadata set. Add key/value pairs to tag this session.',
+    tableLabel: 'Session metadata entries',
+    key: 'Key',
+    value: 'Value',
+    deleteKey: 'Remove {key}',
+    add: 'Add',
+    keyPlaceholder: 'key',
+    valuePlaceholder: 'value',
+    newKeyLabel: 'New metadata key',
+    newValueLabel: 'New metadata value',
+    countHint: '{count}/{max} keys used',
+  },} as const;
 
 export type Messages = typeof en;
 export type MessageKey = string;

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -552,6 +552,7 @@ export const it = {
     timeline: 'Timeline',
     pr: 'PR',
     diff: 'Diff',
+    metadata: 'Metadati',
     insertSlash: 'Inserisci Slash',
     sendingSlash: 'Invio Slash in corso…',
     runSlash: 'Esegui Slash',
@@ -1341,4 +1342,20 @@ export const it = {
     error: 'Errore',
   },
 
+
+  metadata: {
+    panelLabel: 'Metadati sessione',
+    loading: 'Caricamento metadati…',
+    empty: 'Nessun metadato impostato. Aggiungi coppie chiave/valore per taggare questa sessione.',
+    tableLabel: 'Voci metadati sessione',
+    key: 'Chiave',
+    value: 'Valore',
+    deleteKey: 'Rimuovi {key}',
+    add: 'Aggiungi',
+    keyPlaceholder: 'chiave',
+    valuePlaceholder: 'valore',
+    newKeyLabel: 'Nuova chiave metadato',
+    newValueLabel: 'Nuovo valore metadato',
+    countHint: '{count}/{max} chiavi utilizzate',
+  },
 };

--- a/dashboard/src/pages/SessionDetailPage.tsx
+++ b/dashboard/src/pages/SessionDetailPage.tsx
@@ -42,6 +42,7 @@ import { useT } from '../i18n/context';
 
 // Extracted modules
 import type { TabId } from './session-detail/types';
+import { SessionMetadataPanel } from '../components/session/SessionMetadataPanel';
 import { TabBar } from './session-detail/TabBar';
 import { useAuditData } from './session-detail/useAuditData';
 import { useMessageInput } from './session-detail/useMessageInput';
@@ -84,6 +85,7 @@ export default function SessionDetailPage() {
     { id: 'timeline', label: t('sessionDetail.timeline') },
     { id: 'pr', label: t('sessionDetail.pr') },
     { id: 'diff', label: t('sessionDetail.diff') },
+    { id: 'metadata', label: t('sessionDetail.metadata') },
   ];
 
   const {
@@ -512,6 +514,23 @@ export default function SessionDetailPage() {
                     isLoading={prLoading}
                   />
                   </Suspense></ErrorBoundary>
+                </motion.div>
+              )}
+              {activeTab === 'metadata' && (
+                <motion.div
+                  key="panel-metadata"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  transition={{ duration: 0.2 }}
+                  id="panel-metadata"
+                  role="tabpanel"
+                  aria-labelledby="tab-metadata"
+                  tabIndex={0}
+                >
+                  <ErrorBoundary>
+                    <SessionMetadataPanel sessionId={id!} />
+                  </ErrorBoundary>
                 </motion.div>
               )}
             </AnimatePresence>

--- a/dashboard/src/pages/session-detail/types.ts
+++ b/dashboard/src/pages/session-detail/types.ts
@@ -2,7 +2,7 @@
  * session-detail/types.ts — Shared types for SessionDetailPage extracted modules.
  */
 
-export type TabId = 'stream' | 'metrics' | 'audit' | 'timeline' | 'pr' | 'diff';
+export type TabId = 'stream' | 'metrics' | 'audit' | 'timeline' | 'pr' | 'diff' | 'metadata';
 
 export interface ScreenshotState {
   image: string;


### PR DESCRIPTION
## Summary

Dashboard piece of #4484 — per-session metadata KV store in session detail.

### What's New
- **Metadata tab** added to SessionDetailPage (7th tab)
- **SessionMetadataPanel** — view, add, and delete key/value pairs
- Wired to real API: `GET/POST/DELETE /v1/sessions/:id/meta` (Hep already shipped)
- Max 20 keys enforced, entries sorted alphabetically
- Keyboard: Enter to add, ✕ button to delete

### Files
| File | Purpose |
|------|---------|
| `api/session-metadata.ts` | API client (GET/POST/DELETE) |
| `components/session/SessionMetadataPanel.tsx` | Main component |
| `components/session/__tests__/SessionMetadataPanel.test.tsx` | 4 tests |
| `pages/session-detail/types.ts` | TabId updated |
| `pages/SessionDetailPage.tsx` | Tab + panel wired |

### i18n
- `metadata.*` namespace (12 keys)
- en + it parity verified (6/6 integration tests)

### Verification
- 4 tests green
- i18n parity: 6/6
- tsc clean, build clean

Part of #4484

— Daedalus 🏛️