### PR TITLE
docs(adr-0034): update positioning references post-#4842 + #4843

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before starting any work, please read:
 
 - [AGENTS.md](./AGENTS.md) — repository-level policy for humans and AI agents
 - [ROADMAP.md](./ROADMAP.md) — current phase and what is in / out of scope
-- [ADR-0023](./docs/adr/0023-positioning-claude-code-control-plane.md) — product positioning (authoritative)
+- [ADR-0034](./docs/adr/0034-positioning-multi-cli-agent-runtime.md) — product positioning (authoritative; supersedes ADR-0023)
 - [.claude/rules/](./.claude/rules/) — scoped rules (branching, commits, PRs, workflow, positioning, TypeScript)
 
 Active work is limited to the roadmap's current tracks: Phase 3

--- a/charts/aegis/README.md
+++ b/charts/aegis/README.md
@@ -1,6 +1,6 @@
 # Aegis Helm Chart
 
-Deploys [Aegis](https://github.com/OneStepAt4time/aegis) — the control plane for Claude Code — on Kubernetes.
+Deploys [Aegis](https://github.com/OneStepAt4time/aegis) — the control plane for ACP-compatible coding-agent CLIs (Claude Code default; Kimi Code, Gemini CLI supported) — on Kubernetes.
 
 ## Prerequisites
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -756,7 +756,7 @@ curl "http://localhost:9100/v1/sessions?page=1&limit=20&status=working" \
 POST /v1/sessions
 ```
 
-Creates a new Claude Code session. Reuses an existing idle session for the same `workDir` if available. Rate limited: 120 req/min.
+Creates a new ACP session. Reuses an existing idle session for the same `workDir` if available. Rate limited: 120 req/min.
 
 ```bash
 curl -X POST http://localhost:9100/v1/sessions \
@@ -795,6 +795,7 @@ curl -X POST http://localhost:9100/v1/sessions \
 | `memoryKeys` | string[] | no | Pre-load memory entries into session (max 50) |
 | `agentId` | string (UUID) | no | Bind session to an agent — inherits agent identity, profile config, and constraints (see [Agents](#11-agents)) |
 | `effort` | string | no | Reasoning effort level: `low`, `medium`, or `high`. Passed to the CC session via `--effort` flag. |
+| `runnerName` | string | no | Agent runner: `claude-code` (default), `kimi`. See [multi-CLI runtime guide](docs/guides/multi-cli.md). |
 | `systemPrompt` | string | no | Per-session custom system prompt passed via ACP `_meta.systemPrompt` (max 100k chars; ACP only) |
 
 > **Multi-tenancy:** Sessions inherit `tenantId` from the creating API key.


### PR DESCRIPTION
Updates docs to reflect ADR-0034 multi-CLI positioning (merged in #4842 / #4843):

- **CONTRIBUTING.md**: authority link ADR-0023 → ADR-0034 (with superseded note)
- **charts/aegis/README.md**: expand tagline to ACP-compatible CLIs (Claude Code default; Kimi Code, Gemini CLI supported)
- **docs/api-reference.md**: 
  - POST /v1/sessions description → 'ACP session' (was 'Claude Code session')
  - Add  parameter to request body table (claude-code default, kimi experimental)

Gaps identified during heartbeat #781 (Jul 6) — these files still referenced the superseded ADR-0023 positioning after ADR-0034 + M1 implementation landed.

No code changes. Pure docs alignment.

— Scribe 📝