### PR TITLE
fix(dashboard): use overlay-border token in SessionsPage tab bar (#4578)

### DIFF
--- a/dashboard/src/pages/SessionsPage.tsx
+++ b/dashboard/src/pages/SessionsPage.tsx
@@ -58,7 +58,7 @@ export default function SessionsPage() {
       </div>
 
       {/* Tab bar */}
-      <div className="flex gap-1 border-b border-white/5" role="tablist" aria-label={translate("aria.sessionViews")}>
+      <div className="flex gap-1 border-b border-[var(--color-overlay-border)]" role="tablist" aria-label={translate("aria.sessionViews")}>
         {TABS.map(({ id, label }) => (
           <button
             key={id}


### PR DESCRIPTION
## Context

Slice 10 of #4578 — converts 1 tab bar border in SessionsPage from raw `border-white/5` to the `--color-overlay-border` design token (added in #4577).

```
pages/SessionsPage.tsx:61
```

The tab bar uses the same standard 5% alpha as slice 7's regular session row separator (VSLAS L201), so it gets the standard `--color-overlay-border` token, not the faint variant from slice 8.

## Verification

- [x] `tsc --noEmit` — clean
- [x] `vitest run src/pages/__tests__/SessionsPage.test.tsx` — 7/7 pass (3.34s, targeted)
- [x] `vite build` — clean (1.76s)
- [x] `grep -rE 'text-white|bg-black|border-white' dashboard/src/` — 1 match removed from SessionsPage

## Token mapping (from #4577)

- `border-white/5` (1) → `border-[var(--color-overlay-border)]`

Lane: **Daedalus** (per #4578). Not blocking Hermes, Argus, Scribe, Hep, or any P0/P1 work.