### PR TITLE
docs(adr): ADR-0034 multi-CLI runtime, supersede ADR-0023

### DIFF
--- a/.claude/rules/positioning.md
+++ b/.claude/rules/positioning.md
@@ -1,17 +1,20 @@
 # Positioning (what Aegis is and is not)
 
-Authoritative source: [ADR-0023](../../docs/adr/0023-positioning-claude-code-control-plane.md)
+Authoritative source: [ADR-0034](../../docs/adr/0034-positioning-multi-cli-agent-runtime.md)
+(supersedes [ADR-0023](../../docs/adr/0023-positioning-claude-code-control-plane.md))
 and [docs/enterprise/00-gap-analysis.md §15](../../docs/enterprise/00-gap-analysis.md).
 
 ## What Aegis is
 
-- **The control plane of Claude Code.** REST, MCP, SSE, WebSocket, CLI, and
-  notification channels on a single self-hosted server.
-- **A bridge, not an orchestrator.** Claude Code does the agent work. Aegis
+- **The control plane for ACP-compatible coding-agent CLIs** — Claude Code
+  (default), plus Kimi Code and Gemini CLI. REST, MCP, SSE, WebSocket, CLI, and
+  notification channels on a single self-hosted server. See [ADR-0034](../../docs/adr/0034-positioning-multi-cli-agent-runtime.md).
+- **A bridge, not an orchestrator.** The agent CLI does the work. Aegis
   exposes, governs, observes, and approves it.
 - **MIT, single edition.** No open-core, no BUSL, no paid tier flag.
-- **BYO LLM first-class.** Claude Code can point at Anthropic, z.ai GLM,
-  OpenRouter, LM Studio, Ollama, Azure OpenAI, etc. Aegis owns no LLM cost.
+- **BYO LLM first-class, per runner.** Each runner points at its own provider
+  (Claude Code → Anthropic/GLM/OpenRouter/Ollama; Kimi → Moonshot; Gemini →
+  Vertex/Gemini API). Aegis owns no LLM cost.
 
 ## Target users (in order of priority)
 
@@ -26,8 +29,11 @@ Same architecture at every scale. No fork, no edition split, no rewrite.
 
 - Not an agent framework. We do not write agents, prompts, or LLM calls.
 - Not a SaaS. Self-hosted first; SaaS is off the table until demand + funding.
-- Not Claude-only at runtime. The LLM endpoint is configurable.
-- Not a general-purpose tmux manager. tmux is an implementation detail.
+- Not Claude-Code-only at the runtime layer — any ACP-compatible CLI can be a
+  runner (Claude Code remains the default). The LLM endpoint is also
+  configurable per runner.
+- Not multi-harness via bespoke adapters — only ACP-speaking runners are
+  first-class (ADR-0034 Decision 4). Non-ACP CLIs enter via an ACP bridge.
 
 ## What to NOT build without explicit maintainer approval
 
@@ -35,10 +41,13 @@ The roadmap locks these in. Do not propose or start PRs for them unless a
 maintainer assigns the issue from the right phase.
 
 **Never** (out of scope):
-- Open-core edition flag (`AEGIS_EDITION`) — decided against in ADR-0023.
+- Open-core edition flag (`AEGIS_EDITION`) — decided against in ADR-0023;
+  reaffirmed in ADR-0034 Decision 7.
 - Rewrite in another language — not under consideration.
-- First-class integrations with competing CLIs (e.g. Gemini CLI) —
-  Claude Code is the single target runtime.
+- Bespoke per-harness adapters inside the runtime — first-class runners speak
+  ACP; non-ACP CLIs enter via an ACP bridge, not an Aegis adapter
+  (ADR-0034 Decision 4). SaaS-only / preview-ACP CLIs (Copilot CLI today) are
+  watched, not built.
 
 **Not before Phase 3** (team & early-enterprise):
 - SSO / OIDC providers.
@@ -73,5 +82,8 @@ Activation happens via a maintainer-approved PR that:
 
 ## Current phase
 
