### PR TITLE
docs(cli+api): follow-up gaps for #4685/#4689/#4695 — quick-start + auto-resume/auto-approve notes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1611,6 +1611,8 @@ Sends a text message to the Claude Code session.
 **Aliases:** `POST /v1/sessions/:id/input` and `POST /v1/sessions/:id/prompt` — identical behavior.
 
 > **Note:** Session creation accepts a `prompt` field for the initial message; for follow-up messages, use `/send`, `/input`, or `/prompt` with the `text` field.
+>
+> **Auto-resume:** If the session's ACP runtime is inactive (e.g., after a long idle period), the server automatically attempts to resume it before delivering the message. Previously, messages sent to inactive sessions silently failed with `no_acp_runtime`.
 
 ```bash
 curl -X POST http://localhost:9100/v1/sessions/abc123/send \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -226,6 +226,8 @@ ag status <session-id>   # Get session status
 ag read <session-id>     # Read session output
 ag tail <session-id>     # Stream session output live
 ag kill <session-id>     # Kill a running session
+ag approve <session-id>  # Approve a pending permission prompt
+ag reject <session-id>   # Reject a pending permission prompt
 ```
 
 ## 5. Monitor Progress
@@ -289,6 +291,8 @@ You can also set `permissionMode` when creating a session to control approval be
 | `acceptEdits` | Auto-accepts non-destructive edits only |
 | `dontAsk` | Disables all permission prompts (fails on dangerous ops) |
 | `auto` | Claude decides when to prompt (context-dependent) |
+
+> **Note:** When a permission prompt is triggered, sessions with `permissionMode` set to `bypassPermissions`, `acceptEdits`, `dontAsk`, or `auto` automatically approve the request instead of entering `permission_prompt` status. Only `default` and `plan` modes leave permissions pending for manual approval.
 
 ## 9. Run Multiple Sessions in Parallel
 


### PR DESCRIPTION
Closes remaining docs gaps from today's merged PRs:

- **#4685**  /  — added to quick-start  CLI commands section (PR #4701 covers the full CLI reference)
- **#4689** auto-approve for non-default permission modes — added note that , , ,  auto-approve tool requests instead of leaving them pending
- **#4695** auto-resume on send — added note to  that inactive ACP runtimes are auto-resumed instead of failing with 

PR #4701 (Ema) covers the main CLI reference + worktree docs. This is the follow-up for the quick-start guide and API reference edge cases.

---
**Verification:** docs-only change, 2 files, 6 insertions. No code changes.