### PR TITLE
fix(#4526): add unregister method to InMemoryRunnerRegistry

### DIFF
--- a/src/__tests__/fix-3263-runner-abstraction.test.ts
+++ b/src/__tests__/fix-3263-runner-abstraction.test.ts
@@ -195,3 +195,38 @@ describe('Issue #3263 — Runner abstraction layer', () => {
     });
   });
 });
+
+    it('unregisters a runner and updates default', () => {
+      const registry = new InMemoryRunnerRegistry();
+      const first = new MockRunner('first');
+      const second = new MockRunner('second');
+
+      registry.register(first);
+      registry.register(second);
+      expect(registry.getDefault()).toBe(first);
+
+      registry.unregister('first');
+      expect(registry.get('first')).toBeUndefined();
+      expect(registry.listNames()).toEqual(['second']);
+      expect(registry.getDefault()).toBe(second);
+    });
+
+    it('unregisters the last runner and getDefault throws', () => {
+      const registry = new InMemoryRunnerRegistry();
+      const runner = new MockRunner('only');
+
+      registry.register(runner);
+      registry.unregister('only');
+      expect(registry.get('only')).toBeUndefined();
+      expect(registry.listNames()).toEqual([]);
+      expect(() => registry.getDefault()).toThrow('No runners registered');
+    });
+
+    it('unregister of unknown runner is a no-op', () => {
+      const registry = new InMemoryRunnerRegistry();
+      registry.register(new MockRunner('existing'));
+
+      registry.unregister('nonexistent');
+      expect(registry.listNames()).toEqual(['existing']);
+      expect(registry.getDefault().name).toBe('existing');
+    });

--- a/src/runners/registry.ts
+++ b/src/runners/registry.ts
@@ -32,4 +32,12 @@ export class InMemoryRunnerRegistry implements RunnerRegistry {
     }
     return this.defaultRunner;
   }
+
+  unregister(name: string): void {
+    this.runners.delete(name);
+    // If we removed the default, pick a new one
+    if (this.defaultRunner?.name === name) {
+      this.defaultRunner = this.runners.values().next().value;
+    }
+  }
 }

--- a/src/runners/types.ts
+++ b/src/runners/types.ts
@@ -165,4 +165,11 @@ export interface RunnerRegistry {
 
   /** Get the default runner. */
   getDefault(): AgentRunner;
+
+  /**
+   * Unregister a runner by name.
+   *
+   * @param name - Runner name to remove.
+   */
+  unregister(name: string): void;
 }


### PR DESCRIPTION
Closes #4526

## Summary
The InMemoryRunnerRegistry had no way to remove a registered runner. This adds an unregister method to both the interface and implementation.

## Changes
- Add `unregister(name: string): void` to `RunnerRegistry` interface
- Implement `unregister` in `InMemoryRunnerRegistry`:
  - Removes runner from internal Map
  - If removed runner was the default, promotes the next registered runner
  - If no runners remain, `getDefault` continues to throw as before
- Add 3 unit tests:
  - Unregister updates default to next runner
  - Unregister last runner causes getDefault to throw
  - Unregister unknown runner is a no-op

## Verification
- tsc ✅
- tests: 17/17 pass in runner abstraction test suite