### PR TITLE
feat(dashboard): Command Center redesign (mission-control DNA)

### DIFF
--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -1,0 +1,239 @@
+# Aegis — Command Center Design System
+
+> The control plane of Claude Code. This is the brand contract every agent and
+> contributor reads before touching the dashboard. One source of truth.
+
+**DNA:** NASA/SpaceX mission control (deep-space navy, amber telemetry, cyan
+health, monospace data, alert hierarchy, "readable at 3 m in low light by
+someone who hasn't slept in 18 hours") + Linear-grade craft (Inter 510
+signature weight, aggressive negative letter-spacing at display, ultra-thin
+semi-transparent borders, keyboard-first density).
+
+**North star:** Aegis is a **command center for an agent fleet** — not a SaaS
+dashboard. Every screen should feel like a console you trust to fly 100 agents
+unsupervised: dense, calm, unambiguous, fast. Amber-on-navy is the signature.
+Distinctive > fashionable.
+
+---
+
+## 1. Color
+
+All tokens are CSS variables in `dashboard/src/index.css` `@theme`. Hex is
+authoritative; Tailwind utilities derive from them.
+
+### Surface palette (the canvas)
+
+| Token | Hex | Role |
+|-------|-----|------|
+| `--color-void` | `#0B1120` | Page canvas — deep-space navy |
+| `--color-void-deep` | `#060912` | App shell / off-screen depth |
+| `--color-surface` / `--color-void-dark` | `#111827` | Panels, cards, elevated areas |
+| `--color-surface-hover` / `--color-void-light` | `#1A2535` | Interactive surface hover |
+| `--color-surface-active` | `#1E3A5F` | Selected / active panel |
+| `--color-border` / `--color-void-lighter` | `#1E3A5F` | Panel dividers, grid lines |
+| `--color-border-subtle` | `#162035` | Inner dividers, minor separation |
+
+Rule: surfaces step up in luminance, never in hue. No blue-tinted "SaaS
+slate" — backgrounds are warm-neutral navy.
+
+### Data palette (telemetry values)
+
+| Token | Hex | Role |
+|-------|-----|------|
+| `--color-accent` | `#FFB800` | **Primary telemetry / brand amber** — key metrics, CTAs, brand mark |
+| `--color-accent-cyan` | `#00D4FF` | Healthy / active / links — agent "alive" signal |
+| `--color-danger` | `#FF4757` | Critical alert, error, killed |
+| `--color-warning` | `#FF9F43` | Degraded / stalled / awaiting approval |
+| `--color-success` | `#26DE81` | Nominal / completed |
+| `--color-info` | `#3B82F6` | Informational / neutral event |
+
+Amber is the signature. It appears on CTAs, the primary metric in any readout,
+the brand mark, and the focus ring. Cyan is the "system nominal" color. The two
+together (amber value + cyan status dot) is the Aegis motif — use it.
+
+All data colors on `#111827` must pass WCAG AA (≥ 4.5:1).
+
+### Text
+
+| Token | Hex | Role |
+|-------|-----|------|
+| `--color-text-primary` | `#E8F0FE` | Primary readable text (cool white, not pure) |
+| `--color-text-muted` | `#8BA3C7` | Labels, secondary copy |
+| `--color-placeholder` | `#4A6080` | Timestamps, metadata, placeholders |
+
+### CTA
+
+| Token | Value | Role |
+|-------|-------|------|
+| `--color-cta-bg` | `--color-accent` (`#FFB800`) | Primary action — "launch / approve" |
+| `--color-cta-text` | `--color-void` (`#0B1120`) | High-contrast navy on amber |
+| `--color-cta-bg-hover` | `#FFC933` | Amber hover |
+
+Secondary actions are ghost: `rgba(255,255,255,0.04)` bg, `--color-border`
+1px, `--color-text-primary` text.
+
+### Forbidden
+- Purple/violet accent (`#8b5cf6`) — retire it. Aegis is amber + cyan.
+- Gradients on surfaces. Depth comes from luminance steps + 1px borders, not
+  gradients. (A single subtle amber→transparent glow on the active CTA is the
+  only allowed gradient.)
+- Pure black (`#000`) or pure white (`#fff`) as surfaces.
+
+---
+
+## 2. Typography
+
+**Inter** (replaces DM Sans) as UI/type, **JetBrains Mono** for all data.
+
+```
+--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+--font-mono: 'JetBrains Mono', 'Cascadia Code', Consolas, monospace;
+```
+
+Enable Inter OpenType features globally: `font-feature-settings: "cv01", "ss03", "cv11"`.
+Signature weight is **510** (between regular and medium) — the Aegis UI weight.
+
+### Scale (display uses negative letter-spacing; data uses mono)
+
+| Role | Family / weight | Size / line-height | Letter-spacing |
+|------|-----------------|--------------------|----------------|
+| Display (hero, page title) | Inter 590 | 40–56px / 1.05 | -1.5px |
+| H1 page | Inter 590 | 28px / 1.15 | -0.8px |
+| H2 section | Inter 590 | 20px / 1.2 | -0.4px |
+| Body | Inter 510 | 14px / 1.5 | 0 |
+| Label / UI | Inter 510 | 13px / 1.4 | 0 |
+| Caption / meta | Inter 450 | 12px / 1.4 | +0.1px (uppercase labels only) |
+| **Telemetry value** | JetBrains Mono 500 | 13–28px | 0 |
+| **Status / timestamp / ID** | JetBrains Mono 400 | 12–13px | 0 |
+
+**Rule:** every number a user reads as "a reading" — metric, token count,
+duration, latency, cost, session ID, timestamp — is **JetBrains Mono**. Text
+prose is Inter. If it's a value, it's mono. This single rule does more for the
+"command center" feel than any color change.
+
+Uppercase labels (section headers, table column heads, KPI captions) use
+`text-transform: uppercase; letter-spacing: +0.08em; font-size: 11px;
+font-weight: 590; color: --color-text-muted`.
+
+---
+
+## 3. Spacing, radius, borders, depth
+
+- **Spacing scale:** 4 / 8 / 12 / 16 / 24 / 32 / 48 px. Cards pad 16–24.
+- **Radius:** 6px controls, 10px cards, 14px panels/modals. **Not** pill-round
+  (except status dots and the command-palette input). 6–14px reads
+  "engineered", not "consumer".
+- **Borders:** 1px `--color-border` (`#1E3A5F`) default;
+  `--color-border-subtle` (`#162035`) for inner divisions. Mission-control
+  grids are visible structure — don't hide borders, celebrate them at 1px.
+- **Shadow / depth:** prefer 1px border + one luminance step over blur shadows.
+  Elevated surfaces (modals, popovers): `0 0 0 1px #1E3A5F, 0 8px 24px rgba(0,0,0,0.5)`.
+- **Grid lines:** tables and telemetry grids show 1px `--color-border-subtle`
+  row dividers. No zebra striping — dividers carry it.
+
+---
+
+## 4. Signature components
+
+### Status dot + telemetry pair (the motif)
+Every agent/session/metric pairs a **cyan/amber/red dot** with a **mono value**:
+`● idle   2.3k tok` — dot encodes state, mono value is the reading, Inter label
+names it. This pair repeats everywhere (session row, KPI, header, badge).
+
+### Status color map (single source — reuse everywhere)
+| State | Dot/text | Hex |
+|-------|----------|-----|
+| idle / ready | cyan | `#00D4FF` |
+| working / running | amber (pulsing) | `#FFB800` |
+| waiting_for_input / awaiting_approval | warning | `#FF9F43` |
+| permission_prompt | warning | `#FF9F43` |
+| completed / nominal | success | `#26DE81` |
+| error / crashed / killed | danger | `#FF4757` |
+| stalled | warning (slow pulse) | `#FF9F43` |
+| unknown | text-muted | `#4A6080` |
+
+### KPI / telemetry card
+`#111827` surface, 1px `#1E3A5F` border, 16px pad. Top: uppercase Inter 590
+11px muted label. Center: huge JetBrains Mono value (amber if primary, else
+text-primary). Bottom: delta + sparkline (cyan). No icon unless it earns it.
+
+### Data table (session list)
+1px row dividers `#162035`, header row uppercase 11px muted on `#0B1120`.
+Status = dot+label. IDs/timestamps/tokens = mono. Hover row = `#1A2535`.
+Active row = left 2px amber border + `#1A2535`. Dense: 36–40px row height.
+
+### Command palette (⌘K)
+Full-width-minus-margins overlay, `#0F172A`, 1px `#1E3A5F`, 14px radius.
+Input: Inter, 18px, placeholder muted. Results: mono for session IDs / hotkeys,
+Inter for labels. Selected row: `--color-surface-active` + 2px amber left bar.
+
+### Primary CTA
+Amber bg, navy text, Inter 590 13px, 6px radius, 1px amber-hover border.
+Reserved for the single most important action on the screen (Launch session,
+Approve). Never two amber CTAs in one viewport.
+
+### Approval / permission toast
+Border-left 3px `--color-warning`. `#111827` surface. Mono session ID +
+Inter tool name. Actions: Approve (amber CTA) / Reject (ghost danger).
+
+---
+
+## 5. Motion
+
+- Status transitions are calm: dot color crossfade 150ms ease.
+- "working" agent dot pulses amber (opacity 1→0.4→1, 1.6s) — the only ambient
+  motion on a static screen. It signals "the system is alive".
+- No bounce, no spring, no parallax on data. Motion conveys state, never
+  decoration.
+- Loading = a 1px amber top-progress bar (indeterminate), not a spinner, for
+  full-page loads. Skeletons for content.
+
+---
+
+## 6. Voice & copy
+
+Operator-console voice. Terse, declarative, no marketing words.
+- "3 agents running · 2 awaiting approval" not "You have agents working!"
+- Statuses lowercase: `idle`, `working`, `awaiting approval`.
+- Numbers always paired with units: `2.3k tok`, `412 ms`, `$0.42`.
+- Empty states name the next action: "No sessions — press ⌘N to launch."
+
+---
+
+## 7. Redesign slices (ordered — each is one aegis-driven PR)
+
+Each slice is bounded enough for a single Claude Code session (via aegis,
+`permissionMode: acceptEdits`) to execute against this DESIGN.md. Verify gate
++ visual before merging.
+
+1. **Tokens + fonts.** Rewrite `src/index.css` `@theme` to the palette/type
+   above. Add `@fontsource/inter/latin.css`, retire DM Sans + purple. Map
+   every renamed token so existing utilities resolve. (Foundation — everything
+   else depends on this.)
+2. **Status system.** Centralize the status→color map (§4) into one module
+   (`utils/statusStyles` or similar); replace the scattered `--color-dot-*`
+   ad-hoc usage across components with it. Touches: SessionTable, StallBadge,
+   SessionMobileCard, status pills everywhere.
+3. **Mono-for-values sweep.** Find every numeric reading (tokens, ms, cost, IDs,
+   timestamps) rendered in Inter and switch to `--font-mono`. Mechanical,
+   high-impact.
+4. **KPI / telemetry cards.** Restyle overview KPI banner + metrics cards to
+   the §4 KPI pattern (uppercase label, big mono value, sparkline).
+5. **Data tables.** SessionTable + VirtualizedSessionList to the §4 table
+   pattern (dividers, active-row amber bar, dense rows).
+6. **Command palette + app shell.** Sidebar, header, ⌘K palette to Command
+   Center (navy surfaces, amber active, mono hotkeys). Brand mark restyle.
+7. **Session detail.** Transcript/terminal chrome, approval toast, the
+   "Send continue" composer → console aesthetic.
+8. **Page pass.** Remaining pages (Pipelines, Audit, Metrics, Cost, Analytics,
+   Templates, Routines, Settings, AuthKeys, Inbox, Activity) — apply tokens,
+   cut visual noise, enforce component patterns.
+9. **Cuts.** Remove dead/redundant UI, collapse low-value sections, tighten
+   information hierarchy. (The "tagli" the brief asks for.)
+10. **Polish + a11y.** Focus rings (amber), contrast audit (AA on all
+    data-on-surface pairs), keyboard nav, reduced-motion respect, loading
+    skeletons.
+
+**Per-slice definition of done:** `npm run build:dashboard` passes; the
+slice's touched components render correctly in the running dashboard; a
+before/after screenshot is captured; no new `any`/`as`; gate green on CI.

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/atkinson-hyperlegible": "^5.2.8",
         "@fontsource/dm-sans": "^5.2.8",
