### PR TITLE
docs: fix factual errors in branch-protection-checklist.md (post-#4733)

### DIFF
--- a/docs/devops/branch-protection-checklist.md
+++ b/docs/devops/branch-protection-checklist.md
@@ -1,9 +1,15 @@
 # Branch protection checklist (`develop` and `main`)
 
-> **Status:** Living doc. The required checks are enforced by the GitHub repo
-> settings UI; this document is the canonical checklist for what those
-> settings **must** be. If you change a check name, a workflow file, or a
-> required-reviewer rule, update this doc in the same PR.
+> **Status:** Living doc. This document is the canonical checklist for what the
+> GitHub branch protection settings **must be**. Where the doc lists a check
+> or reviewer that is **not yet enforced** in the repo settings UI, that row
+> is marked as **Planned** in the table below — do not enable it in the UI
+> until the prerequisite issue lands. If you change a check name, a workflow
+> file, or a required-reviewer rule, update this doc in the same PR.
+>
+> **Cross-reference:** [`docs/devops/per-agent-identities.md`](./per-agent-identities.md)
+> covers the per-agent App identity model and the related #4665 / #4731
+> work. This doc covers the **branch protection** half of that picture.
 
 This document is the source of truth for branch protection on the two
 release-relevant branches in `OneStepAt4time/aegis`:
@@ -15,58 +21,145 @@ release-relevant branches in `OneStepAt4time/aegis`:
 `docs/` and other long-lived branches use looser rules and aren't covered
 here.
 
+## Quick reference — actual state (verified 2026-06-15)
+
+Verified against `gh api repos/OneStepAt4time/aegis/branches/{develop,main}/protection`.
+
+| Setting | `develop` | `main` |
+|---|---|---|
+| Required status checks | `lint-pr-title`, `test (ubuntu-latest, 22)`, `lint`, `Analyze` (4 checks) | `lint-pr-title`, `test (ubuntu-latest, 22)`, `lint`, `Analyze` (4 checks) |
+| Strict (branches up-to-date) | `false` | `true` |
+| Required approving reviews | 1 | 1 |
+| CODEOWNER reviews required | **`false`** | **`true`** |
+| Dismiss stale reviews on push | `true` | `true` |
+| Require conversation resolution | `true` | `true` |
+| Enforce admins | `false` | `true` |
+| Force-pushes allowed | `false` | `false` |
+| Deletions allowed | `false` | `false` |
+| Linear history required | `false` | `false` |
+| Required signatures | `false` | `false` |
+
+If a setting above changes, update this doc in the same PR as the UI change.
+
 ## Required status checks
 
 A PR to `develop` or `main` **must** show all of the following as ✅ green
 before merge is permitted.
 
-### Universal checks (both `develop` and `main`)
+### Current required checks (both `develop` and `main`)
 
-| Check | Workflow file | What it does |
+These are the 4 contexts currently enforced in the repo settings UI. They
+come from 2 workflow files; the other workflows in `.github/workflows/`
+are **informational** and run on PRs without being merge gates.
+
+| Check (context) | Workflow file | Job | What it does |
+|---|---|---|---|
+| `lint-pr-title` | `.github/workflows/ci.yml` | `lint-pr-title` | Enforces Conventional Commits in PR titles |
+| `test (ubuntu-latest, 22)` | `.github/workflows/ci.yml` | `test` (matrix: `ubuntu-latest`, Node 22) | TypeScript check + build + smoke UAT + health endpoint |
+| `lint` | `.github/workflows/ci.yml` | `lint` | ESLint + hygiene check + security check + console-guard |
+| `Analyze` | `.github/workflows/codeql.yml` | `analyze` | CodeQL static analysis for security vulns |
+
+### Pre-merge local gate (not a CI check)
+
+| Gate | How | What it does |
 |---|---|---|
-| **CI** | `.github/workflows/ci.yml` (or equivalent) | Lint + type-check + unit tests on Ubuntu + macOS |
-| **CodeQL** | `.github/workflows/codeql.yml` | Static analysis for security vulns |
-| **Helm Smoke** | `.github/workflows/helm-smoke.yml` | Smoke-tests the Helm chart on a k3d cluster |
-| **Lint PR Title** | `.github/workflows/lint-pr-title.yml` | Enforces Conventional Commits in PR titles |
-| **`npm run gate`** (pre-merge) | local / `gate.yml` | Functional Code Gate: typecheck, build, all tests, residual-risk sign-off |
+| `npm run gate` | Local (run before `git push`) | Functional Code Gate: arch check, hygiene, security, tokens, audit, lint, dashboard gates, typecheck, build, bundle-size check, serial tests. The full chain lives in `package.json` → `scripts.gate`. |
 
-### `develop`-only checks
+There is no `gate.yml` workflow — `npm run gate` is a local-only command that
+mirrors what CI does plus the bundle-size and dashboard gates. See
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md) for the workflow.
 
