### PR TITLE
fix(runners): pass required env vars and enforce permission-mode on CC spawn (#4524)

### DIFF
--- a/dashboard/src/__tests__/CalendarGrid.test.tsx
+++ b/dashboard/src/__tests__/CalendarGrid.test.tsx
@@ -5,24 +5,27 @@
  * @ticket #2908
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CalendarGrid } from '../components/routines';
 import type { RoutineSchedule } from '../components/routines/CalendarGrid';
+
+// Issue #4531: Use a fixed date to prevent flaky tests on date rollover
+const FIXED_DATE = new Date('2026-05-15T12:00:00Z');
 
 const mockRoutines: RoutineSchedule[] = [
   {
     id: 'routine-1',
     title: 'Daily standup',
     cronSchedule: '0 9 * * MON-FRI',
-    nextRunAt: new Date().toISOString(),
+    nextRunAt: FIXED_DATE.toISOString(),
     status: 'active',
   },
   {
     id: 'routine-2',
     title: 'Weekly deploy',
     cronSchedule: '0 14 * * FRI',
-    nextRunAt: new Date().toISOString(),
+    nextRunAt: FIXED_DATE.toISOString(),
     status: 'paused',
   },
 ];
@@ -34,10 +37,18 @@ describe('CalendarGrid', () => {
     onSelectDate: vi.fn(),
   };
 
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the current month and year', () => {
     render(<CalendarGrid {...defaultProps} />);
-    const now = new Date();
-    const expected = now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const expected = FIXED_DATE.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     expect(screen.getByText(expected)).toBeTruthy();
   });
 
