### PR TITLE
fix(docs): correct remaining wrong approve/reject endpoint paths

### DIFF
--- a/docs/drafts/release-notes-v0.7.0.md
+++ b/docs/drafts/release-notes-v0.7.0.md
@@ -49,7 +49,7 @@ When a session is created, Aegis sends a Telegram notification with inline Appro
 **New features:**
 - Session approval state machine: `pending_approval → approved → running` or `rejected`
 - Telegram inline keyboard buttons on session creation
-- New API endpoints: `POST /v1/sessions/:id/permission/approve` and `POST /v1/sessions/:id/permission/reject`
+- New API endpoints: `POST /v1/sessions/:id/session-approve` and `POST /v1/sessions/:id/session-reject`
 - Bot callback authentication with secret token verification
 - Configurable `sessionApproval` section with timeout auto-reject
 - Dashboard status indicators for pending approval sessions

--- a/docs/drafts/release-notes-v0.7.0.md
+++ b/docs/drafts/release-notes-v0.7.0.md
@@ -49,7 +49,7 @@ When a session is created, Aegis sends a Telegram notification with inline Appro
 **New features:**
 - Session approval state machine: `pending_approval → approved → running` or `rejected`
 - Telegram inline keyboard buttons on session creation
-- New API endpoints: `POST /v1/sessions/:id/session-approve` and `POST /v1/sessions/:id/session-reject`
+- New API endpoints: `POST /v1/sessions/:id/permission/approve` and `POST /v1/sessions/:id/permission/reject`
 - Bot callback authentication with secret token verification
 - Configurable `sessionApproval` section with timeout auto-reject
 - Dashboard status indicators for pending approval sessions

--- a/docs/drafts/release-notes-v0.7.0.md
+++ b/docs/drafts/release-notes-v0.7.0.md
@@ -49,7 +49,7 @@ When a session is created, Aegis sends a Telegram notification with inline Appro
 **New features:**
 - Session approval state machine: `pending_approval → approved → running` or `rejected`
 - Telegram inline keyboard buttons on session creation
-- New API endpoints: `POST /v1/sessions/:id/approve` and `POST /v1/sessions/:id/reject`
+- New API endpoints: `POST /v1/sessions/:id/session-approve` and `POST /v1/sessions/:id/session-reject`
 - Bot callback authentication with secret token verification
 - Configurable `sessionApproval` section with timeout auto-reject
 - Dashboard status indicators for pending approval sessions

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -72,8 +72,8 @@ Every session tracks its `ownerKeyId` — the API key that created it. Protected
 | Operation | Check |
 |-----------|-------|
 | `POST /v1/sessions/:id/send` | Key must own session |
-| `POST /v1/sessions/:id/approve` | Key must own session |
-| `POST /v1/sessions/:id/reject` | Key must own session |
+| `POST /v1/sessions/:id/permission/approve` | Key must own session |
+| `POST /v1/sessions/:id/permission/reject` | Key must own session |
 | `DELETE /v1/sessions/:id` | Key must own session |
 | `POST /v1/sessions/:id/interrupt` | Key must own session |
 | `POST /v1/sessions/:id/escape` | Key must own session |

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -269,8 +269,8 @@ All endpoints are under `/v1/`. Base URL: `http://localhost:9100`
 | `GET` | `/v1/sessions/:id/transcript` | Read transcript |
 | `DELETE` | `/v1/sessions/:id` | Kill session |
 | `GET` | `/v1/sessions/:id/sse` | SSE event stream |
-| `POST` | `/v1/sessions/:id/approve` | Approve permission |
-| `POST` | `/v1/sessions/:id/reject` | Reject permission |
+| `POST` | `/v1/sessions/:id/permission/approve` | Approve permission |
+| `POST` | `/v1/sessions/:id/permission/reject` | Reject permission |
 | `GET` | `/v1/metrics` | Prometheus metrics |
 | `GET` | `/v1/openapi.json` | OpenAPI 3.1 spec |
 


### PR DESCRIPTION
## Summary

Follow-up to PR #a6b6310a which claimed to fix all wrong /approve and /reject endpoint paths but missed three files.

## Changes

| File | Before | After | Endpoint type |
|------|--------|-------|-----------------|
| docs/enterprise.md:75 | POST /v1/sessions/:id/approve | POST /v1/sessions/:id/permission/approve | Permission approval |
| docs/enterprise.md:76 | POST /v1/sessions/:id/reject | POST /v1/sessions/:id/permission/reject | Permission approval |
| docs/onboarding.md:272 | POST /v1/sessions/:id/approve | POST /v1/sessions/:id/permission/approve | Permission approval |
| docs/onboarding.md:273 | POST /v1/sessions/:id/reject | POST /v1/sessions/:id/permission/reject | Permission approval |
| docs/drafts/release-notes-v0.7.0.md:52 | POST /v1/sessions/:id/approve | POST /v1/sessions/:id/session-approve | Session approval gate |
| docs/drafts/release-notes-v0.7.0.md:52 | POST /v1/sessions/:id/reject | POST /v1/sessions/:id/session-reject | Session approval gate |

## Verification

Canonical sources checked:
- **Permission endpoints:** src/routes/quick-approve-reject.ts:67,69,106 → POST /v1/sessions/:id/permission/approve|reject
- **Session approval endpoints:** src/routes/session-approval.ts:21,52,53,55,85,86 → POST /v1/sessions/:id/session-approve|reject
- **Legacy paths:** src/routes/control-actions.ts:10,11 → register as /approval/approve|reject (with Deprecation + Sunset headers)

## Checklist

- [x] Paths verified against canonical source code
- [x] No code changes (docs only)
- [x] Branch follows docs/* convention

Closes: docs accuracy gap from #a6b6310a