### PR TITLE
docs: #4704 fatal stderr detection + #4705/#4703 prompt delivery 422 response

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1627,7 +1627,7 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/send \
 |-----------|------|----------|-------------|
 | `text` | string | **yes** | Message to send |
 
-**Response:**
+**Response (success — `200 OK`):**
 
 ```json
 {
@@ -1637,13 +1637,29 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/send \
 }
 ```
 
+**Response (failure — `422 Unprocessable Entity`):**
+
+When the message cannot be delivered to the Claude Code runtime (e.g., timeout waiting for prompt acknowledgment, or no active transport).
+
+```json
+{
+  "error": "PROMPT_DELIVERY_FAILED",
+  "message": "prompt_ack_timeout",
+  "delivered": false,
+  "attempts": 3
+}
+```
+
+> **Error values:** `message` may be `prompt_ack_timeout` (ACP runtime did not acknowledge within the timeout), `no_active_transport` (session has no active ACP transport), or another backend-specific error string.
+
 **Errors:**
 
-| Status | Condition |
-|--------|-----------|
-| 400 | Invalid request body |
-| 404 | Session not found |
-| 429 | Per-key token/spend quota exceeded |
+| Status | Code | Condition |
+|--------|------|-----------|
+| 400 | — | Invalid request body |
+| 404 | — | Session not found |
+| 422 | `PROMPT_DELIVERY_FAILED` | Message could not be delivered to the CC runtime. Check `message` field for cause. |
+| 429 | — | Per-key token/spend quota exceeded |
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -328,6 +328,24 @@ echo $AEGIS_AUTH_TOKEN
 
 ---
 
+### Session status suddenly changes to `runtime_failed`
+
+**Cause:** The Claude Code ACP runtime encountered a fatal error (e.g., `No onPostToolUseHook found for tool use ID` or an unhandled error in the `session/prompt` handler). Aegis detects these fatal stderr patterns and automatically shuts down the runtime to prevent the session from hanging indefinitely.
+
+**Fix:**
+```bash
+# Check the session transcript for the error
+ag read <session-id> | tail -20
+
+# Or via API
+curl http://localhost:9100/v1/sessions/<id>/transcript \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Once the root cause (e.g., a malformed tool call or CC version incompatibility) is fixed, create a new session. The `runtime_failed` state is terminal — the session cannot be resumed.
+
+---
+
 ## Performance Issues
 
 ### High memory usage with many sessions


### PR DESCRIPTION
## Summary

Documents two commits that landed on develop since last heartbeat:

- **feat(acp): #4704** — Fatal CC stderr pattern detection (e.g., `No onPostToolUseHook`, `Error handling request...session/prompt`). Aegis now auto-shuts down the runtime to trigger `runtime_failed` instead of letting the session hang indefinitely.
- **fix(acp,api,cli): #4705 + #4703** — `POST /v1/sessions/:id/send` now returns **422** `PROMPT_DELIVERY_FAILED` when prompt delivery fails (was silent 200 with `delivered:false`). Error values include `prompt_ack_timeout` and `no_active_transport`. CLI `ag send` now includes `Content-Type: application/json`.

## Changes

- `docs/api-reference.md` — Updated `/send` endpoint docs:
  - Documented success (200) and failure (422) response shapes
  - Added `PROMPT_DELIVERY_FAILED` error table entry with possible `message` values
- `docs/troubleshooting.md` — Added section explaining sudden `runtime_failed` transitions after fatal CC errors, with recovery steps.

## Verification

- Read the edited sections to confirm formatting and accuracy
- Error response shape matches code in `src/routes/session-actions.ts` (commit 8bdfce21)
- Fatal stderr behavior matches `src/services/acp/backend/utils.ts` (commit 3283440c)

---

**Reviewer:** Argus
**Branch:** `docs/4704-4705-prompt-delivery-api-docs` → `develop`