### PR TITLE
fix(dashboard): use overlay-faint tokens for non-standard alpha sites (#4578)

### DIFF
--- a/dashboard/src/components/ActivityStream.tsx
+++ b/dashboard/src/components/ActivityStream.tsx
@@ -247,7 +247,7 @@ export default function ActivityStream({
           const Icon = meta.icon;
           const description = describeEvent(event);
           return (
-            <div key={event.renderKey} className="group flex items-start gap-3 px-4 py-3 transition-all duration-150 hover:bg-white/[0.04] cursor-default">
+            <div key={event.renderKey} className="group flex items-start gap-3 px-4 py-3 transition-all duration-150 hover:bg-[color:var(--color-overlay-bg-faint-hover)] cursor-default">
               {/* Icon bubble with colored glow */}
               <div
                 className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full shadow-inner transition-shadow group-hover:shadow-md"

--- a/dashboard/src/components/LiveAuditStream.tsx
+++ b/dashboard/src/components/LiveAuditStream.tsx
@@ -169,7 +169,7 @@ export default function LiveAuditStream({ maxItems = 20 }: LiveAuditStreamProps)
                   </div>
 
                   {/* Content */}
-                  <div className="flex-1 min-w-0 pb-3 border-b border-white/[0.04] group-last:border-0">
+                  <div className="flex-1 min-w-0 pb-3 border-b border-[color:var(--color-overlay-border-faint)] group-last:border-0">
                     <div className="flex items-center justify-between gap-1 mb-0.5">
                       <div className="flex items-center gap-1.5 min-w-0">
                         <span

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -171,7 +171,7 @@ function VirtualizedRow(props: {
     return (
       <div
         style={style}
-        className="border-b border-white/5 bg-white/[0.02]"
+        className="border-b border-[color:var(--color-overlay-border-faint)] bg-[color:var(--color-overlay-bg-faint)]"
         {...ariaAttributes}
       >
         <button

--- a/dashboard/src/components/shared/LiveAuditStream.tsx
+++ b/dashboard/src/components/shared/LiveAuditStream.tsx
@@ -100,7 +100,7 @@ export default function LiveAuditStream() {
             >
               <Link
                 to={`/sessions/${encodeURIComponent(ev.sessionId)}`}
-                className="flex items-start gap-2 rounded-lg px-2 py-1.5 hover:bg-white/[0.03] transition-colors"
+                className="flex items-start gap-2 rounded-lg px-2 py-1.5 hover:bg-[color:var(--color-overlay-bg-faint-hover)] transition-colors"
               >
                 <EventIcon event={ev.event} />
                 <div className="flex-1 min-w-0">

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -113,6 +113,9 @@
   --color-overlay-border-strong: rgba(255, 255, 255, 0.1);  /* white/10  */
   --color-overlay-bg: rgba(255, 255, 255, 0.05);            /* white/5   */
   --color-overlay-bg-hover: rgba(255, 255, 255, 0.1);       /* white/10  */
+  --color-overlay-border-faint: rgba(255, 255, 255, 0.04);  /* white/4   */
+  --color-overlay-bg-faint: rgba(255, 255, 255, 0.02);      /* white/2   */
+  --color-overlay-bg-faint-hover: rgba(255, 255, 255, 0.04);/* white/4   */
   --color-scrim: rgba(0, 0, 0, 0.6);                         /* black/60  */
 
   /* ------------------------------------------------------------------ */
@@ -257,6 +260,9 @@
   --color-overlay-border-strong: rgba(15, 23, 42, 0.14); /* slate-900/14 */
   --color-overlay-bg: rgba(15, 23, 42, 0.04);            /* slate-900/4  */
   --color-overlay-bg-hover: rgba(15, 23, 42, 0.08);      /* slate-900/8  */
+  --color-overlay-border-faint: rgba(15, 23, 42, 0.05);  /* slate-900/5  */
+  --color-overlay-bg-faint: rgba(15, 23, 42, 0.02);      /* slate-900/2  */
+  --color-overlay-bg-faint-hover: rgba(15, 23, 42, 0.05);/* slate-900/5  */
   --color-scrim: rgba(0, 0, 0, 0.5);                      /* black/50     */
 }
 
@@ -302,6 +308,9 @@
   --color-overlay-border-strong: rgba(10, 10, 10, 0.16);
   --color-overlay-bg: rgba(10, 10, 10, 0.04);
   --color-overlay-bg-hover: rgba(10, 10, 10, 0.10);
+  --color-overlay-border-faint: rgba(10, 10, 10, 0.05);
+  --color-overlay-bg-faint: rgba(10, 10, 10, 0.02);
+  --color-overlay-bg-faint-hover: rgba(10, 10, 10, 0.05);
   --color-scrim: rgba(0, 0, 0, 0.5);
 }
 
@@ -347,6 +356,9 @@
   --color-overlay-border-strong: rgba(0, 0, 0, 0.2);
   --color-overlay-bg: rgba(0, 0, 0, 0.05);
   --color-overlay-bg-hover: rgba(0, 0, 0, 0.12);
+  --color-overlay-border-faint: rgba(0, 0, 0, 0.05);
+  --color-overlay-bg-faint: rgba(0, 0, 0, 0.02);
+  --color-overlay-bg-faint-hover: rgba(0, 0, 0, 0.05);
   --color-scrim: rgba(0, 0, 0, 0.7);
 }
 


### PR DESCRIPTION
Closes the audit arc after the seven #4578 overlay-token slices.

## What

Adds three new tokens to all four themes (dark, light-blue, light-paper, light-aaa):

- `--color-overlay-border-faint` — replaces `border-white/[0.04]`
- `--color-overlay-bg-faint` — replaces `bg-white/[0.02]`
- `--color-overlay-bg-faint-hover` — replaces `hover:bg-white/[0.03]` and `hover:bg-white/[0.04]`

Converts four remaining non-standard alpha sites:

- `overview/VirtualizedSessionList.tsx:174` — group row border + bg
- `LiveAuditStream.tsx:172` — event timeline divider
- `ActivityStream.tsx:250` — event hover
- `shared/LiveAuditStream.tsx:103` — rail event hover

## Why

The seven prior #4578 PRs normalized the standard 5/10/15/20% alphas through tokens but left four fainter (2/3/4%) sites as raw `/[0.0X]` brackets. They were a separate visual tier (faintest borders and group backgrounds) and didn't fit the existing token values, so this slice adds the missing tier.

## Quality gate

- `tsc --noEmit`: clean
- `vitest run`: 2252 passed, 2 skipped (224 files)
- `vite build`: clean (1.79s)
- `grep -rE 'bg-white/\[0\.0[0-9]\]|border-white/\[0\.0[0-9]\]' src --include='*.tsx'`: **0 matches**

## Diff stat

```
5 files changed, 16 insertions(+), 4 deletions(-)
```

Refs #4578. Self-LGTM pending Argus review.