### PR TITLE
docs(rules): cross-link Path (b) Fallback from prs.md + branching.md (#4725)

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -36,3 +36,27 @@ hotfix/<issue-number>-<short-description>
 - ❌ Never open a PR targeting `main` unless maintainer explicitly says so
 - ❌ Never merge your own PR — Argus reviews and merges
 - ❌ Never open a PR with failing CI
+- ❌ Never open a bot-authored PR without a documented approval path — see
+  the [Path (b) Fallback in CONTRIBUTING.md](../../CONTRIBUTING.md#path-b-fallback-boss-approves-via-cli-on-bot-authored-prs)
+
+## Bot-authored PRs
+
+If you are submitting a PR from a bot identity (e.g., `aegis-gh-agent[bot]`,
+`dependabot[bot]`, or a per-agent App once registered), the PR cannot
+self-approve. The [Path (b) Fallback in CONTRIBUTING.md](../../CONTRIBUTING.md#path-b-fallback-boss-approves-via-cli-on-bot-authored-prs)
+documents the lane:
+
+```bash
+# Ema (or another authorized human) runs this from their machine
+gh pr review --approve <PR_NUMBER>
+```
+
+The structural fix (a dedicated reviewer App / PAT) is tracked in
+[#4725](https://github.com/OneStepAt4time/aegis/issues/4725). Until that lands,
+Path (b) is the documented lane. Branch protection's
+`required_approving_review_count: 1` is still enforced — the human click
+counts as the approval; Argus's pre-stage review is the technical LGTM.
+
+For unattended-merge scenarios (overnight, hotfix window), see
+[#4728](https://github.com/OneStepAt4time/aegis/issues/4728) (fallback approver
+chain — adds an owner-overridable bot approver).

--- a/.claude/rules/prs.md
+++ b/.claude/rules/prs.md
@@ -24,3 +24,39 @@ Keep PRs minimal and focused. One concern per PR. If a PR touches more than 20 f
 ## Review
 
 All PRs require review before merge. Argus is the validation steward.
+
+## Bot-authored PRs (Path (b) Fallback)
+
+Bot-authored PRs (e.g., `aegis-gh-agent[bot]`, `dependabot[bot]`, or per-agent
+Apps once registered) cannot self-approve on GitHub. The
+[Path (b) Fallback in CONTRIBUTING.md](../../CONTRIBUTING.md#path-b-fallback-boss-approves-via-cli-on-bot-authored-prs)
+documents the lane convention Ema uses to unblock such PRs:
+
+```bash
+# Ema runs this from their machine (NOT a bot, NOT a CI runner)
+gh pr review --approve <PR_NUMBER>
+```
+
+The structural fix (a dedicated reviewer App / PAT) is tracked in
+[#4725](https://github.com/OneStepAt4time/aegis/issues/4725). Until that lands,
+Path (b) is the documented lane for human approval clicks on bot-authored PRs.
+Branch protection's `required_approving_review_count: 1` is still enforced
+(Argus pre-stages the review, Ema's click counts as the second eye).
+
+**When you're submitting a bot-authored PR:**
+
+1. Open the PR with the bot identity (the bot must be the author, not a
+   human proxy).
+2. Wait for CI green + Argus's pre-stage review.
+3. Request an explicit human approval click in `#aegis-devs` with
+   `@<Ema's Discord ID>` — do **not** assume the bot can self-approve.
+4. Once the human approves, the PR is mergeable per the standard flow.
+
+**When you're reviewing a bot-authored PR:**
+
+- Bot-authored PRs follow the same review bar as human-authored ones
+  (Functional Code Gate, evidence template, CI green).
+- The approval step is split: Argus does the technical LGTM, Ema (or
+  another authorized human) does the approval click. See
+  [Path (b) in CONTRIBUTING.md](../../CONTRIBUTING.md#path-b-fallback-boss-approves-via-cli-on-bot-authored-prs)
+  for the full rationale.


### PR DESCRIPTION
## Summary

Cross-links the [Path (b) Fallback section in CONTRIBUTING.md](https://github.com/OneStepAt4time/aegis/blob/develop/CONTRIBUTING.md#path-b-fallback-boss-approves-via-cli-on-bot-authored-prs) (which landed via #4733) into the two `.claude/rules/` files that govern PR and branching workflow.

## What is in this PR

**`.claude/rules/prs.md`** — adds a new "Bot-authored PRs (Path (b) Fallback)" section after "Review":
- Captures the `gh pr review --approve <PR_NUMBER>` invocation **verbatim**
- Explains when you're submitting a bot-authored PR vs. when you're reviewing one
- Cross-links to CONTRIBUTING.md's Path (b) section for the full rationale
- Notes that branch protection's `required_approving_review_count: 1` is still enforced (Argus's pre-stage + Ema's click = 2 eyes)

**`.claude/rules/branching.md`** — adds:
- A new rule against opening a bot-authored PR without a documented approval path (with cross-link)
- A new "Bot-authored PRs" section explaining the lane, the structural fix in #4725, and the unattended-merge fallback in #4728

## Acceptance criteria (per Boss 2026-06-15 14:22)

- [x] (1) PR open with the lane recipe + `gh pr review --approve <N>` invocation captured verbatim
- [ ] (2) Themis ack on the documented security model (bot ≠ author, `required_approving_review_count: 1` still enforced) — **PENDING Themis review**
- [x] (3) `npm run gate` green — ✅ ran 2026-06-15 14:41:55Z, 443/444 test files (1 pre-existing skip), 6281/6281 tests pass, 10 pre-existing skips, duration 289.87s

## Gate result detail

```
@onestepat4time/aegis@0.6.7 gate
> npm run gate:arch && npm run hygiene-check && npm run security-check && npm run token-check && npm run audit-check && npm run lint && npm run dashboard:tokens:gate && npm run dashboard:clickable:gate && npx tsc --noEmit && npm run build && npm run check-bundle-size && npm run test:serial

✅ gate:arch (no circular deps, no as-any)
✅ hygiene-check
✅ security-check (no shell: true)
✅ token-check (no hardcoded tokens)
✅ audit-check (0 npm audit vulns, lockfile-lint clean)
✅ lint (eslint clean)
✅ dashboard:tokens:gate
✅ dashboard:clickable:gate
✅ tsc --noEmit
✅ build
✅ check-bundle-size
✅ test:serial (443 files, 6281/6281 tests, 10 pre-existing skips, 289.87s)

Process exited with code 0.
```

Note: the first gate run had 1 screenshot-test timeout (pre-existing flake, the test passes in 1.21s in isolation). Re-run was clean. Worth filing a separate flake ticket if it recurs.

## Out of scope

- Implementation of the structural fix (Path (a) — reviewer App / PAT as required reviewer) — that's the larger scope in #4725
- Updates to `CONTRIBUTING.md` — already done in #4733 (merged 2026-06-15)
- `.claude/rules/workflow.md` or other rules files — not in scope for this PR

## Risk profile

- **Reversibility:** HIGH (doc-only, no schema or workflow changes)
- **Production impact:** NONE (rules files are dev-process docs, not runtime)
- **Workflow risk:** LOW (no CI changes)

## References

- Issue: #4725 (Path (b) — cross-link half)
- Source section: #4733 (CONTRIBUTING.md Path (b) section, merged 2026-06-15)
- Boss's directive: #aegis-devs msg 1516056129837207713 (2026-06-15 14:22)
- Related: #4728 (unattended-merge fallback chain)