### PR TITLE
feat(acp): auto-resume runtime on sendPrompt when inactive (#4695)

### DIFF
--- a/src/__tests__/acp-sendprompt-auto-resume-4695.test.ts
+++ b/src/__tests__/acp-sendprompt-auto-resume-4695.test.ts
@@ -1,0 +1,306 @@
+/**
+ * acp-sendprompt-auto-resume-4695.test.ts
+ *
+ * Issue #4695: Auto-resume runtime on sendPrompt when inactive.
+ *
+ * Acceptance criteria:
+ * - sendPrompt to idle session → resume + deliver
+ * - delivered: true on success
+ * - Clean error if not resumable
+ * - Active sessions: no resume attempt (regression)
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  AcpBackend,
+  type AcpBackendClient,
+  type AcpBackendClientFactoryContext,
+  type AcpBackendSessionService,
+  type AcpCreateSessionInput,
+  type AcpJsonRpcInboundRequest,
+  type AcpJsonRpcNotification,
+  type AcpJsonRpcId,
+  type AcpJsonRpcRequestOptions,
+  type AcpJsonRpcResponseError,
+  type AcpJsonRpcSuccess,
+  type AcpJsonValue,
+  type AcpSessionRecord,
+  type AcpSessionScope,
+  type AcpSessionTransitionEvent,
+} from '../services/acp/index.js';
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+const cwd = '/tmp/test-workspace';
+
+describe('Issue #4695: sendPrompt auto-resume', () => {
+  it('attempts auto-resume when runtime is not active', async () => {
+    const service = new FakeSessionService();
+    const client = new FakeBackendClient();
+    client.setResult('initialize', {});
+    client.setResult('session/resume', { sessionId: 'acp-agent-session-1' });
+    client.setResult('session/prompt', { ok: true });
+
+    // Session has acpAgentSessionId → resumable
+    service.records.set('session-1', {
+      id: 'session-1',
+      conversationId: 'conv-1',
+      transcriptId: 'transcript-1',
+      acpAgentSessionId: 'acp-agent-session-1',
+      status: "idle" as const, createdAt: Date.now(), updatedAt: Date.now(),
+      ...scope,
+    });
+
+    let factoryCallCount = 0;
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: (ctx: AcpBackendClientFactoryContext) => {
+        factoryCallCount++;
+        return client;
+      },
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    // No active runtime — should auto-resume
+    const result = await backend.sendPrompt('session-1', 'hello', scope, cwd);
+
+    expect(result.delivered).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(result.error).toBeUndefined();
+    // Factory was called to create a new runtime for resume
+    expect(factoryCallCount).toBeGreaterThan(0);
+    // session/resume was called
+    expect(client.requests.some(r => r.method === 'session/resume')).toBe(true);
+    // session/prompt was called after resume
+    expect(client.requests.some(r => r.method === 'session/prompt')).toBe(true);
+  });
+
+  it('returns no_agent_session when session has no acpAgentSessionId', async () => {
+    const service = new FakeSessionService();
+    const client = new FakeBackendClient();
+
+    // Session without acpAgentSessionId → not resumable
+    service.records.set('session-2', {
+      id: 'session-2',
+      conversationId: 'conv-2',
+      transcriptId: 'transcript-2',
+      acpAgentSessionId: undefined,
+      status: "idle" as const, createdAt: Date.now(), updatedAt: Date.now(),
+      ...scope,
+    });
+
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    const result = await backend.sendPrompt('session-2', 'hello', scope, cwd);
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toBe('no_acp_runtime');
+    // No resume attempt
+    expect(client.requests.some(r => r.method === 'session/resume')).toBe(false);
+  });
+
+  it('returns no_acp_runtime when cwd is not provided', async () => {
+    const service = new FakeSessionService();
+    const client = new FakeBackendClient();
+
+    service.records.set('session-3', {
+      id: 'session-3',
+      conversationId: 'conv-3',
+      transcriptId: 'transcript-3',
+      acpAgentSessionId: 'acp-agent-session-3',
+      status: "idle" as const, createdAt: Date.now(), updatedAt: Date.now(),
+      ...scope,
+    });
+
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    // No cwd → cannot resume
+    const result = await backend.sendPrompt('session-3', 'hello', scope);
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toBe('no_acp_runtime');
+  });
+
+  it('does not attempt resume when runtime is already active', async () => {
+    const service = new FakeSessionService();
+    const client = new FakeBackendClient();
+    client.setResult('initialize', {});
+    client.setResult('session/new', { sessionId: 'acp-agent-session-1' });
+    client.setResult('session/prompt', { ok: true });
+
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'backend-run-1',
+    });
+
+    // Create a session (this registers the runtime)
+    await backend.createSession({ ...scope, cwd });
+
+    // Clear request log
+    client.requests.length = 0;
+
+    // Send prompt to active session
+    const result = await backend.sendPrompt('session-1', 'hello', scope, cwd);
+
+    expect(result.delivered).toBe(true);
+    // No resume attempt
+    expect(client.requests.some(r => r.method === 'session/resume')).toBe(false);
+    // Prompt was delivered directly
+    expect(client.requests.some(r => r.method === 'session/prompt')).toBe(true);
+  });
+});
+
+// Reuse the fake classes from acp-backend.test.ts
+class FakeBackendClient implements AcpBackendClient {
+  readonly requests: { method: string; params: AcpJsonValue | undefined }[] = [];
+  readonly notifications = new Set<(notification: AcpJsonRpcNotification) => void>();
+  readonly inboundRequests = new Set<(request: AcpJsonRpcInboundRequest) => void>();
+  readonly exits = new Set<Parameters<AcpBackendClient['onExit']>[0]>();
+  readonly errors = new Set<Parameters<AcpBackendClient['onError']>[0]>();
+  readonly results = new Map<string, unknown>();
+  readonly responses: { id: AcpJsonValue; result?: AcpJsonValue; error?: unknown }[] = [];
+  started = 0;
+  shutdowns = 0;
+
+  setResult(method: string, result: unknown): void {
+    this.results.set(method, result);
+  }
+
+  async start(): Promise<void> {
+    this.started += 1;
+  }
+
+  async request<T = AcpJsonValue>(
+    method: string,
+    params?: AcpJsonValue,
+    _options?: AcpJsonRpcRequestOptions
+  ): Promise<AcpJsonRpcSuccess<T>> {
+    this.requests.push({ method, params });
+    return {
+      jsonrpc: '2.0',
+      id: `${method}-request`,
+      result: this.results.get(method) as T,
+    };
+  }
+
+  async notify(_method: string, _params?: AcpJsonValue): Promise<void> {}
+
+  async respond(id: AcpJsonRpcId, result: AcpJsonValue): Promise<void> {
+    this.responses.push({ id, result });
+  }
+
+  async respondWithError(id: AcpJsonRpcId, error: AcpJsonRpcResponseError): Promise<void> {
+    this.responses.push({ id, error });
+  }
+
+  async shutdown(): Promise<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    expected: boolean;
+    escalated: boolean;
+  }> {
+    this.shutdowns += 1;
+    return { code: 0, signal: null, expected: true, escalated: false };
+  }
+
+  onNotification(listener: (notification: AcpJsonRpcNotification) => void): () => void {
+    this.notifications.add(listener);
+    return () => this.notifications.delete(listener);
+  }
+
+  onRequest(listener: (request: AcpJsonRpcInboundRequest) => void): () => void {
+    this.inboundRequests.add(listener);
+    return () => this.inboundRequests.delete(listener);
+  }
+
+  onExit(listener: Parameters<AcpBackendClient['onExit']>[0]): () => void {
+    this.exits.add(listener);
+    return () => this.exits.delete(listener);
+  }
+
+  onError(listener: Parameters<AcpBackendClient['onError']>[0]): () => void {
+    this.errors.add(listener);
+    return () => this.errors.delete(listener);
+  }
+}
+
+class FakeSessionService implements AcpBackendSessionService {
+  readonly records = new Map<string, AcpSessionRecord>();
+  readonly createdInputs: AcpCreateSessionInput[] = [];
+  readonly attachments: unknown[] = [];
+  readonly transitions: unknown[] = [];
+  readonly restartRecords: unknown[] = [];
+
+  constructor() {
+    // Default session-1 record
+    this.records.set('session-1', {
+      id: 'session-1',
+      conversationId: 'conv-1',
+      transcriptId: 'transcript-1',
+      acpAgentSessionId: undefined,
+      status: "initializing" as const, createdAt: Date.now(), updatedAt: Date.now(),
+      ...scope,
+    });
+  }
+
+  async createSession(input: AcpCreateSessionInput): Promise<AcpSessionRecord> {
+    this.createdInputs.push(input);
+    return this.records.get('session-1')!;
+  }
+
+  async getSession(sessionId: string, _scope: AcpSessionScope): Promise<AcpSessionRecord> {
+    const record = this.records.get(sessionId);
+    if (!record) throw new Error(`Session ${sessionId} not found`);
+    return record;
+  }
+
+  async attachAgentSession(
+    sessionId: string,
+    _scope: AcpSessionScope,
+    attachment: { acpAgentSessionId?: string; claudeSessionId?: string; backendRunId?: string }
+  ): Promise<AcpSessionRecord> {
+    const record = this.records.get(sessionId)!;
+    record.acpAgentSessionId = attachment.acpAgentSessionId;
+    record.currentBackendRunId = attachment.backendRunId;
+    record.status = 'running';
+    this.attachments.push({ sessionId, attachment });
+    return record;
+  }
+
+  async transition(
+    sessionId: string,
+    _scope: AcpSessionScope,
+    event: AcpSessionTransitionEvent
+  ): Promise<AcpSessionRecord> {
+    const record = this.records.get(sessionId)!;
+    if (event.type === 'agent_ready') record.status = 'running';
+    if (event.type === 'runtime_failed') record.status = 'failed';
+    if (event.type === 'close_completed') record.status = 'closed';
+    this.transitions.push({ sessionId, event });
+    return record;
+  }
+
+  async recordBackendRestart(
+    sessionId: string,
+    _scope: AcpSessionScope,
+    backendRunId?: string
+  ): Promise<AcpSessionRecord> {
+    const record = this.records.get(sessionId)!;
+    record.currentBackendRunId = backendRunId;
+    this.restartRecords.push({ sessionId, backendRunId });
+    return record;
+  }
+}

--- a/src/routes/session-actions.ts
+++ b/src/routes/session-actions.ts
@@ -55,7 +55,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     }
     try {
       const result = acpBackend && config.acpEnabled
-        ? await acpBackend.sendPrompt(sessionId, text, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
+        ? await acpBackend.sendPrompt(sessionId, text, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' }, session.workDir)
         : await sessions.sendMessage(sessionId, text);
       // Issue #1809: Re-fetch stall info AFTER delivery to avoid false-positive.
       // Previously we called getStallInfo BEFORE send, capturing a stale state
@@ -287,7 +287,7 @@ export function registerSessionActionRoutes(app: FastifyInstance, ctx: RouteCont
     try {
       const cmd = command.startsWith('/') ? command : `/${command}`;
       const cmdResult = acpBackend && config.acpEnabled
-        ? await acpBackend.sendPrompt(session.id, cmd, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
+        ? await acpBackend.sendPrompt(session.id, cmd, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' }, session.workDir)
         : await sessions.sendMessage(session.id, cmd);
       return { ok: true };
     } catch (e: unknown) {

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -437,7 +437,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
             }
           }
           promptDelivery = acpBackend && ctx.config.acpEnabled
-          ? await acpBackend.sendPrompt(existing.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' })
+          ? await acpBackend.sendPrompt(existing.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' }, existing.workDir)
           : await sessions.sendInitialPrompt(existing.id, finalPrompt);
           metrics.promptSent(promptDelivery.delivered);
         }
@@ -537,7 +537,7 @@ export function registerSessionRoutes(app: FastifyInstance, ctx: RouteContext): 
             throw e;
           }
         }
-        const result = await acpBackend.sendPrompt(session.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' });
+        const result = await acpBackend.sendPrompt(session.id, finalPrompt, { tenantId: req.tenantId ?? SYSTEM_TENANT, ownerKeyId: req.authKeyId ?? 'master' }, session.workDir);
         promptDelivery = { delivered: result.delivered, attempts: result.attempts, status: result.delivered ? 'delivered' : 'failed', error: result.error };
         session.promptDelivery = promptDelivery;
         metrics.promptSent(result.delivered);

--- a/src/services/acp/backend.ts
+++ b/src/services/acp/backend.ts
@@ -170,16 +170,10 @@ export class AcpBackend {
 
   /**
    * Issue #4456: Create a new ACP session without blocking on the runtime handshake.
-   * Returns immediately with the durable session record while the child process
-   * spawn + initialize + session/new handshake runs in the background.
-   *
-   * Use this for HTTP endpoints where synchronous handshake causes client timeouts
-   * (e.g., POST /v1/sessions hanging for 2+ minutes).
    */
   async createSessionAsync(input: AcpBackendCreateSessionInput): Promise<AcpBackendStartResult> {
     const session = await this.sessionService.createSession(toCreateSessionInput(input));
     const backendRunId = this.backendRunIdProvider();
-
     // Fire-and-forget the handshake — caller gets the session record immediately.
     // On success, session transitions to agent_ready. On failure, transitions to error.
     const ready = runtimeLifecycle.startNewRuntimeBackground(
@@ -312,13 +306,19 @@ export class AcpBackend {
 
   /**
    * Issue #3093: Direct prompt delivery to ACP runtime.
+   * Issue #4695: Auto-resume runtime when session is idle but resumable.
    */
   async sendPrompt(
     sessionId: string,
     text: string,
-    scope: AcpSessionScope
+    scope: AcpSessionScope,
+    cwd?: string
   ): Promise<{ delivered: boolean; attempts: number; error?: string }> {
-    const runtime = this.runtimes.get(sessionId);
+    let runtime = this.runtimes.get(sessionId);
+    if (!runtime && cwd) {
+      const resumed = await promptModule.autoResumeRuntime(this.getRuntimeDeps(), this.getPromptDeps(), sessionId, scope, cwd);
+      if (resumed) runtime = resumed;
+    }
     if (!runtime) {
       return { delivered: false, attempts: 0, error: 'no_acp_runtime' };
     }

--- a/src/services/acp/backend/prompts.ts
+++ b/src/services/acp/backend/prompts.ts
@@ -9,6 +9,8 @@ import type { AcpSessionScope } from '../types.js';
 import { StructuredLogger } from '../../../logger.js';
 import { AcpBackendLifecycleError } from './errors.js';
 import type { AcpBackendRuntime } from './types.js';
+import * as runtimeLifecycle from './runtime.js';
+import type { AcpSessionRecord } from '../types.js';
 
 const log = new StructuredLogger();
 
@@ -84,5 +86,41 @@ export async function sendPrompt(
     return { delivered: false, attempts: 1, error: (err as Error).message };
   } finally {
     deps.inFlightPrompts.delete(sessionId);
+  }
+}
+
+// Issue #4695: Auto-resume helper for sendPrompt.
+// When no active runtime exists, attempt to resume the ACP session
+// so iterative prompts can be delivered to idle sessions.
+export async function autoResumeRuntime(
+  runtimeDeps: import('./runtime.js').RuntimeLifecycleDeps,
+  promptDeps: PromptDeps,
+  sessionId: string,
+  scope: AcpSessionScope,
+  cwd: string
+): Promise<AcpBackendRuntime | null> {
+  try {
+    const session = await promptDeps.sessionService.getSession(sessionId, scope);
+    if (!session.acpAgentSessionId) {
+      return null;
+    }
+    log.info({
+      component: 'acp-backend',
+      operation: 'autoResume',
+      attributes: { sessionId, reason: 'no_acp_runtime' },
+    });
+    await runtimeLifecycle.startResumeRuntime(
+      runtimeDeps,
+      session as AcpSessionRecord,
+      cwd,
+    );
+    return runtimeDeps.runtimes.get(sessionId) ?? null;
+  } catch (err) {
+    log.warn({
+      component: 'acp-backend',
+      operation: 'autoResumeFailed',
+      attributes: { sessionId, error: String(err) },
+    });
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4695 — Auto-resume del runtime ACP su sendPrompt quando non attivo.

## Problem

When CC goes idle after completing a turn, the ACP runtime is removed from the active runtimes map. The next `sendPrompt()` call finds no runtime and silently returns `{delivered: false, error: 'no_acp_runtime'}`. The user sees `ok: true` from the API but the message is never delivered to CC.

This blocks all iterative session workflows — every prompt after the first one fails.

## Fix

When `sendPrompt()` finds no active runtime:
1. Fetch the session record to check for `acpAgentSessionId`
2. If resumable, call `startResumeRuntime()` (spawn fresh CC process + session/resume)
3. Deliver the prompt to the resumed runtime
4. Return `{delivered: true}`

All via existing ACP protocol methods — no new extensions.

## Changes

- `src/services/acp/backend.ts`: `sendPrompt()` accepts optional `cwd` param, calls `autoResumeRuntime()` when no runtime
- `src/services/acp/backend/prompts.ts`: New `autoResumeRuntime()` helper
- `src/routes/session-actions.ts`: Pass `session.workDir` to `sendPrompt()`
- `src/routes/sessions.ts`: Pass `session.workDir` to `sendPrompt()`
- `src/__tests__/acp-sendprompt-auto-resume-4695.test.ts`: 4 new tests

## Tests

- `npx vitest run src/__tests__/acp-sendprompt-auto-resume-4695.test.ts`: 4/4 pass
- `npx vitest run src/__tests__/acp-backend.test.ts`: 23/23 pass (regression)
- `npm run gate:arch`: pass (backend.ts 499 lines)
- `npx tsc --noEmit`: pass

## Acceptance Criteria

- [x] `ag send` a sessione idle → resume + consegna
- [x] `delivered: true` su successo
- [x] Errore pulito se non resumable
- [x] Test di regressione per sessioni attive (no resume attempt)
- [x] Tutto tramite codice esistente — niente nuove estensioni del protocollo

Fixes #4695