### PR TITLE
docs(adr): catch up README index for ADR-0029 through 0033

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,14 @@ ADRs document significant architectural decisions made during Aegis development.
 | [ADR-0026](0026-oidc-trust-model.md) | OIDC Trust Model for Dashboard SSO | Proposed | — | #1942 |
 | [ADR-0027](0027-acp-feasibility-spike-verdict.md) | ACP Feasibility Spike Verdict | Proposed | — | #2576 |
 | [ADR-0028](0028-acp-native-session-identity-model.md) | ACP-Native Session Identity Model | Proposed | 2026-05-04 | #2584 |
+| [ADR-0029](0029-solo-dev-first-phase-4-deferred.md) | Strategic Refocus — Solo Developer First, Phase 4 Deferred | Proposed | 2026-05-16 | — |
+| [ADR-0030](0030-network-isolation-scope-by-deployment-tier.md) | Network Isolation Scope by Deployment Tier | Accepted | 2026-05-22 | #3998, #3980 |
+| [ADR-0030](0030-agent-auth-rfc.md) | Agent Auth — Per-agent PAT vs Second GitHub App (RFC) | Proposed | 2026-06-05 | — |
+| [ADR-0031](0031-budgets-api-design.md) | /v1/budgets API Design for Cost Alerts | Proposed | 2026-05-25 | #4196 |
+| [ADR-0032](0032-multi-agent-architecture.md) | Multi-Agent Support — Architecture Design | Approved | 2026-05-30 | #3180 |
+| [ADR-0033](0033-positioning-vs-ecc.md) | Positioning vs ECC (affaan-m) — Aegis = Production Platform, ECC = Power-User Config | Proposed | 2026-06-20 | — |
+
+> **Note on duplicate numbers:** ADR-0030 currently has two files (`0030-network-isolation-scope-by-deployment-tier.md` and `0030-agent-auth-rfc.md`). Both are linked above with disambiguated titles. A follow-up renumbering PR is needed (Boss decision pending). The older duplicates at ADR-0024 and ADR-0025 (pre-existing) are also pending renumbering and out of scope for this index catch-up.
 
 ## Creating a New ADR
 


### PR DESCRIPTION
## Why
PR #4771 (ADR-0033 positioning vs ECC) shipped with an explicit out-of-scope line in the PR body:
> *ADR README index update (the index is stale at 0028; separate cleanup)*

That cleanup was punted. This PR is that cleanup.

## What
**1 file changed, +8/-0** — `docs/adr/README.md` only.

Added 6 entries to the index that exist on `origin/develop` but were unlinked:
| Number | Title | Status | Date | Issue |
|--------|-------|--------|------|-------|
| ADR-0029 | Strategic Refocus — Solo Developer First, Phase 4 Deferred | Proposed | 2026-05-16 | — |
| ADR-0030 (a) | Network Isolation Scope by Deployment Tier | Accepted | 2026-05-22 | #3998, #3980 |
| ADR-0030 (b) | Agent Auth — Per-agent PAT vs Second GitHub App (RFC) | Proposed | 2026-06-05 | — |
| ADR-0031 | /v1/budgets API Design for Cost Alerts | Proposed | 2026-05-25 | #4196 |
| ADR-0032 | Multi-Agent Support — Architecture Design | Approved | 2026-05-30 | #3180 |
| ADR-0033 | Positioning vs ECC (affaan-m) — Aegis = Production Platform, ECC = Power-User Config | Proposed | 2026-06-20 | — |

Plus a short note flagging the ADR-0030 duplicate-numbering problem and the pre-existing duplicates at ADR-0024 and ADR-0025.

## Verification
- [x] All 6 added entries link to files that exist on `origin/develop` (verified via `ls docs/adr/`)
- [x] Status/Date/Issue values read from each ADR's header, not inferred
- [x] Diff is +8/-0 — single file, surgical change
- [x] ADR-0033 cross-links verified (links to #4768 — exists, CLOSED, status:not-active; ADR-0023, ADR-0029, ADR-0006 — all exist)
- [x] No user-facing API/config surface touched
- [x] `npm run docs` not applicable (markdown only)

## Decisions / non-decisions
- **Renumbered nothing.** ADR-0030 has two real files with the same number; linked both with disambiguated titles instead of silently picking a winner. The renumbering PR is a Boss call.
- **Did not touch pre-existing duplicates at ADR-0024 and ADR-0025.** They were already stale before this work and need their own Boss-side renumbering decision (separate concern).
- **Did not add entries for the still-pending ADR-0024-agent-identity-model and ADR-0025-multi-tenancy files.** They predate the "stale at 0028" cleanup scope and would inflate the diff.

## Out of scope (intentionally not addressed here)
- ADR renumbering (Boss decision)
- New ADR content (out of Scribe lane per SOUL.md)
- CHANGELOG entry (release-please owns this per Boss's 04:50 UTC call)

Closes the docs gap introduced by #4771's punt.