### PR TITLE
fix(identity): derive stable actor id for relay-drift defense (#4615)

### DIFF
--- a/src/__tests__/identity/stable-actor.test.ts
+++ b/src/__tests__/identity/stable-actor.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  resolveStableActor,
+  _resetStableActorCacheForTesting,
+} from '../../identity/stable-actor.js';
+
+describe('resolveStableActor (#4615 — relay drift defense)', () => {
+  beforeEach(() => {
+    // Each test starts with a clean baseline cache.
+    _resetStableActorCacheForTesting();
+  });
+
+  // DoD scenario 1: deterministic identity across calls with no relayAccountId.
+  it('returns the same stableActorId across 3 calls when only (channel, userId) are given', () => {
+    const a = resolveStableActor({ channel: 'telegram', userId: 42 });
+    const b = resolveStableActor({ channel: 'telegram', userId: 42 });
+    const c = resolveStableActor({ channel: 'telegram', userId: 42 });
+
+    expect(a.stableActorId).toBe(b.stableActorId);
+    expect(b.stableActorId).toBe(c.stableActorId);
+    // No baseline candidate present, so no drift signal either.
+    expect(a.isDriftSuspected).toBe(false);
+    expect(b.isDriftSuspected).toBe(false);
+    expect(c.isDriftSuspected).toBe(false);
+  });
+
+  // DoD scenario 1 (edge): firstName does not affect stableActorId.
+  it('ignores firstName when computing stableActorId (display name is not identity)', () => {
+    const alice = resolveStableActor({ channel: 'telegram', userId: 42, firstName: 'Alice' });
+    const aliceRenamed = resolveStableActor({
+      channel: 'telegram',
+      userId: 42,
+      firstName: 'Alicia',
+    });
+    expect(aliceRenamed.stableActorId).toBe(alice.stableActorId);
+  });
+
+  // DoD scenario 2: drift detection when relayAccountId changes.
+  it('flags isDriftSuspected=true on the drifted call while stableActorId stays stable', () => {
+    const first = resolveStableActor({
+      channel: 'telegram',
+      userId: 999,
+      relayAccountId: 'relay-A',
+    });
+    expect(first.isDriftSuspected).toBe(false);
+
+    const drifted = resolveStableActor({
+      channel: 'telegram',
+      userId: 999,
+      relayAccountId: 'relay-B',
+    });
+
+    expect(drifted.stableActorId).toBe(first.stableActorId);
+    expect(drifted.isDriftSuspected).toBe(true);
+  });
+
+  // DoD scenario 2 (complement): matching baseline is not drift.
+  it('does not flag drift when relayAccountId matches the established baseline', () => {
+    const first = resolveStableActor({
+      channel: 'telegram',
+      userId: 1000,
+      relayAccountId: 'relay-X',
+    });
+    const same = resolveStableActor({
+      channel: 'telegram',
+      userId: 1000,
+      relayAccountId: 'relay-X',
+    });
+
+    expect(first.isDriftSuspected).toBe(false);
+    expect(same.isDriftSuspected).toBe(false);
+    expect(same.stableActorId).toBe(first.stableActorId);
+  });
+
+  // DoD scenario 2 (edge): absent relayAccountId is never drift.
+  it('does not flag drift when relayAccountId is absent (no baseline to differ from)', () => {
+    const r1 = resolveStableActor({ channel: 'telegram', userId: 7 });
+    const r2 = resolveStableActor({ channel: 'telegram', userId: 7 });
+    expect(r1.isDriftSuspected).toBe(false);
+    expect(r2.isDriftSuspected).toBe(false);
+  });
+
+  // DoD scenario 3: distinct identities.
+  it('returns different stableActorId for different (channel, userId) pairs', () => {
+    const alice = resolveStableActor({ channel: 'telegram', userId: 1 });
+    const bob = resolveStableActor({ channel: 'telegram', userId: 2 });
+    const aliceOnDiscord = resolveStableActor({ channel: 'discord', userId: 1 });
+
+    expect(alice.stableActorId).not.toBe(bob.stableActorId);
+    expect(alice.stableActorId).not.toBe(aliceOnDiscord.stableActorId);
+    expect(bob.stableActorId).not.toBe(aliceOnDiscord.stableActorId);
+  });
+
+  // Drift isolation: drift on one actor does not flag another.
+  it('isolates drift detection per actor (one actor drifting does not flag another)', () => {
+    // Alice has a stable baseline.
+    resolveStableActor({ channel: 'telegram', userId: 42, relayAccountId: 'a-1' });
+    const aliceAgain = resolveStableActor({ channel: 'telegram', userId: 42, relayAccountId: 'a-1' });
+    // Bob is observed fresh — not drift.
+    const bob = resolveStableActor({ channel: 'telegram', userId: 43, relayAccountId: 'b-1' });
+    // Bob's relay now drifts — drift.
+    const bobDrifted = resolveStableActor({ channel: 'telegram', userId: 43, relayAccountId: 'b-2' });
+
+    expect(aliceAgain.isDriftSuspected).toBe(false);
+    expect(bob.isDriftSuspected).toBe(false);
+    expect(bobDrifted.isDriftSuspected).toBe(true);
+  });
+});

