### PR TITLE
fix(acp): auto-approve permissions for non-default modes to prevent deadlock (#4689)

### DIFF
--- a/src/__tests__/acp-permission-auto-approve-4689.test.ts
+++ b/src/__tests__/acp-permission-auto-approve-4689.test.ts
@@ -1,0 +1,251 @@
+/**
+ * acp-permission-auto-approve-4689.test.ts
+ *
+ * Issue #4689: Prevent permission approval deadlock for non-default modes.
+ *
+ * When permission mode is acceptEdits/bypassPermissions/auto/dontAsk,
+ * session/request_permission should be auto-approved instead of stored
+ * as pending (which causes deadlock).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  AcpBackend,
+  type AcpBackendClient,
+  type AcpBackendClientFactoryContext,
+  type AcpBackendSessionService,
+  type AcpCreateSessionInput,
+  type AcpJsonRpcId,
+  type AcpJsonRpcInboundRequest,
+  type AcpJsonRpcNotification,
+  type AcpJsonRpcRequestOptions,
+  type AcpJsonRpcResponseError,
+  type AcpJsonRpcSuccess,
+  type AcpJsonValue,
+  type AcpSessionRecord,
+  type AcpSessionScope,
+  type AcpSessionTransitionEvent,
+} from '../services/acp/index.js';
+
+const scope: AcpSessionScope = {
+  tenantId: 'tenant-a',
+  ownerKeyId: 'owner-a',
+};
+
+const cwd = '/tmp/test-workspace';
+
+describe('Issue #4689: Permission auto-approve for non-default modes', () => {
+  it('auto-approves permission requests for acceptEdits mode', async () => {
+    const service = new FakeSessionService({ permissionMode: 'acceptEdits' });
+    const client = new FakeBackendClient();
+    client.setResult('initialize', {});
+    client.setResult('session/new', { sessionId: 'acp-agent-1' });
+
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'run-1',
+    });
+
+    await backend.createSession({ ...scope, cwd });
+
+    // Simulate bridge sending session/request_permission
+    const permRequest: AcpJsonRpcInboundRequest = {
+      jsonrpc: '2.0',
+      id: 'perm-1',
+      method: 'session/request_permission',
+      params: { sessionId: 'acp-agent-1', toolCall: { kind: 'Read' } },
+      raw: {},
+    };
+    client.emitRequest(permRequest);
+
+    // Give the async respond() a tick to fire
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // Should have auto-responded with allow-once
+    expect(client.responses.length).toBe(1);
+    expect(client.responses[0].id).toBe('perm-1');
+    expect(client.responses[0].result).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' },
+    });
+
+    // Should NOT have stored as pending approval
+    expect(backend.getPendingApproval('session-1')).toBeNull();
+  });
+
+  it('stores permission requests for default mode (no auto-approve)', async () => {
+    const service = new FakeSessionService({ permissionMode: 'default' });
+    const client = new FakeBackendClient();
+    client.setResult('initialize', {});
+    client.setResult('session/new', { sessionId: 'acp-agent-1' });
+
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'run-1',
+    });
+
+    await backend.createSession({ ...scope, cwd });
+
+    const permRequest: AcpJsonRpcInboundRequest = {
+      jsonrpc: '2.0',
+      id: 'perm-2',
+      method: 'session/request_permission',
+      params: { sessionId: 'acp-agent-1', toolCall: { kind: 'Bash' } },
+      raw: {},
+    };
+    client.emitRequest(permRequest);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // Should NOT have auto-responded
+    expect(client.responses.length).toBe(0);
+
+    // Should have stored as pending approval
+    const pending = backend.getPendingApproval('session-1');
+    expect(pending).not.toBeNull();
+    expect(pending!.approvalId).toBe('perm-2');
+  });
+
+  it('auto-approves for bypassPermissions mode', async () => {
+    const service = new FakeSessionService({ permissionMode: 'bypassPermissions' });
+    const client = new FakeBackendClient();
+    client.setResult('initialize', {});
+    client.setResult('session/new', { sessionId: 'acp-agent-1' });
+
+    const backend = new AcpBackend({
+      sessionService: service,
+      clientFactory: () => client,
+      backendRunIdProvider: () => 'run-1',
+    });
+
+    await backend.createSession({ ...scope, cwd });
+
+    client.emitRequest({
+      jsonrpc: '2.0',
+      id: 'perm-3',
+      method: 'session/request_permission',
+      params: {},
+      raw: {},
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(client.responses.length).toBe(1);
+    expect(backend.getPendingApproval('session-1')).toBeNull();
+  });
+});
+
+// Fake classes (same pattern as acp-backend.test.ts)
+class FakeBackendClient implements AcpBackendClient {
+  readonly requests: { method: string; params: AcpJsonValue | undefined }[] = [];
+  readonly notifications = new Set<(n: AcpJsonRpcNotification) => void>();
+  readonly inboundRequests = new Set<(r: AcpJsonRpcInboundRequest) => void>();
+  readonly exits = new Set<Parameters<AcpBackendClient['onExit']>[0]>();
+  readonly errors = new Set<Parameters<AcpBackendClient['onError']>[0]>();
+  readonly results = new Map<string, unknown>();
+  readonly responses: { id: AcpJsonValue; result?: AcpJsonValue; error?: unknown }[] = [];
+  started = 0;
+  shutdowns = 0;
+
+  setResult(method: string, result: unknown): void {
+    this.results.set(method, result);
+  }
+
+  async start(): Promise<void> { this.started++; }
+
+  async request<T = AcpJsonValue>(
+    method: string,
+    params?: AcpJsonValue,
+    _options?: AcpJsonRpcRequestOptions
+  ): Promise<AcpJsonRpcSuccess<T>> {
+    this.requests.push({ method, params });
+    return { jsonrpc: '2.0', id: `${method}-req`, result: this.results.get(method) as T };
+  }
+
+  async notify(_method: string, _params?: AcpJsonValue): Promise<void> {}
+
+  async respond(id: AcpJsonRpcId, result: AcpJsonValue): Promise<void> {
+    this.responses.push({ id, result });
+  }
+
+  async respondWithError(id: AcpJsonRpcId, error: AcpJsonRpcResponseError): Promise<void> {
+    this.responses.push({ id, error });
+  }
+
+  async shutdown(): Promise<{ code: number | null; signal: NodeJS.Signals | null; expected: boolean; escalated: boolean }> {
+    this.shutdowns++;
+    return { code: 0, signal: null, expected: true, escalated: false };
+  }
+
+  onNotification(l: (n: AcpJsonRpcNotification) => void): () => void {
+    this.notifications.add(l);
+    return () => this.notifications.delete(l);
+  }
+
+  onRequest(l: (r: AcpJsonRpcInboundRequest) => void): () => void {
+    this.inboundRequests.add(l);
+    return () => this.inboundRequests.delete(l);
+  }
+
+  onExit(l: Parameters<AcpBackendClient['onExit']>[0]): () => void {
+    this.exits.add(l);
+    return () => this.exits.delete(l);
+  }
+
+  onError(l: Parameters<AcpBackendClient['onError']>[0]): () => void {
+    this.errors.add(l);
+    return () => this.errors.delete(l);
+  }
+
+  emitRequest(request: AcpJsonRpcInboundRequest): void {
+    for (const l of this.inboundRequests) l(request);
+  }
+}
+
+class FakeSessionService implements AcpBackendSessionService {
+  private record: AcpSessionRecord;
+  readonly createdInputs: AcpCreateSessionInput[] = [];
+
+  constructor(opts: { permissionMode?: string } = {}) {
+    this.record = {
+      id: 'session-1',
+      conversationId: 'conv-1',
+      transcriptId: 'transcript-1',
+      status: 'initializing' as const,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      permissionMode: opts.permissionMode,
+      ...scope,
+    };
+  }
+
+  async createSession(input: AcpCreateSessionInput): Promise<AcpSessionRecord> {
+    this.createdInputs.push(input);
+    return this.record;
+  }
+
+  async getSession(): Promise<AcpSessionRecord> {
+    return this.record;
+  }
+
+  async attachAgentSession(): Promise<AcpSessionRecord> {
+    this.record.acpAgentSessionId = 'acp-agent-1';
+    this.record.status = 'running';
+    return this.record;
+  }
+
+  async transition(
+    _sessionId: string,
+    _scope: AcpSessionScope,
+    event: AcpSessionTransitionEvent
+  ): Promise<AcpSessionRecord> {
+    if (event.type === 'agent_ready') this.record.status = 'running';
+    return this.record;
+  }
+
+  async recordBackendRestart(): Promise<AcpSessionRecord> {
+    return this.record;
+  }
+}

--- a/src/services/acp/backend/runtime.ts
+++ b/src/services/acp/backend/runtime.ts
@@ -244,6 +244,7 @@ export async function createRuntime(
     backendRunId,
     client: deps.clientFactory(context),
     disposers: [],
+    permissionMode: session.permissionMode,
   });
 }
 
@@ -257,7 +258,17 @@ export function bindRuntime(
     }),
     runtime.client.onRequest((request) => {
       if (request.method === 'session/request_permission') {
-        trackPendingApproval(deps, runtime.sessionId, request);
+        // Issue #4689: Auto-approve permission requests for non-default
+        // permission modes to prevent deadlock. In acceptEdits/bypassPermissions/auto
+        // modes, CC should be allowed to proceed without manual approval.
+        const mode = runtime.permissionMode ?? 'default';
+        if (mode === 'acceptEdits' || mode === 'bypassPermissions' || mode === 'auto' || mode === 'dontAsk') {
+          void runtime.client.respond(request.id, {
+            outcome: { outcome: 'selected', optionId: 'allow-once' },
+          });
+        } else {
+          trackPendingApproval(deps, runtime.sessionId, request);
+        }
       }
       deps.options.onRawRequest?.(request);
     }),

--- a/src/services/acp/backend/types.ts
+++ b/src/services/acp/backend/types.ts
@@ -248,4 +248,9 @@ export interface AcpBackendRuntime {
   disposers: (() => void)[];
   cleanupPromise?: Promise<AcpBackendShutdownResult>;
   agentCapabilities?: AcpJsonValue;
+  /**
+   * Issue #4689: Session permission mode. Used by the onRequest handler
+   * to auto-approve permission requests when mode allows it.
+   */
+  permissionMode?: string;
 }