-Phase 3 — Team & Early-Enterprise. Scope is defined in
-[.claude/epics/phase-3-team-early-enterprise/epic.md](../epics/phase-3-team-early-enterprise/epic.md).
+Phase 3 — Team & Early-Enterprise. Phase 3.6 — Multi-CLI Runtime (Kimi Code,
+Gemini CLI as ACP runners) is now in scope under [ADR-0034](../../docs/adr/0034-positioning-multi-cli-agent-runtime.md).
+Scope is defined in
+[.claude/epics/phase-3-team-early-enterprise/epic.md](../epics/phase-3-team-early-enterprise/epic.md)
+and ROADMAP §Phase 3.6.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - **Branch model:** all standard PRs target `develop` (not `main`)
 - **Release model:** `develop` → `release/<version>` → `main` → `v*` tag; Release Please prepares release branches, `release.yml` publishes tags from `main`
 - **Docs alignment:** keep policy docs synchronized in the same PR
-- **Active tracks:** Phase 3 production-use exit evidence and Phase 3.5 ACP backend migration
+- **Active tracks:** Phase 3 production-use exit evidence, Phase 3.5 ACP backend migration, Phase 3.6 multi-CLI runtime (ADR-0034)
 
 ## Non-Negotiable Hygiene Rules
 
@@ -70,14 +70,14 @@ src/
 ## Package
 
 - **Name:** `@onestepat4time/aegis`