--- a/src/identity/stable-actor.ts
+++ b/src/identity/stable-actor.ts
@@ -1,0 +1,78 @@
+/**
+ * Aegis actor identity resolver (issue #4615).
+ *
+ * The OpenClaw relay layer sometimes mangles or rotates the
+ * `account_id` field on cross-agent relay messages (observed in
+ * #aegis-devs, 2026-06-08 20:17 GMT+2 by ag-hermes and ag-scribe).
+ * Aegis should not depend on that field for identity.
+ *
+ * `resolveStableActor` derives a deterministic actor id from the
+ * stable parts of an inbound actor (channel + userId) and detects
+ * when the relay-layer `relayAccountId` drifts between calls for
+ * the same logical actor. The stable id is what downstream code
+ * should consume; `isDriftSuspected` is a soft signal for audit
+ * and warnings, never a reason to reject a message.
+ *
+ * This is aegis-side defensive hardening. The OpenClaw relay
+ * layer's garble is upstream and out of scope for this module.
+ */
+import { createHash } from 'node:crypto';
+
+export interface ResolveStableActorInput {
+  channel: string;
+  userId: number | string;
+  firstName?: string;
+  relayAccountId?: string;
+}
+
+export interface ResolveStableActorResult {
+  stableActorId: string;
+  isDriftSuspected: boolean;
+}
+
+// In-memory baseline relayAccountId per stable actor. Lost on
+// process restart by design — drift is a session-level signal,
+// not an audit log. A process restart invalidates the baseline
+// and the next observed relayAccountId becomes the new baseline.
+const baselineRelayAccountIdByActor = new Map<string, string>();
+
+/** Truncation length for the SHA-256 hex digest (16 hex = 64 bits). */
+const STABLE_ACTOR_ID_HEX_CHARS = 16;
+
+export function resolveStableActor(input: ResolveStableActorInput): ResolveStableActorResult {
+  const stableActorId = hashStableActorId(input.channel, input.userId);
+  const isDriftSuspected = detectDrift(stableActorId, input.relayAccountId);
+  return { stableActorId, isDriftSuspected };
+}
+
+function hashStableActorId(channel: string, userId: number | string): string {
+  return createHash('sha256')
+    .update(`${channel}:${userId}`)
+    .digest('hex')
+    .slice(0, STABLE_ACTOR_ID_HEX_CHARS);
+}
+
+function detectDrift(stableActorId: string, relayAccountId: string | undefined): boolean {
+  // Absent relayAccountId is never drift — we have no baseline to
+  // differ from. This is the only path that can ever return
+  // `false` while the baseline is undefined for this actor.
+  if (relayAccountId === undefined) {
+    return false;
+  }
+  const baseline = baselineRelayAccountIdByActor.get(stableActorId);
+  if (baseline === undefined) {
+    // First observation for this actor — establish the baseline.
+    baselineRelayAccountIdByActor.set(stableActorId, relayAccountId);
+    return false;
+  }
+  return baseline !== relayAccountId;
+}
+
+/**
+ * Test-only: clear the in-memory baseline cache. Exported solely
+ * so the test suite can isolate scenarios. Not part of the public
+ * API surface; the underscore prefix signals "internal/test".
+ */
+export function _resetStableActorCacheForTesting(): void {
+  baselineRelayAccountIdByActor.clear();
+}


### PR DESCRIPTION
Closes #4615

## Summary

Aegis-side defensive module that derives a deterministic actor id from the stable parts of an inbound actor (channel + userId) and detects when the OpenClaw relay layer's `relayAccountId` drifts between calls for the same logical actor.

