### PR TITLE
fix(dashboard): use design tokens for raw color classes in SessionMobileCard

### DIFF
--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -35,7 +35,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
 }: SessionRowProps) {
   const t = useT();
   return (
-    <div className={`card-glass p-5 animate-bento-reveal transition-all ${isFocused ? 'border-[var(--color-accent-cyan)] ring-1 ring-cyan-500/30' : ''}${needsApproval(session) ? ' approval-pending-row' : ''}`}>
+    <div className={`card-glass p-5 animate-bento-reveal transition-all ${isFocused ? 'border-[var(--color-accent-cyan)] ring-1 ring-[var(--color-accent-cyan)]/30' : ''}${needsApproval(session) ? ' approval-pending-row' : ''}`}>
       <div className="mb-2 flex items-start justify-between gap-3">
         <label className="flex min-w-0 flex-1 items-center gap-3 text-sm text-[var(--color-text-primary)]">
           <input
@@ -90,7 +90,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
             onClick={(e) => onInterrupt(e, session.id)}
             disabled={currentAction === 'interrupt' || currentAction === 'kill'}
             aria-label={`Interrupt session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
-            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-yellow-900/30 p-2 text-[var(--color-warning)] transition-colors hover:bg-yellow-900/50 disabled:pointer-events-none disabled:opacity-40"
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-[var(--color-warning)]/15 p-2 text-[var(--color-warning-glow)] transition-colors hover:bg-[var(--color-warning)]/25 disabled:pointer-events-none disabled:opacity-40"
             title={t('aria.interrupt')}
           >
             <Ban className="h-4 w-4" />


### PR DESCRIPTION
## Summary
Two raw Tailwind color classes in SessionMobileCard.tsx replaced with design tokens.

## Changes
1. Line 38 (focus ring on the card): ring-cyan-500/30 -> ring-[var(--color-accent-cyan)]/30. The border color on the same line is already var(--color-accent-cyan), so the ring color now matches. The /30 opacity is preserved.
2. Line 93 (Interrupt button on mobile cards): yellow pattern -> --color-warning tokens. The opacity values (15% bg, 25% hover, glow text) match the sibling Kill button (bg-danger/15, text-danger-glow, hover:bg-danger/25) and the SessionTable equivalent fixed in #4566.

## Why
Third small PR in the #4564 audit (Path B: per-file). Mobile variant of the buttons I fixed in SessionTable. Consistent with #4563 (SessionHistory), #4565 (AgentBadge), #4566 (SessionTable).

## Verification
- npm --prefix dashboard run typecheck — clean, 0 errors
- npm --prefix dashboard test — 2230/2230 passing (222 files, 2 skipped)
- npm --prefix dashboard run build — clean, 2.63s
- SessionMobileCard tests: passing (no styling assertions on the affected classes)

## Visual note
- The Interrupt button on mobile will appear slightly brighter than before (15% opacity vs 30%) — matches the established convention for token-based buttons.
- The focus ring color now uses the same accent-cyan token as the border, so a focused card looks consistent.

## Out of scope
- The bridge in index.css lines 736-744 remains in place. Other files may still use it. Will sweep in a separate PR if/when no other text-gray-900 / text-slate-900 instances remain.

## Follow-up (#4564 Path B queue)
1. #4563 — SessionHistoryPage (merged)
2. #4565 — AgentBadge (merged)
3. #4566 — SessionTable (merged)
4. This PR — SessionMobileCard
5. HomeStatusPanel.tsx
6. OnboardingWizard.tsx
7. Header.tsx
8. Type-level: types/acp-approval.ts, types/acp-driver-observer.ts