### PR TITLE
fix(docs): correct src/channels/ file count 18 → 19 in #4619 audit

### DIFF
--- a/docs/audit-4619-channels.md
+++ b/docs/audit-4619-channels.md
@@ -3,7 +3,7 @@
 **Author:** Hephaestus (`<hephaestus@aegis.dev>`)
 **Branch:** `audit/4619-channels`
 **Date:** 2026-06-09
-**Scope:** `src/channels/**` (3,861 lines across 18 files) — quality review, coverage analysis, security/error-handling findings, refactor opportunities.
+**Scope:** `src/channels/**` (3,861 lines across 19 files (18 source files + 1 barrel: channels/index.ts)) — quality review, coverage analysis, security/error-handling findings, refactor opportunities.
 **DoD items addressed in this report:** #1 (audit report).
 
 ---


### PR DESCRIPTION
# fix(docs): correct src/channels/ file count 18 → 19 in #4619 audit (#4620 follow-up)

Argus caught the off-by-one in the §1 exec summary: `find src/channels/ -type f -name '*.ts'` returns 19 files, not 18. The §2 file-by-file table is correct (19 rows); only the scope header was wrong.

The line count (3,861) was correct because `wc -l` was run on a glob that included `src/channels/index.ts` (the 43-line barrel), but the file count summary grouped it incorrectly. The new header disambiguates: 19 total = 18 source files + 1 barrel.

## Diff

```diff
-**Scope:** `src/channels/**` (3,861 lines across 18 files) — quality review, coverage analysis, security/error-handling findings, refactor opportunities.
+**Scope:** `src/channels/**` (3,861 lines across 19 files (18 source files + 1 barrel: channels/index.ts)) — quality review, coverage analysis, security/error-handling findings, refactor opportunities.
```

## Hygiene evidence

```text
$ node scripts/hygiene-check.cjs
Hygiene check passed.

$ npx prettier --check docs/audit-4619-channels.md
All matched files use Prettier code style!

$ git ls-files --others --exclude-standard
(none)

$ git grep -n "UAT_BUG_REPORT.md|UAT_CHECKLIST.md|UAT_PLAN.md|DEPLOYMENT.md|coverage-gap-analysis.md"
(only matches inside the policy files themselves: AGENTS.md:130, CLAUDE.md:41, PHASE2_EXIT_CHECKLIST.md:79, scripts/hygiene-check.cjs:225-226)
```

## Process notes

- Docs-only, no source touched, so `npm run lint` and `npx tsc --noEmit` not required (per the audit's §7 process notes).
- Lane: backend. Reviewer: @Argus. Merge target: develop.
- Not blocking #4624's PR #4625 or any of the PR2 workstream (#4621/#4622/#4623).
