### PR TITLE
fix(dashboard): use design tokens for AgentBadge default/gray variant

### DIFF
--- a/dashboard/src/components/agents/AgentBadge.tsx
+++ b/dashboard/src/components/agents/AgentBadge.tsx
@@ -18,7 +18,7 @@ const COLOR_CLASSES: Record<string, string> = {
   amber: "bg-[var(--color-warning)]/15 text-[var(--color-warning-glow)] border-[var(--color-warning)]/25",
   cyan: "bg-[var(--color-accent-cyan)]/15 text-[var(--color-accent-cyan-glow)] border-[var(--color-accent-cyan)]/25",
   rose: "bg-[var(--color-danger)]/15 text-[var(--color-danger-glow)] border-[var(--color-danger)]/25",
-  gray: "bg-gray-500/15 text-gray-400 border-gray-500/25",
+  gray: "bg-[var(--color-void-lighter)]/15 text-[var(--color-text-muted)] border-[var(--color-void-lighter)]/25",
 };
 
 export interface AgentBadgeProps {


### PR DESCRIPTION
## Summary
- Replace raw Tailwind color classes with design tokens in `AgentBadge.tsx` for the `gray` (default/fallback) entry in `COLOR_CLASSES`.
- One-line change: `bg-gray-500/15 text-gray-400 border-gray-500/25` → `bg-[var(--color-void-lighter)]/15 text-[var(--color-text-muted)] border-[var(--color-void-lighter)]/25`.

## Why
The `gray` entry in `COLOR_CLASSES` is the fallback for unknown agent runners (forward-compat per #3682). Every other entry (purple, green, blue, amber, cyan, rose) already uses the design token system. This one was missed in the original token audit.

Mapping rationale:
- `gray-500` (slate-500) → `--color-void-lighter` (slate-700) for bg + border, with opacity
- `gray-400` (slate-400) → `--color-text-muted` (slate-400, identical)
- Maintains the subdued/muted visual intent appropriate for the "unknown agent" fallback

## Verification
- `npm --prefix dashboard run typecheck` — clean, 0 errors
- `npm --prefix dashboard test` — 2230/2230 passing (222 files, 2 skipped)
- `npm --prefix dashboard run build` — clean, 2.65s
- `AgentBadge.test.tsx` — 9/9 passing (no styling assertions, safe to swap)

## Follow-up (#4564)
This is the first small PR in Path B (per-file). Remaining in the audit:
- `SessionTable.tsx` — `text-gray-900`, `bg-yellow-900/30`, `ring-cyan-500/30`
- `SessionMobileCard.tsx` — `ring-cyan-500/30`, `bg-yellow-900/30`
- `HomeStatusPanel.tsx` — `from-red-500/10 via-transparent to-red-500/5`
- `OnboardingWizard.tsx` — `text-green-400`, `text-yellow-400` (icon colors)
- `Header.tsx` — `text-slate-950`, `border-slate-300`, `bg-slate-50`
- Type-level: `types/acp-approval.ts`, `types/acp-driver-observer.ts`