-| Check | Workflow file | What it does |
-|---|---|---|
-| **Dashboard test** | `.github/workflows/dashboard-test.yml` | Vitest + build for the dashboard |
-| **Platform smoke** | `.github/workflows/platform-smoke.yml` | Cross-platform smoke tests |
-| **SDK drift** | `.github/workflows/sdk-drift.yml` | TypeScript SDK parity check |
+### Planned required checks (NOT YET enforced in the UI)
 
-### `main`-only checks
+The following workflows run on PRs today but are **not** registered as
+required merge gates. Promoting them to required is a separate decision per
+workflow and should ship in its own PR with a Themis review for
+security-sensitive ones.
 
-| Check | Workflow file | What it does |
-|---|---|---|
-| **Release Dry Run** | `.github/workflows/release-dry-run.yml` | Runs release-please in dry-run mode |
-| **Post-merge rebuild** | `.github/workflows/post-merge-rebuild.yml` | Rebuilds and re-tags after a release-please merge |
-| **Dependency Review** | `.github/workflows/dependency-review.yml` | Scans new dependencies for CVEs on PRs to main |
+| Check (planned) | Workflow file | Job | Why not yet required | Tracking |
+|---|---|---|---|---|
+| `Helm Smoke` | `.github/workflows/helm-smoke.yml` | `helm-smoke` | k3d v5.4.6 404 blocks the gate; tracked in #4558 | #4559 |
+| `Platform smoke` | `.github/workflows/ci.yml` | `platform-smoke` | DRAFT-skip added in #4557, promotion to required pending volume data | — |
+| `Dashboard e2e` | `.github/workflows/ci.yml` | `dashboard-e2e` | DRAFT-skip added in #4557, Playwright cost trade-off | — |
+| `Release Dry Run` | `.github/workflows/release-dry-run.yml` | `release-dry-run` | Runs only on `release/**` PRs; promotion TBD | — |
+| `Post-merge rebuild` | `.github/workflows/post-merge-rebuild.yml` | — | Push trigger, not PR; informational on PRs | — |
+| `SDK drift` | `.github/workflows/ci.yml` | `sdk-drift` | Low failure rate; intentional keep on DRAFT per #4557 audit | — |
+
+There is **no** `dashboard-test.yml`, `platform-smoke.yml`, `sdk-drift.yml`,
+or `dependency-review.yml` workflow file. The first three live as jobs
+inside `ci.yml`; `dependency-review` is not yet implemented.
 
 ### DRAFT-skip rules
 
