### PR TITLE
fix(docs): correct dashboard static rate limit (100→600 req/min) after #4646

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OTEL PII redaction** — redact hostname and PID from resource attributes ([#4039](https://github.com/OneStepAt4time/aegis/pull/4039))
 - **Multi-agent security requirements** — documented review protocol and security requirements ([#3980](https://github.com/OneStepAt4time/aegis/pull/3980))
 - **Workdir redaction in Email + Slack channels** — `workDir` in outbound messages is masked (home → `~`, last 2 path segments) matching the existing Telegram pattern; closes audit §4.7 inconsistency ([#4641](https://github.com/OneStepAt4time/aegis/pull/4641), closes [#4630](https://github.com/OneStepAt4time/aegis/issues/4630))
+- **Dashboard static rate limiter rewritten with `@fastify/rate-limit`** — replaces the custom `StaticRateLimiter` with Fastify's official rate-limit plugin (600 req/min per IP, `429` with `Retry-After: 60`) to satisfy CodeQL `js/missing-rate-limiting` ([#4646](https://github.com/OneStepAt4time/aegis/pull/4646), closes [#140](https://github.com/OneStepAt4time/aegis/issues/140), [#138](https://github.com/OneStepAt4time/aegis/issues/138))
+- **Vitest + Hono security bump** — `vitest` → `^4.1.8` (closes CVE-2026-47429, CVSS 9.8) and `hono` → `^4.12.25` (closes 4 medium CVEs: GHSA-3hrh-pfw6-9m5x, GHSA-2gcr-mfcq-wcc3, GHSA-xrhx-7g5j-rcj5, GHSA-f577-qrjj-4474) ([#4648](https://github.com/OneStepAt4time/aegis/pull/4648), closes [#4643](https://github.com/OneStepAt4time/aegis/issues/4643), [#4644](https://github.com/OneStepAt4time/aegis/issues/4644))
 
 ### Bug Fixes
 
+- **Audit-log cleanup race** — `secureFilePermissions` now guards against `ENOENT` when the file was already removed by a concurrent `fs.unlink` ([#4652](https://github.com/OneStepAt4time/aegis/pull/4652), closes [#4649](https://github.com/OneStepAt4time/aegis/issues/4649))
 - **Rate-limit error guidance** — surface actionable guidance when Claude Code API rate limits are hit ([#3631](https://github.com/OneStepAt4time/aegis/pull/3631), [#3758](https://github.com/OneStepAt4time/aegis/pull/3758))
 - **Stream timeout tuning** — less aggressive timeout for `ag run` streaming ([#3733](https://github.com/OneStepAt4time/aegis/pull/3733))
 - **INVALID_WORKDIR error** — include allowed directories in error message for guidance ([#3734](https://github.com/OneStepAt4time/aegis/pull/3734), [#3799](https://github.com/OneStepAt4time/aegis/pull/3799))

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -153,7 +153,7 @@ Aegis includes built-in rate limiting at multiple levels:
 | Auth failure | 5/min per IP | Locks out after repeated failed auth attempts |
 | Per-key | 100 req/min | Separate limits per API key |
 | Master token | 300 req/min | Higher limit for the master `AEGIS_AUTH_TOKEN` |
-| Dashboard static | 100 req/min per IP | Per-IP fixed-window rate limiter on `/dashboard` static assets |
+| Dashboard static | 600 req/min per IP | Per-IP rate limiter (via `@fastify/rate-limit`) on `/dashboard` static assets, `/`, and `/manifest.json`; responds `429` with `Retry-After: 60` |
 | SSE | Configurable | Rate limiting per SSE client connection |
 
 Rate limiting is enforced in all modes — including unauthenticated localhost deployments. Authenticated and unauthenticated traffic are tracked in separate buckets. Auth failure lockout triggers after 5 failed attempts per IP within 1 minute. Stale buckets are pruned automatically.


### PR DESCRIPTION
## Summary

PR #4646 replaced the custom `StaticRateLimiter` (100 req/min per IP) with `@fastify/rate-limit` (600 req/min per IP) to satisfy CodeQL's `js/missing-rate-limiting` rule. The enterprise docs still documented the old values.

## Accuracy gap

`docs/enterprise.md:156` (added by #3228):
| Dashboard static | 100 req/min per IP | Per-IP fixed-window rate limiter on `/dashboard` static assets |

Actual post-#4646 behavior in `src/plugins/dashboard-static.ts:54`:
```ts
const DASHBOARD_RATE_LIMIT_CONFIG = {
  max: 600,
  timeWindow: '1 minute',
  ...
} as const;
```

6× undercount + wrong implementation description ("fixed-window" → `@fastify/rate-limit`).

## Changes

- **docs/enterprise.md** — update Dashboard static row: 100→600 req/min, `@fastify/rate-limit`, scope (`/dashboard/*`, `/`, `/manifest.json`), and `429 + Retry-After: 60` response.
- **CHANGELOG.md** — add Unreleased entries for #4646 (Security, rate-limiter rewrite), #4648 (Security, vitest CVE-2026-47429 + hono CVEs), #4652 (Bug Fixes, audit-log cleanup ENOENT race). All three are recent merges I would normally catch in subsequent heartbeats.

## Verification

- **npm run gate**: 430 test files, 6191 passed / 10 skipped / 0 failed, 243.11s.
- **Code match**: `src/plugins/dashboard-static.ts:54` confirms 600 req/min per IP, 1-minute window.
- **Scope**: `registerDashboardStatic()` in `server-bootstrap.ts` registers the plugin for `/dashboard/*`, `/`, and `/manifest.json` (per #4646 PR body).
- **Functional code gate**: PASSED — checked canonical sources (config + plugin code + bootstrap registration) before opening.

## Closes

No associated issue; preemptive accuracy fix from heartbeat scan.