### PR TITLE
fix(telegram): retry on network-level fetch failures in tgApi (#4675)

### DIFF
--- a/src/__tests__/channels/telegram-api.test.ts
+++ b/src/__tests__/channels/telegram-api.test.ts
@@ -18,6 +18,7 @@ describe('TelegramApiClient', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('returns data.result on success', async () => {
@@ -148,5 +149,69 @@ describe('TelegramApiClient retry_after clamping (#4627)', () => {
     // Clamped to 60 → rateLimitUntil should be ~60500ms out, not ~999999500ms
     expect(client['rateLimitUntil']).toBeGreaterThan(Date.now() + 55000);
     expect(client['rateLimitUntil']).toBeLessThan(Date.now() + 65000);
+  });
+});
+
+// #4675: network-level fetch failure retry. The tgApi retry loop previously
+// only handled HTTP-level errors (429, 500). If fetch() itself threw (e.g.
+// TypeError: fetch failed from DNS/TLS/IPv6 issues), the exception propagated
+// immediately with no retry. This describe adds coverage for the fix.
+describe('TelegramApiClient network error retry (#4675)', () => {
+  const config = { botToken: 'test-token-123', hookTimeoutMs: 5_000 };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('retries on fetch failure and succeeds on next attempt', async () => {
+    const client = new TelegramApiClient(config);
+    const networkError = new TypeError('fetch failed');
+    const mockResult = { message_id: 42 };
+
+    global.fetch = vi.fn()
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ ok: true, result: mockResult }),
+      } as unknown as Response);
+
+    const result = await client.tgApi('sendMessage', { chat_id: 1 }, 1);
+    expect(result).toEqual(mockResult);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting retries on persistent fetch failure', async () => {
+    const client = new TelegramApiClient(config);
+    const networkError = new TypeError('fetch failed');
+
+    global.fetch = vi.fn().mockRejectedValue(networkError);
+
+    await expect(client.tgApi('sendMessage', { chat_id: 1 }, 1)).rejects.toThrow('fetch failed');
+    expect(global.fetch).toHaveBeenCalledTimes(2); // attempt 0 + attempt 1 (retries=1)
+  });
+
+  it('retries up to default 3 retries (4 total attempts) on fetch failure', async () => {
+    const client = new TelegramApiClient(config);
+    const networkError = new TypeError('fetch failed');
+
+    global.fetch = vi.fn().mockRejectedValue(networkError);
+
+    await expect(client.tgApi('sendMessage', { chat_id: 1 })).rejects.toThrow('fetch failed');
+    expect(global.fetch).toHaveBeenCalledTimes(4); // 1 + 3 retries
+  }, 10_000);
+
+  it('logs each retry attempt with method and error message', async () => {
+    const client = new TelegramApiClient(config);
+    const networkError = new TypeError('fetch failed');
+
+    global.fetch = vi.fn().mockRejectedValue(networkError);
+
+    await expect(client.tgApi('sendMessage', { chat_id: 1 }, 1)).rejects.toThrow('fetch failed');
+    // The retry loop logs a warning on each failed attempt before the final throw.
+    // We verify the code path ran by checking fetch call count.
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/channels/telegram/api.ts
+++ b/src/channels/telegram/api.ts
@@ -35,43 +35,57 @@ export class TelegramApiClient {
         await sleep(waitMs);
       }
 
-      const res = await fetch(`https://api.telegram.org/bot${this.config.botToken}/${method}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(this.config.hookTimeoutMs ?? 10_000),
-      });
-      const data = (await res.json()) as {
-        ok: boolean;
-        result?: unknown;
-        description?: string;
-        parameters?: { retry_after?: number };
-      };
+      try {
+        const res = await fetch(`https://api.telegram.org/bot${this.config.botToken}/${method}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(this.config.hookTimeoutMs ?? 10_000),
+        });
+        const data = (await res.json()) as {
+          ok: boolean;
+          result?: unknown;
+          description?: string;
+          parameters?: { retry_after?: number };
+        };
 
-      if (data.ok) return data.result;
+        if (data.ok) return data.result;
 
-      if (res.status === 429 && data.parameters?.retry_after) {
-        let retryAfter = data.parameters.retry_after;
-        // #4627: clamp retry_after to 60s max to prevent a malicious or buggy
-        // upstream from blocking the channel for extended periods.
-        const MAX_RETRY_AFTER_S = 60;
-        if (retryAfter > MAX_RETRY_AFTER_S) {
-          log.warn({ component: 'telegram', operation: 'rateLimitRetryAfterClamped', attributes: { original: retryAfter, clamped: MAX_RETRY_AFTER_S } });
-          retryAfter = MAX_RETRY_AFTER_S;
+        if (res.status === 429 && data.parameters?.retry_after) {
+          let retryAfter = data.parameters.retry_after;
+          // #4627: clamp retry_after to 60s max to prevent a malicious or buggy
+          // upstream from blocking the channel for extended periods.
+          const MAX_RETRY_AFTER_S = 60;
+          if (retryAfter > MAX_RETRY_AFTER_S) {
+            log.warn({ component: 'telegram', operation: 'rateLimitRetryAfterClamped', attributes: { original: retryAfter, clamped: MAX_RETRY_AFTER_S } });
+            retryAfter = MAX_RETRY_AFTER_S;
+          }
+          this.rateLimitUntil = Date.now() + retryAfter * 1000 + 500;
+          log.info({ component: 'telegram', operation: 'rateLimit429', attributes: { retryAfter, attempt: attempt + 1, maxAttempts: retries + 1 } });
+          if (attempt < retries) {
+            await sleep(retryAfter * 1000 + 500);
+            continue;
+          }
         }
-        this.rateLimitUntil = Date.now() + retryAfter * 1000 + 500;
-        log.info({ component: 'telegram', operation: 'rateLimit429', attributes: { retryAfter, attempt: attempt + 1, maxAttempts: retries + 1 } });
-        if (attempt < retries) {
-          await sleep(retryAfter * 1000 + 500);
-          continue;
-        }
-      }
 
-      if (attempt === retries) {
-        const error = new Error(`Telegram API ${method}: ${data.description || 'unknown error'}`);
-        throw this.config.redactError ? this.config.redactError(error) : error;
+        if (attempt === retries) {
+          const error = new Error(`Telegram API ${method}: ${data.description || 'unknown error'}`);
+          throw this.config.redactError ? this.config.redactError(error) : error;
+        }
+        await sleep(1000 * (attempt + 1));
+      } catch (e) {
+        // Don't mask Telegram API errors we already constructed above.
+        if (e instanceof Error && e.message.startsWith(`Telegram API ${method}:`)) {
+          throw this.config.redactError ? this.config.redactError(e) : e;
+        }
+
+        // Network-level or parse error — retry with backoff.
+        if (attempt === retries) {
+          throw this.config.redactError ? this.config.redactError(e) : e;
+        }
+        log.warn({ component: 'telegram', operation: 'fetchRetry', attributes: { method, attempt: attempt + 1, maxAttempts: retries + 1, error: e instanceof Error ? e.message : String(e) } });
+        await sleep(1000 * (attempt + 1));
       }
-      await sleep(1000 * (attempt + 1));
     }
     const unreachable = new Error('Unreachable');
     throw this.config.redactError ? this.config.redactError(unreachable) : unreachable;


### PR DESCRIPTION
## Summary

Fixes #4675 — Telegram poll loop throwing persistent `TypeError: fetch failed`.

## Root Cause

The `tgApi` retry loop in `src/channels/telegram/api.ts` previously only handled HTTP-level errors (429, 500). If `fetch()` itself threw (e.g. `TypeError: fetch failed` from DNS/TLS/IPv6 issues), the exception propagated immediately with no retry, causing the polling loop to crash and restart.

## Fix

Wrapped the `fetch()` and `res.json()` calls in a `try/catch` inside the retry loop. Network-level errors are now caught, logged with the method name, and retried with the existing exponential backoff (1s, 2s, 3s). After exhausting retries, the original error is re-thrown (with redaction if configured).

## Changes

- `src/channels/telegram/api.ts`: +21 lines (wrap fetch/res.json in try/catch, log retries, preserve existing HTTP error handling)
- `src/__tests__/channels/telegram-api.test.ts`: +4 new test cases for network error retry behavior

## Verification

- `npx vitest run src/__tests__/channels/telegram-api.test.ts`: 11/11 passed
- `npx vitest run --maxWorkers=1`: 6246/6246 passed, 10 skipped (full suite)

## Risk Assessment

- **Low**: Purely additive retry logic. No API changes. Existing HTTP error path untouched. The new catch block only intercepts errors that previously crashed the loop.

## Checklist

- [x] Tests added
- [x] Full test suite passes
- [x] No lint errors (433 pre-existing warnings, 0 new)
- [x] Branch targets `develop`