### PR TITLE
docs(#4555): CC hook bridge updates — MessageDisplay, SessionStart return fields, --permission-mode boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- **CC hook bridge updates (v2.1.152)** — `SessionStart` returns `reloadSkills: true` and echoes `hookSpecificOutput.sessionTitle` (persisted to `session.metadata.title`); new `MessageDisplay` hook event with HTML-escape sanitization and `visible: false` rejected by default; new `message_display` SSE event ([#4555](https://github.com/OneStepAt4time/aegis/pull/4555), closes [#4522](https://github.com/OneStepAt4time/aegis/issues/4522))
+- **Argv-level `--permission-mode` injection** — Aegis now injects `--permission-mode <mode>` into every CC child process spawn based on the session's `permissionMode`; `--dangerously-skip-permissions` is rejected at spawn as a hard security boundary ([#4555](https://github.com/OneStepAt4time/aegis/pull/4555), closes [#4522](https://github.com/OneStepAt4time/aegis/issues/4522))
+
 - **Worktree isolation policy** — enforce per-session isolation mode (worktree|none) with config, env var, and API parameter ([#3651](https://github.com/OneStepAt4time/aegis/pull/3651))
 - **Sensible session display names** — `ag run` derives human-readable names from prompts; OIDC-aware conditional CLI help ([#3654](https://github.com/OneStepAt4time/aegis/pull/3654))
 - **Session creation timeout configurable** — `AEGIS_SESSION_CREATION_TIMEOUT_MS` env var to control how long ACP session startup may take ([#3909](https://github.com/OneStepAt4time/aegis/pull/3909), closes [#3904](https://github.com/OneStepAt4time/aegis/issues/3904))

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1439,7 +1439,7 @@ curl -N "http://localhost:9100/v1/sessions/abc123/events?token=$SSE_TOKEN"
 
 **Rate limited:** Per-IP and global connection limits apply.
 
-**Events:** `connected`, `heartbeat`, `status.*`, `approval`, `approval_resolved`, `permission.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`.
+**Events:** `connected`, `heartbeat`, `status.*`, `approval`, `approval_resolved`, `permission.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`, `message_display`.
 
 > **`approval_resolved`** — emitted after an approval or rejection via `POST /v1/sessions/:id/approval/approve` or `/reject`. Payload: `{ action: "approved" | "rejected", approvalId: string }`.
 
@@ -4739,7 +4739,7 @@ curl -N "http://localhost:9100/v1/events?token=$SSE_TOKEN"
 
 **Authentication:** SSE token via query parameter (`?token=<sse-token>`) or Bearer header (`Authorization: Bearer sse_...`). Regular API keys are rejected.
 
-**Event types:** `connected`, `heartbeat`, `session.created`, `session.idle`, `session.working`, `session.stalled`, `session.killed`, `permission.requested`, `permission.granted`, `permission.denied`, `approval_resolved`, `message.user`, `status.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`.
+**Event types:** `connected`, `heartbeat`, `session.created`, `session.idle`, `session.working`, `session.stalled`, `session.killed`, `permission.requested`, `permission.granted`, `permission.denied`, `approval_resolved`, `message.user`, `status.*`, `verification.*`, `subagent_start`, `subagent_stop`, `circuit_breaker`, `message_display`.
 
 **Heartbeat payload:** The `heartbeat` event includes a `sessionCosts` map with `estimatedCostUsd` per session, enabling real-time cost tracking on the dashboard.
 

--- a/docs/enterprise/02-security.md
+++ b/docs/enterprise/02-security.md
@@ -147,6 +147,22 @@ Recommend an explicit denylist of security-sensitive env keys (`ANTHROPIC_API_KE
 2. **`permissionProfile`** per session — `allow`/`deny`/`ask` rules evaluated in `evaluatePermissionProfile()` against each incoming `PreToolUse` hook event.
 3. **`permission-guard.ts`** — neutralizes CC settings files that declare `bypassPermissions`.
 
+### Argv-Level Security Boundary (Issue #4522)
+
+Aegis always injects `--permission-mode <mode>` into the CC child process argv at spawn time, derived from the session's `permissionMode` (`default`, `plan`, `bypassPermissions`, `acceptEdits`, `dontAsk`, or `auto`). This is the source of truth — env-var-only paths are no longer sufficient.
+
+**Hard reject:** `--dangerously-skip-permissions` is rejected at spawn with `AcpChildProcessStartError`. The check is case-insensitive and covers both the bare flag and the `=value` single-arg form (`--dangerously-skip-permissions=true`, `=1`, `=disabled`, etc.). This closes a window where CC could inherit a previously-supplied permissive state across retire→wake cycles.
+
+| `permissionMode` value | Injected CC flag | Notes |
+|------------------------|------------------|-------|
+| `default` | `--permission-mode default` | Default for most sessions. |
+| `plan` | `--permission-mode plan` | Read-only exploration, no edits. |
+| `bypassPermissions` | `--permission-mode bypassPermissions` | Auto-approve all — controlled via `autoApprove` or `--accept-permissions`. |
+| `acceptEdits` | `--permission-mode acceptEdits` | Auto-approve file edits, prompt for Bash. |
+| `dontAsk` | `--permission-mode dontAsk` | Auto-deny prompts that would otherwise escalate. |
+| `auto` | `--permission-mode auto` | CC decides per-tool. |
+| _invalid value_ | _(not injected, warning logged)_ | Operator should fix upstream config. |
+
 ### Bypass Vectors
 
 **[SD-PERM-01] MEDIUM — `extractCandidatePaths()` only checks known field names** (`path`, `file_path`, `target`, `paths[]`). A CC tool naming its path argument `destination`, `output_path`, or `filename` would bypass path constraints entirely.

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -14,7 +14,7 @@ When Claude Code runs a session, it emits lifecycle events at key points. Claude
 | **HTTP** | POST to a URL with JSON body | Network-accessible |
 | **Prompt** | LLM prompt injection | In-process |
 
-Aegis uses **HTTP hooks** exclusively — registering a single endpoint (`POST /v1/hooks/:eventName`) that receives all 29+ CC lifecycle events. This gives Aegis a centralized event bus that no shell-only or config-only approach can match.
+Aegis uses **HTTP hooks** exclusively — registering a single endpoint (`POST /v1/hooks/:eventName`) that receives all 30+ CC lifecycle events. This gives Aegis a centralized event bus that no shell-only or config-only approach can match.
 
 ## Complete Event Reference
 
@@ -24,11 +24,17 @@ Aegis handles all Claude Code lifecycle events. Here's the full taxonomy:
 
 | Event | Trigger | Aegis Action |
 |-------|---------|-------------|
-| `SessionStart` | Session begins or resumes | Track session state |
+| `SessionStart` | Session begins or resumes | Track session state; respond with `reloadSkills: true` and optional `sessionTitle` (see [SessionStart — Return Fields](#sessionstart--return-fields)) |
 | `SessionEnd` | Session terminates | Clean up resources, emit final metrics |
 | `Setup` | `--init-only` or `--maintenance` mode | One-time CI preparation |
 | `Stop` | Claude finishes responding | Detect waiting-for-input, emit `session.idle` |
 | `StopFailure` | Turn ends due to API error | Circuit breaker protection (see below) |
+
+### Message Display
+
+| Event | Trigger | Aegis Action |
+|-------|---------|-------------|
+| `MessageDisplay` | A hook transforms message text/visibility before display | HTML-escape the text, reject `visible: false` by default, emit `message_display` SSE (see [MessageDisplay — Transform Hook](#messagedisplay--transform-hook)) |
 
 ### Tool Lifecycle (Agentic Loop)
 
@@ -141,6 +147,87 @@ curl -X POST "http://localhost:9100/v1/hooks/Stop" \
 ```
 
 Response: `{ "ok": true }`
+
+### SessionStart — Return Fields
+
+Aegis augments the `SessionStart` response with two fields so hooks can re-apply skills and label the session title. Both fields are returned on every `SessionStart` call:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reloadSkills` | `boolean` | Always `true` — signals that the session's skill set should be re-applied on resume. |
+| `hookSpecificOutput.sessionTitle` | `string` (optional) | Echo of the request body's `sessionTitle`. Persisted on `session.metadata.title` and used by the dashboard. |
+
+If the request body includes a `sessionTitle` (1–200 characters), Aegis sanitizes it (HTML-escape + control-char strip) and stores it on `session.metadata.title`. The sanitized value is echoed back in the response.
+
+```bash
+curl -X POST "http://localhost:9100/v1/hooks/SessionStart" \
+  -H "X-Session-Id: <session-uuid>" \
+  -H "X-Hook-Secret: <hook-secret>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionTitle": "Refactor billing module"
+  }'
+```
+
+Response:
+
+```json
+{
+  "reloadSkills": true,
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "sessionTitle": "Refactor billing module"
+  }
+}
+```
+
+### MessageDisplay — Transform Hook
+
+The `MessageDisplay` event lets a hook transform message text and visibility before it is rendered. Aegis sanitizes the returned text (HTML-escape + control-char strip) and forwards the result to downstream consumers via the `message_display` SSE event.
+
+| Input field | Type | Behavior |
+|-------------|------|----------|
+| `hookSpecificOutput.message.text` | `string` | HTML-escaped before being stored or emitted. `<`, `>`, `&`, `"`, `'` become entities; control chars are stripped; `javascript:` URLs are removed. |
+| `hookSpecificOutput.message.visible` | `boolean` | When `false`, Aegis **rejects the request with a warning** by default — suppression requires Themis sign-off. |
+| `hookSpecificOutput.message.redactReasons` | `string[]` | Optional reasons the message was redacted; passed through to the SSE payload. |
+
+```bash
+curl -X POST "http://localhost:9100/v1/hooks/MessageDisplay" \
+  -H "X-Session-Id: <session-uuid>" \
+  -H "X-Hook-Secret: <hook-secret>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "hookSpecificOutput": {
+      "message": {
+        "text": "Patched package version to <1.2.3>",
+        "visible": true
+      }
+    }
+  }'
+```
+
+Response:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "MessageDisplay",
+    "message": {
+      "text": "Patched package version to &lt;1.2.3&gt;",
+      "visible": true
+    }
+  }
+}
+```
+
+Subscribers to the [per-session SSE stream](./api-reference.md#get-session-events) receive a `message_display` event:
+
+```
+data: {"event":"message_display","sessionId":"<uuid>","timestamp":"...","data":{"text":"Patched package version to &lt;1.2.3&gt;","visible":true}}
+```
+
+> **Security boundary — `visible: false`** is rejected with `200 { "ok": true, "warning": "visible:false rejected — requires Themis sign-off" }`. Hooks that need to suppress message rendering must be pre-approved by Themis.
+
 
 ### PreToolUse — Approve a Tool Call
 
@@ -257,6 +344,24 @@ When Claude Code asks a question via `AskUserQuestion`, Aegis can intercept and 
 | **Payload truncation protection** | Warns when hook payloads exceed 1.5KB (CC silently truncates at ~2KB) |
 | **Session validation** | Rejects non-UUID session IDs before lookup |
 | **Event allowlist** | Unknown event names return `400` — prevents injection |
+| **Permission mode enforcement** | Aegis always injects `--permission-mode <mode>` into the CC child process argv; `--dangerously-skip-permissions` is rejected at spawn with `AcpChildProcessStartError` (see [Permission Mode Boundary](#permission-mode-boundary)) |
+| **MessageDisplay sanitization** | `MessageDisplay` text is HTML-escaped; `visible: false` is rejected by default |
+
+### Permission Mode Boundary
+
+Every CC child process spawned by Aegis is launched with `--permission-mode <mode>` derived from the session's effective `permissionMode` (`default`, `plan`, `bypassPermissions`, `acceptEdits`, `dontAsk`, or `auto`). This prevents a previously-supplied permissive state from being inherited across retire→wake cycles.
+
+If a caller (or a custom profile) attempts to spawn CC with `--dangerously-skip-permissions` in argv, the spawn **fails closed** with an `AcpChildProcessStartError`:
+
+```
+--dangerously-skip-permissions is forbidden in ACP spawn args (Issue #4522 security boundary).
+Use --permission-mode <mode> instead.
+```
+
+The check is case-insensitive and matches both the bare flag (`--dangerously-skip-permissions`) and the single-arg form (`--dangerously-skip-permissions=true`, `=1`, `=disabled`, etc.). If a session is created with an invalid `permissionMode` value, the flag is not injected and a warning is logged — the spawn proceeds, but the operator should fix the upstream config.
+
+> **Migration note:** If you previously relied on `AEGIS_PERMISSION_MODE` env var + the env-var-only injection path, the argv-level boundary is now the source of truth. Setting `permissionMode` per session on the `CreateSessionRequest` is the supported way to control this flag.
+
 
 ## Observability
 


### PR DESCRIPTION
Documents the user-facing surface added in #4555 (Issue #4522 AC #1, #2, #3).

## Surface added

- New `MessageDisplay` hook event with HTML-escape sanitization and `visible: false` rejected by default; emits `message_display` SSE event for downstream consumers
- `SessionStart` response now includes `reloadSkills: true` and optional `hookSpecificOutput.sessionTitle` (persisted to `session.metadata.title`)
- Argv-level `--permission-mode` injection for every CC child process; `--dangerously-skip-permissions` rejected at spawn as hard security boundary (covers bare flag and =value single-arg form, case-insensitive)

## Files updated

- **docs/hooks-guide.md** — new MessageDisplay row in event taxonomy, new SessionStart Return Fields section, new MessageDisplay Transform Hook section with curl example, security model table additions, new Permission Mode Boundary subsection
- **docs/api-reference.md** — add `message_display` to per-session SSE event list (line 1442) and global SSE event list (line 4742)
- **docs/enterprise/02-security.md** — new Argv-Level Security Boundary subsection with full permission mode table mapping each `permissionMode` value to its injected flag
- **CHANGELOG.md** — [Unreleased] Features entries for the two new surface areas

## Verification

- Walkthrough scan: 8 pre-existing failures / 55 findings unchanged from baseline — no new failures introduced
- Code-surface checks: read `src/hooks-cc-bridge-4522.ts` (response shape, sanitizer, prototype-pollution guard), `src/services/acp/permission-mode-args-4522.ts` (valid modes, case-insensitive dangerous-flag check, idempotent injection), `src/events.ts` (SSE event union), `src/services/acp/acp-child-process-errors.ts` (error class)
- All documented fields, status values, and behavioral claims match source

## Follow-up

This PR pairs with the implementation PR (#4555). If the implementation gets a follow-up that changes the sanitizer or adds new permission modes, please ping Scribe to update this docs branch.

cc: <@1490089546099069048> (Hep) for visibility on the new hook event