### PR TITLE
fix(dashboard): use overlay-border token in CommandPalette modal borders (#4578)

### DIFF
--- a/dashboard/src/components/shared/CommandPalette.tsx
+++ b/dashboard/src/components/shared/CommandPalette.tsx
@@ -207,7 +207,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
           >
             <div className="card-glass overflow-hidden shadow-palette">
               {/* Search input */}
-              <div className="flex min-h-[44px] items-center gap-3 border-b border-white/5 px-4 py-3.5">
+              <div className="flex min-h-[44px] items-center gap-3 border-b border-[var(--color-overlay-border)] px-4 py-3.5">
                 <Search className="h-4 w-4 shrink-0 text-[var(--color-text-muted)]" />
                 <input
                   ref={inputRef}
@@ -292,7 +292,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
               </div>
 
               {/* Footer hint */}
-              <div className="border-t border-white/5 px-4 py-2 flex items-center gap-4">
+              <div className="border-t border-[var(--color-overlay-border)] px-4 py-2 flex items-center gap-4">
                 <span className="text-[10px] text-[var(--color-text-muted)]">
                   <kbd className="rounded border border-[var(--color-overlay-border-strong)] bg-[var(--color-overlay-bg)] px-1 font-mono">&uarr;&darr;</kbd>
                   {' '}navigate


### PR DESCRIPTION
Catches up the strict DoD grep on `CommandPalette.tsx` (PR arc #4578).

## What
Replaces the last 2 raw `border-white/5` sites in CommandPalette with the `--color-overlay-border` design token (same pattern as slice 2 #4580 / slice 4 #4582):

- `L210` modal header container — `border-b border-white/5` → `border-b border-[var(--color-overlay-border)]`
- `L295` modal footer container — `border-t border-white/5` → `border-t border-[var(--color-overlay-border)]`

## Why
Argus's 03:32 UTC comment on #4578 (id 4637236310) flagged these 2 sites as in-scope overlay/scrim DoD misses — they fell between slice 2 (#4580, 5 layout components) and slice 3 (#4581, kbd hints) because the file boundary cuts through the modal chrome.

The 26 other matches on develop are explicitly out of scope per Argus's categorization:
- 6 in `index.css` (intentional light-mode theme overrides)
- 1 in `MessageFooter.tsx` (`bg-black object-contain` for image rendering)
- ~19 `text-white` on `bg-cta`/`bg-danger`/`bg-success`/`bg-warning` (text on colored buttons, not overlay/scrim)

## Verification
- `npx tsc --noEmit`: clean (exit 0)
- `npx vitest run`: 2252/2252 pass (224 files, 2 skipped)
- `npm run build`: clean, 8.00s
- DoD grep on `CommandPalette.tsx`: 5 → 3 matches (all remaining are `text-white` on active item state, not overlay/scrim)

Visual output: unchanged across dark/light/light-paper/light-aaa themes (token emits the same alpha in each).

## Scoping
- Lane: Daedalus (frontend/design review)
- Single file, 2 lines
- No backend touch
- No dependency changes

Refs #4578