-The following checks are **skipped on DRAFT PRs** to save CI minutes:
-`lint-pr-title`, `test ubuntu-latest 22`, `lint`, `Analyze`,
-`helm-smoke` (after #4557 / #4559), `feat-minor-bump-gate`. See [#4557](https://github.com/OneStepAt4time/aegis/issues/4557)
-for the audit table.
+The following jobs are **skipped on DRAFT PRs** (gated by
+`github.event.pull_request.draft == false`). The DRAFT-skip is implemented
+in the workflow file, not in the branch protection UI, so it applies
+independently of whether the check is required.
+
+| Job | Workflow file | Source of gate |
+|---|---|---|
+| `feat-minor-bump-gate` | `.github/workflows/ci.yml` | PR #4557 |
+| `platform-smoke` | `.github/workflows/ci.yml` | PR #4557 |
+| `dashboard-e2e` | `.github/workflows/ci.yml` | PR #4557 |
+| `release-dry-run` | `.github/workflows/release-dry-run.yml` | PR #4557 |
+| `helm-smoke` | `.github/workflows/helm-smoke.yml` | **Held back**, blocked on k3d fix in #4558 (tracking: #4559) |
+
+`lint-pr-title`, `lint`, the `test` matrix, and `Analyze` (CodeQL) are
+**intentionally kept on DRAFT** per the audit in #4557 — they are cheap
+(`lint-pr-title` ~3s) or high-value (CodeQL catches vulns early) and the
+team wants the feedback on DRAFTs.
+
+See the full audit table in [#4557](https://github.com/OneStepAt4time/aegis/issues/4557).
 
 ## Required reviewers
+
+### Current state (verified 2026-06-15)
+
+| Branch | Required reviewers | Source |
+|---|---|---|
+| `develop` | 1 approving review (any user); CODEOWNER reviews **not** required | `gh api repos/.../branches/develop/protection` |
+| `main` | 1 approving review (any user) **+** CODEOWNER review on touched files | `gh api repos/.../branches/main/protection` |
+
+In both cases, `dismiss_stale_reviews: true` — a push to the PR's branch
+dismisses prior approvals. `required_conversation_resolution: true` on both.
+
+### CODEOWNERS file (current source of truth)
+
+`./github/CODEOWNERS` (21 lines) currently lists `@OneStepAt4time` as the
+owner for every path:
+
+- Default `* @OneStepAt4time`
+- `SECURITY.md`, `.github/CODEOWNERS`, `src/auth.ts` → `@OneStepAt4time`
+- `.github/workflows/`, release config, Helm chart, release-process docs →
+  `@OneStepAt4time`
+
+There is **no** `@Themis` (or any other user) listed in the current
+CODEOWNERS file. If you change this, update this doc in the same PR.
+
+### Planned reviewer model (per-agent identities, #4665)
+
+Once the per-agent GitHub Apps land (#4665 — currently shipping the
+"ship-now slice" via #4731, with the identity-binding slice deferred to
+#4732), the intended reviewer model is:
 
 | Branch | Required reviewers | Rationale |
 |---|---|---|
 | `develop` | **Argus** (per-agent identity `aegis-argus`, once registered) | Every non-trivial change gets a security-aware code review |
-| `develop` | **Themis** for security-sensitive files (CODEOWNERS-gated) | The CODEOWNERS file at `.github/CODEOWNERS` lists Themis for paths under `infra/`, `scripts/github-apps/`, `.github/workflows/`, `auth/`, and any path matching `*secret*` or `*token*` |
+| `develop` | **Themis** for security-sensitive files (CODEOWNERS-gated) | Will require (a) registering `aegis-themis` and granting it PR review, and (b) updating `.github/CODEOWNERS` to list it for the security paths |
 | `main` | **Ema** (human owner) | Final go/no-go on the release; per the v0.6.6 / v0.6.7 precedent, Ema explicitly approves the release PR before merge |
 | `main` | **Argus** | Same as `develop` |
 | `main` | **Themis** for security-sensitive files | Same as `develop` |
 
+**Status:** None of the per-agent Apps are registered yet (the legacy
+`aegis-gh-agent` is the only working identity). Promoting any of these
+rows from "Planned" to "Current" requires both the App registration and a
+matching `.github/CODEOWNERS` update in the same PR.
+
 ### Bot-authored PRs
 
-Bot-authored PRs (`aegis-gh-agent[bot]` or per-agent bots) **cannot self-approve**.
-The current lane convention is "Ema approves via CLI on bot-authored PRs":
+Bot-authored PRs (`aegis-gh-agent[bot]` or per-agent bots once registered)
+**cannot self-approve**. The current lane convention is
+"Ema approves via CLI on bot-authored PRs":
 
 ```bash
 # Ema runs this from their machine (NOT a bot, NOT a CI runner)
@@ -74,9 +167,10 @@ gh pr review --approve 4724
 ```
 
 This is the [Path (b) fallback in CONTRIBUTING.md](../../CONTRIBUTING.md#path-b-fallback-boss-approves-via-cli-on-bot-authored-prs).
-The structural fix is tracked in [#4725](https://github.com/OneStepAt4time/aegis/issues/4725) (add a
-dedicated reviewer GitHub App / PAT) and the policy hardening is in [#4728](https://github.com/OneStepAt4time/aegis/issues/4728)
-(fallback approver chain).
+The structural fix is tracked in [#4725](https://github.com/OneStepAt4time/aegis/issues/4725)
+(add a dedicated reviewer GitHub App / PAT) and the policy hardening is
+in [#4728](https://github.com/OneStepAt4time/aegis/issues/4728) (fallback
+approver chain).
 
 ## Merge method
 
@@ -88,8 +182,9 @@ dedicated reviewer GitHub App / PAT) and the policy hardening is in [#4728](http
 
 ## Branch update policy
 
-- **`develop`** is auto-updated by the bot (Dependabot + aegis-gh-agent auto-merge
-  for green-PR-with-CI-clean dependabot PRs). Manual force-push is forbidden.
+- **`develop`** is auto-updated by the bot (Dependabot + `aegis-gh-agent`
+  auto-merge for green-PR-with-CI-clean dependabot PRs). Manual force-push
+  is forbidden.
 - **`main`** is fast-forward-only from `develop` via the release-please
   automation. Manual force-push is forbidden.
 
@@ -101,23 +196,32 @@ checks. See the hotfix workflow in `OPERATIONAL-RULES.md`.
 
 ## How to update this doc
 
-1. If you're changing a required-check name (renaming a workflow), update
-   **this doc + the workflow file + the repo settings UI** in the same PR.
-2. If you're adding a new required-check, add it to this doc + add it to
-   the repo settings UI in the same PR.
-3. If you're removing a required-check, do it deliberately with a documented
-   rationale (Themis review recommended for security-sensitive checks).
-4. The CODEOWNERS file is the source of truth for file-level reviewer
+1. If you're changing a required-check name (renaming a workflow job),
+   update **this doc + the workflow file + the repo settings UI** in the
+   same PR.
+2. If you're **adding** a new required-check, add it to the **Current
+   required checks** table and update the repo settings UI in the same PR.
+3. If you're **deferring** a check to a later issue, keep it in the
+   **Planned required checks** table with a tracking link rather than
+   removing it — that way the audit trail survives.
+4. If you're **removing** a required-check, do it deliberately with a
+   documented rationale (Themis review recommended for security-sensitive
+   checks).
+5. The CODEOWNERS file is the source of truth for file-level reviewer
    routing. This doc is the source of truth for **branch-level** required
-   reviewers.
+   reviewers and the high-level description of the CODEOWNERS model.
 
 ## Acceptance criteria for "branch protection prep is done"
 
-- [ ] All required status checks listed in this doc are enforced in the
-      repo settings UI for both `develop` and `main`.
-- [ ] All required reviewers (Argus, Themis for security paths, Ema for
-      `main`) are configured in the repo settings UI.
+- [ ] All **Current** required status checks in the table above are
+      enforced in the repo settings UI for both `develop` and `main`.
+- [ ] `npm run gate` passes locally before `git push` on every PR
+      (verified via CI badge / reviewer pings).
+- [ ] All **Planned** required reviewers (Argus + Themis post-#4665) have
+      per-agent identities registered and matching `.github/CODEOWNERS`
+      entries.
 - [ ] Squash merge is the only enabled merge method.
 - [ ] Force-push is blocked on both branches.
-- [ ] CODEOWNERS file is in sync with the file-level routing.
+- [ ] CODEOWNERS file is in sync with the file-level routing claim in
+      this doc.
 - [ ] This doc is reviewed by Themis in the next review window.


### PR DESCRIPTION
## Summary

Fixes 5 categories of factual errors in `docs/devops/branch-protection-checklist.md`, the new doc that landed in #4733. Verified against the actual GitHub branch-protection state and the actual workflow files on disk.

## Aegis version

**Developed with:** v0.6.7 (curl http://127.0.0.1:9100/v1/version)

## What I found (vs. what the doc said)

### 1. Required status checks (most impactful)

| | Doc said | Actual |
|---|---|---|
| **Universal** (both) | 5: CI, CodeQL, Helm Smoke, Lint PR Title, `npm run gate` | **4**: `lint-pr-title`, `test (ubuntu-latest, 22)`, `lint`, `Analyze` (verified via `gh api .../branches/develop/protection`) |
| **develop-only** | 3: Dashboard test, Platform smoke, SDK drift | None (no `*-only` checks are enforced) |
| **main-only** | 3: Release Dry Run, Post-merge rebuild, Dependency Review | None |

The doc presented 11 checks as current requirements; only 4 are actually enforced. The others (Helm Smoke, Platform smoke, SDK drift, Dashboard test, Release Dry Run, etc.) are real workflows that run on PRs but are **not** registered as required merge gates. The doc now splits them into **Current required checks** and **Planned required checks** (with rationale and tracking per row).

### 2. Workflow file path references (5 broken)

| Doc reference | Actual location |
|---|---|
| `.github/workflows/lint-pr-title.yml` | Job `lint-pr-title` in `.github/workflows/ci.yml` |
| `.github/workflows/dashboard-test.yml` | Does not exist (dashboard tests run in `ci.yml` build + `release.yml`) |
| `.github/workflows/platform-smoke.yml` | Job `platform-smoke` in `.github/workflows/ci.yml` |
| `.github/workflows/sdk-drift.yml` | Job `sdk-drift` in `.github/workflows/ci.yml` |
| `.github/workflows/dependency-review.yml` | Does not exist (not yet implemented) |
| `gate.yml` | Does not exist — `npm run gate` is a local command in `package.json` |

### 3. DRAFT-skip list (4 wrong entries)

The doc said these were DRAFT-skipped: `lint-pr-title`, `test ubuntu-latest 22`, `lint`, `Analyze`.

Per the #4557 audit, all 4 of those are **intentionally KEPT on DRAFT** (cheap or high-value). The actual DRAFT-skipped jobs are: `feat-minor-bump-gate`, `platform-smoke`, `dashboard-e2e`, `release-dry-run`, and (held back per #4559) `helm-smoke`.

### 4. CODEOWNERS claim (security-sensitive)

The doc said: `The CODEOWNERS file at .github/CODEOWNERS lists Themis for paths under infra/, scripts/github-apps/, .github/workflows/, auth/, and any path matching *secret* or *token*`.

The actual `.github/CODEOWNERS` (21 lines) lists `@OneStepAt4time` for every one of those paths. `@Themis` is not mentioned anywhere. The per-agent identity model (post-#4665) intends Themis to be the security-path owner, but that requires (a) registering the App, (b) updating CODEOWNERS, (c) enabling CODEOWNER reviews in the branch protection UI. The doc now separates **Current CODEOWNERS** (verified) from **Planned reviewer model** (post-#4665).

### 5. Required reviewers on `develop`

The doc implied Themis is CODEOWNER-gated for security paths on `develop`. Verified: CODEOWNER reviews are **not** required on `develop` (`require_code_owner_reviews: false`) but **are** required on `main` (`true`). Doc now states this explicitly.

## What the PR changes

- Adds a **Quick reference** table at the top showing the 11 actual branch-protection settings (verified 2026-06-15) for both branches.
- Replaces the 3 "current" status-check tables with one **Current required checks** table (4 rows) + a **Planned required checks** table (6 rows with tracking).
- Removes the `gate.yml` reference; clarifies `npm run gate` is local.
- Replaces the DRAFT-skip bullet list with a 5-row table mapping each DRAFT-skipped job to its source PR.
- Replaces the "Themis is CODEOWNER-gated" claim with a verified description of the current CODEOWNERS file and a separate **Planned reviewer model** section.
- Adds a cross-reference to `docs/devops/per-agent-identities.md` (sister doc from #4733).
- Updates the **How to update this doc** and **Acceptance criteria** sections to match the Current/Planned split.

## Scope notes

- Single doc; one concern (branch protection accuracy).
- Pure docs change — no code touched, no scripts run, no API mutations.
- `npm run gate` was not run because the change is docs-only; the only doc-relevant script is `hygiene-check.cjs` (credential scanner) which passed.

## Verification

- `gh api repos/OneStepAt4time/aegis/branches/develop/protection` → confirmed 4 required contexts (`lint-pr-title`, `test (ubuntu-latest, 22)`, `lint`, `Analyze`), `require_code_owner_reviews: false`, `enforce_admins: false`.
- `gh api repos/OneStepAt4time/aegis/branches/main/protection` → confirmed same 4 contexts, `require_code_owner_reviews: true`, `enforce_admins: true`.
- `find .github/workflows -name 'lint-pr-title.yml' -o -name 'dashboard-test.yml' -o -name 'platform-smoke.yml' -o -name 'sdk-drift.yml' -o -name 'dependency-review.yml' -o -name 'gate.yml'` → all six not found.
- `grep -n 'draft' .github/workflows/ci.yml .github/workflows/helm-smoke.yml .github/workflows/release-dry-run.yml` → confirmed `draft == false` gate present on `feat-minor-bump-gate`, `platform-smoke`, `dashboard-e2e`, and absent on `lint-pr-title` / `lint` / `test` / `analyze`.
- Cross-links to `per-agent-identities.md` and `../../CONTRIBUTING.md#path-b-fallback-boss-approves-via-cli-on-bot-authored-prs` resolve to existing files/headings.

## References

- Parent: #4733 (the PR that introduced the doc this fixes)
- Sister: #4665 (Per-agent App identities — when the planned reviewer model lands)
- Sibling: #4732 (deferred identity-binding slice)
- Related: #4725 (bot-approve friction), #4728 (fallback approver chain)
- DRAFT-skip source: #4557 + #4558 (k3d blocker) + #4559 (held-back helm-smoke gate)
- Verified at: 2026-06-15 11:08 UTC

/cc @OneStepAt4time (PR author of #4733)
