### PR TITLE
feat(session): create git worktree for session isolation (#4694)

### DIFF
--- a/src/__tests__/session/worktree-4694.test.ts
+++ b/src/__tests__/session/worktree-4694.test.ts
@@ -9,14 +9,22 @@ import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import { createSessionWorktree, removeSessionWorktree } from '../../services/session/worktree.js';
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-}));
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-  mkdirSync: vi.fn(),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
 
 describe('Issue #4694: createSessionWorktree', () => {
   beforeEach(() => { vi.clearAllMocks(); });

--- a/src/__tests__/session/worktree-4694.test.ts
+++ b/src/__tests__/session/worktree-4694.test.ts
@@ -1,0 +1,85 @@
+/**
+ * worktree-4694.test.ts
+ *
+ * Issue #4694: Git worktree creation for session isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import { createSessionWorktree, removeSessionWorktree } from '../../services/session/worktree.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+describe('Issue #4694: createSessionWorktree', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('creates a worktree when in a git repo', () => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args: string[], opts?: any) => {
+      const enc = typeof opts === 'object' && opts ? opts.encoding : undefined;
+      const asStr = (s: string) => enc === 'utf8' ? s : Buffer.from(s);
+      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return asStr('true\n');
+      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return asStr('develop\n');
+      return asStr('');
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = createSessionWorktree('/fake/repo', 'acc154fb-ec97');
+
+    expect(result.path).toContain('.claude/worktrees/acc154fb-ec9');
+    expect(result.branch).toBe('session/acc154fb');
+  });
+
+  it('returns repoRoot when not a git repo', () => {
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('not a git repo'); });
+
+    const result = createSessionWorktree('/fake/dir', 'test12345');
+
+    expect(result.path).toBe('/fake/dir');
+    expect(result.branch).toBe('');
+  });
+
+  it('reuses existing worktree if path exists', () => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args: string[], opts?: any) => {
+      const enc = typeof opts === 'object' && opts ? opts.encoding : undefined;
+      const asStr = (s: string) => enc === 'utf8' ? s : Buffer.from(s);
+      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return asStr('true\n');
+      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return asStr('develop\n');
+      return asStr('');
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const result = createSessionWorktree('/fake/repo', 'acc154fb-ec97');
+
+    expect(result.path).toContain('.claude/worktrees/acc154fb-ec9');
+    const worktreeCalls = vi.mocked(execFileSync).mock.calls.filter(
+      ([cmd, args]) => cmd === 'git' && args?.[0] === 'worktree'
+    );
+    expect(worktreeCalls.length).toBe(0);
+  });
+});
+
+describe('Issue #4694: removeSessionWorktree', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('removes worktree and branch', () => {
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(''));
+
+    removeSessionWorktree('/fake/repo', '/fake/repo/.claude/worktrees/session123', 'session/session12');
+
+    expect(execFileSync).toHaveBeenCalledWith('git', expect.arrayContaining(['worktree', 'remove']), expect.any(Object));
+    expect(execFileSync).toHaveBeenCalledWith('git', expect.arrayContaining(['branch', '-D']), expect.any(Object));
+  });
+
+  it('no-ops when path equals repoRoot', () => {
+    removeSessionWorktree('/fake/repo', '/fake/repo', '');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/session/worktree-4694.test.ts
+++ b/src/__tests__/session/worktree-4694.test.ts
@@ -17,13 +17,13 @@ vi.mock('node:child_process', async (importOriginal) => {
   };
 });
 
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
+vi.mock(import('node:fs'), async (importOriginal) => {
+  const actual = await importOriginal();
   return {
     ...actual,
     existsSync: vi.fn(),
     mkdirSync: vi.fn(),
-  };
+  } as any;
 });
 
 describe('Issue #4694: createSessionWorktree', () => {
@@ -47,11 +47,13 @@ describe('Issue #4694: createSessionWorktree', () => {
 
   it('returns repoRoot when not a git repo', () => {
     vi.mocked(execFileSync).mockImplementation(() => { throw new Error('not a git repo'); });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
 
     const result = createSessionWorktree('/fake/dir', 'test12345');
 
     expect(result.path).toBe('/fake/dir');
     expect(result.branch).toBe('');
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
   });
 
   it('reuses existing worktree if path exists', () => {

--- a/src/__tests__/session/worktree-4694.test.ts
+++ b/src/__tests__/session/worktree-4694.test.ts
@@ -22,11 +22,11 @@ describe('Issue #4694: createSessionWorktree', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
   it('creates a worktree when in a git repo', () => {
-    vi.mocked(execFileSync).mockImplementation((cmd: string, args: string[], opts?: any) => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args?: readonly string[] | undefined, opts?: any): any => {
       const enc = typeof opts === 'object' && opts ? opts.encoding : undefined;
       const asStr = (s: string) => enc === 'utf8' ? s : Buffer.from(s);
-      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return asStr('true\n');
-      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return asStr('develop\n');
+      if (cmd === 'git' && args?.[0] === 'rev-parse' && args?.[1] === '--is-inside-work-tree') return asStr('true\n');
+      if (cmd === 'git' && args?.[0] === 'rev-parse' && args?.[1] === '--abbrev-ref') return asStr('develop\n');
       return asStr('');
     });
     vi.mocked(fs.existsSync).mockReturnValue(false);
@@ -47,11 +47,11 @@ describe('Issue #4694: createSessionWorktree', () => {
   });
 
   it('reuses existing worktree if path exists', () => {
-    vi.mocked(execFileSync).mockImplementation((cmd: string, args: string[], opts?: any) => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args?: readonly string[] | undefined, opts?: any): any => {
       const enc = typeof opts === 'object' && opts ? opts.encoding : undefined;
       const asStr = (s: string) => enc === 'utf8' ? s : Buffer.from(s);
-      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return asStr('true\n');
-      if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return asStr('develop\n');
+      if (cmd === 'git' && args?.[0] === 'rev-parse' && args?.[1] === '--is-inside-work-tree') return asStr('true\n');
+      if (cmd === 'git' && args?.[0] === 'rev-parse' && args?.[1] === '--abbrev-ref') return asStr('develop\n');
       return asStr('');
     });
     vi.mocked(fs.existsSync).mockReturnValue(true);
@@ -60,7 +60,7 @@ describe('Issue #4694: createSessionWorktree', () => {
 
     expect(result.path).toContain('.claude/worktrees/acc154fb-ec9');
     const worktreeCalls = vi.mocked(execFileSync).mock.calls.filter(
-      ([cmd, args]) => cmd === 'git' && args?.[0] === 'worktree'
+      ([cmd, args]) => cmd === 'git' && (args as readonly string[] | undefined)?.[0] === 'worktree'
     );
     expect(worktreeCalls.length).toBe(0);
   });

--- a/src/services/session/session-factory.ts
+++ b/src/services/session/session-factory.ts
@@ -22,6 +22,7 @@ import {
   detectIsolationMode,
   detectModelFromSettings,
 } from '../../session-helpers.js';
+import { createSessionWorktree } from './worktree.js';
 import type { SessionInfo, UIState } from '../../session-types.js';
 import { StructuredLogger } from '../../logger.js';
 
@@ -192,12 +193,27 @@ export async function buildSessionInfo(
     }
   }
 
+  // Issue #4694: Create git worktree for session isolation when mode is 'worktree'
+  let effectiveWorkDir = opts.workDir;
+  if (isolationMode === 'worktree') {
+    const worktreeResult = createSessionWorktree(opts.workDir, id);
+    if (worktreeResult.path !== opts.workDir) {
+      effectiveWorkDir = worktreeResult.path;
+      log.info({
+        component: 'session',
+        operation: 'worktreeIsolationActive',
+        sessionId: id,
+        attributes: { worktreePath: effectiveWorkDir, branch: worktreeResult.branch },
+      });
+    }
+  }
+
   // Step 9: Build the SessionInfo object
   const session: SessionInfo = {
     id,
     windowId: '',
     displayName,
-    workDir: opts.workDir,
+    workDir: effectiveWorkDir,
     claudeSessionId: undefined,
     byteOffset: 0,
     monitorOffset: 0,

--- a/src/services/session/worktree.ts
+++ b/src/services/session/worktree.ts
@@ -1,0 +1,150 @@
+/**
+ * session/worktree.ts — Git worktree creation for session isolation.
+ *
+ * Issue #4694: When isolationMode is 'worktree', Aegis creates a git worktree
+ * so the session operates in an isolated branch, preventing uncommitted changes
+ * from polluting the main workspace.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { StructuredLogger } from '../../logger.js';
+
+const log = new StructuredLogger();
+
+export interface WorktreeCreationResult {
+  /** Absolute path to the created worktree. */
+  path: string;
+  /** Branch name used for the worktree. */
+  branch: string;
+}
+
+/**
+ * Create a git worktree for session isolation.
+ *
+ * @param repoRoot - The repository root directory
+ * @param sessionId - The Aegis session ID (used for branch naming)
+ * @returns The worktree path and branch name
+ * @throws if git operations fail
+ */
+export function createSessionWorktree(
+  repoRoot: string,
+  sessionId: string
+): WorktreeCreationResult {
+  const worktreeDir = join(repoRoot, '.claude', 'worktrees');
+  const branch = `session/${sessionId.slice(0, 8)}`;
+  const worktreePath = join(worktreeDir, sessionId.slice(0, 12));
+
+  // Ensure the worktrees parent directory exists
+  if (!existsSync(worktreeDir)) {
+    mkdirSync(worktreeDir, { recursive: true });
+  }
+
+  // Check if this is a git repo
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+      timeout: 5_000,
+    });
+  } catch {
+    log.warn({
+      component: 'session',
+      operation: 'worktreeNotARepo',
+      attributes: { repoRoot },
+    });
+    // Not a git repo — can't create worktree, return original dir
+    return { path: repoRoot, branch: '' };
+  }
+
+  // Check if worktree already exists for this session
+  if (existsSync(worktreePath)) {
+    log.info({
+      component: 'session',
+      operation: 'worktreeReused',
+      attributes: { sessionId, worktreePath },
+    });
+    return { path: worktreePath, branch };
+  }
+
+  // Create worktree from current HEAD
+  const baseBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: 5_000,
+  }).trim();
+
+  try {
+    execFileSync('git', [
+      'worktree', 'add',
+      '-b', branch,
+      worktreePath,
+      baseBranch,
+    ], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+      timeout: 30_000,
+    });
+
+    log.info({
+      component: 'session',
+      operation: 'worktreeCreated',
+      attributes: { sessionId, worktreePath, branch, baseBranch },
+    });
+
+    return { path: worktreePath, branch };
+  } catch (err) {
+    log.warn({
+      component: 'session',
+      operation: 'worktreeCreationFailed',
+      attributes: { sessionId, error: String(err) },
+    });
+    // Fallback: return original dir (session works without isolation)
+    return { path: repoRoot, branch: '' };
+  }
+}
+
+/**
+ * Remove a session worktree after the session ends.
+ *
+ * @param repoRoot - The repository root directory
+ * @param worktreePath - The worktree path to remove
+ * @param branch - The branch to delete
+ */
+export function removeSessionWorktree(
+  repoRoot: string,
+  worktreePath: string,
+  branch: string
+): void {
+  if (!worktreePath || worktreePath === repoRoot) return;
+
+  try {
+    execFileSync('git', ['worktree', 'remove', '--force', worktreePath], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+      timeout: 10_000,
+    });
+
+    if (branch) {
+      execFileSync('git', ['branch', '-D', branch], {
+        cwd: repoRoot,
+        stdio: 'pipe',
+        timeout: 5_000,
+      });
+    }
+
+    log.info({
+      component: 'session',
+      operation: 'worktreeRemoved',
+      attributes: { worktreePath, branch },
+    });
+  } catch (err) {
+    log.warn({
+      component: 'session',
+      operation: 'worktreeRemovalFailed',
+      attributes: { worktreePath, error: String(err) },
+    });
+  }
+}

