### PR TITLE
docs(notifications): document workDir redaction in Slack + Email (closes #4630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MCP secrets moved to env vars** — remove hardcoded secrets, add CI gate ([#4040](https://github.com/OneStepAt4time/aegis/pull/4040))
 - **OTEL PII redaction** — redact hostname and PID from resource attributes ([#4039](https://github.com/OneStepAt4time/aegis/pull/4039))
 - **Multi-agent security requirements** — documented review protocol and security requirements ([#3980](https://github.com/OneStepAt4time/aegis/pull/3980))
+- **Workdir redaction in Email + Slack channels** — `workDir` in outbound messages is masked (home → `~`, last 2 path segments) matching the existing Telegram pattern; closes audit §4.7 inconsistency ([#4641](https://github.com/OneStepAt4time/aegis/pull/4641), closes [#4630](https://github.com/OneStepAt4time/aegis/issues/4630))
 
 ### Bug Fixes
 

--- a/docs/integrations/notifications.md
+++ b/docs/integrations/notifications.md
@@ -196,6 +196,8 @@ Slack messages use Block Kit with color-coded severity:
 | `status.dead` | :skull: | Red |
 | `status.error` | :x: | Red |
 
+> 🔒 **Path privacy:** the `WorkDir` field in Slack messages is redacted to protect user privacy — your home directory is replaced with `~` and only the last 2 path segments are shown (e.g. `/home/alice/projects/aegis/src` → `…/projects/src`). This matches the redaction pattern used in Telegram. Webhooks always show `workDir` as `[REDACTED]`.
+
 ---
 
 ## Email (SMTP)
@@ -234,6 +236,8 @@ Subject lines indicate severity:
 - `[CRITICAL] Session Dead` — session unresponsive
 - `[ERROR] Session Error` — error state detected
 - `[WARNING] Permission Timeout` — user didn't respond in time
+
+> 🔒 **Path privacy:** the `WorkDir` line in Email bodies is redacted to protect user privacy — your home directory is replaced with `~` and only the last 2 path segments are shown (e.g. `/home/alice/projects/aegis/src` → `…/projects/src`). This matches the redaction pattern used in Telegram and Slack. Webhooks always show `workDir` as `[REDACTED]`.
 
 ---
 


### PR DESCRIPTION
Follows up PR #4641 (merged 16:21 UTC) which introduced shared `redactWorkDir()` for Email and Slack channels. The user-facing behavior changed — outbound messages now show `~/last-2-segments` (e.g. `…/projects/src`) instead of the full path. The existing Telegram channel already used this pattern (via `shortenHomePath`) but it was undocumented.

## Changes

- `docs/integrations/notifications.md` — added `🔒 Path privacy` blockquote in both Slack and Email sections explaining the redaction behavior and giving the input → output example
- `CHANGELOG.md` — new entry under `Unreleased > Security` referencing #4641 and the audit §4.7 inconsistency it closes

## Cross-channel consistency note

The blockquote mentions that webhooks always show `workDir` as `[REDACTED]` (hard-coded in `src/channels/webhook.ts:162`), distinct from the path-truncation pattern used by Telegram/Email/Slack. This is a pre-existing three-way distinction worth surfacing to users.

A separate pre-existing accuracy gap: the webhook payload example at line 150 still shows `workDir: "/home/user/project"` — but webhooks actually return `workDir: '[REDACTED]'`. Out of scope here; will file a follow-up.

## Verification

```
npm run gate → 430 test files, 6194 tests passed, 10 skipped, 0 failures (238.79s)
```

Closes #4630.