### PR TITLE
fix(dashboard): add 8 missing i18n keys across overview, audit, aria namespaces

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -47,6 +47,9 @@ export const en = {
     avgDurationChart: 'Avg Duration Over Time',
     noDataAvailable: 'No data available yet',
     calculating: 'Calculating…',
+    costPerDay: 'Cost per Day',
+    heatmapPending: 'Loading heatmap…',
+    loadingMetrics: 'Loading metrics…',
   },
   
   sessions: {
@@ -250,6 +253,10 @@ export const en = {
     endpointNotAvailable: 'Audit endpoint not available yet',
     failedToLoad: 'Failed to load audit logs',
     pageSize: 'Page size',
+    endpointMissingDescription: 'The audit API endpoint is not configured.',
+    exportFiltersNote: 'Export includes currently applied filters.',
+    fullRecordJson: 'Full Record JSON',
+    verifyingChain: 'Verifying chain integrity…',
   },
   analytics: {
     title: 'Analytics',
@@ -942,6 +949,8 @@ export const en = {
     sessionControls: 'Session controls',
     closeControlRail: 'Close control rail',
     holdToKill: 'Hold to kill session',
+    interrupt: 'Interrupt session',
+    kill: 'Kill session',
     moreActions: 'More session actions',
     toolApprovalRequired: 'Tool approval required',
     approveTool: 'Approve tool',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -49,6 +49,9 @@ export const it = {
     avgDurationChart: 'Durata Media nel Tempo',
     noDataAvailable: 'Nessun dato disponibile',
     calculating: 'Calcolo…',
+    costPerDay: 'Costo al giorno',
+    heatmapPending: 'Caricamento heatmap…',
+    loadingMetrics: 'Caricamento metriche…',
   },
 
   sessions: {
@@ -252,6 +255,10 @@ export const it = {
     endpointNotAvailable: 'Endpoint audit non ancora disponibile',
     failedToLoad: 'Caricamento log audit fallito',
     pageSize: 'Dimensione pagina',
+    endpointMissingDescription: "L'endpoint di audit non è ancora configurato.",
+    exportFiltersNote: "L'esportazione include i filtri attualmente applicati.",
+    fullRecordJson: 'Record JSON completo',
+    verifyingChain: 'Verifica integrità catena…',
   },
 
   analytics: {
@@ -937,6 +944,8 @@ export const it = {
     sessionControls: 'Controlli sessione',
     closeControlRail: 'Chiudi pannello controlli',
     holdToKill: 'Tieni premuto per terminare la sessione',
+    interrupt: 'Interrompi sessione',
+    kill: 'Termina sessione',
     moreActions: 'Altre azioni sessione',
     toolApprovalRequired: 'Approvazione strumento richiesta',
     approveTool: 'Approva strumento',


### PR DESCRIPTION
## Summary

Closes #4507

Adds 8 missing translation keys that were referenced in production code but not defined in the i18n catalogs.

### Keys Added
| Namespace | Key | en | it |
|-----------|-----|----|----|
| overview | costPerDay | ✅ | ✅ |
| overview | heatmapPending | ✅ | ✅ |
| overview | loadingMetrics | ✅ | ✅ |
| audit | endpointMissingDescription | ✅ | ✅ |
| audit | exportFiltersNote | ✅ | ✅ |
| audit | fullRecordJson | ✅ | ✅ |
| audit | verifyingChain | ✅ | ✅ |
| aria | interrupt | ✅ | ✅ |
| aria | kill | ✅ | ✅ |

### Note
The original issue reported 80+ missing keys, but automated verification found only 8 truly missing (the rest were either defined under different quote styles, existed in correct namespaces, or were import path false positives).

### Quality
- tsc: clean (0 errors)
- Build: clean (1.60s)
- i18n tests: 29/29 pass (including en/it parity check)

— Daedalus 🏛️