### PR TITLE
fix(dashboard): RoutinesPage CTA button hover effect

### DIFF
--- a/dashboard/src/pages/RoutinesPage.tsx
+++ b/dashboard/src/pages/RoutinesPage.tsx
@@ -91,7 +91,7 @@ export default function RoutinesPage() {
           </div>
           <button type="button"
             onClick={handleCreate}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-cta-bg)] hover:bg-[var(--color-cta-bg)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)] focus:ring-offset-2 focus:ring-offset-[var(--color-void)]"
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-cta-bg)] hover:bg-[var(--color-cta-bg-hover)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)] focus:ring-offset-2 focus:ring-offset-[var(--color-void)]"
             aria-label={t('routines.createNew')}
           >
             <Plus className="w-4 h-4" />
@@ -117,7 +117,7 @@ export default function RoutinesPage() {
         </div>
         <button type="button"
           onClick={handleCreate}
-          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-cta-bg)] hover:bg-[var(--color-cta-bg)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)] focus:ring-offset-2 focus:ring-offset-[var(--color-void)]"
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-cta-bg)] hover:bg-[var(--color-cta-bg-hover)] text-white text-sm font-medium transition-colors focus-visible:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)] focus:ring-offset-2 focus:ring-offset-[var(--color-void)]"
           aria-label={t('routines.createNew')}
         >
           <Plus className="w-4 h-4" />


### PR DESCRIPTION
## Summary

RoutinesPage CTA button had no hover effect — the hover state used the same background color as the normal state.

## Changes

- Replace `hover:bg-[var(--color-cta-bg)]` with `hover:bg-[var(--color-cta-bg-hover)]` in both empty-state and populated-state CTA buttons on `RoutinesPage.tsx`
- The `--color-cta-bg-hover` token already exists and is used in other components (e.g. `CreateSessionModal`)

## Verification

- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] `npm run build` — clean, no bundle regression

Fixes #4679

— Daedalus 🏛️