The OpenClaw relay layer sometimes mangles or rotates the `account_id` field on cross-agent relay messages (observed by ag-hermes and ag-scribe in #aegis-devs, 2026-06-08 20:17 GMT+2). Aegis should not depend on that field for identity — this module is the defensive layer aegis-side consumers can call to get a stable id that's robust to relay drift.

## TDD history (red → green in two commits)

- `9318188b` — `test(identity): add failing TDD spec for stable-actor (#4615)` (RED)
- `4ab0fbc3` — `feat(identity): implement stable-actor resolver for relay-drift defense (#4615)` (GREEN)

## Changes

| File | Status | Lines |
|------|--------|-------|
| `src/identity/stable-actor.ts` | added | +78 |
| `src/__tests__/identity/stable-actor.test.ts` | added | +108 |

Aegis version: 0.6.7 (root `package.json`)

## Design

- **`stableActorId`** = `SHA-256("channel:userId")` truncated to 16 hex chars (64 bits). Deterministic, collision-resistant for any realistic agent population. `firstName` and `relayAccountId` are intentionally **not** in the hash input.
- **`isDriftSuspected`** = `true` only when `relayAccountId` differs from a cached baseline for the same `stableActorId`. First observation always returns `false` (no baseline to differ from). Absent `relayAccountId` is never drift.
- Module-level `Map<stableActorId, relayAccountId>` for the baseline. Intentionally ephemeral — lost on process restart, drift is a session-level signal, not an audit log.

## FCG impact map (manual — gitnexus not installed in this environment)

| Symbol | Status | Risk |
|--------|--------|------|
| `resolveStableActor` (new) | leaf, no production callers | **0** |
| `_resetStableActorCacheForTesting` (new) | test-only, underscore prefix | **0** |
| `src/identity/stable-actor.ts` consumers in `src/` | none (verified via `grep -rln "from.*['\"].*identity" src/`) | **0** |
| Existing `cmd.actor` consumer | `src/server-inbound.ts:50,74` (untouched, out of scope per DoD) | **0** |

**Blast radius: 0.** This is a purely additive module. No existing test or production path imports it yet. A follow-up issue can wire it into the Telegram handler at `src/server-inbound.ts:50,74` if desired (deferred to keep this PR surgical per the DoD's "Scope guard").

## Verification (`npm run gate` per AGENTS.md)

| Check | Result |
|-------|--------|
| `vitest src/__tests__/identity/stable-actor.test.ts` | **7/7 pass** (3 DoD scenarios + 4 edge cases) |
| `vitest run --maxWorkers=1` (full suite, excluding e2e/fault-injection) | **5964 pass, 24 skipped, 0 failed** |
| `tsc --noEmit` | clean |
| `eslint src` (root) | 0 errors, 428 pre-existing warnings, **0 on new files** |
| `eslint src/identity src/__tests__/identity` (new files only) | **0 errors, 0 warnings** |
| `check-file-size.cjs` | pass (new files <500 lines) |
| `check-as-any.cjs` | pass (no new forbidden casts vs `origin/develop`) |
| `check-circular-deps.cjs` | pass |
| `check-no-shell-true.cjs` | pass |
| `check-no-hardcoded-tokens.cjs` | pass |
| `hygiene-check.cjs` | pass |
| `pre-push` hook (`npm run gate`) | passed, push allowed |

## Test scenarios covered

1. **DoD scenario 1** — same `(channel, userId)`, no `relayAccountId` → `stableActorId` is deterministic across 3 calls.
2. **DoD scenario 2** — same `(channel, userId)`, `relayAccountId` drifts between calls → `isDriftSuspected === true` on the drifted call; `stableActorId` invariant.
3. **DoD scenario 3** — different `(channel, userId)` pairs → different `stableActorId`.
4. **Complement (scenario 2)** — matching baseline is not drift.
5. **Edge (scenario 2)** — absent `relayAccountId` is not drift (no baseline candidate).
6. **Complement (scenario 1)** — `firstName` does not affect `stableActorId` (display name is not identity).
7. **Isolation** — drift on one actor does not flag another actor.

## Out of scope (per DoD)

- Fixing the OpenClaw relay layer's garble (upstream).
- Changes to `src/channels/` consumption sites.
- Wiring the resolver into the Telegram handler (`src/server-inbound.ts:50,74`) — follow-up issue.

## Lane

- `backend` (Hephaestus per AGENTS.md / Lane field on the issue).

