### PR TITLE
docs: document /command soft-fail to 200 + /send 500 post-delivery catch (#4741)

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -362,10 +362,17 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/command \
 
 Sends a slash command. Prefix with `/` if not provided.
 
-**Response `200`:**
+**Response `200` (success):**
 ```json
-{"ok": true}
+{"ok": true, "delivered": true, "attempts": 1}
 ```
+
+**Response `200` (soft-fail — command did not reach CC):**
+```json
+{"ok": true, "delivered": false, "attempts": 0, "error": "no_active_transport"}
+```
+
+> **Soft-fail contract:** Delivery failures return `200` with `delivered: false`, not a 4xx. Always check `delivered` in the response, not just the HTTP status.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1639,7 +1639,9 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/send \
 
 **Response (failure — `422 Unprocessable Entity`):**
 
-When the message cannot be delivered to the Claude Code runtime (e.g., timeout waiting for prompt acknowledgment, or no active transport).
+Returned in two cases with the same response shape:
+1. The CC runtime acknowledged but reported the message as not delivered (`result.delivered === false`).
+2. The inner delivery call threw (e.g., JSON-RPC error from the runtime during a handshake race, no active transport, or a backend-specific failure).
 
 ```json
 {
@@ -1650,16 +1652,17 @@ When the message cannot be delivered to the Claude Code runtime (e.g., timeout w
 }
 ```
 
-> **Error values:** `message` may be `prompt_ack_timeout` (ACP runtime did not acknowledge within the timeout), `no_active_transport` (session has no active ACP transport), or another backend-specific error string.
+> **Error values:** `message` may be `prompt_ack_timeout` (ACP runtime did not acknowledge within the timeout), `no_active_transport` (session has no active ACP transport), a JSON-RPC error code (e.g. `-32601 Method not found`), or another backend-specific error string. `attempts` is the number of delivery attempts the backend made before giving up.
 
 **Errors:**
 
 | Status | Code | Condition |
 |--------|------|-----------|
 | 400 | — | Invalid request body |
-| 404 | — | Session not found |
+| 404 | — | Session not found (returned by the ownership check upstream of delivery) |
 | 422 | `PROMPT_DELIVERY_FAILED` | Message could not be delivered to the CC runtime. Check `message` field for cause. |
 | 429 | — | Per-key token/spend quota exceeded |
+| 500 | — | Internal error after successful delivery (e.g. monitor or channels threw). Delivery itself succeeded; the failure is in post-delivery bookkeeping. |
 
 ---
 
@@ -1932,7 +1935,36 @@ curl -X POST http://localhost:9100/v1/sessions/abc123/command \
 |-----------|------|----------|-------------|
 | `command` | string | **yes** | Slash command to send |
 
-**Response:** `{ "ok": true }`
+**Response (`200 OK`):**
+
+```json
+{
+  "ok": true,
+  "delivered": true,
+  "attempts": 1
+}
+```
+
+> **Soft-fail contract:** Slash-command delivery failures (handshake race, JSON-RPC error from the runtime, no active transport) do **not** return an error status. The HTTP request succeeds with `200 OK` and `delivered: false` so the caller knows the command did not reach CC. This matches the pre-`/send`-split behavior and is the contract the CLI `ag command` and MCP `send_command` callers depend on.
+
+**Response (soft-fail — `200 OK` with `delivered: false`):**
+
+```json
+{
+  "ok": true,
+  "delivered": false,
+  "attempts": 0,
+  "error": "no_active_transport"
+}
+```
+
+**Errors:**
+
+| Status | Code | Condition |
+|--------|------|-----------|
+| 400 | — | Invalid request body |
+| 404 | — | Session not found (returned by the ownership check upstream of delivery) |
+| 429 | — | Per-key token/spend quota exceeded |
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the user-facing route-catch changes shipped in PR #4741 (merged at f6f54327).

**What changed in the code (PR #4741):**
- `/send` delivery catch now returns **422** consistently (was 404 via the catch path; the `!result.delivered` path was already 422).
- `/send` post-delivery catch (monitor/channels) now returns **500** for internal errors.
- `/command` delivery catch soft-fails to **200** with `delivered: false` (was 404).
- `/command` success responses now include `delivered` and `attempts` fields.
- 404 is reserved for session-not-found (returned by `requireSessionOwnership` upstream of delivery on both routes).

## Doc changes

- **docs/api-reference.md** — `/send`: 422 shape clarification (two paths), 500 row added, 404 description pinned to ownership check. `/command`: success + soft-fail response shapes documented, 400/404/429 rows added.
- **docs/api-examples.md** — `/command` example updated to show `delivered` and `attempts` plus a soft-fail example with the "always check `delivered`" callout.

## Verification

- Lint: 0 errors (warnings are pre-existing in `src/`, unrelated).
- Hygiene check: passed.
- Code-path review: traced through `src/routes/session-actions.ts` post-#4741 to confirm the documented response shapes match the actual code paths for both routes in both ACP and non-ACP modes.

Refs: #4738