### PR TITLE
fix(dashboard): use scrim tokens in modal backdrops (#4578)

### DIFF
--- a/dashboard/src/components/CreatePipelineModal.tsx
+++ b/dashboard/src/components/CreatePipelineModal.tsx
@@ -118,7 +118,7 @@ export default function CreatePipelineModal({ open, onClose }: CreatePipelineMod
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
+      <div className="absolute inset-0 bg-[color:var(--color-scrim)] backdrop-blur-sm" onClick={handleClose} />
 
       <div ref={trapRef} role="dialog" aria-modal="true" aria-label={t("aria.createNewPipeline")} className="relative w-full max-w-2xl mx-4 bg-[var(--color-surface)] border border-[var(--color-void-lighter)] rounded-lg shadow-2xl max-h-[90vh] overflow-y-auto">
         {/* Header */}

--- a/dashboard/src/components/CreateSessionModal.tsx
+++ b/dashboard/src/components/CreateSessionModal.tsx
@@ -204,7 +204,7 @@ export default function CreateSessionModal({ open, onClose }: CreateSessionModal
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-[color:var(--color-scrim)] backdrop-blur-sm"
         onClick={handleClose}
       />
 

--- a/dashboard/src/components/TemplateModal.tsx
+++ b/dashboard/src/components/TemplateModal.tsx
@@ -149,7 +149,7 @@ export default function TemplateModal({ open, onClose, template, onSaved }: Temp
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-[color:var(--color-scrim)] backdrop-blur-sm"
         onClick={handleClose}
       />
 


### PR DESCRIPTION
## Context

Slice 9 of #4578 — converts 3 modal backdrops from raw `bg-black/60` to the `--color-scrim` design token (added in #4577).

```
components/CreateSessionModal.tsx:207
components/CreatePipelineModal.tsx:121
components/TemplateModal.tsx:152
```

All three backdrops are the identical pattern `absolute inset-0 bg-black/60 backdrop-blur-sm`. The new `--color-scrim` token is defined as `black/60` in dark theme, with theme variants in light/light-paper/light-aaa (slight reduction to `black/50` for better contrast on lighter surfaces — see #4577 for rationale).

## Verification

- [x] `tsc --noEmit` — clean (3 pre-existing errors in chartTheme.tsx/logger.ts are unrelated, present on develop HEAD)
- [x] `vitest run` — 224 files, 2252 tests pass, 2 skipped (~172s)
- [x] `vite build` — clean (2.72s)
- [x] `grep -rE 'text-white|bg-black|border-white' dashboard/src/` — matches in the 3 changed files removed (1 match each eliminated)

## Token mapping (from #4577)

- `bg-black/60` (3) → `bg-[color:var(--color-scrim)]`

## Out of scope (deferred to future slices)

- `FirstRunTour.tsx:246` — `bg-black/80` (heavier scrim, no matching token — would need a new `--color-scrim-heavy` variant)
- `SessionDetailPage.tsx:292` — `bg-black/40` (lighter scrim, no matching token — would need a new `--color-scrim-light` variant)
- `SettingsPage`, `SessionHistoryPage`, `SessionsPage`, `NewSessionDrawer`, `Layout` — remaining border-white and bg-white matches for future Path B slices

Lane: **Daedalus** (per #4578). Not blocking Hermes, Argus, Scribe, Hep, or any P0/P1 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)