### PR TITLE
fix(drafts): correct 'ag setup telegram' to env-var / config setup in v0.7.0 docs

### DIFF
--- a/docs/drafts/blog-phone-approvals.md
+++ b/docs/drafts/blog-phone-approvals.md
@@ -36,14 +36,24 @@ Every minute your agent spends waiting for you to approve something is a minute 
 
 ## Set it up in 60 seconds
 
+1. Create a Telegram bot via [@BotFather](https://t.me/BotFather) (30 seconds)
+2. Add the bot to a group (or DM it) and grab the chat ID via `https://api.telegram.org/bot<TOKEN>/getUpdates`
+3. Set two env vars where Aegis runs:
+
 ```bash
-# 1. Create a Telegram bot via @BotFather (takes 30 seconds)
-# 2. Create a group, add the bot, get the chat ID
-# 3. Run setup
-ag setup telegram
+export AEGIS_TG_BOT_TOKEN="<your-bot-token>"
+export AEGIS_TG_GROUP="<your-chat-id>"   # positive for DM, negative for group
 ```
 
-That's it. Aegis handles the rest — notifications, inline buttons, callback authentication, timeout auto-reject if you don't respond.
+Or add to `aegis.config.json`:
+
+```json
+{ "tgBotToken": "<token>", "tgGroupId": "<chat-id>" }
+```
+
+Then restart Aegis. That's it — notifications, inline buttons, callback authentication, timeout auto-reject if you don't respond.
+
+See [`docs/guides/phone-approvals.md`](https://github.com/OneStepAt4time/aegis/blob/develop/docs/guides/phone-approvals.md) for the full walkthrough.
 
 ## What's next
 
@@ -55,7 +65,7 @@ That's it. Aegis handles the rest — notifications, inline buttons, callback au
 
 ```bash
 npx --package=@onestepat4time/aegis ag init
-ag setup telegram
+# set AEGIS_TG_BOT_TOKEN and AEGIS_TG_GROUP (see above)
 ag run "Build a REST API for a todo app" --cwd ./my-project
 ```
 

--- a/docs/drafts/reddit-post-v0.7.0.md
+++ b/docs/drafts/reddit-post-v0.7.0.md
@@ -41,10 +41,16 @@ When Claude Code needs permission, Aegis sends a Telegram push notification with
 
 It works for session creation too — new session starts, you get a notification, approve it from your phone, agent goes to work.
 
-Setup:
+Setup — set two env vars and restart Aegis:
+
 ```bash
-ag setup telegram  # guided, 60 seconds
+export AEGIS_TG_BOT_TOKEN="<your-bot-token>"
+export AEGIS_TG_GROUP="<your-chat-id>"   # positive for DM, negative for group
 ```
+
+(or add `tgBotToken` / `tgGroupId` to `aegis.config.json`)
+
+See [`docs/guides/phone-approvals.md`](https://github.com/OneStepAt4time/aegis/blob/develop/docs/guides/phone-approvals.md) for the full walkthrough.
 
 The approval state machine is: `pending_approval → approved → running` or `rejected`. Timeout auto-reject if you don't respond within the configured window.
 
@@ -105,8 +111,8 @@ npx @onestepat4time/aegis init
 # Run your first agent
 ag run "Summarize this project and suggest improvements" --cwd ./my-project
 
-# Set up phone approvals
-ag setup telegram
+# Set up phone approvals (env vars AEGIS_TG_BOT_TOKEN and AEGIS_TG_GROUP)
+# see docs/guides/phone-approvals.md for the full walkthrough
 ```
 
 GitHub: https://github.com/OneStepAt4time/aegis  

--- a/docs/drafts/release-notes-v0.7.0.md
+++ b/docs/drafts/release-notes-v0.7.0.md
@@ -56,9 +56,21 @@ When a session is created, Aegis sends a Telegram notification with inline Appro
 - Telegram notification settings page in the dashboard
 
 **Setup:**
+
+Set two env vars and restart Aegis:
+
 ```bash
-ag setup telegram
+export AEGIS_TG_BOT_TOKEN="<your-bot-token>"
+export AEGIS_TG_GROUP="<your-chat-id>"   # positive for DM, negative for group
 ```
+
+Or add to `aegis.config.json`:
+
+```json
+{ "tgBotToken": "<token>", "tgGroupId": "<chat-id>" }
+```
+
+See [`docs/guides/phone-approvals.md`](https://github.com/OneStepAt4time/aegis/blob/develop/docs/guides/phone-approvals.md) for the full walkthrough (creating a bot, getting the chat ID, security notes).
 
 ---
 


### PR DESCRIPTION
## What this fixes

The fictional `ag setup telegram` subcommand was repeated across the v0.7.0 DevRel drafts and traced back to the shipped `docs/five-minute-setup.md`. The actual setup path is env vars (`AEGIS_TG_BOT_TOKEN` / `AEGIS_TG_GROUP`) or config file (`tgBotToken` / `tgGroupId`) — see `docs/guides/phone-approvals.md`.

## Files corrected in this PR (3)

- `docs/drafts/blog-phone-approvals.md` — 2 occurrences replaced with the env-var / config walkthrough from `docs/guides/phone-approvals.md`
- `docs/drafts/release-notes-v0.7.0.md` — 1 occurrence in the Telegram approvals **Setup:** block
- `docs/drafts/reddit-post-v0.7.0.md` — 2 occurrences in the Setup snippet and the "Run your first agent" snippet

All 5 `ag setup telegram` references on develop have been removed. Verified with `grep`.

## Why

Caught by DevRel pre-publish review. Functional Code Gate: "do not draft public claims that depend on a user flow without running the dogfood path." Cross-checked against `src/commands/` (no `telegram.ts` subcommand exists) and `src/cli.ts` startup hint (fixed separately in #4610).

## HELD status — clarification

These three drafts (`blog-phone-approvals.md`, `release-notes-v0.7.0.md`, `reddit-post-v0.7.0.md`) are **HELD for Ema's v0.7.0 go/no-go**. This PR is purely an **accuracy fix** and does not change the HELD status:

- `docs/drafts/` is the holding pen for unreleased v0.7.0 release materials — they live on `develop` but are not shipped.
- Fixing a known inaccuracy in drafts/ on develop does not publish them. Publication is gated on Ema's go/no-go.
- The drafts have not been released; v0.7.0 is not yet cut (latest release on GitHub is v0.6.6).

## Related (resolved, not in this PR)

- #4605 / #4607 — `docs/five-minute-setup.md` (shipped onboarding doc) — merged
- #4609 / #4610 — env-var name consistency in `docs/guides/phone-approvals.md`, `docs/integrations/cli.md`, `docs/integrations/notifications.md`, and `src/cli.ts` startup hint — merged

## Functional Code Gate verification

- ✅ `src/commands/` — no `telegram.ts` or `setup.ts` subcommand exists
- ✅ `src/config/index.ts` — env var mapping is `AEGIS_TG_BOT_TOKEN` / `AEGIS_TG_GROUP` → `tgBotToken` / `tgGroupId`
- ✅ `docs/guides/phone-approvals.md` — canonical setup walkthrough (link target valid)
- ✅ Replacement snippets in all 3 drafts match that guide
- ✅ No `ag setup telegram` references remain in the 3 corrected files

## Out of scope (flagged separately)

- `positioning-aegis-vs-cc-connect.md` and the other 3 v0.7.0 drafts (`discord-announcement-v0.7.0.md`, `readme-hero-rewrite.md`, `twitter-thread-v0.7.0.md`) were not part of this fix. The cc-connect stats in the positioning brief will need separate verification before publication (per the reviewer's note).