### PR TITLE
fix(dashboard): use design tokens for status icon colors in OnboardingWizard

### DIFF
--- a/dashboard/src/components/brand/OnboardingWizard.tsx
+++ b/dashboard/src/components/brand/OnboardingWizard.tsx
@@ -127,7 +127,7 @@ function ConnectStep({ health, loading }: { health: HealthState | null; loading:
           </h2>
           <p className="mx-auto max-w-md text-sm leading-relaxed text-[var(--color-text-muted)]">
             <span className="inline-flex items-center gap-1.5">
-              <CheckCircle2 className="h-4 w-4 text-green-400" />
+              <CheckCircle2 className="h-4 w-4 text-[var(--color-success-glow)]" />
               {t('onboarding.claudeHealthy', { version: health.claudeVersion ?? '' })}
             </span>
           </p>
@@ -139,7 +139,7 @@ function ConnectStep({ health, loading }: { health: HealthState | null; loading:
           </h2>
           <p className="mx-auto max-w-md text-sm leading-relaxed text-[var(--color-text-muted)]">
             <span className="inline-flex items-center gap-1.5">
-              <AlertTriangle className="h-4 w-4 text-yellow-400" />
+              <AlertTriangle className="h-4 w-4 text-[var(--color-warning-glow)]" />
               {t('onboarding.claudeIssues')}
             </span>
           </p>


### PR DESCRIPTION
## Summary
Two raw Tailwind color classes in `OnboardingWizard.tsx` replaced with design tokens, both in the same file (1 file, +2 / −2). Both are status-indicator icon colors in the Connect step.

## Changes
1. **Claude healthy state** (`CheckCircle2` icon, line 130): `text-green-400` → `text-[var(--color-success-glow)]`.
   - Color note: Tailwind's `green-400` is actually `#4ade80`, which is identical to `--color-success-glow` (emerald-400). Exact match — no visual change.
2. **Claude issues state** (`AlertTriangle` icon, line 142): `text-yellow-400` → `text-[var(--color-warning-glow)]`.
   - Color note: yellow-400 (`#facc15`) → amber-300 (`#fcd34d`). Slight warming — both are 'warning' tones, the token is the semantic match and matches the pattern used in `statusClass()` for warning state.

## Why
Sixth small PR in the #4564 audit (Path B). These were the last status-indicator icon colors that bypassed the design token system in this file. Continues the cleanup established by #4563 (SessionHistory), #4565 (AgentBadge), #4566 (SessionTable), #4567 (SessionMobileCard), #4569 (HomeStatusPanel).

## Verification
- `npm --prefix dashboard run typecheck` — clean, 0 errors
- `npm --prefix dashboard test` — 2230/2230 passing (222 files, 2 skipped)
- `npm --prefix dashboard run build` — clean, 1.48s
- `OnboardingWizard.test.tsx` — 24/24 passing (focused run)

## Path B Progress
1. ✅ #4563 SessionHistoryPage — MERGED
2. ✅ #4565 AgentBadge — MERGED
3. ✅ #4566 SessionTable — MERGED
4. ✅ #4567 SessionMobileCard — MERGED
5. ✅ #4569 HomeStatusPanel — MERGED
6. **This PR** — OnboardingWizard
7. ⏸ Header.tsx — `text-slate-950`, `border-slate-300`, `bg-slate-50` (next, after this lands)
8. ⏸ Type-level: types/acp-approval.ts, types/acp-driver-observer.ts (Path A)