### PR TITLE
fix(five-minute-setup): correct non-existent 'ag setup telegram' to env-var / config setup (#4605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Awaiting_approval status + riskLevel crash** — dashboard handles approval status without crashing ([#4155](https://github.com/OneStepAt4time/aegis/pull/4155), [#4156](https://github.com/OneStepAt4time/aegis/pull/4156), [#4150](https://github.com/OneStepAt4time/aegis/issues/4150))
 - **Auth: remove __Host- cookie prefix** — dashboard auth works over HTTP without TLS ([#4146](https://github.com/OneStepAt4time/aegis/pull/4146))
 - **ag status shows cumulative total** — totalCreated persists across restarts instead of in-memory counter ([#4171](https://github.com/OneStepAt4time/aegis/pull/4171))
+- **Onboarding phone-approval setup command** — `docs/five-minute-setup.md` "Approve from your phone" section now uses the documented env-var (`AEGIS_TG_BOT_TOKEN` / `AEGIS_TG_GROUP`) and config (`tgBotToken` / `tgGroupId`) setup path instead of the non-existent `ag setup telegram` subcommand (closes [#4605](https://github.com/OneStepAt4time/aegis/issues/4605))
 - **ACP OOM prevention** — event compaction and debounced persist prevent memory crash loops ([#4032](https://github.com/OneStepAt4time/aegis/pull/4032))
 - **Transcript API returns full messages** — no more truncated responses from `/read` ([#3863](https://github.com/OneStepAt4time/aegis/pull/3863))
 - **Cross-session rate-limit coordination** — prevent concurrent retry storms across sessions ([#3931](https://github.com/OneStepAt4time/aegis/pull/3931))

--- a/docs/five-minute-setup.md
+++ b/docs/five-minute-setup.md
@@ -79,11 +79,20 @@ ag run "Your prompt here" --cwd ./my-project
 
 ## Optional: Approve from your phone (1 minute)
 
+Set two environment variables, then restart Aegis:
+
 ```bash
-ag setup telegram
+export AEGIS_TG_BOT_TOKEN="<your-bot-token>"
+export AEGIS_TG_GROUP="<your-chat-id>"   # positive for DM, negative for group
 ```
 
-Follow the guided setup. After that, Claude's permission prompts arrive on Telegram — approve or deny from anywhere.
+Or add them to `aegis.config.json`:
+
+```json
+{ "tgBotToken": "<token>", "tgGroupId": "<chat-id>" }
+```
+
+After restart, Claude's permission prompts arrive on Telegram — approve or deny from anywhere.
 
 > 📖 For the full walkthrough (create a bot, get chat ID, configure security), see the [Phone Approvals guide](./guides/phone-approvals.md).
 


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.7

## What this fixes

The shipped onboarding doc (`docs/five-minute-setup.md`, the 5-minute quickstart) instructed users to run `ag setup telegram`. That subcommand does not exist — `src/commands/` contains only `auth`, `init`, `kill`, `list`, `login`, `logout`, `read`, `run`, `status`, `tail`, `update`, `whoami`. There is no `telegram.ts` and no `setup.ts`.

A new user following the quickstart would click the phone-approval link, run the command, and get `Unknown command` with no recovery path in the onboarding flow.

## The fix

Replaced the "Approve from your phone (1 minute)" block with the documented setup path:

- **Env vars:** `AEGIS_TG_BOT_TOKEN` and `AEGIS_TG_GROUP` (then restart Aegis)
- **Config file:** `{ "tgBotToken": "<token>", "tgGroupId": "<chat-id>" }` in `aegis.config.json`

The link to `docs/guides/phone-approvals.md` (the canonical walkthrough) is preserved.

## Why now

- **Functional Code Gate:** do not document user flows that don't exist. The shipped onboarding doc failed the dogfood check.
- **#4606 (DevRel drafts):** the same wrong command leaked into the v0.7.0 blog, release notes, and reddit drafts. Orpheus is correcting those in #4606 (held for Ema's v0.7.0 go/no-go).
- **#4605 (this issue):** the production onboarding doc is fixed here so the devrel drafts don't inherit the error when they're published.

## Verification (Functional Code Gate)

- ✅ `src/commands/` — no `telegram.ts` or `setup.ts` subcommand exists
- ✅ `src/config/index.ts:443` — env var mapping is `AEGIS_TG_GROUP` (no `_ID` suffix) → `tgGroupId`
- ✅ `src/__tests__/config-domains.test.ts:71-76` — config keys are `tgBotToken` / `tgGroupId`
- ✅ `docs/guides/phone-approvals.md` — canonical setup walkthrough (link target valid)
- ✅ Lint: 0 errors (pre-existing warnings only)
- ✅ Hygiene check: passed

## Out of scope (flagged separately)

While verifying, I noticed `docs/guides/phone-approvals.md:80` uses the env var `AEGIS_TG_GROUP_ID` (with `_ID` suffix) which is **inconsistent with `src/config/index.ts:443`** (which maps `AEGIS_TG_GROUP` → `tgGroupId`). This would silently fail on a user who copies the guide verbatim. This is a separate bug from #4605 and is **not** fixed in this PR to keep the scope tight — flagging here for the docs team / Orpheus to address in a follow-up.

Also flagged (not mine to fix): `src/cli.ts:82` startup hint says `ag telegram` which is also non-existent.

## Scope

- `docs/five-minute-setup.md` — +11 / -2 lines
- `CHANGELOG.md` — +1 line (Unreleased / Bug Fixes)

Two files, 13 line delta. Single concern, no batching needed.

Closes #4605