### PR TITLE
docs(api): document recoveryDisabled field on SessionInfo (#4802)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -864,12 +864,13 @@ curl http://localhost:9100/v1/sessions/abc123 \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-**Response:** Session object with `actionHints` for current interactive state, `latestActivityText` for live agent activity, `ccSessionId` when correlated with a Claude Code session, and `telegramTopicId` when a Telegram topic is linked.
+**Response:** Session object with `actionHints` for current interactive state, `latestActivityText` for live agent activity, `ccSessionId` when correlated with a Claude Code session, `telegramTopicId` when a Telegram topic is linked, and `recoveryDisabled` when stall auto-recovery is paused on this session.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `latestActivityText` | string | Human-readable description of current agent activity (e.g. `"Running: npm test"`, `"Editing: server.ts"`, `"Idle"`, `"Waiting for input"`, `"Compacting context"`). Updated in real-time from CC hook events. |
 | `ccSessionId` | string | Claude Code session ID correlated with this Aegis session via the `CLAUDE_CODE_SESSION_ID` environment variable. Only present when the CC→Aegis mapping has been established through MCP tool usage. |
+| `recoveryDisabled` | boolean | Per-session kill-switch for stall auto-recovery. When `true`, Aegis will not auto-restart a stalled session — the operator has paused recovery. Persists across Aegis restarts. Only present when explicitly set (defaults to `false`). Currently toggled via the dashboard stall pill; no REST endpoint to set it directly. |
 
 **Errors:**
 


### PR DESCRIPTION
## Summary
Documents the new optional `recoveryDisabled?: boolean` field on the `GET /v1/sessions/:id` response, introduced in PR #4803 (Issue #4802 F-4).

## What changed
- `docs/api-reference.md`: added `recoveryDisabled` to the response field table for `GET /v1/sessions/:id` with semantics (per-session stall auto-recovery kill-switch, persists across restarts, currently dashboard-only toggle).

## Why
PR #4803 ship the F-4 per-session kill-switch as an additive SessionInfo field. API consumers polling `GET /v1/sessions/:id` will see this field appear when an operator pauses auto-recovery on a session. Without docs, the field is opaque — operators reading the API response can't tell why a stalled session stopped auto-recovering.

## Aegis version
**Developed with:** v0.6.7

## Cross-references
- Issue #4802 (F-4 spec)
- PR #4803 (server-side implementation)
- PR #4804 (dashboard stall pill follow-up — not yet merged)

## Verification
- `npm run hygiene-check` — passed
- `npm run security-check` — passed
- `npm run token-check` — passed
- `npm run audit-check` — passed
- `npm run gate:arch` — passed (no changed TS files)
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npx tsc --noEmit` — passed
- `npm run dashboard:tokens:gate` — passed
- `npm run dashboard:clickable:gate` — passed

Diff: 1 file, +2/-1 (3 lines).