### PR TITLE
test(screenshot): bump timeout 5s → 30s on captureScreenshot error test (#4736)

### DIFF
--- a/src/__tests__/screenshot.test.ts
+++ b/src/__tests__/screenshot.test.ts
@@ -18,7 +18,10 @@ describe('Screenshot capability', () => {
   });
 
   describe('captureScreenshot — error handling', () => {
-    it('should throw when capture fails (playwright missing or browser unavailable)', async () => {
+    it(
+      'should throw when capture fails (playwright missing or browser unavailable)',
+      { timeout: 30_000 }, // #4736: real browser launch + page.goto; inner page.goto timeout is 30s (src/screenshot.ts:62). Outer 5s aborts under test:serial system load. Match inner.
+      async () => {
       try {
         const { captureScreenshot } = await import('../screenshot.js');
         await captureScreenshot({ url: 'https://example.com' });


### PR DESCRIPTION
## Summary

1-line test infra fix for #4736 (P2 flake). The 'should throw when capture fails' test in `src/__tests__/screenshot.test.ts` was tightening the 5s vitest default against a function whose internal `page.goto` already uses 30s — under `test:serial` system load, the launch can exceed 5s and vitest aborts as a timeout instead of a real throw. Bumping the per-test timeout to 30s matches the inner constraint.

## Acceptance criteria

- [x] `npm run gate` passes (444/444 test files, 6285/6285 tests, 0 failed, 10 pre-existing skipped)
- [x] `src/__tests__/screenshot.test.ts` runs 8/8 in 1.69s in isolation with the new timeout
- [x] Diff is +4/-1 on a single test file, no other files touched
- [x] No source code changed, no public API change

## Tests added

None. This IS a test — the fix is a 1-line timeout bump on an existing test that was timing out under load.

## Commands run

```bash
# Targeted (fast feedback)
./node_modules/.bin/vitest run --maxWorkers=1 src/__tests__/screenshot.test.ts
# → 8/8 pass, 1.69s

# Full gate (canonical pre-push)
npm run gate
# → 444/444 files, 6285/6285 tests, exit 0
```

## Manual QA

- Re-ran the targeted screenshot test 3x consecutively — all 3 pass in 1.6-1.7s
- The previously flaky 'should throw when capture fails' test is the one that consumed the 1.13s in the issue's reproduction — now passes deterministically at 1.13s with a 30s budget
- No regression in any of the other 7 tests in the file (all are pure type/shape sync tests, unaffected by the timeout change)

## Residual risk

**Low.** The change adds 25s of headroom to a single test's vitest timeout. Worst case: if a future regression causes the test to actually hang (e.g., playwright install corrupted, browser binary missing), CI sees a 30s hang instead of 5s — a real cost on test:serial (~0.005% of total runtime). Mitigation: the inner `page.goto` already enforces a 30s bound, so the test cannot hang longer than that. Acceptable tradeoff for flake immunity.

## Out of scope

- **Option B (mock the browser-launch call)** from the issue body — deferred. Would eliminate the flake entirely but is more invasive (requires mocking the playwright module, restructuring the test). P2 priority doesn't justify the larger blast radius; 1-line timeout fix is the right minimal change. Issue body lists Option B as fallback if Option A doesn't hold.
- **Other 7 tests in the file** — they're all sync type/shape tests, no I/O, no flake. Untouched.
- **Other 444 test files in test:serial** — not affected. This fix is local to one test.

## Lane

Hephaestus (test infra — root `src/__tests__/` files are explicitly in my territory per Daedalus's 2026-06-16 lane confirmation in #aegis-devs).