### PR TITLE
fix(dashboard): use design tokens for SessionHistory source='live' badge

### DIFF
--- a/dashboard/src/pages/SessionHistoryPage.tsx
+++ b/dashboard/src/pages/SessionHistoryPage.tsx
@@ -55,7 +55,7 @@ function statusClass(status: SessionHistoryRecord['finalStatus']): string {
 
 function sourceClass(source: SessionHistoryRecord['source']): string {
   if (source === 'audit+live') return 'text-[var(--color-accent-cyan-glow)] bg-[var(--color-accent-cyan)]/10 border-[var(--color-accent-cyan)]/25';
-  if (source === 'live') return 'text-sky-300 bg-sky-500/10 border-sky-500/25';
+  if (source === 'live') return 'text-[var(--color-info-glow)] bg-[var(--color-info)]/10 border-[var(--color-info)]/25';
   return 'text-[var(--color-text-muted)] dark:text-[var(--color-text-primary)] bg-[var(--color-void-lighter)]/40 border-[var(--color-void-lighter)]';
 }
 


### PR DESCRIPTION
## Summary
- Replace raw Tailwind color classes with design tokens in `SessionHistoryPage.sourceClass` for the `source === 'live'` branch.
- One-line change: `text-sky-300 bg-sky-500/10 border-sky-500/25` → `text-[var(--color-info-glow)] bg-[var(--color-info)]/10 border-[var(--color-info)]/25`.

## Why
The 2026-05-23 design-token sweep cleaned up most raw Tailwind color classes, but this one was missed. Result: `sourceClass()` was asymmetric — three branches using `var(--color-*)`, one branch using raw Tailwind. The sibling `statusClass()` function right above it already uses the `success`/`danger`/`warning`/`info` pattern.

`sky` (Tailwind) maps to `info` (blue) in our token system (`--color-info: #3b82f6`, `--color-info-glow: #93c5fd`), matching the visual it was approximating.

## Verification
- `npm --prefix dashboard run typecheck` — clean
- `npm --prefix dashboard test` — 2230/2230 passing (222 files, 2 skipped)
- `npm --prefix dashboard run build` — clean, 1.23s
- `SessionHistoryPage.test.tsx` — 6/6 passing (no styling assertions, so the swap is non-breaking)

## Out of scope (separate follow-ups if desired)
- ~20 other raw Tailwind color classes remain in `AgentBadge`, `SessionTable`, `Header`, `OnboardingWizard`, etc. Most are type-level colors, light-mode utilities, or component-internal variants. Not touched here to keep this PR small and reviewable.