### PR TITLE
fix(dashboard): use design tokens for raw color classes in HomeStatusPanel

### DIFF
--- a/dashboard/src/components/overview/HomeStatusPanel.tsx
+++ b/dashboard/src/components/overview/HomeStatusPanel.tsx
@@ -67,7 +67,7 @@ function StatusCard({ label, value, detail, tone, icon, actionButton }: StatusCa
     >
       {/* Critical Alert Glowing Underlay */}
       {isCritical && (
-        <div className="absolute inset-0 bg-gradient-to-r from-red-500/10 via-transparent to-red-500/5 animate-pulse pointer-events-none" />
+        <div className="absolute inset-0 bg-gradient-to-r from-[var(--color-danger)]/10 via-transparent to-[var(--color-danger)]/5 animate-pulse pointer-events-none" />
       )}
 
       <div className="flex flex-col gap-2 relative z-10">
@@ -258,7 +258,7 @@ export default function HomeStatusPanel({ onCreateFirstSession }: HomeStatusPane
             <button
               type="button"
               onClick={onCreateFirstSession}
-              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--color-accent-cyan)] px-4 py-2.5 text-sm font-medium text-slate-950 transition-opacity hover:opacity-90"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--color-accent-cyan)] px-4 py-2.5 text-sm font-medium text-[var(--color-cta-text)] transition-opacity hover:opacity-90"
             >
               <Plus className="h-4 w-4" />
               Create first session


### PR DESCRIPTION
## Summary
Two raw Tailwind color classes in `HomeStatusPanel.tsx` replaced with design tokens, both in the same file (1 file, +2 / −2).

## Changes
1. **Critical Alert Glowing Underlay** (`StatusCard`, `isCritical` state): `from-red-500/10 ... to-red-500/5` → `from-[var(--color-danger)]/10 ... to-[var(--color-danger)]/5`.
2. **'Create first session' CTA button**: `text-slate-950` → `text-[var(--color-cta-text)]`. The `--color-cta-text` token is defined as `var(--color-void)` and resolves to slate-950 in dark theme — semantically the right token since it's the 'text on a CTA button' token by design.

## Why
Fourth small PR in the #4564 audit (Path B). Continues the cleanup of raw Tailwind color classes that should resolve to design tokens. The `text-slate-950` in particular was a holdover — there's a dedicated CTA-text token for exactly this use case.

## Verification
- `npm --prefix dashboard run typecheck` — clean, 0 errors
- `npm --prefix dashboard test` — 2230/2230 passing (222 files, 2 skipped)
- `npm --prefix dashboard run build` — clean, 2.49s
- `HomeStatusPanel.test.tsx` (and the two related test files) — 7/7 passing on the focused run

## Path B Progress
1. ✅ #4563 SessionHistoryPage — MERGED
2. ✅ #4565 AgentBadge — MERGED (1.84k +1/-1)
3. ✅ #4566 SessionTable — MERGED (+4/-4)
4. ✅ #4567 SessionMobileCard — MERGED (Ema's, +2/-2)
5. **This PR** — HomeStatusPanel (+2/-2)
6. ⏸ OnboardingWizard.tsx — `text-green-400`, `text-yellow-400` icon colors (next)
7. ⏸ Header.tsx — `text-slate-950`, `border-slate-300`, `bg-slate-50` (note: `text-slate-950` here is in a similar context — light-mode text on a dark button — so different semantic than the CTA case above; will use `--color-text-primary`)
8. ⏸ Type-level: types/acp-approval.ts, types/acp-driver-observer.ts (Path A)