### PR TITLE
test(channels): cover circuit-breaker cooldown re-enable (#4624)

### DIFF
--- a/src/__tests__/channels/manager.test.ts
+++ b/src/__tests__/channels/manager.test.ts
@@ -474,5 +474,36 @@ describe('ChannelManager', () => {
       // Channel still not disabled — all calls went through
       expect(onMessage).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD * 3);
     });
+
+    it('re-enables channel after COOLDOWN_MS elapses (cooldown recovery)', async () => {
+      vi.useFakeTimers();
+      try {
+        const manager = new ChannelManager();
+        const { channel: ch, onSessionCreated } = createMockChannel('webhook');
+
+        // 5 consecutive retriable failures → channel disabled for COOLDOWN_MS
+        onSessionCreated.mockRejectedValue(new RetriableError('HTTP 503'));
+        manager.register(ch);
+
+        for (let i = 0; i < ChannelManager.FAILURE_THRESHOLD; i++) {
+          await manager.sessionCreated(createPayload('session.created'));
+        }
+        expect(onSessionCreated).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD);
+
+        // During cooldown: next call is skipped (channel still disabled)
+        await manager.sessionCreated(createPayload('session.created'));
+        expect(onSessionCreated).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD);
+
+        // Advance time past the cooldown
+        vi.advanceTimersByTime(ChannelManager.COOLDOWN_MS + 1);
+
+        // Channel re-enabled: next call goes through
+        onSessionCreated.mockResolvedValue(undefined);
+        await manager.sessionCreated(createPayload('session.created'));
+        expect(onSessionCreated).toHaveBeenCalledTimes(ChannelManager.FAILURE_THRESHOLD + 1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });


### PR DESCRIPTION
# test(channels): cover circuit-breaker cooldown re-enable (#4624)

Closes the DoD #2 leftover from #4619 audit (PR #4620).

## Context

The existing `src/__tests__/channels/manager.test.ts` covers trip behavior for the circuit breaker — 4xx vs 5xx classification, network errors, FAILURE_THRESHOLD trip, success-resets-failure-count, mixed errors — but **not** recovery. After a channel is disabled and `COOLDOWN_MS` elapses, it must be re-enabled on the next send attempt. This commit adds that test.

## Changes

- `src/__tests__/channels/manager.test.ts` — one new test (~31 lines) in the existing `circuit breaker — 4xx vs 5xx (#638)` describe block.

## Acceptance criteria (per #4624)

- [x] Single new test, `re-enables channel after COOLDOWN_MS elapses (cooldown recovery)`.
- [x] Uses `vi.useFakeTimers()` to advance past `COOLDOWN_MS` deterministically (real timers would make the suite 5 minutes long).
- [x] Asserts both directions:
  - During cooldown → `send` is skipped (channel `disabledUntil` is in the future).
  - After cooldown → `send` is called and the channel is re-enabled.
- [x] No source changes to `manager.ts`; tests only.
- [x] Coverage floor preserved (manager.ts: 87.03% lines / 75% branches / 78.94% functions on this scope; aggregate over the full suite is 91% per the audit).

## Tests added

- `it('re-enables channel after COOLDOWN_MS elapses (cooldown recovery)')` — 5 consecutive RetriableErrors → channel disabled → next call skipped → advance past `COOLDOWN_MS` → next call goes through.

## Commands run

```text
$ npx vitest run src/__tests__/channels/manager.test.ts
 Test Files  1 passed (1)
      Tests  24 passed (24)   ← was 23, +1 for cooldown recovery
   Duration  600ms
```

```text
$ npx tsc --noEmit
(clean)
```

```text
$ npm run lint
✖ 428 problems (0 errors, 428 warnings)   ← all pre-existing, 0 new from this PR
```

```text
$ npx vitest run --coverage src/__tests__/channels/manager.test.ts
manager.ts     | 86.15% stmts | 75% branch | 78.94% funcs | 87.03% lines
(single-file scope; the audit's 91% baseline is the multi-file aggregate)
```

## Out of scope

- Refactoring the circuit-breaker pattern (not needed — implementation is sound).
- Manager.test.ts → other test files (separate tickets #4621 / #4622 / #4623 for the telegram subdir coverage batches).
- §3.1 refactor of `telegram/index.ts` (god module) — separate ticket.
- §4.1, §4.6, §4.7 defensive fixes from the audit — separate tickets; not yet filed per my survey of issues #4619-#4624.

## Lane / reviewer

- Lane: backend.
- Reviewer: @Argus.
- PR2a of the 2-PR split recommended in audit §5.7.
