### PR TITLE
test(infra): per-agent App identity script structure tests (#4665 §B+§C)

### DIFF
--- a/src/__tests__/auth/per-agent-apps.test.ts
+++ b/src/__tests__/auth/per-agent-apps.test.ts
@@ -72,7 +72,7 @@ describe.skipIf(!scriptsAvailable)('manage-aegis-apps.sh permission-matrix guard
 
   it('contains the ADR-0030 permission matrix for all 3 roles', () => {
     const content = readFileSync(manageScript, 'utf-8');
-    for (const [role, perms] of Object.entries(PERMISSION_MATRIX)) {
+    for (const [_role, perms] of Object.entries(PERMISSION_MATRIX)) {
       for (const perm of perms) {
         expect(content).toContain(perm);
       }


### PR DESCRIPTION
## Summary

Addresses a pre-existing lint warning on the unused destructured `role` variable in #4665's test file. The substantive test work (21 structure tests for the per-agent App identity scripts) was already merged via **#4670** (squashed into `cb965b07` on develop at 20:22 UTC) before this PR was opened.

**This PR's actual scope:** 1 line in `src/__tests__/auth/per-agent-apps.test.ts` (line 75: rename `role` → `_role` to satisfy the no-unused-vars rule).

## Context

- PR #4670 landed the full test work for #4665 §B+§C: structure tests for the 3 per-agent App identity scripts + the manage-script permission-matrix guard.
- After the squash, ESLint surfaced a warning on the unused destructured `role` variable in the permission-matrix test (`for (const [role, perms] of Object.entries(PERMISSION_MATRIX))`).
- This is a follow-up to silence that warning.

## Functional evidence

- **Tests added:** 0 new (the 21 tests are in #4670 / `cb965b07`).
- **Files changed:** `src/__tests__/auth/per-agent-apps.test.ts` (+1/-1).
- **Commands run (post-rebase onto current develop):**
  - `npx tsc --noEmit` → **PASS** (0 errors)
  - `npx eslint src/__tests__/auth/per-agent-apps.test.ts` → **0 warnings, 0 errors**
  - `npx vitest run src/__tests__/auth/per-agent-apps.test.ts` → **21/21 PASS** (regression of #4670's work)
  - `npm run gate` (root) → **PASS** (6242 tests, 10 skipped, exit 0)
- **Manual QA:** the rename is conventional ESLint pattern for "intentionally unused destructured variable."

## Commits

- `2552976d` — `test(infra): address lint warning on unused destructured role in #4665 tests`

(Originally `c4824ce9`, rebased to `2552976d` after this PR was flagged as based on a stale develop state. The earlier `84c6eb9a` was dropped during the rebase because it was already on develop via #4670.)

## Lane

Hephaestus (backend / infrastructure tests). Reviewer: @Argus for 9-gate review.
