### PR TITLE
test: throwaway regression test for helm-smoke chart validation (DO NOT MERGE)

### DIFF
--- a/.github/workflows/helm-smoke.yml
+++ b/.github/workflows/helm-smoke.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           cluster-name: aegis-helm-smoke
           args: --agents 1
+          k3d-version: v5.9.0
       - name: Prepare smoke image assets
         shell: bash
         run: |

--- a/deploy/helm/aegis/templates/service.yaml
+++ b/deploy/helm/aegis/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - name: {{ .Values.service.portName }}
-      port: {{ .Values.service.port }}
+      port: {{ .Values.service.port
       targetPort: {{ .Values.service.portName }}
       protocol: TCP
   selector:


### PR DESCRIPTION
## ⚠️ THROWAWAY / DO NOT MERGE / NEGATIVE TEST

This PR exists ONLY to validate that helm-smoke catches a real chart error AFTER the k3d v5.9.0 fix in PR #4560 lands. It will be closed without merging once the CI run completes and the failure mode is documented in the main fix PR (#4560).

## What this PR does

Introduces a deliberate Go template syntax error in `deploy/helm/aegis/templates/service.yaml`:

```diff
       port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.portName }}
+      targetPort: {{ .Values.service.portName }}
```

Wait, that's not right. Let me re-check the actual error.

```diff
       port: {{ .Values.service.port }}
```
→
```diff
       port: {{ .Values.service.port
```

Missing closing `}}`. This is a Go template parse error that `helm lint` MUST catch.

## Why this PR is in the branch

This branch is rebased on top of `ci/helm-smoke-k3d-fix` (PR #4560), so the workflow includes the k3d v5.9.0 pin. When the PR is opened:

1. **If the k3d fix is correct:** the k3d cluster spins up successfully (step 9 passes)
2. **If chart validation still works:** the helm lint step (step 7) catches the unclosed template expression and fails before k3d is invoked
3. **Combined:** this proves the k3d fix works AND chart validation still catches real errors

## Expected failure mode

helm-smoke should fail at step 7 (`Helm lint`) with an error like:
```
Error: parse error at (aegis/templates/service.yaml:15): unclosed action started at aegis/templates/service.yaml:15
```

If helm-smoke instead fails at step 9 (`Create k3d cluster`), that would mean the k3d fix isn't working AND the chart error is being skipped for some reason. That would be a bug.

## After this test

Once the CI run completes:
1. Document the actual failure step and error message in PR #4560's body
2. Close this PR without merging
3. Force-delete the `ci/helm-smoke-regression-test` branch

## Out of scope

- This PR is not for review. It will be closed immediately after the test.
- No code changes from this PR will land in develop.