### PR TITLE
feat(server-inbound): wire stable-actor resolver into approve/reject paths (#4617)

### DIFF
--- a/src/__tests__/server-inbound-stable-actor.test.ts
+++ b/src/__tests__/server-inbound-stable-actor.test.ts
@@ -36,7 +36,6 @@ function makeCtx(): TestCtx {
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function asAppCtx(ctx: TestCtx): AppContext {
   return ctx as unknown as AppContext;
 }
@@ -143,7 +142,7 @@ describe('handleInbound + stable-actor resolver (#4617)', () => {
 
       // Warning fired exactly once
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      const warnArg = warnSpy.mock.calls[0][0] as Record<string, unknown>;
+      const warnArg = warnSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
       expect(warnArg).toMatchObject({
         component: 'server-inbound',
         operation: 'stable_actor_drift',

--- a/src/__tests__/server-inbound-stable-actor.test.ts
+++ b/src/__tests__/server-inbound-stable-actor.test.ts
@@ -1,0 +1,234 @@
+/**
+ * server-inbound-stable-actor.test.ts — Wiring of stable-actor resolver into
+ * the inbound command handler (#4617).
+ *
+ * Covers:
+ *   - stableActorId appears in approvedBy / statusChange detail
+ *   - Drift detection (relayAccountId mismatch) logs a structured warning
+ *   - Common path (no drift) preserves the human-readable form and emits no warning
+ *   - Fallback (no actor) returns the default 'telegram' string
+ *
+ * TDD red phase: this file references `cmd.actor.relayAccountId` and a
+ * `resolveInboundActor` helper that do not exist yet. The next commits add
+ * the actor-type extension and the helper to make these tests pass.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { handleInbound } from '../server-inbound.js';
+import type { AppContext } from '../app-context.js';
+import type { InboundCommand } from '../channels/index.js';
+import { _resetStableActorCacheForTesting } from '../identity/stable-actor.js';
+import { logger } from '../logger.js';
+import { channels } from '../server-channels.js';
+
+interface TestCtx {
+  sessions: {
+    approveSession: Mock;
+    rejectSession: Mock;
+  };
+}
+
+function makeCtx(): TestCtx {
+  return {
+    sessions: {
+      approveSession: vi.fn().mockResolvedValue(undefined),
+      rejectSession: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function asAppCtx(ctx: TestCtx): AppContext {
+  return ctx as unknown as AppContext;
+}
+
+describe('handleInbound + stable-actor resolver (#4617)', () => {
+  beforeEach(() => {
+    _resetStableActorCacheForTesting();
+    vi.clearAllMocks();
+  });
+
+  describe('session_approve wiring', () => {
+    it('includes the stableActorId in approvedBy and the statusChange detail', async () => {
+      const ctx = makeCtx();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const statusChangeSpy = vi.spyOn(channels, 'statusChange').mockImplementation(() => {});
+
+      const cmd: InboundCommand = {
+        sessionId: 'sess-1',
+        action: 'session_approve',
+        actor: { type: 'telegram', userId: 42, firstName: 'Alice' },
+      };
+      await handleInbound(cmd, asAppCtx(ctx));
+
+      // approvedBy was passed to approveSession
+      expect(ctx.sessions.approveSession).toHaveBeenCalledTimes(1);
+      const approvedBy = ctx.sessions.approveSession.mock.calls[0][1] as string;
+      // Form: "telegram:<userId> (<firstName>) [stable:<16-hex>]"
+      expect(approvedBy).toMatch(/^telegram:42 \(Alice\) \[stable:[0-9a-f]{16}\]$/);
+
+      // statusChange detail includes the same tagged form
+      expect(statusChangeSpy).toHaveBeenCalledTimes(1);
+      const detail = statusChangeSpy.mock.calls[0][0].detail as string;
+      expect(detail).toContain('Session approved by telegram:42 (Alice) [stable:');
+      expect(detail).toMatch(/\[stable:[0-9a-f]{16}\]/);
+
+      // No drift on first observation → no warning
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves the human-readable form as a substring of approvedBy (no functional regression)', async () => {
+      const ctx = makeCtx();
+      const cmd: InboundCommand = {
+        sessionId: 'sess-2',
+        action: 'session_approve',
+        actor: { type: 'telegram', userId: 7, firstName: 'Bob' },
+      };
+      await handleInbound(cmd, asAppCtx(ctx));
+
+      const approvedBy = ctx.sessions.approveSession.mock.calls[0][1] as string;
+      // The pre-#4617 form is still present (substring)
+      expect(approvedBy).toContain('telegram:7 (Bob)');
+    });
+
+    it('does not log a warning when relayAccountId is absent (no baseline to differ from)', async () => {
+      const ctx = makeCtx();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      const cmd: InboundCommand = {
+        sessionId: 'sess-3',
+        action: 'session_approve',
+        actor: { type: 'telegram', userId: 100, firstName: 'Carol' },
+      };
+      await handleInbound(cmd, asAppCtx(ctx));
+      await handleInbound(cmd, asAppCtx(ctx));
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not log a warning when relayAccountId matches the baseline', async () => {
+      const ctx = makeCtx();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      const base: InboundCommand = {
+        sessionId: 'sess-4',
+        action: 'session_approve',
+        actor: { type: 'telegram', userId: 200, firstName: 'Dave', relayAccountId: 'acc-1' },
+      };
+      await handleInbound(base, asAppCtx(ctx));
+      await handleInbound(base, asAppCtx(ctx));
+      await handleInbound(base, asAppCtx(ctx));
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs a structured warning when relayAccountId drifts between calls', async () => {
+      // First call establishes baseline.
+      const ctx1 = makeCtx();
+      const cmd1: InboundCommand = {
+        sessionId: 'sess-5a',
+        action: 'session_approve',
+        actor: { type: 'telegram', userId: 300, firstName: 'Eve', relayAccountId: 'relay-A' },
+      };
+      await handleInbound(cmd1, asAppCtx(ctx1));
+
+      // Second call with a different relayAccountId → drift.
+      const ctx2 = makeCtx();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const cmd2: InboundCommand = {
+        sessionId: 'sess-5b',
+        action: 'session_approve',
+        actor: { type: 'telegram', userId: 300, firstName: 'Eve', relayAccountId: 'relay-B' },
+      };
+      await handleInbound(cmd2, asAppCtx(ctx2));
+
+      // Warning fired exactly once
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnArg = warnSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(warnArg).toMatchObject({
+        component: 'server-inbound',
+        operation: 'stable_actor_drift',
+        sessionId: 'sess-5b',
+      });
+      const attrs = warnArg.attributes as Record<string, unknown>;
+      expect(attrs.observedRelayAccountId).toBe('relay-B');
+      expect(attrs.stableActorId).toMatch(/^[0-9a-f]{16}$/);
+
+      // The stableActorId is the SAME across the drift (relay drift doesn't change identity)
+      const approvedBy1 = ctx1.sessions.approveSession.mock.calls[0][1] as string;
+      const approvedBy2 = ctx2.sessions.approveSession.mock.calls[0][1] as string;
+      const id1 = approvedBy1.match(/\[stable:([0-9a-f]{16})\]/)?.[1];
+      const id2 = approvedBy2.match(/\[stable:([0-9a-f]{16})\]/)?.[1];
+      expect(id1).toBeDefined();
+      expect(id1).toBe(id2);
+    });
+  });
+
+  describe('session_reject wiring', () => {
+    it('includes the stableActorId in the statusChange detail', async () => {
+      const ctx = makeCtx();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const statusChangeSpy = vi.spyOn(channels, 'statusChange').mockImplementation(() => {});
+
+      const cmd: InboundCommand = {
+        sessionId: 'sess-r1',
+        action: 'session_reject',
+        actor: { type: 'telegram', userId: 11, firstName: 'Frank' },
+      };
+      await handleInbound(cmd, asAppCtx(ctx));
+
+      // rejectSession takes only the sessionId (current signature)
+      expect(ctx.sessions.rejectSession).toHaveBeenCalledWith('sess-r1');
+      // The detail field on the channel event carries the tagged form
+      expect(statusChangeSpy).toHaveBeenCalledTimes(1);
+      const detail = statusChangeSpy.mock.calls[0][0].detail as string;
+      expect(detail).toContain('Session rejected by telegram:11 (Frank) [stable:');
+      expect(detail).toMatch(/\[stable:[0-9a-f]{16}\]/);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs a structured warning when relayAccountId drifts on a session_reject', async () => {
+      const ctx1 = makeCtx();
+      await handleInbound(
+        {
+          sessionId: 'sess-r2a',
+          action: 'session_reject',
+          actor: { type: 'telegram', userId: 12, firstName: 'Gina', relayAccountId: 'relay-X' },
+        },
+        asAppCtx(ctx1),
+      );
+
+      const ctx2 = makeCtx();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      await handleInbound(
+        {
+          sessionId: 'sess-r2b',
+          action: 'session_reject',
+          actor: { type: 'telegram', userId: 12, firstName: 'Gina', relayAccountId: 'relay-Y' },
+        },
+        asAppCtx(ctx2),
+      );
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatchObject({
+        component: 'server-inbound',
+        operation: 'stable_actor_drift',
+        sessionId: 'sess-r2b',
+      });
+    });
+  });
+
+  describe('fallback (no actor supplied)', () => {
+    it('uses the default "telegram" string and emits no warning', async () => {
+      const ctx = makeCtx();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      const cmd: InboundCommand = { sessionId: 'sess-f1', action: 'session_approve' };
+      await handleInbound(cmd, asAppCtx(ctx));
+
+      const approvedBy = ctx.sessions.approveSession.mock.calls[0][1] as string;
+      expect(approvedBy).toBe('telegram');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -64,7 +64,11 @@ export interface InboundCommand {
   action: 'approve' | 'reject' | 'escape' | 'kill' | 'message' | 'command' | 'session_approve' | 'session_reject';
   text?: string;
   /** Issue #4117: Actor who triggered this command (e.g. Telegram user info). */
-  actor?: { type: 'telegram'; userId: number; firstName: string };
+  /** Issue #4617: relayAccountId is the OpenClaw-side identity passed through
+   *  the inbound message envelope. Used by the stable-actor resolver to
+   *  detect relay-layer drift (see src/identity/stable-actor.ts). Optional
+   *  because not all channels supply it. */
+  actor?: { type: 'telegram'; userId: number; firstName: string; relayAccountId?: string };
 }
 
 /** Callback for inbound commands. */

--- a/src/server-inbound.ts
+++ b/src/server-inbound.ts
@@ -16,8 +16,45 @@ import type { AppContext } from './app-context.js';
 import { shutdownAcpRuntime, cleanupTerminatedSessionState } from './session-cleanup.js';
 import { logger } from './logger.js';
 import { channels } from './server-channels.js';
+import { resolveStableActor } from './identity/stable-actor.js';
 import { makePayload as makePayloadFromCtx } from './routes/context.js';
 
+
+
+/**
+ * Resolve the inbound actor to an audit-string, threading the stable
+ * actor id through the resolver and emitting a structured drift warning
+ * if the OpenClaw relay's `relayAccountId` differs from a previously
+ * observed baseline for the same (channel, userId) (issue #4617).
+ *
+ * Returns the human-readable form augmented with a `[stable:<id>]` tag,
+ * preserving the pre-#4617 form (`telegram:<userId> (<firstName>)`) as
+ * a substring. The default 'telegram' string is returned when no actor
+ * is supplied (preserves pre-#4617 fallback).
+ */
+function resolveInboundActor(cmd: InboundCommand, sessionId: string): string {
+  if (cmd.actor?.type !== 'telegram') {
+    return 'telegram';
+  }
+  const resolution = resolveStableActor({
+    channel: 'telegram',
+    userId: cmd.actor.userId,
+    firstName: cmd.actor.firstName,
+    relayAccountId: cmd.actor.relayAccountId,
+  });
+  if (resolution.isDriftSuspected) {
+    logger.warn({
+      component: 'server-inbound',
+      operation: 'stable_actor_drift',
+      sessionId,
+      attributes: {
+        stableActorId: resolution.stableActorId,
+        observedRelayAccountId: cmd.actor.relayAccountId,
+      },
+    });
+  }
+  return `telegram:${cmd.actor.userId} (${cmd.actor.firstName}) [stable:${resolution.stableActorId}]`;
+}
 
 async function handleInbound(cmd: InboundCommand, ctx: AppContext): Promise<void> {
   try {
@@ -45,10 +82,9 @@ async function handleInbound(cmd: InboundCommand, ctx: AppContext): Promise<void
         if (recentApprovalActions.has(cmd.sessionId)) break;
         recentApprovalActions.add(cmd.sessionId);
         setTimeout(() => recentApprovalActions.delete(cmd.sessionId), 2000);
-        // Issue #4117: Include actor info (Telegram user) in approvedBy.
-        const approveActor = cmd.actor?.type === 'telegram'
-          ? `telegram:${cmd.actor.userId} (${cmd.actor.firstName})`
-          : 'telegram';
+        // Issue #4117/#4617: Include actor info (Telegram user) in approvedBy,
+        // threading the stable actor id through the resolver for drift defense.
+        const approveActor = resolveInboundActor(cmd, cmd.sessionId);
         // Issue #4092: Wrap in try/catch — stale Telegram callbacks (e.g. user taps
         // Approve after session was already approved via API) should not crash callback processing.
         try {
@@ -69,10 +105,8 @@ async function handleInbound(cmd: InboundCommand, ctx: AppContext): Promise<void
         if (recentApprovalActions.has(cmd.sessionId)) break;
         recentApprovalActions.add(cmd.sessionId);
         setTimeout(() => recentApprovalActions.delete(cmd.sessionId), 2000);
-        // Issue #4117: Include actor info in rejection log.
-        const rejectActor = cmd.actor?.type === 'telegram'
-          ? `telegram:${cmd.actor.userId} (${cmd.actor.firstName})`
-          : 'telegram';
+        // Issue #4117/#4617: Include actor info in rejection log + stable id.
+        const rejectActor = resolveInboundActor(cmd, cmd.sessionId);
         try {
           await ctx.sessions.rejectSession(cmd.sessionId);
           channels.statusChange({


### PR DESCRIPTION
Closes #4617

## Summary

Wires the stable-actor resolver from #4616 into the inbound command handler at `src/server-inbound.ts:50,74`. The two call sites (`session_approve` and `session_reject`) now flow through a new module-internal `resolveInboundActor` helper that:

1. Derives a deterministic `stableActorId` + drift signal via `resolveStableActor({ channel, userId, firstName, relayAccountId })`
2. Returns an audit string `telegram:<userId> (<firstName>) [stable:<16-hex>]` — pre-#4616 form preserved as a substring, stable id appended as a tag
3. Emits a structured `logger.warn` when `isDriftSuspected === true` (observability only, no user-facing change, no control-flow change)

## TDD history (red → green in two commits)

- `efceec33` — `test(server-inbound): add failing TDD spec for stable-actor wiring (#4617)` (RED, 4/8 failing)
- `9e1da436` — `feat(server-inbound): wire stable-actor resolver into approve/reject paths (#4617)` (GREEN, 8/8 passing)

## Changes

| File | Status | Lines |
|------|--------|-------|
| `src/__tests__/server-inbound-stable-actor.test.ts` | added | +234 |
| `src/server-inbound.ts` | modified | +41 / -9 |
| `src/channels/types.ts` | modified | +6 / -1 |

Aegis version: 0.6.7 (root `package.json`)

## Type extension (non-breaking, additive)

`InboundCommand.actor` gains an optional `relayAccountId?: string` field. This is the OpenClaw-side identity passed through the inbound message envelope. The relay layer sometimes garbles the `account_id` (observed in #aegis-devs 2026-06-08 20:17 GMT+2 by ag-hermes + ag-scribe); threading it through the resolver lets us detect and audit drift live.

No DB schema, no auth, no permissions, no new dependencies.

## FCG impact map (manual — gitnexus not installed in this env)

| Symbol | Status | Risk |
|--------|--------|------|
| `resolveInboundActor` (new helper) | module-internal, called from exactly 2 sites | **2 (small)** |
| `InboundCommand.actor.relayAccountId` (new optional field) | non-breaking type addition | **0** |
| `approveSession(sessionId, approvedBy)` arg | shape change: string now has `[stable:<id>]` suffix | **low** — pre-#4616 form preserved as substring, no consumer parses the suffix |
| `statusChange` channel event `detail` field | same: substring + suffix | **low** |
| Drift warning log | new observability only | **0** — gated on `isDriftSuspected`, no control-flow change |
| Existing `cmd.actor` consumers | `src/server-inbound.ts:50,74` (now wired) + `src/channels/index.ts` + `src/channels/types.ts:67` definition | **0** — unchanged |

**Blast radius: 2 lines of pre-existing actor-string derivation now flow through the helper.** The pre-#4616 form is preserved as a substring; downstream consumers that don't care about the suffix (humans reading audit logs) see no functional change.

## Verification (`npm run gate` per AGENTS.md)

| Check | Result |
|-------|--------|
| `vitest src/__tests__/server-inbound-stable-actor.test.ts` | **8/8 pass** |
| `vitest src/__tests__/session-approval-security-4114.test.ts` (regression) | **14/14 pass** |
| `vitest src/__tests__/identity/stable-actor.test.ts` (regression) | **7/7 pass** |
| `vitest run --maxWorkers=1` (full suite, excluding e2e/fault-injection) | **5972 pass, 24 skipped, 0 failed** (delta: +8 from new tests) |
| `tsc --noEmit` | clean |
| `eslint` (root) | 0 errors, 428 pre-existing warnings, **0 on new + modified files** |
| `eslint` (new + modified files only) | **0 errors, 0 warnings** |
| `check-file-size.cjs` | pass |
| `check-as-any.cjs` | pass (no new forbidden casts vs `origin/develop`) |
| `check-circular-deps.cjs` | pass |
| `check-no-shell-true.cjs` | pass |
| `check-no-hardcoded-tokens.cjs` | pass |
| `hygiene-check.cjs` | pass |
| `pre-push` hook (`npm run gate`) | passed, push allowed |

## Test scenarios covered (8 tests)

**session_approve (5):**
1. `stableActorId` appears in `approvedBy` AND in `statusChange.detail`
2. Pre-#4616 form (`telegram:<userId> (<firstName>)`) preserved as substring
3. No warning when `relayAccountId` is absent (no baseline to differ from)
4. No warning when `relayAccountId` matches the baseline
5. Structured warning when `relayAccountId` drifts; `stableActorId` invariant across the drift

**session_reject (2):**
6. `stableActorId` appears in `statusChange.detail` for `session_reject`
7. Structured warning fires on drift for `session_reject` too

**Fallback (1):**
8. No-actor case returns default `'telegram'` string with no warning

## Live signal expected

Once merged, the @Hermess-misroute observation (and any other relay-layer `@tag` garbles) will surface as `isDriftSuspected: true` in `logger.warn` lines with `operation: 'stable_actor_drift'`. The `approvedBy` audit string will still carry a stable actor identity even when the relay garbles the @tag.

## Out of scope (per DoD)

- Fixing the OpenClaw relay layer's garble (upstream)
- Changes to `src/channels/` beyond the optional `relayAccountId` field
- Surface changes to the public CLI / API
- Replacing the human-readable form (preserved; `stableActorId` is additive)

## Post-merge audit hook (suggested by Boss 2026-06-08)

For Athena / Themis to quantify the win (per Boss's drift-log-volume sanity check):

```bash
# Count drift events over a window — should be > 0 if the relay is misbehaving
grep "operation: 'stable_actor_drift'" logs/*.log 2>/dev/null | wc -l

# Per-actor breakdown (which actors are drifting the most)
grep "operation: 'stable_actor_drift'" logs/*.log 2>/dev/null   | jq -r '.attributes.stableActorId' 2>/dev/null   | sort | uniq -c | sort -rn | head -20
```

Before this PR: this drift was a silent misroute (the relay-garble pattern observed in #aegis-devs 2026-06-08 20:17 GMT+2 by ag-hermes and ag-scribe, including the @Hermess / @Hephaestus tag conflation in this same conversation). After this PR: same drift class surfaces as a structured `logger.warn` line, with the stable id preserved in `approvedBy` so action attribution stays correct.

A non-zero count post-merge confirms the resolver is catching real drift in the wild. A zero count means either (a) the relay is healthy, or (b) the drift is happening at a layer this resolver doesn't see (e.g. the OpenClaw `sender` metadata garble observed 2026-06-08 22:50 GMT+2) — the latter is out of scope for this PR but worth flagging if the count stays zero for a sustained window.

## Lane

- `backend` — Hephaestus (continuing from #4616).