### PR DESCRIPTION
## Summary

Fixes #4689 — CC tool results never delivered via ACP bridge. Sessions hang at first tool call.

## Root Cause

Three-way deadlock:
1. CC wants to use a tool → bridge sends `session/request_permission` to Aegis
2. Aegis stores as pending approval, waits for user to call `approveSession()`
3. Bridge is blocked awaiting JSON-RPC response → CC is blocked awaiting tool result
4. **Session hangs forever**

## Fix

When permission mode is `acceptEdits`, `bypassPermissions`, `auto`, or `dontAsk`, Aegis auto-responds to `session/request_permission` with `allow-once` instead of storing it as pending.

`default` mode still stores as pending for manual approval (unchanged behavior).

## Changes

- `AcpBackendRuntime`: added `permissionMode` field
- `bindRuntime` onRequest handler: auto-approve for non-default modes
- 3 new tests + 32 regression tests pass

## Tests

- `npx vitest run src/__tests__/acp-permission-auto-approve-4689.test.ts`: 3/3 pass
- `npx vitest run src/__tests__/acp-backend.test.ts`: 23/23 pass (regression)
- `npx vitest run src/__tests__/acp-permission-mode-4522.test.ts`: 9/9 pass (regression)
- `npm run gate:arch`: pass
- `npx tsc --noEmit`: pass

## Acceptance Criteria

- [x] Permission requests auto-approved for acceptEdits mode
- [x] Permission requests stored for default mode (manual approval)
- [x] No regression on existing permission mode tests (#4522)

## Related Issues

- #4691 (orphaned processes): caused by sessions killed while deadlocked — fixed by preventing deadlock
- #4693 (byteOffset 0): caused by session never progressing past first tool — same root cause

Fixes #4689