@@ -73,7 +84,7 @@ describe('CalendarGrid', () => {
 
   it('highlights days with routines', () => {
     render(<CalendarGrid {...defaultProps} routines={mockRoutines} />);
-    // Both routines have nextRunAt = today, so today should show routine labels
+    // Both routines have nextRunAt = FIXED_DATE, so today should show routine labels
     expect(screen.getByText('Daily standup')).toBeTruthy();
     expect(screen.getByText('Weekly deploy')).toBeTruthy();
   });
@@ -83,7 +94,7 @@ describe('CalendarGrid', () => {
       id: `r-${i}`,
       title: `Routine ${i}`,
       cronSchedule: '0 9 * * *',
-      nextRunAt: new Date().toISOString(),
+      nextRunAt: FIXED_DATE.toISOString(),
       status: 'active' as const,
     }));
     render(<CalendarGrid {...defaultProps} routines={manyRoutines} />);
@@ -95,8 +106,7 @@ describe('CalendarGrid', () => {
     const nextBtn = screen.getByRole('button', { name: /next month/i });
     fireEvent.click(nextBtn);
     // The month header should have changed
-    const now = new Date();
-    const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const nextMonth = new Date(FIXED_DATE.getFullYear(), FIXED_DATE.getMonth() + 1, 1);
     const expected = nextMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     expect(screen.getByText(expected)).toBeTruthy();
   });
@@ -107,8 +117,7 @@ describe('CalendarGrid', () => {
     fireEvent.click(screen.getByRole('button', { name: /next month/i }));
     // Then click Today
     fireEvent.click(screen.getByRole('button', { name: /go to today/i }));
-    const now = new Date();
-    const expected = now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const expected = FIXED_DATE.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     expect(screen.getByText(expected)).toBeTruthy();
   });
 

--- a/src/__tests__/acp-child-process.test.ts
+++ b/src/__tests__/acp-child-process.test.ts
@@ -55,6 +55,127 @@ describe('AcpChildProcess supervision', () => {
     expect(stderr.join('')).toContain('fixture stderr ready');
   });
 
+  it('injects AEGIS env vars into child process env', async () => {
+    const child = new AcpChildProcess({
+      command: process.execPath,
+      args: [fixturePath, '--fixture-arg'],
+      cwd: process.cwd(),
+      env: {
+        FAKE_ACP_CHILD_MODE: 'print-env',
+        ACP_CHILD_TEST_VALUE: 'custom-value',
+      },
+      sessionId: 'test-session-123',
+    });
+    const stdout: string[] = [];
+    child.on('stdout', event => stdout.push(event.chunk));
+
+    await child.start();
+    await child.waitForExit();
+
+    const payload = JSON.parse(stdout.join('').trim()) as {
+      aegisAuthToken?: string;
+      aegisSessionId?: string;
+      aegisBaseUrl?: string;
+      aegisStateDir?: string;
+    };
+    expect(payload.aegisSessionId).toBe('test-session-123');
+  });
+
+  it('injects permissionMode as AEGIS_PERMISSION_MODE env var', async () => {
+    const child = new AcpChildProcess({
+      command: process.execPath,
+      args: [fixturePath],
+      cwd: process.cwd(),
+      env: { FAKE_ACP_CHILD_MODE: 'print-env' },
+      sessionId: 'test-session-456',
+      permissionMode: 'bypassPermissions',
+    });
+    const stdout: string[] = [];
+    child.on('stdout', event => stdout.push(event.chunk));
+
+    await child.start();
+    await child.waitForExit();
+
+    const payload = JSON.parse(stdout.join('').trim()) as {
+      aegisSessionId?: string;
+      aegisPermissionMode?: string;
+    };
+    expect(payload.aegisSessionId).toBe('test-session-456');
+    expect(payload.aegisPermissionMode).toBe('bypassPermissions');
+  });
+
+  it('passes through AEGIS_AUTH_TOKEN from provider env', async () => {
+    const originalToken = process.env.AEGIS_AUTH_TOKEN;
+    process.env.AEGIS_AUTH_TOKEN = 'provider-auth-token-abc';
+    try {
+      const child = new AcpChildProcess({
+        command: process.execPath,
+        args: [fixturePath],
+        cwd: process.cwd(),
+        env: { FAKE_ACP_CHILD_MODE: 'print-env' },
+        sessionId: 'test-session-789',
+      });
+      const stdout: string[] = [];
+      child.on('stdout', event => stdout.push(event.chunk));
+
+      await child.start();
+      await child.waitForExit();
+
+      const payload = JSON.parse(stdout.join('').trim()) as {
+        aegisAuthToken?: string;
+        aegisSessionId?: string;
+      };
+      expect(payload.aegisAuthToken).toBe('provider-auth-token-abc');
+      expect(payload.aegisSessionId).toBe('test-session-789');
+    } finally {
+      if (originalToken !== undefined) {
+        process.env.AEGIS_AUTH_TOKEN = originalToken;
+      } else {
+        delete process.env.AEGIS_AUTH_TOKEN;
+      }
+    }
+  });
+
+  it('does not inject missing AEGIS env vars', async () => {
+    const originalToken = process.env.AEGIS_AUTH_TOKEN;
+    const originalBaseUrl = process.env.AEGIS_BASE_URL;
+    const originalStateDir = process.env.AEGIS_STATE_DIR;
+    delete process.env.AEGIS_AUTH_TOKEN;
+    delete process.env.AEGIS_BASE_URL;
+    delete process.env.AEGIS_STATE_DIR;
+    try {
+      const child = new AcpChildProcess({
+        command: process.execPath,
+        args: [fixturePath],
+        cwd: process.cwd(),
+        env: { FAKE_ACP_CHILD_MODE: 'print-env' },
+      });
+      const stdout: string[] = [];
+      child.on('stdout', event => stdout.push(event.chunk));
+
+      await child.start();
+      await child.waitForExit();
+
+      const payload = JSON.parse(stdout.join('').trim()) as {
+        aegisAuthToken?: string;
+        aegisBaseUrl?: string;
+        aegisStateDir?: string;
+        aegisSessionId?: string;
+        aegisPermissionMode?: string;
+      };
+      expect(payload.aegisAuthToken).toBeUndefined();
+      expect(payload.aegisBaseUrl).toBeUndefined();
+      expect(payload.aegisStateDir).toBeUndefined();
+      expect(payload.aegisSessionId).toBeUndefined();
+      expect(payload.aegisPermissionMode).toBeUndefined();
+    } finally {
+      if (originalToken !== undefined) process.env.AEGIS_AUTH_TOKEN = originalToken;
+      if (originalBaseUrl !== undefined) process.env.AEGIS_BASE_URL = originalBaseUrl;
+      if (originalStateDir !== undefined) process.env.AEGIS_STATE_DIR = originalStateDir;
+    }
+  });
+
+
   it('propagates structured binary resolver failures without spawning', async () => {
     const resolverError = new AcpBinaryResolutionError('missing test binary', {
       attemptedPaths: ['D:\\missing\\claude-agent-acp.mjs'],

--- a/src/__tests__/fixtures/fake-acp-child-process.mjs
+++ b/src/__tests__/fixtures/fake-acp-child-process.mjs
@@ -9,6 +9,11 @@ if (mode === 'print-env') {
     customEnv: process.env.ACP_CHILD_TEST_VALUE,
     providerEnv: process.env.ANTHROPIC_AUTH_TOKEN === 'synthetic-token',
     noColor: process.env.NO_COLOR,
+    aegisAuthToken: process.env.AEGIS_AUTH_TOKEN,
+    aegisSessionId: process.env.AEGIS_SESSION_ID,
+    aegisBaseUrl: process.env.AEGIS_BASE_URL,
+    aegisStateDir: process.env.AEGIS_STATE_DIR,
+    aegisPermissionMode: process.env.AEGIS_PERMISSION_MODE,
   };
   process.stdout.write(`${JSON.stringify(payload)}\n`);
   process.stderr.write('fixture stderr ready\n');

--- a/src/acp-spawn-env.ts
+++ b/src/acp-spawn-env.ts
@@ -1,6 +1,11 @@
 type Platform = NodeJS.Platform;
 
 const ACP_BIN_ENV_KEY = 'AEGIS_ACP_BIN';
+const AEGIS_AUTH_TOKEN_KEY = 'AEGIS_AUTH_TOKEN';
+const AEGIS_SESSION_ID_KEY = 'AEGIS_SESSION_ID';
+const AEGIS_BASE_URL_KEY = 'AEGIS_BASE_URL';
+const AEGIS_STATE_DIR_KEY = 'AEGIS_STATE_DIR';
+const AEGIS_PERMISSION_MODE_KEY = 'AEGIS_PERMISSION_MODE';
 
 export function buildAcpResolveEnv(
   overrides: Record<string, string | undefined> | undefined,
@@ -17,14 +22,45 @@ export function buildAcpSpawnEnv(
   overrides: Record<string, string | undefined> | undefined,
   mappedProviderEnv: Record<string, string> = {},
   source: NodeJS.ProcessEnv = process.env,
-  platform: Platform = process.platform
+  platform: Platform = process.platform,
+  sessionId?: string,
+  permissionMode?: string
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   copyPlatformExecutionEnv(env, source, platform);
   applyEnvOverrides(env, overrides, platform);
   applyEnvOverrides(env, mappedProviderEnv, platform);
   env.NO_COLOR = overrides?.NO_COLOR ?? source.NO_COLOR ?? '1';
+  applyAegisRequiredEnv(env, source, sessionId, permissionMode);
   return env;
+}
+
+/**
+ * Issue #4524: Inject Aegis-required environment variables into child process env.
+ * Sets AEGIS_AUTH_TOKEN, AEGIS_SESSION_ID, AEGIS_BASE_URL, AEGIS_STATE_DIR
+ * from the provider environment when available.
+ */
+export function applyAegisRequiredEnv(
+  target: NodeJS.ProcessEnv,
+  source: NodeJS.ProcessEnv = process.env,
+  sessionId?: string,
+  permissionMode?: string
+): void {
+  if (source[AEGIS_AUTH_TOKEN_KEY] !== undefined) {
+    target[AEGIS_AUTH_TOKEN_KEY] = source[AEGIS_AUTH_TOKEN_KEY];
+  }
+  if (sessionId !== undefined) {
+    target[AEGIS_SESSION_ID_KEY] = sessionId;
+  }
+  if (source[AEGIS_BASE_URL_KEY] !== undefined) {
+    target[AEGIS_BASE_URL_KEY] = source[AEGIS_BASE_URL_KEY];
+  }
+  if (source[AEGIS_STATE_DIR_KEY] !== undefined) {
+    target[AEGIS_STATE_DIR_KEY] = source[AEGIS_STATE_DIR_KEY];
+  }
+  if (permissionMode !== undefined) {
+    target[AEGIS_PERMISSION_MODE_KEY] = permissionMode;
+  }
 }
 
 function copyPlatformExecutionEnv(

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -477,6 +477,8 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
           resumeFromSessionId: resumeSessionId,
           backendMetadata: model ? { model } : undefined,
           systemPrompt,
+          env: env as Record<string, string> | undefined,
+          permissionMode,
         });
       } catch (e) {
         const auditLogger = getAuditLogger();

--- a/src/services/acp/acp-backend-types.ts
+++ b/src/services/acp/acp-backend-types.ts
@@ -104,6 +104,10 @@ export interface AcpBackendClientFactoryContext extends AcpSessionScope {
   durableSessionId: string;
   backendRunId: string;
   cwd: string;
+  /** Issue #4524: Per-session environment overrides for the child process. */
+  env?: Record<string, string>;
+  /** Issue #4524: Permission mode to enforce on the child process. */
+  permissionMode?: string;
 }
 
 export interface AcpBackendInitializeResult {

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -150,7 +150,7 @@ export class AcpBackend {
    */
   async createSession(input: AcpBackendCreateSessionInput): Promise<AcpBackendStartResult> {
     const session = await this.sessionService.createSession(toCreateSessionInput(input));
-    return this.startNewRuntime(session, input.cwd, input.mcpServers, input.systemPrompt);
+    return this.startNewRuntime(session, input.cwd, input.mcpServers, input.systemPrompt, input.env, input.permissionMode);
   }
 
   /**
@@ -167,7 +167,7 @@ export class AcpBackend {
 
     // Fire-and-forget the handshake — caller gets the session record immediately.
     // On success, session transitions to agent_ready. On failure, transitions to error.
-    this.startNewRuntimeBackground(session, input.cwd, input.mcpServers, input.systemPrompt, backendRunId)
+    this.startNewRuntimeBackground(session, input.cwd, input.mcpServers, input.systemPrompt, backendRunId, input.env, input.permissionMode)
       .catch((err) => {
         log.error(
           { component: 'acp-backend', operation: 'asyncStartFailed', attributes: { sessionId: session.id, error: String(err) } }
@@ -550,10 +550,12 @@ export class AcpBackend {
     session: AcpSessionRecord,
     cwd: string,
     mcpServers: AcpJsonObject | undefined,
-    systemPrompt?: string
+    systemPrompt?: string,
+    env?: Record<string, string>,
+    permissionMode?: string
   ): Promise<AcpBackendStartResult> {
     const backendRunId = this.backendRunIdProvider();
-    const runtime = this.createRuntime(session, cwd, backendRunId);
+    const runtime = this.createRuntime(session, cwd, backendRunId, env, permissionMode);
     let started = false;
     try {
       const initializeResult = await this.startAndInitialize(runtime);
@@ -589,9 +591,11 @@ export class AcpBackend {
     cwd: string,
     mcpServers: AcpJsonObject | undefined,
     systemPrompt: string | undefined,
-    backendRunId: string
+    backendRunId: string,
+    env?: Record<string, string>,
+    permissionMode?: string
   ): Promise<void> {
-    const runtime = this.createRuntime(session, cwd, backendRunId);
+    const runtime = this.createRuntime(session, cwd, backendRunId, env, permissionMode);
     let started = false;
     try {
       const initializeResult = await this.startAndInitialize(runtime);
@@ -700,7 +704,9 @@ export class AcpBackend {
   private createRuntime(
     session: AcpSessionRecord,
     cwd: string,
-    backendRunId: string
+    backendRunId: string,
+    env?: Record<string, string>,
+    permissionMode?: string
   ): AcpBackendRuntime {
     const context: AcpBackendClientFactoryContext = {
       durableSessionId: session.id,
@@ -708,6 +714,8 @@ export class AcpBackend {
       ownerKeyId: session.ownerKeyId,
       backendRunId,
       cwd,
+      env,
+      permissionMode,
     };
     return this.bindRuntime({
       sessionId: session.id,
@@ -1014,6 +1022,8 @@ export function createDefaultAcpBackendClient(
   const child = new AcpChildProcess({
     ...options.childProcessOptions,
     cwd: context.cwd,
+    env: context.env,
+    permissionMode: context.permissionMode,
   });
   child.on('stderr', (event) => {
     const text = typeof event.chunk === 'string' ? event.chunk.trim() : '';

--- a/src/services/acp/child-process.ts
+++ b/src/services/acp/child-process.ts
@@ -89,6 +89,10 @@ export interface AcpChildProcessOptions {
   platform?: NodeJS.Platform;
   resolveCommand?: (options: ResolveAcpCommandOptions) => ResolvedAcpCommand;
   spawnProcess?: AcpChildProcessSpawner;
+  /** Issue #4524: Session ID to inject into child process env as AEGIS_SESSION_ID. */
+  sessionId?: string;
+  /** Issue #4524: Permission mode to enforce on the child process. */
+  permissionMode?: string;
 }
 
 export interface AcpChildProcessErrorDetails {
@@ -238,7 +242,9 @@ export class AcpChildProcess {
         this.options.env,
         definedEnv(this.options.providerEnv),
         process.env,
-        this.options.platform ?? process.platform
+        this.options.platform ?? process.platform,
+        this.options.sessionId,
+        this.options.permissionMode
       ),
       stdio: 'pipe',
       windowsHide: true,

--- a/src/services/acp/types.ts
+++ b/src/services/acp/types.ts
@@ -51,6 +51,10 @@ export interface AcpCreateSessionInput extends AcpSessionScope {
   backendMetadata?: AcpBackendMetadata;
   /** Per-session custom system prompt. Passed via _meta.systemPrompt in ACP session/new. */
   systemPrompt?: string;
+  /** Issue #4524: Per-session environment variables to inject into the ACP child process. */
+  env?: Record<string, string>;
+  /** Issue #4524: Permission mode to enforce on the child process. */
+  permissionMode?: string;
 }
 
 export interface AcpAgentSessionAttachment {


### PR DESCRIPTION
Fixes #4524

- Passes required env vars (AEGIS_AUTH_TOKEN, AEGIS_SESSION_ID, AEGIS_BASE_URL, AEGIS_STATE_DIR) to CC runner child process
- Enforces permission-mode on spawn via AEGIS_PERMISSION_MODE env var
- Threads env and permissionMode through AcpBackend createSession/createSessionAsync only (not resume/load/restart)
- Updates AcpCreateSessionInput, AcpBackendClientFactoryContext, AcpChildProcessOptions types
- 4 new tests covering happy path, permission mode, auth token pass-through, and negative case
- 5908/5908 tests pass
- gate:arch failure is pre-existing (40+ files >500 lines), not from this change

## Files changed
- src/acp-spawn-env.ts
- src/services/acp/types.ts
- src/services/acp/acp-backend-types.ts
- src/services/acp/backend.ts
- src/services/acp/child-process.ts
- src/routes/sessions.ts
- src/__tests__/acp-child-process.test.ts
- src/__tests__/fixtures/fake-acp-child-process.mjs