### PR TITLE
fix(dashboard): update useLastUpdated test interval to 5s (#4787)

### DIFF
--- a/dashboard/src/hooks/__tests__/useLastUpdated.test.ts
+++ b/dashboard/src/hooks/__tests__/useLastUpdated.test.ts
@@ -23,7 +23,7 @@ describe('useLastUpdated', () => {
     const { result } = renderHook(() => useLastUpdated());
     vi.advanceTimersByTime(10000);
     // Force re-render by advancing timer tick
-    act(() => { vi.advanceTimersByTime(1000); });
+    act(() => { vi.advanceTimersByTime(5000); });
     // After ~11s, should show "10s ago" or similar
     expect(result.current.relativeTime).toMatch(/\ds ago/);
   });


### PR DESCRIPTION
## Summary
Fixes failing dashboard E2E test after #4786 changed the interval from 1000ms to 5000ms.

## Change
- Updated test timer advancement from 1000ms to 5000ms to match the new interval

## Verification
- All 6 tests in useLastUpdated.test.ts pass

## Fixes
- #4787

cc @Hephaestus for review