### PR TITLE
fix: eliminate last 2 circular dependencies

### DIFF
--- a/src/channels/telegram/session-topic-types.ts
+++ b/src/channels/telegram/session-topic-types.ts
@@ -1,0 +1,16 @@
+/**
+ * session-topic-types.ts — SessionTopic interface for the Telegram channel.
+ *
+ * Extracted from types.ts to break the circular dependency:
+ *   types.ts ↔ topic-persistence.ts
+ */
+
+export interface SessionTopic {
+  sessionId: string;
+  topicId: number;
+  displayName: string;
+  endedAt: number | null;
+  cleanupScheduledAt: number | null;
+  cleanupRetries: number;
+  deleting: boolean;
+}

--- a/src/channels/telegram/topic-persistence.ts
+++ b/src/channels/telegram/topic-persistence.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, unlinkSync } from 'node:fs';
 
 import { StructuredLogger } from '../../logger.js';
-import type { SessionTopic } from './types.js';
+import type { SessionTopic } from './session-topic-types.js';
 
 const log = new StructuredLogger();
 

--- a/src/channels/telegram/types.ts
+++ b/src/channels/telegram/types.ts
@@ -17,15 +17,9 @@ export interface TelegramChannelConfig {
   verbose?: boolean;
 }
 
-export interface SessionTopic {
-  sessionId: string;
-  topicId: number;
-  displayName: string;
-  endedAt: number | null;
-  cleanupScheduledAt: number | null;
-  cleanupRetries: number;
-  deleting: boolean;
-}
+// Re-exported from session-topic-types.ts for backward compatibility.
+export type { SessionTopic } from './session-topic-types.js';
+import type { SessionTopic } from './session-topic-types.js';
 
 export interface SessionProgress {
   totalMessages: number;

--- a/src/pipeline-types.ts
+++ b/src/pipeline-types.ts
@@ -1,0 +1,52 @@
+/**
+ * pipeline-types.ts — Shared type interfaces for the pipeline subsystem.
+ *
+ * Extracted from pipeline.ts to break the circular dependency:
+ *   pipeline.ts ↔ state-store.ts
+ *
+ * Both files import types from here instead of from each other.
+ */
+
+export interface PipelineStage {
+  name: string;
+  workDir?: string;
+  prompt: string;
+  dependsOn?: string[];
+  permissionMode?: string;
+  /** @deprecated Use permissionMode instead. */
+  autoApprove?: boolean;
+  stageTimeoutMs?: number;
+}
+
+export interface PipelineConfig {
+  name: string;
+  workDir: string;  // Default workDir for all stages
+  stages: PipelineStage[];
+}
+
+export type PipelineStageStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface PipelineState {
+  id: string;
+  name: string;
+  currentStage: 'plan' | 'execute' | 'verify' | 'fix' | 'submit' | 'done';
+  status: 'running' | 'completed' | 'failed';
+  retryCount: number;
+  maxRetries: number;
+  stageHistory: Array<{
+    stage: string;
+    enteredAt: number;
+    exitedAt?: number;
+    output?: unknown;
+  }>;
+  stages: Array<{
+    name: string;
+    status: PipelineStageStatus;
+    sessionId?: string;
+    dependsOn: string[];
+    startedAt?: number;
+    completedAt?: number;
+    error?: string;
+  }>;
+  createdAt: number;
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -35,49 +35,9 @@ export interface BatchResult {
   errors: string[];
 }
 
-export interface PipelineStage {
-  name: string;
-  workDir?: string;
-  prompt: string;
-  dependsOn?: string[];
-  permissionMode?: string;
-  /** @deprecated Use permissionMode instead. */
-  autoApprove?: boolean;
-  stageTimeoutMs?: number;
-}
-
-export interface PipelineConfig {
-  name: string;
-  workDir: string;  // Default workDir for all stages
-  stages: PipelineStage[];
-}
-
-export type PipelineStageStatus = 'pending' | 'running' | 'completed' | 'failed';
-
-export interface PipelineState {
-  id: string;
-  name: string;
-  currentStage: 'plan' | 'execute' | 'verify' | 'fix' | 'submit' | 'done';
-  status: 'running' | 'completed' | 'failed';
-  retryCount: number;
-  maxRetries: number;
-  stageHistory: Array<{
-    stage: string;
-    enteredAt: number;
-    exitedAt?: number;
-    output?: unknown;
-  }>;
-  stages: Array<{
-    name: string;
-    status: PipelineStageStatus;
-    sessionId?: string;
-    dependsOn: string[];
-    startedAt?: number;
-    completedAt?: number;
-    error?: string;
-  }>;
-  createdAt: number;
-}
+// Re-exported from pipeline-types.ts for backward compatibility.
+export type { PipelineStage, PipelineConfig, PipelineStageStatus, PipelineState } from './pipeline-types.js';
+import type { PipelineStage, PipelineConfig, PipelineStageStatus, PipelineState } from './pipeline-types.js';
 
 export class PipelineManager {
   private static readonly PIPELINE_RETRY_MAX_ATTEMPTS = 3;

--- a/src/services/state/state-store.ts
+++ b/src/services/state/state-store.ts
@@ -17,7 +17,7 @@
  */
 
 import type { SessionInfo, SessionState } from '../../session-types.js';
-import type { PipelineState, PipelineConfig } from '../../pipeline.js';
+import type { PipelineState, PipelineConfig } from '../../pipeline-types.js';
 import type { LifecycleService, ServiceHealth } from '../../container.js';
 
 /** Serializable representation of a SessionInfo (Set<string> → string[], no Buffers). */


### PR DESCRIPTION
## Summary

Eliminates the last 2 remaining circular dependencies (out of 5 originally detected):

1. **pipeline.ts ↔ state-store.ts**: Extract `PipelineState`, `PipelineStage`, `PipelineConfig`, `PipelineStageStatus` → `pipeline-types.ts`
2. **telegram/types.ts ↔ topic-persistence.ts**: Extract `SessionTopic` → `session-topic-types.ts`

The other 3 circular deps were already resolved by PRs #4488 and #4492.

## Verification
- ✅ `tsc --noEmit` clean
- ✅ `madge --circular --extensions ts src/` → **0 circular dependencies**
- ✅ All re-exports preserved for backward compatibility
- ✅ Clean merge against latest develop confirmed locally

Part of Architecture Fix Plan — Priority 1.