### PR TITLE
docs: ACP child-process env vars from #4524

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -781,7 +781,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 | `resumeSessionId` | string (UUID) | no | Resume an existing session by UUID |
 | `model` | string | no | Model name for analytics grouping (max 200 chars) |
 | `claudeCommand` | string | no | Custom Claude Code CLI flags (max 500 chars, alphanumeric/safe chars only) |
-| `env` | object | no | Environment variables (subject to denylist) |
+| `env` | object | no | Environment variables injected into the ACP child process (subject to denylist). Keys starting with `ANTHROPIC_` or `CLAUDE_` are always passed through. See [ACP Environment Variables](#acp-environment-variables) below. |
 | `stallThresholdMs` | number | no | Stall detection timeout (default: 300000, max: 3600000) |
 | `permissionMode` | string | no | `default`, `bypassPermissions`, `plan`, `acceptEdits`, `dontAsk`, `auto` |
 | `autoApprove` | boolean | no | Skip permission prompts (= `permissionMode: bypassPermissions`) |
@@ -826,6 +826,18 @@ curl -X POST http://localhost:9100/v1/sessions \
 | 403 | `TENANT_WORKDIR_DENIED` | workDir outside tenant root |
 | 422 | `CC_VERSION_TOO_OLD` | Claude Code version below minimum |
 | 429 | `QUOTA_EXCEEDED` | Per-key session quota exceeded |
+
+> **ACP Environment Variables:** When ACP spawns a child process (Claude Code or other agent), it injects the following Aegis-specific environment variables:
+>
+> | Variable | Source | Description |
+> |----------|--------|-------------|
+> | `AEGIS_AUTH_TOKEN` | Server env | Auth token for the ACP child to call back to Aegis |
+> | `AEGIS_SESSION_ID` | Session ID | The session UUID — child can reference its own session |
+> | `AEGIS_BASE_URL` | Server env | Aegis API origin for callbacks |
+> | `AEGIS_STATE_DIR` | Server env | State directory path |
+> | `AEGIS_PERMISSION_MODE` | Session `permissionMode` | Permission mode enforced on the child process |
+>
+> Additionally, all environment variables starting with `ANTHROPIC_` or `CLAUDE_` are automatically passed through from the server environment to the ACP child, allowing the child to authenticate with Anthropic APIs.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,8 @@ If the server is already running, `ag run` skips bootstrap and start — goes st
 | `--name <name>` | Set a display name for the session |
 | `--yes` | Suppress all status messages for non-interactive/CI usage |
 | `--accept-permissions` / `-y` | Auto-approve all permission prompts (sets `permissionMode: bypassPermissions`) |
+| `--env key=value` | Set environment variables for the ACP child process (repeatable). Keys starting with `ANTHROPIC_` or `CLAUDE_` are always passed through. |
+| `--permission-mode <mode>` | Permission mode for the session: `default`, `bypassPermissions`, `plan`, `acceptEdits`, `dontAsk`, `auto` |
 
 > **Note:** `ag run --help` currently shows the general help. For `ag run` flags, refer to this table.
 

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -71,6 +71,8 @@ If the server is already running, skips straight to session creation. Existing c
 | `--cwd <path>` | Working directory (default: current directory) |
 | `--port <number>` | Server port override |
 | `--no-stream` | Don't stream output; print curl commands instead |
+| `--env key=value` | Set environment variables for the ACP child process (repeatable). Keys starting with `ANTHROPIC_` or `CLAUDE_` are always passed through. |
+| `--permission-mode <mode>` | Permission mode for the session: `default`, `bypassPermissions`, `plan`, `acceptEdits`, `dontAsk`, `auto` |
 
 ### `ag` — Start Server
 
@@ -107,6 +109,8 @@ AEGIS_AUTH_TOKEN=secret ag
 | `AEGIS_AUTH_TOKEN` | _(none)_ | Bearer token (required for production) |
 | `AEGIS_DASHBOARD_ENABLED` | `true` | Serve the bundled dashboard |
 | `AEGIS_STATE_DIR` | `~/.aegis` | Session state directory |
+| `AEGIS_SESSION_ID` | _(injected)_ | Passed to ACP child process — session UUID for self-reference |
+| `AEGIS_PERMISSION_MODE` | _(injected)_ | Passed to ACP child process — permission mode enforced on the child |
 | `AEGIS_MAX_SESSIONS` | _(unlimited)_ | Max concurrent sessions |
 | `AEGIS_IDLE_TIMEOUT_MS` | `600000` | Idle timeout (10 min) |
 | `AEGIS_STALL_THRESHOLD_MS` | `120000` | Stall threshold (2 min) |
@@ -229,6 +233,10 @@ ag create "Fix the failing tests"                     # Uses current directory
 | Flag | Description |
 |------|-------------|
 | `--cwd <dir>` | Working directory for the session |
+| `--model <provider/model>` | Override the default model for this session |
+| `--effort <level>` | Set reasoning effort: `low`, `medium`, `high`, or `0.0`–`1.0` |
+| `--env key=value` | Set environment variables for the ACP child process (repeatable). Keys starting with `ANTHROPIC_` or `CLAUDE_` are always passed through. |
+| `--permission-mode <mode>` | Permission mode for the session: `default`, `bypassPermissions`, `plan`, `acceptEdits`, `dontAsk`, `auto` |
 | `--port <port>` | Aegis API port (default: `AEGIS_PORT` or `9100`) |
 
 This is a convenience wrapper that:


### PR DESCRIPTION
Documents the ACP environment variable injection feature from PR #4524.

## Changes (3 files, ~23 lines)

- **api-reference.md**:
  - Document AEGIS_SESSION_ID, AEGIS_PERMISSION_MODE, AEGIS_AUTH_TOKEN, AEGIS_BASE_URL, AEGIS_STATE_DIR injection into ACP child processes
  - Clarify `env` field description for session creation (per-session env vars for ACP child)
  - Document ANTHROPIC_/CLAUDE_ env var passthrough

- **cli.md**:
  - Add `--env key=value` flag for `ag create` and `ag run`
  - Add `--permission-mode` flag for `ag create` and `ag run`
  - Document injected env vars in environment variables table

- **getting-started.md**:
  - Add `--env` and `--permission-mode` flags for `ag run`

Fixes docs gate blocker for v0.6.7 release promotion #4533.

cc @1490089830472880218 (Argus) for review