### PR TITLE
fix(dashboard): use design tokens for Header light-mode utilities

### DIFF
--- a/dashboard/src/components/layout/Header.tsx
+++ b/dashboard/src/components/layout/Header.tsx
@@ -81,7 +81,8 @@ export function Header({
             <button
               type="button"
               onClick={() => onPaletteOpenChange(true)}
-              className="min-h-[44px] inline-flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] bg-white px-3 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-slate-50 hover:text-[var(--color-text-primary)] dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10 transition-all"
+              // TODO(#4564 follow-up): dark:border-white/10, dark:bg-white/5, dark:hover:bg-white/10 have no design token (translucent white overlay in dark mode). Adding tokens for these is on the Path A follow-up.
+              className="min-h-[44px] inline-flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10 transition-all"
               aria-label={t('aria.openCommandPalette')}
             >
               <Search className="h-3 w-3" />
@@ -89,7 +90,7 @@ export function Header({
               <kbd className="hidden sm:inline ml-1 font-mono text-[10px] text-[var(--color-text-primary)] border border-white/10 rounded px-1">⌘K</kbd>
             </button>
 
-            <div className="inline-flex items-center gap-1 sm:gap-2 rounded-md border border-[var(--color-border-strong)] bg-white px-1.5 py-1 sm:px-2 text-xs text-[var(--color-text-primary)] dark:border-[var(--color-void-lighter)] dark:bg-[var(--color-void-dark)] dark:text-[var(--color-text-primary)]">
+            <div className="inline-flex items-center gap-1 sm:gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-1.5 py-1 sm:px-2 text-xs text-[var(--color-text-primary)] dark:border-[var(--color-void-lighter)] dark:bg-[var(--color-void-dark)] dark:text-[var(--color-text-primary)]">
               <button
                 type="button"
                 onClick={toggleTheme}
@@ -106,7 +107,7 @@ export function Header({
               type="button"
               onClick={onCheckUpdates}
               disabled={updateCheckLoading || aegisVersion === '...'}
-              className="hidden min-h-[44px] sm:inline-flex items-center gap-1 rounded-md border border-[var(--color-border-strong)] px-2 py-1 text-xs text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] dark:border-[var(--color-void-lighter)] dark:hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:border-slate-300 disabled:bg-slate-50 disabled:text-[var(--color-text-primary)] dark:disabled:border-[var(--color-void-lighter)] dark:disabled:bg-transparent dark:disabled:text-[var(--color-text-muted)]"
+              className="hidden min-h-[44px] sm:inline-flex items-center gap-1 rounded-md border border-[var(--color-border-strong)] px-2 py-1 text-xs text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] dark:border-[var(--color-void-lighter)] dark:hover:bg-[var(--color-void-lighter)] disabled:cursor-not-allowed disabled:border-[var(--color-border-strong)] disabled:bg-[var(--color-surface-hover)] disabled:text-[var(--color-text-primary)] dark:disabled:border-[var(--color-void-lighter)] dark:disabled:bg-transparent dark:disabled:text-[var(--color-text-muted)]"
             >
               <RefreshCw className={`h-3 w-3 ${updateCheckLoading ? 'animate-spin' : ''}`} />
               {updateCheckLoading ? 'Checking…' : 'Check updates'}


### PR DESCRIPTION
## Summary
Three raw Tailwind color classes in `Header.tsx` replaced with design tokens, all the same theme (light-mode utilities + `bg-white`). One TODO comment added for the dark-mode white-overlay classes that have no direct token equivalent.

## Changes
1. **Line 84** (search palette button):
   - `bg-white` → `bg-[var(--color-surface)]`
   - `hover:bg-slate-50` → `hover:bg-[var(--color-surface-hover)]`
2. **Line 92** (second button bg): `bg-white` → `bg-[var(--color-surface)]`
3. **Line 109** (check updates button, disabled state):
   - `disabled:border-slate-300` → `disabled:border-[var(--color-border-strong)]`
   - `disabled:bg-slate-50` → `disabled:bg-[var(--color-surface-hover)]`

## Kept as raw (with TODO comment for follow-up)
- `dark:border-white/10` (line 84)
- `dark:bg-white/5` (line 84)
- `dark:hover:bg-white/10` (line 84)
- `border-white/10` (line 89, kbd)
- **Reason**: no design token for "translucent white overlay in dark mode" (a subtle design-intent effect). Adding these tokens is on the Path A follow-up issue #4564.

## Token mappings
| Raw | Token | Light-theme match |
| --- | --- | --- |
| `bg-white` (#ffffff) | `var(--color-surface)` | #ffffff — **exact** |
| `bg-slate-50` (#f8fafc) | `var(--color-surface-hover)` | #f1f5f9 — close |
| `border-slate-300` (#cbd5e1) | `var(--color-border-strong)` | #cbd5e1 — **exact** |

The existing `index.css` bridge for light-mode color classes (lines 720-790) handles the prior behavior, so this change is a source-code cleanup with no visual change in light mode.

## Verification
- `npm --prefix dashboard run typecheck` — clean, 0 errors
- `npm --prefix dashboard test` — 2230/2230 passing (Header.test: 12/12)
- `npm --prefix dashboard run build` — clean, 1.23s

## Why
**Seventh and last small per-file PR** in the #4564 audit (Path B). This finishes the design-token cleanup for `Header.tsx` and the entire dashboard components folder. Only the type-level (Path A) and the dark-mode white-overlay token additions remain.

## Path B Progress (COMPLETE on this PR)
1. ✅ #4563 SessionHistoryPage — MERGED
2. ✅ #4565 AgentBadge.tsx — MERGED
3. ✅ #4566 SessionTable.tsx — MERGED
4. ✅ #4567 SessionMobileCard.tsx — MERGED
5. ✅ #4569 HomeStatusPanel.tsx — MERGED
6. ✅ #4570 OnboardingWizard.tsx — MERGED
7. **This PR** — Header.tsx (light-mode utilities; dark-mode overlay TODO'd)
8. ⏸ Type-level: types/acp-approval.ts, types/acp-driver-observer.ts (Path A — needs contract change review)
9. ⏸ Dark-mode white-overlay tokens (Path A — new token additions)

## Path A follow-ups (separate from this PR)
- Add design tokens for "translucent white overlay in dark mode" (e.g., `--color-overlay-border: rgba(255, 255, 255, 0.1)`, `--color-overlay-bg: rgba(255, 255, 255, 0.05)`, `--color-overlay-bg-hover: rgba(255, 255, 255, 0.1)`)
- Refactor type-level color classes in `types/acp-approval.ts` and `types/acp-driver-observer.ts` (Path A — needs contract change review)