--- a/src/services/session/worktree.ts
+++ b/src/services/session/worktree.ts
@@ -36,11 +36,6 @@ export function createSessionWorktree(
   const branch = `session/${sessionId.slice(0, 8)}`;
   const worktreePath = join(worktreeDir, sessionId.slice(0, 12));
 
-  // Ensure the worktrees parent directory exists
-  if (!existsSync(worktreeDir)) {
-    mkdirSync(worktreeDir, { recursive: true });
-  }
-
   // Check if this is a git repo
   try {
     execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
@@ -56,6 +51,11 @@ export function createSessionWorktree(
     });
     // Not a git repo — can't create worktree, return original dir
     return { path: repoRoot, branch: '' };
+  }
+
+  // Ensure the worktrees parent directory exists (only after confirming git repo)
+  if (!existsSync(worktreeDir)) {
+    mkdirSync(worktreeDir, { recursive: true });
   }
 
   // Check if worktree already exists for this session


### PR DESCRIPTION
## Summary

Fixes #4694 — Sessions with `isolationMode: "worktree"` now get an actual git worktree.

## Problem

Aegis recorded `isolationMode: "worktree"` on session records but never created the worktree. CC sessions worked directly in the main workspace, causing uncommitted changes to pollute the repo and no isolation between concurrent sessions.

## Fix

When `isolationMode` is `worktree`, `session-factory.ts` now calls `createSessionWorktree()` which:

1. Checks if the workDir is a git repo
2. Creates `.claude/worktrees/<session-id>` as a git worktree branched from current HEAD
3. Sets the session's `workDir` to the worktree path
4. Falls back to the original workDir if not a git repo or creation fails

## Changes

- **New:** `src/services/session/worktree.ts` — `createSessionWorktree()` + `removeSessionWorktree()`
- **Modified:** `src/services/session/session-factory.ts` — wired worktree creation into the session build
- **New:** `src/__tests__/session/worktree-4694.test.ts` — 5 unit tests

## Tests

- `npx vitest run src/__tests__/session/worktree-4694.test.ts`: 5/5 pass
- `npm run gate:arch`: pass
- `npx tsc --noEmit`: pass

Fixes #4694