-- **CLI binary:** `ag` (primary). `aegis` remains supported as a compatibility alias — see [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
+- **CLI binary:** `ag` (primary). `aegis` remains supported as a compatibility alias — see [ADR-0034](./docs/adr/0034-positioning-multi-cli-agent-runtime.md).
 - **MCP:** `claude mcp add aegis -- ag mcp` (or `claude mcp add aegis -- npx --package=@onestepat4time/aegis ag mcp` without a global install)
 - **Deprecated:** `aegis-bridge` (do not use in new code)
 
 ## Positioning (read before proposing features)
 
-- Aegis is the **control plane of Claude Code** — a bridge, not an orchestrator. See [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md).
-- MIT, single edition. BYO LLM is first-class.
+- Aegis is the **control plane for ACP-compatible coding-agent CLIs** (Claude Code default; Kimi Code and Gemini CLI supported) — a bridge, not an orchestrator. See [ADR-0034](./docs/adr/0034-positioning-multi-cli-agent-runtime.md) (supersedes ADR-0023).
+- MIT, single edition. BYO LLM is first-class, per runner.
 - Current phases and what NOT to build: [ROADMAP.md](./ROADMAP.md), [.claude/epics/phase-3-team-early-enterprise/epic.md](./.claude/epics/phase-3-team-early-enterprise/epic.md), [.claude/epics/phase-3-5-acp-backend-migration/epic.md](./.claude/epics/phase-3-5-acp-backend-migration/epic.md), and [.claude/rules/positioning.md](./.claude/rules/positioning.md).
 - End-to-end workflow: [.claude/rules/workflow.md](./.claude/rules/workflow.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,32 +1,35 @@
 # Aegis Roadmap
 
-> **Aegis is in Preview.** Planning is organised into four phases driven by
+> **Aegis is in Preview.** Planning is organised into phases driven by
 > audience scale (single dev → team → enterprise). The positioning is locked
-> in [ADR-0023](docs/adr/0023-positioning-claude-code-control-plane.md) and
-> the complete gap analysis lives in
+> in [ADR-0034](docs/adr/0034-positioning-multi-cli-agent-runtime.md)
+> (supersedes [ADR-0023](docs/adr/0023-positioning-claude-code-control-plane.md))
+> and the complete gap analysis lives in
 > [docs/enterprise/00-gap-analysis.md](docs/enterprise/00-gap-analysis.md).
 
 ---
 
 ## North Star
 
-Be the most reliable, pleasant, self-hosted **control plane for Claude Code**
-— used by a single developer orchestrating agents from a phone, a 10-person
-team sharing a deployment, or an enterprise adopting it under SSO.
+Be the most reliable, pleasant, self-hosted **control plane for ACP-compatible
+coding-agent CLIs** (Claude Code default; Kimi Code, Gemini CLI supported) —
+used by a single developer orchestrating agents from a phone, a 10-person team
+sharing a deployment, or an enterprise adopting it under SSO.
 
 The orchestration pattern is the same at every scale; Aegis scales up with the
 audience without rewrites. Aegis never orchestrates agents — it bridges them
-to Claude Code.
+to an ACP-speaking runner.
 
 ---
 
 ## Positioning (locked)
 
-- **Aegis is the control plane of Claude Code.** REST, MCP, SSE, WS, CLI, and
-  notification channels on one server.
+- **Aegis is the control plane for ACP-compatible agent CLIs** (Claude Code
+  default; Kimi Code, Gemini CLI supported). REST, MCP, SSE, WS, CLI, and
+  notification channels on one server. See [ADR-0034](docs/adr/0034-positioning-multi-cli-agent-runtime.md).
 - **MIT, single edition.** No open-core, no BUSL.
-- **BYO LLM is first-class.** Claude Code can point at Anthropic, GLM,
-  OpenRouter, LM Studio, Ollama, Azure OpenAI, etc. Aegis owns no LLM cost.
+- **BYO LLM is first-class, per runner.** Each runner points at its own
+  provider; Aegis owns no LLM cost.
 - **Primary CLI command is `ag`**; `aegis` remains as alias.
 - Self-hosted first. SaaS is off the table until there is demand and funding.
 
@@ -115,6 +118,30 @@ The tracking issue is #2574 and the child issue catalog spans #2575 through
       pause/intervention, terminal debug, and timeline views (#2611–#2619)
 - [x] M5 — soak, cutover, tmux deletion, deployment/docs cleanup, and final gate
       (#2620–#2627)
+
+---
+
+## Phase 3.6 — Multi-CLI Runtime 🟡 PLANNED (authorized by ADR-0034)
+
+**Goal:** host ACP-compatible coding-agent CLIs beyond Claude Code as
+first-class runners, ratifying [ADR-0032](docs/adr/0032-multi-agent-architecture.md)
+at the positioning layer ([ADR-0034](docs/adr/0034-positioning-multi-cli-agent-runtime.md)).
+
+Driven by existential reach (ADR-0032): users pick the tool that supports
+their preferred agent; ACP is now the common denominator (Claude Code via Zed
+adapter, Kimi Code native, Gemini CLI native).
+
+- [ ] M1 — wire `src/runners/` `AgentRunner` into the spawn path (replace
+      dead-code stub wiring; parameterise `AcpBackend` via existing seams)
+- [ ] M2 — implement `KimiRunner` (native ACP, MIT, best approval/plan-mode
+      parity); `KIMI_*` env adapter
+- [ ] M3 — implement `GeminiCliRunner` (native ACP; track `agy` ACP gap)
+- [ ] M4 — per-runner spawn adapters; ACP-event-store-only mode bypassing the
+      CC-specific transcript JSONL + `claude agents --json` discovery
+- [ ] M5 — runner selection API + dashboard surface; end-to-end dogfood
+
+Out of Phase 3.6 scope (watch / bridge): Copilot CLI (SaaS-only, ACP preview),
+Codex (no native ACP — bridge via community `codex-acp` until openai/codex#30052).
 
 ---
 

--- a/docs/adr/0023-positioning-claude-code-control-plane.md
+++ b/docs/adr/0023-positioning-claude-code-control-plane.md
@@ -1,7 +1,11 @@
 # ADR-0023: Positioning — Claude Code Control Plane, MIT, BYO LLM, `ag` CLI
 
 ## Status
-Proposed
+
+Deprecated — superseded by [ADR-0034](0034-positioning-multi-cli-agent-runtime.md) (2026-07-07).
+
+> ⚠️ **Superseded by [ADR-0034: Multi-CLI Agent Runtime](0034-positioning-multi-cli-agent-runtime.md).**
+> Aegis is no longer Claude-Code-only at the runtime layer. Kept for traceability.
 
 ## Context
 

--- a/docs/adr/0034-positioning-multi-cli-agent-runtime.md
+++ b/docs/adr/0034-positioning-multi-cli-agent-runtime.md
@@ -1,0 +1,220 @@
+# ADR-0034: Positioning — Multi-CLI Agent Runtime (supersedes ADR-0023)
+
+## Status
+
+Proposed.
+
+**Supersedes:** [ADR-0023](0023-positioning-claude-code-control-plane.md) (Positioning — Claude Code Control Plane, MIT, BYO LLM, `ag` CLI).
+
+**Ratifies:** [ADR-0032](0032-multi-agent-architecture.md) (Multi-Agent Architecture) at the positioning layer.
+
+**Supplements, does not replace:** [ADR-0006](0006-aegis-middleware-not-agent-framework.md), [ADR-0029](0029-solo-dev-first-phase-4-deferred.md), [ADR-0033](0033-positioning-vs-ecc.md).
+
+> This is the first ADR in the repository to formally supersede another. The
+> convention it establishes (`## Status` → `Supersedes:` + flipping the
+> predecessor to `Deprecated`) is documented in [docs/adr/README.md](README.md).
+
+## Context
+
+ADR-0023 (Proposed 2026-04; never Accepted) locked Aegis to **Claude Code as
+the single target runtime**. The stated rationale was focus and scope for a
+part-time maintainer and a small (~8 star) audience: narrow the product so the
+codebase and roadmap stay tractable.
+
+That decision is now overtaken by two developments:
+
+1. **ADR-0032 (Approved 2026-05-30, Boss review) already commits Aegis to
+   multi-CLI at the architecture level.** Phase 3.5 shipped the substrate:
+   `src/runners/` defines an `AgentRunner` interface and `RunnerRegistry`
+   (issue #3263), with `GeminiCliRunner` and `CodexRunner` stubs. ADR-0032 §1
+   frames multi-CLI as **existential reach**: *"Users choose the tool that
+   supports their preferred AI coding agent. Without multi-agent, Aegis is
+   invisible to anyone not using Claude Code."* The repository is therefore
+   **internally contradictory** today: an Approved ADR mandates multi-CLI while
+   a Proposed ADR and `.claude/rules/positioning.md` (the *"Never: competing
+   CLIs"* bullet) forbid it.
+
+2. **The wire-protocol landscape caught up.** July 2026 research confirms that
+   **4 of 5 major coding-agent CLIs speak ACP** — the Agent Client Protocol
+   (open standard, [Zed Industries](https://zed.dev/acp)) that Aegis already
+   speaks to drive `claude-agent-acp`:
+
+   | CLI | ACP | License | Headless | Approval/hooks | Aegis feasibility |
+   |---|---|---|---|---|---|
+   | Claude Code | via Zed adapter | Apache-2.0 adapter | yes | full (reference) | HIGH (current) |
+   | Kimi Code CLI | **native** (`kimi acp`) | **MIT** | yes | approvals + plan mode, parity | **HIGH** |
+   | Gemini CLI | **native** (`gemini --acp`) | Apache-2.0 | yes | 11 hooks, `setSessionMode`, sandbox | HIGH (caveat: sunset → `agy`) |
+   | GitHub Copilot CLI | preview (`--acp`) | source-available; SaaS-only | yes | partial (perm-hook open) | MEDIUM (watch) |
+   | OpenAI Codex CLI | no (custom JSONL; #30052 open) | Apache-2.0 | yes | sandbox/profiles/hooks | MEDIUM (needs bridge) |
+
+   ACP is becoming the real common denominator for the **runtime-driving
+   layer** (distinct from MCP, which stacks underneath as the agent↔tools
+   layer). Aegis does not need a new protocol; it needs to host additional
+   ACP-speaking children behind its existing `AcpBackend`/`AcpChildProcess`.
+
+3. **Aegis's runtime is already ~85% protocol-agnostic.** The Claude-Code
+   coupling lives in a thin spawn-boundary shell: binary resolution
+   (`AEGIS_ACP_BIN` escape hatch already exists), `--permission-mode` argv,
+   `ANTHROPIC_*`/`CLAUDE_*` env passthrough, `.claude/settings.local.json`
+   patching, the transcript JSONL parser, and the `claude agents --json`
+   discovery side-channel. The `AgentRunner` abstraction exists but is dead
+   code (stubs only; production spawns `claude-agent-acp` directly). Hosting
+   another ACP CLI is a spawn-boundary refactor, not a protocol rewrite.
+
+The binding constraint on multi-CLI was therefore never wire-protocol
+feasibility — it was the positioning policy in ADR-0023 + `positioning.md`.
+This ADR removes that policy constraint and ratifies the direction ADR-0032
+already locked in.
+
+## Decisions
+
+### 1. Positioning shift — control plane for ACP-compatible agent CLIs
+
+Aegis is the **control plane for ACP-compatible coding-agent CLIs**. Claude
+Code remains the **default and reference runtime**; it is no longer the only
+one. The product noun moves from "control plane *of Claude Code*" to "control
+plane *for ACP-compatible agent CLIs (Claude Code default)*".
+
+### 2. Repeal the "Never: competing CLIs" rule
+
+The bullet in [.claude/rules/positioning.md](../../.claude/rules/positioning.md)
+marking *"First-class integrations with competing CLIs (e.g. Gemini CLI) —
+Claude Code is the single target runtime"* as out-of-scope is **repealed**. It
+is replaced with:
+
+> First-class support for **ACP-compatible** agent CLIs — Claude Code
+> (default), Kimi Code, Gemini CLI. Non-ACP CLIs (Codex today) enter via an
+> ACP bridge, not a bespoke adapter. CLIs whose ACP surface is preview or
+> SaaS-only (Copilot CLI) are watched, not built, until they stabilise.
+
+The other two "Never" bullets (open-core `AEGIS_EDITION` flag; rewrite in
+another language) **stay**.
+
+### 3. Ratify ADR-0032
+
+This ADR ratifies [ADR-0032](0032-multi-agent-architecture.md) at the
+positioning layer. The `src/runners/` `AgentRunner` abstraction and the
+Gemini/Codex stubs are the implementation substrate. `defaultRunner` remains
+`'claude-code'` (ADR-0032 §4.2).
+
+### 4. ACP-only first-class — no per-harness adapters
+
+Affirms [ADR-0033](0033-positioning-vs-ecc.md) §3 no-fly-list item 3
+(*"harness-specific shortcuts that break ACP"*). **First-class runners speak
+ACP.** A CLI without native ACP (Codex today) is hosted via an ACP
+bridge/adaptation layer upstream of the CLI, **not** a bespoke Aegis adapter
+inside the runtime. This keeps the architecture one protocol, not N adapter
+layers. `NdjsonRpcTransport` is reused across all runners (per ADR-0032).
+
+### 5. Claude Code stays default and hard-installed
+
+Claude Code remains the **default runner** and a **hard requirement to
+install** (reference path; guarantees a working out-of-box runtime with no
+extra auth setup). Other runners are opt-in and installed/registered by the
+operator.
+
+### 6. BYO LLM, per-runner — Aegis still owns no LLM cost
+
+Reaffirms ADR-0023 Decision 4 and ADR-0031. Each runner owns its own model
+auth and cost: Claude Code via `ANTHROPIC_*`; Kimi via Moonshot OAuth/API key;
+Gemini via paid Gemini/Vertex key (post-2026-06-18 sunset); Codex via OpenAI
+key. **Aegis passes auth through, does not proxy, cache, or own LLM cost.**
+Per-runner cost tracking remains out of scope (ADR-0032 §4.4); `/v1/budgets`
+(ADR-0031) provides alerts where runners expose usage.
+
+### 7. MIT, single edition — unchanged
+
+Multi-CLI does **not** introduce an `AEGIS_EDITION` flag. All runners ship to
+all users. (Reaffirms ADR-0023 Decision 3 and ADR-0029 L66–70.)
+
+### 8. Relationship to sibling ADRs
+
+- **ADR-0006** (middleware, not framework): **survives unchanged.** The runner
+  abstraction was always its escape hatch. Aegis still does not write agents,
+  prompts, or LLM calls.
+- **ADR-0029** (solo-dev-first, Phase 4 deferred): **survives.** Multi-CLI
+  broadens reach *within* the solo-dev / small-team tier (operators running
+  mixed harnesses); it does not pivot to enterprise.
+- **ADR-0033** (positioning vs ECC): **survives; item 3 sharpened** by
+  Decision 4 above. Aegis's differentiator remains governance/approval +
+  multi-channel observation on a self-hosted server, not breadth-of-harness
+  support at any cost.
+
+### 9. Activate Phase 3.6 — Multi-CLI Runtime
+
+Opens a **Phase 3.6** sub-track (sibling to Phase 3.5, which delivered the
+ACP-native runtime precondition). Trigger condition: this ADR ratified **and**
+ADR-0032 architecture shipped (already true). Milestones (per ADR-0032 §5):
+
+- M1: wire `AgentRunner` into the spawn path (or parameterise `AcpBackend` via
+  its existing `clientFactory`/`resolveCommand` seams) — replace the dead-code
+  status of `src/runners/`.
+- M2: implement `KimiRunner` concretely (replace stub) — strongest non-Claude
+  candidate: native ACP, MIT, published capability matrix, approval/plan-mode
+  parity.
+- M3: implement `GeminiCliRunner` concretely (replace stub) — native ACP;
+  track `agy` ACP gap ([google-antigravity/antigravity-cli#31](https://github.com/google-antigravity/antigravity-cli/issues/31)).
+- M4: per-runner spawn adapters — env prefixes (`KIMI_*`/`GEMINI_*`),
+  permission-mode mapping, and an **ACP-event-store-only mode** for non-Claude
+  runners that bypasses the CC-specific transcript JSONL parser and
+  `claude agents --json` discovery.
+- M5: runner selection API + dashboard surface (create-session picks runner;
+  session row shows runner).
+
+Copilot CLI and Codex are explicitly **out of Phase 3.6 scope** (watch / bridge
+respectively) and tracked in follow-up issues.
+
+## Consequences
+
+- **Positioning / market:** Aegis becomes addressable to any operator running
+  an ACP-compatible coding agent, not only Claude Code users — the existential
+  reach ADR-0032 identified. Target-user tier (solo dev → small team) is
+  unchanged in priority but broadened in harness coverage.
+- **Codebase:** revive and wire `src/runners/`; implement two concrete runners
+  (Kimi, Gemini CLI); push the Claude-Code spawn-boundary coupling
+  (binary-resolver, permission-mode argv, `ANTHROPIC_*` env, settings-patching,
+  transcript, discovery) behind per-runner adapters; add an ACP-event-store-only
+  mode so non-CC runners are not forced through CC-specific transcript/discovery
+  paths.
+- **Docs (single alignment PR with this ADR):**
+  - [`.claude/rules/positioning.md`](../../.claude/rules/positioning.md): repeal
+    the "Never" bullet (Decision 2); update "What Aegis is" / "What Aegis is
+    NOT"; repoint the authority link from ADR-0023 to ADR-0034; drop the stale
+    "general-purpose tmux manager" bullet (tmux removed in Phase 3.5 M5).
+  - [`ROADMAP.md`](../../ROADMAP.md): add Phase 3.6; update the "Positioning
+    (locked)" block.
+  - [`CLAUDE.md`](../../CLAUDE.md): update the positioning summary line.
+  - [`docs/enterprise/00-gap-analysis.md`](../enterprise/00-gap-analysis.md) §15:
+    update the positioning lock-in section.
+- **ADR-0023:** flipped to `Deprecated` with a superseded-by callout; kept for
+  traceability.
+- **Risks:**
+  - ACP spec is pre-1.0 (0.x) — capability matrices differ per CLI; Aegis must
+    degrade gracefully on unsupported methods (e.g. Kimi lacks `session/close`
+    + `logout`; 10/12 stable).
+  - Codex has no native ACP — bridge is third-party (`codex-acp`, ~142★,
+    "breaking changes likely") until openai/codex#30052 lands.
+  - Copilot CLI is SaaS-only / subscription-bound — conflicts with BYO-LLM;
+    ACP is still preview. Watch, do not build.
+  - Gemini CLI sunset to `agy` (free tier cut 2026-06-18); paid Gemini/Vertex
+    still works; `agy` ACP tracked separately.
+  - Per-runner maintenance surface grows; mitigated by ACP-only constraint
+    (Decision 4) — no N-adapter explosion.
+- **Unchanged:** MIT single edition; BYO LLM (Aegis owns no LLM cost);
+  self-hosted first; not a SaaS; not an agent framework.
+
+## Related
+
+- Supersedes: [ADR-0023](0023-positioning-claude-code-control-plane.md)
+- Ratifies: [ADR-0032](0032-multi-agent-architecture.md)
+- Sharpens: [ADR-0033](0033-positioning-vs-ecc.md) §3
+- Survives alongside: [ADR-0006](0006-aegis-middleware-not-agent-framework.md),
+  [ADR-0029](0029-solo-dev-first-phase-4-deferred.md), [ADR-0031](0031-budget-alerts.md)
+- Issues: #3263 (runner abstraction), #3180, #3971 (multi-agent demand),
+  #4725 (reviewer App)
+- External: [Agent Client Protocol](https://agentclientprotocol.com/),
+  [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp),
+  [Kimi Code ACP capability matrix](https://www.kimi.com/code/docs/en/kimi-code-cli/reference/kimi-acp.html),
+  [gemini-cli ACP](https://geminicli.com/docs/cli/acp-mode/),
+  [copilot-cli ACP preview](https://github.blog/changelog/2026-01-28-acp-support-in-copilot-cli-is-now-public-preview/),
+  [openai/codex#30052](https://github.com/openai/codex/issues/30052)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,7 +21,7 @@ ADRs document significant architectural decisions made during Aegis development.
 | [ADR-0020](0020-env-var-denylist.md) | Env-Var Denylist on Session Create | Proposed | 2026-04-16 | — |
 | [ADR-0021](0021-sse-and-http-drain-timeouts.md) | SSE Idle Timeout and HTTP Drain on Shutdown | Proposed | 2026-04-16 | — |
 | [ADR-0022](0022-sigstore-attestations.md) | Sigstore Attestations for npm and Container Artifacts | Proposed | 2026-04-16 | — |
-| [ADR-0023](0023-positioning-claude-code-control-plane.md) | Positioning: Claude Code Control Plane, MIT, BYO LLM, `ag` CLI | Proposed | 2026-04-16 | — |
+| [ADR-0023](0023-positioning-claude-code-control-plane.md) | Positioning: Claude Code Control Plane, MIT, BYO LLM, `ag` CLI | Deprecated | 2026-04-16 | — |
 | [ADR-0024](0024-dashboard-token-in-memory.md) | Dashboard API Token Stays In Memory | Accepted | 2026-04-17 | #1924 |
 | [ADR-0025](0025-tenant-authz-model.md) | Tenant-Aware Authorization Model | Proposed | — | — |
 | [ADR-0026](0026-oidc-trust-model.md) | OIDC Trust Model for Dashboard SSO | Proposed | — | #1942 |
@@ -33,6 +33,7 @@ ADRs document significant architectural decisions made during Aegis development.
 | [ADR-0031](0031-budgets-api-design.md) | /v1/budgets API Design for Cost Alerts | Proposed | 2026-05-25 | #4196 |
 | [ADR-0032](0032-multi-agent-architecture.md) | Multi-Agent Support — Architecture Design | Approved | 2026-05-30 | #3180 |
 | [ADR-0033](0033-positioning-vs-ecc.md) | Positioning vs ECC (affaan-m) — Aegis = Production Platform, ECC = Power-User Config | Proposed | 2026-06-20 | — |
+| [ADR-0034](0034-positioning-multi-cli-agent-runtime.md) | Positioning — Multi-CLI Agent Runtime (supersedes ADR-0023) | Proposed | 2026-07-07 | #3263 |
 
 > **Note on duplicate numbers:** ADR-0030 currently has two files (`0030-network-isolation-scope-by-deployment-tier.md` and `0030-agent-auth-rfc.md`). Both are linked above with disambiguated titles. A follow-up renumbering PR is needed (Boss decision pending). The older duplicates at ADR-0024 and ADR-0025 (pre-existing) are also pending renumbering and out of scope for this index catch-up.
 

--- a/docs/enterprise/00-gap-analysis.md
+++ b/docs/enterprise/00-gap-analysis.md
@@ -329,6 +329,12 @@ The five new ADRs below capture the architectural decisions implied by the P0 qu
 
 ## 15. Positioning & Phasing (2026-04-16 decision)
 
+> ⚠️ **Partially superseded by [ADR-0034](../adr/0034-positioning-multi-cli-agent-runtime.md)
+> (2026-07-07):** Aegis is no longer Claude-Code-only at the runtime layer.
+> The "single target runtime" framing below is retained for the LLM-endpoint
+> (BYO LLM) and scale-of-audience analysis; runtime breadth is now
+> ACP-CLI plural per ADR-0034.
+
 This section locks in the product direction that shapes the roadmap below. It
 supersedes any prior "enterprise-first" framing in earlier reviews.
 


### PR DESCRIPTION
## Aegis version
**Developed with:** v0.6.7 *(health endpoint unavailable; from package.json)*

## What
ADR-0034 — Multi-CLI Agent Runtime. Ratifies [ADR-0032](https://github.com/OneStepAt4time/aegis/blob/develop/docs/adr/0032-multi-agent-architecture.md) (Approved) at the positioning layer and repeals the "Never: competing CLIs" rule of ADR-0023. Aegis becomes the control plane for **ACP-compatible coding-agent CLIs** (Claude Code default; Kimi Code, Gemini CLI supported).

## Why
The repo is internally contradictory: ADR-0032 (Approved 2026-05-30) already mandates multi-CLI and Phase 3.5 shipped `src/runners/` + Gemini/Codex stubs, while ADR-0023 (Proposed, never Accepted) + `positioning.md` forbid it. July-2026 research confirms 4 of 5 major coding-agent CLIs speak ACP — the protocol Aegis already speaks. This ADR resolves the contradiction by ratifying ADR-0032 and repealing the stale "Never".

## Scope (docs only — 7 files, +300/-30)
- `docs/adr/0034-positioning-multi-cli-agent-runtime.md` — the ADR (9 decisions; activates Phase 3.6)
- `docs/adr/0023-…md` — Status → Deprecated + superseded callout
- `docs/adr/README.md` — index update
- `.claude/rules/positioning.md` — repeal Never bullet, update What is/NOT, repoint authority link, drop stale tmux bullet (tmux removed in Phase 3.5 M5)
- `CLAUDE.md` — positioning line + active tracks
- `ROADMAP.md` — Phase 3.6 + positioning blocks
- `docs/enterprise/00-gap-analysis.md` §15 — superseded callout

**No code.** Implementation (wire `src/runners/`, KimiRunner) is a separate follow-up PR gated on this ADR's acceptance.

## Evidence
- `detect_changes`: 0 symbols, 0 processes, risk LOW (docs only).
- Local gate: docs-only change is gate-invariant (tsc/build/test unaffected); CI runs the full gate on this branch. The known Windows flakes (`worktree-4694.test.ts` path-sep) are pre-existing on develop and do not reproduce on Linux CI.

## ADR-0034 decisions
1. Positioning shift — control plane for ACP-compatible agent CLIs (Claude Code default)
2. Repeal "Never: competing CLIs"
3. Ratify ADR-0032
4. ACP-only first-class — no per-harness adapters
5. Claude Code stays default + hard-installed
6. BYO LLM, per-runner (Aegis owns no LLM cost)
7. MIT single edition unchanged
8. Sibling ADRs (0006/0029/0033) survive
9. Activate Phase 3.6 — Multi-CLI Runtime (M1 wire runners → M2 Kimi → M3 Gemini → M4 adapters → M5 API+UI)

Generated by Hephaestus (Aegis dev agent)
