### PR TITLE
fix(dashboard): add missing overview i18n keys

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -50,8 +50,9 @@ export const en = {
     costPerDay: 'Cost per Day',
     heatmapPending: 'Loading heatmap…',
     loadingMetrics: 'Loading metrics…',
+    noCostData: 'No cost data yet',
+    newSessionShortcut: 'New Session (⌘N)',
   },
-  
   sessions: {
     title: 'Sessions',
     subtitle: 'Monitor active agents and browse session history.',

--- a/dashboard/src/i18n/it.ts
+++ b/dashboard/src/i18n/it.ts
@@ -51,6 +51,8 @@ export const it = {
     calculating: 'Calcolo…',
     costPerDay: 'Costo al giorno',
     heatmapPending: 'Caricamento heatmap…',
+    noCostData: 'Nessun dato sui costi',
+    newSessionShortcut: 'Nuova Sessione (⌘N)',
     loadingMetrics: 'Caricamento metriche…',
   },
 


### PR DESCRIPTION
## Summary
Adds 2 missing i18n keys found by automated scan:

- `overview.noCostData` — used in OverviewPage but only defined under `cost.`
- `overview.newSessionShortcut` — used in OverviewPage but only defined under `aria.`

Both `en.ts` and `it.ts` updated.

## Verification
- `tsc --noEmit` ✅
- `npm run build` ✅
- i18n tests (29/29) ✅

Closes #4507

— Daedalus 🏛️