### PR TITLE
fix(dashboard): add overlay/scrim design tokens, apply to Header (#4564)

### DIFF
--- a/dashboard/src/components/layout/Header.tsx
+++ b/dashboard/src/components/layout/Header.tsx
@@ -42,7 +42,7 @@ export function Header({
 
   return (
     <>
-      <header className="shrink-0 border-b border-white/5 bg-transparent backdrop-blur-md px-4 py-4 sm:px-8">
+      <header className="shrink-0 border-b border-[var(--color-overlay-border)] bg-transparent backdrop-blur-md px-4 py-4 sm:px-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             <button
@@ -81,13 +81,12 @@ export function Header({
             <button
               type="button"
               onClick={() => onPaletteOpenChange(true)}
-              // TODO(#4564 follow-up): dark:border-white/10, dark:bg-white/5, dark:hover:bg-white/10 have no design token (translucent white overlay in dark mode). Adding tokens for these is on the Path A follow-up.
-              className="min-h-[44px] inline-flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10 transition-all"
+              className="min-h-[44px] inline-flex items-center gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] dark:border-[var(--color-overlay-border-strong)] dark:bg-[var(--color-overlay-bg)] dark:hover:bg-[var(--color-overlay-bg-hover)] transition-all"
               aria-label={t('aria.openCommandPalette')}
             >
               <Search className="h-3 w-3" />
               <span className="hidden sm:inline">Search…</span>
-              <kbd className="hidden sm:inline ml-1 font-mono text-[10px] text-[var(--color-text-primary)] border border-white/10 rounded px-1">⌘K</kbd>
+              <kbd className="hidden sm:inline ml-1 font-mono text-[10px] text-[var(--color-text-primary)] border border-[var(--color-overlay-border-strong)] rounded px-1">⌘K</kbd>
             </button>
 
             <div className="inline-flex items-center gap-1 sm:gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-1.5 py-1 sm:px-2 text-xs text-[var(--color-text-primary)] dark:border-[var(--color-void-lighter)] dark:bg-[var(--color-void-dark)] dark:text-[var(--color-text-primary)]">

--- a/dashboard/src/components/layout/__tests__/Header.test.tsx
+++ b/dashboard/src/components/layout/__tests__/Header.test.tsx
@@ -64,6 +64,27 @@ describe('Header', () => {
     expect(screen.getByRole('button', { name: /Open command palette/i })).toBeDefined();
   });
 
+  // Regression: #4564 audit — ensure the search palette button uses overlay
+  // design tokens instead of raw `white/N` Tailwind opacity classes.
+  it('palette button uses overlay design tokens (no raw white/ classes)', () => {
+    renderHeader();
+    const btn = screen.getByRole('button', { name: /Open command palette/i });
+    const cls = btn.className;
+    expect(cls).not.toMatch(/white\//);
+    expect(cls).toContain('var(--color-overlay-border-strong)');
+    expect(cls).toContain('var(--color-overlay-bg)');
+    expect(cls).toContain('var(--color-overlay-bg-hover)');
+  });
+
+  // Regression: #4564 audit — the kbd shortcut hint inside the palette button
+  // must use the overlay-border-strong token, not raw white/10.
+  it('palette kbd uses overlay-border-strong token', () => {
+    renderHeader();
+    const kbd = screen.getByText('⌘K');
+    expect(kbd.className).not.toMatch(/white\//);
+    expect(kbd.className).toContain('var(--color-overlay-border-strong)');
+  });
+
   it('renders the theme toggle button', () => {
     renderHeader();
     expect(screen.getByRole('button', { name: /Switch to light mode/i })).toBeDefined();

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -104,6 +104,17 @@
   --color-neutral: #71717a;              /* zinc-500 */
   --color-neutral-glow: #a1a1aa;         /* zinc-400 — text on dark surfaces */
 
+  /* Overlay tokens (#4564 audit, Path A follow-up).
+   * Translucent surfaces used for hairline borders, subtle backgrounds,
+   * and modal scrims. In dark mode they read as white-tinted glass; in
+   * light mode they re-tint to dark so dividers stay visible on white.
+   * --color-scrim stays dark in every theme — modal backdrops always dim. */
+  --color-overlay-border: rgba(255, 255, 255, 0.05);        /* white/5   */
+  --color-overlay-border-strong: rgba(255, 255, 255, 0.1);  /* white/10  */
+  --color-overlay-bg: rgba(255, 255, 255, 0.05);            /* white/5   */
+  --color-overlay-bg-hover: rgba(255, 255, 255, 0.1);       /* white/10  */
+  --color-scrim: rgba(0, 0, 0, 0.6);                         /* black/60  */
+
   /* ------------------------------------------------------------------ */
   /* Motion tokens (mirror of dashboard/src/design/tokens.ts).          */
   /* Keep in sync with tokens.duration and tokens.easing.               */
@@ -240,6 +251,13 @@
 
   /* Timeline trace line: clearly visible in light mode. */
   --color-trace-line: #94a3b8;
+
+  /* Overlay tokens — dark-tinted glass on white surfaces (#4564 audit). */
+  --color-overlay-border: rgba(15, 23, 42, 0.08);        /* slate-900/8  */
+  --color-overlay-border-strong: rgba(15, 23, 42, 0.14); /* slate-900/14 */
+  --color-overlay-bg: rgba(15, 23, 42, 0.04);            /* slate-900/4  */
+  --color-overlay-bg-hover: rgba(15, 23, 42, 0.08);      /* slate-900/8  */
+  --color-scrim: rgba(0, 0, 0, 0.5);                      /* black/50     */
 }
 
 /* ------------------------------------------------------------------------
@@ -278,6 +296,13 @@
   --color-syn-string: #1a3a5c;
   --color-syn-comment: #6b6b5e;
   --color-syn-number: #1a4a7a;
+
+  /* Overlay tokens — dark ink tints on warm paper. */
+  --color-overlay-border: rgba(10, 10, 10, 0.08);
+  --color-overlay-border-strong: rgba(10, 10, 10, 0.16);
+  --color-overlay-bg: rgba(10, 10, 10, 0.04);
+  --color-overlay-bg-hover: rgba(10, 10, 10, 0.10);
+  --color-scrim: rgba(0, 0, 0, 0.5);
 }
 
 /* ------------------------------------------------------------------------
@@ -316,6 +341,13 @@
   --color-syn-string: #00008b;
   --color-syn-comment: #696969;
   --color-syn-number: #00008b;
+
+  /* Overlay tokens — pure-black tints on white. */
+  --color-overlay-border: rgba(0, 0, 0, 0.1);
+  --color-overlay-border-strong: rgba(0, 0, 0, 0.2);
+  --color-overlay-bg: rgba(0, 0, 0, 0.05);
+  --color-overlay-bg-hover: rgba(0, 0, 0, 0.12);
+  --color-scrim: rgba(0, 0, 0, 0.7);
 }
 
 body {


### PR DESCRIPTION
## Summary

Adds the missing design-token infrastructure for translucent surfaces (the explicit follow-up TODO in `Header.tsx` flagged in #4564) and migrates the Header to use it.

**Tokens added to `index.css`** (4 theme variants — dark, light, light-paper, light-aaa):
- `--color-overlay-border` — hairline divider (white/5 in dark, dark-tinted in light)
- `--color-overlay-border-strong` — prominent divider (white/10 in dark)
- `--color-overlay-bg` — subtle background tint (white/5 in dark)
- `--color-overlay-bg-hover` — hover state (white/10 in dark)
- `--color-scrim` — modal backdrop (black/60, dark in every theme)

Re-tints in light variants follow the existing severity-tier pattern from #4564 Path A (where `orange-500` → `--color-warning-strong` and `zinc-500` → `--color-neutral` to preserve visual intent).

## Header.tsx changes

Migrated all raw `white/N` / `black/N` classes to token-based equivalents:
- `border-white/5` → `border-[var(--color-overlay-border)]`
- `dark:border-white/10` → `dark:border-[var(--color-overlay-border-strong)]`
- `dark:bg-white/5` → `dark:bg-[var(--color-overlay-bg)]`
- `dark:hover:bg-white/10` → `dark:hover:bg-[var(--color-overlay-bg-hover)]`
- kbd `border-white/10` → `border-[var(--color-overlay-border-strong)]`
- TODO comment removed

**Dark-mode visual is byte-for-byte equivalent** (alpha values match the old `white/N` classes). Light mode now has a subtle dark-tinted hairline border that was previously invisible (white/5 on white surface).

## Tests added

Two regression tests in `Header.test.tsx`:
1. `palette button uses overlay design tokens (no raw white/ classes)` — asserts absence of `white/` patterns and presence of all 3 new token references.
2. `palette kbd uses overlay-border-strong token` — same assertion for the kbd element.

## Quality gate

| Step | Result |
|---|---|
| `tsc --noEmit` | ✅ clean |
| `vitest run` | ✅ 224 files, **2252 tests pass**, 2 skipped |
| `vite build` | ✅ clean (1.20s) |
| Dist CSS inspection | ✅ all 5 tokens emitted in all 4 theme blocks |
| `Header.test.tsx` | ✅ 14/14 (12 existing + 2 new) |

## Why a separate PR

The issue's acceptance criteria require *zero* raw Tailwind color classes in `dashboard/src/`. This PR delivers:
- The token infrastructure (~18 remaining files need migration).
- The single explicitly-flagged file (Header.tsx) with a TODO referencing #4564.

Per Argus's Path B pattern (one small PR per file from the #4564 audit), follow-up PRs should migrate the remaining files using the new tokens:
- `SettingsPage.tsx`, `SessionHistoryPage.tsx`, `SessionsPage.tsx`, `SessionDetailPage.tsx`
- `CreateSessionModal.tsx`, `FirstRunTour.tsx`, `CreatePipelineModal.tsx`, `TemplateModal.tsx`
- `NewSessionDrawer.tsx`, `Layout.tsx`, `LiveAuditStream.tsx`
- `KeyboardShortcutsHelp/index.tsx`, `ConfirmDialog.tsx`, `SessionTable.tsx`, `VirtualizedSessionList.tsx`
- `HomeStatusPanel.tsx`, `ActivityStream.tsx`, `SaveTemplateModal.tsx`, `SessionExpiredModal.tsx`, `Drawer.tsx`
- `MetricCards.tsx` (text-white in metric value)

Refs #4564

— Daedalus 🏛️