+        "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@tanstack/react-virtual": "^3.14.3",
         "canvas-confetti": "^1.9.4",
@@ -365,6 +366,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/dm-sans/-/dm-sans-5.2.8.tgz",
       "integrity": "sha512-tlovG42m9ESG28WiHpLq3F5umAlm64rv0RkqTbYowRn70e9OlRr5a3yTJhrhrY+k5lftR/OFJjPzOLQzk8EfCA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -884,9 +894,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,9 +911,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,9 +928,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,9 +945,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.2.8",
     "@fontsource/dm-sans": "^5.2.8",
+    "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@tanstack/react-virtual": "^3.14.3",
     "canvas-confetti": "^1.9.4",

--- a/dashboard/src/__tests__/MetricCards.mobile-responsive.test.tsx
+++ b/dashboard/src/__tests__/MetricCards.mobile-responsive.test.tsx
@@ -57,32 +57,32 @@ describe('MetricCards mobile responsive', () => {
     vi.restoreAllMocks();
   });
 
-  it('Delivery Rate card uses flex-col on mobile and sm:flex-row on larger screens', async () => {
+  it('Delivery Rate section uses flex-col on mobile and sm:flex-row on larger screens', async () => {
     render(<MemoryRouter><MetricCards /></MemoryRouter>);
 
     await act(async () => { await vi.runAllTicks(); });
 
-    // Find the card containing "Delivery Rate"
+    // Find the heading and traverse up to the container section
     const heading = screen.getByText('Delivery Rate');
-    const card = heading.closest('.card-glass');
-    expect(card).not.toBeNull();
+    // The container is the parent div with rounded-[10px] border etc.
+    const container = heading.closest('div[class*="rounded-[10px]"]');
+    expect(container).not.toBeNull();
 
     // The flex container holding RingGauge + text details
-    const flexContainer = card!.querySelector('.flex.flex-col');
+    const flexContainer = container!.querySelector('.flex.flex-col');
     expect(flexContainer).not.toBeNull();
     expect(flexContainer!.classList.contains('sm:flex-row')).toBe(true);
   });
 
-  it('Delivery Rate card uses responsive padding (p-4 sm:p-5)', async () => {
+  it('Delivery Rate section uses responsive padding (p-4)', async () => {
     render(<MemoryRouter><MetricCards /></MemoryRouter>);
 
     await act(async () => { await vi.runAllTicks(); });
 
     const heading = screen.getByText('Delivery Rate');
-    const card = heading.closest('.card-glass');
-    expect(card).not.toBeNull();
-    expect(card!.classList.contains('p-4')).toBe(true);
-    expect(card!.classList.contains('sm:p-5')).toBe(true);
+    const container = heading.closest('div[class*="rounded-[10px]"]');
+    expect(container).not.toBeNull();
+    expect(container!.classList.contains('p-4')).toBe(true);
   });
 
   it('Delivery Rate text content is centered on mobile, left-aligned on sm+', async () => {
@@ -91,23 +91,23 @@ describe('MetricCards mobile responsive', () => {
     await act(async () => { await vi.runAllTicks(); });
 
     const heading = screen.getByText('Delivery Rate');
-    const card = heading.closest('.card-glass');
+    const container = heading.closest('div[class*="rounded-[10px]"]');
     // The text details div
-    const textDiv = card!.querySelector('.flex-1.space-y-3');
+    const textDiv = container!.querySelector('.flex-1.space-y-3');
     expect(textDiv).not.toBeNull();
     expect(textDiv!.classList.contains('text-center')).toBe(true);
     expect(textDiv!.classList.contains('sm:text-left')).toBe(true);
   });
 
-  it('RingGauge renders inside the delivery rate card', async () => {
+  it('RingGauge renders inside the delivery rate section', async () => {
     render(<MemoryRouter><MetricCards /></MemoryRouter>);
 
     await act(async () => { await vi.runAllTicks(); });
 
     const heading = screen.getByText('Delivery Rate');
-    const card = heading.closest('.card-glass');
+    const container = heading.closest('div[class*="rounded-[10px]"]');
     // RingGauge renders an SVG element
-    const svg = card!.querySelector('svg');
+    const svg = container!.querySelector('svg');
     expect(svg).not.toBeNull();
   });
 });

--- a/dashboard/src/__tests__/a11y-css.test.ts
+++ b/dashboard/src/__tests__/a11y-css.test.ts
@@ -25,7 +25,8 @@ describe('index.css — focus ring tokens', () => {
 
   it('applies focus ring via :focus-visible', () => {
     expect(css).toContain(':focus-visible');
-    expect(css).toContain('box-shadow: var(--focus-ring-offset), var(--focus-ring)');
+    // Command Center redesign uses outline-based focus ring (DESIGN.md §1)
+    expect(css).toContain('outline: 2px solid var(--color-accent)');
   });
 
   it('removes outline for :focus:not(:focus-visible)', () => {

--- a/dashboard/src/components/analytics/KPIBanner.tsx
+++ b/dashboard/src/components/analytics/KPIBanner.tsx
@@ -61,7 +61,7 @@ export function KPIBanner({ items, className = '' }: KPIBannerProps) {
   if (items.length === 0) {
     return (
       <div
-        className="flex h-[52px] items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] text-sm text-[var(--color-text-muted)]"
+        className="flex h-[52px] items-center justify-center rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] text-sm text-[var(--color-text-muted)]"
         role="status"
         aria-label={t("aria.noKpiData")}
       >
@@ -72,7 +72,7 @@ export function KPIBanner({ items, className = '' }: KPIBannerProps) {
 
   return (
     <div
-      className={`grid divide-x divide-[var(--color-border)] rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] min-h-[52px] ${className}`}
+      className={`grid divide-x divide-[var(--color-border)] rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] min-h-[52px] ${className}`}
       style={{ gridTemplateColumns: `repeat(${items.length}, minmax(0, 1fr))` }}
       role="list"
       aria-label={t("aria.keyPerformanceIndicators")}
@@ -84,7 +84,10 @@ export function KPIBanner({ items, className = '' }: KPIBannerProps) {
           role="listitem"
           aria-label={`${item.label}: ${item.value}`}
         >
-          <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
+          <span
+            className="text-[11px] uppercase text-[var(--color-text-muted)]"
+            style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+          >
             {item.label}
           </span>
           <span className={`font-mono text-lg font-semibold tabular-nums ${COLOR_MAP[item.color]}`}>

--- a/dashboard/src/components/approvals/ApprovalBanner.tsx
+++ b/dashboard/src/components/approvals/ApprovalBanner.tsx
@@ -69,7 +69,7 @@ export function ApprovalBanner({ sessionId, sessionName }: ApprovalBannerProps) 
 
   return (
     <div
-      className="flex flex-col gap-3 rounded-lg border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+      className="flex flex-col gap-3 rounded-lg border border-[var(--color-border)] border-l-[3px] border-l-[var(--color-warning)] bg-[var(--color-surface)] px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
       role="alert"
       aria-label={t('aria.sessionAwaitingApproval')}
     >

--- a/dashboard/src/components/cost/SessionCostTable.tsx
+++ b/dashboard/src/components/cost/SessionCostTable.tsx
@@ -145,8 +145,8 @@ export function SessionCostTable({ sessions, concurrency = 5 }: SessionCostTable
           Session Cost Breakdown
         </h3>
         <div className="flex items-center gap-3 text-xs text-[var(--color-text-muted)]">
-          <span>{totalSessions} sessions</span>
-          <span>Total: {formatUsd(totalCost)}</span>
+          <span><span className="font-mono">{totalSessions}</span> sessions</span>
+          <span>Total: <span className="font-mono">{formatUsd(totalCost)}</span></span>
           {loadedCount < totalSessions && (
             <span className="flex items-center gap-1">
               <Loader2 className="h-3 w-3 animate-spin" />
@@ -229,12 +229,12 @@ export function SessionCostTable({ sessions, concurrency = 5 }: SessionCostTable
             </div>
 
             {/* Duration */}
-            <div className="w-20 hidden md:block text-right text-[var(--color-text-muted)]" role="cell">
+            <div className="w-20 hidden md:block text-right font-mono text-[var(--color-text-muted)]" role="cell">
               {row.loading ? '—' : formatDuration(row.cost?.durationMinutes ?? null)}
             </div>
 
             {/* Cache hit */}
-            <div className="w-20 hidden lg:block text-right text-[var(--color-text-muted)]" role="cell">
+            <div className="w-20 hidden lg:block text-right font-mono text-[var(--color-text-muted)]" role="cell">
               {row.loading ? '—' : (
                 row.cost ? `${(row.cost.cacheHitRate * 100).toFixed(0)}%` : '—'
               )}

--- a/dashboard/src/components/cost/SpendSummary.tsx
+++ b/dashboard/src/components/cost/SpendSummary.tsx
@@ -105,7 +105,7 @@ export function SpendSummary({ dailyTrends }: SpendSummaryProps) {
           <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
             {stat.label}
           </p>
-          <p className="mt-1 text-lg font-semibold text-[var(--color-text-primary)]">
+          <p className="mt-1 font-mono text-lg font-semibold text-[var(--color-text-primary)]">
             {stat.value}
           </p>
           <p className="mt-0.5 text-xs text-[var(--color-text-muted)]">

--- a/dashboard/src/components/cost/__tests__/SessionCostTable.test.tsx
+++ b/dashboard/src/components/cost/__tests__/SessionCostTable.test.tsx
@@ -59,7 +59,8 @@ describe('SessionCostTable', () => {
     render(<SessionCostTable sessions={[mockSession]} />);
     await act(async () => { resolve!(mockCost as SessionCostEntry); });
 
-    expect(screen.getByText('$1.25')).not.toBeNull();
+    // $1.25 appears in both header total and row, use getAllByText
+    expect(screen.getAllByText('$1.25').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('67%')).not.toBeNull();
   });
 
@@ -99,6 +100,13 @@ describe('SessionCostTable', () => {
     render(<SessionCostTable sessions={[mockSession]} />);
     await act(async () => { resolve!(mockCost as SessionCostEntry); });
 
-    expect(screen.getByText('Total: $1.25')).not.toBeNull();
+    // The header now renders "Total: " and "$1.25" in separate spans
+    // $1.25 appears in both header and row, so use getAllByText
+    const costElements = screen.getAllByText('$1.25');
+    expect(costElements.length).toBeGreaterThanOrEqual(1);
+    // Verify the total cost value is displayed in the header area
+    const header = screen.getByText('Session Cost Breakdown').closest('div');
+    expect(header!.textContent).toContain('Total:');
+    expect(header!.textContent).toContain('$1.25');
   });
 });

--- a/dashboard/src/components/layout/Header.tsx
+++ b/dashboard/src/components/layout/Header.tsx
@@ -42,7 +42,7 @@ export function Header({
 
   return (
     <>
-      <header className="shrink-0 border-b border-[var(--color-overlay-border)] bg-transparent backdrop-blur-md px-4 py-4 sm:px-8">
+      <header className="shrink-0 border-b border-[var(--color-border)] bg-[var(--color-void)] px-4 py-4 sm:px-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             <button

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar({
     <aside
       aria-label={t("aria.primarySidebar")}
       className={`
-        fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--color-overlay-border)] bg-transparent backdrop-blur-xl
+        fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--color-border)] bg-[var(--color-void-deep)]
         transition-all duration-300 ease-in-out
         ${sidebarWidth}
         ${isMobileDrawerOpen ? 'translate-x-0' : '-translate-x-full'}
@@ -71,9 +71,8 @@ export function Sidebar({
       `}
       aria-hidden={isMobileSidebarHidden ? 'true' : undefined}
       inert={isMobileSidebarHidden ? true : undefined}
-      style={{ backgroundImage: 'var(--sidebar-glow)' }}
     >
-      <div className="flex items-center justify-between gap-3 px-6 py-6 border-b border-[var(--color-overlay-border)]">
+      <div className="flex items-center justify-between gap-3 px-6 py-6 border-b border-[var(--color-border)]">
         <ShieldWordmark size="md" collapsed={isCollapsed} />
         <button
           type="button"
@@ -106,8 +105,8 @@ export function Sidebar({
                 className={({ isActive }) =>
                   `flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all min-h-[44px] ${
                     isActive
-                      ? 'border-l-2 border-[var(--color-accent-on-light)] bg-[var(--color-accent-on-light)]/10 text-[var(--color-accent-on-light)] dark:border-[var(--color-accent-cyan)] dark:bg-[var(--color-cta-bg)]/10 dark:text-[var(--color-accent-cyan)] glow-nav-active'
-                      : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] border-l-2 border-transparent dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-void-lighter)] dark:hover:text-[var(--color-text-primary)]'
+                      ? 'border-l-2 border-[var(--color-accent)] bg-[var(--color-surface-hover)] text-[var(--color-accent)] dark:border-[var(--color-accent)] dark:bg-[var(--color-surface-hover)] dark:text-[var(--color-accent)]'
+                      : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] border-l-2 border-transparent dark:text-[var(--color-text-muted)] dark:hover:bg-[var(--color-surface-hover)] dark:hover:text-[var(--color-text-primary)]'
                   } ${isCollapsed ? 'justify-center' : ''}`
                 }
                 title={isCollapsed ? label : undefined}
@@ -122,7 +121,7 @@ export function Sidebar({
         ))}
       </nav>
 
-      <div className="border-t border-[var(--color-overlay-border)] px-3 py-4 flex flex-col gap-2">
+      <div className="border-t border-[var(--color-border)] px-3 py-4 flex flex-col gap-2">
         {identityLabel && identityDetailLabel && !isCollapsed && (
           <div className="px-3 py-2" aria-label={t("aria.signedInUser")}>
             <p className="truncate text-xs font-medium text-[var(--color-text-primary)] dark:text-[var(--color-text-primary)]">{identityLabel}</p>

--- a/dashboard/src/components/overview/MetricCard.tsx
+++ b/dashboard/src/components/overview/MetricCard.tsx
@@ -80,7 +80,7 @@ export default function MetricCard({
     <div
       role="article"
       aria-label={`${label}: ${value}${suffix ?? ''}`}
-      className={`card-glass card-glass-interactive animate-bento-reveal p-5 flex flex-col metric-card${expanded ? ' metric-card--expanded' : ''} ${className}`}
+      className={`animate-bento-reveal flex flex-col rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 transition-colors hover:bg-[var(--color-surface-hover)] metric-card${expanded ? ' metric-card--expanded' : ''} ${className}`}
       {...(hasDetail
         ? {
             onClick: () => setExpanded((e) => !e),
@@ -94,7 +94,10 @@ export default function MetricCard({
           }
         : {})}
     >
-      <div className="mb-2 flex items-center gap-2 text-sm text-[var(--color-text-muted)] font-medium">
+      <div
+        className="mb-2 flex items-center gap-2 text-[11px] uppercase text-[var(--color-text-muted)]"
+        style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+      >
         {icon}
         {label}
       </div>
@@ -105,7 +108,7 @@ export default function MetricCard({
         </div>
       ) : (
         <>
-          <div className={`font-mono text-2xl ${colorMap[color]}`}>
+          <div className={`font-mono text-2xl tabular-nums ${colorMap[color]}`}>
             {animated && isNumeric ? (
               <AnimatedNumber
                 value={numericValue}
@@ -116,7 +119,7 @@ export default function MetricCard({
             ) : (
               <>
                 {value}
-                {suffix && <span className="ml-1 text-base text-muted-foreground">{suffix}</span>}
+                {suffix && <span className="ml-1 text-base text-[var(--color-text-muted)]">{suffix}</span>}
               </>
             )}
           </div>
@@ -153,7 +156,7 @@ export default function MetricCard({
       )}
 
       {subLabel && !customVisual && (
-        <div className="mt-1.5 text-xs text-muted-foreground">{subLabel}</div>
+        <div className="mt-1.5 text-xs text-[var(--color-text-muted)]">{subLabel}</div>
       )}
     </div>
   );

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -151,12 +151,15 @@ export default function MetricCards() {
         />
       )}
       {failedSessions > 0 && (
-        <div className="card-glass card-glass-interactive animate-bento-reveal p-5 flex flex-col gap-2">
-          <div className="flex items-center gap-2 text-sm text-[var(--color-text-muted)] font-medium">
+        <div className="animate-bento-reveal flex flex-col gap-2 rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 transition-colors hover:bg-[var(--color-surface-hover)]">
+          <div
+            className="flex items-center gap-2 text-[11px] uppercase text-[var(--color-text-muted)]"
+            style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+          >
             <AlertTriangle className="h-4 w-4 text-[var(--color-danger)]" />
             {t('metricCards.failedSessions')}
           </div>
-          <p className="font-mono text-2xl text-[var(--color-danger)] font-bold">{failedSessions}</p>
+          <p className="font-mono text-2xl tabular-nums text-[var(--color-danger)] font-bold">{failedSessions}</p>
           <NavLink
             to="/audit"
             className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest text-[var(--color-danger)] hover:text-[var(--color-danger-glow)] transition-colors"
@@ -169,8 +172,11 @@ export default function MetricCards() {
 
 
       {/* ── Prompt Delivery ──────────────────────────────── */}
-      <div className="col-span-2 lg:col-span-4 card-glass card-glass-interactive animate-bento-reveal p-4 sm:p-5 flex flex-col">
-        <div className="mb-1 flex items-center gap-2 text-sm text-[var(--color-text-muted)] font-medium">
+      <div className="col-span-2 lg:col-span-4 animate-bento-reveal flex flex-col rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 transition-colors hover:bg-[var(--color-surface-hover)]">
+        <div
+          className="mb-1 flex items-center gap-2 text-[11px] uppercase text-[var(--color-text-muted)]"
+          style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+        >
           <Zap className="h-4 w-4" />
           {t('metricCards.deliveryRate')}
         </div>
@@ -183,7 +189,7 @@ export default function MetricCards() {
           />
           <div className="flex-1 space-y-3 text-center sm:text-left">
             <div>
-              <p className="text-2xl font-mono font-bold text-white">
+              <p className="text-2xl font-mono font-bold tabular-nums text-[var(--color-text-primary)]">
                 {deliveryRate_ !== null ? `${deliveryRate_.toFixed(1)}%` : '—'}
               </p>
               <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{t('metricsOverview.trailingAverage')}</p>

--- a/dashboard/src/components/overview/MetricCards.tsx
+++ b/dashboard/src/components/overview/MetricCards.tsx
@@ -192,19 +192,19 @@ export default function MetricCards() {
               <div className="flex gap-4">
                 {promptsDelivered > 0 && (
                   <div>
-                    <p className="text-sm font-semibold text-[var(--color-success-glow)]">{promptsDelivered}</p>
+                    <p className="font-mono text-sm font-semibold text-[var(--color-success-glow)]">{promptsDelivered}</p>
                     <p className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-wider">{t('metricsOverview.delivered')}</p>
                   </div>
                 )}
                 {promptsFailed > 0 && (
                   <div>
-                    <p className="text-sm font-semibold text-[var(--color-danger)]">{promptsFailed}</p>
+                    <p className="font-mono text-sm font-semibold text-[var(--color-danger)]">{promptsFailed}</p>
                     <p className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-wider">{t('metricsOverview.failed')}</p>
                   </div>
                 )}
                 {promptsSent > 0 && (
                   <div>
-                    <p className="text-sm font-semibold text-[var(--color-text-muted)]">{promptsSent}</p>
+                    <p className="font-mono text-sm font-semibold text-[var(--color-text-muted)]">{promptsSent}</p>
                     <p className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-wider">{t('metricsOverview.totalSent')}</p>
                   </div>
                 )}

--- a/dashboard/src/components/overview/MetricsPanel.tsx
+++ b/dashboard/src/components/overview/MetricsPanel.tsx
@@ -55,13 +55,18 @@ interface StatTileProps {
 
 function StatTile({ icon, label, value, color = 'text-[var(--color-cta-bg)]' }: StatTileProps) {
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] px-4 py-3">
+    <div className="flex items-center gap-3 rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3">
       <div className="flex h-9 w-9 items-center justify-center rounded-md bg-[var(--color-void-dark)] text-[var(--color-text-muted)]">
         {icon}
       </div>
       <div>
-        <div className="text-xs text-muted-foreground">{label}</div>
-        <div className={`font-mono text-lg font-semibold ${color}`}>{value}</div>
+        <div
+          className="text-[11px] uppercase text-[var(--color-text-muted)]"
+          style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+        >
+          {label}
+        </div>
+        <div className={`font-mono text-lg font-semibold tabular-nums ${color}`}>{value}</div>
       </div>
     </div>
   );
@@ -161,7 +166,7 @@ export default function MetricsPanel() {
           icon={<Clock className="h-4 w-4" />}
           label={t('metricsPanel.uptime')}
           value={formatUptime(d.uptime)}
-          color="text-[var(--color-accent-violet)]"
+          color="text-[var(--color-text-primary)]"
         />
       </div>
     </div>

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -108,8 +108,8 @@ export const SessionMobileCard = memo(function SessionMobileCard({
       </div>
 
       <div className="flex flex-wrap items-center gap-3 text-xs text-[var(--color-text-muted)]">
-        <span>Age: {formatTimeAgo(session.createdAt)}</span>
-        <span>Active: {formatTimeAgo(session.lastActivity)}</span>
+        <span>Age: <span className="font-mono">{formatTimeAgo(session.createdAt)}</span></span>
+        <span>Active: <span className="font-mono">{formatTimeAgo(session.lastActivity)}</span></span>
         {session.latestActivityText && (
           <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-accent-cyan)]/10 px-2 py-0.5 text-[10px] text-[var(--color-accent-cyan)] truncate max-w-[180px]">
             {session.latestActivityText}

--- a/dashboard/src/components/overview/SessionMobileCard.tsx
+++ b/dashboard/src/components/overview/SessionMobileCard.tsx
@@ -35,7 +35,7 @@ export const SessionMobileCard = memo(function SessionMobileCard({
 }: SessionRowProps) {
   const t = useT();
   return (
-    <div className={`card-glass p-5 animate-bento-reveal transition-all ${isFocused ? 'border-[var(--color-accent-cyan)] ring-1 ring-[var(--color-accent-cyan)]/30' : ''}${needsApproval(session) ? ' approval-pending-row' : ''}`}>
+    <div className={`card-glass p-5 animate-bento-reveal transition-colors ${isFocused ? 'bg-[var(--color-surface-hover)] shadow-[inset_2px_0_0_var(--color-accent)]' : ''}${needsApproval(session) ? ' approval-pending-row' : ''}`}>
       <div className="mb-2 flex items-start justify-between gap-3">
         <label className="flex min-w-0 flex-1 items-center gap-3 text-sm text-[var(--color-text-primary)]">
           <input

--- a/dashboard/src/components/overview/SessionTable.tsx
+++ b/dashboard/src/components/overview/SessionTable.tsx
@@ -816,8 +816,8 @@ export default React.memo(function SessionTable({ maxRows }: SessionTableProps =
           <div className="hidden overflow-x-auto rounded-lg border border-[var(--color-void-lighter)] bg-[var(--color-surface)] md:block" tabIndex={0} aria-label={t("aria.sessionsTableScroll")}>
             <table className="w-full text-left text-sm" aria-label={t("aria.sessionsTable")}>
               <thead>
-                <tr className="border-b border-[var(--color-void-lighter)] text-[var(--color-text-muted)]">
-                  <th scope="col" className="px-4 py-3 font-medium">
+                <tr className="border-b border-[var(--color-void-lighter)] bg-[var(--color-void)]">
+                  <th scope="col" className="px-4 py-2.5">
                     <input
                       type="checkbox"
                       aria-label={t("aria.selectAll")}
@@ -826,15 +826,15 @@ export default React.memo(function SessionTable({ maxRows }: SessionTableProps =
                       className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
                     />
                   </th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.status')}</th>
-                  <th scope="col" className="hidden md:table-cell px-4 py-3 font-medium">{t('sessionTable.createdBy')}</th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.name')}</th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.workDir')}</th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.age')}</th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.lastActivity')}</th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.permission')}</th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.cost')}</th>
-                  <th scope="col" className="px-4 py-3 font-medium">{t('sessionTable.actions')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.status')}</th>
+                  <th scope="col" className="hidden md:table-cell px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.createdBy')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.name')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.workDir')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.age')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.lastActivity')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.permission')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.cost')}</th>
+                  <th scope="col" className="px-4 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">{t('sessionTable.actions')}</th>
                 </tr>
               </thead>
               <tbody className="sr-only">

--- a/dashboard/src/components/overview/StatusDot.tsx
+++ b/dashboard/src/components/overview/StatusDot.tsx
@@ -9,32 +9,11 @@ import { useEffect, useRef, useState } from 'react';
 import type { UIState } from '../../types';
 import { useT } from '../../i18n/context';
 import type { SessionHealthState } from '../../types';
+import { getStatusStyle } from '../../utils/statusStyles';
 
-const STATUS_COLORS: Record<UIState, string> = {
-  idle: 'var(--color-success)',
-  working: 'var(--color-cta-bg)',
-  permission_prompt: 'var(--color-warning)',
-  bash_approval: 'var(--color-warning)',
-  plan_mode: 'var(--color-dot-orange)',
-  ask_question: 'var(--color-error)',
-  settings: 'var(--color-cta-bg)',
-  error: 'var(--color-dot-red)',
-  rate_limit: 'var(--color-dot-red)',
-  compacting: 'var(--color-warning)',
-  context_warning: 'var(--color-warning)',
-  waiting_for_input: 'var(--color-warning)',
-  pending: 'var(--color-dot-pending)',
-  awaiting_approval: 'var(--color-dot-awaiting-approval)',
-  unknown: 'var(--color-dot-unknown)',
-  killed: 'var(--color-dot-killed)',
-  completed: 'var(--color-dot-completed)',
-  crashed: 'var(--color-dot-crashed)',
-};
-
-const HEALTH_COLORS: Record<SessionHealthState, string> = {
-  stall: 'var(--color-warning)',
-  dead: 'var(--color-dot-red)',
-};
+// Dead is a health state (not a UIState) with no row in the §4 status map.
+// It keeps its own danger token; all UIState colors come from getStatusStyle.
+const DEAD_DOT_COLOR = 'var(--color-dot-red)';
 
 const PULSE_STATUSES: ReadonlySet<UIState> = new Set([
   'working',
@@ -86,10 +65,10 @@ export default function StatusDot({ status, health }: StatusDotProps) {
   const isDead = health === 'dead';
 
   const baseColor = isDead
-    ? HEALTH_COLORS.dead
+    ? DEAD_DOT_COLOR
     : isStall
-    ? HEALTH_COLORS.stall
-    : STATUS_COLORS[status] ?? STATUS_COLORS.unknown;
+    ? getStatusStyle('stalled').dotColor
+    : getStatusStyle(status).dotColor;
 
   const shouldPulse = isStall || PULSE_STATUSES.has(status);
   // Dead uses faster pulse to signal urgency

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -259,10 +259,10 @@ function VirtualizedRow(props: {
       <div className="flex items-center max-w-[150px] truncate px-3 font-mono text-xs text-[var(--color-text-muted)]" title={session.workDir}>
         {truncateDir(session.workDir)}
       </div>
-      <div className="flex items-center whitespace-nowrap px-3 text-[var(--color-text-muted)] text-sm">
+      <div className="flex items-center whitespace-nowrap px-3 font-mono text-[var(--color-text-muted)] text-sm">
         {formatTimeAgo(session.createdAt)}
       </div>
-      <div className="flex items-center whitespace-nowrap px-3 text-[var(--color-text-muted)] text-sm">
+      <div className="flex items-center whitespace-nowrap px-3 font-mono text-[var(--color-text-muted)] text-sm">
         {formatTimeAgo(session.lastActivity)}
       </div>
       <div className="flex items-center px-3 text-xs text-[var(--color-text-muted)] truncate" title={session.latestActivityText ?? ''}>
@@ -282,7 +282,7 @@ function VirtualizedRow(props: {
           </span>
         )}
       </div>
-      <div className="flex items-center px-3 text-xs text-[var(--color-text-muted)]">
+      <div className="flex items-center px-3 font-mono text-xs text-[var(--color-text-muted)]">
         {estimatedCostUsd != null ? `$${estimatedCostUsd.toFixed(2)}` : '—'}
       </div>
       <div className="flex items-center gap-1 px-3">

--- a/dashboard/src/components/overview/VirtualizedSessionList.tsx
+++ b/dashboard/src/components/overview/VirtualizedSessionList.tsx
@@ -26,6 +26,7 @@ import {
 import type { SessionHealthState, SessionInfo } from '../../types';
 import { formatTimeAgo } from '../../utils/format';
 import StatusDot from './StatusDot';
+import { getStatusStyle } from '../../utils/statusStyles';
 import { useT } from '../../i18n/context';
 
 const needsApproval = (session: SessionInfo): boolean =>
@@ -67,8 +68,8 @@ export interface VirtualizedSessionListProps {
 
 // ── Constants ───────────────────────────────────────────────
 
-export const ROW_HEIGHT = 52;
-export const GROUP_ROW_HEIGHT = 44;
+export const ROW_HEIGHT = 40;
+export const GROUP_ROW_HEIGHT = 36;
 const DEFAULT_MAX_VISIBLE_ROWS = 12;
 const OVERSCAN_COUNT = 5;
 
@@ -86,7 +87,7 @@ const GROUP_ROW_STABLE_STYLE: Pick<CSSProperties, 'minHeight' | 'contentVisibili
   containIntrinsicSize: `0 ${GROUP_ROW_HEIGHT}px` as unknown as CSSProperties['containIntrinsicSize'],
 };
 
-const GRID_COLUMNS = '36px 40px 80px 1fr 150px 80px 90px 1fr 80px 60px 80px';
+const GRID_COLUMNS = '36px 128px 80px 1fr 150px 80px 90px 1fr 80px 60px 80px';
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -136,7 +137,7 @@ function ApproveButton({
       onClick={(e) => onApprove(e, session.id)}
       disabled={currentAction === 'approve'}
       aria-label={`Approve session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
-      className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-[var(--color-success)]/15 text-xs font-medium text-[var(--color-success)] transition-colors hover:bg-[var(--color-success)]/25 disabled:pointer-events-none disabled:opacity-40"
+      className="flex min-h-[36px] min-w-[36px] items-center justify-center rounded-md bg-[var(--color-success)]/15 text-xs font-medium text-[var(--color-success)] transition-colors hover:bg-[var(--color-success)]/25 disabled:pointer-events-none disabled:opacity-40"
       title={t('aria.approve')}
     >
       <Play className="h-3 w-3" />
@@ -161,7 +162,7 @@ function RejectButton({
       onClick={(e) => onReject(e, session.id)}
       disabled={currentAction === 'reject'}
       aria-label={`Reject session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
-      className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-[var(--color-danger)]/15 text-xs font-medium text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger)]/25 disabled:pointer-events-none disabled:opacity-40"
+      className="flex min-h-[36px] min-w-[36px] items-center justify-center rounded-md bg-[var(--color-danger)]/15 text-xs font-medium text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger)]/25 disabled:pointer-events-none disabled:opacity-40"
       title={t('aria.reject')}
     >
       <XCircle className="h-3 w-3" />
@@ -185,12 +186,12 @@ function VirtualizedRow(props: {
     return (
       <div
         style={{ ...style, ...GROUP_ROW_STABLE_STYLE }}
-        className="border-b border-[color:var(--color-overlay-border-faint)] bg-[color:var(--color-overlay-bg-faint)]"
+        className="border-b border-[var(--color-border-subtle)] bg-[var(--color-void)]"
         {...ariaAttributes}
       >
         <button
           type="button"
-          className="flex h-full min-h-[44px] w-full items-center gap-2 px-4 text-left text-sm text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-overlay-bg)]"
+          className="flex h-full min-h-[36px] w-full items-center gap-2 px-4 text-left text-sm text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)]"
           onClick={() => onToggleGroup(dirKey)}
           aria-expanded={!isCollapsed}
           aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${dirKey} group, ${count} sessions`}
@@ -208,14 +209,15 @@ function VirtualizedRow(props: {
 
   const { data } = item;
   const { session, isAlive, health, selected, currentAction, estimatedCostUsd, isFocused } = data;
+  const statusStyle = getStatusStyle(session.status);
 
   return (
     <div
       style={{ ...style, ...SESSION_ROW_STABLE_STYLE, gridTemplateColumns: GRID_COLUMNS }}
-      className={`grid border-b border-[var(--color-overlay-border)] transition-[background-color,border-color,box-shadow,transform,opacity,color] duration-150 ease-out ${
+      className={`grid border-b border-[var(--color-border-subtle)] transition-colors duration-150 ease-out ${
         isFocused
-          ? 'bg-[var(--color-accent-cyan)]/10 ring-1 ring-inset ring-[var(--color-accent-cyan)]/40 shadow-[0_0_15px_rgba(6,182,212,0.15)]'
-          : 'hover:bg-[var(--color-overlay-bg)] hover:scale-[1.002] cursor-pointer'
+          ? 'bg-[var(--color-surface-hover)] shadow-[inset_2px_0_0_var(--color-accent)]'
+          : 'hover:bg-[var(--color-surface-hover)] cursor-pointer'
       }${needsApproval(session) ? ' approval-pending-row' : ''}`}
       data-session-id={session.id}
       {...ariaAttributes}
@@ -229,14 +231,17 @@ function VirtualizedRow(props: {
           className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
         />
       </div>
-      <div className="flex items-center px-2">
-        <span className={needsApproval(session) ? 'relative' : ''}>
+      <div className="flex min-w-0 items-center gap-2 px-2">
+        <span className={`shrink-0 ${needsApproval(session) ? 'relative' : ''}`}>
           <StatusDot status={session.status} health={health} />
           {needsApproval(session) && (
             <span className="absolute -inset-1 animate-pulse rounded-full bg-[var(--color-warning)]/20" aria-hidden="true" />
           )}
         </span>
-        {!isAlive && <XCircle className="h-3.5 w-3.5 text-[var(--color-danger)]" />}
+        <span className="truncate font-mono text-xs" style={{ color: statusStyle.dotColor }}>
+          {statusStyle.label}
+        </span>
+        {!isAlive && <XCircle className="h-3.5 w-3.5 shrink-0 text-[var(--color-danger)]" />}
       </div>
       <div className="hidden md:flex items-center whitespace-nowrap px-3 font-mono text-xs text-[var(--color-text-muted)]">
         {session.ownerKeyId
@@ -246,7 +251,7 @@ function VirtualizedRow(props: {
       <div className="flex min-w-0 items-center px-3">
         <Link
           to={`/sessions/${encodeURIComponent(session.id)}`}
-          className="inline-flex min-h-[44px] min-w-0 items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-cyan)]"
+          className="inline-flex min-h-[36px] min-w-0 items-center truncate font-medium text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-cyan)]"
           title={session.displayName || session.id}
         >
           {formatSessionName(session.displayName, session.id.slice(0, 8))}
@@ -298,7 +303,7 @@ function VirtualizedRow(props: {
           type="button"
           onClick={(e) => onInterrupt(e, session.id)}
           aria-label={`Interrupt session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
-          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-[var(--color-text-muted)] hover:text-[var(--color-warning)] hover:bg-[var(--color-warning)]/10 transition-colors"
+          className="flex min-h-[36px] min-w-[36px] items-center justify-center rounded text-[var(--color-text-muted)] hover:text-[var(--color-warning)] hover:bg-[var(--color-warning)]/10 transition-colors"
           title={t('aria.interrupt')}
         >
           <Ban className="h-3.5 w-3.5" />
@@ -307,7 +312,7 @@ function VirtualizedRow(props: {
           type="button"
           onClick={(e) => onKill(e, session.id)}
           aria-label={`Kill session ${formatSessionName(session.displayName, session.id.slice(0, 8))}`}
-          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-[var(--color-text-muted)] hover:text-[var(--color-danger)] hover:bg-[var(--color-danger)]/10 transition-colors"
+          className="flex min-h-[36px] min-w-[36px] items-center justify-center rounded text-[var(--color-text-muted)] hover:text-[var(--color-danger)] hover:bg-[var(--color-danger)]/10 transition-colors"
           title={t('aria.kill')}
         >
           <XCircle className="h-3.5 w-3.5" />
@@ -382,10 +387,10 @@ export function VirtualizedSessionList({
     <div className="rounded-lg border border-[var(--color-void-lighter)] overflow-hidden" style={{ minHeight: containerMinHeight, containLayout: true, contain: 'layout' } as CSSProperties}>
       {showHeader && (
         <div
-          className="grid border-b border-[var(--color-void-lighter)] text-[var(--color-text-muted)] text-sm text-left bg-[var(--color-surface)]"
+          className="grid border-b border-[var(--color-void-lighter)] text-left bg-[var(--color-void)]"
           style={{ gridTemplateColumns: GRID_COLUMNS }}
         >
-          <div className="px-3 py-3 font-medium">
+          <div className="px-3 py-2.5">
             <input
               type="checkbox"
               aria-label={t("aria.selectAll")}
@@ -394,16 +399,16 @@ export function VirtualizedSessionList({
               className="h-4 w-4 rounded border border-[var(--color-void-lighter)] bg-[var(--color-void-dark)] text-[var(--color-accent-cyan)] focus:ring-1 focus:ring-[var(--color-accent-cyan)]"
             />
           </div>
-          <div className="px-2 py-3 font-medium" role="columnheader">{t('sessionTable.status')}</div>
-          <div className="hidden md:flex px-3 py-3 font-medium" role="columnheader">{t('sessionTable.createdBy')}</div>
-          <div className="px-3 py-3 font-medium" role="columnheader">{t('sessionTable.name')}</div>
-          <div className="flex px-3 py-3 font-medium" role="columnheader">{t('sessionTable.workDir')}</div>
-          <div className="px-3 py-3 font-medium" role="columnheader">{t('sessionTable.age')}</div>
-          <div className="px-3 py-3 font-medium" role="columnheader">{t('sessionTable.lastActivity')}</div>
-          <div className="px-3 py-3 font-medium" role="columnheader">{t('sessionTable.activity')}</div>
-          <div className="px-3 py-3 font-medium" role="columnheader">{t('sessionTable.permission')}</div>
-          <div className="px-3 py-3 font-medium" role="columnheader">{t('sessionTable.cost')}</div>
-          <div className="px-3 py-3 font-medium" role="columnheader">{t('sessionTable.actions')}</div>
+          <div className="px-2 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.status')}</div>
+          <div className="hidden md:flex px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.createdBy')}</div>
+          <div className="px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.name')}</div>
+          <div className="flex px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.workDir')}</div>
+          <div className="px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.age')}</div>
+          <div className="px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.lastActivity')}</div>
+          <div className="px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.activity')}</div>
+          <div className="px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.permission')}</div>
+          <div className="px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.cost')}</div>
+          <div className="px-3 py-2.5 text-[11px] font-[590] uppercase tracking-[0.08em] text-[var(--color-text-muted)]" role="columnheader">{t('sessionTable.actions')}</div>
         </div>
       )}
 

--- a/dashboard/src/components/overview/__tests__/cls-regression.test.tsx
+++ b/dashboard/src/components/overview/__tests__/cls-regression.test.tsx
@@ -37,12 +37,12 @@ const KPI_ITEMS: KPIItem[] = [
 // ── 1. Row height constants ─────────────────────────────────
 
 describe('VirtualizedSessionList row height constants (CLS regression #4726)', () => {
-  it('ROW_HEIGHT is 52px — changing this breaks CLS budget', () => {
-    expect(ROW_HEIGHT).toBe(52);
+  it('ROW_HEIGHT is 40px — changing this breaks CLS budget', () => {
+    expect(ROW_HEIGHT).toBe(40);
   });
 
-  it('GROUP_ROW_HEIGHT is 44px — changing this breaks CLS budget', () => {
-    expect(GROUP_ROW_HEIGHT).toBe(44);
+  it('GROUP_ROW_HEIGHT is 36px — changing this breaks CLS budget', () => {
+    expect(GROUP_ROW_HEIGHT).toBe(36);
   });
 });
 
@@ -125,23 +125,16 @@ describe('VirtualizedSessionList row transitions (CLS regression #4739)', () => 
     expect(rowClassName).not.toContain('duration-[var(--duration-slow)]');
   });
 
-  it('row className uses a precise transition list restricted to paint/composite properties', () => {
-    // Must declare a precise transition directive (Tailwind arbitrary value list).
-    expect(rowClassName).toMatch(/transition-\[/);
+  it('row className uses transition-colors restricted to paint/composite properties', () => {
+    // Uses transition-colors (shorthand for background-color, border-color, color)
+    expect(rowClassName).toContain('transition-colors');
 
-    // The list must not animate layout-triggering keywords.
-    // Acceptable list content examples: background-color, border-color, box-shadow,
-    // transform, opacity, color. Disallowed: width, height, padding, margin.
-    const listMatch = rowClassName.match(/transition-\[([^\]]+)\]/);
-    expect(listMatch, 'expected a transition-[...] directive on the row').toBeTruthy();
-    if (listMatch) {
-      const properties = listMatch[1].split(',').map((p) => p.trim().toLowerCase());
-      for (const forbidden of ['width', 'height', 'padding', 'margin']) {
-        expect(
-          properties.includes(forbidden),
-          `row transition list must not include layout property "${forbidden}" — found: ${properties.join(', ')}`,
-        ).toBe(false);
-      }
+    // transition-colors is safe (only color-related properties)
+    for (const forbidden of ['transition-all', 'transition-[']) {
+      expect(
+        rowClassName.includes(forbidden),
+        `row must not use broad transition "${forbidden}"`,
+      ).toBe(false);
     }
   });
 

--- a/dashboard/src/components/session/ApprovalBanner.tsx
+++ b/dashboard/src/components/session/ApprovalBanner.tsx
@@ -52,22 +52,13 @@ export function ApprovalBanner({
   }
 
   return (
-    <motion.div 
-      initial={{ opacity: 0, scale: 0.98, background: 'rgba(var(--color-warning-rgb, 245,158,11), 0.05)' }}
-      animate={{ 
-        opacity: 1, 
-        scale: 1,
-        boxShadow: ['0 0 0px rgba(var(--color-warning-rgb, 245,158,11), 0)', '0 0 15px rgba(var(--color-warning-rgb, 245,158,11), 0.2)', '0 0 0px rgba(var(--color-warning-rgb, 245,158,11), 0)'],
-        borderColor: ['rgba(var(--color-warning-rgb, 245,158,11), 0.2)', 'rgba(var(--color-warning-rgb, 245,158,11), 0.5)', 'rgba(var(--color-warning-rgb, 245,158,11), 0.2)']
-      }}
-      transition={{ 
-        boxShadow: { repeat: Infinity, duration: 3, ease: 'easeInOut' },
-        borderColor: { repeat: Infinity, duration: 3, ease: 'easeInOut' },
-        scale: { type: "spring", bounce: 0.4, duration: 0.6 }
-      }}
-      className="flex flex-col gap-3 rounded-xl border border-[var(--color-warning)]/40 bg-[var(--color-void-dark)]/90 backdrop-blur-md px-4 py-4 sm:flex-row sm:items-center sm:justify-between shadow-lg relative overflow-hidden"
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+      className="flex flex-col gap-3 rounded-xl border border-[var(--color-border)] border-l-[3px] border-l-[var(--color-warning)] bg-[var(--color-surface)] px-4 py-4 sm:flex-row sm:items-center sm:justify-between shadow-lg relative overflow-hidden"
     >
-      <div className="absolute inset-0 bg-gradient-to-r from-transparent via-[var(--color-warning)]/5 to-transparent pointer-events-none" />
+      <div className="absolute inset-0 pointer-events-none" />
 
       <div className="min-w-0 flex-1 relative z-10">
         <div className="flex flex-wrap items-center gap-3">
@@ -108,7 +99,7 @@ export function ApprovalBanner({
           type="button"
           onClick={handleApprove}
           disabled={isLoading}
-          className="min-h-[44px] rounded-lg border border-[var(--color-success)]/40 bg-[var(--color-success)]/20 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-success)] transition-colors hover:bg-[var(--color-success)]/30 hover:border-[var(--color-success)]/60 shadow-[0_0_15px_rgba(34,197,94,0.15)] hover:shadow-[0_0_20px_rgba(34,197,94,0.3)] disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-[44px] rounded border border-[var(--color-cta-bg)] bg-[var(--color-cta-bg)] px-4 py-2 text-[13px] font-semibold tracking-wide text-[var(--color-cta-text)] transition-colors hover:bg-[var(--color-cta-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isLoading ? '…' : 'APPROVE'}
         </motion.button>
@@ -118,7 +109,7 @@ export function ApprovalBanner({
           type="button"
           onClick={handleReject}
           disabled={isLoading}
-          className="min-h-[44px] rounded-lg border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/10 px-4 py-2 text-xs font-semibold tracking-wide text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger)]/20 hover:border-[var(--color-danger)]/50 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-[44px] rounded border border-[var(--color-danger)] bg-transparent px-4 py-2 text-[13px] font-semibold tracking-wide text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger)]/10 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isLoading ? '…' : 'REJECT'}
         </motion.button>

--- a/dashboard/src/components/session/SendContinueButton.tsx
+++ b/dashboard/src/components/session/SendContinueButton.tsx
@@ -50,9 +50,9 @@ export function SendContinueButton({ sessionId, className }: SendContinueButtonP
         disabled={isLoading}
         aria-label="Send continue (manual recovery after auto-recovery gave up)"
         className={[
-          'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium',
-          'border-amber-500/40 bg-amber-500/10 text-amber-200',
-          'hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-400/40',
+          'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-semibold',
+          'border-[var(--color-cta-bg)] bg-[var(--color-cta-bg)] text-[var(--color-cta-text)]',
+          'hover:bg-[var(--color-cta-bg-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--color-cta-bg)]/40',
           'disabled:cursor-not-allowed disabled:opacity-60',
         ].join(' ')}
       >

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -225,14 +225,14 @@ export function SessionHeader({
             <button
               type="button"
               onClick={onApprove}
-              className="hidden min-h-[44px] rounded border border-[var(--color-success)]/30 bg-[var(--color-success-bg)] px-3 py-2 text-xs font-medium text-[var(--color-success)] transition-colors hover:bg-[var(--color-success-bg-hover)] sm:inline-flex"
+              className="hidden min-h-[44px] rounded border border-[var(--color-cta-bg)] bg-[var(--color-cta-bg)] px-3 py-2 text-xs font-semibold text-[var(--color-cta-text)] transition-colors hover:bg-[var(--color-cta-bg-hover)] sm:inline-flex"
             >
               Approve
             </button>
             <button
               type="button"
               onClick={onReject}
-              className="hidden min-h-[44px] rounded border border-[var(--color-error)]/30 bg-[var(--color-error-bg)] px-3 py-2 text-xs font-medium text-[var(--color-error)] transition-colors hover:bg-[var(--color-error-bg-hover)] sm:inline-flex"
+              className="hidden min-h-[44px] rounded border border-[var(--color-danger)] bg-transparent px-3 py-2 text-xs font-semibold text-[var(--color-danger)] transition-colors hover:bg-[var(--color-danger)]/10 sm:inline-flex"
             >
               Reject
             </button>

--- a/dashboard/src/components/session/SessionHeader.tsx
+++ b/dashboard/src/components/session/SessionHeader.tsx
@@ -184,8 +184,8 @@ export function SessionHeader({
       {/* Metadata row — permission mode lives here as a small muted chip
            (epic 03.2), not as a primary badge in the title row. */}
       <div className="mb-3 flex flex-wrap items-center gap-3 text-[11px] text-[var(--color-text-muted)]">
-        <span>Created: {formatDate(session.createdAt)}</span>
-        <span className="hidden sm:inline">Last activity: {formatDate(session.lastActivity)}</span>
+        <span>Created: <span className="font-mono">{formatDate(session.createdAt)}</span></span>
+        <span className="hidden sm:inline">Last activity: <span className="font-mono">{formatDate(session.lastActivity)}</span></span>
         <span className="group inline-flex items-center gap-1 font-mono">
           <span className="hidden sm:inline">{t('sessionDetail.idLabel')}</span>
           {truncateMiddle(session.id, 16)}

--- a/dashboard/src/components/session/StallBadge.tsx
+++ b/dashboard/src/components/session/StallBadge.tsx
@@ -24,16 +24,12 @@ import {
   isRecoveryDisabled,
   formatStallTooltip,
 } from '../../utils/stallClassLabels';
+import { getStatusStyle } from '../../utils/statusStyles';
 
 export interface StallBadgeProps {
   payload: Partial<StallEventPayload>;
   className?: string;
 }
-
-const STALL_COLOR_CLASSES: Record<'amber' | 'red', string> = {
-  amber: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
-  red: 'border-red-500/40 bg-red-500/10 text-red-200',
-};
 
 /**
  * Compact "kill-switch" indicator icon (operator paused auto-recovery for
@@ -86,10 +82,12 @@ export function StallBadge({ payload, className }: StallBadgeProps) {
   const disabled = isRecoveryDisabled(payload);
   const tooltip = formatStallTooltip(payload);
 
-  // Color: amber for transient_5xx (retry-eligible), red for others (more severe).
-  const colorKey: 'amber' | 'red' =
-    payload.errorClass === 'transient_5xx' ? 'amber' : 'red';
-  const colorClasses = STALL_COLOR_CLASSES[colorKey];
+  // Color from the centralized §4 status map: transient_5xx is retry-eligible
+  // (warning/amber, mapped via `stalled`); other classes are more severe (danger/red).
+  const colorClasses =
+    payload.errorClass === 'transient_5xx'
+      ? getStatusStyle('stalled').className
+      : getStatusStyle('error').className;
 
   // Subtle visual cue when cap is reached: slight ring outline.
   const ringClass = exhausted ? 'ring-1 ring-amber-400/40' : '';

--- a/dashboard/src/components/session/TranscriptBubble.tsx
+++ b/dashboard/src/components/session/TranscriptBubble.tsx
@@ -314,7 +314,7 @@ export function TranscriptBubble({ entry, index, onFocus, focused }: TranscriptB
           </div>
           <RenderWithCodeBlocks text={entry.text} />
           {entry.timestamp && (
-            <div className={`text-[10px] mt-1 ${isUser ? 'text-[var(--color-void)]/60' : 'text-[var(--color-text-muted)]'}`}>
+            <div className={`text-[10px] mt-1 font-mono ${isUser ? 'text-[var(--color-void)]/60' : 'text-[var(--color-text-muted)]'}`}>
               {absoluteTime}
             </div>
           )}

--- a/dashboard/src/components/session/TranscriptView.tsx
+++ b/dashboard/src/components/session/TranscriptView.tsx
@@ -201,7 +201,7 @@ export function TranscriptView({ sessionId }: TranscriptViewProps) {
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto px-4 py-3"
+        className="flex-1 overflow-y-auto px-4 py-3 bg-[var(--color-void)]"
       >
         {filteredMessages.length === 0 && (
           <div className="flex flex-col items-center justify-center h-full text-[var(--color-text-muted)] text-center gap-3">

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -7,7 +7,7 @@
  * Self-hosted fonts via npm packages (no CDN) so the dashboard's
  * strict CSP stays quiet on first load.
  * ================================================================ */
-@import "@fontsource/dm-sans/latin.css";
+@import "@fontsource/inter/latin.css";
 @import "@fontsource/jetbrains-mono/latin.css";
 @import "@fontsource/atkinson-hyperlegible/index.css";
 
@@ -22,61 +22,64 @@
 }
 
 @theme {
-  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', "Cascadia Code", "Consolas", monospace;
 
-  /* Deep SaaS Dark Mode Palette */
-  --color-void: #020617; /* Background */
-  --color-void-deep: #000000;
-  --color-void-dark: #0f172a; /* Primary */
-  --color-void-light: #1e293b; /* Secondary */
-  --color-void-lighter: #334155;
-  --color-surface: #0f172a;
-  --color-surface-hover: #1e293b;
+  /* Command Center — deep-space navy surfaces (DESIGN.md §1) */
+  --color-void: #0B1120; /* Page canvas — deep-space navy */
+  --color-void-deep: #060912; /* App shell / off-screen depth */
+  --color-void-dark: #111827; /* Panels, cards, elevated areas */
+  --color-void-light: #1A2535; /* Interactive surface hover */
+  --color-void-lighter: #1E3A5F; /* Panel dividers, grid lines */
+  --color-surface: #111827; /* alias of --color-void-dark */
+  --color-surface-hover: #1A2535; /* alias of --color-void-light */
+  --color-surface-active: #1E3A5F; /* Selected / active panel */
+  --color-border-subtle: #162035; /* Inner dividers, minor separation */
   
-  --color-text-primary: #f8fafc;
-  --color-text-muted: #94a3b8;
-   --color-placeholder: #94a3b8; /* slate-400 — placeholder text (WCAG AA 6.96:1 on dark) */
+  --color-text-primary: #E8F0FE; /* cool white (DESIGN.md §1) */
+  --color-text-muted: #8BA3C7; /* labels, secondary copy */
+  --color-placeholder: #4A6080; /* timestamps, metadata, placeholders */
   
   /* Primary Gradients and Accents */
-  --color-accent: #3b82f6; /* Modern Blue */
-  --color-accent-dim: #3b82f620;
-  --color-accent-cyan: #06b6d4;
-  --color-accent-cyan-rgb: 6, 182, 212;
+  --color-accent: #FFB800; /* Primary telemetry / brand amber (DESIGN.md §1) */
+  --color-accent-dim: #FFB80020; /* amber @ ~12% — dim accent wash */
+  --color-accent-cyan: #00D4FF; /* healthy / active / links */
+  --color-accent-cyan-rgb: 0, 212, 255;
   --color-accent-cyan-glow: #67e8f9; /* cyan-300 — glow/shadow color */
-  --color-accent-purple: #8b5cf6;
-  --color-accent-purple-rgb: 139, 92, 246;
+  --color-accent-purple: var(--color-accent); /* deprecated: use --color-accent */
+  --color-accent-purple-rgb: 255, 184, 0; /* deprecated: amber mirror of --color-accent */
   /* Accent tuned for light-mode contrast (blue-600 ≥ 4.5:1 on #f8fafc). */
   --color-accent-on-light: #2563eb;
 
   /* Brand wordmark color (dark fallback = text-primary, overridden per theme). */
   --color-brand: #f8fafc;
 
-  /* Surfaces (strong = fully-opaque card surface for light theme). */
-  --color-surface-strong: #0f172a;
-  --color-border-strong: #334155;
+  /* Surfaces (strong = fully-opaque card surface). */
+  --color-surface-strong: #111827;
+  --color-border-strong: #1E3A5F;
 
-  /* Primary CTA pair. Dark-mode stays accent-cyan; light-mode uses emerald-600. */
-  --color-cta-bg: var(--color-accent-cyan);
+  /* Primary CTA pair — amber bg, navy text (DESIGN.md §1). Light-mode overrides below. */
+  --color-cta-bg: var(--color-accent);
   --color-cta-text: var(--color-void);
-  --color-cta-bg-hover: var(--color-accent-cyan);
+  --color-cta-bg-hover: #FFC933;
 
-  /* Status Colors */
-  --color-danger: #ef4444;
-  --color-danger-rgb: 239, 68, 68;
-  --color-success: #22c55e;
-  --color-success-rgb: 34, 197, 94;
-  --color-warning: #f59e0b;
-  --color-warning-rgb: 245, 158, 11;
-  --color-dot-pending: #f0ad4e;
-  --color-dot-unknown: #666;
-  --color-dot-killed: #888;
-  --color-dot-completed: #4CAF50;
-  --color-dot-crashed: #F44336;
-  --color-dot-orange: #f97316;
-  --color-dot-red: #ef4444;
-  --color-dot-awaiting-approval: #f59e0b;
-  --color-info: #3b82f6;
+  /* Status colors (DESIGN.md §1 data palette) */
+  --color-danger: #FF4757;
+  --color-danger-rgb: 255, 71, 87;
+  --color-success: #26DE81;
+  --color-success-rgb: 38, 222, 129;
+  --color-warning: #FF9F43;
+  --color-warning-rgb: 255, 159, 67;
+  /* Status dots — single source map (DESIGN.md §4) */
+  --color-dot-pending: #FF9F43; /* awaiting → warning */
+  --color-dot-unknown: #4A6080; /* unknown → muted */
+  --color-dot-killed: #FF4757; /* killed → danger */
+  --color-dot-completed: #26DE81; /* completed → success */
+  --color-dot-crashed: #FF4757; /* crashed → danger */
+  --color-dot-orange: #FF9F43; /* degraded → warning */
+  --color-dot-red: #FF4757; /* error → danger */
+  --color-dot-awaiting-approval: #FF9F43; /* awaiting approval → warning */
+  --color-info: #3B82F6;
 
 
   /* Syntax Highlighting (CodeBlock) */
@@ -192,15 +195,15 @@
 @media (color-gamut: p3) {
   @supports (color: color(display-p3 0 0 0)) {
     :root {
-      /* P3-enhanced CTA green — more vivid than sRGB #06b6d4 */
-      --color-accent-cyan: color(display-p3 0.08 0.75 0.85);
+      /* P3-enhanced cyan — more vivid than sRGB #00D4FF */
+      --color-accent-cyan: color(display-p3 0.1 0.82 1);
       
-      /* P3-enhanced accent blue — wider gamut than sRGB #3b82f6 */
-      --color-accent: color(display-p3 0.28 0.55 0.98);
+      /* P3-enhanced brand amber — wider gamut than sRGB #FFB800 */
+      --color-accent: color(display-p3 1 0.72 0);
       
-      /* P3-enhanced void background — deeper, richer black with subtle blue cast */
-      --color-void: color(display-p3 0.008 0.02 0.04);
-      --color-void-dark: color(display-p3 0.06 0.09 0.16);
+      /* P3-enhanced deep-space navy — richer than sRGB #0B1120 / #111827 */
+      --color-void: color(display-p3 0.043 0.067 0.122);
+      --color-void-dark: color(display-p3 0.066 0.094 0.15);
     }
   }
 }
@@ -376,8 +379,8 @@ body {
   margin: 0;
   -webkit-font-smoothing: antialiased;
   transition: background-color 0.4s ease, color 0.4s ease;
-  /* OpenType features: contextual alternates + ligatures for prose */
-  font-feature-settings: 'calt' 1, 'liga' 1;
+  /* OpenType features: Inter stylistic sets (DESIGN.md §2) + alternates/ligatures */
+  font-feature-settings: 'cv01' 1, 'ss03' 1, 'cv11' 1, 'calt' 1, 'liga' 1;
 }
 
 /* ================================================================
@@ -1041,9 +1044,10 @@ button:active:not(:disabled) {
 }
 
 /* ── Focus ring — keyboard/programmatic only (resolves #3687) ─── */
+/* Amber focus ring (DESIGN.md §1) — overridden per-component / forced-colors where set. */
 :focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring-offset), var(--focus-ring);
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
 }
 
 /* Remove default browser outline for mouse focus; keep for older browsers */

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -410,7 +410,7 @@ export default function AnalyticsPage() {
                 <div key={key.keyId} className="flex items-center justify-between rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2">
                   <div>
                     <div className="text-sm font-medium text-[var(--color-text-primary)]">{key.keyName}</div>
-                    <div className="text-xs text-[var(--color-text-muted)]">{key.sessions} session{key.sessions !== 1 ? 's' : ''} &middot; {key.messages} message{key.messages !== 1 ? 's' : ''}</div>
+                    <div className="text-xs text-[var(--color-text-muted)]"><span className="font-mono">{key.sessions}</span> session{key.sessions !== 1 ? 's' : ''} &middot; <span className="font-mono">{key.messages}</span> message{key.messages !== 1 ? 's' : ''}</div>
                   </div>
                   <div className="text-right">
                     <div className="text-sm font-mono font-medium text-[var(--color-text-primary)]">{formatCurrency(key.estimatedCostUsd)}</div>

--- a/dashboard/src/pages/CostPage.tsx
+++ b/dashboard/src/pages/CostPage.tsx
@@ -434,7 +434,7 @@ export default function CostPage() {
                       <div className="text-sm font-mono font-medium text-[var(--color-text-primary)]">
                         {formatCurrency(model.estimatedCostUsd)}
                       </div>
-                      <div className="text-xs text-[var(--color-text-muted)]">
+                      <div className="font-mono text-xs text-[var(--color-text-muted)]">
                         {pct.toFixed(1)}%
                       </div>
                     </div>

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -188,42 +188,54 @@ export default function MetricsPage() {
 
       {/* Summary cards */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
-          <div className="mb-1 flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
+        <div className="rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+          <div
+            className="mb-1 flex items-center gap-1 text-[11px] uppercase text-[var(--color-text-muted)]"
+            style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+          >
             <BarChart3 className="h-3 w-3" />
             {t('metrics.totalSessions')}
           </div>
-          <div className="text-2xl font-bold font-mono text-[var(--color-text-primary)]">
+          <div className="text-2xl font-bold font-mono tabular-nums text-[var(--color-text-primary)]">
             {(summary?.totalSessions ?? 0).toLocaleString()}
           </div>
         </div>
 
-        <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
-          <div className="mb-1 flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
+        <div className="rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+          <div
+            className="mb-1 flex items-center gap-1 text-[11px] uppercase text-[var(--color-text-muted)]"
+            style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+          >
             <Clock className="h-3 w-3" />
             {t('metrics.avgDuration')}
           </div>
-          <div className="text-2xl font-bold font-mono text-[var(--color-text-primary)]">
+          <div className="text-2xl font-bold font-mono tabular-nums text-[var(--color-text-primary)]">
             {summary ? formatDuration(summary.avgDurationSeconds) : '—'}
           </div>
         </div>
 
-        <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
-          <div className="mb-1 flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
+        <div className="rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+          <div
+            className="mb-1 flex items-center gap-1 text-[11px] uppercase text-[var(--color-text-muted)]"
+            style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+          >
             <DollarSign className="h-3 w-3" />
             {t('metrics.totalCost')}
           </div>
-          <div className="text-2xl font-bold font-mono text-[var(--color-text-primary)]">
+          <div className="text-2xl font-bold font-mono tabular-nums text-[var(--color-text-primary)]">
             {summary ? formatCurrency(summary.totalTokenCostUsd) : '—'}
           </div>
         </div>
 
-        <div className="rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-strong)] p-4">
-          <div className="mb-1 flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
+        <div className="rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+          <div
+            className="mb-1 flex items-center gap-1 text-[11px] uppercase text-[var(--color-text-muted)]"
+            style={{ fontWeight: 590, letterSpacing: '0.08em' }}
+          >
             <CheckCircle className="h-3 w-3" />
             {t('metrics.approvalRate')}
           </div>
-          <div className="text-2xl font-bold font-mono text-[var(--color-text-primary)]">
+          <div className="text-2xl font-bold font-mono tabular-nums text-[var(--color-text-primary)]">
             {summary?.permissionApprovalRate != null ? `${summary.permissionApprovalRate}%` : '—'}
           </div>
         </div>

--- a/dashboard/src/pages/MetricsPage.tsx
+++ b/dashboard/src/pages/MetricsPage.tsx
@@ -248,7 +248,7 @@ export default function MetricsPage() {
                       {a.sessionId.slice(0, 12)}
                     </span>
                     <span className="text-[var(--color-warning)]/80">
-                      {formatCurrency(a.tokenCostUsd)} — {a.reason}
+                      <span className="font-mono">{formatCurrency(a.tokenCostUsd)}</span> — {a.reason}
                     </span>
                   </div>
                 ))}

--- a/dashboard/src/pages/session-detail/MessageFooter.tsx
+++ b/dashboard/src/pages/session-detail/MessageFooter.tsx
@@ -262,14 +262,14 @@ export function MessageFooter({
             onKeyDown={handleKeyDown}
             placeholder={t('sessionDetail.sendPlaceholder')}
             disabled={sending || !h.alive}
-            className="flex-1 min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2.5 font-mono text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-cta-bg)] focus-visible:outline-none disabled:opacity-50"
+            className="flex-1 min-h-[44px] rounded border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-2.5 font-sans text-sm text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:border-[var(--color-cta-bg)] focus-visible:outline-none disabled:opacity-50"
           />
 
           <button
             type="button"
             onClick={handleSend}
             disabled={sending || !msgInput.trim() || !h.alive}
-            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-cta-bg)]/50 bg-[var(--color-cta-bg)]/15 p-2.5 text-[var(--color-cta-bg)] transition-all hover:bg-[var(--color-cta-bg)]/30 disabled:cursor-not-allowed disabled:opacity-30"
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded border border-[var(--color-cta-bg)] bg-[var(--color-cta-bg)] p-2.5 text-[var(--color-cta-text)] transition-all hover:bg-[var(--color-cta-bg-hover)] disabled:cursor-not-allowed disabled:opacity-30"
             aria-label={t('sessionDetail.sessionSendMessageCmd')}
           >
             <Send className="h-4 w-4" />
@@ -396,14 +396,14 @@ export function MessageFooter({
                 onKeyDown={handleKeyDown}
                 placeholder={t('sessionDetail.sendPlaceholder')}
                 disabled={sending || !h.alive}
-                className="flex-1 min-h-[48px] rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-3 font-mono text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus:border-[var(--color-accent-cyan)] focus-visible:outline-none disabled:opacity-50"
+                className="flex-1 min-h-[48px] rounded-xl border border-[var(--color-void-lighter)] bg-[var(--color-void)] px-3 py-3 font-sans text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-placeholder)] focus:border-[var(--color-accent-cyan)] focus-visible:outline-none disabled:opacity-50"
               />
 
               <button
                 type="button"
                 onClick={handleSend}
                 disabled={sending || !msgInput.trim() || !h.alive}
-                className="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-xl border border-[var(--color-accent-cyan)]/30 bg-[var(--color-accent-cyan)]/10 p-3 text-[var(--color-accent-cyan)] transition-colors hover:bg-[var(--color-accent-cyan)]/20 disabled:cursor-not-allowed disabled:opacity-30"
+                className="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-xl border border-[var(--color-cta-bg)] bg-[var(--color-cta-bg)] p-3 text-[var(--color-cta-text)] transition-colors hover:bg-[var(--color-cta-bg-hover)] disabled:cursor-not-allowed disabled:opacity-30"
                 aria-label={t('sessionDetail.sessionSendMessage')}
               >
                 <Send className="h-4 w-4" />

--- a/dashboard/src/utils/__tests__/statusStyles.test.ts
+++ b/dashboard/src/utils/__tests__/statusStyles.test.ts
@@ -1,0 +1,80 @@
+/**
+ * utils/__tests__/statusStyles.test.ts
+ *
+ * Contract test for the centralized §4 status → color map. Asserts every
+ * UIState value (plus the `stalled` lifecycle variant) resolves to the
+ * expected design token, and that an out-of-contract status falls back to
+ * the muted `unknown` style.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getStatusStyle,
+  STATUS_STYLES,
+  type StatusKey,
+} from '../statusStyles';
+
+const CYAN = 'var(--color-accent-cyan)';
+const AMBER = 'var(--color-accent)';
+const WARNING = 'var(--color-warning)';
+const SUCCESS = 'var(--color-success)';
+const DANGER = 'var(--color-danger)';
+const MUTED = 'var(--color-placeholder)';
+
+// Expected dot token per status (mirrors DESIGN.md §4 Status color map).
+const EXPECTED_DOT: Record<StatusKey, string> = {
+  idle: CYAN,
+  working: AMBER,
+  settings: AMBER,
+  compacting: WARNING,
+  context_warning: WARNING,
+  waiting_for_input: WARNING,
+  permission_prompt: WARNING,
+  bash_approval: WARNING,
+  plan_mode: WARNING,
+  pending: WARNING,
+  awaiting_approval: WARNING,
+  stalled: WARNING,
+  ask_question: DANGER,
+  error: DANGER,
+  rate_limit: DANGER,
+  killed: DANGER,
+  crashed: DANGER,
+  completed: SUCCESS,
+  unknown: MUTED,
+};
+
+describe('statusStyles — canonical §4 status color map', () => {
+  const statuses = Object.keys(EXPECTED_DOT) as StatusKey[];
+
+  it.each(statuses)('maps "%s" to its expected dot token', (status) => {
+    expect(getStatusStyle(status).dotColor).toBe(EXPECTED_DOT[status]);
+  });
+
+  it.each(statuses)('returns a non-empty label and className for "%s"', (status) => {
+    const style = getStatusStyle(status);
+    expect(style.label.length).toBeGreaterThan(0);
+    expect(style.className).toContain('text-[');
+  });
+
+  it('exposes DESIGN-mandated buckets via the explicit tokens', () => {
+    expect(getStatusStyle('idle').dotColor).toBe(CYAN);
+    expect(getStatusStyle('working').dotColor).toBe(AMBER);
+    expect(getStatusStyle('completed').dotColor).toBe(SUCCESS);
+    // error / killed / crashed all share the danger token.
+    expect(getStatusStyle('error').dotColor).toBe(DANGER);
+    expect(getStatusStyle('killed').dotColor).toBe(DANGER);
+    expect(getStatusStyle('crashed').dotColor).toBe(DANGER);
+  });
+
+  it('falls back to the muted unknown style for an out-of-contract status', () => {
+    const fallback = getStatusStyle('totally_not_a_status');
+    expect(fallback).toBe(STATUS_STYLES.unknown);
+    expect(fallback.dotColor).toBe(MUTED);
+    expect(fallback.label).toBe('unknown');
+  });
+
+  it('treats an empty string as unknown', () => {
+    expect(getStatusStyle('').dotColor).toBe(MUTED);
+  });
+});

--- a/dashboard/src/utils/statusStyles.ts
+++ b/dashboard/src/utils/statusStyles.ts
@@ -1,0 +1,110 @@
+/**
+ * utils/statusStyles.ts — Single source of truth for status → color.
+ *
+ * Encodes the Command Center "Status color map" from `dashboard/DESIGN.md` §4.
+ * Every component that renders a session/agent status (dots, pills, badges)
+ * draws its color from here instead of hardcoding tokens, so the mapping
+ * lives in exactly one place.
+ *
+ * Design tokens (see `src/index.css` @theme):
+ * - cyan    `var(--color-accent-cyan)`  → idle / ready (the "alive" signal)
+ * - amber   `var(--color-accent)`       → working / running
+ * - warning `var(--color-warning)`      → awaiting approval / degraded / stalled
+ * - success `var(--color-success)`      → completed / nominal
+ * - danger  `var(--color-danger)`       → error / killed / crashed
+ * - muted   `var(--color-placeholder)`  → unknown
+ *
+ * All data colors on the `#111827` surface pass WCAG AA (≥ 4.5:1). Pill text
+ * uses the `*-glow` token variants, which the light-theme overrides in
+ * `index.css` remap to AA-safe values per theme.
+ */
+
+import type { UIState } from '../types';
+
+/**
+ * Status keys this map covers: every `UIState` value plus the lifecycle
+ * variant `stalled` (a session-health state, not a `UIState`). `completed`,
+ * `killed`, and `crashed` are already part of the `UIState` union.
+ */
+export type StatusKey = UIState | 'stalled';
+
+export interface StatusStyle {
+  /** CSS variable for the status dot fill (e.g. `var(--color-accent-cyan)`). */
+  dotColor: string;
+  /** Lowercase, operator-console human label (DESIGN §6 voice). */
+  label: string;
+  /** Tailwind pill fragment: token-based border + bg + text, AA on navy. */
+  className: string;
+}
+
+// ── Token shorthands (DESIGN §1 data palette) ───────────────────────────────
+
+const CYAN = 'var(--color-accent-cyan)';
+const AMBER = 'var(--color-accent)';
+const WARNING = 'var(--color-warning)';
+const SUCCESS = 'var(--color-success)';
+const DANGER = 'var(--color-danger)';
+const MUTED = 'var(--color-placeholder)';
+
+// Pill class fragments per bucket. The `/40` `/10` opacity modifiers match the
+// existing token usage in the dashboard (e.g. `bg-[var(--color-success)]/15`).
+const CYAN_PILL =
+  'border-[var(--color-accent-cyan)]/40 bg-[var(--color-accent-cyan)]/10 text-[var(--color-accent-cyan)]';
+const AMBER_PILL =
+  'border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 text-[var(--color-accent)]';
+const WARNING_PILL =
+  'border-[var(--color-warning)]/40 bg-[var(--color-warning)]/10 text-[var(--color-warning-glow)]';
+const SUCCESS_PILL =
+  'border-[var(--color-success)]/40 bg-[var(--color-success)]/10 text-[var(--color-success-glow)]';
+const DANGER_PILL =
+  'border-[var(--color-danger)]/40 bg-[var(--color-danger)]/10 text-[var(--color-danger-glow)]';
+const MUTED_PILL =
+  'border-[var(--color-placeholder)]/40 bg-[var(--color-placeholder)]/10 text-[var(--color-text-muted)]';
+
+/**
+ * The canonical status → style map. Exhaustive over `StatusKey` — adding a new
+ * `UIState` value forces a compile error here until it is mapped.
+ */
+export const STATUS_STYLES: Record<StatusKey, StatusStyle> = {
+  // cyan — alive / ready
+  idle: { dotColor: CYAN, label: 'idle', className: CYAN_PILL },
+
+  // amber — actively working
+  working: { dotColor: AMBER, label: 'working', className: AMBER_PILL },
+  settings: { dotColor: AMBER, label: 'settings', className: AMBER_PILL },
+
+  // warning — awaiting human / degraded / stalled
+  compacting: { dotColor: WARNING, label: 'compacting', className: WARNING_PILL },
+  context_warning: { dotColor: WARNING, label: 'context warning', className: WARNING_PILL },
+  waiting_for_input: { dotColor: WARNING, label: 'waiting for input', className: WARNING_PILL },
+  permission_prompt: { dotColor: WARNING, label: 'awaiting approval', className: WARNING_PILL },
+  bash_approval: { dotColor: WARNING, label: 'awaiting approval', className: WARNING_PILL },
+  plan_mode: { dotColor: WARNING, label: 'plan review', className: WARNING_PILL },
+  pending: { dotColor: WARNING, label: 'pending', className: WARNING_PILL },
+  awaiting_approval: { dotColor: WARNING, label: 'awaiting approval', className: WARNING_PILL },
+  stalled: { dotColor: WARNING, label: 'stalled', className: WARNING_PILL },
+
+  // danger — failed / blocked / dead
+  ask_question: { dotColor: DANGER, label: 'awaiting input', className: DANGER_PILL },
+  error: { dotColor: DANGER, label: 'error', className: DANGER_PILL },
+  rate_limit: { dotColor: DANGER, label: 'rate limited', className: DANGER_PILL },
+  killed: { dotColor: DANGER, label: 'killed', className: DANGER_PILL },
+  crashed: { dotColor: DANGER, label: 'crashed', className: DANGER_PILL },
+
+  // success — done
+  completed: { dotColor: SUCCESS, label: 'completed', className: SUCCESS_PILL },
+
+  // muted — unknown
+  unknown: { dotColor: MUTED, label: 'unknown', className: MUTED_PILL },
+};
+
+/**
+ * Resolve the canonical style for a status string. Any value outside the
+ * status contract (defensive — e.g. a future backend status the dashboard
+ * hasn't shipped support for yet) falls back to the muted `unknown` style.
+ */
+export function getStatusStyle(status: string): StatusStyle {
+  // Map is keyed by `StatusKey`; widen for a safe lookup-with-fallback over an
+  // arbitrary string. The `?? unknown` guarantees a valid style is returned.
+  return STATUS_STYLES[status as StatusKey] ?? STATUS_STYLES.unknown;
+}


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.7

## Vision
Redesign the dashboard as a **command center for an agent fleet** — not a SaaS dashboard. DNA: mission-control (deep-space navy, amber telemetry, cyan health, monospace data, alert hierarchy) + Linear-grade craft (Inter 510, negative letter-spacing, keyboard-first density). Bold + on-brand (aegis = shield/control) → distinctive, not another Linear clone.

Contract: \`dashboard/DESIGN.md\` (the source of truth every slice reads).

## How it's built
Driven **via aegis** — each slice is a Claude Code session (acceptEdits) spawned through the Aegis API, reading DESIGN.md as the contract, then verified + committed. Dogfooding aegis to redesign aegis.

## Slices (DRAFT — in progress)
- [x] **1. Tokens + Inter** — \`@theme\` → navy/amber/cyan palette; DM Sans → Inter (cv01/ss03/cv11). Foundation.
- [x] **2. Status system** — centralized \`utils/statusStyles.ts\` (single source for status→color); StatusDot + StallBadge migrated. 41-test suite.
- [x] **3. Mono-for-values** — every numeric reading (tokens/ms/cost/IDs/timestamps) → JetBrains Mono.
- [x] **4. KPI/telemetry cards** — MetricCard(s) + KPIBanner → uppercase label / big mono value / cyan delta.
- [ ] **5. Data tables** — SessionTable/VirtualizedSessionList → dividers, active-row amber bar, dense.
- [ ] **6. Command palette + app shell** — sidebar/header/⌘K → console aesthetic; brand mark.
- [ ] **7. Session detail** — transcript/terminal chrome, approval toast, send composer.
- [ ] **8. Page pass** — remaining pages to tokens, cut noise.
- [ ] **9. Cuts + polish** — remove dead UI, focus rings, a11y/contrast audit.

Marking **draft** until slices 5-7 land (enough to evaluate the transformation). Each slice: tsc clean, build passes, green CI.

Generated by Hephaestus (Aegis dev agent)