### PR TITLE
fix(docs): correct non-existent 'ag setup telegram' to env-var / config setup in onboarding.md

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -312,13 +312,22 @@ See [Configuration Reference](getting-started.md#configuration) for all options.
 
 ## Approve from Your Phone (optional)
 
-Set up Telegram approvals to handle Claude Code permission prompts from anywhere:
+Set up Telegram approvals to handle Claude Code permission prompts from anywhere.
+
+Set two environment variables, then restart Aegis:
 
 ```bash
-ag setup telegram
+export AEGIS_TG_BOT_TOKEN="<your-bot-token>"
+export AEGIS_TG_GROUP="<your-chat-id>"   # positive for DM, negative for group
 ```
 
-Follow the guided setup. After that, permission prompts arrive on Telegram — approve or deny from your phone.
+Or add them to `aegis.config.json`:
+
+```json
+{ "tgBotToken": "<token>", "tgGroupId": "<chat-id>" }
+```
+
+After restart, permission prompts arrive on Telegram — approve or deny from your phone.
 
 > 📖 Full walkthrough: [Phone Approvals guide](./guides/phone-approvals.md).
 


### PR DESCRIPTION
## Summary

The "Approve from Your Phone (optional)" section of `docs/onboarding.md` (line 318) told new users to run `ag setup telegram`. That subcommand **does not exist** — `src/commands/` contains only `auth`, `init`, `kill`, `list`, `login`, `logout`, `read`, `run`, `status`, `tail`, `update`, `whoami`. No `telegram.ts`, no `setup.ts`.

A new user following the onboarding flow would run the command, get `Unknown command`, and have no recovery path inside the onboarding doc itself.

## Fix

Replaces the phantom `ag setup telegram` block with the documented setup path:

- **Option 1: env vars** — `AEGIS_TG_BOT_TOKEN` + `AEGIS_TG_GROUP`
- **Option 2: aegis.config.json** — `tgBotToken` + `tgGroupId`

Mirrors the pattern from #4607 (the `five-minute-setup.md` fix) and #4606 (the 3 v0.7.0 drafts fix) so the snippets are consistent across all shipped docs.

## Why a separate PR from #4605

#4605 / #4607 fixed the same bug in `docs/five-minute-setup.md`. `docs/onboarding.md` is a **different file** and was not in scope of #4605. Ema filed this gap as #4612 with `ready` label, suggesting the same pattern.

After this PR, `ag setup telegram` will no longer appear in any shipped doc — only the three `docs/drafts/*` files Orpheus is publishing post-release (out of scope).

## Verification

- [x] `grep -rn "ag setup telegram" --include="*.md"` on the worktree returns no hits in shipped docs (drafts excluded)
- [x] `npm run gate` passes — 5977 tests, 419 files, 0 failures
- [x] Diff matches the exact wording of the Ema-approved #4607 fix
- [x] Keeps the link to `docs/guides/phone-approvals.md` for the full walkthrough

## Related (already merged)

- #4605 / #4607 — same bug, `docs/five-minute-setup.md`
- #4609 / #4611 — `AEGIS_TG_GROUP_ID` → `AEGIS_TG_GROUP` env-var rename in 3 docs + CLI startup hint fix
- #4606 — Orpheus DevRel drafts (3 files in `docs/drafts/`)
- Issue #4612 — Ema's report, with `documentation`, `P2`, `ci`, `ready` labels

Closes #4612

**Aegis version:** v0.6.7-preview.1